### PR TITLE
C++ flexible ComponentBatch, AsComponents, logging unification

### DIFF
--- a/crates/re_types_builder/src/codegen/cpp/method.rs
+++ b/crates/re_types_builder/src/codegen/cpp/method.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::Docs;

--- a/crates/re_types_builder/src/codegen/cpp/method.rs
+++ b/crates/re_types_builder/src/codegen/cpp/method.rs
@@ -38,7 +38,7 @@ impl MethodDeclaration {
         }
     }
 
-    pub fn to_cpp_tokens(&self, class_or_struct_name: &Ident) -> TokenStream {
+    pub fn to_cpp_tokens(&self, class_or_struct_name: &TokenStream) -> TokenStream {
         let Self {
             is_static: _,
             return_type,
@@ -140,7 +140,7 @@ impl Method {
         }
     }
 
-    pub fn to_cpp_tokens(&self, class_or_struct_name: &Ident) -> TokenStream {
+    pub fn to_cpp_tokens(&self, class_or_struct_name: &TokenStream) -> TokenStream {
         let Self {
             docs: _,
             declaration,

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1847,7 +1847,7 @@ fn quote_archetype_field_type(hpp_includes: &mut Includes, obj_field: &ObjectFie
             let elem_type = quote_element_type(hpp_includes, elem_type);
             quote! { ComponentBatch<#elem_type> }
         }
-        // TODO(andreas): This should emit `MonoComponentBatch` which will be a constrainted version of `ComponentBatch`.
+        // TODO(andreas): This should emit `MonoComponentBatch` which will be a constrained version of `ComponentBatch`.
         // (simply adapting `MonoComponentBatch` breaks some existing code, so this not entirely trivial to do.
         //  Designing constraints for `MonoComponentBatch` is harder still)
         Type::Object(fqname) => quote_fqname_as_type_path(hpp_includes, fqname),

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -477,6 +477,9 @@ impl QuotedObject {
                     #(#methods_hpp)*
             }
         };
+
+        let indicator_comment = quote_doc_comment("Indicator component, used to identify the archetype when converting to a list of components.");
+
         let hpp = quote! {
             #hpp_includes
 
@@ -488,6 +491,8 @@ impl QuotedObject {
 
                         #(#constants_hpp;)*
 
+                        #NEWLINE_TOKEN
+                        #indicator_comment
                         using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
                         #hpp_type_extensions

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -502,6 +502,8 @@ impl QuotedObject {
                     #NEWLINE_TOKEN
                     #NEWLINE_TOKEN
                 }
+                #NEWLINE_TOKEN
+                #NEWLINE_TOKEN
 
                 // Instead of including as_components.hpp, simply re-declare the template since it's trivial.
                 template<typename T>
@@ -525,8 +527,9 @@ impl QuotedObject {
                     #(#constants_cpp;)*
 
                     #(#methods_cpp)*
-
                 }
+                #NEWLINE_TOKEN
+                #NEWLINE_TOKEN
                 #serialize_cpp
             }
         };

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -398,8 +398,10 @@ impl QuotedObject {
                 .unzip();
 
             methods.push(Method {
+                // Making the constructor explicit prevents all sort of strange errors.
+                // (e.g. `Points3D({{0.0f, 0.0f, 0.0f}})` would previously be ambiguous with the move constructor?!)
                 declaration: MethodDeclaration::constructor(quote! {
-                    #type_ident(#(#parameters),*) : #(#assignments),*
+                    explicit #type_ident(#(#parameters),*) : #(#assignments),*
                 }),
                 ..Method::default()
             });

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1296,8 +1296,6 @@ fn archetype_serialize(
 
     let num_fields = quote_integer(obj.fields.len());
     let push_batches = obj.fields.iter().map(|field| {
-        // TODO: trait will simplify these things (RIGHT?!)
-
         let field_name = format_ident!("{}", field.name);
         let field_accessor = quote!(archetype.#field_name);
         if field.typ.is_plural() {

--- a/docs/code-examples/box3d_batch.cpp
+++ b/docs/code-examples/box3d_batch.cpp
@@ -22,7 +22,7 @@ int main() {
                     rr::datatypes::Angle::degrees(30.0f)
                 ),
             })
-            .with_radii(0.025f)
+            .with_radii({0.025f})
             .with_colors({
                 rr::datatypes::Rgba32(255, 0, 0),
                 rr::datatypes::Rgba32(0, 255, 0),

--- a/docs/code-examples/disconnected_space.cpp
+++ b/docs/code-examples/disconnected_space.cpp
@@ -2,17 +2,15 @@
 
 #include <rerun.hpp>
 
-namespace rr = rerun;
-
 int main() {
-    auto rec = rr::RecordingStream("rerun_example_disconnected_space");
+    auto rec = rerun::RecordingStream("rerun_example_disconnected_space");
     rec.connect("127.0.0.1:9876").throw_on_failure();
 
     // These two points can be projected into the same space..
-    rec.log("world/room1/point", rr::Points3D(rr::datatypes::Vec3D{0.0f, 0.0f, 0.0f}));
-    rec.log("world/room2/point", rr::Points3D(rr::datatypes::Vec3D{1.0f, 1.0f, 1.0f}));
+    rec.log("world/room1/point", rerun::Points3D({0.0f, 0.0f, 0.0f}));
+    rec.log("world/room2/point", rerun::Points3D({1.0f, 1.0f, 1.0f}));
 
     // ..but this one lives in a completely separate space!
-    rec.log("world/wormhole", rr::DisconnectedSpace(true));
-    rec.log("world/wormhole/point", rr::Points3D(rr::datatypes::Vec3D{2.0f, 2.0f, 2.0f}));
+    rec.log("world/wormhole", rerun::DisconnectedSpace(true));
+    rec.log("world/wormhole/point", rerun::Points3D({2.0f, 2.0f, 2.0f}));
 }

--- a/docs/code-examples/disconnected_space.cpp
+++ b/docs/code-examples/disconnected_space.cpp
@@ -7,10 +7,10 @@ int main() {
     rec.connect("127.0.0.1:9876").throw_on_failure();
 
     // These two points can be projected into the same space..
-    rec.log("world/room1/point", rerun::Points3D({0.0f, 0.0f, 0.0f}));
-    rec.log("world/room2/point", rerun::Points3D({1.0f, 1.0f, 1.0f}));
+    rec.log("world/room1/point", rerun::Points3D({{0.0f, 0.0f, 0.0f}}));
+    rec.log("world/room2/point", rerun::Points3D({{1.0f, 1.0f, 1.0f}}));
 
     // ..but this one lives in a completely separate space!
     rec.log("world/wormhole", rerun::DisconnectedSpace(true));
-    rec.log("world/wormhole/point", rerun::Points3D({2.0f, 2.0f, 2.0f}));
+    rec.log("world/wormhole/point", rerun::Points3D({{2.0f, 2.0f, 2.0f}}));
 }

--- a/docs/code-examples/line_strip2d_simple.cpp
+++ b/docs/code-examples/line_strip2d_simple.cpp
@@ -8,7 +8,7 @@ int main() {
     auto rec = rr::RecordingStream("rerun_example_line_strip2d");
     rec.connect("127.0.0.1:9876").throw_on_failure();
 
-    std::vector<rr::datatypes::Vec2D> strip = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}};
+    rr::components::LineStrip2D strip({{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}});
     rec.log("strip", rr::LineStrips2D(strip));
 
     // Log an extra rect to set the view bounds

--- a/docs/code-examples/line_strip3d_simple.cpp
+++ b/docs/code-examples/line_strip3d_simple.cpp
@@ -8,7 +8,7 @@ int main() {
     auto rec = rr::RecordingStream("rerun_example_line_strip3d");
     rec.connect("127.0.0.1:9876").throw_on_failure();
 
-    std::vector<rr::datatypes::Vec3D> points = {
+    rr::components::LineStrip3D linestrip({
         {0.f, 0.f, 0.f},
         {0.f, 0.f, 1.f},
         {1.f, 0.f, 0.f},
@@ -17,6 +17,6 @@ int main() {
         {1.f, 1.f, 1.f},
         {0.f, 1.f, 0.f},
         {0.f, 1.f, 1.f},
-    };
-    rec.log("strip", rr::LineStrips3D(points));
+    });
+    rec.log("strip", rr::LineStrips3D(linestrip));
 }

--- a/docs/code-examples/manual_indicator.cpp
+++ b/docs/code-examples/manual_indicator.cpp
@@ -22,9 +22,8 @@ int main() {
 
     // Specify both a Mesh3D and a Points3D indicator component so that the data is shown as both a
     // 3D mesh _and_ a point cloud by default.
-    rec.log_component_batches(
+    rec.log(
         "points_and_mesh",
-        3,
         rr::Points3D::IndicatorComponent(),
         rr::Mesh3D::IndicatorComponent(),
         positions,

--- a/docs/code-examples/manual_indicator.cpp
+++ b/docs/code-examples/manual_indicator.cpp
@@ -22,13 +22,14 @@ int main() {
 
     // Specify both a Mesh3D and a Points3D indicator component so that the data is shown as both a
     // 3D mesh _and_ a point cloud by default.
-    rec.log_component_batches(
-        "points_and_mesh",
-        3,
-        rr::Points3D::indicator(),
-        rr::Mesh3D::indicator(),
-        positions,
-        colors,
-        radii
-    );
+    // TODO:
+    // rec.log_component_batches(
+    //     "points_and_mesh",
+    //     3,
+    //     rr::Points3D::indicator(),
+    //     rr::Mesh3D::indicator(),
+    //     positions,
+    //     colors,
+    //     radii
+    // );
 }

--- a/docs/code-examples/manual_indicator.cpp
+++ b/docs/code-examples/manual_indicator.cpp
@@ -22,14 +22,13 @@ int main() {
 
     // Specify both a Mesh3D and a Points3D indicator component so that the data is shown as both a
     // 3D mesh _and_ a point cloud by default.
-    // TODO:
-    // rec.log_component_batches(
-    //     "points_and_mesh",
-    //     3,
-    //     rr::Points3D::indicator(),
-    //     rr::Mesh3D::indicator(),
-    //     positions,
-    //     colors,
-    //     radii
-    // );
+    rec.log_component_batches(
+        "points_and_mesh",
+        3,
+        rr::Points3D::IndicatorComponent(),
+        rr::Mesh3D::IndicatorComponent(),
+        positions,
+        colors,
+        radii
+    );
 }

--- a/docs/code-examples/mesh3d_indexed.cpp
+++ b/docs/code-examples/mesh3d_indexed.cpp
@@ -27,7 +27,7 @@ int main() {
     rec.log(
         "triangle",
         rr::Mesh3D(vertex_positions)
-            .with_vertex_normals({0.0, 0.0, 1.0})
+            .with_vertex_normals({{0.0, 0.0, 1.0}})
             .with_vertex_colors(vertex_colors)
             .with_mesh_properties(rrc::MeshProperties::from_triangle_indices(indices))
             .with_mesh_material(rrc::Material::from_albedo_factor(0xCC00CCFF))

--- a/docs/code-examples/mesh3d_simple.cpp
+++ b/docs/code-examples/mesh3d_simple.cpp
@@ -25,7 +25,7 @@ int main() {
     rec.log(
         "triangle",
         rr::Mesh3D(vertex_positions)
-            .with_vertex_normals({0.0, 0.0, 1.0})
+            .with_vertex_normals({{0.0f, 0.0f, 1.0f}})
             .with_vertex_colors(vertex_colors)
     );
 }

--- a/docs/code-examples/transform3d_simple.cpp
+++ b/docs/code-examples/transform3d_simple.cpp
@@ -13,7 +13,7 @@ int main() {
     auto rec = rr::RecordingStream("rerun_example_transform3d");
     rec.connect("127.0.0.1:9876").throw_on_failure();
 
-    auto arrow = rr::Arrows3D::from_vectors({0.0f, 1.0f, 0.0f}).with_origins({0.0f, 0.0f, 0.0f});
+    auto arrow = rr::Arrows3D::from_vectors({0.0f, 1.0f, 0.0f}).with_origins({{0.0f, 0.0f, 0.0f}});
 
     rec.log("base", arrow);
 

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -31,9 +31,8 @@ int main(int argc, char** argv) {
     // Log points with the components api - this is the advanced way of logging components in a
     // fine-grained matter. It supports passing various types of containers.
     rrc::Text c_style_array[3] = {rrc::Text("hello"), rrc::Text("friend"), rrc::Text("yo")};
-    rec.log_component_batches(
+    rec.log(
         "2d/points",
-        3,
         std::vector{
             rrc::Position2D(0.0f, 0.0f),
             rrc::Position2D(1.0f, 3.0f),

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -7,24 +7,30 @@ namespace rerun {
     namespace archetypes {
         const char AnnotationContext::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.AnnotationContextIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> AnnotationContext::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(1);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<
+        archetypes::AnnotationContext>::serialize(const archetypes::AnnotationContext& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(1);
 
-            {
-                auto result =
-                    ComponentBatch<rerun::components::AnnotationContext>(context).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result =
+                ComponentBatch<rerun::components::AnnotationContext>(archetype.context).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        {
+            auto result = ComponentBatch<AnnotationContext::IndicatorComponent>(
+                              AnnotationContext::IndicatorComponent()
+            )
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -10,22 +10,24 @@ namespace rerun {
         const char AnnotationContext::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.AnnotationContextIndicator";
 
-        AnonymousComponentBatch AnnotationContext::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<AnnotationContext::INDICATOR_COMPONENT_NAME>>(
-                nullptr,
-                1
-            );
-        }
+        Result<std::vector<SerializedComponentBatch>> AnnotationContext::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(1);
 
-        std::vector<AnonymousComponentBatch> AnnotationContext::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(1);
+            {
+                auto result = ComponentBatch(context).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                components::IndicatorComponent<AnnotationContext::INDICATOR_COMPONENT_NAME>
+                    indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            comp_batches.emplace_back(context);
-            comp_batches.emplace_back(AnnotationContext::indicator());
-
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -3,8 +3,6 @@
 
 #include "annotation_context.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char AnnotationContext::INDICATOR_COMPONENT_NAME[] =
@@ -15,14 +13,13 @@ namespace rerun {
             cells.reserve(1);
 
             {
-                auto result = ComponentBatch(context).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AnnotationContext>(context).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<AnnotationContext::INDICATOR_COMPONENT_NAME>
-                    indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -10,8 +10,7 @@ namespace rerun {
     }
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<
-        archetypes::AnnotationContext>::serialize(const archetypes::AnnotationContext& archetype
-    ) const {
+        archetypes::AnnotationContext>::serialize(const archetypes::AnnotationContext& archetype) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(1);

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -48,6 +48,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/annotation_context.hpp"
 #include "../data_cell.hpp"
@@ -47,14 +46,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::AnnotationContext> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::AnnotationContext& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -7,6 +7,7 @@
 #include "../component_batch.hpp"
 #include "../components/annotation_context.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -30,6 +31,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             AnnotationContext() = default;

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -44,9 +44,17 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::AnnotationContext> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::AnnotationContext& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -30,6 +30,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -36,7 +36,7 @@ namespace rerun {
             AnnotationContext() = default;
             AnnotationContext(AnnotationContext&& other) = default;
 
-            AnnotationContext(rerun::components::AnnotationContext _context)
+            explicit AnnotationContext(rerun::components::AnnotationContext _context)
                 : context(std::move(_context)) {}
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -33,6 +33,7 @@ namespace rerun {
 
           public:
             AnnotationContext() = default;
+            AnnotationContext(AnnotationContext&& other) = default;
 
             AnnotationContext(rerun::components::AnnotationContext _context)
                 : context(std::move(_context)) {}
@@ -42,16 +43,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -16,37 +16,37 @@ namespace rerun {
         cells.reserve(7);
 
         {
-            auto result = archetype.vectors.serialize();
+            auto result = (archetype.vectors).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.origins.has_value()) {
-            auto result = archetype.origins.value().serialize();
+            auto result = (archetype.origins.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radii.has_value()) {
-            auto result = archetype.radii.value().serialize();
+            auto result = (archetype.radii.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.colors.has_value()) {
-            auto result = archetype.colors.value().serialize();
+            auto result = (archetype.colors.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.labels.has_value()) {
-            auto result = archetype.labels.value().serialize();
+            auto result = (archetype.labels.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = archetype.class_ids.value().serialize();
+            auto result = (archetype.class_ids.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = archetype.instance_keys.value().serialize();
+            auto result = (archetype.instance_keys.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -10,7 +10,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Arrows3D>::serialize(
         const archetypes::Arrows3D& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(7);

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -3,8 +3,6 @@
 
 #include "arrows3d.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char Arrows3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Arrows3DIndicator";
@@ -49,8 +47,7 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<Arrows3D::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -6,53 +6,58 @@
 namespace rerun {
     namespace archetypes {
         const char Arrows3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Arrows3DIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> Arrows3D::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(7);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Arrows3D>::serialize(
+        const archetypes::Arrows3D& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(7);
 
-            {
-                auto result = vectors.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (origins.has_value()) {
-                auto result = origins.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (radii.has_value()) {
-                auto result = radii.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (colors.has_value()) {
-                auto result = colors.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (labels.has_value()) {
-                auto result = labels.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (class_ids.has_value()) {
-                auto result = class_ids.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (instance_keys.has_value()) {
-                auto result = instance_keys.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = archetype.vectors.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.origins.has_value()) {
+            auto result = archetype.origins.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.radii.has_value()) {
+            auto result = archetype.radii.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.colors.has_value()) {
+            auto result = archetype.colors.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.labels.has_value()) {
+            auto result = archetype.labels.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.class_ids.has_value()) {
+            auto result = archetype.class_ids.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.instance_keys.has_value()) {
+            auto result = archetype.instance_keys.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<Arrows3D::IndicatorComponent>(Arrows3D::IndicatorComponent())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -9,37 +9,53 @@ namespace rerun {
     namespace archetypes {
         const char Arrows3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Arrows3DIndicator";
 
-        AnonymousComponentBatch Arrows3D::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<Arrows3D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
+        Result<std::vector<SerializedComponentBatch>> Arrows3D::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(7);
 
-        std::vector<AnonymousComponentBatch> Arrows3D::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(7);
-
-            comp_batches.emplace_back(vectors);
+            {
+                auto result = vectors.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
             if (origins.has_value()) {
-                comp_batches.emplace_back(origins.value());
+                auto result = origins.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (radii.has_value()) {
-                comp_batches.emplace_back(radii.value());
+                auto result = radii.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (colors.has_value()) {
-                comp_batches.emplace_back(colors.value());
+                auto result = colors.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (labels.has_value()) {
-                comp_batches.emplace_back(labels.value());
+                auto result = labels.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (class_ids.has_value()) {
-                comp_batches.emplace_back(class_ids.value());
+                auto result = class_ids.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (instance_keys.has_value()) {
-                comp_batches.emplace_back(instance_keys.value());
+                auto result = instance_keys.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
-            comp_batches.emplace_back(Arrows3D::indicator());
+            {
+                components::IndicatorComponent<Arrows3D::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -13,6 +13,7 @@
 #include "../components/text.hpp"
 #include "../components/vector3d.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -94,6 +95,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             // Extensions to generated type defined in 'arrows3d_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -172,14 +171,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::Arrows3D> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::Arrows3D& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -94,6 +94,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -64,32 +64,32 @@ namespace rerun {
         /// ```
         struct Arrows3D {
             /// All the vectors for each arrow in the batch.
-            std::vector<rerun::components::Vector3D> vectors;
+            ComponentBatch<rerun::components::Vector3D> vectors;
 
             /// All the origin (base) positions for each arrow in the batch.
             ///
             /// If no origins are set, (0, 0, 0) is used as the origin for each arrow.
-            std::optional<std::vector<rerun::components::Position3D>> origins;
+            std::optional<ComponentBatch<rerun::components::Position3D>> origins;
 
             /// Optional radii for the arrows.
             ///
             /// The shaft is rendered as a line with `radius = 0.5 * radius`.
             /// The tip is rendered with `height = 2.0 * radius` and `radius = 1.0 * radius`.
-            std::optional<std::vector<rerun::components::Radius>> radii;
+            std::optional<ComponentBatch<rerun::components::Radius>> radii;
 
             /// Optional colors for the points.
-            std::optional<std::vector<rerun::components::Color>> colors;
+            std::optional<ComponentBatch<rerun::components::Color>> colors;
 
             /// Optional text labels for the arrows.
-            std::optional<std::vector<rerun::components::Text>> labels;
+            std::optional<ComponentBatch<rerun::components::Text>> labels;
 
             /// Optional class Ids for the points.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            std::optional<std::vector<rerun::components::ClassId>> class_ids;
+            std::optional<ComponentBatch<rerun::components::ClassId>> class_ids;
 
             /// Unique identifiers for each individual point in the batch.
-            std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
+            std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
@@ -116,92 +116,51 @@ namespace rerun {
 
           public:
             Arrows3D() = default;
+            Arrows3D(Arrows3D&& other) = default;
 
             /// All the origin (base) positions for each arrow in the batch.
             ///
             /// If no origins are set, (0, 0, 0) is used as the origin for each arrow.
-            Arrows3D& with_origins(std::vector<rerun::components::Position3D> _origins) {
+            Arrows3D with_origins(ComponentBatch<rerun::components::Position3D> _origins) && {
                 origins = std::move(_origins);
-                return *this;
-            }
-
-            /// All the origin (base) positions for each arrow in the batch.
-            ///
-            /// If no origins are set, (0, 0, 0) is used as the origin for each arrow.
-            Arrows3D& with_origins(rerun::components::Position3D _origins) {
-                origins = std::vector(1, std::move(_origins));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional radii for the arrows.
             ///
             /// The shaft is rendered as a line with `radius = 0.5 * radius`.
             /// The tip is rendered with `height = 2.0 * radius` and `radius = 1.0 * radius`.
-            Arrows3D& with_radii(std::vector<rerun::components::Radius> _radii) {
+            Arrows3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
                 radii = std::move(_radii);
-                return *this;
-            }
-
-            /// Optional radii for the arrows.
-            ///
-            /// The shaft is rendered as a line with `radius = 0.5 * radius`.
-            /// The tip is rendered with `height = 2.0 * radius` and `radius = 1.0 * radius`.
-            Arrows3D& with_radii(rerun::components::Radius _radii) {
-                radii = std::vector(1, std::move(_radii));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional colors for the points.
-            Arrows3D& with_colors(std::vector<rerun::components::Color> _colors) {
+            Arrows3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
                 colors = std::move(_colors);
-                return *this;
-            }
-
-            /// Optional colors for the points.
-            Arrows3D& with_colors(rerun::components::Color _colors) {
-                colors = std::vector(1, std::move(_colors));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional text labels for the arrows.
-            Arrows3D& with_labels(std::vector<rerun::components::Text> _labels) {
+            Arrows3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
                 labels = std::move(_labels);
-                return *this;
-            }
-
-            /// Optional text labels for the arrows.
-            Arrows3D& with_labels(rerun::components::Text _labels) {
-                labels = std::vector(1, std::move(_labels));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional class Ids for the points.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            Arrows3D& with_class_ids(std::vector<rerun::components::ClassId> _class_ids) {
+            Arrows3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
-                return *this;
-            }
-
-            /// Optional class Ids for the points.
-            ///
-            /// The class ID provides colors and labels if not specified explicitly.
-            Arrows3D& with_class_ids(rerun::components::ClassId _class_ids) {
-                class_ids = std::vector(1, std::move(_class_ids));
-                return *this;
+                return std::move(*this);
             }
 
             /// Unique identifiers for each individual point in the batch.
-            Arrows3D& with_instance_keys(std::vector<rerun::components::InstanceKey> _instance_keys
-            ) {
+            Arrows3D with_instance_keys(
+                ComponentBatch<rerun::components::InstanceKey> _instance_keys
+            ) && {
                 instance_keys = std::move(_instance_keys);
-                return *this;
-            }
-
-            /// Unique identifiers for each individual point in the batch.
-            Arrows3D& with_instance_keys(rerun::components::InstanceKey _instance_keys) {
-                instance_keys = std::vector(1, std::move(_instance_keys));
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -209,16 +168,8 @@ namespace rerun {
                 return vectors.size();
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -173,6 +173,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -169,9 +169,17 @@ namespace rerun {
             size_t num_instances() const {
                 return vectors.size();
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::Arrows3D> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::Arrows3D& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/asset3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.cpp
@@ -6,36 +6,40 @@
 namespace rerun {
     namespace archetypes {
         const char Asset3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Asset3DIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> Asset3D::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(3);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Asset3D>::serialize(
+        const archetypes::Asset3D& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(3);
 
-            {
-                auto result = ComponentBatch<rerun::components::Blob>(blob).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (media_type.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::MediaType>(media_type.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (transform.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::OutOfTreeTransform3D>(transform.value())
-                        .serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = ComponentBatch<rerun::components::Blob>(archetype.blob).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.media_type.has_value()) {
+            auto result = ComponentBatch<rerun::components::MediaType>(archetype.media_type.value())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.transform.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::OutOfTreeTransform3D>(archetype.transform.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = ComponentBatch<Asset3D::IndicatorComponent>(Asset3D::IndicatorComponent())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/asset3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.cpp
@@ -10,7 +10,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Asset3D>::serialize(
         const archetypes::Asset3D& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(3);

--- a/rerun_cpp/src/rerun/archetypes/asset3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.cpp
@@ -3,8 +3,6 @@
 
 #include "asset3d.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char Asset3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Asset3DIndicator";
@@ -14,23 +12,25 @@ namespace rerun {
             cells.reserve(3);
 
             {
-                auto result = ComponentBatch(blob).serialize();
+                auto result = ComponentBatch<rerun::components::Blob>(blob).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (media_type.has_value()) {
-                auto result = ComponentBatch(media_type.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::MediaType>(media_type.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (transform.has_value()) {
-                auto result = ComponentBatch(transform.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::OutOfTreeTransform3D>(transform.value())
+                        .serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<Asset3D::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/asset3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.cpp
@@ -9,25 +9,33 @@ namespace rerun {
     namespace archetypes {
         const char Asset3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Asset3DIndicator";
 
-        AnonymousComponentBatch Asset3D::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<Asset3D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
+        Result<std::vector<SerializedComponentBatch>> Asset3D::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(3);
 
-        std::vector<AnonymousComponentBatch> Asset3D::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(3);
-
-            comp_batches.emplace_back(blob);
+            {
+                auto result = ComponentBatch(blob).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
             if (media_type.has_value()) {
-                comp_batches.emplace_back(media_type.value());
+                auto result = ComponentBatch(media_type.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (transform.has_value()) {
-                comp_batches.emplace_back(transform.value());
+                auto result = ComponentBatch(transform.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
-            comp_batches.emplace_back(Asset3D::indicator());
+            {
+                components::IndicatorComponent<Asset3D::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -169,9 +169,16 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::Asset3D> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Asset3D& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -140,7 +140,7 @@ namespace rerun {
             Asset3D() = default;
             Asset3D(Asset3D&& other) = default;
 
-            Asset3D(rerun::components::Blob _blob) : blob(std::move(_blob)) {}
+            explicit Asset3D(rerun::components::Blob _blob) : blob(std::move(_blob)) {}
 
             /// The Media Type of the asset.
             ///

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/blob.hpp"
 #include "../components/media_type.hpp"
@@ -172,13 +171,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::Asset3D> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Asset3D& archetype
-        ) const;
+        static Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::Asset3D& archetype
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -9,6 +9,7 @@
 #include "../components/media_type.hpp"
 #include "../components/out_of_tree_transform3d.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -78,6 +79,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             // Extensions to generated type defined in 'asset3d_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -137,6 +137,7 @@ namespace rerun {
 
           public:
             Asset3D() = default;
+            Asset3D(Asset3D&& other) = default;
 
             Asset3D(rerun::components::Blob _blob) : blob(std::move(_blob)) {}
 
@@ -149,17 +150,17 @@ namespace rerun {
             ///
             /// If omitted, the viewer will try to guess from the data blob.
             /// If it cannot guess, it won't be able to render the asset.
-            Asset3D& with_media_type(rerun::components::MediaType _media_type) {
+            Asset3D with_media_type(rerun::components::MediaType _media_type) && {
                 media_type = std::move(_media_type);
-                return *this;
+                return std::move(*this);
             }
 
             /// An out-of-tree transform.
             ///
             /// Applies a transformation to the asset itself without impacting its children.
-            Asset3D& with_transform(rerun::components::OutOfTreeTransform3D _transform) {
+            Asset3D with_transform(rerun::components::OutOfTreeTransform3D _transform) && {
                 transform = std::move(_transform);
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -167,16 +168,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -78,6 +78,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -173,6 +173,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
@@ -10,7 +10,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::BarChart>::serialize(
         const archetypes::BarChart& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(1);

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
@@ -6,23 +6,29 @@
 namespace rerun {
     namespace archetypes {
         const char BarChart::INDICATOR_COMPONENT_NAME[] = "rerun.components.BarChartIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> BarChart::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(1);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::BarChart>::serialize(
+        const archetypes::BarChart& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(1);
 
-            {
-                auto result = ComponentBatch<rerun::components::TensorData>(values).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result =
+                ComponentBatch<rerun::components::TensorData>(archetype.values).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        {
+            auto result =
+                ComponentBatch<BarChart::IndicatorComponent>(BarChart::IndicatorComponent())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
@@ -9,19 +9,23 @@ namespace rerun {
     namespace archetypes {
         const char BarChart::INDICATOR_COMPONENT_NAME[] = "rerun.components.BarChartIndicator";
 
-        AnonymousComponentBatch BarChart::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<BarChart::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
+        Result<std::vector<SerializedComponentBatch>> BarChart::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(1);
 
-        std::vector<AnonymousComponentBatch> BarChart::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(1);
+            {
+                auto result = ComponentBatch(values).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                components::IndicatorComponent<BarChart::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            comp_batches.emplace_back(values);
-            comp_batches.emplace_back(BarChart::indicator());
-
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
@@ -3,8 +3,6 @@
 
 #include "bar_chart.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char BarChart::INDICATOR_COMPONENT_NAME[] = "rerun.components.BarChartIndicator";
@@ -14,13 +12,12 @@ namespace rerun {
             cells.reserve(1);
 
             {
-                auto result = ComponentBatch(values).serialize();
+                auto result = ComponentBatch<rerun::components::TensorData>(values).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<BarChart::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -32,7 +32,7 @@ namespace rerun {
             BarChart() = default;
             BarChart(BarChart&& other) = default;
 
-            BarChart(rerun::components::TensorData _values) : values(std::move(_values)) {}
+            explicit BarChart(rerun::components::TensorData _values) : values(std::move(_values)) {}
 
             /// Returns the number of primary instances of this archetype.
             size_t num_instances() const {

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -29,6 +29,7 @@ namespace rerun {
 
           public:
             BarChart() = default;
+            BarChart(BarChart&& other) = default;
 
             BarChart(rerun::components::TensorData _values) : values(std::move(_values)) {}
 
@@ -37,16 +38,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -26,6 +26,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -39,9 +39,17 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::BarChart> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::BarChart& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -43,6 +43,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -7,6 +7,7 @@
 #include "../component_batch.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -26,6 +27,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             BarChart() = default;

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
@@ -42,14 +41,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::BarChart> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::BarChart& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
@@ -6,59 +6,63 @@
 namespace rerun {
     namespace archetypes {
         const char Boxes2D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Boxes2DIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> Boxes2D::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(8);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Boxes2D>::serialize(
+        const archetypes::Boxes2D& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(8);
 
-            {
-                auto result = half_sizes.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (centers.has_value()) {
-                auto result = centers.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (colors.has_value()) {
-                auto result = colors.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (radii.has_value()) {
-                auto result = radii.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (labels.has_value()) {
-                auto result = labels.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (draw_order.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::DrawOrder>(draw_order.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (class_ids.has_value()) {
-                auto result = class_ids.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (instance_keys.has_value()) {
-                auto result = instance_keys.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = archetype.half_sizes.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.centers.has_value()) {
+            auto result = archetype.centers.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.colors.has_value()) {
+            auto result = archetype.colors.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.radii.has_value()) {
+            auto result = archetype.radii.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.labels.has_value()) {
+            auto result = archetype.labels.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.draw_order.has_value()) {
+            auto result = ComponentBatch<rerun::components::DrawOrder>(archetype.draw_order.value())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.class_ids.has_value()) {
+            auto result = archetype.class_ids.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.instance_keys.has_value()) {
+            auto result = archetype.instance_keys.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = ComponentBatch<Boxes2D::IndicatorComponent>(Boxes2D::IndicatorComponent())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
@@ -3,8 +3,6 @@
 
 #include "boxes2d.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char Boxes2D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Boxes2DIndicator";
@@ -39,7 +37,8 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             if (draw_order.has_value()) {
-                auto result = ComponentBatch(draw_order.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::DrawOrder>(draw_order.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
@@ -54,8 +53,7 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<Boxes2D::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
@@ -9,40 +9,58 @@ namespace rerun {
     namespace archetypes {
         const char Boxes2D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Boxes2DIndicator";
 
-        AnonymousComponentBatch Boxes2D::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<Boxes2D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
+        Result<std::vector<SerializedComponentBatch>> Boxes2D::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(8);
 
-        std::vector<AnonymousComponentBatch> Boxes2D::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(8);
-
-            comp_batches.emplace_back(half_sizes);
+            {
+                auto result = half_sizes.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
             if (centers.has_value()) {
-                comp_batches.emplace_back(centers.value());
+                auto result = centers.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (colors.has_value()) {
-                comp_batches.emplace_back(colors.value());
+                auto result = colors.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (radii.has_value()) {
-                comp_batches.emplace_back(radii.value());
+                auto result = radii.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (labels.has_value()) {
-                comp_batches.emplace_back(labels.value());
+                auto result = labels.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (draw_order.has_value()) {
-                comp_batches.emplace_back(draw_order.value());
+                auto result = ComponentBatch(draw_order.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (class_ids.has_value()) {
-                comp_batches.emplace_back(class_ids.value());
+                auto result = class_ids.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (instance_keys.has_value()) {
-                comp_batches.emplace_back(instance_keys.value());
+                auto result = instance_keys.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
-            comp_batches.emplace_back(Boxes2D::indicator());
+            {
+                components::IndicatorComponent<Boxes2D::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
@@ -16,27 +16,27 @@ namespace rerun {
         cells.reserve(8);
 
         {
-            auto result = archetype.half_sizes.serialize();
+            auto result = (archetype.half_sizes).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.centers.has_value()) {
-            auto result = archetype.centers.value().serialize();
+            auto result = (archetype.centers.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.colors.has_value()) {
-            auto result = archetype.colors.value().serialize();
+            auto result = (archetype.colors.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radii.has_value()) {
-            auto result = archetype.radii.value().serialize();
+            auto result = (archetype.radii.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.labels.has_value()) {
-            auto result = archetype.labels.value().serialize();
+            auto result = (archetype.labels.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
@@ -47,12 +47,12 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = archetype.class_ids.value().serialize();
+            auto result = (archetype.class_ids.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = archetype.instance_keys.value().serialize();
+            auto result = (archetype.instance_keys.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
@@ -10,7 +10,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Boxes2D>::serialize(
         const archetypes::Boxes2D& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(8);

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -14,6 +14,7 @@
 #include "../components/radius.hpp"
 #include "../components/text.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -80,6 +81,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             // Extensions to generated type defined in 'boxes2d_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -194,13 +193,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::Boxes2D> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Boxes2D& archetype
-        ) const;
+        static Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::Boxes2D& archetype
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -48,19 +48,19 @@ namespace rerun {
         /// ```
         struct Boxes2D {
             /// All half-extents that make up the batch of boxes.
-            std::vector<rerun::components::HalfSizes2D> half_sizes;
+            ComponentBatch<rerun::components::HalfSizes2D> half_sizes;
 
             /// Optional center positions of the boxes.
-            std::optional<std::vector<rerun::components::Position2D>> centers;
+            std::optional<ComponentBatch<rerun::components::Position2D>> centers;
 
             /// Optional colors for the boxes.
-            std::optional<std::vector<rerun::components::Color>> colors;
+            std::optional<ComponentBatch<rerun::components::Color>> colors;
 
             /// Optional radii for the lines that make up the boxes.
-            std::optional<std::vector<rerun::components::Radius>> radii;
+            std::optional<ComponentBatch<rerun::components::Radius>> radii;
 
             /// Optional text labels for the boxes.
-            std::optional<std::vector<rerun::components::Text>> labels;
+            std::optional<ComponentBatch<rerun::components::Text>> labels;
 
             /// An optional floating point value that specifies the 2D drawing order.
             ///
@@ -72,10 +72,10 @@ namespace rerun {
             /// Optional `ClassId`s for the boxes.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            std::optional<std::vector<rerun::components::ClassId>> class_ids;
+            std::optional<ComponentBatch<rerun::components::ClassId>> class_ids;
 
             /// Unique identifiers for each individual boxes in the batch.
-            std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
+            std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
@@ -85,19 +85,21 @@ namespace rerun {
             // Extensions to generated type defined in 'boxes2d_ext.cpp'
 
             /// Creates new `Boxes2D` with `half_sizes` centered around the local origin.
-            static Boxes2D from_half_sizes(std::vector<components::HalfSizes2D> _half_sizes) {
+            static Boxes2D from_half_sizes(ComponentBatch<components::HalfSizes2D> half_sizes) {
                 Boxes2D boxes;
-                boxes.half_sizes = std::move(_half_sizes);
+                boxes.half_sizes = std::move(half_sizes);
                 return boxes;
             }
 
             /// Creates new `Boxes2D` with `centers` and `half_sizes`.
             static Boxes2D from_centers_and_half_sizes(
-                std::vector<components::Position2D> _centers,
-                std::vector<components::HalfSizes2D> _half_sizes
+                ComponentBatch<components::Position2D> centers,
+                ComponentBatch<components::HalfSizes2D> half_sizes
             ) {
-                return Boxes2D::from_half_sizes(std::move(_half_sizes))
-                    .with_centers(std::move(_centers));
+                Boxes2D boxes;
+                boxes.half_sizes = std::move(half_sizes);
+                boxes.centers = std::move(centers);
+                return boxes;
             }
 
             /// Creates new `Boxes2D` with `half_sizes` created from (full) sizes.
@@ -112,10 +114,12 @@ namespace rerun {
             /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and
             /// half-sizes from the input data.
             static Boxes2D from_centers_and_sizes(
-                std::vector<components::Position2D> centers,
+                ComponentBatch<components::Position2D> centers,
                 const std::vector<datatypes::Vec2D>& sizes
             ) {
-                return from_sizes(sizes).with_centers(std::move(centers));
+                Boxes2D boxes = from_sizes(std::move(sizes));
+                boxes.centers = std::move(centers);
+                return boxes;
             }
 
             /// Creates new `Boxes2D` with `half_sizes` and `centers` created from minimums and
@@ -130,53 +134,30 @@ namespace rerun {
 
           public:
             Boxes2D() = default;
+            Boxes2D(Boxes2D&& other) = default;
 
             /// Optional center positions of the boxes.
-            Boxes2D& with_centers(std::vector<rerun::components::Position2D> _centers) {
+            Boxes2D with_centers(ComponentBatch<rerun::components::Position2D> _centers) && {
                 centers = std::move(_centers);
-                return *this;
-            }
-
-            /// Optional center positions of the boxes.
-            Boxes2D& with_centers(rerun::components::Position2D _centers) {
-                centers = std::vector(1, std::move(_centers));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional colors for the boxes.
-            Boxes2D& with_colors(std::vector<rerun::components::Color> _colors) {
+            Boxes2D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
                 colors = std::move(_colors);
-                return *this;
-            }
-
-            /// Optional colors for the boxes.
-            Boxes2D& with_colors(rerun::components::Color _colors) {
-                colors = std::vector(1, std::move(_colors));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional radii for the lines that make up the boxes.
-            Boxes2D& with_radii(std::vector<rerun::components::Radius> _radii) {
+            Boxes2D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
                 radii = std::move(_radii);
-                return *this;
-            }
-
-            /// Optional radii for the lines that make up the boxes.
-            Boxes2D& with_radii(rerun::components::Radius _radii) {
-                radii = std::vector(1, std::move(_radii));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional text labels for the boxes.
-            Boxes2D& with_labels(std::vector<rerun::components::Text> _labels) {
+            Boxes2D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
                 labels = std::move(_labels);
-                return *this;
-            }
-
-            /// Optional text labels for the boxes.
-            Boxes2D& with_labels(rerun::components::Text _labels) {
-                labels = std::vector(1, std::move(_labels));
-                return *this;
+                return std::move(*this);
             }
 
             /// An optional floating point value that specifies the 2D drawing order.
@@ -184,38 +165,24 @@ namespace rerun {
             /// Objects with higher values are drawn on top of those with lower values.
             ///
             /// The default for 2D boxes is 10.0.
-            Boxes2D& with_draw_order(rerun::components::DrawOrder _draw_order) {
+            Boxes2D with_draw_order(rerun::components::DrawOrder _draw_order) && {
                 draw_order = std::move(_draw_order);
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional `ClassId`s for the boxes.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            Boxes2D& with_class_ids(std::vector<rerun::components::ClassId> _class_ids) {
+            Boxes2D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
-                return *this;
-            }
-
-            /// Optional `ClassId`s for the boxes.
-            ///
-            /// The class ID provides colors and labels if not specified explicitly.
-            Boxes2D& with_class_ids(rerun::components::ClassId _class_ids) {
-                class_ids = std::vector(1, std::move(_class_ids));
-                return *this;
+                return std::move(*this);
             }
 
             /// Unique identifiers for each individual boxes in the batch.
-            Boxes2D& with_instance_keys(std::vector<rerun::components::InstanceKey> _instance_keys
-            ) {
+            Boxes2D with_instance_keys(ComponentBatch<rerun::components::InstanceKey> _instance_keys
+            ) && {
                 instance_keys = std::move(_instance_keys);
-                return *this;
-            }
-
-            /// Unique identifiers for each individual boxes in the batch.
-            Boxes2D& with_instance_keys(rerun::components::InstanceKey _instance_keys) {
-                instance_keys = std::vector(1, std::move(_instance_keys));
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -223,16 +190,8 @@ namespace rerun {
                 return half_sizes.size();
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -195,6 +195,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -191,9 +191,16 @@ namespace rerun {
             size_t num_instances() const {
                 return half_sizes.size();
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::Boxes2D> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Boxes2D& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -80,6 +80,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/boxes2d_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d_ext.cpp
@@ -9,19 +9,21 @@ namespace rerun {
         // [CODEGEN COPY TO HEADER START]
 
         /// Creates new `Boxes2D` with `half_sizes` centered around the local origin.
-        static Boxes2D from_half_sizes(std::vector<components::HalfSizes2D> _half_sizes) {
+        static Boxes2D from_half_sizes(ComponentBatch<components::HalfSizes2D> half_sizes) {
             Boxes2D boxes;
-            boxes.half_sizes = std::move(_half_sizes);
+            boxes.half_sizes = std::move(half_sizes);
             return boxes;
         }
 
         /// Creates new `Boxes2D` with `centers` and `half_sizes`.
         static Boxes2D from_centers_and_half_sizes(
-            std::vector<components::Position2D> _centers,
-            std::vector<components::HalfSizes2D> _half_sizes
+            ComponentBatch<components::Position2D> centers,
+            ComponentBatch<components::HalfSizes2D> half_sizes
         ) {
-            return Boxes2D::from_half_sizes(std::move(_half_sizes))
-                .with_centers(std::move(_centers));
+            Boxes2D boxes;
+            boxes.half_sizes = std::move(half_sizes);
+            boxes.centers = std::move(centers);
+            return boxes;
         }
 
         /// Creates new `Boxes2D` with `half_sizes` created from (full) sizes.
@@ -36,9 +38,12 @@ namespace rerun {
         /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and half-sizes
         /// from the input data.
         static Boxes2D from_centers_and_sizes(
-            std::vector<components::Position2D> centers, const std::vector<datatypes::Vec2D>& sizes
+            ComponentBatch<components::Position2D> centers,
+            const std::vector<datatypes::Vec2D>& sizes
         ) {
-            return from_sizes(sizes).with_centers(std::move(centers));
+            Boxes2D boxes = from_sizes(std::move(sizes));
+            boxes.centers = std::move(centers);
+            return boxes;
         }
 
         /// Creates new `Boxes2D` with `half_sizes` and `centers` created from minimums and (full)
@@ -55,29 +60,36 @@ namespace rerun {
         Boxes2D Boxes2D::from_sizes(const std::vector<datatypes::Vec2D>& sizes) {
             std::vector<components::HalfSizes2D> half_sizes;
             half_sizes.reserve(sizes.size());
-            for (const auto& wh : sizes) {
-                half_sizes.emplace_back(wh.x() / 2.0, wh.y() / 2.0);
+            for (const auto& size : sizes) {
+                half_sizes.emplace_back(size.x() / 2.0, size.y() / 2.0);
             }
 
-            return Boxes2D::from_half_sizes(std::move(half_sizes));
+            // Move the vector into a component batch.
+            return Boxes2D::from_half_sizes(ComponentBatch(std::move(half_sizes)));
         }
 
         Boxes2D Boxes2D::from_mins_and_sizes(
             const std::vector<datatypes::Vec2D>& mins, const std::vector<datatypes::Vec2D>& sizes
         ) {
-            auto boxes = from_sizes(sizes);
+            auto num_components = std::min(mins.size(), sizes.size());
 
-            auto num_centers = std::min(mins.size(), sizes.size());
+            std::vector<components::HalfSizes2D> half_sizes;
             std::vector<components::Position2D> centers;
-            centers.reserve(num_centers);
-            for (size_t i = 0; i < num_centers; ++i) {
-                centers.emplace_back(
-                    mins[i].x() + boxes.half_sizes[i].x(),
-                    mins[i].y() + boxes.half_sizes[i].y()
-                );
+            half_sizes.reserve(num_components);
+            centers.reserve(num_components);
+
+            for (size_t i = 0; i < num_components; ++i) {
+                float half_size_x = sizes[i].x() * 0.5f;
+                float half_size_y = sizes[i].y() * 0.5f;
+
+                half_sizes.emplace_back(half_size_x, half_size_y);
+                centers.emplace_back(mins[i].x() + half_size_x, mins[i].y() + half_size_y);
             }
 
-            return boxes.with_centers(centers);
+            Boxes2D boxes;
+            boxes.half_sizes = std::move(half_sizes);
+            boxes.centers = std::move(centers);
+            return boxes;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes2d_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d_ext.cpp
@@ -65,7 +65,7 @@ namespace rerun {
             }
 
             // Move the vector into a component batch.
-            return Boxes2D::from_half_sizes(ComponentBatch(std::move(half_sizes)));
+            return Boxes2D::from_half_sizes(std::move(half_sizes));
         }
 
         Boxes2D Boxes2D::from_mins_and_sizes(

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
@@ -10,7 +10,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Boxes3D>::serialize(
         const archetypes::Boxes3D& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(8);

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
@@ -6,58 +6,62 @@
 namespace rerun {
     namespace archetypes {
         const char Boxes3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Boxes3DIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> Boxes3D::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(8);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Boxes3D>::serialize(
+        const archetypes::Boxes3D& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(8);
 
-            {
-                auto result = half_sizes.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (centers.has_value()) {
-                auto result = centers.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (rotations.has_value()) {
-                auto result = rotations.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (colors.has_value()) {
-                auto result = colors.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (radii.has_value()) {
-                auto result = radii.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (labels.has_value()) {
-                auto result = labels.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (class_ids.has_value()) {
-                auto result = class_ids.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (instance_keys.has_value()) {
-                auto result = instance_keys.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = archetype.half_sizes.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.centers.has_value()) {
+            auto result = archetype.centers.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.rotations.has_value()) {
+            auto result = archetype.rotations.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.colors.has_value()) {
+            auto result = archetype.colors.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.radii.has_value()) {
+            auto result = archetype.radii.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.labels.has_value()) {
+            auto result = archetype.labels.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.class_ids.has_value()) {
+            auto result = archetype.class_ids.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.instance_keys.has_value()) {
+            auto result = archetype.instance_keys.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = ComponentBatch<Boxes3D::IndicatorComponent>(Boxes3D::IndicatorComponent())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
@@ -3,8 +3,6 @@
 
 #include "boxes3d.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char Boxes3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Boxes3DIndicator";
@@ -54,8 +52,7 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<Boxes3D::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
@@ -16,42 +16,42 @@ namespace rerun {
         cells.reserve(8);
 
         {
-            auto result = archetype.half_sizes.serialize();
+            auto result = (archetype.half_sizes).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.centers.has_value()) {
-            auto result = archetype.centers.value().serialize();
+            auto result = (archetype.centers.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.rotations.has_value()) {
-            auto result = archetype.rotations.value().serialize();
+            auto result = (archetype.rotations.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.colors.has_value()) {
-            auto result = archetype.colors.value().serialize();
+            auto result = (archetype.colors.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radii.has_value()) {
-            auto result = archetype.radii.value().serialize();
+            auto result = (archetype.radii.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.labels.has_value()) {
-            auto result = archetype.labels.value().serialize();
+            auto result = (archetype.labels.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = archetype.class_ids.value().serialize();
+            auto result = (archetype.class_ids.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = archetype.instance_keys.value().serialize();
+            auto result = (archetype.instance_keys.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
@@ -9,40 +9,58 @@ namespace rerun {
     namespace archetypes {
         const char Boxes3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Boxes3DIndicator";
 
-        AnonymousComponentBatch Boxes3D::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<Boxes3D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
+        Result<std::vector<SerializedComponentBatch>> Boxes3D::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(8);
 
-        std::vector<AnonymousComponentBatch> Boxes3D::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(8);
-
-            comp_batches.emplace_back(half_sizes);
+            {
+                auto result = half_sizes.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
             if (centers.has_value()) {
-                comp_batches.emplace_back(centers.value());
+                auto result = centers.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (rotations.has_value()) {
-                comp_batches.emplace_back(rotations.value());
+                auto result = rotations.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (colors.has_value()) {
-                comp_batches.emplace_back(colors.value());
+                auto result = colors.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (radii.has_value()) {
-                comp_batches.emplace_back(radii.value());
+                auto result = radii.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (labels.has_value()) {
-                comp_batches.emplace_back(labels.value());
+                auto result = labels.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (class_ids.has_value()) {
-                comp_batches.emplace_back(class_ids.value());
+                auto result = class_ids.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (instance_keys.has_value()) {
-                comp_batches.emplace_back(instance_keys.value());
+                auto result = instance_keys.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
-            comp_batches.emplace_back(Boxes3D::indicator());
+            {
+                components::IndicatorComponent<Boxes3D::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -93,6 +93,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -206,6 +206,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -55,7 +55,7 @@ namespace rerun {
         ///                     rr::datatypes::Angle::degrees(30.0f)
         ///                 ),
         ///             })
-        ///             .with_radii(0.025f)
+        ///             .with_radii({0.025f})
         ///             .with_colors({
         ///                 rr::datatypes::Rgba32(255, 0, 0),
         ///                 rr::datatypes::Rgba32(0, 255, 0),

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -122,6 +122,7 @@ namespace rerun {
             ///
             /// TODO(#3285): Does *not* preserve data as-is and instead creates half-sizes from the
             /// input data.
+            /// TODO(#3794): This should not take an std::vector.
             static Boxes3D from_sizes(const std::vector<datatypes::Vec3D>& sizes);
 
             /// Creates new `Boxes3D` with `centers` and `half_sizes` created from centers and
@@ -129,6 +130,7 @@ namespace rerun {
             ///
             /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and
             /// half-sizes from the input data.
+            /// TODO(#3794): This should not take an std::vector.
             static Boxes3D from_centers_and_sizes(
                 ComponentBatch<components::Position3D> centers,
                 const std::vector<datatypes::Vec3D>& sizes
@@ -143,6 +145,7 @@ namespace rerun {
             ///
             /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and
             /// half-sizes from the input data.
+            /// TODO(#3794): This should not take an std::vector.
             static Boxes3D from_mins_and_sizes(
                 const std::vector<datatypes::Vec3D>& mins,
                 const std::vector<datatypes::Vec3D>& sizes

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -66,29 +66,29 @@ namespace rerun {
         /// ```
         struct Boxes3D {
             /// All half-extents that make up the batch of boxes.
-            std::vector<rerun::components::HalfSizes3D> half_sizes;
+            ComponentBatch<rerun::components::HalfSizes3D> half_sizes;
 
             /// Optional center positions of the boxes.
-            std::optional<std::vector<rerun::components::Position3D>> centers;
+            std::optional<ComponentBatch<rerun::components::Position3D>> centers;
 
-            std::optional<std::vector<rerun::components::Rotation3D>> rotations;
+            std::optional<ComponentBatch<rerun::components::Rotation3D>> rotations;
 
             /// Optional colors for the boxes.
-            std::optional<std::vector<rerun::components::Color>> colors;
+            std::optional<ComponentBatch<rerun::components::Color>> colors;
 
             /// Optional radii for the lines that make up the boxes.
-            std::optional<std::vector<rerun::components::Radius>> radii;
+            std::optional<ComponentBatch<rerun::components::Radius>> radii;
 
             /// Optional text labels for the boxes.
-            std::optional<std::vector<rerun::components::Text>> labels;
+            std::optional<ComponentBatch<rerun::components::Text>> labels;
 
             /// Optional `ClassId`s for the boxes.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            std::optional<std::vector<rerun::components::ClassId>> class_ids;
+            std::optional<ComponentBatch<rerun::components::ClassId>> class_ids;
 
             /// Unique identifiers for each individual boxes in the batch.
-            std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
+            std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
@@ -98,19 +98,21 @@ namespace rerun {
             // Extensions to generated type defined in 'boxes3d_ext.cpp'
 
             /// Creates new `Boxes3D` with `half_sizes` centered around the local origin.
-            static Boxes3D from_half_sizes(std::vector<components::HalfSizes3D> _half_sizes) {
+            static Boxes3D from_half_sizes(ComponentBatch<components::HalfSizes3D> half_sizes) {
                 Boxes3D boxes;
-                boxes.half_sizes = std::move(_half_sizes);
+                boxes.half_sizes = std::move(half_sizes);
                 return boxes;
             }
 
             /// Creates new `Boxes3D` with `centers` and `half_sizes`.
             static Boxes3D from_centers_and_half_sizes(
-                std::vector<components::Position3D> _centers,
-                std::vector<components::HalfSizes3D> _half_sizes
+                ComponentBatch<components::Position3D> centers,
+                ComponentBatch<components::HalfSizes3D> half_sizes
             ) {
-                return Boxes3D::from_half_sizes(std::move(_half_sizes))
-                    .with_centers(std::move(_centers));
+                Boxes3D boxes;
+                boxes.half_sizes = std::move(half_sizes);
+                boxes.centers = std::move(centers);
+                return boxes;
             }
 
             /// Creates new `Boxes3D` with `half_sizes` created from (full) sizes.
@@ -125,10 +127,12 @@ namespace rerun {
             /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and
             /// half-sizes from the input data.
             static Boxes3D from_centers_and_sizes(
-                std::vector<components::Position3D> centers,
+                ComponentBatch<components::Position3D> centers,
                 const std::vector<datatypes::Vec3D>& sizes
             ) {
-                return from_sizes(sizes).with_centers(std::move(centers));
+                Boxes3D boxes = from_sizes(std::move(sizes));
+                boxes.centers = std::move(centers);
+                return boxes;
             }
 
             /// Creates new `Boxes3D` with `half_sizes` and `centers` created from minimums and
@@ -143,92 +147,50 @@ namespace rerun {
 
           public:
             Boxes3D() = default;
+            Boxes3D(Boxes3D&& other) = default;
 
             /// Optional center positions of the boxes.
-            Boxes3D& with_centers(std::vector<rerun::components::Position3D> _centers) {
+            Boxes3D with_centers(ComponentBatch<rerun::components::Position3D> _centers) && {
                 centers = std::move(_centers);
-                return *this;
+                return std::move(*this);
             }
 
-            /// Optional center positions of the boxes.
-            Boxes3D& with_centers(rerun::components::Position3D _centers) {
-                centers = std::vector(1, std::move(_centers));
-                return *this;
-            }
-
-            Boxes3D& with_rotations(std::vector<rerun::components::Rotation3D> _rotations) {
+            Boxes3D with_rotations(ComponentBatch<rerun::components::Rotation3D> _rotations) && {
                 rotations = std::move(_rotations);
-                return *this;
-            }
-
-            Boxes3D& with_rotations(rerun::components::Rotation3D _rotations) {
-                rotations = std::vector(1, std::move(_rotations));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional colors for the boxes.
-            Boxes3D& with_colors(std::vector<rerun::components::Color> _colors) {
+            Boxes3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
                 colors = std::move(_colors);
-                return *this;
-            }
-
-            /// Optional colors for the boxes.
-            Boxes3D& with_colors(rerun::components::Color _colors) {
-                colors = std::vector(1, std::move(_colors));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional radii for the lines that make up the boxes.
-            Boxes3D& with_radii(std::vector<rerun::components::Radius> _radii) {
+            Boxes3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
                 radii = std::move(_radii);
-                return *this;
-            }
-
-            /// Optional radii for the lines that make up the boxes.
-            Boxes3D& with_radii(rerun::components::Radius _radii) {
-                radii = std::vector(1, std::move(_radii));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional text labels for the boxes.
-            Boxes3D& with_labels(std::vector<rerun::components::Text> _labels) {
+            Boxes3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
                 labels = std::move(_labels);
-                return *this;
-            }
-
-            /// Optional text labels for the boxes.
-            Boxes3D& with_labels(rerun::components::Text _labels) {
-                labels = std::vector(1, std::move(_labels));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional `ClassId`s for the boxes.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            Boxes3D& with_class_ids(std::vector<rerun::components::ClassId> _class_ids) {
+            Boxes3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
-                return *this;
-            }
-
-            /// Optional `ClassId`s for the boxes.
-            ///
-            /// The class ID provides colors and labels if not specified explicitly.
-            Boxes3D& with_class_ids(rerun::components::ClassId _class_ids) {
-                class_ids = std::vector(1, std::move(_class_ids));
-                return *this;
+                return std::move(*this);
             }
 
             /// Unique identifiers for each individual boxes in the batch.
-            Boxes3D& with_instance_keys(std::vector<rerun::components::InstanceKey> _instance_keys
-            ) {
+            Boxes3D with_instance_keys(ComponentBatch<rerun::components::InstanceKey> _instance_keys
+            ) && {
                 instance_keys = std::move(_instance_keys);
-                return *this;
-            }
-
-            /// Unique identifiers for each individual boxes in the batch.
-            Boxes3D& with_instance_keys(rerun::components::InstanceKey _instance_keys) {
-                instance_keys = std::vector(1, std::move(_instance_keys));
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -236,16 +198,8 @@ namespace rerun {
                 return half_sizes.size();
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -14,6 +14,7 @@
 #include "../components/rotation3d.hpp"
 #include "../components/text.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -93,6 +94,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             // Extensions to generated type defined in 'boxes3d_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -202,13 +201,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::Boxes3D> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Boxes3D& archetype
-        ) const;
+        static Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::Boxes3D& archetype
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -199,9 +199,16 @@ namespace rerun {
             size_t num_instances() const {
                 return half_sizes.size();
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::Boxes3D> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Boxes3D& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes3d_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d_ext.cpp
@@ -65,7 +65,7 @@ namespace rerun {
             }
 
             // Move the vector into a component batch.
-            return Boxes3D::from_half_sizes(ComponentBatch(std::move(half_sizes)));
+            return Boxes3D::from_half_sizes(std::move(half_sizes));
         }
 
         Boxes3D Boxes3D::from_mins_and_sizes(

--- a/rerun_cpp/src/rerun/archetypes/boxes3d_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d_ext.cpp
@@ -30,6 +30,7 @@ namespace rerun {
         ///
         /// TODO(#3285): Does *not* preserve data as-is and instead creates half-sizes from the
         /// input data.
+        /// TODO(#3794): This should not take an std::vector.
         static Boxes3D from_sizes(const std::vector<datatypes::Vec3D>& sizes);
 
         /// Creates new `Boxes3D` with `centers` and `half_sizes` created from centers and (full)
@@ -37,6 +38,7 @@ namespace rerun {
         ///
         /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and half-sizes
         /// from the input data.
+        /// TODO(#3794): This should not take an std::vector.
         static Boxes3D from_centers_and_sizes(
             ComponentBatch<components::Position3D> centers,
             const std::vector<datatypes::Vec3D>& sizes
@@ -51,6 +53,7 @@ namespace rerun {
         ///
         /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and half-sizes
         /// from the input data.
+        /// TODO(#3794): This should not take an std::vector.
         static Boxes3D from_mins_and_sizes(
             const std::vector<datatypes::Vec3D>& mins, const std::vector<datatypes::Vec3D>& sizes
         );

--- a/rerun_cpp/src/rerun/archetypes/boxes3d_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d_ext.cpp
@@ -9,19 +9,21 @@ namespace rerun {
         // [CODEGEN COPY TO HEADER START]
 
         /// Creates new `Boxes3D` with `half_sizes` centered around the local origin.
-        static Boxes3D from_half_sizes(std::vector<components::HalfSizes3D> _half_sizes) {
+        static Boxes3D from_half_sizes(ComponentBatch<components::HalfSizes3D> half_sizes) {
             Boxes3D boxes;
-            boxes.half_sizes = std::move(_half_sizes);
+            boxes.half_sizes = std::move(half_sizes);
             return boxes;
         }
 
         /// Creates new `Boxes3D` with `centers` and `half_sizes`.
         static Boxes3D from_centers_and_half_sizes(
-            std::vector<components::Position3D> _centers,
-            std::vector<components::HalfSizes3D> _half_sizes
+            ComponentBatch<components::Position3D> centers,
+            ComponentBatch<components::HalfSizes3D> half_sizes
         ) {
-            return Boxes3D::from_half_sizes(std::move(_half_sizes))
-                .with_centers(std::move(_centers));
+            Boxes3D boxes;
+            boxes.half_sizes = std::move(half_sizes);
+            boxes.centers = std::move(centers);
+            return boxes;
         }
 
         /// Creates new `Boxes3D` with `half_sizes` created from (full) sizes.
@@ -36,9 +38,12 @@ namespace rerun {
         /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and half-sizes
         /// from the input data.
         static Boxes3D from_centers_and_sizes(
-            std::vector<components::Position3D> centers, const std::vector<datatypes::Vec3D>& sizes
+            ComponentBatch<components::Position3D> centers,
+            const std::vector<datatypes::Vec3D>& sizes
         ) {
-            return from_sizes(sizes).with_centers(std::move(centers));
+            Boxes3D boxes = from_sizes(std::move(sizes));
+            boxes.centers = std::move(centers);
+            return boxes;
         }
 
         /// Creates new `Boxes3D` with `half_sizes` and `centers` created from minimums and (full)
@@ -59,26 +64,37 @@ namespace rerun {
                 half_sizes.emplace_back(size.x() / 2.0, size.y() / 2.0, size.z() / 2.0);
             }
 
-            return Boxes3D::from_half_sizes(std::move(half_sizes));
+            // Move the vector into a component batch.
+            return Boxes3D::from_half_sizes(ComponentBatch(std::move(half_sizes)));
         }
 
         Boxes3D Boxes3D::from_mins_and_sizes(
             const std::vector<datatypes::Vec3D>& mins, const std::vector<datatypes::Vec3D>& sizes
         ) {
-            auto boxes = from_sizes(sizes);
+            auto num_components = std::min(mins.size(), sizes.size());
 
-            auto num_centers = std::min(mins.size(), sizes.size());
+            std::vector<components::HalfSizes3D> half_sizes;
             std::vector<components::Position3D> centers;
-            centers.reserve(num_centers);
-            for (size_t i = 0; i < num_centers; ++i) {
+            half_sizes.reserve(num_components);
+            centers.reserve(num_components);
+
+            for (size_t i = 0; i < num_components; ++i) {
+                float half_size_x = sizes[i].x() * 0.5f;
+                float half_size_y = sizes[i].y() * 0.5f;
+                float half_size_z = sizes[i].z() * 0.5f;
+
+                half_sizes.emplace_back(half_size_x, half_size_y, half_size_z);
                 centers.emplace_back(
-                    mins[i].x() + boxes.half_sizes[i].x(),
-                    mins[i].y() + boxes.half_sizes[i].y(),
-                    mins[i].z() + boxes.half_sizes[i].z()
+                    mins[i].x() + half_size_x,
+                    mins[i].y() + half_size_y,
+                    mins[i].z() + half_size_z
                 );
             }
 
-            return boxes.with_centers(centers);
+            Boxes3D boxes;
+            boxes.half_sizes = std::move(half_sizes);
+            boxes.centers = std::move(centers);
+            return boxes;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/clear.cpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.cpp
@@ -3,8 +3,6 @@
 
 #include "clear.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char Clear::INDICATOR_COMPONENT_NAME[] = "rerun.components.ClearIndicator";
@@ -14,13 +12,13 @@ namespace rerun {
             cells.reserve(1);
 
             {
-                auto result = ComponentBatch(is_recursive).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::ClearIsRecursive>(is_recursive).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<Clear::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/clear.cpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.cpp
@@ -9,21 +9,23 @@ namespace rerun {
     namespace archetypes {
         const char Clear::INDICATOR_COMPONENT_NAME[] = "rerun.components.ClearIndicator";
 
-        AnonymousComponentBatch Clear::indicator() {
-            return ComponentBatch<components::IndicatorComponent<Clear::INDICATOR_COMPONENT_NAME>>(
-                nullptr,
-                1
-            );
-        }
+        Result<std::vector<SerializedComponentBatch>> Clear::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(1);
 
-        std::vector<AnonymousComponentBatch> Clear::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(1);
+            {
+                auto result = ComponentBatch(is_recursive).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                components::IndicatorComponent<Clear::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            comp_batches.emplace_back(is_recursive);
-            comp_batches.emplace_back(Clear::indicator());
-
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/clear.cpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.cpp
@@ -10,7 +10,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Clear>::serialize(
         const archetypes::Clear& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(1);

--- a/rerun_cpp/src/rerun/archetypes/clear.cpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.cpp
@@ -6,24 +6,29 @@
 namespace rerun {
     namespace archetypes {
         const char Clear::INDICATOR_COMPONENT_NAME[] = "rerun.components.ClearIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> Clear::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(1);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Clear>::serialize(
+        const archetypes::Clear& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(1);
 
-            {
-                auto result =
-                    ComponentBatch<rerun::components::ClearIsRecursive>(is_recursive).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result =
+                ComponentBatch<rerun::components::ClearIsRecursive>(archetype.is_recursive)
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        {
+            auto result =
+                ComponentBatch<Clear::IndicatorComponent>(Clear::IndicatorComponent()).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -7,6 +7,7 @@
 #include "../component_batch.hpp"
 #include "../components/clear_is_recursive.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -74,6 +75,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             // Extensions to generated type defined in 'clear_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -74,6 +74,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/clear_is_recursive.hpp"
 #include "../data_cell.hpp"
@@ -101,13 +100,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::Clear> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Clear& archetype
-        ) const;
+        static Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::Clear& archetype
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -98,9 +98,16 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::Clear> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Clear& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -87,6 +87,7 @@ namespace rerun {
 
           public:
             Clear() = default;
+            Clear(Clear&& other) = default;
 
             Clear(rerun::components::ClearIsRecursive _is_recursive)
                 : is_recursive(std::move(_is_recursive)) {}
@@ -96,16 +97,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -90,7 +90,7 @@ namespace rerun {
             Clear() = default;
             Clear(Clear&& other) = default;
 
-            Clear(rerun::components::ClearIsRecursive _is_recursive)
+            explicit Clear(rerun::components::ClearIsRecursive _is_recursive)
                 : is_recursive(std::move(_is_recursive)) {}
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -102,6 +102,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/depth_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.cpp
@@ -6,35 +6,40 @@
 namespace rerun {
     namespace archetypes {
         const char DepthImage::INDICATOR_COMPONENT_NAME[] = "rerun.components.DepthImageIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> DepthImage::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(3);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::DepthImage>::serialize(
+        const archetypes::DepthImage& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(3);
 
-            {
-                auto result = ComponentBatch<rerun::components::TensorData>(data).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (meter.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::DepthMeter>(meter.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (draw_order.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::DrawOrder>(draw_order.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = ComponentBatch<rerun::components::TensorData>(archetype.data).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.meter.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::DepthMeter>(archetype.meter.value()).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.draw_order.has_value()) {
+            auto result = ComponentBatch<rerun::components::DrawOrder>(archetype.draw_order.value())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<DepthImage::IndicatorComponent>(DepthImage::IndicatorComponent())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/depth_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.cpp
@@ -9,25 +9,33 @@ namespace rerun {
     namespace archetypes {
         const char DepthImage::INDICATOR_COMPONENT_NAME[] = "rerun.components.DepthImageIndicator";
 
-        AnonymousComponentBatch DepthImage::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<DepthImage::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
+        Result<std::vector<SerializedComponentBatch>> DepthImage::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(3);
 
-        std::vector<AnonymousComponentBatch> DepthImage::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(3);
-
-            comp_batches.emplace_back(data);
+            {
+                auto result = ComponentBatch(data).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
             if (meter.has_value()) {
-                comp_batches.emplace_back(meter.value());
+                auto result = ComponentBatch(meter.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (draw_order.has_value()) {
-                comp_batches.emplace_back(draw_order.value());
+                auto result = ComponentBatch(draw_order.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
-            comp_batches.emplace_back(DepthImage::indicator());
+            {
+                components::IndicatorComponent<DepthImage::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/depth_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.cpp
@@ -10,7 +10,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::DepthImage>::serialize(
         const archetypes::DepthImage& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(3);

--- a/rerun_cpp/src/rerun/archetypes/depth_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.cpp
@@ -3,8 +3,6 @@
 
 #include "depth_image.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char DepthImage::INDICATOR_COMPONENT_NAME[] = "rerun.components.DepthImageIndicator";
@@ -14,23 +12,24 @@ namespace rerun {
             cells.reserve(3);
 
             {
-                auto result = ComponentBatch(data).serialize();
+                auto result = ComponentBatch<rerun::components::TensorData>(data).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (meter.has_value()) {
-                auto result = ComponentBatch(meter.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::DepthMeter>(meter.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (draw_order.has_value()) {
-                auto result = ComponentBatch(draw_order.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::DrawOrder>(draw_order.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<DepthImage::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -41,6 +41,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/depth_meter.hpp"
 #include "../components/draw_order.hpp"
@@ -75,14 +74,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::DepthImage> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::DepthImage& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -44,6 +44,7 @@ namespace rerun {
 
           public:
             DepthImage() = default;
+            DepthImage(DepthImage&& other) = default;
 
             DepthImage(rerun::components::TensorData _data) : data(std::move(_data)) {}
 
@@ -52,17 +53,17 @@ namespace rerun {
             ///
             /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter
             /// precision and a range of up to ~65 meters (2^16 / 1000).
-            DepthImage& with_meter(rerun::components::DepthMeter _meter) {
+            DepthImage with_meter(rerun::components::DepthMeter _meter) && {
                 meter = std::move(_meter);
-                return *this;
+                return std::move(*this);
             }
 
             /// An optional floating point value that specifies the 2D drawing order.
             ///
             /// Objects with higher values are drawn on top of those with lower values.
-            DepthImage& with_draw_order(rerun::components::DrawOrder _draw_order) {
+            DepthImage with_draw_order(rerun::components::DrawOrder _draw_order) && {
                 draw_order = std::move(_draw_order);
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -70,16 +71,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -47,7 +47,7 @@ namespace rerun {
             DepthImage() = default;
             DepthImage(DepthImage&& other) = default;
 
-            DepthImage(rerun::components::TensorData _data) : data(std::move(_data)) {}
+            explicit DepthImage(rerun::components::TensorData _data) : data(std::move(_data)) {}
 
             /// An optional floating point value that specifies how long a meter is in the native
             /// depth units.

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -72,9 +72,17 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::DepthImage> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::DepthImage& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -76,6 +76,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -9,6 +9,7 @@
 #include "../components/draw_order.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -41,6 +42,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             DepthImage() = default;

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
@@ -3,8 +3,6 @@
 
 #include "disconnected_space.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char DisconnectedSpace::INDICATOR_COMPONENT_NAME[] =
@@ -15,14 +13,14 @@ namespace rerun {
             cells.reserve(1);
 
             {
-                auto result = ComponentBatch(disconnected_space).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::DisconnectedSpace>(disconnected_space)
+                        .serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<DisconnectedSpace::INDICATOR_COMPONENT_NAME>
-                    indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
@@ -10,22 +10,24 @@ namespace rerun {
         const char DisconnectedSpace::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.DisconnectedSpaceIndicator";
 
-        AnonymousComponentBatch DisconnectedSpace::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<DisconnectedSpace::INDICATOR_COMPONENT_NAME>>(
-                nullptr,
-                1
-            );
-        }
+        Result<std::vector<SerializedComponentBatch>> DisconnectedSpace::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(1);
 
-        std::vector<AnonymousComponentBatch> DisconnectedSpace::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(1);
+            {
+                auto result = ComponentBatch(disconnected_space).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                components::IndicatorComponent<DisconnectedSpace::INDICATOR_COMPONENT_NAME>
+                    indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            comp_batches.emplace_back(disconnected_space);
-            comp_batches.emplace_back(DisconnectedSpace::indicator());
-
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
@@ -7,25 +7,31 @@ namespace rerun {
     namespace archetypes {
         const char DisconnectedSpace::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.DisconnectedSpaceIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> DisconnectedSpace::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(1);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<
+        archetypes::DisconnectedSpace>::serialize(const archetypes::DisconnectedSpace& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(1);
 
-            {
-                auto result =
-                    ComponentBatch<rerun::components::DisconnectedSpace>(disconnected_space)
-                        .serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result =
+                ComponentBatch<rerun::components::DisconnectedSpace>(archetype.disconnected_space)
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        {
+            auto result = ComponentBatch<DisconnectedSpace::IndicatorComponent>(
+                              DisconnectedSpace::IndicatorComponent()
+            )
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
@@ -10,8 +10,7 @@ namespace rerun {
     }
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<
-        archetypes::DisconnectedSpace>::serialize(const archetypes::DisconnectedSpace& archetype
-    ) const {
+        archetypes::DisconnectedSpace>::serialize(const archetypes::DisconnectedSpace& archetype) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(1);

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -31,20 +31,17 @@ namespace rerun {
         ///
         /// #include <rerun.hpp>
         ///
-        /// namespace rr = rerun;
-        ///
         /// int main() {
-        ///     auto rec = rr::RecordingStream("rerun_example_disconnected_space");
+        ///     auto rec = rerun::RecordingStream("rerun_example_disconnected_space");
         ///     rec.connect("127.0.0.1:9876").throw_on_failure();
         ///
         ///     // These two points can be projected into the same space..
-        ///     rec.log("world/room1/point", rr::Points3D(rr::datatypes::Vec3D{0.0f, 0.0f, 0.0f}));
-        ///     rec.log("world/room2/point", rr::Points3D(rr::datatypes::Vec3D{1.0f, 1.0f, 1.0f}));
+        ///     rec.log("world/room1/point", rerun::Points3D({0.0f, 0.0f, 0.0f}));
+        ///     rec.log("world/room2/point", rerun::Points3D({1.0f, 1.0f, 1.0f}));
         ///
         ///     // ..but this one lives in a completely separate space!
-        ///     rec.log("world/wormhole", rr::DisconnectedSpace(true));
-        ///     rec.log("world/wormhole/point",
-        ///     rr::Points3D(rr::datatypes::Vec3D{2.0f, 2.0f, 2.0f}));
+        ///     rec.log("world/wormhole", rerun::DisconnectedSpace(true));
+        ///     rec.log("world/wormhole/point", rerun::Points3D({2.0f, 2.0f, 2.0f}));
         /// }
         /// ```
         struct DisconnectedSpace {

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -56,6 +56,7 @@ namespace rerun {
 
           public:
             DisconnectedSpace() = default;
+            DisconnectedSpace(DisconnectedSpace&& other) = default;
 
             DisconnectedSpace(rerun::components::DisconnectedSpace _disconnected_space)
                 : disconnected_space(std::move(_disconnected_space)) {}
@@ -65,16 +66,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/disconnected_space.hpp"
 #include "../data_cell.hpp"
@@ -67,14 +66,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::DisconnectedSpace> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::DisconnectedSpace& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -64,9 +64,17 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::DisconnectedSpace> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::DisconnectedSpace& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -68,6 +68,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -56,7 +56,7 @@ namespace rerun {
             DisconnectedSpace() = default;
             DisconnectedSpace(DisconnectedSpace&& other) = default;
 
-            DisconnectedSpace(rerun::components::DisconnectedSpace _disconnected_space)
+            explicit DisconnectedSpace(rerun::components::DisconnectedSpace _disconnected_space)
                 : disconnected_space(std::move(_disconnected_space)) {}
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -7,6 +7,7 @@
 #include "../component_batch.hpp"
 #include "../components/disconnected_space.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -50,6 +51,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             DisconnectedSpace() = default;

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -50,6 +50,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -37,12 +37,12 @@ namespace rerun {
         ///     rec.connect("127.0.0.1:9876").throw_on_failure();
         ///
         ///     // These two points can be projected into the same space..
-        ///     rec.log("world/room1/point", rerun::Points3D({0.0f, 0.0f, 0.0f}));
-        ///     rec.log("world/room2/point", rerun::Points3D({1.0f, 1.0f, 1.0f}));
+        ///     rec.log("world/room1/point", rerun::Points3D({{0.0f, 0.0f, 0.0f}}));
+        ///     rec.log("world/room2/point", rerun::Points3D({{1.0f, 1.0f, 1.0f}}));
         ///
         ///     // ..but this one lives in a completely separate space!
         ///     rec.log("world/wormhole", rerun::DisconnectedSpace(true));
-        ///     rec.log("world/wormhole/point", rerun::Points3D({2.0f, 2.0f, 2.0f}));
+        ///     rec.log("world/wormhole/point", rerun::Points3D({{2.0f, 2.0f, 2.0f}}));
         /// }
         /// ```
         struct DisconnectedSpace {

--- a/rerun_cpp/src/rerun/archetypes/image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image.cpp
@@ -10,7 +10,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Image>::serialize(
         const archetypes::Image& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(2);

--- a/rerun_cpp/src/rerun/archetypes/image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image.cpp
@@ -6,29 +6,33 @@
 namespace rerun {
     namespace archetypes {
         const char Image::INDICATOR_COMPONENT_NAME[] = "rerun.components.ImageIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> Image::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(2);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Image>::serialize(
+        const archetypes::Image& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(2);
 
-            {
-                auto result = ComponentBatch<rerun::components::TensorData>(data).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (draw_order.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::DrawOrder>(draw_order.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = ComponentBatch<rerun::components::TensorData>(archetype.data).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.draw_order.has_value()) {
+            auto result = ComponentBatch<rerun::components::DrawOrder>(archetype.draw_order.value())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<Image::IndicatorComponent>(Image::IndicatorComponent()).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image.cpp
@@ -3,8 +3,6 @@
 
 #include "image.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char Image::INDICATOR_COMPONENT_NAME[] = "rerun.components.ImageIndicator";
@@ -14,18 +12,18 @@ namespace rerun {
             cells.reserve(2);
 
             {
-                auto result = ComponentBatch(data).serialize();
+                auto result = ComponentBatch<rerun::components::TensorData>(data).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (draw_order.has_value()) {
-                auto result = ComponentBatch(draw_order.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::DrawOrder>(draw_order.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<Image::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/draw_order.hpp"
 #include "../components/tensor_data.hpp"
@@ -62,13 +61,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::Image> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Image& archetype
-        ) const;
+        static Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::Image& archetype
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -38,6 +38,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -44,7 +44,7 @@ namespace rerun {
             Image() = default;
             Image(Image&& other) = default;
 
-            Image(rerun::components::TensorData _data) : data(std::move(_data)) {}
+            explicit Image(rerun::components::TensorData _data) : data(std::move(_data)) {}
 
             /// An optional floating point value that specifies the 2D drawing order.
             ///

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -8,6 +8,7 @@
 #include "../components/draw_order.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -38,6 +39,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             Image() = default;

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -59,9 +59,16 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::Image> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Image& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -41,15 +41,16 @@ namespace rerun {
 
           public:
             Image() = default;
+            Image(Image&& other) = default;
 
             Image(rerun::components::TensorData _data) : data(std::move(_data)) {}
 
             /// An optional floating point value that specifies the 2D drawing order.
             ///
             /// Objects with higher values are drawn on top of those with lower values.
-            Image& with_draw_order(rerun::components::DrawOrder _draw_order) {
+            Image with_draw_order(rerun::components::DrawOrder _draw_order) && {
                 draw_order = std::move(_draw_order);
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -57,16 +58,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -63,6 +63,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -11,7 +11,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::LineStrips2D>::serialize(
         const archetypes::LineStrips2D& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(7);

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -7,54 +7,59 @@ namespace rerun {
     namespace archetypes {
         const char LineStrips2D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.LineStrips2DIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> LineStrips2D::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(7);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::LineStrips2D>::serialize(
+        const archetypes::LineStrips2D& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(7);
 
-            {
-                auto result = strips.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (radii.has_value()) {
-                auto result = radii.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (colors.has_value()) {
-                auto result = colors.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (labels.has_value()) {
-                auto result = labels.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (draw_order.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::DrawOrder>(draw_order.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (class_ids.has_value()) {
-                auto result = class_ids.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (instance_keys.has_value()) {
-                auto result = instance_keys.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = archetype.strips.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.radii.has_value()) {
+            auto result = archetype.radii.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.colors.has_value()) {
+            auto result = archetype.colors.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.labels.has_value()) {
+            auto result = archetype.labels.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.draw_order.has_value()) {
+            auto result = ComponentBatch<rerun::components::DrawOrder>(archetype.draw_order.value())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.class_ids.has_value()) {
+            auto result = archetype.class_ids.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.instance_keys.has_value()) {
+            auto result = archetype.instance_keys.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<LineStrips2D::IndicatorComponent>(LineStrips2D::IndicatorComponent())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -10,37 +10,53 @@ namespace rerun {
         const char LineStrips2D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.LineStrips2DIndicator";
 
-        AnonymousComponentBatch LineStrips2D::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<LineStrips2D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
+        Result<std::vector<SerializedComponentBatch>> LineStrips2D::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(7);
 
-        std::vector<AnonymousComponentBatch> LineStrips2D::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(7);
-
-            comp_batches.emplace_back(strips);
+            {
+                auto result = strips.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
             if (radii.has_value()) {
-                comp_batches.emplace_back(radii.value());
+                auto result = radii.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (colors.has_value()) {
-                comp_batches.emplace_back(colors.value());
+                auto result = colors.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (labels.has_value()) {
-                comp_batches.emplace_back(labels.value());
+                auto result = labels.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (draw_order.has_value()) {
-                comp_batches.emplace_back(draw_order.value());
+                auto result = ComponentBatch(draw_order.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (class_ids.has_value()) {
-                comp_batches.emplace_back(class_ids.value());
+                auto result = class_ids.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (instance_keys.has_value()) {
-                comp_batches.emplace_back(instance_keys.value());
+                auto result = instance_keys.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
-            comp_batches.emplace_back(LineStrips2D::indicator());
+            {
+                components::IndicatorComponent<LineStrips2D::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -17,22 +17,22 @@ namespace rerun {
         cells.reserve(7);
 
         {
-            auto result = archetype.strips.serialize();
+            auto result = (archetype.strips).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radii.has_value()) {
-            auto result = archetype.radii.value().serialize();
+            auto result = (archetype.radii.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.colors.has_value()) {
-            auto result = archetype.colors.value().serialize();
+            auto result = (archetype.colors.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.labels.has_value()) {
-            auto result = archetype.labels.value().serialize();
+            auto result = (archetype.labels.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
@@ -43,12 +43,12 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = archetype.class_ids.value().serialize();
+            auto result = (archetype.class_ids.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = archetype.instance_keys.value().serialize();
+            auto result = (archetype.instance_keys.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -3,8 +3,6 @@
 
 #include "line_strips2d.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char LineStrips2D::INDICATOR_COMPONENT_NAME[] =
@@ -35,7 +33,8 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             if (draw_order.has_value()) {
-                auto result = ComponentBatch(draw_order.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::DrawOrder>(draw_order.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
@@ -50,8 +49,7 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<LineStrips2D::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -91,7 +91,7 @@ namespace rerun {
             LineStrips2D() = default;
             LineStrips2D(LineStrips2D&& other) = default;
 
-            LineStrips2D(ComponentBatch<rerun::components::LineStrip2D> _strips)
+            explicit LineStrips2D(ComponentBatch<rerun::components::LineStrip2D> _strips)
                 : strips(std::move(_strips)) {}
 
             /// Optional radii for the line strips.

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -145,14 +144,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::LineStrips2D> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::LineStrips2D& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -146,6 +146,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -142,9 +142,17 @@ namespace rerun {
             size_t num_instances() const {
                 return strips.size();
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::LineStrips2D> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::LineStrips2D& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -13,6 +13,7 @@
 #include "../components/radius.hpp"
 #include "../components/text.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -85,6 +86,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             LineStrips2D() = default;

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -57,16 +57,16 @@ namespace rerun {
         /// ```
         struct LineStrips2D {
             /// All the actual 2D line strips that make up the batch.
-            std::vector<rerun::components::LineStrip2D> strips;
+            ComponentBatch<rerun::components::LineStrip2D> strips;
 
             /// Optional radii for the line strips.
-            std::optional<std::vector<rerun::components::Radius>> radii;
+            std::optional<ComponentBatch<rerun::components::Radius>> radii;
 
             /// Optional colors for the line strips.
-            std::optional<std::vector<rerun::components::Color>> colors;
+            std::optional<ComponentBatch<rerun::components::Color>> colors;
 
             /// Optional text labels for the line strips.
-            std::optional<std::vector<rerun::components::Text>> labels;
+            std::optional<ComponentBatch<rerun::components::Text>> labels;
 
             /// An optional floating point value that specifies the 2D drawing order of each line
             /// strip.
@@ -77,10 +77,10 @@ namespace rerun {
             /// Optional `ClassId`s for the lines.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            std::optional<std::vector<rerun::components::ClassId>> class_ids;
+            std::optional<ComponentBatch<rerun::components::ClassId>> class_ids;
 
             /// Unique identifiers for each individual line strip in the batch.
-            std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
+            std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
@@ -88,85 +88,52 @@ namespace rerun {
 
           public:
             LineStrips2D() = default;
+            LineStrips2D(LineStrips2D&& other) = default;
 
-            LineStrips2D(std::vector<rerun::components::LineStrip2D> _strips)
+            LineStrips2D(ComponentBatch<rerun::components::LineStrip2D> _strips)
                 : strips(std::move(_strips)) {}
 
-            LineStrips2D(rerun::components::LineStrip2D _strips) : strips(1, std::move(_strips)) {}
-
             /// Optional radii for the line strips.
-            LineStrips2D& with_radii(std::vector<rerun::components::Radius> _radii) {
+            LineStrips2D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
                 radii = std::move(_radii);
-                return *this;
-            }
-
-            /// Optional radii for the line strips.
-            LineStrips2D& with_radii(rerun::components::Radius _radii) {
-                radii = std::vector(1, std::move(_radii));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional colors for the line strips.
-            LineStrips2D& with_colors(std::vector<rerun::components::Color> _colors) {
+            LineStrips2D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
                 colors = std::move(_colors);
-                return *this;
-            }
-
-            /// Optional colors for the line strips.
-            LineStrips2D& with_colors(rerun::components::Color _colors) {
-                colors = std::vector(1, std::move(_colors));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional text labels for the line strips.
-            LineStrips2D& with_labels(std::vector<rerun::components::Text> _labels) {
+            LineStrips2D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
                 labels = std::move(_labels);
-                return *this;
-            }
-
-            /// Optional text labels for the line strips.
-            LineStrips2D& with_labels(rerun::components::Text _labels) {
-                labels = std::vector(1, std::move(_labels));
-                return *this;
+                return std::move(*this);
             }
 
             /// An optional floating point value that specifies the 2D drawing order of each line
             /// strip.
             ///
             /// Objects with higher values are drawn on top of those with lower values.
-            LineStrips2D& with_draw_order(rerun::components::DrawOrder _draw_order) {
+            LineStrips2D with_draw_order(rerun::components::DrawOrder _draw_order) && {
                 draw_order = std::move(_draw_order);
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional `ClassId`s for the lines.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            LineStrips2D& with_class_ids(std::vector<rerun::components::ClassId> _class_ids) {
+            LineStrips2D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
-                return *this;
-            }
-
-            /// Optional `ClassId`s for the lines.
-            ///
-            /// The class ID provides colors and labels if not specified explicitly.
-            LineStrips2D& with_class_ids(rerun::components::ClassId _class_ids) {
-                class_ids = std::vector(1, std::move(_class_ids));
-                return *this;
+                return std::move(*this);
             }
 
             /// Unique identifiers for each individual line strip in the batch.
-            LineStrips2D& with_instance_keys(
-                std::vector<rerun::components::InstanceKey> _instance_keys
-            ) {
+            LineStrips2D with_instance_keys(
+                ComponentBatch<rerun::components::InstanceKey> _instance_keys
+            ) && {
                 instance_keys = std::move(_instance_keys);
-                return *this;
-            }
-
-            /// Unique identifiers for each individual line strip in the batch.
-            LineStrips2D& with_instance_keys(rerun::components::InstanceKey _instance_keys) {
-                instance_keys = std::vector(1, std::move(_instance_keys));
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -174,16 +141,8 @@ namespace rerun {
                 return strips.size();
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -85,6 +85,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -3,8 +3,6 @@
 
 #include "line_strips3d.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char LineStrips3D::INDICATOR_COMPONENT_NAME[] =
@@ -45,8 +43,7 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<LineStrips3D::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -7,48 +7,53 @@ namespace rerun {
     namespace archetypes {
         const char LineStrips3D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.LineStrips3DIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> LineStrips3D::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(6);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::LineStrips3D>::serialize(
+        const archetypes::LineStrips3D& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(6);
 
-            {
-                auto result = strips.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (radii.has_value()) {
-                auto result = radii.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (colors.has_value()) {
-                auto result = colors.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (labels.has_value()) {
-                auto result = labels.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (class_ids.has_value()) {
-                auto result = class_ids.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (instance_keys.has_value()) {
-                auto result = instance_keys.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = archetype.strips.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.radii.has_value()) {
+            auto result = archetype.radii.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.colors.has_value()) {
+            auto result = archetype.colors.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.labels.has_value()) {
+            auto result = archetype.labels.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.class_ids.has_value()) {
+            auto result = archetype.class_ids.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.instance_keys.has_value()) {
+            auto result = archetype.instance_keys.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<LineStrips3D::IndicatorComponent>(LineStrips3D::IndicatorComponent())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -11,7 +11,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::LineStrips3D>::serialize(
         const archetypes::LineStrips3D& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(6);

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -10,34 +10,48 @@ namespace rerun {
         const char LineStrips3D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.LineStrips3DIndicator";
 
-        AnonymousComponentBatch LineStrips3D::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<LineStrips3D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
+        Result<std::vector<SerializedComponentBatch>> LineStrips3D::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(6);
 
-        std::vector<AnonymousComponentBatch> LineStrips3D::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(6);
-
-            comp_batches.emplace_back(strips);
+            {
+                auto result = strips.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
             if (radii.has_value()) {
-                comp_batches.emplace_back(radii.value());
+                auto result = radii.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (colors.has_value()) {
-                comp_batches.emplace_back(colors.value());
+                auto result = colors.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (labels.has_value()) {
-                comp_batches.emplace_back(labels.value());
+                auto result = labels.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (class_ids.has_value()) {
-                comp_batches.emplace_back(class_ids.value());
+                auto result = class_ids.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (instance_keys.has_value()) {
-                comp_batches.emplace_back(instance_keys.value());
+                auto result = instance_keys.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
-            comp_batches.emplace_back(LineStrips3D::indicator());
+            {
+                components::IndicatorComponent<LineStrips3D::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -17,32 +17,32 @@ namespace rerun {
         cells.reserve(6);
 
         {
-            auto result = archetype.strips.serialize();
+            auto result = (archetype.strips).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radii.has_value()) {
-            auto result = archetype.radii.value().serialize();
+            auto result = (archetype.radii.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.colors.has_value()) {
-            auto result = archetype.colors.value().serialize();
+            auto result = (archetype.colors.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.labels.has_value()) {
-            auto result = archetype.labels.value().serialize();
+            auto result = (archetype.labels.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = archetype.class_ids.value().serialize();
+            auto result = (archetype.class_ids.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = archetype.instance_keys.value().serialize();
+            auto result = (archetype.instance_keys.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -138,6 +138,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -137,14 +136,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::LineStrips3D> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::LineStrips3D& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -86,6 +86,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -12,6 +12,7 @@
 #include "../components/radius.hpp"
 #include "../components/text.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -86,6 +87,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             LineStrips3D() = default;

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -64,24 +64,24 @@ namespace rerun {
         /// ```
         struct LineStrips3D {
             /// All the actual 3D line strips that make up the batch.
-            std::vector<rerun::components::LineStrip3D> strips;
+            ComponentBatch<rerun::components::LineStrip3D> strips;
 
             /// Optional radii for the line strips.
-            std::optional<std::vector<rerun::components::Radius>> radii;
+            std::optional<ComponentBatch<rerun::components::Radius>> radii;
 
             /// Optional colors for the line strips.
-            std::optional<std::vector<rerun::components::Color>> colors;
+            std::optional<ComponentBatch<rerun::components::Color>> colors;
 
             /// Optional text labels for the line strips.
-            std::optional<std::vector<rerun::components::Text>> labels;
+            std::optional<ComponentBatch<rerun::components::Text>> labels;
 
             /// Optional `ClassId`s for the lines.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            std::optional<std::vector<rerun::components::ClassId>> class_ids;
+            std::optional<ComponentBatch<rerun::components::ClassId>> class_ids;
 
             /// Unique identifiers for each individual line strip in the batch.
-            std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
+            std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
@@ -89,76 +89,43 @@ namespace rerun {
 
           public:
             LineStrips3D() = default;
+            LineStrips3D(LineStrips3D&& other) = default;
 
-            LineStrips3D(std::vector<rerun::components::LineStrip3D> _strips)
+            LineStrips3D(ComponentBatch<rerun::components::LineStrip3D> _strips)
                 : strips(std::move(_strips)) {}
 
-            LineStrips3D(rerun::components::LineStrip3D _strips) : strips(1, std::move(_strips)) {}
-
             /// Optional radii for the line strips.
-            LineStrips3D& with_radii(std::vector<rerun::components::Radius> _radii) {
+            LineStrips3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
                 radii = std::move(_radii);
-                return *this;
-            }
-
-            /// Optional radii for the line strips.
-            LineStrips3D& with_radii(rerun::components::Radius _radii) {
-                radii = std::vector(1, std::move(_radii));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional colors for the line strips.
-            LineStrips3D& with_colors(std::vector<rerun::components::Color> _colors) {
+            LineStrips3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
                 colors = std::move(_colors);
-                return *this;
-            }
-
-            /// Optional colors for the line strips.
-            LineStrips3D& with_colors(rerun::components::Color _colors) {
-                colors = std::vector(1, std::move(_colors));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional text labels for the line strips.
-            LineStrips3D& with_labels(std::vector<rerun::components::Text> _labels) {
+            LineStrips3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
                 labels = std::move(_labels);
-                return *this;
-            }
-
-            /// Optional text labels for the line strips.
-            LineStrips3D& with_labels(rerun::components::Text _labels) {
-                labels = std::vector(1, std::move(_labels));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional `ClassId`s for the lines.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            LineStrips3D& with_class_ids(std::vector<rerun::components::ClassId> _class_ids) {
+            LineStrips3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
-                return *this;
-            }
-
-            /// Optional `ClassId`s for the lines.
-            ///
-            /// The class ID provides colors and labels if not specified explicitly.
-            LineStrips3D& with_class_ids(rerun::components::ClassId _class_ids) {
-                class_ids = std::vector(1, std::move(_class_ids));
-                return *this;
+                return std::move(*this);
             }
 
             /// Unique identifiers for each individual line strip in the batch.
-            LineStrips3D& with_instance_keys(
-                std::vector<rerun::components::InstanceKey> _instance_keys
-            ) {
+            LineStrips3D with_instance_keys(
+                ComponentBatch<rerun::components::InstanceKey> _instance_keys
+            ) && {
                 instance_keys = std::move(_instance_keys);
-                return *this;
-            }
-
-            /// Unique identifiers for each individual line strip in the batch.
-            LineStrips3D& with_instance_keys(rerun::components::InstanceKey _instance_keys) {
-                instance_keys = std::vector(1, std::move(_instance_keys));
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -166,16 +133,8 @@ namespace rerun {
                 return strips.size();
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -134,9 +134,17 @@ namespace rerun {
             size_t num_instances() const {
                 return strips.size();
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::LineStrips3D> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::LineStrips3D& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -92,7 +92,7 @@ namespace rerun {
             LineStrips3D() = default;
             LineStrips3D(LineStrips3D&& other) = default;
 
-            LineStrips3D(ComponentBatch<rerun::components::LineStrip3D> _strips)
+            explicit LineStrips3D(ComponentBatch<rerun::components::LineStrip3D> _strips)
                 : strips(std::move(_strips)) {}
 
             /// Optional radii for the line strips.

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
@@ -3,8 +3,6 @@
 
 #include "mesh3d.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char Mesh3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Mesh3DIndicator";
@@ -19,7 +17,9 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             if (mesh_properties.has_value()) {
-                auto result = ComponentBatch(mesh_properties.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::MeshProperties>(mesh_properties.value())
+                        .serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
@@ -34,7 +34,8 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             if (mesh_material.has_value()) {
-                auto result = ComponentBatch(mesh_material.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::Material>(mesh_material.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
@@ -49,8 +50,7 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<Mesh3D::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
@@ -16,7 +16,7 @@ namespace rerun {
         cells.reserve(7);
 
         {
-            auto result = archetype.vertex_positions.serialize();
+            auto result = (archetype.vertex_positions).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
@@ -28,12 +28,12 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.vertex_normals.has_value()) {
-            auto result = archetype.vertex_normals.value().serialize();
+            auto result = (archetype.vertex_normals.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.vertex_colors.has_value()) {
-            auto result = archetype.vertex_colors.value().serialize();
+            auto result = (archetype.vertex_colors.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
@@ -45,12 +45,12 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = archetype.class_ids.value().serialize();
+            auto result = (archetype.class_ids.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = archetype.instance_keys.value().serialize();
+            auto result = (archetype.instance_keys.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
@@ -6,56 +6,61 @@
 namespace rerun {
     namespace archetypes {
         const char Mesh3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Mesh3DIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> Mesh3D::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(7);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Mesh3D>::serialize(
+        const archetypes::Mesh3D& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(7);
 
-            {
-                auto result = vertex_positions.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (mesh_properties.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::MeshProperties>(mesh_properties.value())
-                        .serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (vertex_normals.has_value()) {
-                auto result = vertex_normals.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (vertex_colors.has_value()) {
-                auto result = vertex_colors.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (mesh_material.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::Material>(mesh_material.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (class_ids.has_value()) {
-                auto result = class_ids.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (instance_keys.has_value()) {
-                auto result = instance_keys.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = archetype.vertex_positions.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.mesh_properties.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::MeshProperties>(archetype.mesh_properties.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.vertex_normals.has_value()) {
+            auto result = archetype.vertex_normals.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.vertex_colors.has_value()) {
+            auto result = archetype.vertex_colors.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.mesh_material.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::Material>(archetype.mesh_material.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.class_ids.has_value()) {
+            auto result = archetype.class_ids.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.instance_keys.has_value()) {
+            auto result = archetype.instance_keys.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = ComponentBatch<Mesh3D::IndicatorComponent>(Mesh3D::IndicatorComponent())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
@@ -10,7 +10,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Mesh3D>::serialize(
         const archetypes::Mesh3D& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(7);

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
@@ -9,39 +9,53 @@ namespace rerun {
     namespace archetypes {
         const char Mesh3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Mesh3DIndicator";
 
-        AnonymousComponentBatch Mesh3D::indicator() {
-            return ComponentBatch<components::IndicatorComponent<Mesh3D::INDICATOR_COMPONENT_NAME>>(
-                nullptr,
-                1
-            );
-        }
+        Result<std::vector<SerializedComponentBatch>> Mesh3D::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(7);
 
-        std::vector<AnonymousComponentBatch> Mesh3D::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(7);
-
-            comp_batches.emplace_back(vertex_positions);
+            {
+                auto result = vertex_positions.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
             if (mesh_properties.has_value()) {
-                comp_batches.emplace_back(mesh_properties.value());
+                auto result = ComponentBatch(mesh_properties.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (vertex_normals.has_value()) {
-                comp_batches.emplace_back(vertex_normals.value());
+                auto result = vertex_normals.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (vertex_colors.has_value()) {
-                comp_batches.emplace_back(vertex_colors.value());
+                auto result = vertex_colors.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (mesh_material.has_value()) {
-                comp_batches.emplace_back(mesh_material.value());
+                auto result = ComponentBatch(mesh_material.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (class_ids.has_value()) {
-                comp_batches.emplace_back(class_ids.value());
+                auto result = class_ids.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (instance_keys.has_value()) {
-                comp_batches.emplace_back(instance_keys.value());
+                auto result = instance_keys.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
-            comp_batches.emplace_back(Mesh3D::indicator());
+            {
+                components::IndicatorComponent<Mesh3D::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -59,7 +59,7 @@ namespace rerun {
         ///     rec.log(
         ///         "triangle",
         ///         rr::Mesh3D(vertex_positions)
-        ///             .with_vertex_normals({0.0, 0.0, 1.0})
+        ///             .with_vertex_normals({{0.0, 0.0, 1.0}})
         ///             .with_vertex_colors(vertex_colors)
         ///             .with_mesh_properties(rrc::MeshProperties::from_triangle_indices(indices))
         ///             .with_mesh_material(rrc::Material::from_albedo_factor(0xCC00CCFF))

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -156,13 +155,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::Mesh3D> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Mesh3D& archetype
-        ) const;
+        static Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::Mesh3D& archetype
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -13,6 +13,7 @@
 #include "../components/position3d.hpp"
 #include "../components/vector3d.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -97,6 +98,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             Mesh3D() = default;

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -153,9 +153,16 @@ namespace rerun {
             size_t num_instances() const {
                 return vertex_positions.size();
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::Mesh3D> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Mesh3D& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -103,7 +103,7 @@ namespace rerun {
             Mesh3D() = default;
             Mesh3D(Mesh3D&& other) = default;
 
-            Mesh3D(ComponentBatch<rerun::components::Position3D> _vertex_positions)
+            explicit Mesh3D(ComponentBatch<rerun::components::Position3D> _vertex_positions)
                 : vertex_positions(std::move(_vertex_positions)) {}
 
             /// Optional properties for the mesh as a whole (including indexed drawing).

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -70,7 +70,7 @@ namespace rerun {
             ///
             /// If no `indices` are specified, then each triplet of positions is interpreted as a
             /// triangle.
-            std::vector<rerun::components::Position3D> vertex_positions;
+            ComponentBatch<rerun::components::Position3D> vertex_positions;
 
             /// Optional properties for the mesh as a whole (including indexed drawing).
             std::optional<rerun::components::MeshProperties> mesh_properties;
@@ -78,10 +78,10 @@ namespace rerun {
             /// An optional normal for each vertex.
             ///
             /// If specified, this must have as many elements as `vertex_positions`.
-            std::optional<std::vector<rerun::components::Vector3D>> vertex_normals;
+            std::optional<ComponentBatch<rerun::components::Vector3D>> vertex_normals;
 
             /// An optional color for each vertex.
-            std::optional<std::vector<rerun::components::Color>> vertex_colors;
+            std::optional<ComponentBatch<rerun::components::Color>> vertex_colors;
 
             /// Optional material properties for the mesh as a whole.
             std::optional<rerun::components::Material> mesh_material;
@@ -89,10 +89,10 @@ namespace rerun {
             /// Optional class Ids for the vertices.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            std::optional<std::vector<rerun::components::ClassId>> class_ids;
+            std::optional<ComponentBatch<rerun::components::ClassId>> class_ids;
 
             /// Unique identifiers for each individual vertex in the mesh.
-            std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
+            std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
@@ -100,79 +100,51 @@ namespace rerun {
 
           public:
             Mesh3D() = default;
+            Mesh3D(Mesh3D&& other) = default;
 
-            Mesh3D(std::vector<rerun::components::Position3D> _vertex_positions)
+            Mesh3D(ComponentBatch<rerun::components::Position3D> _vertex_positions)
                 : vertex_positions(std::move(_vertex_positions)) {}
 
-            Mesh3D(rerun::components::Position3D _vertex_positions)
-                : vertex_positions(1, std::move(_vertex_positions)) {}
-
             /// Optional properties for the mesh as a whole (including indexed drawing).
-            Mesh3D& with_mesh_properties(rerun::components::MeshProperties _mesh_properties) {
+            Mesh3D with_mesh_properties(rerun::components::MeshProperties _mesh_properties) && {
                 mesh_properties = std::move(_mesh_properties);
-                return *this;
+                return std::move(*this);
             }
 
             /// An optional normal for each vertex.
             ///
             /// If specified, this must have as many elements as `vertex_positions`.
-            Mesh3D& with_vertex_normals(std::vector<rerun::components::Vector3D> _vertex_normals) {
+            Mesh3D with_vertex_normals(ComponentBatch<rerun::components::Vector3D> _vertex_normals
+            ) && {
                 vertex_normals = std::move(_vertex_normals);
-                return *this;
-            }
-
-            /// An optional normal for each vertex.
-            ///
-            /// If specified, this must have as many elements as `vertex_positions`.
-            Mesh3D& with_vertex_normals(rerun::components::Vector3D _vertex_normals) {
-                vertex_normals = std::vector(1, std::move(_vertex_normals));
-                return *this;
+                return std::move(*this);
             }
 
             /// An optional color for each vertex.
-            Mesh3D& with_vertex_colors(std::vector<rerun::components::Color> _vertex_colors) {
+            Mesh3D with_vertex_colors(ComponentBatch<rerun::components::Color> _vertex_colors) && {
                 vertex_colors = std::move(_vertex_colors);
-                return *this;
-            }
-
-            /// An optional color for each vertex.
-            Mesh3D& with_vertex_colors(rerun::components::Color _vertex_colors) {
-                vertex_colors = std::vector(1, std::move(_vertex_colors));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional material properties for the mesh as a whole.
-            Mesh3D& with_mesh_material(rerun::components::Material _mesh_material) {
+            Mesh3D with_mesh_material(rerun::components::Material _mesh_material) && {
                 mesh_material = std::move(_mesh_material);
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional class Ids for the vertices.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            Mesh3D& with_class_ids(std::vector<rerun::components::ClassId> _class_ids) {
+            Mesh3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
-                return *this;
-            }
-
-            /// Optional class Ids for the vertices.
-            ///
-            /// The class ID provides colors and labels if not specified explicitly.
-            Mesh3D& with_class_ids(rerun::components::ClassId _class_ids) {
-                class_ids = std::vector(1, std::move(_class_ids));
-                return *this;
+                return std::move(*this);
             }
 
             /// Unique identifiers for each individual vertex in the mesh.
-            Mesh3D& with_instance_keys(std::vector<rerun::components::InstanceKey> _instance_keys) {
+            Mesh3D with_instance_keys(ComponentBatch<rerun::components::InstanceKey> _instance_keys
+            ) && {
                 instance_keys = std::move(_instance_keys);
-                return *this;
-            }
-
-            /// Unique identifiers for each individual vertex in the mesh.
-            Mesh3D& with_instance_keys(rerun::components::InstanceKey _instance_keys) {
-                instance_keys = std::vector(1, std::move(_instance_keys));
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -180,16 +152,8 @@ namespace rerun {
                 return vertex_positions.size();
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -97,6 +97,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -157,6 +157,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/pinhole.cpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.cpp
@@ -6,37 +6,43 @@
 namespace rerun {
     namespace archetypes {
         const char Pinhole::INDICATOR_COMPONENT_NAME[] = "rerun.components.PinholeIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> Pinhole::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(3);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Pinhole>::serialize(
+        const archetypes::Pinhole& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(3);
 
-            {
-                auto result =
-                    ComponentBatch<rerun::components::PinholeProjection>(image_from_camera)
-                        .serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (resolution.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::Resolution>(resolution.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (camera_xyz.has_value()) {
-                auto result = ComponentBatch<rerun::components::ViewCoordinates>(camera_xyz.value())
-                                  .serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result =
+                ComponentBatch<rerun::components::PinholeProjection>(archetype.image_from_camera)
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.resolution.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::Resolution>(archetype.resolution.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.camera_xyz.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::ViewCoordinates>(archetype.camera_xyz.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = ComponentBatch<Pinhole::IndicatorComponent>(Pinhole::IndicatorComponent())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/pinhole.cpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.cpp
@@ -3,8 +3,6 @@
 
 #include "pinhole.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char Pinhole::INDICATOR_COMPONENT_NAME[] = "rerun.components.PinholeIndicator";
@@ -14,23 +12,26 @@ namespace rerun {
             cells.reserve(3);
 
             {
-                auto result = ComponentBatch(image_from_camera).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::PinholeProjection>(image_from_camera)
+                        .serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (resolution.has_value()) {
-                auto result = ComponentBatch(resolution.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::Resolution>(resolution.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (camera_xyz.has_value()) {
-                auto result = ComponentBatch(camera_xyz.value()).serialize();
+                auto result = ComponentBatch<rerun::components::ViewCoordinates>(camera_xyz.value())
+                                  .serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<Pinhole::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/pinhole.cpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.cpp
@@ -10,7 +10,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Pinhole>::serialize(
         const archetypes::Pinhole& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(3);

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/pinhole_projection.hpp"
 #include "../components/resolution.hpp"
@@ -187,13 +186,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::Pinhole> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Pinhole& archetype
-        ) const;
+        static Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::Pinhole& archetype
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -188,6 +188,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -184,9 +184,16 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::Pinhole> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Pinhole& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -105,6 +105,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -9,6 +9,7 @@
 #include "../components/resolution.hpp"
 #include "../components/view_coordinates.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -105,6 +106,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             // Extensions to generated type defined in 'pinhole_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -123,6 +123,7 @@ namespace rerun {
 
           public:
             Pinhole() = default;
+            Pinhole(Pinhole&& other) = default;
 
             Pinhole(rerun::components::PinholeProjection _image_from_camera)
                 : image_from_camera(std::move(_image_from_camera)) {}
@@ -135,9 +136,9 @@ namespace rerun {
             /// ```
             ///
             /// `image_from_camera` project onto the space spanned by `(0,0)` and `resolution - 1`.
-            Pinhole& with_resolution(rerun::components::Resolution _resolution) {
+            Pinhole with_resolution(rerun::components::Resolution _resolution) && {
                 resolution = std::move(_resolution);
-                return *this;
+                return std::move(*this);
             }
 
             /// Sets the view coordinates for the camera.
@@ -172,9 +173,9 @@ namespace rerun {
             /// The pinhole matrix (the `image_from_camera` argument) always project along the third
             /// (Z) axis, but will be re-oriented to project along the forward axis of the
             /// `camera_xyz` argument.
-            Pinhole& with_camera_xyz(rerun::components::ViewCoordinates _camera_xyz) {
+            Pinhole with_camera_xyz(rerun::components::ViewCoordinates _camera_xyz) && {
                 camera_xyz = std::move(_camera_xyz);
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -182,16 +183,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -126,7 +126,7 @@ namespace rerun {
             Pinhole() = default;
             Pinhole(Pinhole&& other) = default;
 
-            Pinhole(rerun::components::PinholeProjection _image_from_camera)
+            explicit Pinhole(rerun::components::PinholeProjection _image_from_camera)
                 : image_from_camera(std::move(_image_from_camera)) {}
 
             /// Pixel resolution (usually integers) of child image space. Width and height.

--- a/rerun_cpp/src/rerun/archetypes/pinhole_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole_ext.cpp
@@ -25,12 +25,13 @@ namespace rerun {
             const float u_cen = _resolution.x() / 2.0f;
             const float v_cen = _resolution.y() / 2.0f;
 
-            return Pinhole(datatypes::Mat3x3(
-                               {{focal_length.x(), 0.0f, 0.0f},
-                                {0.0f, focal_length.y(), 0.0f},
-                                {u_cen, v_cen, 1.0f}}
-                           )
-            ).with_resolution(_resolution);
+            auto pinhole = Pinhole(datatypes::Mat3x3(
+                {{focal_length.x(), 0.0f, 0.0f},
+                 {0.0f, focal_length.y(), 0.0f},
+                 {u_cen, v_cen, 1.0f}}
+            ));
+            pinhole.resolution = _resolution;
+            return pinhole;
         }
 
     } // namespace archetypes

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -10,7 +10,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Points2D>::serialize(
         const archetypes::Points2D& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(8);

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -16,22 +16,22 @@ namespace rerun {
         cells.reserve(8);
 
         {
-            auto result = archetype.positions.serialize();
+            auto result = (archetype.positions).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radii.has_value()) {
-            auto result = archetype.radii.value().serialize();
+            auto result = (archetype.radii.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.colors.has_value()) {
-            auto result = archetype.colors.value().serialize();
+            auto result = (archetype.colors.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.labels.has_value()) {
-            auto result = archetype.labels.value().serialize();
+            auto result = (archetype.labels.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
@@ -42,17 +42,17 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = archetype.class_ids.value().serialize();
+            auto result = (archetype.class_ids.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.keypoint_ids.has_value()) {
-            auto result = archetype.keypoint_ids.value().serialize();
+            auto result = (archetype.keypoint_ids.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = archetype.instance_keys.value().serialize();
+            auto result = (archetype.instance_keys.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -3,8 +3,6 @@
 
 #include "points2d.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char Points2D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points2DIndicator";
@@ -34,7 +32,8 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             if (draw_order.has_value()) {
-                auto result = ComponentBatch(draw_order.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::DrawOrder>(draw_order.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
@@ -54,8 +53,7 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<Points2D::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -6,59 +6,64 @@
 namespace rerun {
     namespace archetypes {
         const char Points2D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points2DIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> Points2D::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(8);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Points2D>::serialize(
+        const archetypes::Points2D& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(8);
 
-            {
-                auto result = positions.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (radii.has_value()) {
-                auto result = radii.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (colors.has_value()) {
-                auto result = colors.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (labels.has_value()) {
-                auto result = labels.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (draw_order.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::DrawOrder>(draw_order.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (class_ids.has_value()) {
-                auto result = class_ids.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (keypoint_ids.has_value()) {
-                auto result = keypoint_ids.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (instance_keys.has_value()) {
-                auto result = instance_keys.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = archetype.positions.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.radii.has_value()) {
+            auto result = archetype.radii.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.colors.has_value()) {
+            auto result = archetype.colors.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.labels.has_value()) {
+            auto result = archetype.labels.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.draw_order.has_value()) {
+            auto result = ComponentBatch<rerun::components::DrawOrder>(archetype.draw_order.value())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.class_ids.has_value()) {
+            auto result = archetype.class_ids.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.keypoint_ids.has_value()) {
+            auto result = archetype.keypoint_ids.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.instance_keys.has_value()) {
+            auto result = archetype.instance_keys.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<Points2D::IndicatorComponent>(Points2D::IndicatorComponent())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -9,40 +9,58 @@ namespace rerun {
     namespace archetypes {
         const char Points2D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points2DIndicator";
 
-        AnonymousComponentBatch Points2D::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<Points2D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
+        Result<std::vector<SerializedComponentBatch>> Points2D::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(8);
 
-        std::vector<AnonymousComponentBatch> Points2D::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(8);
-
-            comp_batches.emplace_back(positions);
+            {
+                auto result = positions.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
             if (radii.has_value()) {
-                comp_batches.emplace_back(radii.value());
+                auto result = radii.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (colors.has_value()) {
-                comp_batches.emplace_back(colors.value());
+                auto result = colors.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (labels.has_value()) {
-                comp_batches.emplace_back(labels.value());
+                auto result = labels.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (draw_order.has_value()) {
-                comp_batches.emplace_back(draw_order.value());
+                auto result = ComponentBatch(draw_order.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (class_ids.has_value()) {
-                comp_batches.emplace_back(class_ids.value());
+                auto result = class_ids.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (keypoint_ids.has_value()) {
-                comp_batches.emplace_back(keypoint_ids.value());
+                auto result = keypoint_ids.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (instance_keys.has_value()) {
-                comp_batches.emplace_back(instance_keys.value());
+                auto result = instance_keys.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
-            comp_batches.emplace_back(Points2D::indicator());
+            {
+                components::IndicatorComponent<Points2D::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -171,9 +171,17 @@ namespace rerun {
             size_t num_instances() const {
                 return positions.size();
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::Points2D> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::Points2D& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -175,6 +175,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -14,6 +14,7 @@
 #include "../components/radius.hpp"
 #include "../components/text.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -102,6 +103,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             Points2D() = default;

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -66,16 +66,16 @@ namespace rerun {
         /// ```
         struct Points2D {
             /// All the 2D positions at which the point cloud shows points.
-            std::vector<rerun::components::Position2D> positions;
+            ComponentBatch<rerun::components::Position2D> positions;
 
             /// Optional radii for the points, effectively turning them into circles.
-            std::optional<std::vector<rerun::components::Radius>> radii;
+            std::optional<ComponentBatch<rerun::components::Radius>> radii;
 
             /// Optional colors for the points.
-            std::optional<std::vector<rerun::components::Color>> colors;
+            std::optional<ComponentBatch<rerun::components::Color>> colors;
 
             /// Optional text labels for the points.
-            std::optional<std::vector<rerun::components::Text>> labels;
+            std::optional<ComponentBatch<rerun::components::Text>> labels;
 
             /// An optional floating point value that specifies the 2D drawing order.
             ///
@@ -85,7 +85,7 @@ namespace rerun {
             /// Optional class Ids for the points.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            std::optional<std::vector<rerun::components::ClassId>> class_ids;
+            std::optional<ComponentBatch<rerun::components::ClassId>> class_ids;
 
             /// Optional keypoint IDs for the points, identifying them within a class.
             ///
@@ -94,10 +94,10 @@ namespace rerun {
             /// This is useful to identify points within a single classification (which is
             /// identified with `class_id`). E.g. the classification might be 'Person' and the
             /// keypoints refer to joints on a detected skeleton.
-            std::optional<std::vector<rerun::components::KeypointId>> keypoint_ids;
+            std::optional<ComponentBatch<rerun::components::KeypointId>> keypoint_ids;
 
             /// Unique identifiers for each individual point in the batch.
-            std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
+            std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
@@ -105,71 +105,43 @@ namespace rerun {
 
           public:
             Points2D() = default;
+            Points2D(Points2D&& other) = default;
 
-            Points2D(std::vector<rerun::components::Position2D> _positions)
+            Points2D(ComponentBatch<rerun::components::Position2D> _positions)
                 : positions(std::move(_positions)) {}
 
-            Points2D(rerun::components::Position2D _positions)
-                : positions(1, std::move(_positions)) {}
-
             /// Optional radii for the points, effectively turning them into circles.
-            Points2D& with_radii(std::vector<rerun::components::Radius> _radii) {
+            Points2D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
                 radii = std::move(_radii);
-                return *this;
-            }
-
-            /// Optional radii for the points, effectively turning them into circles.
-            Points2D& with_radii(rerun::components::Radius _radii) {
-                radii = std::vector(1, std::move(_radii));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional colors for the points.
-            Points2D& with_colors(std::vector<rerun::components::Color> _colors) {
+            Points2D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
                 colors = std::move(_colors);
-                return *this;
-            }
-
-            /// Optional colors for the points.
-            Points2D& with_colors(rerun::components::Color _colors) {
-                colors = std::vector(1, std::move(_colors));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional text labels for the points.
-            Points2D& with_labels(std::vector<rerun::components::Text> _labels) {
+            Points2D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
                 labels = std::move(_labels);
-                return *this;
-            }
-
-            /// Optional text labels for the points.
-            Points2D& with_labels(rerun::components::Text _labels) {
-                labels = std::vector(1, std::move(_labels));
-                return *this;
+                return std::move(*this);
             }
 
             /// An optional floating point value that specifies the 2D drawing order.
             ///
             /// Objects with higher values are drawn on top of those with lower values.
-            Points2D& with_draw_order(rerun::components::DrawOrder _draw_order) {
+            Points2D with_draw_order(rerun::components::DrawOrder _draw_order) && {
                 draw_order = std::move(_draw_order);
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional class Ids for the points.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            Points2D& with_class_ids(std::vector<rerun::components::ClassId> _class_ids) {
+            Points2D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
-                return *this;
-            }
-
-            /// Optional class Ids for the points.
-            ///
-            /// The class ID provides colors and labels if not specified explicitly.
-            Points2D& with_class_ids(rerun::components::ClassId _class_ids) {
-                class_ids = std::vector(1, std::move(_class_ids));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional keypoint IDs for the points, identifying them within a class.
@@ -179,34 +151,18 @@ namespace rerun {
             /// This is useful to identify points within a single classification (which is
             /// identified with `class_id`). E.g. the classification might be 'Person' and the
             /// keypoints refer to joints on a detected skeleton.
-            Points2D& with_keypoint_ids(std::vector<rerun::components::KeypointId> _keypoint_ids) {
+            Points2D with_keypoint_ids(ComponentBatch<rerun::components::KeypointId> _keypoint_ids
+            ) && {
                 keypoint_ids = std::move(_keypoint_ids);
-                return *this;
-            }
-
-            /// Optional keypoint IDs for the points, identifying them within a class.
-            ///
-            /// If keypoint IDs are passed in but no class IDs were specified, the class ID will
-            /// default to 0.
-            /// This is useful to identify points within a single classification (which is
-            /// identified with `class_id`). E.g. the classification might be 'Person' and the
-            /// keypoints refer to joints on a detected skeleton.
-            Points2D& with_keypoint_ids(rerun::components::KeypointId _keypoint_ids) {
-                keypoint_ids = std::vector(1, std::move(_keypoint_ids));
-                return *this;
+                return std::move(*this);
             }
 
             /// Unique identifiers for each individual point in the batch.
-            Points2D& with_instance_keys(std::vector<rerun::components::InstanceKey> _instance_keys
-            ) {
+            Points2D with_instance_keys(
+                ComponentBatch<rerun::components::InstanceKey> _instance_keys
+            ) && {
                 instance_keys = std::move(_instance_keys);
-                return *this;
-            }
-
-            /// Unique identifiers for each individual point in the batch.
-            Points2D& with_instance_keys(rerun::components::InstanceKey _instance_keys) {
-                instance_keys = std::vector(1, std::move(_instance_keys));
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -214,16 +170,8 @@ namespace rerun {
                 return positions.size();
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -174,14 +173,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::Points2D> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::Points2D& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -102,6 +102,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -108,7 +108,7 @@ namespace rerun {
             Points2D() = default;
             Points2D(Points2D&& other) = default;
 
-            Points2D(ComponentBatch<rerun::components::Position2D> _positions)
+            explicit Points2D(ComponentBatch<rerun::components::Position2D> _positions)
                 : positions(std::move(_positions)) {}
 
             /// Optional radii for the points, effectively turning them into circles.

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -6,53 +6,58 @@
 namespace rerun {
     namespace archetypes {
         const char Points3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points3DIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> Points3D::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(7);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Points3D>::serialize(
+        const archetypes::Points3D& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(7);
 
-            {
-                auto result = positions.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (radii.has_value()) {
-                auto result = radii.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (colors.has_value()) {
-                auto result = colors.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (labels.has_value()) {
-                auto result = labels.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (class_ids.has_value()) {
-                auto result = class_ids.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (keypoint_ids.has_value()) {
-                auto result = keypoint_ids.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (instance_keys.has_value()) {
-                auto result = instance_keys.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = archetype.positions.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.radii.has_value()) {
+            auto result = archetype.radii.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.colors.has_value()) {
+            auto result = archetype.colors.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.labels.has_value()) {
+            auto result = archetype.labels.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.class_ids.has_value()) {
+            auto result = archetype.class_ids.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.keypoint_ids.has_value()) {
+            auto result = archetype.keypoint_ids.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.instance_keys.has_value()) {
+            auto result = archetype.instance_keys.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<Points3D::IndicatorComponent>(Points3D::IndicatorComponent())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -3,8 +3,6 @@
 
 #include "points3d.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char Points3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points3DIndicator";
@@ -49,8 +47,7 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<Points3D::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -16,37 +16,37 @@ namespace rerun {
         cells.reserve(7);
 
         {
-            auto result = archetype.positions.serialize();
+            auto result = (archetype.positions).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radii.has_value()) {
-            auto result = archetype.radii.value().serialize();
+            auto result = (archetype.radii.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.colors.has_value()) {
-            auto result = archetype.colors.value().serialize();
+            auto result = (archetype.colors.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.labels.has_value()) {
-            auto result = archetype.labels.value().serialize();
+            auto result = (archetype.labels.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = archetype.class_ids.value().serialize();
+            auto result = (archetype.class_ids.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.keypoint_ids.has_value()) {
-            auto result = archetype.keypoint_ids.value().serialize();
+            auto result = (archetype.keypoint_ids.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = archetype.instance_keys.value().serialize();
+            auto result = (archetype.instance_keys.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -10,7 +10,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Points3D>::serialize(
         const archetypes::Points3D& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(7);

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -9,37 +9,53 @@ namespace rerun {
     namespace archetypes {
         const char Points3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points3DIndicator";
 
-        AnonymousComponentBatch Points3D::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<Points3D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
+        Result<std::vector<SerializedComponentBatch>> Points3D::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(7);
 
-        std::vector<AnonymousComponentBatch> Points3D::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(7);
-
-            comp_batches.emplace_back(positions);
+            {
+                auto result = positions.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
             if (radii.has_value()) {
-                comp_batches.emplace_back(radii.value());
+                auto result = radii.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (colors.has_value()) {
-                comp_batches.emplace_back(colors.value());
+                auto result = colors.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (labels.has_value()) {
-                comp_batches.emplace_back(labels.value());
+                auto result = labels.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (class_ids.has_value()) {
-                comp_batches.emplace_back(class_ids.value());
+                auto result = class_ids.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (keypoint_ids.has_value()) {
-                comp_batches.emplace_back(keypoint_ids.value());
+                auto result = keypoint_ids.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (instance_keys.has_value()) {
-                comp_batches.emplace_back(instance_keys.value());
+                auto result = instance_keys.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
-            comp_batches.emplace_back(Points3D::indicator());
+            {
+                components::IndicatorComponent<Points3D::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -93,6 +93,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -13,6 +13,7 @@
 #include "../components/radius.hpp"
 #include "../components/text.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -93,6 +94,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             Points3D() = default;

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -158,6 +158,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -157,14 +156,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::Points3D> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::Points3D& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -154,9 +154,17 @@ namespace rerun {
             size_t num_instances() const {
                 return positions.size();
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::Points3D> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::Points3D& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -99,7 +99,7 @@ namespace rerun {
             Points3D() = default;
             Points3D(Points3D&& other) = default;
 
-            Points3D(ComponentBatch<rerun::components::Position3D> _positions)
+            explicit Points3D(ComponentBatch<rerun::components::Position3D> _positions)
                 : positions(std::move(_positions)) {}
 
             /// Optional radii for the points, effectively turning them into circles.

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -62,21 +62,21 @@ namespace rerun {
         /// ```
         struct Points3D {
             /// All the 3D positions at which the point cloud shows points.
-            std::vector<rerun::components::Position3D> positions;
+            ComponentBatch<rerun::components::Position3D> positions;
 
             /// Optional radii for the points, effectively turning them into circles.
-            std::optional<std::vector<rerun::components::Radius>> radii;
+            std::optional<ComponentBatch<rerun::components::Radius>> radii;
 
             /// Optional colors for the points.
-            std::optional<std::vector<rerun::components::Color>> colors;
+            std::optional<ComponentBatch<rerun::components::Color>> colors;
 
             /// Optional text labels for the points.
-            std::optional<std::vector<rerun::components::Text>> labels;
+            std::optional<ComponentBatch<rerun::components::Text>> labels;
 
             /// Optional class Ids for the points.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            std::optional<std::vector<rerun::components::ClassId>> class_ids;
+            std::optional<ComponentBatch<rerun::components::ClassId>> class_ids;
 
             /// Optional keypoint IDs for the points, identifying them within a class.
             ///
@@ -85,10 +85,10 @@ namespace rerun {
             /// This is useful to identify points within a single classification (which is
             /// identified with `class_id`). E.g. the classification might be 'Person' and the
             /// keypoints refer to joints on a detected skeleton.
-            std::optional<std::vector<rerun::components::KeypointId>> keypoint_ids;
+            std::optional<ComponentBatch<rerun::components::KeypointId>> keypoint_ids;
 
             /// Unique identifiers for each individual point in the batch.
-            std::optional<std::vector<rerun::components::InstanceKey>> instance_keys;
+            std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
@@ -96,63 +96,35 @@ namespace rerun {
 
           public:
             Points3D() = default;
+            Points3D(Points3D&& other) = default;
 
-            Points3D(std::vector<rerun::components::Position3D> _positions)
+            Points3D(ComponentBatch<rerun::components::Position3D> _positions)
                 : positions(std::move(_positions)) {}
 
-            Points3D(rerun::components::Position3D _positions)
-                : positions(1, std::move(_positions)) {}
-
             /// Optional radii for the points, effectively turning them into circles.
-            Points3D& with_radii(std::vector<rerun::components::Radius> _radii) {
+            Points3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
                 radii = std::move(_radii);
-                return *this;
-            }
-
-            /// Optional radii for the points, effectively turning them into circles.
-            Points3D& with_radii(rerun::components::Radius _radii) {
-                radii = std::vector(1, std::move(_radii));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional colors for the points.
-            Points3D& with_colors(std::vector<rerun::components::Color> _colors) {
+            Points3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
                 colors = std::move(_colors);
-                return *this;
-            }
-
-            /// Optional colors for the points.
-            Points3D& with_colors(rerun::components::Color _colors) {
-                colors = std::vector(1, std::move(_colors));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional text labels for the points.
-            Points3D& with_labels(std::vector<rerun::components::Text> _labels) {
+            Points3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
                 labels = std::move(_labels);
-                return *this;
-            }
-
-            /// Optional text labels for the points.
-            Points3D& with_labels(rerun::components::Text _labels) {
-                labels = std::vector(1, std::move(_labels));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional class Ids for the points.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
-            Points3D& with_class_ids(std::vector<rerun::components::ClassId> _class_ids) {
+            Points3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
-                return *this;
-            }
-
-            /// Optional class Ids for the points.
-            ///
-            /// The class ID provides colors and labels if not specified explicitly.
-            Points3D& with_class_ids(rerun::components::ClassId _class_ids) {
-                class_ids = std::vector(1, std::move(_class_ids));
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional keypoint IDs for the points, identifying them within a class.
@@ -162,34 +134,18 @@ namespace rerun {
             /// This is useful to identify points within a single classification (which is
             /// identified with `class_id`). E.g. the classification might be 'Person' and the
             /// keypoints refer to joints on a detected skeleton.
-            Points3D& with_keypoint_ids(std::vector<rerun::components::KeypointId> _keypoint_ids) {
+            Points3D with_keypoint_ids(ComponentBatch<rerun::components::KeypointId> _keypoint_ids
+            ) && {
                 keypoint_ids = std::move(_keypoint_ids);
-                return *this;
-            }
-
-            /// Optional keypoint IDs for the points, identifying them within a class.
-            ///
-            /// If keypoint IDs are passed in but no class IDs were specified, the class ID will
-            /// default to 0.
-            /// This is useful to identify points within a single classification (which is
-            /// identified with `class_id`). E.g. the classification might be 'Person' and the
-            /// keypoints refer to joints on a detected skeleton.
-            Points3D& with_keypoint_ids(rerun::components::KeypointId _keypoint_ids) {
-                keypoint_ids = std::vector(1, std::move(_keypoint_ids));
-                return *this;
+                return std::move(*this);
             }
 
             /// Unique identifiers for each individual point in the batch.
-            Points3D& with_instance_keys(std::vector<rerun::components::InstanceKey> _instance_keys
-            ) {
+            Points3D with_instance_keys(
+                ComponentBatch<rerun::components::InstanceKey> _instance_keys
+            ) && {
                 instance_keys = std::move(_instance_keys);
-                return *this;
-            }
-
-            /// Unique identifiers for each individual point in the batch.
-            Points3D& with_instance_keys(rerun::components::InstanceKey _instance_keys) {
-                instance_keys = std::vector(1, std::move(_instance_keys));
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -197,16 +153,8 @@ namespace rerun {
                 return positions.size();
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
@@ -7,29 +7,35 @@ namespace rerun {
     namespace archetypes {
         const char SegmentationImage::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.SegmentationImageIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> SegmentationImage::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(2);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<
+        archetypes::SegmentationImage>::serialize(const archetypes::SegmentationImage& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(2);
 
-            {
-                auto result = ComponentBatch<rerun::components::TensorData>(data).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (draw_order.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::DrawOrder>(draw_order.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = ComponentBatch<rerun::components::TensorData>(archetype.data).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.draw_order.has_value()) {
+            auto result = ComponentBatch<rerun::components::DrawOrder>(archetype.draw_order.value())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = ComponentBatch<SegmentationImage::IndicatorComponent>(
+                              SegmentationImage::IndicatorComponent()
+            )
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
@@ -3,8 +3,6 @@
 
 #include "segmentation_image.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char SegmentationImage::INDICATOR_COMPONENT_NAME[] =
@@ -15,19 +13,18 @@ namespace rerun {
             cells.reserve(2);
 
             {
-                auto result = ComponentBatch(data).serialize();
+                auto result = ComponentBatch<rerun::components::TensorData>(data).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (draw_order.has_value()) {
-                auto result = ComponentBatch(draw_order.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::DrawOrder>(draw_order.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<SegmentationImage::INDICATOR_COMPONENT_NAME>
-                    indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
@@ -10,8 +10,7 @@ namespace rerun {
     }
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<
-        archetypes::SegmentationImage>::serialize(const archetypes::SegmentationImage& archetype
-    ) const {
+        archetypes::SegmentationImage>::serialize(const archetypes::SegmentationImage& archetype) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(2);

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -8,6 +8,7 @@
 #include "../components/draw_order.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -36,6 +37,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             SegmentationImage() = default;

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -57,9 +57,17 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::SegmentationImage> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::SegmentationImage& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -62,6 +62,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -39,15 +39,16 @@ namespace rerun {
 
           public:
             SegmentationImage() = default;
+            SegmentationImage(SegmentationImage&& other) = default;
 
             SegmentationImage(rerun::components::TensorData _data) : data(std::move(_data)) {}
 
             /// An optional floating point value that specifies the 2D drawing order.
             ///
             /// Objects with higher values are drawn on top of those with lower values.
-            SegmentationImage& with_draw_order(rerun::components::DrawOrder _draw_order) {
+            SegmentationImage with_draw_order(rerun::components::DrawOrder _draw_order) && {
                 draw_order = std::move(_draw_order);
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -55,16 +56,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -36,6 +36,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/draw_order.hpp"
 #include "../components/tensor_data.hpp"
@@ -60,14 +59,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::SegmentationImage> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::SegmentationImage& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -42,7 +42,8 @@ namespace rerun {
             SegmentationImage() = default;
             SegmentationImage(SegmentationImage&& other) = default;
 
-            SegmentationImage(rerun::components::TensorData _data) : data(std::move(_data)) {}
+            explicit SegmentationImage(rerun::components::TensorData _data)
+                : data(std::move(_data)) {}
 
             /// An optional floating point value that specifies the 2D drawing order.
             ///

--- a/rerun_cpp/src/rerun/archetypes/tensor.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.cpp
@@ -10,7 +10,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Tensor>::serialize(
         const archetypes::Tensor& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(1);

--- a/rerun_cpp/src/rerun/archetypes/tensor.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.cpp
@@ -9,21 +9,23 @@ namespace rerun {
     namespace archetypes {
         const char Tensor::INDICATOR_COMPONENT_NAME[] = "rerun.components.TensorIndicator";
 
-        AnonymousComponentBatch Tensor::indicator() {
-            return ComponentBatch<components::IndicatorComponent<Tensor::INDICATOR_COMPONENT_NAME>>(
-                nullptr,
-                1
-            );
-        }
+        Result<std::vector<SerializedComponentBatch>> Tensor::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(1);
 
-        std::vector<AnonymousComponentBatch> Tensor::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(1);
+            {
+                auto result = ComponentBatch(data).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                components::IndicatorComponent<Tensor::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            comp_batches.emplace_back(data);
-            comp_batches.emplace_back(Tensor::indicator());
-
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/tensor.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.cpp
@@ -6,23 +6,27 @@
 namespace rerun {
     namespace archetypes {
         const char Tensor::INDICATOR_COMPONENT_NAME[] = "rerun.components.TensorIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> Tensor::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(1);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Tensor>::serialize(
+        const archetypes::Tensor& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(1);
 
-            {
-                auto result = ComponentBatch<rerun::components::TensorData>(data).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = ComponentBatch<rerun::components::TensorData>(archetype.data).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        {
+            auto result = ComponentBatch<Tensor::IndicatorComponent>(Tensor::IndicatorComponent())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/tensor.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.cpp
@@ -3,8 +3,6 @@
 
 #include "tensor.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char Tensor::INDICATOR_COMPONENT_NAME[] = "rerun.components.TensorIndicator";
@@ -14,13 +12,12 @@ namespace rerun {
             cells.reserve(1);
 
             {
-                auto result = ComponentBatch(data).serialize();
+                auto result = ComponentBatch<rerun::components::TensorData>(data).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<Tensor::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -36,9 +36,16 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::Tensor> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Tensor& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -23,6 +23,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -40,6 +40,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
@@ -39,13 +38,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::Tensor> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::Tensor& archetype
-        ) const;
+        static Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::Tensor& archetype
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -26,6 +26,7 @@ namespace rerun {
 
           public:
             Tensor() = default;
+            Tensor(Tensor&& other) = default;
 
             Tensor(rerun::components::TensorData _data) : data(std::move(_data)) {}
 
@@ -34,16 +35,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -7,6 +7,7 @@
 #include "../component_batch.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -23,6 +24,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             Tensor() = default;

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -29,7 +29,7 @@ namespace rerun {
             Tensor() = default;
             Tensor(Tensor&& other) = default;
 
-            Tensor(rerun::components::TensorData _data) : data(std::move(_data)) {}
+            explicit Tensor(rerun::components::TensorData _data) : data(std::move(_data)) {}
 
             /// Returns the number of primary instances of this archetype.
             size_t num_instances() const {

--- a/rerun_cpp/src/rerun/archetypes/text_document.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.cpp
@@ -11,7 +11,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::TextDocument>::serialize(
         const archetypes::TextDocument& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(2);

--- a/rerun_cpp/src/rerun/archetypes/text_document.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.cpp
@@ -3,8 +3,6 @@
 
 #include "text_document.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char TextDocument::INDICATOR_COMPONENT_NAME[] =
@@ -15,18 +13,18 @@ namespace rerun {
             cells.reserve(2);
 
             {
-                auto result = ComponentBatch(text).serialize();
+                auto result = ComponentBatch<rerun::components::Text>(text).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (media_type.has_value()) {
-                auto result = ComponentBatch(media_type.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::MediaType>(media_type.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<TextDocument::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/text_document.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.cpp
@@ -7,29 +7,34 @@ namespace rerun {
     namespace archetypes {
         const char TextDocument::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.TextDocumentIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> TextDocument::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(2);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::TextDocument>::serialize(
+        const archetypes::TextDocument& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(2);
 
-            {
-                auto result = ComponentBatch<rerun::components::Text>(text).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (media_type.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::MediaType>(media_type.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = ComponentBatch<rerun::components::Text>(archetype.text).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.media_type.has_value()) {
+            auto result = ComponentBatch<rerun::components::MediaType>(archetype.media_type.value())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<TextDocument::IndicatorComponent>(TextDocument::IndicatorComponent())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/media_type.hpp"
 #include "../components/text.hpp"
@@ -64,14 +63,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::TextDocument> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::TextDocument& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -8,6 +8,7 @@
 #include "../components/media_type.hpp"
 #include "../components/text.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -36,6 +37,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             TextDocument() = default;

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -39,6 +39,7 @@ namespace rerun {
 
           public:
             TextDocument() = default;
+            TextDocument(TextDocument&& other) = default;
 
             TextDocument(rerun::components::Text _text) : text(std::move(_text)) {}
 
@@ -49,9 +50,9 @@ namespace rerun {
             /// * `text/markdown`
             ///
             /// If omitted, `text/plain` is assumed.
-            TextDocument& with_media_type(rerun::components::MediaType _media_type) {
+            TextDocument with_media_type(rerun::components::MediaType _media_type) && {
                 media_type = std::move(_media_type);
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -59,16 +60,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -61,9 +61,17 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::TextDocument> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::TextDocument& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -36,6 +36,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -65,6 +65,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -42,7 +42,7 @@ namespace rerun {
             TextDocument() = default;
             TextDocument(TextDocument&& other) = default;
 
-            TextDocument(rerun::components::Text _text) : text(std::move(_text)) {}
+            explicit TextDocument(rerun::components::Text _text) : text(std::move(_text)) {}
 
             /// The Media Type of the text.
             ///

--- a/rerun_cpp/src/rerun/archetypes/text_log.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.cpp
@@ -10,7 +10,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::TextLog>::serialize(
         const archetypes::TextLog& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(3);

--- a/rerun_cpp/src/rerun/archetypes/text_log.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.cpp
@@ -6,34 +6,39 @@
 namespace rerun {
     namespace archetypes {
         const char TextLog::INDICATOR_COMPONENT_NAME[] = "rerun.components.TextLogIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> TextLog::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(3);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::TextLog>::serialize(
+        const archetypes::TextLog& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(3);
 
-            {
-                auto result = ComponentBatch<rerun::components::Text>(text).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (level.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::TextLogLevel>(level.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (color.has_value()) {
-                auto result = ComponentBatch<rerun::components::Color>(color.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = ComponentBatch<rerun::components::Text>(archetype.text).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.level.has_value()) {
+            auto result = ComponentBatch<rerun::components::TextLogLevel>(archetype.level.value())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.color.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::Color>(archetype.color.value()).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = ComponentBatch<TextLog::IndicatorComponent>(TextLog::IndicatorComponent())
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_log.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.cpp
@@ -3,8 +3,6 @@
 
 #include "text_log.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char TextLog::INDICATOR_COMPONENT_NAME[] = "rerun.components.TextLogIndicator";
@@ -14,23 +12,23 @@ namespace rerun {
             cells.reserve(3);
 
             {
-                auto result = ComponentBatch(text).serialize();
+                auto result = ComponentBatch<rerun::components::Text>(text).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (level.has_value()) {
-                auto result = ComponentBatch(level.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::TextLogLevel>(level.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (color.has_value()) {
-                auto result = ComponentBatch(color.value()).serialize();
+                auto result = ComponentBatch<rerun::components::Color>(color.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<TextLog::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/text_log.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.cpp
@@ -9,25 +9,33 @@ namespace rerun {
     namespace archetypes {
         const char TextLog::INDICATOR_COMPONENT_NAME[] = "rerun.components.TextLogIndicator";
 
-        AnonymousComponentBatch TextLog::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<TextLog::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
+        Result<std::vector<SerializedComponentBatch>> TextLog::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(3);
 
-        std::vector<AnonymousComponentBatch> TextLog::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(3);
-
-            comp_batches.emplace_back(text);
+            {
+                auto result = ComponentBatch(text).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
             if (level.has_value()) {
-                comp_batches.emplace_back(level.value());
+                auto result = ComponentBatch(level.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (color.has_value()) {
-                comp_batches.emplace_back(color.value());
+                auto result = ComponentBatch(color.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
-            comp_batches.emplace_back(TextLog::indicator());
+            {
+                components::IndicatorComponent<TextLog::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -34,6 +34,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -40,7 +40,7 @@ namespace rerun {
             TextLog() = default;
             TextLog(TextLog&& other) = default;
 
-            TextLog(rerun::components::Text _text) : text(std::move(_text)) {}
+            explicit TextLog(rerun::components::Text _text) : text(std::move(_text)) {}
 
             /// The verbosity level of the message.
             ///

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -9,6 +9,7 @@
 #include "../components/text.hpp"
 #include "../components/text_log_level.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -34,6 +35,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             TextLog() = default;

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -37,21 +37,22 @@ namespace rerun {
 
           public:
             TextLog() = default;
+            TextLog(TextLog&& other) = default;
 
             TextLog(rerun::components::Text _text) : text(std::move(_text)) {}
 
             /// The verbosity level of the message.
             ///
             /// This can be used to filter the log messages in the Rerun Viewer.
-            TextLog& with_level(rerun::components::TextLogLevel _level) {
+            TextLog with_level(rerun::components::TextLogLevel _level) && {
                 level = std::move(_level);
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional color to use for the log line in the Rerun Viewer.
-            TextLog& with_color(rerun::components::Color _color) {
+            TextLog with_color(rerun::components::Color _color) && {
                 color = std::move(_color);
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -59,16 +60,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/color.hpp"
 #include "../components/text.hpp"
@@ -64,13 +63,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::TextLog> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::TextLog& archetype
-        ) const;
+        static Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::TextLog& archetype
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -65,6 +65,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -61,9 +61,16 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::TextLog> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(const archetypes::TextLog& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
@@ -10,8 +10,7 @@ namespace rerun {
     }
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<
-        archetypes::TimeSeriesScalar>::serialize(const archetypes::TimeSeriesScalar& archetype
-    ) const {
+        archetypes::TimeSeriesScalar>::serialize(const archetypes::TimeSeriesScalar& archetype) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(5);

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
@@ -7,44 +7,54 @@ namespace rerun {
     namespace archetypes {
         const char TimeSeriesScalar::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.TimeSeriesScalarIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> TimeSeriesScalar::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(5);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<
+        archetypes::TimeSeriesScalar>::serialize(const archetypes::TimeSeriesScalar& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(5);
 
-            {
-                auto result = ComponentBatch<rerun::components::Scalar>(scalar).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (radius.has_value()) {
-                auto result = ComponentBatch<rerun::components::Radius>(radius.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (color.has_value()) {
-                auto result = ComponentBatch<rerun::components::Color>(color.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (label.has_value()) {
-                auto result = ComponentBatch<rerun::components::Text>(label.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (scattered.has_value()) {
-                auto result = ComponentBatch<rerun::components::ScalarScattering>(scattered.value())
-                                  .serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = ComponentBatch<rerun::components::Scalar>(archetype.scalar).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.radius.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::Radius>(archetype.radius.value()).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.color.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::Color>(archetype.color.value()).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.label.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::Text>(archetype.label.value()).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.scattered.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::ScalarScattering>(archetype.scattered.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = ComponentBatch<TimeSeriesScalar::IndicatorComponent>(
+                              TimeSeriesScalar::IndicatorComponent()
+            )
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
@@ -10,34 +10,44 @@ namespace rerun {
         const char TimeSeriesScalar::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.TimeSeriesScalarIndicator";
 
-        AnonymousComponentBatch TimeSeriesScalar::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<TimeSeriesScalar::INDICATOR_COMPONENT_NAME>>(
-                nullptr,
-                1
-            );
-        }
+        Result<std::vector<SerializedComponentBatch>> TimeSeriesScalar::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(5);
 
-        std::vector<AnonymousComponentBatch> TimeSeriesScalar::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(5);
-
-            comp_batches.emplace_back(scalar);
+            {
+                auto result = ComponentBatch(scalar).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
             if (radius.has_value()) {
-                comp_batches.emplace_back(radius.value());
+                auto result = ComponentBatch(radius.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (color.has_value()) {
-                comp_batches.emplace_back(color.value());
+                auto result = ComponentBatch(color.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (label.has_value()) {
-                comp_batches.emplace_back(label.value());
+                auto result = ComponentBatch(label.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (scattered.has_value()) {
-                comp_batches.emplace_back(scattered.value());
+                auto result = ComponentBatch(scattered.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
-            comp_batches.emplace_back(TimeSeriesScalar::indicator());
+            {
+                components::IndicatorComponent<TimeSeriesScalar::INDICATOR_COMPONENT_NAME>
+                    indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
@@ -3,8 +3,6 @@
 
 #include "time_series_scalar.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char TimeSeriesScalar::INDICATOR_COMPONENT_NAME[] =
@@ -15,34 +13,33 @@ namespace rerun {
             cells.reserve(5);
 
             {
-                auto result = ComponentBatch(scalar).serialize();
+                auto result = ComponentBatch<rerun::components::Scalar>(scalar).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (radius.has_value()) {
-                auto result = ComponentBatch(radius.value()).serialize();
+                auto result = ComponentBatch<rerun::components::Radius>(radius.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (color.has_value()) {
-                auto result = ComponentBatch(color.value()).serialize();
+                auto result = ComponentBatch<rerun::components::Color>(color.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (label.has_value()) {
-                auto result = ComponentBatch(label.value()).serialize();
+                auto result = ComponentBatch<rerun::components::Text>(label.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (scattered.has_value()) {
-                auto result = ComponentBatch(scattered.value()).serialize();
+                auto result = ComponentBatch<rerun::components::ScalarScattering>(scattered.value())
+                                  .serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<TimeSeriesScalar::INDICATOR_COMPONENT_NAME>
-                    indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -11,6 +11,7 @@
 #include "../components/scalar_scattering.hpp"
 #include "../components/text.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -74,6 +75,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             TimeSeriesScalar() = default;

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -146,6 +146,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -77,6 +77,7 @@ namespace rerun {
 
           public:
             TimeSeriesScalar() = default;
+            TimeSeriesScalar(TimeSeriesScalar&& other) = default;
 
             TimeSeriesScalar(rerun::components::Scalar _scalar) : scalar(std::move(_scalar)) {}
 
@@ -88,9 +89,9 @@ namespace rerun {
             /// If all points within a single entity path (i.e. a line) share the same
             /// radius, then this radius will be used as the line width too. Otherwise, the
             /// line will use the default width of `1.0`.
-            TimeSeriesScalar& with_radius(rerun::components::Radius _radius) {
+            TimeSeriesScalar with_radius(rerun::components::Radius _radius) && {
                 radius = std::move(_radius);
-                return *this;
+                return std::move(*this);
             }
 
             /// Optional color for the scalar entry.
@@ -104,9 +105,9 @@ namespace rerun {
             /// If all points within a single entity path (i.e. a line) share the same
             /// color, then this color will be used as the line color in the plot legend.
             /// Otherwise, the line will appear gray in the legend.
-            TimeSeriesScalar& with_color(rerun::components::Color _color) {
+            TimeSeriesScalar with_color(rerun::components::Color _color) && {
                 color = std::move(_color);
-                return *this;
+                return std::move(*this);
             }
 
             /// An optional label for the point.
@@ -117,9 +118,9 @@ namespace rerun {
             /// this label will be used as the label for the line itself. Otherwise, the
             /// line will be named after the entity path. The plot itself is named after
             /// the space it's in.
-            TimeSeriesScalar& with_label(rerun::components::Text _label) {
+            TimeSeriesScalar with_label(rerun::components::Text _label) && {
                 label = std::move(_label);
-                return *this;
+                return std::move(*this);
             }
 
             /// Specifies whether a point in a scatter plot should form a continuous line.
@@ -129,9 +130,9 @@ namespace rerun {
             /// Points within a single line do not have to all share the same scatteredness:
             /// the line will switch between a scattered and a continuous representation as
             /// required.
-            TimeSeriesScalar& with_scattered(rerun::components::ScalarScattering _scattered) {
+            TimeSeriesScalar with_scattered(rerun::components::ScalarScattering _scattered) && {
                 scattered = std::move(_scattered);
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -139,16 +140,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -74,6 +74,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/color.hpp"
 #include "../components/radius.hpp"
@@ -144,14 +143,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::TimeSeriesScalar> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::TimeSeriesScalar& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -141,9 +141,17 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::TimeSeriesScalar> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::TimeSeriesScalar& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -80,7 +80,8 @@ namespace rerun {
             TimeSeriesScalar() = default;
             TimeSeriesScalar(TimeSeriesScalar&& other) = default;
 
-            TimeSeriesScalar(rerun::components::Scalar _scalar) : scalar(std::move(_scalar)) {}
+            explicit TimeSeriesScalar(rerun::components::Scalar _scalar)
+                : scalar(std::move(_scalar)) {}
 
             /// An optional radius for the point.
             ///

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -3,8 +3,6 @@
 
 #include "transform3d.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char Transform3D::INDICATOR_COMPONENT_NAME[] =
@@ -15,13 +13,12 @@ namespace rerun {
             cells.reserve(1);
 
             {
-                auto result = ComponentBatch(transform).serialize();
+                auto result = ComponentBatch<rerun::components::Transform3D>(transform).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<Transform3D::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -11,7 +11,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Transform3D>::serialize(
         const archetypes::Transform3D& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(1);

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -10,19 +10,23 @@ namespace rerun {
         const char Transform3D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.Transform3DIndicator";
 
-        AnonymousComponentBatch Transform3D::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<Transform3D::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
+        Result<std::vector<SerializedComponentBatch>> Transform3D::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(1);
 
-        std::vector<AnonymousComponentBatch> Transform3D::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(1);
+            {
+                auto result = ComponentBatch(transform).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                components::IndicatorComponent<Transform3D::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            comp_batches.emplace_back(transform);
-            comp_batches.emplace_back(Transform3D::indicator());
-
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -7,23 +7,29 @@ namespace rerun {
     namespace archetypes {
         const char Transform3D::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.Transform3DIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> Transform3D::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(1);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::Transform3D>::serialize(
+        const archetypes::Transform3D& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(1);
 
-            {
-                auto result = ComponentBatch<rerun::components::Transform3D>(transform).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result =
+                ComponentBatch<rerun::components::Transform3D>(archetype.transform).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        {
+            auto result =
+                ComponentBatch<Transform3D::IndicatorComponent>(Transform3D::IndicatorComponent())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -7,6 +7,7 @@
 #include "../component_batch.hpp"
 #include "../components/transform3d.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -61,6 +62,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             // Extensions to generated type defined in 'transform3d_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -252,9 +252,17 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::Transform3D> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::Transform3D& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/transform3d.hpp"
 #include "../data_cell.hpp"
@@ -255,14 +254,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::Transform3D> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::Transform3D& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -37,8 +37,8 @@ namespace rerun {
         ///     auto rec = rr::RecordingStream("rerun_example_transform3d");
         ///     rec.connect("127.0.0.1:9876").throw_on_failure();
         ///
-        ///     auto arrow = rr::Arrows3D::from_vectors({0.0f, 1.0f, 0.0f}).with_origins({0.0f,
-        ///     0.0f, 0.0f});
+        ///     auto arrow = rr::Arrows3D::from_vectors({0.0f, 1.0f, 0.0f}).with_origins({{0.0f,
+        ///     0.0f, 0.0f}});
         ///
         ///     rec.log("base", arrow);
         ///

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -241,6 +241,7 @@ namespace rerun {
 
           public:
             Transform3D() = default;
+            Transform3D(Transform3D&& other) = default;
 
             Transform3D(rerun::components::Transform3D _transform)
                 : transform(std::move(_transform)) {}
@@ -250,16 +251,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -256,6 +256,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -61,6 +61,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -244,7 +244,7 @@ namespace rerun {
             Transform3D() = default;
             Transform3D(Transform3D&& other) = default;
 
-            Transform3D(rerun::components::Transform3D _transform)
+            explicit Transform3D(rerun::components::Transform3D _transform)
                 : transform(std::move(_transform)) {}
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
@@ -10,22 +10,23 @@ namespace rerun {
         const char ViewCoordinates::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.ViewCoordinatesIndicator";
 
-        AnonymousComponentBatch ViewCoordinates::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<ViewCoordinates::INDICATOR_COMPONENT_NAME>>(
-                nullptr,
-                1
-            );
-        }
+        Result<std::vector<SerializedComponentBatch>> ViewCoordinates::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(1);
 
-        std::vector<AnonymousComponentBatch> ViewCoordinates::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(1);
+            {
+                auto result = ComponentBatch(xyz).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                components::IndicatorComponent<ViewCoordinates::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            comp_batches.emplace_back(xyz);
-            comp_batches.emplace_back(ViewCoordinates::indicator());
-
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
@@ -10,8 +10,7 @@ namespace rerun {
     }
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<
-        archetypes::ViewCoordinates>::serialize(const archetypes::ViewCoordinates& archetype
-    ) const {
+        archetypes::ViewCoordinates>::serialize(const archetypes::ViewCoordinates& archetype) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(1);

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
@@ -3,8 +3,6 @@
 
 #include "view_coordinates.hpp"
 
-#include "../indicator_component.hpp"
-
 namespace rerun {
     namespace archetypes {
         const char ViewCoordinates::INDICATOR_COMPONENT_NAME[] =
@@ -15,13 +13,12 @@ namespace rerun {
             cells.reserve(1);
 
             {
-                auto result = ComponentBatch(xyz).serialize();
+                auto result = ComponentBatch<rerun::components::ViewCoordinates>(xyz).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<ViewCoordinates::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
@@ -7,23 +7,30 @@ namespace rerun {
     namespace archetypes {
         const char ViewCoordinates::INDICATOR_COMPONENT_NAME[] =
             "rerun.components.ViewCoordinatesIndicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> ViewCoordinates::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(1);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<
+        archetypes::ViewCoordinates>::serialize(const archetypes::ViewCoordinates& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(1);
 
-            {
-                auto result = ComponentBatch<rerun::components::ViewCoordinates>(xyz).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result =
+                ComponentBatch<rerun::components::ViewCoordinates>(archetype.xyz).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        {
+            auto result = ComponentBatch<ViewCoordinates::IndicatorComponent>(
+                              ViewCoordinates::IndicatorComponent()
+            )
+                              .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -133,7 +133,8 @@ namespace rerun {
             ViewCoordinates() = default;
             ViewCoordinates(ViewCoordinates&& other) = default;
 
-            ViewCoordinates(rerun::components::ViewCoordinates _xyz) : xyz(std::move(_xyz)) {}
+            explicit ViewCoordinates(rerun::components::ViewCoordinates _xyz)
+                : xyz(std::move(_xyz)) {}
 
             /// Returns the number of primary instances of this archetype.
             size_t num_instances() const {

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -7,6 +7,7 @@
 #include "../component_batch.hpp"
 #include "../components/view_coordinates.hpp"
 #include "../data_cell.hpp"
+#include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -56,6 +57,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             // Extensions to generated type defined in 'view_coordinates_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -130,6 +130,7 @@ namespace rerun {
 
           public:
             ViewCoordinates() = default;
+            ViewCoordinates(ViewCoordinates&& other) = default;
 
             ViewCoordinates(rerun::components::ViewCoordinates _xyz) : xyz(std::move(_xyz)) {}
 
@@ -138,16 +139,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../arrow.hpp"
 #include "../component_batch.hpp"
 #include "../components/view_coordinates.hpp"
 #include "../data_cell.hpp"
@@ -143,14 +142,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::ViewCoordinates> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::ViewCoordinates& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -56,6 +56,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -145,6 +145,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -140,9 +140,17 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::ViewCoordinates> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::ViewCoordinates& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/as_components.hpp
+++ b/rerun_cpp/src/rerun/as_components.hpp
@@ -16,7 +16,8 @@ namespace rerun {
 
         // TODO(andreas): This should also mention an example of how to implement this.
         static_assert(
-            NoAsComponentsFor<T>::value,
+            NoAsComponentsFor<T>::value, // Always evaluate to false, but in a way that requires
+                                         // template instantiation.
             "AsComponents is not implemented for this type. "
             "It is implemented for all built-in archetypes as well as std::vector, std::array, and "
             "c-arrays of components. "

--- a/rerun_cpp/src/rerun/as_components.hpp
+++ b/rerun_cpp/src/rerun/as_components.hpp
@@ -7,14 +7,14 @@ namespace rerun {
     /// It is implemented for various built-in types as well as collections of components.
     /// You can build your own archetypes by implementing this trait.
     /// Anything that implements `AsComponents` can be logged to a recording stream.
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents {
-        template <typename T>
+        template <typename T2>
         struct NoAsComponentsFor : std::false_type {};
 
         // TODO(andreas): This should also mention an example of how to implement this.
         static_assert(
-            NoAsComponentsFor<TComponent>::value,
+            NoAsComponentsFor<T>::value,
             "AsComponents is not implemented for this type. "
             "It is implemented for all built-in archetypes as well as std::vector, std::array, and "
             "c-arrays of components. "
@@ -25,9 +25,9 @@ namespace rerun {
     /// AsComponents for a std::vector of components.
     template <typename TComponent>
     struct AsComponents<std::vector<TComponent>> {
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const std::vector<TComponent>& components
-        ) const {
+        ) {
             const auto result = ComponentBatch<TComponent>(components).serialize();
             RR_RETURN_NOT_OK(result.error);
             return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
@@ -37,9 +37,9 @@ namespace rerun {
     /// AsComponents for an std::array of components.
     template <typename TComponent, size_t NumInstances>
     struct AsComponents<std::array<TComponent, NumInstances>> {
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const std::array<TComponent, NumInstances>& components
-        ) const {
+        ) {
             const auto result = ComponentBatch<TComponent>(components).serialize();
             RR_RETURN_NOT_OK(result.error);
             return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
@@ -49,8 +49,8 @@ namespace rerun {
     /// AsComponents for an c-array of components.
     template <typename TComponent, size_t NumInstances>
     struct AsComponents<TComponent[NumInstances]> {
-        Result<std::vector<SerializedComponentBatch>> serialize(const TComponent (&array
-        )[NumInstances]) const {
+        static Result<std::vector<SerializedComponentBatch>> serialize(const TComponent (&array
+        )[NumInstances]) {
             const auto result = ComponentBatch<TComponent>(array).serialize();
             RR_RETURN_NOT_OK(result.error);
             return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
@@ -60,9 +60,9 @@ namespace rerun {
     /// AsComponents for an ComponentBatch.
     template <typename TComponent>
     struct AsComponents<ComponentBatch<TComponent>> {
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const ComponentBatch<TComponent>& components
-        ) const {
+        ) {
             const auto result = components.serialize();
             RR_RETURN_NOT_OK(result.error);
             return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
@@ -72,9 +72,9 @@ namespace rerun {
     /// AsComponents for single indicators
     template <const char Name[]>
     struct AsComponents<components::IndicatorComponent<Name>> {
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const components::IndicatorComponent<Name>& indicator
-        ) const {
+        ) {
             const auto result =
                 ComponentBatch<components::IndicatorComponent<Name>>(indicator).serialize();
             RR_RETURN_NOT_OK(result.error);

--- a/rerun_cpp/src/rerun/as_components.hpp
+++ b/rerun_cpp/src/rerun/as_components.hpp
@@ -24,7 +24,7 @@ namespace rerun {
         );
     };
 
-    /// AsComponents for an ComponentBatch.
+    /// AsComponents for a ComponentBatch.
     template <typename TComponent>
     struct AsComponents<ComponentBatch<TComponent>> {
         static Result<std::vector<SerializedComponentBatch>> serialize(

--- a/rerun_cpp/src/rerun/as_components.hpp
+++ b/rerun_cpp/src/rerun/as_components.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "component_batch.hpp"
 #include "indicator_component.hpp"
 
@@ -69,7 +71,9 @@ namespace rerun {
         static Result<std::vector<SerializedComponentBatch>> serialize(
             const components::IndicatorComponent<Name>& indicator
         ) {
-            return AsComponents<components::IndicatorComponent<Name>>::serialize(indicator);
+            return AsComponents<ComponentBatch<components::IndicatorComponent<Name>>>::serialize(
+                indicator
+            );
         }
     };
 

--- a/rerun_cpp/src/rerun/as_components.hpp
+++ b/rerun_cpp/src/rerun/as_components.hpp
@@ -22,41 +22,6 @@ namespace rerun {
         );
     };
 
-    /// AsComponents for a std::vector of components.
-    template <typename TComponent>
-    struct AsComponents<std::vector<TComponent>> {
-        static Result<std::vector<SerializedComponentBatch>> serialize(
-            const std::vector<TComponent>& components
-        ) {
-            const auto result = ComponentBatch<TComponent>(components).serialize();
-            RR_RETURN_NOT_OK(result.error);
-            return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
-        }
-    };
-
-    /// AsComponents for an std::array of components.
-    template <typename TComponent, size_t NumInstances>
-    struct AsComponents<std::array<TComponent, NumInstances>> {
-        static Result<std::vector<SerializedComponentBatch>> serialize(
-            const std::array<TComponent, NumInstances>& components
-        ) {
-            const auto result = ComponentBatch<TComponent>(components).serialize();
-            RR_RETURN_NOT_OK(result.error);
-            return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
-        }
-    };
-
-    /// AsComponents for an c-array of components.
-    template <typename TComponent, size_t NumInstances>
-    struct AsComponents<TComponent[NumInstances]> {
-        static Result<std::vector<SerializedComponentBatch>> serialize(const TComponent (&array
-        )[NumInstances]) {
-            const auto result = ComponentBatch<TComponent>(array).serialize();
-            RR_RETURN_NOT_OK(result.error);
-            return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
-        }
-    };
-
     /// AsComponents for an ComponentBatch.
     template <typename TComponent>
     struct AsComponents<ComponentBatch<TComponent>> {
@@ -69,16 +34,42 @@ namespace rerun {
         }
     };
 
+    /// AsComponents for a std::vector of components.
+    template <typename TComponent>
+    struct AsComponents<std::vector<TComponent>> {
+        static Result<std::vector<SerializedComponentBatch>> serialize(
+            const std::vector<TComponent>& components
+        ) {
+            return AsComponents<ComponentBatch<TComponent>>::serialize(components);
+        }
+    };
+
+    /// AsComponents for an std::array of components.
+    template <typename TComponent, size_t NumInstances>
+    struct AsComponents<std::array<TComponent, NumInstances>> {
+        static Result<std::vector<SerializedComponentBatch>> serialize(
+            const std::array<TComponent, NumInstances>& components
+        ) {
+            return AsComponents<ComponentBatch<TComponent>>::serialize(components);
+        }
+    };
+
+    /// AsComponents for an c-array of components.
+    template <typename TComponent, size_t NumInstances>
+    struct AsComponents<TComponent[NumInstances]> {
+        static Result<std::vector<SerializedComponentBatch>> serialize(const TComponent (&components
+        )[NumInstances]) {
+            return AsComponents<ComponentBatch<TComponent>>::serialize(components);
+        }
+    };
+
     /// AsComponents for single indicators
     template <const char Name[]>
     struct AsComponents<components::IndicatorComponent<Name>> {
         static Result<std::vector<SerializedComponentBatch>> serialize(
             const components::IndicatorComponent<Name>& indicator
         ) {
-            const auto result =
-                ComponentBatch<components::IndicatorComponent<Name>>(indicator).serialize();
-            RR_RETURN_NOT_OK(result.error);
-            return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
+            return AsComponents<components::IndicatorComponent<Name>>::serialize(indicator);
         }
     };
 

--- a/rerun_cpp/src/rerun/as_components.hpp
+++ b/rerun_cpp/src/rerun/as_components.hpp
@@ -2,10 +2,11 @@
 #include "indicator_component.hpp"
 
 namespace rerun {
-    // TODO: general docs
-    // TODO: can we not put single component into the unspecialized one?
-
-    /// AsComponents for a single component.
+    /// The AsComponents trait is used to convert a type into a list of serialized component.
+    ///
+    /// It is implemented for various built-in types as well as collections of components.
+    /// You can build your own archetypes by implementing this trait.
+    /// Anything that implements `AsComponents` can be logged to a recording stream.
     template <typename TComponent>
     struct AsComponents {
         template <typename T>

--- a/rerun_cpp/src/rerun/as_components.hpp
+++ b/rerun_cpp/src/rerun/as_components.hpp
@@ -1,0 +1,63 @@
+#include "component_batch.hpp"
+
+namespace rerun {
+    // TODO: general docs
+
+    /// AsComponents for a single component.
+    template <typename TComponent>
+    struct AsComponents {
+        Result<std::vector<SerializedComponentBatch>> serialize(const TComponent& single_component
+        ) const {
+            const auto result = ComponentBatch<TComponent>(single_component).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
+        }
+    };
+
+    /// AsComponents for a std::vector of components.
+    template <typename TComponent>
+    struct AsComponents<std::vector<TComponent>> {
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const std::vector<TComponent>& components
+        ) const {
+            const auto result = ComponentBatch<TComponent>(components).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
+        }
+    };
+
+    /// AsComponents for an std::array of components.
+    template <typename TComponent, size_t NumInstances>
+    struct AsComponents<std::array<TComponent, NumInstances>> {
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const std::array<TComponent, NumInstances>& components
+        ) const {
+            const auto result = ComponentBatch<TComponent>(components).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
+        }
+    };
+
+    /// AsComponents for an c-array of components.
+    template <typename TComponent, size_t NumInstances>
+    struct AsComponents<TComponent[NumInstances]> {
+        Result<std::vector<SerializedComponentBatch>> serialize(const TComponent (&array
+        )[NumInstances]) const {
+            const auto result = ComponentBatch<TComponent>().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
+        }
+    };
+
+    /// AsComponents for an ComponentBatch.
+    template <typename TComponent>
+    struct AsComponents<ComponentBatch<TComponent>> {
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const ComponentBatch<TComponent>& components
+        ) const {
+            const auto result = components.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
+        }
+    };
+} // namespace rerun

--- a/rerun_cpp/src/rerun/as_components.hpp
+++ b/rerun_cpp/src/rerun/as_components.hpp
@@ -2,6 +2,7 @@
 
 namespace rerun {
     // TODO: general docs
+    // TODO: can we not put single component into the unspecialized one?
 
     /// AsComponents for a single component.
     template <typename TComponent>

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -40,6 +40,23 @@ namespace rerun {
         );
     };
 
+    /// Type of ownership of the the batch's data.
+    ///
+    /// User access to this is typically only needed for debugging and testing.
+    enum class BatchOwnership {
+        /// The component batch does not own the data and only has a pointer and a
+        /// size.
+        Borrowed,
+
+        /// The component batch owns the data via an std::vector.
+        VectorOwned,
+
+        /// The component batch was moved.
+        /// This could be achieved by other means, but this makes it easiest to follow and
+        /// debug.
+        Moved,
+    };
+
     /// Generic list of components that are contiguous in memory.
     ///
     /// Any creation from a non-temporary will neither copy the data nor take ownership of it.
@@ -218,21 +235,14 @@ namespace rerun {
             }
         }
 
+        /// Returns the ownership of the component batch.
+        ///
+        /// This is usually only needed for debugging and testing.
+        BatchOwnership get_ownership() const {
+            return ownership;
+        }
+
       private:
-        enum class BatchOwnership {
-            /// The component batch does not own the data and only has a pointer and a
-            /// size.
-            Borrowed,
-
-            /// The component batch owns the data via an std::vector.
-            VectorOwned,
-
-            /// The component batch was moved.
-            /// This could be achieved by other means, but this makes it easiest to follow and
-            /// debug.
-            Moved,
-        };
-
         BatchOwnership ownership;
 
         template <typename T>
@@ -305,5 +315,3 @@ namespace rerun {
         }
     };
 } // namespace rerun
-
-// TODO: add tests for when things are owned or not.

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -298,6 +298,17 @@ namespace rerun {
         ComponentBatch<TComponent> operator()(const TComponent (&array)[NumInstances]) {
             return ComponentBatch<TComponent>::borrow(array, NumInstances);
         }
+
+        ComponentBatch<TComponent> operator()(TComponent (&&array)[NumInstances]) {
+            std::vector<TComponent> components;
+            components.reserve(NumInstances);
+            components.insert(
+                components.end(),
+                std::make_move_iterator(array),
+                std::make_move_iterator(array + NumInstances)
+            );
+            return ComponentBatch<TComponent>::take_ownership(std::move(components));
+        }
     };
 
     /// Adapter for a single component, temporary or reference.

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -196,9 +196,7 @@ namespace rerun {
 
         /// Serializes the component batch into a rerun datacell that can be sent to a store.
         Result<SerializedComponentBatch> serialize() const {
-            // TODO(andreas): For improved error messages we should add a static_assert that
-            // TComponent implements `to_data_cell`.
-            // TODO(andreas): Invert this relationship - a user of this *container* should call
+            // TODO(#3794): Invert this relationship - a user of this *container* should call
             // TComponent::serialize (or similar) passing in this container.
             switch (ownership) {
                 case BatchOwnership::Borrowed: {

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -46,6 +46,15 @@ namespace rerun {
         /// TODO(andreas): Optimize this to not allocate a vector.
         ComponentBatch(TComponent&& one_and_only) : ComponentBatch(std::vector{one_and_only}) {}
 
+        /// Construct from a single temporary component with type conversion from one or more
+        /// parameters.
+        ///
+        /// Takes ownership of the data and moves it into the component batch.
+        template <
+            typename... Ts, typename = std::enable_if_t<std::is_constructible_v<TComponent, Ts...>>>
+        ComponentBatch(Ts&&... construction_args)
+            : ComponentBatch(std::move(TComponent(std::forward<Ts>(construction_args)...))) {}
+
         /// Construct from a raw pointer and size.
         ///
         /// Naturally, this does not take ownership of the data.
@@ -204,3 +213,5 @@ namespace rerun {
         ComponentBatchStorage<TComponent> storage;
     };
 } // namespace rerun
+
+// TODO: add tests for when things are owned or not.

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -190,6 +190,7 @@ namespace rerun {
                 case BatchOwnership::Moved:
                     return 0;
             }
+            return 0;
         }
 
         /// Serializes the component batch into a rerun datacell that can be sent to a store.
@@ -230,6 +231,8 @@ namespace rerun {
                         "ComponentBatch was already moved and is now invalid."
                     );
             }
+
+            return Error(ErrorCode::Unknown, "Invalid ownership state");
         }
 
         /// Returns the ownership of the component batch.

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -122,8 +122,7 @@ namespace rerun {
 
         /// Move constructor.
         ComponentBatch(ComponentBatch<TComponent>&& other) {
-            ownership = other.ownership;
-            switch (ownership) {
+            switch (other.ownership) {
                 case BatchOwnership::Borrowed:
                     storage.borrowed = other.storage.borrowed;
                     break;
@@ -137,6 +136,7 @@ namespace rerun {
                     // This shouldn't happen but is well defined. We're now also moved!
                     break;
             }
+            ownership = other.ownership;
             other.ownership = BatchOwnership::Moved;
         }
 

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -8,6 +8,10 @@
 #include "result.hpp"
 
 namespace rerun {
+    // TODO: doc
+    template <typename TComponent, typename... TInputArgs>
+    struct ComponentBatchAdapter;
+
     /// Generic list of components that are contiguous in memory.
     ///
     /// Any creation from a non-temporary will neither copy the data nor take ownership of it.
@@ -24,6 +28,8 @@ namespace rerun {
     template <typename TComponent>
     class ComponentBatch {
       public:
+        using TComponentType = TComponent;
+
         /// Creates a new empty component batch.
         ///
         /// Note that logging an empty component batch is different from logging no component batch:
@@ -34,70 +40,14 @@ namespace rerun {
             storage.borrowed.num_instances = 0;
         }
 
-        /// Construct from a single component.
-        ///
-        /// *Attention*: Does *not* take ownership of the data,
-        /// you need to ensure that the data outlives the component batch.
-        ComponentBatch(const TComponent& one_and_only) : ComponentBatch(&one_and_only, 1) {}
+        /// Construct using a `ComponentBatchAdapter` if there's a fitting specialization.
+        template <typename... Ts>
+        ComponentBatch(Ts&&... args)
+            : ComponentBatch(ComponentBatchAdapter<TComponent, Ts...>()(std::forward<Ts>(args)...)
+              ) {}
 
-        /// Construct from a single temporary component.
-        ///
-        /// Takes ownership of the data and moves it into the component batch.
-        /// TODO(andreas): Optimize this to not allocate a vector.
-        ComponentBatch(TComponent&& one_and_only) : ComponentBatch(std::vector{one_and_only}) {}
-
-        /// Construct from a single temporary component with type conversion from one or more
-        /// parameters.
-        ///
-        /// Takes ownership of the data and moves it into the component batch.
-        template <
-            typename... Ts, typename = std::enable_if_t<std::is_constructible_v<TComponent, Ts...>>>
-        ComponentBatch(Ts&&... construction_args)
-            : ComponentBatch(std::move(TComponent(std::forward<Ts>(construction_args)...))) {}
-
-        /// Construct from a raw pointer and size.
-        ///
-        /// Naturally, this does not take ownership of the data.
-        ComponentBatch(const TComponent* data, size_t num_instances)
-            : ownership(BatchOwnership::Borrowed) {
-            storage.borrowed.data = data;
-            storage.borrowed.num_instances = num_instances;
-        }
-
-        /// Construct from an std::vector.
-        ///
-        /// *Attention*: Does *not* take ownership of the data,
-        /// you need to ensure that the data outlives the component batch.
-        /// In particular, manipulating the passed vector after constructing the component batch,
-        /// will invalidate it, similar to iterator invalidation.
-        ComponentBatch(const std::vector<TComponent>& data)
-            : ComponentBatch(data.data(), data.size()) {}
-
-        /// Construct from a temporary std::vector.
-        ///
-        /// Takes ownership of the data and moves it into the component batch.
-        ComponentBatch(std::vector<TComponent>&& data) : ownership(BatchOwnership::VectorOwned) {
-            // Don't assign, since the vector is in an undefined state and assigning may
-            // attempt to free data.
-            new (&storage.vector_owned) std::vector<TComponent>(data);
-        }
-
-        /// Construct from an std::array.
-        ///
-        /// *Attention*: Does *not* take ownership of the data,
-        /// you need to ensure that the data outlives the component batch.
-        template <size_t NumInstances>
-        ComponentBatch(const std::array<TComponent, NumInstances>& data)
-            : ComponentBatch(data.data(), data.size()) {}
-
-        /// Construct from a C-Array.
-        ///
-        /// *Attention*: Does *not* take ownership of the data,
-        /// you need to ensure that the data outlives the component batch.
-        template <size_t NumInstances>
-        ComponentBatch(const TComponent (&data)[NumInstances])
-            : ComponentBatch(&data[0], NumInstances) {}
-
+        // TODO: why need this??
+        // TODO: make into adapter. Why can't we?
         /// Construct from a temporary list.
         ///
         /// Persists the list into an internal std::vector.
@@ -108,6 +58,27 @@ namespace rerun {
             // Don't assign, since the vector is in an undefined state and assigning may
             // attempt to free data.
             new (&storage.vector_owned) std::vector<TComponent>(data);
+        }
+
+        static ComponentBatch<TComponent> borrow(const TComponent* data, size_t num_instances) {
+            ComponentBatch<TComponent> batch;
+            batch.ownership = BatchOwnership::Borrowed;
+            batch.storage.borrowed.data = data;
+            batch.storage.borrowed.num_instances = num_instances;
+            return batch;
+        }
+
+        /// Construct from a temporary std::vector.
+        ///
+        /// Takes ownership of the data and moves it into the component batch.
+        static ComponentBatch<TComponent> take_ownership(std::vector<TComponent>&& data) {
+            ComponentBatch<TComponent> batch;
+            batch.ownership = BatchOwnership::VectorOwned;
+            // Don't assign, since the vector is in an undefined state and assigning may
+            // attempt to free data.
+            new (&batch.storage.vector_owned) std::vector<TComponent>(std::move(data));
+
+            return batch;
         }
 
         /// Move constructor.
@@ -123,7 +94,11 @@ namespace rerun {
                     new (&storage.vector_owned)
                         std::vector<TComponent>(std::move(other.storage.vector_owned));
                     break;
+                case BatchOwnership::Moved:
+                    // This shouldn't happen but is well defined. We're now also moved!
+                    break;
             }
+            other.ownership = BatchOwnership::Moved;
         }
 
         /// Move assignment
@@ -134,6 +109,7 @@ namespace rerun {
 
         ~ComponentBatch() {
             switch (ownership) {
+                case BatchOwnership::Moved:
                 case BatchOwnership::Borrowed:
                     break; // nothing to do.
                 case BatchOwnership::VectorOwned:
@@ -142,6 +118,9 @@ namespace rerun {
             }
         }
 
+        /// Copy constructor.
+        ComponentBatch(const ComponentBatch<TComponent>&) = delete;
+
         /// Returns the number of instances in this component batch.
         size_t size() const {
             switch (ownership) {
@@ -149,6 +128,8 @@ namespace rerun {
                     return storage.borrowed.num_instances;
                 case BatchOwnership::VectorOwned:
                     return storage.vector_owned.size();
+                case BatchOwnership::Moved:
+                    return 0;
             }
         }
 
@@ -181,6 +162,12 @@ namespace rerun {
                         std::move(cell_result.value)
                     );
                 }
+
+                case BatchOwnership::Moved:
+                    return Error(
+                        ErrorCode::InvalidOperationOnMovedObject,
+                        "ComponentBatch was already moved and is now invalid."
+                    );
             }
         }
 
@@ -192,6 +179,11 @@ namespace rerun {
 
             /// The component batch owns the data via an std::vector.
             VectorOwned,
+
+            /// The component batch was moved.
+            /// This could be achieved by other means, but this makes it easiest to follow and
+            /// debug.
+            Moved,
         };
 
         BatchOwnership ownership;
@@ -212,6 +204,172 @@ namespace rerun {
 
         ComponentBatchStorage<TComponent> storage;
     };
+
+    template <typename TComponent, typename... TInputArgs>
+    struct ComponentBatchAdapter {
+        template <typename = std::enable_if_t<std::is_constructible_v<TComponent, TInputArgs...>>>
+        ComponentBatch<TComponent> operator()(TInputArgs&&... args) {
+            // TODO(andreas): Optimize this to not allocate a vector, instead have space enough
+            // for a single component. (maybe up to a certain size?)
+            return ComponentBatch<TComponent>::take_ownership(
+                {TComponent(std::forward<TInputArgs>(args)...)}
+            );
+        }
+    };
+
+    // TODO: too many variants here. something is wrong
+
+    /// Adapter of reference to std::vector.
+    ///
+    /// *Attention*: Does *not* take ownership of the data,
+    /// you need to ensure that the data outlives the component batch.
+    template <typename TComponent>
+    struct ComponentBatchAdapter<TComponent, std::vector<TComponent>> {
+        using ComponentType = TComponent;
+
+        ComponentBatch<TComponent> operator()(std::vector<TComponent> input) {
+            return ComponentBatch<TComponent>::take_ownership(std::move(input));
+        }
+    };
+
+    template <typename TComponent>
+    struct ComponentBatchAdapter<TComponent, std::vector<TComponent>&> {
+        using ComponentType = TComponent;
+
+        ComponentBatch<TComponent> operator()(const std::vector<TComponent>& input) {
+            return ComponentBatch<TComponent>::borrow(input.data(), input.size());
+        }
+    };
+
+    template <typename TComponent>
+    struct ComponentBatchAdapter<TComponent, const std::vector<TComponent>&> {
+        using ComponentType = TComponent;
+
+        ComponentBatch<TComponent> operator()(const std::vector<TComponent>& input) {
+            return ComponentBatch<TComponent>::borrow(input.data(), input.size());
+        }
+    };
+
+    template <typename TComponent>
+    struct ComponentBatchAdapter<TComponent, std::vector<TComponent>&&> {
+        using ComponentType = TComponent;
+
+        ComponentBatch<TComponent> operator()(std::vector<TComponent>&& input) {
+            return ComponentBatch<TComponent>::take_ownership(std::move(input));
+        }
+    };
+
+    /// Adapter of reference to std::array.
+    ///
+    /// *Attention*: Does *not* take ownership of the data,
+    /// you need to ensure that the data outlives the component batch.
+    template <typename TComponent, size_t NumInstances>
+    struct ComponentBatchAdapter<TComponent, const std::array<TComponent, NumInstances>&> {
+        using ComponentType = TComponent;
+
+        ComponentBatch<TComponent> operator()(const std::array<TComponent, NumInstances>& array) {
+            return ComponentBatch<TComponent>::borrow(array.data(), NumInstances);
+        }
+    };
+
+    /// Adaptor from a C-Array reference.
+    ///
+    /// *Attention*: Does *not* take ownership of the data,
+    /// you need to ensure that the data outlives the component batch.
+    template <typename TComponent, size_t NumInstances>
+    struct ComponentBatchAdapter<TComponent, TComponent[NumInstances]> {
+        using ComponentType = TComponent;
+
+        ComponentBatch<TComponent> operator()(const TComponent (&array)[NumInstances]) {
+            return ComponentBatch<TComponent>::borrow(array, NumInstances);
+        }
+    };
+
+    template <typename TComponent>
+    struct ComponentBatchAdapter<TComponent, TComponent> {
+        using ComponentType = TComponent;
+
+        ComponentBatch<TComponent> operator()(const TComponent& one_and_only) {
+            return ComponentBatch<TComponent>::borrow(&one_and_only, 1);
+        }
+
+        ComponentBatch<TComponent> operator()(TComponent&& one_and_only) {
+            // TODO(andreas): Optimize this to not allocate a vector, instead have space enough for
+            // a single component. (maybe up to a certain size?)
+            return ComponentBatch<TComponent>::take_ownership({one_and_only});
+        }
+    };
+
+    /// Adapt from an initializer list.
+    ///
+    /// Data in initializer lists is temporary, therefore this has to take ownership.
+    // template <typename TComponent>
+    // struct ComponentBatchAdapter<TComponent, std::initializer_list<TComponent>> {
+    //     using ComponentType = TComponent;
+
+    //     ComponentBatch<TComponent> operator()(std::initializer_list<TComponent> data) {
+    //         return ComponentBatch<TComponent>::take_ownership(std::vector<TComponent>{data});
+    //     }
+    // };
+
+    // ----------------------
+    // TODO: separate file for `AsComponents`
+    // TODO: `AsComponents` should be implemented for archetypes
+    // ----------------------
+
+    template <typename TComponent>
+    struct AsComponents {
+        Result<std::vector<SerializedComponentBatch>> serialize(const TComponent& single_component
+        ) const {
+            const auto result = ComponentBatch<TComponent>(single_component).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
+        }
+    };
+
+    template <typename TComponent>
+    struct AsComponents<std::vector<TComponent>> {
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const std::vector<TComponent>& components
+        ) const {
+            const auto result = ComponentBatch<TComponent>(components).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
+        }
+    };
+
+    template <typename TComponent, size_t NumInstances>
+    struct AsComponents<std::array<TComponent, NumInstances>> {
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const std::array<TComponent, NumInstances>& components
+        ) const {
+            const auto result = ComponentBatch<TComponent>(components).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
+        }
+    };
+
+    template <typename TComponent, size_t NumInstances>
+    struct AsComponents<TComponent[NumInstances]> {
+        Result<std::vector<SerializedComponentBatch>> serialize(const TComponent (&array
+        )[NumInstances]) const {
+            const auto result = ComponentBatch<TComponent>().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
+        }
+    };
+
+    template <typename TComponent>
+    struct AsComponents<ComponentBatch<TComponent>> {
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const ComponentBatch<TComponent>& components
+        ) const {
+            const auto result = components.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            return Result(std::vector<SerializedComponentBatch>{std::move(result.value)});
+        }
+    };
+
 } // namespace rerun
 
 // TODO: add tests for when things are owned or not.

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -4,8 +4,8 @@
 #include <utility>
 #include <vector>
 
-#include "data_cell.hpp"
 #include "result.hpp"
+#include "serialized_component_batch.hpp"
 
 namespace rerun {
     /// The ComponentBatchAdaptor trait is responsible for mapping a list of input arguments to a

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -23,6 +23,11 @@ namespace rerun {
     /// By implementing your own adapters for certain component types, you can map your data to
     /// Rerun types which then can be logged.
     ///
+    /// To implement an adapter for a type T, specialize `ComponentBatchAdapter<TComponent, T>` and
+    /// define `ComponentBatch<TComponent> operator()(const T& input)`.
+    /// It is *highly recommended* to also specify `ComponentBatch<TComponent> operator()(T&&
+    /// input)` in order to to accidentally borrow data that is passed in as a temporary!
+    ///
     /// TODO(andreas): Point to an example here and in the assert.
     template <typename TComponent, typename TInput>
     struct ComponentBatchAdapter {

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -60,17 +60,21 @@ namespace rerun {
 
     /// Generic list of components that are contiguous in memory.
     ///
-    /// Any creation from a non-temporary will neither copy the data nor take ownership of it.
-    /// This means that any data passed in (unless temporary) must outlive the component batch!
+    /// Data in the component batch can either be borrowed or owned.
+    /// * Borrowed: If data is borrowed it *must* outlive its source (in particular, the pointer to
+    /// the source musn't invalidate)
+    /// * Owned: Owned data is copied into an internal std::vector
     ///
-    /// However, when created from a temporary, the component batch will take ownership of the data.
-    /// For details, refer to the documentation of the respective constructor.
+    /// ComponentBatches are either filled explicitly using `ComponentBatch::borrow` or
+    /// `ComponentBatch::take_ownership` or (most commonly) implicitly using the
+    /// `ComponentBatchAdapter` trait (see its documentation for more information on how data can be
+    /// adapted).
     ///
-    /// Implementation notes:
+    /// ## Implementation notes:
     ///
     /// Does intentionally not implement copy construction since this for the owned case this may
-    /// be expensive.Typically, there should be no need to copy component batches, so this more than
-    /// likely indicates a bug inside the Rerun SDK.
+    /// be expensive. Typically, there should be no need to copy component batches, so this more
+    /// than likely indicates a bug inside the Rerun SDK.
     template <typename TComponent>
     class ComponentBatch {
       public:

--- a/rerun_cpp/src/rerun/data_cell.hpp
+++ b/rerun_cpp/src/rerun/data_cell.hpp
@@ -7,6 +7,7 @@ namespace arrow {
 }
 
 namespace rerun {
+    /// Equivalent to `rr_data_cell` from the C API.
     struct DataCell {
         /// Name of the logged component.
         const char* component_name;
@@ -18,16 +19,5 @@ namespace rerun {
         /// * <https://arrow.apache.org/docs/format/Columnar.html#format-ipc>
         /// * <https://wesm.github.io/arrow-site-test/format/IPC.html#encapsulated-message-format>
         std::shared_ptr<arrow::Buffer> buffer;
-    };
-
-    // TODO: move and document?
-    struct SerializedComponentBatch {
-        SerializedComponentBatch() = default;
-
-        SerializedComponentBatch(size_t _num_instances, DataCell _data_cell)
-            : num_instances(_num_instances), data_cell(std::move(_data_cell)) {}
-
-        size_t num_instances;
-        DataCell data_cell;
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/data_cell.hpp
+++ b/rerun_cpp/src/rerun/data_cell.hpp
@@ -19,4 +19,15 @@ namespace rerun {
         /// * <https://wesm.github.io/arrow-site-test/format/IPC.html#encapsulated-message-format>
         std::shared_ptr<arrow::Buffer> buffer;
     };
+
+    // TODO: move and document?
+    struct SerializedComponentBatch {
+        SerializedComponentBatch() = default;
+
+        SerializedComponentBatch(size_t _num_instances, DataCell _data_cell)
+            : num_instances(_num_instances), data_cell(std::move(_data_cell)) {}
+
+        size_t num_instances;
+        DataCell data_cell;
+    };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/error.hpp
+++ b/rerun_cpp/src/rerun/error.hpp
@@ -30,7 +30,6 @@ namespace rerun {
         Ok = 0x0000'0000,
         OutOfMemory = 0x0000'0001,
         NotImplemented = 0x0000'0002,
-        InvalidOperationOnMovedObject = 0x0000'0003,
 
         // Invalid argument errors.
         _CategoryArgument = 0x0000'0010,

--- a/rerun_cpp/src/rerun/error.hpp
+++ b/rerun_cpp/src/rerun/error.hpp
@@ -30,6 +30,7 @@ namespace rerun {
         Ok = 0x0000'0000,
         OutOfMemory = 0x0000'0001,
         NotImplemented = 0x0000'0002,
+        InvalidOperationOnMovedObject = 0x0000'0003,
 
         // Invalid argument errors.
         _CategoryArgument = 0x0000'0010,

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -94,7 +94,7 @@ namespace rerun {
         rr_recording_stream_flush_blocking(_id);
     }
 
-    Error RecordingStream::try_log_component_batches(
+    Error RecordingStream::try_log_serialized_batches(
         const char* entity_path, size_t num_instances,
         const std::vector<SerializedComponentBatch>& batches
     ) {

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -95,18 +95,18 @@ namespace rerun {
     }
 
     Error RecordingStream::try_log_serialized_batches(
-        const char* entity_path, size_t num_instances,
-        const std::vector<SerializedComponentBatch>& batches
+        const char* entity_path, const std::vector<SerializedComponentBatch>& batches
     ) {
-        if (num_instances == 0) {
-            return Error::ok();
+        size_t num_instances_max = 0;
+        for (const auto& batch : batches) {
+            num_instances_max = std::max(num_instances_max, batch.num_instances);
         }
 
         std::vector<DataCell> instanced;
         std::vector<DataCell> splatted;
 
         for (const auto& batch : batches) {
-            if (num_instances > 1 && batch.num_instances == 1) {
+            if (num_instances_max > 1 && batch.num_instances == 1) {
                 splatted.push_back(batch.data_cell);
             } else {
                 instanced.push_back(batch.data_cell);
@@ -121,7 +121,7 @@ namespace rerun {
             }
         }
 
-        return try_log_data_row(entity_path, num_instances, instanced.size(), instanced.data());
+        return try_log_data_row(entity_path, num_instances_max, instanced.size(), instanced.data());
     }
 
     Error RecordingStream::try_log_data_row(

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -96,7 +96,7 @@ namespace rerun {
 
     Error RecordingStream::try_log_component_batches(
         const char* entity_path, size_t num_instances,
-        const std::vector<AnonymousComponentBatch>& component_lists
+        const std::vector<SerializedComponentBatch>& batches
     ) {
         if (num_instances == 0) {
             return Error::ok();
@@ -105,15 +105,11 @@ namespace rerun {
         std::vector<DataCell> instanced;
         std::vector<DataCell> splatted;
 
-        for (const auto& component_list : component_lists) {
-            const auto result = component_list.to_data_cell();
-            if (result.is_err()) {
-                return result.error;
-            }
-            if (num_instances > 1 && component_list.num_instances == 1) {
-                splatted.push_back(result.value);
+        for (const auto& batch : batches) {
+            if (num_instances > 1 && batch.num_instances == 1) {
+                splatted.push_back(batch.data_cell);
             } else {
-                instanced.push_back(result.value);
+                instanced.push_back(batch.data_cell);
             }
         }
 

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -3,7 +3,7 @@
 #include <cstdint> // uint32_t etc.
 #include <vector>
 
-#include "component_batch.hpp"
+#include "as_components.hpp"
 #include "error.hpp"
 
 namespace rerun {

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -183,7 +183,7 @@ namespace rerun {
 
         /// Logs several serialized batches batches, returning an error on failure.
         ///
-        /// The number of instances in each batch must either be equal to each other or:
+        /// The number of instances in each batch must either be equal to the maximum or:
         /// - zero instances - implies a clear
         /// - single instance (but other instances have more) - causes a splat
         Error try_log_serialized_batches(

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -134,7 +134,7 @@ namespace rerun {
         /// @see try_log
         template <typename T>
         void log(const char* entity_path, const T& archetype_or_component_batch) {
-            const auto serialized = AsComponents<T>().serialize(archetype_or_component_batch);
+            const auto serialized = AsComponents<T>::serialize(archetype_or_component_batch);
             serialized.error.log_on_failure();
             try_log_serialized_batches(entity_path, serialized.value.size(), {serialized.value})
                 .log_on_failure();
@@ -149,7 +149,7 @@ namespace rerun {
         /// @see log_component_batch, log_component_batches, try_log_component_batches
         template <typename T>
         Error try_log(const char* entity_path, const T& archetype_or_component_batch) {
-            const auto serialized = AsComponents<T>().serialize(archetype_or_component_batch);
+            const auto serialized = AsComponents<T>::serialize(archetype_or_component_batch);
             RR_RETURN_NOT_OK(serialized.error);
             return try_log_serialized_batches(
                 entity_path,

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -156,7 +156,7 @@ namespace rerun {
                         return;
                     }
 
-                    const auto serialization_result =
+                    const Result<std::vector<SerializedComponentBatch>> serialization_result =
                         AsComponents<Ts>().serialize(archetypes_or_component_batches);
                     if (serialization_result.is_err()) {
                         err = serialization_result.error;

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -136,8 +136,7 @@ namespace rerun {
         void log(const char* entity_path, const T& archetype_or_component_batch) {
             const auto serialized = AsComponents<T>::serialize(archetype_or_component_batch);
             serialized.error.log_on_failure();
-            try_log_serialized_batches(entity_path, serialized.value.size(), {serialized.value})
-                .log_on_failure();
+            try_log_serialized_batches(entity_path, serialized.value).log_on_failure();
         }
 
         /// Tries to log a single archetype or component batch.
@@ -151,11 +150,7 @@ namespace rerun {
         Error try_log(const char* entity_path, const T& archetype_or_component_batch) {
             const auto serialized = AsComponents<T>::serialize(archetype_or_component_batch);
             RR_RETURN_NOT_OK(serialized.error);
-            return try_log_serialized_batches(
-                entity_path,
-                serialized.value.size(),
-                {serialized.value}
-            );
+            return try_log_serialized_batches(entity_path, serialized.value);
         }
 
         /// Logs several component batches.
@@ -225,20 +220,16 @@ namespace rerun {
             );
             RR_RETURN_NOT_OK(err);
 
-            return try_log_serialized_batches(entity_path, num_instances, serialized_batches);
+            return try_log_serialized_batches(entity_path, serialized_batches);
         }
 
         /// Logs several serialized batches batches, returning an error on failure.
         ///
-        /// @param num_instances
-        /// Specify the expected number of component instances present in each
-        /// list. Each can have either:
-        /// - exactly `num_instances` instances,
-        /// - a single instance (splat),
-        /// - or zero instance (clear).
+        /// The number of instances in each batch must either be equal to each other or:
+        /// - zero instances - implies a clear
+        /// - single instance (but other instances have more) - causes a splat
         Error try_log_serialized_batches(
-            const char* entity_path, size_t num_instances,
-            const std::vector<SerializedComponentBatch>& batches
+            const char* entity_path, const std::vector<SerializedComponentBatch>& batches
         );
 
         /// Low level API that logs raw data cells to the recording stream.

--- a/rerun_cpp/src/rerun/serialized_component_batch.hpp
+++ b/rerun_cpp/src/rerun/serialized_component_batch.hpp
@@ -1,0 +1,17 @@
+#include "data_cell.hpp"
+
+namespace rerun {
+    /// An arrow serialized `ComponentBatch`.
+    struct SerializedComponentBatch {
+        SerializedComponentBatch() = default;
+
+        SerializedComponentBatch(size_t _num_instances, DataCell _data_cell)
+            : num_instances(_num_instances), data_cell(std::move(_data_cell)) {}
+
+        /// How many components were serialized.
+        size_t num_instances;
+
+        /// The underlying data.
+        DataCell data_cell;
+    };
+} // namespace rerun

--- a/rerun_cpp/src/rerun/serialized_component_batch.hpp
+++ b/rerun_cpp/src/rerun/serialized_component_batch.hpp
@@ -1,7 +1,7 @@
 #include "data_cell.hpp"
 
 namespace rerun {
-    /// An arrow serialized `ComponentBatch`.
+    /// A `ComponentBatch` serialized using Apache Arrow.
     struct SerializedComponentBatch {
         SerializedComponentBatch() = default;
 

--- a/rerun_cpp/tests/archetypes/annotation_context.cpp
+++ b/rerun_cpp/tests/archetypes/annotation_context.cpp
@@ -81,6 +81,6 @@ SCENARIO(
             }
         }
 
-        test_serialization_for_manual_and_builder(from_utilities, manual_archetype);
+        test_compare_archetype_serialization(from_utilities, manual_archetype);
     }
 }

--- a/rerun_cpp/tests/archetypes/archetype_test.hpp
+++ b/rerun_cpp/tests/archetypes/archetype_test.hpp
@@ -3,14 +3,15 @@
 #include <arrow/buffer.h>
 #include <catch2/catch_test_macros.hpp>
 
+#include <rerun/as_components.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/data_cell.hpp>
 
 template <typename T>
 void test_serialization_for_manual_and_builder(const T& from_manual, const T& from_builder) {
     THEN("convert to component lists") {
-        auto from_builder_serialized_result = from_builder.serialize();
-        auto from_manual_serialized_result = from_manual.serialize();
+        auto from_builder_serialized_result = rerun::AsComponents<T>().serialize(from_builder);
+        auto from_manual_serialized_result = rerun::AsComponents<T>().serialize(from_manual);
 
         AND_THEN("serializing each list succeeds") {
             REQUIRE(from_builder_serialized_result.is_ok());

--- a/rerun_cpp/tests/archetypes/archetype_test.hpp
+++ b/rerun_cpp/tests/archetypes/archetype_test.hpp
@@ -10,8 +10,8 @@
 template <typename T>
 void test_serialization_for_manual_and_builder(const T& from_manual, const T& from_builder) {
     THEN("convert to component lists") {
-        auto from_builder_serialized_result = rerun::AsComponents<T>().serialize(from_builder);
-        auto from_manual_serialized_result = rerun::AsComponents<T>().serialize(from_manual);
+        auto from_builder_serialized_result = rerun::AsComponents<T>::serialize(from_builder);
+        auto from_manual_serialized_result = rerun::AsComponents<T>::serialize(from_manual);
 
         AND_THEN("serializing each list succeeds") {
             REQUIRE(from_builder_serialized_result.is_ok());

--- a/rerun_cpp/tests/archetypes/archetype_test.hpp
+++ b/rerun_cpp/tests/archetypes/archetype_test.hpp
@@ -8,31 +8,28 @@
 #include <rerun/data_cell.hpp>
 
 template <typename T>
-void test_serialization_for_manual_and_builder(const T& from_manual, const T& from_builder) {
+void test_compare_archetype_serialization(const T& arch_a, const T& arch_b) {
     THEN("convert to component lists") {
-        auto from_builder_serialized_result = rerun::AsComponents<T>::serialize(from_builder);
-        auto from_manual_serialized_result = rerun::AsComponents<T>::serialize(from_manual);
+        auto arch_b_serialized_result = rerun::AsComponents<T>::serialize(arch_b);
+        auto arch_a_serialized_result = rerun::AsComponents<T>::serialize(arch_a);
 
         AND_THEN("serializing each list succeeds") {
-            REQUIRE(from_builder_serialized_result.is_ok());
-            REQUIRE(from_manual_serialized_result.is_ok());
+            REQUIRE(arch_b_serialized_result.is_ok());
+            REQUIRE(arch_a_serialized_result.is_ok());
 
-            const auto& from_builder_serialized = from_builder_serialized_result.value;
-            const auto& from_manual_serialized = from_manual_serialized_result.value;
-            REQUIRE(from_builder_serialized.size() == from_manual_serialized.size());
+            const auto& arch_b_serialized = arch_b_serialized_result.value;
+            const auto& arch_a_serialized = arch_a_serialized_result.value;
+            REQUIRE(arch_b_serialized.size() == arch_a_serialized.size());
 
             AND_THEN("the serialized data is the same") {
-                for (size_t i = 0; i < from_builder_serialized.size(); ++i) {
+                for (size_t i = 0; i < arch_b_serialized.size(); ++i) {
+                    CHECK(arch_b_serialized[i].num_instances == arch_a_serialized[i].num_instances);
                     CHECK(
-                        from_builder_serialized[i].num_instances ==
-                        from_manual_serialized[i].num_instances
+                        arch_b_serialized[i].data_cell.component_name ==
+                        arch_a_serialized[i].data_cell.component_name
                     );
-                    CHECK(
-                        from_builder_serialized[i].data_cell.component_name ==
-                        from_manual_serialized[i].data_cell.component_name
-                    );
-                    CHECK(from_builder_serialized[i].data_cell.buffer->Equals(
-                        *from_manual_serialized[i].data_cell.buffer
+                    CHECK(arch_b_serialized[i].data_cell.buffer->Equals(
+                        *arch_a_serialized[i].data_cell.buffer
                     ));
                 }
             }

--- a/rerun_cpp/tests/archetypes/archetype_test.hpp
+++ b/rerun_cpp/tests/archetypes/archetype_test.hpp
@@ -9,33 +9,30 @@
 template <typename T>
 void test_serialization_for_manual_and_builder(const T& from_manual, const T& from_builder) {
     THEN("convert to component lists") {
-        std::vector<rerun::AnonymousComponentBatch> from_builder_lists =
-            from_builder.as_component_batches();
-        std::vector<rerun::AnonymousComponentBatch> from_manual_lists =
-            from_manual.as_component_batches();
-
-        REQUIRE(from_builder_lists.size() == from_manual_lists.size());
+        auto from_builder_serialized_result = from_builder.serialize();
+        auto from_manual_serialized_result = from_manual.serialize();
 
         AND_THEN("serializing each list succeeds") {
-            std::vector<rerun::DataCell> from_builder_cells;
-            std::vector<rerun::DataCell> from_manual_cells;
-            for (size_t i = 0; i < from_builder_lists.size(); ++i) {
-                auto from_builder_cell = from_builder_lists[i].to_data_cell();
-                auto from_manual_cell = from_manual_lists[i].to_data_cell();
+            REQUIRE(from_builder_serialized_result.is_ok());
+            REQUIRE(from_manual_serialized_result.is_ok());
 
-                REQUIRE(from_builder_cell.is_ok());
-                REQUIRE(from_manual_cell.is_ok());
-
-                from_builder_cells.push_back(from_builder_cell.value);
-                from_manual_cells.push_back(from_manual_cell.value);
-            }
+            const auto& from_builder_serialized = from_builder_serialized_result.value;
+            const auto& from_manual_serialized = from_manual_serialized_result.value;
+            REQUIRE(from_builder_serialized.size() == from_manual_serialized.size());
 
             AND_THEN("the serialized data is the same") {
-                for (size_t i = 0; i < from_builder_lists.size(); ++i) {
+                for (size_t i = 0; i < from_builder_serialized.size(); ++i) {
                     CHECK(
-                        from_builder_cells[i].component_name == from_manual_cells[i].component_name
+                        from_builder_serialized[i].num_instances ==
+                        from_manual_serialized[i].num_instances
                     );
-                    CHECK(from_builder_cells[i].buffer->Equals(*from_manual_cells[i].buffer));
+                    CHECK(
+                        from_builder_serialized[i].data_cell.component_name ==
+                        from_manual_serialized[i].data_cell.component_name
+                    );
+                    CHECK(from_builder_serialized[i].data_cell.buffer->Equals(
+                        *from_manual_serialized[i].data_cell.buffer
+                    ));
                 }
             }
         }

--- a/rerun_cpp/tests/archetypes/arrows3d.cpp
+++ b/rerun_cpp/tests/archetypes/arrows3d.cpp
@@ -29,6 +29,6 @@ SCENARIO(
         from_manual.class_ids = {126, 127};
         from_manual.instance_keys = {123ull, 124ull};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
+        test_compare_archetype_serialization(from_manual, from_builder);
     }
 }

--- a/rerun_cpp/tests/archetypes/boxes2d.cpp
+++ b/rerun_cpp/tests/archetypes/boxes2d.cpp
@@ -31,7 +31,7 @@
 //         from_manual.class_ids = {126, 127};
 //         from_manual.instance_keys = {66ull, 666ull};
 
-//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//         test_compare_archetype_serialization(from_manual, from_builder);
 //     }
 
 //     GIVEN("Constructed from via from_centers_and_half_sizes and manually") {
@@ -41,7 +41,7 @@
 //         from_manual.centers = {{1.f, 2.f}};
 //         from_manual.half_sizes = {{4.f, 6.f}};
 
-//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//         test_compare_archetype_serialization(from_manual, from_builder);
 //     }
 
 //     GIVEN("Constructed from via from_sizes and manually") {
@@ -50,7 +50,7 @@
 //         Boxes2D from_manual;
 //         from_manual.half_sizes = {{0.5f, 1.f}};
 
-//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//         test_compare_archetype_serialization(from_manual, from_builder);
 //     }
 
 //     GIVEN("Constructed from via from_centers_and_sizes and manually") {
@@ -60,7 +60,7 @@
 //         from_manual.centers = {{1.f, 2.f}};
 //         from_manual.half_sizes = {{2.f, 3.f}};
 
-//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//         test_compare_archetype_serialization(from_manual, from_builder);
 //     }
 
 //     GIVEN("Constructed from via from_mins_and_sizes and manually") {
@@ -70,6 +70,6 @@
 //         from_manual.centers = {{0.f, 1.f}};
 //         from_manual.half_sizes = {{1.f, 2.f}};
 
-//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//         test_compare_archetype_serialization(from_manual, from_builder);
 //     }
 // }

--- a/rerun_cpp/tests/archetypes/boxes2d.cpp
+++ b/rerun_cpp/tests/archetypes/boxes2d.cpp
@@ -1,75 +1,75 @@
-// #include "archetype_test.hpp"
+#include "archetype_test.hpp"
 
-// #include <rerun/archetypes/boxes2d.hpp>
+#include <rerun/archetypes/boxes2d.hpp>
 
-// using namespace rerun::archetypes;
+using namespace rerun::archetypes;
 
-// #define TEST_TAG "[boxes2d][archetypes]"
+#define TEST_TAG "[boxes2d][archetypes]"
 
-// SCENARIO(
-//     "Boxes2D archetype can be serialized with the same result for manually built instances and "
-//     "the builder pattern",
-//     TEST_TAG
-// ) {
-//     GIVEN("Constructed from builder via from_half_sizes and manually") {
-//         auto from_builder = Boxes2D::from_half_sizes({{10.f, 9.f}, {5.f, -5.f}})
-//                                 .with_centers({{0.f, 0.f}, {-1.f, 1.f}})
-//                                 .with_colors({0xAA0000CC, 0x00BB00DD})
-//                                 .with_labels({"hello", "friend"})
-//                                 .with_radii({0.1f, 1.0f})
-//                                 .with_draw_order(300.0f)
-//                                 .with_class_ids({126, 127})
-//                                 .with_instance_keys({66, 666});
+SCENARIO(
+    "Boxes2D archetype can be serialized with the same result for manually built instances and "
+    "the builder pattern",
+    TEST_TAG
+) {
+    GIVEN("Constructed from builder via from_half_sizes and manually") {
+        auto from_builder = Boxes2D::from_half_sizes({{10.f, 9.f}, {5.f, -5.f}})
+                                .with_centers({{0.f, 0.f}, {-1.f, 1.f}})
+                                .with_colors({0xAA0000CC, 0x00BB00DD})
+                                .with_labels({"hello", "friend"})
+                                .with_radii({0.1f, 1.0f})
+                                .with_draw_order(300.0f)
+                                .with_class_ids({126, 127})
+                                .with_instance_keys({66, 666});
 
-//         Boxes2D from_manual;
-//         from_manual.half_sizes = {{10.f, 9.f}, {5.f, -5.f}};
-//         from_manual.centers = {{0.f, 0.f}, {-1.f, 1.f}};
-//         from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
-//         from_manual.labels = {"hello", "friend"};
-//         from_manual.radii = {0.1f, 1.0f};
-//         from_manual.draw_order = 300.0f;
-//         from_manual.class_ids = {126, 127};
-//         from_manual.instance_keys = {66ull, 666ull};
+        Boxes2D from_manual;
+        from_manual.half_sizes = {{10.f, 9.f}, {5.f, -5.f}};
+        from_manual.centers = {{0.f, 0.f}, {-1.f, 1.f}};
+        from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
+        from_manual.labels = {"hello", "friend"};
+        from_manual.radii = {0.1f, 1.0f};
+        from_manual.draw_order = 300.0f;
+        from_manual.class_ids = {126, 127};
+        from_manual.instance_keys = {66ull, 666ull};
 
-//         test_compare_archetype_serialization(from_manual, from_builder);
-//     }
+        test_compare_archetype_serialization(from_manual, from_builder);
+    }
 
-//     GIVEN("Constructed from via from_centers_and_half_sizes and manually") {
-//         auto from_builder = Boxes2D::from_centers_and_half_sizes({{1.f, 2.f}}, {{4.f, 6.f}});
+    GIVEN("Constructed from via from_centers_and_half_sizes and manually") {
+        auto from_builder = Boxes2D::from_centers_and_half_sizes({{1.f, 2.f}}, {{4.f, 6.f}});
 
-//         Boxes2D from_manual;
-//         from_manual.centers = {{1.f, 2.f}};
-//         from_manual.half_sizes = {{4.f, 6.f}};
+        Boxes2D from_manual;
+        from_manual.centers = {{1.f, 2.f}};
+        from_manual.half_sizes = {{4.f, 6.f}};
 
-//         test_compare_archetype_serialization(from_manual, from_builder);
-//     }
+        test_compare_archetype_serialization(from_manual, from_builder);
+    }
 
-//     GIVEN("Constructed from via from_sizes and manually") {
-//         auto from_builder = Boxes2D::from_sizes({{1.f, 2.f}});
+    GIVEN("Constructed from via from_sizes and manually") {
+        auto from_builder = Boxes2D::from_sizes({{1.f, 2.f}});
 
-//         Boxes2D from_manual;
-//         from_manual.half_sizes = {{0.5f, 1.f}};
+        Boxes2D from_manual;
+        from_manual.half_sizes = {{0.5f, 1.f}};
 
-//         test_compare_archetype_serialization(from_manual, from_builder);
-//     }
+        test_compare_archetype_serialization(from_manual, from_builder);
+    }
 
-//     GIVEN("Constructed from via from_centers_and_sizes and manually") {
-//         auto from_builder = Boxes2D::from_centers_and_sizes({{1.f, 2.f}}, {{4.f, 6.f}});
+    GIVEN("Constructed from via from_centers_and_sizes and manually") {
+        auto from_builder = Boxes2D::from_centers_and_sizes({{1.f, 2.f}}, {{4.f, 6.f}});
 
-//         Boxes2D from_manual;
-//         from_manual.centers = {{1.f, 2.f}};
-//         from_manual.half_sizes = {{2.f, 3.f}};
+        Boxes2D from_manual;
+        from_manual.centers = {{1.f, 2.f}};
+        from_manual.half_sizes = {{2.f, 3.f}};
 
-//         test_compare_archetype_serialization(from_manual, from_builder);
-//     }
+        test_compare_archetype_serialization(from_manual, from_builder);
+    }
 
-//     GIVEN("Constructed from via from_mins_and_sizes and manually") {
-//         auto from_builder = Boxes2D::from_mins_and_sizes({{-1.f, -1.f}}, {{2.f, 4.f}});
+    GIVEN("Constructed from via from_mins_and_sizes and manually") {
+        auto from_builder = Boxes2D::from_mins_and_sizes({{-1.f, -1.f}}, {{2.f, 4.f}});
 
-//         Boxes2D from_manual;
-//         from_manual.centers = {{0.f, 1.f}};
-//         from_manual.half_sizes = {{1.f, 2.f}};
+        Boxes2D from_manual;
+        from_manual.centers = {{0.f, 1.f}};
+        from_manual.half_sizes = {{1.f, 2.f}};
 
-//         test_compare_archetype_serialization(from_manual, from_builder);
-//     }
-// }
+        test_compare_archetype_serialization(from_manual, from_builder);
+    }
+}

--- a/rerun_cpp/tests/archetypes/boxes2d.cpp
+++ b/rerun_cpp/tests/archetypes/boxes2d.cpp
@@ -1,75 +1,75 @@
-#include "archetype_test.hpp"
+// #include "archetype_test.hpp"
 
-#include <rerun/archetypes/boxes2d.hpp>
+// #include <rerun/archetypes/boxes2d.hpp>
 
-using namespace rerun::archetypes;
+// using namespace rerun::archetypes;
 
-#define TEST_TAG "[boxes2d][archetypes]"
+// #define TEST_TAG "[boxes2d][archetypes]"
 
-SCENARIO(
-    "Boxes2D archetype can be serialized with the same result for manually built instances and "
-    "the builder pattern",
-    TEST_TAG
-) {
-    GIVEN("Constructed from builder via from_half_sizes and manually") {
-        auto from_builder = Boxes2D::from_half_sizes({{10.f, 9.f}, {5.f, -5.f}})
-                                .with_centers({{0.f, 0.f}, {-1.f, 1.f}})
-                                .with_colors({0xAA0000CC, 0x00BB00DD})
-                                .with_labels({"hello", "friend"})
-                                .with_radii({0.1f, 1.0f})
-                                .with_draw_order(300.0f)
-                                .with_class_ids({126, 127})
-                                .with_instance_keys({66, 666});
+// SCENARIO(
+//     "Boxes2D archetype can be serialized with the same result for manually built instances and "
+//     "the builder pattern",
+//     TEST_TAG
+// ) {
+//     GIVEN("Constructed from builder via from_half_sizes and manually") {
+//         auto from_builder = Boxes2D::from_half_sizes({{10.f, 9.f}, {5.f, -5.f}})
+//                                 .with_centers({{0.f, 0.f}, {-1.f, 1.f}})
+//                                 .with_colors({0xAA0000CC, 0x00BB00DD})
+//                                 .with_labels({"hello", "friend"})
+//                                 .with_radii({0.1f, 1.0f})
+//                                 .with_draw_order(300.0f)
+//                                 .with_class_ids({126, 127})
+//                                 .with_instance_keys({66, 666});
 
-        Boxes2D from_manual;
-        from_manual.half_sizes = {{10.f, 9.f}, {5.f, -5.f}};
-        from_manual.centers = {{0.f, 0.f}, {-1.f, 1.f}};
-        from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
-        from_manual.labels = {"hello", "friend"};
-        from_manual.radii = {0.1f, 1.0f};
-        from_manual.draw_order = 300.0f;
-        from_manual.class_ids = {126, 127};
-        from_manual.instance_keys = {66ull, 666ull};
+//         Boxes2D from_manual;
+//         from_manual.half_sizes = {{10.f, 9.f}, {5.f, -5.f}};
+//         from_manual.centers = {{0.f, 0.f}, {-1.f, 1.f}};
+//         from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
+//         from_manual.labels = {"hello", "friend"};
+//         from_manual.radii = {0.1f, 1.0f};
+//         from_manual.draw_order = 300.0f;
+//         from_manual.class_ids = {126, 127};
+//         from_manual.instance_keys = {66ull, 666ull};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
-    }
+//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//     }
 
-    GIVEN("Constructed from via from_centers_and_half_sizes and manually") {
-        auto from_builder = Boxes2D::from_centers_and_half_sizes({{1.f, 2.f}}, {{4.f, 6.f}});
+//     GIVEN("Constructed from via from_centers_and_half_sizes and manually") {
+//         auto from_builder = Boxes2D::from_centers_and_half_sizes({{1.f, 2.f}}, {{4.f, 6.f}});
 
-        Boxes2D from_manual;
-        from_manual.centers = {{1.f, 2.f}};
-        from_manual.half_sizes = {{4.f, 6.f}};
+//         Boxes2D from_manual;
+//         from_manual.centers = {{1.f, 2.f}};
+//         from_manual.half_sizes = {{4.f, 6.f}};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
-    }
+//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//     }
 
-    GIVEN("Constructed from via from_sizes and manually") {
-        auto from_builder = Boxes2D::from_sizes({{1.f, 2.f}});
+//     GIVEN("Constructed from via from_sizes and manually") {
+//         auto from_builder = Boxes2D::from_sizes({{1.f, 2.f}});
 
-        Boxes2D from_manual;
-        from_manual.half_sizes = {{0.5f, 1.f}};
+//         Boxes2D from_manual;
+//         from_manual.half_sizes = {{0.5f, 1.f}};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
-    }
+//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//     }
 
-    GIVEN("Constructed from via from_centers_and_sizes and manually") {
-        auto from_builder = Boxes2D::from_centers_and_sizes({{1.f, 2.f}}, {{4.f, 6.f}});
+//     GIVEN("Constructed from via from_centers_and_sizes and manually") {
+//         auto from_builder = Boxes2D::from_centers_and_sizes({{1.f, 2.f}}, {{4.f, 6.f}});
 
-        Boxes2D from_manual;
-        from_manual.centers = {{1.f, 2.f}};
-        from_manual.half_sizes = {{2.f, 3.f}};
+//         Boxes2D from_manual;
+//         from_manual.centers = {{1.f, 2.f}};
+//         from_manual.half_sizes = {{2.f, 3.f}};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
-    }
+//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//     }
 
-    GIVEN("Constructed from via from_mins_and_sizes and manually") {
-        auto from_builder = Boxes2D::from_mins_and_sizes({{-1.f, -1.f}}, {{2.f, 4.f}});
+//     GIVEN("Constructed from via from_mins_and_sizes and manually") {
+//         auto from_builder = Boxes2D::from_mins_and_sizes({{-1.f, -1.f}}, {{2.f, 4.f}});
 
-        Boxes2D from_manual;
-        from_manual.centers = {{0.f, 1.f}};
-        from_manual.half_sizes = {{1.f, 2.f}};
+//         Boxes2D from_manual;
+//         from_manual.centers = {{0.f, 1.f}};
+//         from_manual.half_sizes = {{1.f, 2.f}};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
-    }
-}
+//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//     }
+// }

--- a/rerun_cpp/tests/archetypes/boxes3d.cpp
+++ b/rerun_cpp/tests/archetypes/boxes3d.cpp
@@ -1,85 +1,83 @@
-// #include "archetype_test.hpp"
+#include "archetype_test.hpp"
 
-// #include <rerun/archetypes/boxes3d.hpp>
+#include <rerun/archetypes/boxes3d.hpp>
 
-// using namespace rerun::archetypes;
-// using namespace rerun::datatypes;
+using namespace rerun::archetypes;
+using namespace rerun::datatypes;
 
-// #define TEST_TAG "[boxes3d][archetypes]"
+#define TEST_TAG "[boxes3d][archetypes]"
 
-// SCENARIO(
-//     "Boxes3D archetype can be serialized with the same result for manually built instances and "
-//     "the builder pattern",
-//     TEST_TAG
-// ) {
-//     GIVEN("Constructed from builder via from_half_sizes and manually") {
-//         auto from_builder = Boxes3D::from_half_sizes({{10.f, 9.f, 8.f}, {5.f, -5.f, 5.f}})
-//                                 .with_centers({{0.f, 0.f, 0.f}, {-1.f, 1.f, -2.f}})
-//                                 .with_rotations({
-//                                     Quaternion(0.f, 1.f, 2.f, 3.f),
-//                                     RotationAxisAngle({0.f, 1.f, 2.f}, Angle::radians(45.f)),
-//                                 })
-//                                 .with_colors({0xAA0000CC, 0x00BB00DD})
-//                                 .with_labels({"hello", "friend"})
-//                                 .with_radii({0.1f, 1.0f})
-//                                 .with_class_ids({126, 127})
-//                                 .with_instance_keys({66, 666});
+SCENARIO(
+    "Boxes3D archetype can be serialized with the same result for manually built instances and "
+    "the builder pattern",
+    TEST_TAG
+) {
+    GIVEN("Constructed from builder via from_half_sizes and manually") {
+        auto from_builder = Boxes3D::from_half_sizes({{10.f, 9.f, 8.f}, {5.f, -5.f, 5.f}})
+                                .with_centers({{0.f, 0.f, 0.f}, {-1.f, 1.f, -2.f}})
+                                .with_rotations({
+                                    Quaternion(0.f, 1.f, 2.f, 3.f),
+                                    RotationAxisAngle({0.f, 1.f, 2.f}, Angle::radians(45.f)),
+                                })
+                                .with_colors({0xAA0000CC, 0x00BB00DD})
+                                .with_labels({"hello", "friend"})
+                                .with_radii({0.1f, 1.0f})
+                                .with_class_ids({126, 127})
+                                .with_instance_keys({66, 666});
 
-//         Boxes3D from_manual;
-//         from_manual.half_sizes = {{10.f, 9.f, 8.f}, {5.f, -5.f, 5.f}};
-//         from_manual.centers = {{0.f, 0.f, 0.f}, {-1.f, 1.f, -2.f}};
-//         from_manual.rotations = {
-//             Quaternion(0.f, 1.f, 2.f, 3.f),
-//             RotationAxisAngle({0.f, 1.f, 2.f}, Angle::radians(45.f)),
-//         };
-//         from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
-//         from_manual.labels = {"hello", "friend"};
-//         from_manual.radii = {0.1f, 1.0f};
-//         from_manual.class_ids = {126, 127};
-//         from_manual.instance_keys = {66ull, 666ull};
+        Boxes3D from_manual;
+        from_manual.half_sizes = {{10.f, 9.f, 8.f}, {5.f, -5.f, 5.f}};
+        from_manual.centers = {{0.f, 0.f, 0.f}, {-1.f, 1.f, -2.f}};
+        from_manual.rotations = {
+            Quaternion(0.f, 1.f, 2.f, 3.f),
+            RotationAxisAngle({0.f, 1.f, 2.f}, Angle::radians(45.f)),
+        };
+        from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
+        from_manual.labels = {"hello", "friend"};
+        from_manual.radii = {0.1f, 1.0f};
+        from_manual.class_ids = {126, 127};
+        from_manual.instance_keys = {66ull, 666ull};
 
-//         test_compare_archetype_serialization(from_manual, from_builder);
-//     }
+        test_compare_archetype_serialization(from_manual, from_builder);
+    }
 
-//     GIVEN("Constructed from via from_centers_and_half_sizes and manually") {
-//         auto from_builder =
-//             Boxes3D::from_centers_and_half_sizes({{1.f, 2.f, 3.f}}, {{4.f, 6.f, 8.f}});
+    GIVEN("Constructed from via from_centers_and_half_sizes and manually") {
+        auto from_builder =
+            Boxes3D::from_centers_and_half_sizes({{1.f, 2.f, 3.f}}, {{4.f, 6.f, 8.f}});
 
-//         Boxes3D from_manual;
-//         from_manual.centers = {{1.f, 2.f, 3.f}};
-//         from_manual.half_sizes = {{4.f, 6.f, 8.f}};
+        Boxes3D from_manual;
+        from_manual.centers = {{1.f, 2.f, 3.f}};
+        from_manual.half_sizes = {{4.f, 6.f, 8.f}};
 
-//         test_compare_archetype_serialization(from_manual, from_builder);
-//     }
+        test_compare_archetype_serialization(from_manual, from_builder);
+    }
 
-//     GIVEN("Constructed from via from_sizes and manually") {
-//         auto from_builder = Boxes3D::from_sizes({{1.f, 2.f, 3.f}});
+    GIVEN("Constructed from via from_sizes and manually") {
+        auto from_builder = Boxes3D::from_sizes({{1.f, 2.f, 3.f}});
 
-//         Boxes3D from_manual;
-//         from_manual.half_sizes = {{0.5f, 1.f, 1.5f}};
+        Boxes3D from_manual;
+        from_manual.half_sizes = {{0.5f, 1.f, 1.5f}};
 
-//         test_compare_archetype_serialization(from_manual, from_builder);
-//     }
+        test_compare_archetype_serialization(from_manual, from_builder);
+    }
 
-//     GIVEN("Constructed from via from_centers_and_sizes and manually") {
-//         auto from_builder = Boxes3D::from_centers_and_sizes({{1.f, 2.f, 3.f}},
-//         {{4.f, 6.f, 8.f}});
+    GIVEN("Constructed from via from_centers_and_sizes and manually") {
+        auto from_builder = Boxes3D::from_centers_and_sizes({{1.f, 2.f, 3.f}}, {{4.f, 6.f, 8.f}});
 
-//         Boxes3D from_manual;
-//         from_manual.centers = {{1.f, 2.f, 3.f}};
-//         from_manual.half_sizes = {{2.f, 3.f, 4.f}};
+        Boxes3D from_manual;
+        from_manual.centers = {{1.f, 2.f, 3.f}};
+        from_manual.half_sizes = {{2.f, 3.f, 4.f}};
 
-//         test_compare_archetype_serialization(from_manual, from_builder);
-//     }
+        test_compare_archetype_serialization(from_manual, from_builder);
+    }
 
-//     GIVEN("Constructed from via from_mins_and_sizes and manually") {
-//         auto from_builder = Boxes3D::from_mins_and_sizes({{-1.f, -1.f, -1.f}},
-//         {{2.f, 4.f, 2.f}});
+    GIVEN("Constructed from via from_mins_and_sizes and manually") {
+        auto from_builder = Boxes3D::from_mins_and_sizes({{-1.f, -1.f, -1.f}}, {{2.f, 4.f, 2.f}});
 
-//         Boxes3D from_manual;
-//         from_manual.centers = {{0.f, 1.f, 0.f}};
-//         from_manual.half_sizes = {{1.f, 2.f, 1.f}};
+        Boxes3D from_manual;
+        from_manual.centers = {{0.f, 1.f, 0.f}};
+        from_manual.half_sizes = {{1.f, 2.f, 1.f}};
 
-//         test_compare_archetype_serialization(from_manual, from_builder);
-//     }
-// }
+        test_compare_archetype_serialization(from_manual, from_builder);
+    }
+}

--- a/rerun_cpp/tests/archetypes/boxes3d.cpp
+++ b/rerun_cpp/tests/archetypes/boxes3d.cpp
@@ -38,7 +38,7 @@
 //         from_manual.class_ids = {126, 127};
 //         from_manual.instance_keys = {66ull, 666ull};
 
-//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//         test_compare_archetype_serialization(from_manual, from_builder);
 //     }
 
 //     GIVEN("Constructed from via from_centers_and_half_sizes and manually") {
@@ -49,7 +49,7 @@
 //         from_manual.centers = {{1.f, 2.f, 3.f}};
 //         from_manual.half_sizes = {{4.f, 6.f, 8.f}};
 
-//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//         test_compare_archetype_serialization(from_manual, from_builder);
 //     }
 
 //     GIVEN("Constructed from via from_sizes and manually") {
@@ -58,7 +58,7 @@
 //         Boxes3D from_manual;
 //         from_manual.half_sizes = {{0.5f, 1.f, 1.5f}};
 
-//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//         test_compare_archetype_serialization(from_manual, from_builder);
 //     }
 
 //     GIVEN("Constructed from via from_centers_and_sizes and manually") {
@@ -69,7 +69,7 @@
 //         from_manual.centers = {{1.f, 2.f, 3.f}};
 //         from_manual.half_sizes = {{2.f, 3.f, 4.f}};
 
-//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//         test_compare_archetype_serialization(from_manual, from_builder);
 //     }
 
 //     GIVEN("Constructed from via from_mins_and_sizes and manually") {
@@ -80,6 +80,6 @@
 //         from_manual.centers = {{0.f, 1.f, 0.f}};
 //         from_manual.half_sizes = {{1.f, 2.f, 1.f}};
 
-//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//         test_compare_archetype_serialization(from_manual, from_builder);
 //     }
 // }

--- a/rerun_cpp/tests/archetypes/boxes3d.cpp
+++ b/rerun_cpp/tests/archetypes/boxes3d.cpp
@@ -1,83 +1,85 @@
-#include "archetype_test.hpp"
+// #include "archetype_test.hpp"
 
-#include <rerun/archetypes/boxes3d.hpp>
+// #include <rerun/archetypes/boxes3d.hpp>
 
-using namespace rerun::archetypes;
-using namespace rerun::datatypes;
+// using namespace rerun::archetypes;
+// using namespace rerun::datatypes;
 
-#define TEST_TAG "[boxes3d][archetypes]"
+// #define TEST_TAG "[boxes3d][archetypes]"
 
-SCENARIO(
-    "Boxes3D archetype can be serialized with the same result for manually built instances and "
-    "the builder pattern",
-    TEST_TAG
-) {
-    GIVEN("Constructed from builder via from_half_sizes and manually") {
-        auto from_builder = Boxes3D::from_half_sizes({{10.f, 9.f, 8.f}, {5.f, -5.f, 5.f}})
-                                .with_centers({{0.f, 0.f, 0.f}, {-1.f, 1.f, -2.f}})
-                                .with_rotations({
-                                    Quaternion(0.f, 1.f, 2.f, 3.f),
-                                    RotationAxisAngle({0.f, 1.f, 2.f}, Angle::radians(45.f)),
-                                })
-                                .with_colors({0xAA0000CC, 0x00BB00DD})
-                                .with_labels({"hello", "friend"})
-                                .with_radii({0.1f, 1.0f})
-                                .with_class_ids({126, 127})
-                                .with_instance_keys({66, 666});
+// SCENARIO(
+//     "Boxes3D archetype can be serialized with the same result for manually built instances and "
+//     "the builder pattern",
+//     TEST_TAG
+// ) {
+//     GIVEN("Constructed from builder via from_half_sizes and manually") {
+//         auto from_builder = Boxes3D::from_half_sizes({{10.f, 9.f, 8.f}, {5.f, -5.f, 5.f}})
+//                                 .with_centers({{0.f, 0.f, 0.f}, {-1.f, 1.f, -2.f}})
+//                                 .with_rotations({
+//                                     Quaternion(0.f, 1.f, 2.f, 3.f),
+//                                     RotationAxisAngle({0.f, 1.f, 2.f}, Angle::radians(45.f)),
+//                                 })
+//                                 .with_colors({0xAA0000CC, 0x00BB00DD})
+//                                 .with_labels({"hello", "friend"})
+//                                 .with_radii({0.1f, 1.0f})
+//                                 .with_class_ids({126, 127})
+//                                 .with_instance_keys({66, 666});
 
-        Boxes3D from_manual;
-        from_manual.half_sizes = {{10.f, 9.f, 8.f}, {5.f, -5.f, 5.f}};
-        from_manual.centers = {{0.f, 0.f, 0.f}, {-1.f, 1.f, -2.f}};
-        from_manual.rotations = {
-            Quaternion(0.f, 1.f, 2.f, 3.f),
-            RotationAxisAngle({0.f, 1.f, 2.f}, Angle::radians(45.f)),
-        };
-        from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
-        from_manual.labels = {"hello", "friend"};
-        from_manual.radii = {0.1f, 1.0f};
-        from_manual.class_ids = {126, 127};
-        from_manual.instance_keys = {66ull, 666ull};
+//         Boxes3D from_manual;
+//         from_manual.half_sizes = {{10.f, 9.f, 8.f}, {5.f, -5.f, 5.f}};
+//         from_manual.centers = {{0.f, 0.f, 0.f}, {-1.f, 1.f, -2.f}};
+//         from_manual.rotations = {
+//             Quaternion(0.f, 1.f, 2.f, 3.f),
+//             RotationAxisAngle({0.f, 1.f, 2.f}, Angle::radians(45.f)),
+//         };
+//         from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
+//         from_manual.labels = {"hello", "friend"};
+//         from_manual.radii = {0.1f, 1.0f};
+//         from_manual.class_ids = {126, 127};
+//         from_manual.instance_keys = {66ull, 666ull};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
-    }
+//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//     }
 
-    GIVEN("Constructed from via from_centers_and_half_sizes and manually") {
-        auto from_builder =
-            Boxes3D::from_centers_and_half_sizes({{1.f, 2.f, 3.f}}, {{4.f, 6.f, 8.f}});
+//     GIVEN("Constructed from via from_centers_and_half_sizes and manually") {
+//         auto from_builder =
+//             Boxes3D::from_centers_and_half_sizes({{1.f, 2.f, 3.f}}, {{4.f, 6.f, 8.f}});
 
-        Boxes3D from_manual;
-        from_manual.centers = {{1.f, 2.f, 3.f}};
-        from_manual.half_sizes = {{4.f, 6.f, 8.f}};
+//         Boxes3D from_manual;
+//         from_manual.centers = {{1.f, 2.f, 3.f}};
+//         from_manual.half_sizes = {{4.f, 6.f, 8.f}};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
-    }
+//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//     }
 
-    GIVEN("Constructed from via from_sizes and manually") {
-        auto from_builder = Boxes3D::from_sizes({{1.f, 2.f, 3.f}});
+//     GIVEN("Constructed from via from_sizes and manually") {
+//         auto from_builder = Boxes3D::from_sizes({{1.f, 2.f, 3.f}});
 
-        Boxes3D from_manual;
-        from_manual.half_sizes = {{0.5f, 1.f, 1.5f}};
+//         Boxes3D from_manual;
+//         from_manual.half_sizes = {{0.5f, 1.f, 1.5f}};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
-    }
+//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//     }
 
-    GIVEN("Constructed from via from_centers_and_sizes and manually") {
-        auto from_builder = Boxes3D::from_centers_and_sizes({{1.f, 2.f, 3.f}}, {{4.f, 6.f, 8.f}});
+//     GIVEN("Constructed from via from_centers_and_sizes and manually") {
+//         auto from_builder = Boxes3D::from_centers_and_sizes({{1.f, 2.f, 3.f}},
+//         {{4.f, 6.f, 8.f}});
 
-        Boxes3D from_manual;
-        from_manual.centers = {{1.f, 2.f, 3.f}};
-        from_manual.half_sizes = {{2.f, 3.f, 4.f}};
+//         Boxes3D from_manual;
+//         from_manual.centers = {{1.f, 2.f, 3.f}};
+//         from_manual.half_sizes = {{2.f, 3.f, 4.f}};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
-    }
+//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//     }
 
-    GIVEN("Constructed from via from_mins_and_sizes and manually") {
-        auto from_builder = Boxes3D::from_mins_and_sizes({{-1.f, -1.f, -1.f}}, {{2.f, 4.f, 2.f}});
+//     GIVEN("Constructed from via from_mins_and_sizes and manually") {
+//         auto from_builder = Boxes3D::from_mins_and_sizes({{-1.f, -1.f, -1.f}},
+//         {{2.f, 4.f, 2.f}});
 
-        Boxes3D from_manual;
-        from_manual.centers = {{0.f, 1.f, 0.f}};
-        from_manual.half_sizes = {{1.f, 2.f, 1.f}};
+//         Boxes3D from_manual;
+//         from_manual.centers = {{0.f, 1.f, 0.f}};
+//         from_manual.half_sizes = {{1.f, 2.f, 1.f}};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
-    }
-}
+//         test_serialization_for_manual_and_builder(from_manual, from_builder);
+//     }
+// }

--- a/rerun_cpp/tests/archetypes/clear.cpp
+++ b/rerun_cpp/tests/archetypes/clear.cpp
@@ -11,9 +11,7 @@ SCENARIO("clear archetype can be serialized" TEST_TAG) {
         auto from_builder = Clear(true);
 
         THEN("serialization succeeds") {
-            for (auto& list : from_builder.as_component_batches()) {
-                CHECK(list.to_data_cell().is_ok());
-            }
+            CHECK(from_builder.serialize().is_ok());
         }
     }
 }

--- a/rerun_cpp/tests/archetypes/clear.cpp
+++ b/rerun_cpp/tests/archetypes/clear.cpp
@@ -11,7 +11,7 @@ SCENARIO("clear archetype can be serialized" TEST_TAG) {
         auto from_builder = Clear(true);
 
         THEN("serialization succeeds") {
-            CHECK(from_builder.serialize().is_ok());
+            CHECK(rerun::AsComponents<Clear>().serialize(from_builder).is_ok());
         }
     }
 }

--- a/rerun_cpp/tests/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/tests/archetypes/disconnected_space.cpp
@@ -11,7 +11,7 @@ SCENARIO("disconnected_space archetype can be serialized" TEST_TAG) {
         auto from_builder = DisconnectedSpace(true);
 
         THEN("serialization succeeds") {
-            CHECK(from_builder.serialize().is_ok());
+            CHECK(rerun::AsComponents<DisconnectedSpace>().serialize(from_builder).is_ok());
         }
     }
 }

--- a/rerun_cpp/tests/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/tests/archetypes/disconnected_space.cpp
@@ -11,9 +11,7 @@ SCENARIO("disconnected_space archetype can be serialized" TEST_TAG) {
         auto from_builder = DisconnectedSpace(true);
 
         THEN("serialization succeeds") {
-            for (auto& list : from_builder.as_component_batches()) {
-                CHECK(list.to_data_cell().is_ok());
-            }
+            CHECK(from_builder.serialize().is_ok());
         }
     }
 }

--- a/rerun_cpp/tests/archetypes/lines_strips2d.cpp
+++ b/rerun_cpp/tests/archetypes/lines_strips2d.cpp
@@ -37,6 +37,6 @@ SCENARIO(
         from_manual.instance_keys = {123ull, 124ull};
         from_manual.draw_order = 123;
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
+        test_compare_archetype_serialization(from_manual, from_builder);
     }
 }

--- a/rerun_cpp/tests/archetypes/lines_strips2d.cpp
+++ b/rerun_cpp/tests/archetypes/lines_strips2d.cpp
@@ -26,8 +26,10 @@ SCENARIO(
                 .with_draw_order(123);
 
         LineStrips2D from_manual;
-        from_manual.strips.push_back(rr::components::LineStrip2D({{0.f, 0.f}, {1.f, -1.f}}));
-        from_manual.strips.push_back(rr::components::LineStrip2D({{-1.f, 3.f}, {0.f, 1.5f}}));
+        from_manual.strips = {
+            rr::components::LineStrip2D({{0.f, 0.f}, {1.f, -1.f}}),
+            rr::components::LineStrip2D({{-1.f, 3.f}, {0.f, 1.5f}}),
+        };
         from_manual.radii = {1.0, 10.0};
         from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
         from_manual.labels = {"hello", "friend"};

--- a/rerun_cpp/tests/archetypes/lines_strips3d.cpp
+++ b/rerun_cpp/tests/archetypes/lines_strips3d.cpp
@@ -25,11 +25,10 @@ SCENARIO(
                 .with_instance_keys({123ull, 124ull});
 
         LineStrips3D from_manual;
-        from_manual.strips.push_back(rr::components::LineStrip3D({{0.f, 0.f, 0.f}, {2.f, 1.f, -1.f}}
-        ));
-        from_manual.strips.push_back(
-            rr::components::LineStrip3D({{4.f, -1.f, 3.f}, {6.f, 0.f, 1.5f}})
-        );
+        from_manual.strips = {
+            rr::components::LineStrip3D({{0.f, 0.f, 0.f}, {2.f, 1.f, -1.f}}),
+            rr::components::LineStrip3D({{4.f, -1.f, 3.f}, {6.f, 0.f, 1.5f}}),
+        };
         from_manual.radii = {1.0, 10.0};
         from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
         from_manual.labels = {"hello", "friend"};

--- a/rerun_cpp/tests/archetypes/lines_strips3d.cpp
+++ b/rerun_cpp/tests/archetypes/lines_strips3d.cpp
@@ -35,6 +35,6 @@ SCENARIO(
         from_manual.class_ids = {126, 127};
         from_manual.instance_keys = {123ull, 124ull};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
+        test_compare_archetype_serialization(from_manual, from_builder);
     }
 }

--- a/rerun_cpp/tests/archetypes/mesh3d.cpp
+++ b/rerun_cpp/tests/archetypes/mesh3d.cpp
@@ -43,6 +43,6 @@ SCENARIO(
         from_manual.class_ids = {126, 127};
         from_manual.instance_keys = {123ull, 124ull};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
+        test_compare_archetype_serialization(from_manual, from_builder);
     }
 }

--- a/rerun_cpp/tests/archetypes/pinhole.cpp
+++ b/rerun_cpp/tests/archetypes/pinhole.cpp
@@ -30,7 +30,7 @@ SCENARIO(
         });
         from_manual.resolution = rerun::datatypes::Vec2D(1.0f, 2.0f);
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
+        test_compare_archetype_serialization(from_manual, from_builder);
     }
 
     GIVEN("Constructed from via focal_length_and_resolution and manually") {
@@ -44,6 +44,6 @@ SCENARIO(
         });
         from_manual.resolution = rerun::datatypes::Vec2D(3.0f, 4.0f);
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
+        test_compare_archetype_serialization(from_manual, from_builder);
     }
 }

--- a/rerun_cpp/tests/archetypes/points2d.cpp
+++ b/rerun_cpp/tests/archetypes/points2d.cpp
@@ -29,6 +29,6 @@ SCENARIO(
         from_manual.class_ids = {126, 127};
         from_manual.instance_keys = {123ull, 124ull};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
+        test_compare_archetype_serialization(from_manual, from_builder);
     }
 }

--- a/rerun_cpp/tests/archetypes/points3d.cpp
+++ b/rerun_cpp/tests/archetypes/points3d.cpp
@@ -29,6 +29,6 @@ SCENARIO(
         from_manual.class_ids = {126, 127};
         from_manual.instance_keys = {123ull, 124ull};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
+        test_compare_archetype_serialization(from_manual, from_builder);
     }
 }

--- a/rerun_cpp/tests/archetypes/transform3d.cpp
+++ b/rerun_cpp/tests/archetypes/transform3d.cpp
@@ -43,7 +43,7 @@ SCENARIO(
                 manual.transform.repr =
                     rrd::Transform3D::translation_and_mat3x3(translation_and_mat3);
 
-                test_serialization_for_manual_and_builder(manual, utility);
+                test_compare_archetype_serialization(manual, utility);
             }
             AND_GIVEN("matrix as column vectors") {
                 auto utility = from_parent ? Transform3D({1.0f, 2.0f, 3.0f}, columns, true)
@@ -52,7 +52,7 @@ SCENARIO(
                 manual.transform.repr =
                     rrd::Transform3D::translation_and_mat3x3(translation_and_mat3);
 
-                test_serialization_for_manual_and_builder(manual, utility);
+                test_compare_archetype_serialization(manual, utility);
             }
         }
         GIVEN("Transform3D from matrix as initializer list and from_parent==" << from_parent) {
@@ -66,7 +66,7 @@ SCENARIO(
                 manual.transform.repr =
                     rrd::Transform3D::translation_and_mat3x3(translation_and_mat3);
 
-                test_serialization_for_manual_and_builder(manual, utility);
+                test_compare_archetype_serialization(manual, utility);
             }
             AND_GIVEN("matrix as column vectors") {
                 auto utility = from_parent ? Transform3D(columns, true) : Transform3D(columns);
@@ -74,7 +74,7 @@ SCENARIO(
                 manual.transform.repr =
                     rrd::Transform3D::translation_and_mat3x3(translation_and_mat3);
 
-                test_serialization_for_manual_and_builder(manual, utility);
+                test_compare_archetype_serialization(manual, utility);
             }
         }
     }
@@ -96,7 +96,7 @@ SCENARIO(
             manual.transform.repr =
                 rrd::Transform3D::translation_rotation_scale(translation_rotation_scale);
 
-            test_serialization_for_manual_and_builder(manual, utility);
+            test_compare_archetype_serialization(manual, utility);
         }
         GIVEN("Transform3D from translation/rotation/scale and from_parent==" << from_parent) {
             auto utility = from_parent ? Transform3D({1.0f, 2.0f, 3.0f}, rotation, 1.0f, true)
@@ -109,7 +109,7 @@ SCENARIO(
             manual.transform.repr =
                 rrd::Transform3D::translation_rotation_scale(translation_rotation_scale);
 
-            test_serialization_for_manual_and_builder(manual, utility);
+            test_compare_archetype_serialization(manual, utility);
         }
         GIVEN("Transform3D from translation/scale and from_parent==" << from_parent) {
             auto utility = from_parent ? Transform3D({1.0f, 2.0f, 3.0f}, 1.0f, true)
@@ -122,7 +122,7 @@ SCENARIO(
             manual.transform.repr =
                 rrd::Transform3D::translation_rotation_scale(translation_rotation_scale);
 
-            test_serialization_for_manual_and_builder(manual, utility);
+            test_compare_archetype_serialization(manual, utility);
         }
         GIVEN("Transform3D from translation/rotation and from_parent==" << from_parent) {
             auto utility = from_parent ? Transform3D({1.0f, 2.0f, 3.0f}, rotation, true)
@@ -135,7 +135,7 @@ SCENARIO(
             manual.transform.repr =
                 rrd::Transform3D::translation_rotation_scale(translation_rotation_scale);
 
-            test_serialization_for_manual_and_builder(manual, utility);
+            test_compare_archetype_serialization(manual, utility);
         }
         GIVEN("Transform3D from rotation/scale and from_parent==" << from_parent) {
             auto utility =
@@ -148,7 +148,7 @@ SCENARIO(
             manual.transform.repr =
                 rrd::Transform3D::translation_rotation_scale(translation_rotation_scale);
 
-            test_serialization_for_manual_and_builder(manual, utility);
+            test_compare_archetype_serialization(manual, utility);
         }
         GIVEN("Transform3D from rotation only and from_parent==" << from_parent) {
             auto utility = from_parent ? Transform3D(rotation, true) : Transform3D(rotation);
@@ -160,7 +160,7 @@ SCENARIO(
             manual.transform.repr =
                 rrd::Transform3D::translation_rotation_scale(translation_rotation_scale);
 
-            test_serialization_for_manual_and_builder(manual, utility);
+            test_compare_archetype_serialization(manual, utility);
         }
         GIVEN("Transform3D from scale only and from_parent==" << from_parent) {
             auto utility = from_parent ? Transform3D(1.0f, true) : Transform3D(1.0f);
@@ -172,7 +172,7 @@ SCENARIO(
             manual.transform.repr =
                 rrd::Transform3D::translation_rotation_scale(translation_rotation_scale);
 
-            test_serialization_for_manual_and_builder(manual, utility);
+            test_compare_archetype_serialization(manual, utility);
         }
     }
 }

--- a/rerun_cpp/tests/archetypes/view_coordinates.cpp
+++ b/rerun_cpp/tests/archetypes/view_coordinates.cpp
@@ -25,7 +25,7 @@ SCENARIO(
             rerun::components::ViewCoordinates::Down,
             rerun::components::ViewCoordinates::Forward};
 
-        test_serialization_for_manual_and_builder(from_manual, from_builder);
+        test_compare_archetype_serialization(from_manual, from_builder);
     }
 
     GIVEN("Constructed from builder and static") {
@@ -35,6 +35,6 @@ SCENARIO(
             rerun::components::ViewCoordinates::Forward
         );
 
-        test_serialization_for_manual_and_builder(ViewCoordinates::RDF, from_builder);
+        test_compare_archetype_serialization(ViewCoordinates::RDF, from_builder);
     }
 }

--- a/rerun_cpp/tests/component_batch.cpp
+++ b/rerun_cpp/tests/component_batch.cpp
@@ -8,20 +8,22 @@
 
 #define TEST_TAG "[component_batch]"
 
+using namespace rerun::components;
+
 SCENARIO("ComponentBatch creation via common adaptors", TEST_TAG) {
     GIVEN("a vector of components") {
-        std::vector<rerun::components::Position2D> components = {
-            rerun::components::Position2D(0.0f, 1.0f),
-            rerun::components::Position2D(1.0f, 2.0f),
+        std::vector<Position2D> components = {
+            Position2D(0.0f, 1.0f),
+            Position2D(1.0f, 2.0f),
         };
 
         THEN("a component batch created from it borrows its data") {
-            const rerun::ComponentBatch<rerun::components::Position2D> batch(components);
+            const rerun::ComponentBatch<Position2D> batch(components);
             CHECK(batch.size() == components.size());
             CHECK(batch.get_ownership() == rerun::BatchOwnership::Borrowed);
         }
         THEN("a component batch created from it moving it owns the data") {
-            const rerun::ComponentBatch<rerun::components::Position2D> batch(std::move(components));
+            const rerun::ComponentBatch<Position2D> batch(std::move(components));
             CHECK(batch.size() == 2);
             CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
         }
@@ -29,84 +31,78 @@ SCENARIO("ComponentBatch creation via common adaptors", TEST_TAG) {
 
     GIVEN("a temporary vector of components") {
         THEN("a component batch created from it owns its data") {
-            const rerun::ComponentBatch<rerun::components::Position2D> batch(
-                std::vector<rerun::components::Position2D>{
-                    rerun::components::Position2D(0.0f, 1.0f),
-                    rerun::components::Position2D(1.0f, 2.0f),
-                }
-            );
+            const rerun::ComponentBatch<Position2D> batch(std::vector<Position2D>{
+                Position2D(0.0f, 1.0f),
+                Position2D(1.0f, 2.0f),
+            });
             CHECK(batch.size() == 2);
             CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
         }
     }
 
     GIVEN("an std::array of components") {
-        std::array<rerun::components::Position2D, 2> components = {
-            rerun::components::Position2D(0.0f, 1.0f),
-            rerun::components::Position2D(1.0f, 2.0f),
+        std::array<Position2D, 2> components = {
+            Position2D(0.0f, 1.0f),
+            Position2D(1.0f, 2.0f),
         };
 
         THEN("a component batch created from it borrows its data") {
-            const rerun::ComponentBatch<rerun::components::Position2D> batch(components);
+            const rerun::ComponentBatch<Position2D> batch(components);
             CHECK(batch.size() == components.size());
             CHECK(batch.get_ownership() == rerun::BatchOwnership::Borrowed);
         }
         THEN("a component batch created from it moving it owns the data") {
-            const rerun::ComponentBatch<rerun::components::Position2D> batch(std::move(components));
+            const rerun::ComponentBatch<Position2D> batch(std::move(components));
             CHECK(batch.size() == 2);
             CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
         }
     }
     GIVEN("a temporary std::array of components") {
         THEN("a component batch created from it owns its data") {
-            const rerun::ComponentBatch<rerun::components::Position2D> batch(
-                std::array<rerun::components::Position2D, 2>{
-                    rerun::components::Position2D(0.0f, 1.0f),
-                    rerun::components::Position2D(1.0f, 2.0f),
-                }
-            );
+            const rerun::ComponentBatch<Position2D> batch(std::array<Position2D, 2>{
+                Position2D(0.0f, 1.0f),
+                Position2D(1.0f, 2.0f),
+            });
             CHECK(batch.size() == 2);
             CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
         }
     }
 
     GIVEN("a c-array of components") {
-        rerun::components::Position2D components[] = {
-            rerun::components::Position2D(0.0f, 1.0f),
-            rerun::components::Position2D(1.0f, 2.0f),
+        Position2D components[] = {
+            Position2D(0.0f, 1.0f),
+            Position2D(1.0f, 2.0f),
         };
 
         THEN("a component batch created from it borrows its data") {
-            const rerun::ComponentBatch<rerun::components::Position2D> batch(components);
+            const rerun::ComponentBatch<Position2D> batch(components);
             CHECK(batch.size() == 2);
             CHECK(batch.get_ownership() == rerun::BatchOwnership::Borrowed);
         }
         THEN("a component batch created from moving it owns the data") {
-            const rerun::ComponentBatch<rerun::components::Position2D> batch(std::move(components));
+            const rerun::ComponentBatch<Position2D> batch(std::move(components));
             CHECK(batch.size() == 2);
             CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
         }
     }
 
     GIVEN("a single components") {
-        rerun::components::Position2D component = rerun::components::Position2D(0.0f, 1.0f);
+        Position2D component = Position2D(0.0f, 1.0f);
 
         THEN("a component batch created from it borrows its data") {
-            const rerun::ComponentBatch<rerun::components::Position2D> batch(component);
+            const rerun::ComponentBatch<Position2D> batch(component);
             CHECK(batch.size() == 1);
             CHECK(batch.get_ownership() == rerun::BatchOwnership::Borrowed);
         }
         THEN("a component batch created from it moving it owns the data") {
-            const rerun::ComponentBatch<rerun::components::Position2D> batch(std::move(component));
+            const rerun::ComponentBatch<Position2D> batch(std::move(component));
             CHECK(batch.size() == 1);
             CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
         }
     }
     GIVEN("a single temporary component") {
         THEN("a component batch created from it borrows its data") {
-            const rerun::ComponentBatch<rerun::components::Position2D> batch(
-                rerun::components::Position2D(0.0f, 1.0f)
-            );
+            const rerun::ComponentBatch<Position2D> batch(Position2D(0.0f, 1.0f));
             CHECK(batch.size() == 1);
             CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
         }
@@ -145,7 +141,7 @@ SCENARIO(
         container.vecs = {0.0f, 1.0f, 2.0f, 3.0f};
 
         THEN("a component batch created from it that its data") {
-            const rerun::ComponentBatch<rerun::components::Position2D> batch(container);
+            const rerun::ComponentBatch<Position2D> batch(container);
             CHECK(batch.size() == 2);
             CHECK(batch.get_ownership() == rerun::BatchOwnership::Borrowed);
         }
@@ -169,6 +165,68 @@ SCENARIO(
 
                 test_compare_archetype_serialization(from_custom_container, from_rerun_vector);
             }
+        }
+    }
+}
+
+SCENARIO("ComponentBatch move behavior", TEST_TAG) {
+    std::vector<Position2D> components = {
+        Position2D(0.0f, 1.0f),
+        Position2D(1.0f, 2.0f),
+    };
+
+    GIVEN("A borrowed component batch") {
+        auto borrowed = rerun::ComponentBatch<Position2D>::borrow(components.data(), 2);
+
+        THEN("then moving to a new batch moves the data and clears the source") {
+            auto target(std::move(borrowed));
+            CHECK(target.size() == 2);
+            CHECK(target.get_ownership() == rerun::BatchOwnership::Borrowed);
+            CHECK(borrowed.size() == 0);
+            CHECK(borrowed.get_ownership() == rerun::BatchOwnership::Borrowed);
+        }
+
+        THEN("moving it to an owned component batch swaps their data") {
+            auto target =
+                rerun::ComponentBatch<Position2D>::take_ownership(std::vector(components));
+
+            target = std::move(borrowed);
+            CHECK(target.size() == 2);
+            CHECK(target.get_ownership() == rerun::BatchOwnership::Borrowed);
+            CHECK(borrowed.size() == 2);
+            CHECK(borrowed.get_ownership() == rerun::BatchOwnership::VectorOwned);
+        }
+        THEN("moving it to an borrowed component batch swaps their data") {
+            auto target = rerun::ComponentBatch<Position2D>::borrow(components.data(), 2);
+
+            target = std::move(borrowed);
+            CHECK(target.size() == 2);
+            CHECK(target.get_ownership() == rerun::BatchOwnership::Borrowed);
+            CHECK(borrowed.size() == 2);
+            CHECK(borrowed.get_ownership() == rerun::BatchOwnership::Borrowed);
+        }
+    }
+    GIVEN("A owned component batch") {
+        auto borrowed = rerun::ComponentBatch<Position2D>::take_ownership(std::vector(components));
+
+        THEN("moving it to an owned component batch swaps their data") {
+            auto target =
+                rerun::ComponentBatch<Position2D>::take_ownership(std::vector(components));
+
+            target = std::move(borrowed);
+            CHECK(target.size() == 2);
+            CHECK(target.get_ownership() == rerun::BatchOwnership::VectorOwned);
+            CHECK(borrowed.size() == 2);
+            CHECK(borrowed.get_ownership() == rerun::BatchOwnership::VectorOwned);
+        }
+        THEN("moving it to an borrowed component batch swaps their data") {
+            auto target = rerun::ComponentBatch<Position2D>::borrow(components.data(), 2);
+
+            target = std::move(borrowed);
+            CHECK(target.size() == 2);
+            CHECK(target.get_ownership() == rerun::BatchOwnership::VectorOwned);
+            CHECK(borrowed.size() == 2);
+            CHECK(borrowed.get_ownership() == rerun::BatchOwnership::Borrowed);
         }
     }
 }

--- a/rerun_cpp/tests/component_batch.cpp
+++ b/rerun_cpp/tests/component_batch.cpp
@@ -147,10 +147,3 @@ SCENARIO(
         }
     }
 }
-
-MyVec2Container container;
-container.vecs = {0.0f, 1.0f, 2.0f, 3.0f};
-
-const rerun::archetypes::Points2D from_custom_container(container);
-CHECK(from_custom_container.positions.size() == 2);
-CHECK(from_custom_container.positions.get_ownership() == rerun::BatchOwnership::Borrowed);

--- a/rerun_cpp/tests/component_batch.cpp
+++ b/rerun_cpp/tests/component_batch.cpp
@@ -1,0 +1,156 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <rerun/archetypes/points2d.hpp>
+#include <rerun/component_batch.hpp>
+#include <rerun/components/position2d.hpp>
+
+#include "archetypes/archetype_test.hpp"
+
+#define TEST_TAG "[component_batch]"
+
+SCENARIO("ComponentBatch creation via common adaptors", TEST_TAG) {
+    GIVEN("a vector of components") {
+        std::vector<rerun::components::Position2D> components = {
+            rerun::components::Position2D(0.0f, 1.0f),
+            rerun::components::Position2D(1.0f, 2.0f),
+        };
+
+        THEN("a component batch created from it borrows its data") {
+            const rerun::ComponentBatch<rerun::components::Position2D> batch(components);
+            CHECK(batch.size() == components.size());
+            CHECK(batch.get_ownership() == rerun::BatchOwnership::Borrowed);
+        }
+    }
+    GIVEN("a temporary vector of components") {
+        THEN("a component batch created from it owns its data") {
+            const rerun::ComponentBatch<rerun::components::Position2D> batch(
+                std::vector<rerun::components::Position2D>{
+                    rerun::components::Position2D(0.0f, 1.0f),
+                    rerun::components::Position2D(1.0f, 2.0f),
+                }
+            );
+            CHECK(batch.size() == 2);
+            CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
+        }
+    }
+
+    GIVEN("an std::array of components") {
+        std::array<rerun::components::Position2D, 2> components = {
+            rerun::components::Position2D(0.0f, 1.0f),
+            rerun::components::Position2D(1.0f, 2.0f),
+        };
+
+        THEN("a component batch created from it borrows its data") {
+            const rerun::ComponentBatch<rerun::components::Position2D> batch(components);
+            CHECK(batch.size() == 2);
+            CHECK(batch.get_ownership() == rerun::BatchOwnership::Borrowed);
+        }
+    }
+    GIVEN("a temporary std::array of components") {
+        THEN("a component batch created from it owns its data") {
+            const rerun::ComponentBatch<rerun::components::Position2D> batch(
+                std::array<rerun::components::Position2D, 2>{
+                    rerun::components::Position2D(0.0f, 1.0f),
+                    rerun::components::Position2D(1.0f, 2.0f),
+                }
+            );
+            CHECK(batch.size() == 2);
+            CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
+        }
+    }
+
+    GIVEN("a c-array of components") {
+        rerun::components::Position2D components[] = {
+            rerun::components::Position2D(0.0f, 1.0f),
+            rerun::components::Position2D(1.0f, 2.0f),
+        };
+
+        THEN("a component batch created from it borrows its data") {
+            const rerun::ComponentBatch<rerun::components::Position2D> batch(components);
+            CHECK(batch.size() == 2);
+            CHECK(batch.get_ownership() == rerun::BatchOwnership::Borrowed);
+        }
+    }
+    // Temporary c-array isn't possible I believe.
+
+    GIVEN("a single components") {
+        rerun::components::Position2D component = rerun::components::Position2D(0.0f, 1.0f);
+
+        THEN("a component batch created from it borrows its data") {
+            const rerun::ComponentBatch<rerun::components::Position2D> batch(component);
+            CHECK(batch.size() == 1);
+            CHECK(batch.get_ownership() == rerun::BatchOwnership::Borrowed);
+        }
+    }
+    GIVEN("a single temporary component") {
+        THEN("a component batch created from it borrows its data") {
+            const rerun::ComponentBatch<rerun::components::Position2D> batch(
+                rerun::components::Position2D(0.0f, 1.0f)
+            );
+            CHECK(batch.size() == 1);
+            CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
+        }
+    }
+}
+
+struct MyVec2Container {
+    std::vector<float> vecs;
+};
+
+namespace rerun {
+    template <>
+    struct ComponentBatchAdapter<components::Position2D, MyVec2Container> {
+        ComponentBatch<components::Position2D> operator()(const MyVec2Container& container) {
+            static_assert(sizeof(components::Position2D) == sizeof(float) * 2);
+            static_assert(alignof(components::Position2D) <= sizeof(float));
+
+            return ComponentBatch<components::Position2D>::borrow(
+                reinterpret_cast<const components::Position2D*>(container.vecs.data()),
+                container.vecs.size() / 2
+            );
+        }
+    };
+} // namespace rerun
+
+SCENARIO(
+    "ComponentBatch creation via a custom adapter for a datalayout compatible type", TEST_TAG
+) {
+    GIVEN("A custom vec2 container with a defined adapter") {
+        MyVec2Container container;
+        container.vecs = {0.0f, 1.0f, 2.0f, 3.0f};
+
+        THEN("a component batch created from it that its data") {
+            const rerun::ComponentBatch<rerun::components::Position2D> batch(container);
+            CHECK(batch.size() == 2);
+            CHECK(batch.get_ownership() == rerun::BatchOwnership::Borrowed);
+        }
+        THEN("A Point2D archetype can be directly created from this container") {
+            const rerun::archetypes::Points2D from_custom_container(container);
+
+            CHECK(from_custom_container.positions.size() == 2);
+            CHECK(
+                from_custom_container.positions.get_ownership() == rerun::BatchOwnership::Borrowed
+            );
+
+            AND_THEN("it can be serialized and is identical to creation from rerun types directly"
+            ) {
+                const rerun::archetypes::Points2D from_rerun_vector({{0.0f, 1.0f}, {2.0f, 3.0f}});
+
+                CHECK(from_rerun_vector.positions.size() == 2);
+                CHECK(
+                    from_rerun_vector.positions.get_ownership() ==
+                    rerun::BatchOwnership::VectorOwned
+                );
+
+                test_compare_archetype_serialization(from_custom_container, from_rerun_vector);
+            }
+        }
+    }
+}
+
+MyVec2Container container;
+container.vecs = {0.0f, 1.0f, 2.0f, 3.0f};
+
+const rerun::archetypes::Points2D from_custom_container(container);
+CHECK(from_custom_container.positions.size() == 2);
+CHECK(from_custom_container.positions.get_ownership() == rerun::BatchOwnership::Borrowed);

--- a/rerun_cpp/tests/component_batch.cpp
+++ b/rerun_cpp/tests/component_batch.cpp
@@ -20,7 +20,13 @@ SCENARIO("ComponentBatch creation via common adaptors", TEST_TAG) {
             CHECK(batch.size() == components.size());
             CHECK(batch.get_ownership() == rerun::BatchOwnership::Borrowed);
         }
+        THEN("a component batch created from it moving it owns the data") {
+            const rerun::ComponentBatch<rerun::components::Position2D> batch(std::move(components));
+            CHECK(batch.size() == 2);
+            CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
+        }
     }
+    // todo: add explicit move test
     GIVEN("a temporary vector of components") {
         THEN("a component batch created from it owns its data") {
             const rerun::ComponentBatch<rerun::components::Position2D> batch(
@@ -42,8 +48,13 @@ SCENARIO("ComponentBatch creation via common adaptors", TEST_TAG) {
 
         THEN("a component batch created from it borrows its data") {
             const rerun::ComponentBatch<rerun::components::Position2D> batch(components);
-            CHECK(batch.size() == 2);
+            CHECK(batch.size() == components.size());
             CHECK(batch.get_ownership() == rerun::BatchOwnership::Borrowed);
+        }
+        THEN("a component batch created from it moving it owns the data") {
+            const rerun::ComponentBatch<rerun::components::Position2D> batch(std::move(components));
+            CHECK(batch.size() == 2);
+            CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
         }
     }
     GIVEN("a temporary std::array of components") {
@@ -70,8 +81,12 @@ SCENARIO("ComponentBatch creation via common adaptors", TEST_TAG) {
             CHECK(batch.size() == 2);
             CHECK(batch.get_ownership() == rerun::BatchOwnership::Borrowed);
         }
+        THEN("a component batch created from moving it owns the data") {
+            const rerun::ComponentBatch<rerun::components::Position2D> batch(std::move(components));
+            CHECK(batch.size() == 2);
+            CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
+        }
     }
-    // Temporary c-array isn't possible I believe.
 
     GIVEN("a single components") {
         rerun::components::Position2D component = rerun::components::Position2D(0.0f, 1.0f);
@@ -80,6 +95,11 @@ SCENARIO("ComponentBatch creation via common adaptors", TEST_TAG) {
             const rerun::ComponentBatch<rerun::components::Position2D> batch(component);
             CHECK(batch.size() == 1);
             CHECK(batch.get_ownership() == rerun::BatchOwnership::Borrowed);
+        }
+        THEN("a component batch created from it moving it owns the data") {
+            const rerun::ComponentBatch<rerun::components::Position2D> batch(std::move(component));
+            CHECK(batch.size() == 1);
+            CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
         }
     }
     GIVEN("a single temporary component") {
@@ -101,6 +121,7 @@ namespace rerun {
     template <>
     struct ComponentBatchAdapter<components::Position2D, MyVec2Container> {
         ComponentBatch<components::Position2D> operator()(const MyVec2Container& container) {
+            // Sanity check that this is binary compatible.
             static_assert(sizeof(components::Position2D) == sizeof(float) * 2);
             static_assert(alignof(components::Position2D) <= sizeof(float));
 
@@ -109,6 +130,8 @@ namespace rerun {
                 container.vecs.size() / 2
             );
         }
+
+        // TODO: fill in rvalue version and document when it's needed (almost always!)
     };
 } // namespace rerun
 

--- a/rerun_cpp/tests/component_batch.cpp
+++ b/rerun_cpp/tests/component_batch.cpp
@@ -26,7 +26,7 @@ SCENARIO("ComponentBatch creation via common adaptors", TEST_TAG) {
             CHECK(batch.get_ownership() == rerun::BatchOwnership::VectorOwned);
         }
     }
-    // todo: add explicit move test
+
     GIVEN("a temporary vector of components") {
         THEN("a component batch created from it owns its data") {
             const rerun::ComponentBatch<rerun::components::Position2D> batch(
@@ -131,7 +131,9 @@ namespace rerun {
             );
         }
 
-        // TODO: fill in rvalue version and document when it's needed (almost always!)
+        ComponentBatch<components::Position2D> operator()(MyVec2Container&& container) {
+            throw std::runtime_error("Not implemented for temporaries");
+        }
     };
 } // namespace rerun
 

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -7,135 +7,149 @@ namespace rerun {
     namespace archetypes {
         const char AffixFuzzer1::INDICATOR_COMPONENT_NAME[] =
             "rerun.testing.components.AffixFuzzer1Indicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> AffixFuzzer1::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(21);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::AffixFuzzer1>::serialize(
+        const archetypes::AffixFuzzer1& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(21);
 
-            {
-                auto result = ComponentBatch<rerun::components::AffixFuzzer1>(fuzz1001).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<rerun::components::AffixFuzzer2>(fuzz1002).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<rerun::components::AffixFuzzer3>(fuzz1003).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<rerun::components::AffixFuzzer4>(fuzz1004).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<rerun::components::AffixFuzzer5>(fuzz1005).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<rerun::components::AffixFuzzer6>(fuzz1006).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<rerun::components::AffixFuzzer7>(fuzz1007).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<rerun::components::AffixFuzzer8>(fuzz1008).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<rerun::components::AffixFuzzer9>(fuzz1009).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer10>(fuzz1010).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer11>(fuzz1011).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer12>(fuzz1012).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer13>(fuzz1013).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer14>(fuzz1014).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer15>(fuzz1015).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer16>(fuzz1016).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer17>(fuzz1017).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer18>(fuzz1018).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer19>(fuzz1019).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer20>(fuzz1020).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer21>(fuzz1021).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer1>(archetype.fuzz1001).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer2>(archetype.fuzz1002).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer3>(archetype.fuzz1003).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer4>(archetype.fuzz1004).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer5>(archetype.fuzz1005).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer6>(archetype.fuzz1006).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer7>(archetype.fuzz1007).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer8>(archetype.fuzz1008).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer9>(archetype.fuzz1009).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer10>(archetype.fuzz1010).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer11>(archetype.fuzz1011).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer12>(archetype.fuzz1012).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer13>(archetype.fuzz1013).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer14>(archetype.fuzz1014).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer15>(archetype.fuzz1015).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer16>(archetype.fuzz1016).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer17>(archetype.fuzz1017).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer18>(archetype.fuzz1018).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer19>(archetype.fuzz1019).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer20>(archetype.fuzz1020).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer21>(archetype.fuzz1021).serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<AffixFuzzer1::IndicatorComponent>(AffixFuzzer1::IndicatorComponent())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -3,8 +3,6 @@
 
 #include "affix_fuzzer1.hpp"
 
-#include <rerun/indicator_component.hpp>
-
 namespace rerun {
     namespace archetypes {
         const char AffixFuzzer1::INDICATOR_COMPONENT_NAME[] =
@@ -15,113 +13,124 @@ namespace rerun {
             cells.reserve(21);
 
             {
-                auto result = ComponentBatch(fuzz1001).serialize();
+                auto result = ComponentBatch<rerun::components::AffixFuzzer1>(fuzz1001).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1002).serialize();
+                auto result = ComponentBatch<rerun::components::AffixFuzzer2>(fuzz1002).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1003).serialize();
+                auto result = ComponentBatch<rerun::components::AffixFuzzer3>(fuzz1003).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1004).serialize();
+                auto result = ComponentBatch<rerun::components::AffixFuzzer4>(fuzz1004).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1005).serialize();
+                auto result = ComponentBatch<rerun::components::AffixFuzzer5>(fuzz1005).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1006).serialize();
+                auto result = ComponentBatch<rerun::components::AffixFuzzer6>(fuzz1006).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1007).serialize();
+                auto result = ComponentBatch<rerun::components::AffixFuzzer7>(fuzz1007).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1008).serialize();
+                auto result = ComponentBatch<rerun::components::AffixFuzzer8>(fuzz1008).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1009).serialize();
+                auto result = ComponentBatch<rerun::components::AffixFuzzer9>(fuzz1009).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1010).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer10>(fuzz1010).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1011).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer11>(fuzz1011).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1012).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer12>(fuzz1012).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1013).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer13>(fuzz1013).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1014).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer14>(fuzz1014).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1015).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer15>(fuzz1015).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1016).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer16>(fuzz1016).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1017).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer17>(fuzz1017).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1018).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer18>(fuzz1018).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1019).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer19>(fuzz1019).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1020).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer20>(fuzz1020).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                auto result = ComponentBatch(fuzz1021).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer21>(fuzz1021).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<AffixFuzzer1::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -11,7 +11,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::AffixFuzzer1>::serialize(
         const archetypes::AffixFuzzer1& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(21);

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -10,39 +10,123 @@ namespace rerun {
         const char AffixFuzzer1::INDICATOR_COMPONENT_NAME[] =
             "rerun.testing.components.AffixFuzzer1Indicator";
 
-        AnonymousComponentBatch AffixFuzzer1::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<AffixFuzzer1::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
+        Result<std::vector<SerializedComponentBatch>> AffixFuzzer1::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(21);
 
-        std::vector<AnonymousComponentBatch> AffixFuzzer1::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(21);
+            {
+                auto result = ComponentBatch(fuzz1001).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1002).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1003).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1004).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1005).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1006).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1007).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1008).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1009).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1010).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1011).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1012).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1013).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1014).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1015).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1016).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1017).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1018).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1019).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1020).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = ComponentBatch(fuzz1021).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                components::IndicatorComponent<AffixFuzzer1::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            comp_batches.emplace_back(fuzz1001);
-            comp_batches.emplace_back(fuzz1002);
-            comp_batches.emplace_back(fuzz1003);
-            comp_batches.emplace_back(fuzz1004);
-            comp_batches.emplace_back(fuzz1005);
-            comp_batches.emplace_back(fuzz1006);
-            comp_batches.emplace_back(fuzz1007);
-            comp_batches.emplace_back(fuzz1008);
-            comp_batches.emplace_back(fuzz1009);
-            comp_batches.emplace_back(fuzz1010);
-            comp_batches.emplace_back(fuzz1011);
-            comp_batches.emplace_back(fuzz1012);
-            comp_batches.emplace_back(fuzz1013);
-            comp_batches.emplace_back(fuzz1014);
-            comp_batches.emplace_back(fuzz1015);
-            comp_batches.emplace_back(fuzz1016);
-            comp_batches.emplace_back(fuzz1017);
-            comp_batches.emplace_back(fuzz1018);
-            comp_batches.emplace_back(fuzz1019);
-            comp_batches.emplace_back(fuzz1020);
-            comp_batches.emplace_back(fuzz1021);
-            comp_batches.emplace_back(AffixFuzzer1::indicator());
-
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -84,6 +84,7 @@ namespace rerun {
 
           public:
             AffixFuzzer1() = default;
+            AffixFuzzer1(AffixFuzzer1&& other) = default;
 
             AffixFuzzer1(
                 rerun::components::AffixFuzzer1 _fuzz1001,
@@ -135,16 +136,8 @@ namespace rerun {
                 return 1;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -26,7 +26,6 @@
 #include "../components/affix_fuzzer9.hpp"
 
 #include <cstdint>
-#include <rerun/arrow.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/data_cell.hpp>
 #include <rerun/indicator_component.hpp>
@@ -140,14 +139,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::AffixFuzzer1> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::AffixFuzzer1& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -137,9 +137,17 @@ namespace rerun {
             size_t num_instances() const {
                 return 1;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::AffixFuzzer1> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::AffixFuzzer1& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -81,6 +81,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -29,6 +29,7 @@
 #include <rerun/arrow.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/data_cell.hpp>
+#include <rerun/indicator_component.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 #include <vector>
@@ -81,6 +82,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             AffixFuzzer1() = default;

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -87,7 +87,7 @@ namespace rerun {
             AffixFuzzer1() = default;
             AffixFuzzer1(AffixFuzzer1&& other) = default;
 
-            AffixFuzzer1(
+            explicit AffixFuzzer1(
                 rerun::components::AffixFuzzer1 _fuzz1001,
                 rerun::components::AffixFuzzer2 _fuzz1002,
                 rerun::components::AffixFuzzer3 _fuzz1003,

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -141,6 +141,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
@@ -7,108 +7,113 @@ namespace rerun {
     namespace archetypes {
         const char AffixFuzzer2::INDICATOR_COMPONENT_NAME[] =
             "rerun.testing.components.AffixFuzzer2Indicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> AffixFuzzer2::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(18);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::AffixFuzzer2>::serialize(
+        const archetypes::AffixFuzzer2& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(18);
 
-            {
-                auto result = fuzz1101.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1102.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1103.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1104.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1105.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1106.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1107.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1108.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1109.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1110.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1111.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1112.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1113.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1114.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1115.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1116.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1117.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = fuzz1118.serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        {
+            auto result = archetype.fuzz1101.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        {
+            auto result = archetype.fuzz1102.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1103.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1104.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1105.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1106.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1107.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1108.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1109.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1110.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1111.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1112.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1113.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1114.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1115.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1116.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1117.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result = archetype.fuzz1118.serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<AffixFuzzer2::IndicatorComponent>(AffixFuzzer2::IndicatorComponent())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
@@ -3,8 +3,6 @@
 
 #include "affix_fuzzer2.hpp"
 
-#include <rerun/indicator_component.hpp>
-
 namespace rerun {
     namespace archetypes {
         const char AffixFuzzer2::INDICATOR_COMPONENT_NAME[] =
@@ -105,8 +103,7 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<AffixFuzzer2::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
@@ -10,36 +10,108 @@ namespace rerun {
         const char AffixFuzzer2::INDICATOR_COMPONENT_NAME[] =
             "rerun.testing.components.AffixFuzzer2Indicator";
 
-        AnonymousComponentBatch AffixFuzzer2::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<AffixFuzzer2::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
+        Result<std::vector<SerializedComponentBatch>> AffixFuzzer2::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(18);
 
-        std::vector<AnonymousComponentBatch> AffixFuzzer2::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(18);
+            {
+                auto result = fuzz1101.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1102.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1103.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1104.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1105.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1106.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1107.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1108.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1109.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1110.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1111.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1112.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1113.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1114.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1115.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1116.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1117.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                auto result = fuzz1118.serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
+            {
+                components::IndicatorComponent<AffixFuzzer2::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            comp_batches.emplace_back(fuzz1101);
-            comp_batches.emplace_back(fuzz1102);
-            comp_batches.emplace_back(fuzz1103);
-            comp_batches.emplace_back(fuzz1104);
-            comp_batches.emplace_back(fuzz1105);
-            comp_batches.emplace_back(fuzz1106);
-            comp_batches.emplace_back(fuzz1107);
-            comp_batches.emplace_back(fuzz1108);
-            comp_batches.emplace_back(fuzz1109);
-            comp_batches.emplace_back(fuzz1110);
-            comp_batches.emplace_back(fuzz1111);
-            comp_batches.emplace_back(fuzz1112);
-            comp_batches.emplace_back(fuzz1113);
-            comp_batches.emplace_back(fuzz1114);
-            comp_batches.emplace_back(fuzz1115);
-            comp_batches.emplace_back(fuzz1116);
-            comp_batches.emplace_back(fuzz1117);
-            comp_batches.emplace_back(fuzz1118);
-            comp_batches.emplace_back(AffixFuzzer2::indicator());
-
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
@@ -17,92 +17,92 @@ namespace rerun {
         cells.reserve(18);
 
         {
-            auto result = archetype.fuzz1101.serialize();
+            auto result = (archetype.fuzz1101).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1102.serialize();
+            auto result = (archetype.fuzz1102).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1103.serialize();
+            auto result = (archetype.fuzz1103).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1104.serialize();
+            auto result = (archetype.fuzz1104).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1105.serialize();
+            auto result = (archetype.fuzz1105).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1106.serialize();
+            auto result = (archetype.fuzz1106).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1107.serialize();
+            auto result = (archetype.fuzz1107).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1108.serialize();
+            auto result = (archetype.fuzz1108).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1109.serialize();
+            auto result = (archetype.fuzz1109).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1110.serialize();
+            auto result = (archetype.fuzz1110).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1111.serialize();
+            auto result = (archetype.fuzz1111).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1112.serialize();
+            auto result = (archetype.fuzz1112).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1113.serialize();
+            auto result = (archetype.fuzz1113).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1114.serialize();
+            auto result = (archetype.fuzz1114).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1115.serialize();
+            auto result = (archetype.fuzz1115).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1116.serialize();
+            auto result = (archetype.fuzz1116).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1117.serialize();
+            auto result = (archetype.fuzz1117).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = archetype.fuzz1118.serialize();
+            auto result = (archetype.fuzz1118).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
@@ -11,7 +11,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::AffixFuzzer2>::serialize(
         const archetypes::AffixFuzzer2& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(18);

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
@@ -26,6 +26,7 @@
 #include <rerun/arrow.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/data_cell.hpp>
+#include <rerun/indicator_component.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 #include <vector>
@@ -72,6 +73,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             AffixFuzzer2() = default;

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
@@ -72,6 +72,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
@@ -33,41 +33,41 @@
 namespace rerun {
     namespace archetypes {
         struct AffixFuzzer2 {
-            std::vector<rerun::components::AffixFuzzer1> fuzz1101;
+            ComponentBatch<rerun::components::AffixFuzzer1> fuzz1101;
 
-            std::vector<rerun::components::AffixFuzzer2> fuzz1102;
+            ComponentBatch<rerun::components::AffixFuzzer2> fuzz1102;
 
-            std::vector<rerun::components::AffixFuzzer3> fuzz1103;
+            ComponentBatch<rerun::components::AffixFuzzer3> fuzz1103;
 
-            std::vector<rerun::components::AffixFuzzer4> fuzz1104;
+            ComponentBatch<rerun::components::AffixFuzzer4> fuzz1104;
 
-            std::vector<rerun::components::AffixFuzzer5> fuzz1105;
+            ComponentBatch<rerun::components::AffixFuzzer5> fuzz1105;
 
-            std::vector<rerun::components::AffixFuzzer6> fuzz1106;
+            ComponentBatch<rerun::components::AffixFuzzer6> fuzz1106;
 
-            std::vector<rerun::components::AffixFuzzer7> fuzz1107;
+            ComponentBatch<rerun::components::AffixFuzzer7> fuzz1107;
 
-            std::vector<rerun::components::AffixFuzzer8> fuzz1108;
+            ComponentBatch<rerun::components::AffixFuzzer8> fuzz1108;
 
-            std::vector<rerun::components::AffixFuzzer9> fuzz1109;
+            ComponentBatch<rerun::components::AffixFuzzer9> fuzz1109;
 
-            std::vector<rerun::components::AffixFuzzer10> fuzz1110;
+            ComponentBatch<rerun::components::AffixFuzzer10> fuzz1110;
 
-            std::vector<rerun::components::AffixFuzzer11> fuzz1111;
+            ComponentBatch<rerun::components::AffixFuzzer11> fuzz1111;
 
-            std::vector<rerun::components::AffixFuzzer12> fuzz1112;
+            ComponentBatch<rerun::components::AffixFuzzer12> fuzz1112;
 
-            std::vector<rerun::components::AffixFuzzer13> fuzz1113;
+            ComponentBatch<rerun::components::AffixFuzzer13> fuzz1113;
 
-            std::vector<rerun::components::AffixFuzzer14> fuzz1114;
+            ComponentBatch<rerun::components::AffixFuzzer14> fuzz1114;
 
-            std::vector<rerun::components::AffixFuzzer15> fuzz1115;
+            ComponentBatch<rerun::components::AffixFuzzer15> fuzz1115;
 
-            std::vector<rerun::components::AffixFuzzer16> fuzz1116;
+            ComponentBatch<rerun::components::AffixFuzzer16> fuzz1116;
 
-            std::vector<rerun::components::AffixFuzzer17> fuzz1117;
+            ComponentBatch<rerun::components::AffixFuzzer17> fuzz1117;
 
-            std::vector<rerun::components::AffixFuzzer18> fuzz1118;
+            ComponentBatch<rerun::components::AffixFuzzer18> fuzz1118;
 
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
@@ -75,26 +75,27 @@ namespace rerun {
 
           public:
             AffixFuzzer2() = default;
+            AffixFuzzer2(AffixFuzzer2&& other) = default;
 
             AffixFuzzer2(
-                std::vector<rerun::components::AffixFuzzer1> _fuzz1101,
-                std::vector<rerun::components::AffixFuzzer2> _fuzz1102,
-                std::vector<rerun::components::AffixFuzzer3> _fuzz1103,
-                std::vector<rerun::components::AffixFuzzer4> _fuzz1104,
-                std::vector<rerun::components::AffixFuzzer5> _fuzz1105,
-                std::vector<rerun::components::AffixFuzzer6> _fuzz1106,
-                std::vector<rerun::components::AffixFuzzer7> _fuzz1107,
-                std::vector<rerun::components::AffixFuzzer8> _fuzz1108,
-                std::vector<rerun::components::AffixFuzzer9> _fuzz1109,
-                std::vector<rerun::components::AffixFuzzer10> _fuzz1110,
-                std::vector<rerun::components::AffixFuzzer11> _fuzz1111,
-                std::vector<rerun::components::AffixFuzzer12> _fuzz1112,
-                std::vector<rerun::components::AffixFuzzer13> _fuzz1113,
-                std::vector<rerun::components::AffixFuzzer14> _fuzz1114,
-                std::vector<rerun::components::AffixFuzzer15> _fuzz1115,
-                std::vector<rerun::components::AffixFuzzer16> _fuzz1116,
-                std::vector<rerun::components::AffixFuzzer17> _fuzz1117,
-                std::vector<rerun::components::AffixFuzzer18> _fuzz1118
+                ComponentBatch<rerun::components::AffixFuzzer1> _fuzz1101,
+                ComponentBatch<rerun::components::AffixFuzzer2> _fuzz1102,
+                ComponentBatch<rerun::components::AffixFuzzer3> _fuzz1103,
+                ComponentBatch<rerun::components::AffixFuzzer4> _fuzz1104,
+                ComponentBatch<rerun::components::AffixFuzzer5> _fuzz1105,
+                ComponentBatch<rerun::components::AffixFuzzer6> _fuzz1106,
+                ComponentBatch<rerun::components::AffixFuzzer7> _fuzz1107,
+                ComponentBatch<rerun::components::AffixFuzzer8> _fuzz1108,
+                ComponentBatch<rerun::components::AffixFuzzer9> _fuzz1109,
+                ComponentBatch<rerun::components::AffixFuzzer10> _fuzz1110,
+                ComponentBatch<rerun::components::AffixFuzzer11> _fuzz1111,
+                ComponentBatch<rerun::components::AffixFuzzer12> _fuzz1112,
+                ComponentBatch<rerun::components::AffixFuzzer13> _fuzz1113,
+                ComponentBatch<rerun::components::AffixFuzzer14> _fuzz1114,
+                ComponentBatch<rerun::components::AffixFuzzer15> _fuzz1115,
+                ComponentBatch<rerun::components::AffixFuzzer16> _fuzz1116,
+                ComponentBatch<rerun::components::AffixFuzzer17> _fuzz1117,
+                ComponentBatch<rerun::components::AffixFuzzer18> _fuzz1118
             )
                 : fuzz1101(std::move(_fuzz1101)),
                   fuzz1102(std::move(_fuzz1102)),
@@ -115,60 +116,13 @@ namespace rerun {
                   fuzz1117(std::move(_fuzz1117)),
                   fuzz1118(std::move(_fuzz1118)) {}
 
-            AffixFuzzer2(
-                rerun::components::AffixFuzzer1 _fuzz1101,
-                rerun::components::AffixFuzzer2 _fuzz1102,
-                rerun::components::AffixFuzzer3 _fuzz1103,
-                rerun::components::AffixFuzzer4 _fuzz1104,
-                rerun::components::AffixFuzzer5 _fuzz1105,
-                rerun::components::AffixFuzzer6 _fuzz1106,
-                rerun::components::AffixFuzzer7 _fuzz1107,
-                rerun::components::AffixFuzzer8 _fuzz1108,
-                rerun::components::AffixFuzzer9 _fuzz1109,
-                rerun::components::AffixFuzzer10 _fuzz1110,
-                rerun::components::AffixFuzzer11 _fuzz1111,
-                rerun::components::AffixFuzzer12 _fuzz1112,
-                rerun::components::AffixFuzzer13 _fuzz1113,
-                rerun::components::AffixFuzzer14 _fuzz1114,
-                rerun::components::AffixFuzzer15 _fuzz1115,
-                rerun::components::AffixFuzzer16 _fuzz1116,
-                rerun::components::AffixFuzzer17 _fuzz1117,
-                rerun::components::AffixFuzzer18 _fuzz1118
-            )
-                : fuzz1101(1, std::move(_fuzz1101)),
-                  fuzz1102(1, std::move(_fuzz1102)),
-                  fuzz1103(1, std::move(_fuzz1103)),
-                  fuzz1104(1, std::move(_fuzz1104)),
-                  fuzz1105(1, std::move(_fuzz1105)),
-                  fuzz1106(1, std::move(_fuzz1106)),
-                  fuzz1107(1, std::move(_fuzz1107)),
-                  fuzz1108(1, std::move(_fuzz1108)),
-                  fuzz1109(1, std::move(_fuzz1109)),
-                  fuzz1110(1, std::move(_fuzz1110)),
-                  fuzz1111(1, std::move(_fuzz1111)),
-                  fuzz1112(1, std::move(_fuzz1112)),
-                  fuzz1113(1, std::move(_fuzz1113)),
-                  fuzz1114(1, std::move(_fuzz1114)),
-                  fuzz1115(1, std::move(_fuzz1115)),
-                  fuzz1116(1, std::move(_fuzz1116)),
-                  fuzz1117(1, std::move(_fuzz1117)),
-                  fuzz1118(1, std::move(_fuzz1118)) {}
-
             /// Returns the number of primary instances of this archetype.
             size_t num_instances() const {
                 return fuzz1101.size();
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
@@ -23,7 +23,6 @@
 #include "../components/affix_fuzzer9.hpp"
 
 #include <cstdint>
-#include <rerun/arrow.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/data_cell.hpp>
 #include <rerun/indicator_component.hpp>
@@ -125,14 +124,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::AffixFuzzer2> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::AffixFuzzer2& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
@@ -126,6 +126,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
@@ -122,9 +122,17 @@ namespace rerun {
             size_t num_instances() const {
                 return fuzz1101.size();
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::AffixFuzzer2> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::AffixFuzzer2& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
@@ -78,7 +78,7 @@ namespace rerun {
             AffixFuzzer2() = default;
             AffixFuzzer2(AffixFuzzer2&& other) = default;
 
-            AffixFuzzer2(
+            explicit AffixFuzzer2(
                 ComponentBatch<rerun::components::AffixFuzzer1> _fuzz1101,
                 ComponentBatch<rerun::components::AffixFuzzer2> _fuzz1102,
                 ComponentBatch<rerun::components::AffixFuzzer3> _fuzz1103,

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
@@ -11,7 +11,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::AffixFuzzer3>::serialize(
         const archetypes::AffixFuzzer3& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(18);

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
@@ -10,72 +10,108 @@ namespace rerun {
         const char AffixFuzzer3::INDICATOR_COMPONENT_NAME[] =
             "rerun.testing.components.AffixFuzzer3Indicator";
 
-        AnonymousComponentBatch AffixFuzzer3::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<AffixFuzzer3::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
-
-        std::vector<AnonymousComponentBatch> AffixFuzzer3::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(18);
+        Result<std::vector<SerializedComponentBatch>> AffixFuzzer3::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(18);
 
             if (fuzz2001.has_value()) {
-                comp_batches.emplace_back(fuzz2001.value());
+                auto result = ComponentBatch(fuzz2001.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2002.has_value()) {
-                comp_batches.emplace_back(fuzz2002.value());
+                auto result = ComponentBatch(fuzz2002.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2003.has_value()) {
-                comp_batches.emplace_back(fuzz2003.value());
+                auto result = ComponentBatch(fuzz2003.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2004.has_value()) {
-                comp_batches.emplace_back(fuzz2004.value());
+                auto result = ComponentBatch(fuzz2004.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2005.has_value()) {
-                comp_batches.emplace_back(fuzz2005.value());
+                auto result = ComponentBatch(fuzz2005.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2006.has_value()) {
-                comp_batches.emplace_back(fuzz2006.value());
+                auto result = ComponentBatch(fuzz2006.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2007.has_value()) {
-                comp_batches.emplace_back(fuzz2007.value());
+                auto result = ComponentBatch(fuzz2007.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2008.has_value()) {
-                comp_batches.emplace_back(fuzz2008.value());
+                auto result = ComponentBatch(fuzz2008.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2009.has_value()) {
-                comp_batches.emplace_back(fuzz2009.value());
+                auto result = ComponentBatch(fuzz2009.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2010.has_value()) {
-                comp_batches.emplace_back(fuzz2010.value());
+                auto result = ComponentBatch(fuzz2010.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2011.has_value()) {
-                comp_batches.emplace_back(fuzz2011.value());
+                auto result = ComponentBatch(fuzz2011.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2012.has_value()) {
-                comp_batches.emplace_back(fuzz2012.value());
+                auto result = ComponentBatch(fuzz2012.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2013.has_value()) {
-                comp_batches.emplace_back(fuzz2013.value());
+                auto result = ComponentBatch(fuzz2013.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2014.has_value()) {
-                comp_batches.emplace_back(fuzz2014.value());
+                auto result = ComponentBatch(fuzz2014.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2015.has_value()) {
-                comp_batches.emplace_back(fuzz2015.value());
+                auto result = ComponentBatch(fuzz2015.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2016.has_value()) {
-                comp_batches.emplace_back(fuzz2016.value());
+                auto result = ComponentBatch(fuzz2016.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2017.has_value()) {
-                comp_batches.emplace_back(fuzz2017.value());
+                auto result = ComponentBatch(fuzz2017.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2018.has_value()) {
-                comp_batches.emplace_back(fuzz2018.value());
+                auto result = ComponentBatch(fuzz2018.value()).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
-            comp_batches.emplace_back(AffixFuzzer3::indicator());
+            {
+                components::IndicatorComponent<AffixFuzzer3::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
@@ -3,8 +3,6 @@
 
 #include "affix_fuzzer3.hpp"
 
-#include <rerun/indicator_component.hpp>
-
 namespace rerun {
     namespace archetypes {
         const char AffixFuzzer3::INDICATOR_COMPONENT_NAME[] =
@@ -15,98 +13,115 @@ namespace rerun {
             cells.reserve(18);
 
             if (fuzz2001.has_value()) {
-                auto result = ComponentBatch(fuzz2001.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer1>(fuzz2001.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2002.has_value()) {
-                auto result = ComponentBatch(fuzz2002.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer2>(fuzz2002.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2003.has_value()) {
-                auto result = ComponentBatch(fuzz2003.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer3>(fuzz2003.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2004.has_value()) {
-                auto result = ComponentBatch(fuzz2004.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer4>(fuzz2004.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2005.has_value()) {
-                auto result = ComponentBatch(fuzz2005.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer5>(fuzz2005.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2006.has_value()) {
-                auto result = ComponentBatch(fuzz2006.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer6>(fuzz2006.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2007.has_value()) {
-                auto result = ComponentBatch(fuzz2007.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer7>(fuzz2007.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2008.has_value()) {
-                auto result = ComponentBatch(fuzz2008.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer8>(fuzz2008.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2009.has_value()) {
-                auto result = ComponentBatch(fuzz2009.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer9>(fuzz2009.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2010.has_value()) {
-                auto result = ComponentBatch(fuzz2010.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer10>(fuzz2010.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2011.has_value()) {
-                auto result = ComponentBatch(fuzz2011.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer11>(fuzz2011.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2012.has_value()) {
-                auto result = ComponentBatch(fuzz2012.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer12>(fuzz2012.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2013.has_value()) {
-                auto result = ComponentBatch(fuzz2013.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer13>(fuzz2013.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2014.has_value()) {
-                auto result = ComponentBatch(fuzz2014.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer14>(fuzz2014.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2015.has_value()) {
-                auto result = ComponentBatch(fuzz2015.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer15>(fuzz2015.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2016.has_value()) {
-                auto result = ComponentBatch(fuzz2016.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer16>(fuzz2016.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2017.has_value()) {
-                auto result = ComponentBatch(fuzz2017.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer17>(fuzz2017.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             if (fuzz2018.has_value()) {
-                auto result = ComponentBatch(fuzz2018.value()).serialize();
+                auto result =
+                    ComponentBatch<rerun::components::AffixFuzzer18>(fuzz2018.value()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<AffixFuzzer3::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
@@ -7,126 +7,149 @@ namespace rerun {
     namespace archetypes {
         const char AffixFuzzer3::INDICATOR_COMPONENT_NAME[] =
             "rerun.testing.components.AffixFuzzer3Indicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> AffixFuzzer3::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(18);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::AffixFuzzer3>::serialize(
+        const archetypes::AffixFuzzer3& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(18);
 
-            if (fuzz2001.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer1>(fuzz2001.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2002.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer2>(fuzz2002.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2003.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer3>(fuzz2003.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2004.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer4>(fuzz2004.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2005.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer5>(fuzz2005.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2006.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer6>(fuzz2006.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2007.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer7>(fuzz2007.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2008.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer8>(fuzz2008.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2009.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer9>(fuzz2009.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2010.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer10>(fuzz2010.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2011.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer11>(fuzz2011.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2012.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer12>(fuzz2012.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2013.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer13>(fuzz2013.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2014.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer14>(fuzz2014.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2015.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer15>(fuzz2015.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2016.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer16>(fuzz2016.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2017.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer17>(fuzz2017.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2018.has_value()) {
-                auto result =
-                    ComponentBatch<rerun::components::AffixFuzzer18>(fuzz2018.value()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        if (archetype.fuzz2001.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer1>(archetype.fuzz2001.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.fuzz2002.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer2>(archetype.fuzz2002.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2003.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer3>(archetype.fuzz2003.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2004.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer4>(archetype.fuzz2004.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2005.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer5>(archetype.fuzz2005.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2006.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer6>(archetype.fuzz2006.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2007.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer7>(archetype.fuzz2007.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2008.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer8>(archetype.fuzz2008.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2009.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer9>(archetype.fuzz2009.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2010.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer10>(archetype.fuzz2010.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2011.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer11>(archetype.fuzz2011.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2012.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer12>(archetype.fuzz2012.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2013.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer13>(archetype.fuzz2013.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2014.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer14>(archetype.fuzz2014.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2015.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer15>(archetype.fuzz2015.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2016.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer16>(archetype.fuzz2016.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2017.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer17>(archetype.fuzz2017.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2018.has_value()) {
+            auto result =
+                ComponentBatch<rerun::components::AffixFuzzer18>(archetype.fuzz2018.value())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<AffixFuzzer3::IndicatorComponent>(AffixFuzzer3::IndicatorComponent())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -174,9 +174,17 @@ namespace rerun {
             size_t num_instances() const {
                 return 0;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::AffixFuzzer3> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::AffixFuzzer3& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -178,6 +178,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -73,6 +73,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -76,95 +76,96 @@ namespace rerun {
 
           public:
             AffixFuzzer3() = default;
+            AffixFuzzer3(AffixFuzzer3&& other) = default;
 
-            AffixFuzzer3& with_fuzz2001(rerun::components::AffixFuzzer1 _fuzz2001) {
+            AffixFuzzer3 with_fuzz2001(rerun::components::AffixFuzzer1 _fuzz2001) && {
                 fuzz2001 = std::move(_fuzz2001);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2002(rerun::components::AffixFuzzer2 _fuzz2002) {
+            AffixFuzzer3 with_fuzz2002(rerun::components::AffixFuzzer2 _fuzz2002) && {
                 fuzz2002 = std::move(_fuzz2002);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2003(rerun::components::AffixFuzzer3 _fuzz2003) {
+            AffixFuzzer3 with_fuzz2003(rerun::components::AffixFuzzer3 _fuzz2003) && {
                 fuzz2003 = std::move(_fuzz2003);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2004(rerun::components::AffixFuzzer4 _fuzz2004) {
+            AffixFuzzer3 with_fuzz2004(rerun::components::AffixFuzzer4 _fuzz2004) && {
                 fuzz2004 = std::move(_fuzz2004);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2005(rerun::components::AffixFuzzer5 _fuzz2005) {
+            AffixFuzzer3 with_fuzz2005(rerun::components::AffixFuzzer5 _fuzz2005) && {
                 fuzz2005 = std::move(_fuzz2005);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2006(rerun::components::AffixFuzzer6 _fuzz2006) {
+            AffixFuzzer3 with_fuzz2006(rerun::components::AffixFuzzer6 _fuzz2006) && {
                 fuzz2006 = std::move(_fuzz2006);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2007(rerun::components::AffixFuzzer7 _fuzz2007) {
+            AffixFuzzer3 with_fuzz2007(rerun::components::AffixFuzzer7 _fuzz2007) && {
                 fuzz2007 = std::move(_fuzz2007);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2008(rerun::components::AffixFuzzer8 _fuzz2008) {
+            AffixFuzzer3 with_fuzz2008(rerun::components::AffixFuzzer8 _fuzz2008) && {
                 fuzz2008 = std::move(_fuzz2008);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2009(rerun::components::AffixFuzzer9 _fuzz2009) {
+            AffixFuzzer3 with_fuzz2009(rerun::components::AffixFuzzer9 _fuzz2009) && {
                 fuzz2009 = std::move(_fuzz2009);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2010(rerun::components::AffixFuzzer10 _fuzz2010) {
+            AffixFuzzer3 with_fuzz2010(rerun::components::AffixFuzzer10 _fuzz2010) && {
                 fuzz2010 = std::move(_fuzz2010);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2011(rerun::components::AffixFuzzer11 _fuzz2011) {
+            AffixFuzzer3 with_fuzz2011(rerun::components::AffixFuzzer11 _fuzz2011) && {
                 fuzz2011 = std::move(_fuzz2011);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2012(rerun::components::AffixFuzzer12 _fuzz2012) {
+            AffixFuzzer3 with_fuzz2012(rerun::components::AffixFuzzer12 _fuzz2012) && {
                 fuzz2012 = std::move(_fuzz2012);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2013(rerun::components::AffixFuzzer13 _fuzz2013) {
+            AffixFuzzer3 with_fuzz2013(rerun::components::AffixFuzzer13 _fuzz2013) && {
                 fuzz2013 = std::move(_fuzz2013);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2014(rerun::components::AffixFuzzer14 _fuzz2014) {
+            AffixFuzzer3 with_fuzz2014(rerun::components::AffixFuzzer14 _fuzz2014) && {
                 fuzz2014 = std::move(_fuzz2014);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2015(rerun::components::AffixFuzzer15 _fuzz2015) {
+            AffixFuzzer3 with_fuzz2015(rerun::components::AffixFuzzer15 _fuzz2015) && {
                 fuzz2015 = std::move(_fuzz2015);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2016(rerun::components::AffixFuzzer16 _fuzz2016) {
+            AffixFuzzer3 with_fuzz2016(rerun::components::AffixFuzzer16 _fuzz2016) && {
                 fuzz2016 = std::move(_fuzz2016);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2017(rerun::components::AffixFuzzer17 _fuzz2017) {
+            AffixFuzzer3 with_fuzz2017(rerun::components::AffixFuzzer17 _fuzz2017) && {
                 fuzz2017 = std::move(_fuzz2017);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer3& with_fuzz2018(rerun::components::AffixFuzzer18 _fuzz2018) {
+            AffixFuzzer3 with_fuzz2018(rerun::components::AffixFuzzer18 _fuzz2018) && {
                 fuzz2018 = std::move(_fuzz2018);
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -172,16 +173,8 @@ namespace rerun {
                 return 0;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -24,7 +24,6 @@
 
 #include <cstdint>
 #include <optional>
-#include <rerun/arrow.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/data_cell.hpp>
 #include <rerun/indicator_component.hpp>
@@ -177,14 +176,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::AffixFuzzer3> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::AffixFuzzer3& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -27,6 +27,7 @@
 #include <rerun/arrow.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/data_cell.hpp>
+#include <rerun/indicator_component.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 #include <vector>
@@ -73,6 +74,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             AffixFuzzer3() = default;

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
@@ -11,7 +11,7 @@ namespace rerun {
 
     Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::AffixFuzzer4>::serialize(
         const archetypes::AffixFuzzer4& archetype
-    ) const {
+    ) {
         using namespace archetypes;
         std::vector<SerializedComponentBatch> cells;
         cells.reserve(18);

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
@@ -3,8 +3,6 @@
 
 #include "affix_fuzzer4.hpp"
 
-#include <rerun/indicator_component.hpp>
-
 namespace rerun {
     namespace archetypes {
         const char AffixFuzzer4::INDICATOR_COMPONENT_NAME[] =
@@ -105,8 +103,7 @@ namespace rerun {
                 cells.emplace_back(std::move(result.value));
             }
             {
-                components::IndicatorComponent<AffixFuzzer4::INDICATOR_COMPONENT_NAME> indicator;
-                auto result = ComponentBatch(indicator).serialize();
+                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
@@ -10,72 +10,108 @@ namespace rerun {
         const char AffixFuzzer4::INDICATOR_COMPONENT_NAME[] =
             "rerun.testing.components.AffixFuzzer4Indicator";
 
-        AnonymousComponentBatch AffixFuzzer4::indicator() {
-            return ComponentBatch<
-                components::IndicatorComponent<AffixFuzzer4::INDICATOR_COMPONENT_NAME>>(nullptr, 1);
-        }
-
-        std::vector<AnonymousComponentBatch> AffixFuzzer4::as_component_batches() const {
-            std::vector<AnonymousComponentBatch> comp_batches;
-            comp_batches.reserve(18);
+        Result<std::vector<SerializedComponentBatch>> AffixFuzzer4::serialize() const {
+            std::vector<SerializedComponentBatch> cells;
+            cells.reserve(18);
 
             if (fuzz2101.has_value()) {
-                comp_batches.emplace_back(fuzz2101.value());
+                auto result = fuzz2101.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2102.has_value()) {
-                comp_batches.emplace_back(fuzz2102.value());
+                auto result = fuzz2102.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2103.has_value()) {
-                comp_batches.emplace_back(fuzz2103.value());
+                auto result = fuzz2103.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2104.has_value()) {
-                comp_batches.emplace_back(fuzz2104.value());
+                auto result = fuzz2104.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2105.has_value()) {
-                comp_batches.emplace_back(fuzz2105.value());
+                auto result = fuzz2105.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2106.has_value()) {
-                comp_batches.emplace_back(fuzz2106.value());
+                auto result = fuzz2106.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2107.has_value()) {
-                comp_batches.emplace_back(fuzz2107.value());
+                auto result = fuzz2107.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2108.has_value()) {
-                comp_batches.emplace_back(fuzz2108.value());
+                auto result = fuzz2108.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2109.has_value()) {
-                comp_batches.emplace_back(fuzz2109.value());
+                auto result = fuzz2109.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2110.has_value()) {
-                comp_batches.emplace_back(fuzz2110.value());
+                auto result = fuzz2110.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2111.has_value()) {
-                comp_batches.emplace_back(fuzz2111.value());
+                auto result = fuzz2111.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2112.has_value()) {
-                comp_batches.emplace_back(fuzz2112.value());
+                auto result = fuzz2112.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2113.has_value()) {
-                comp_batches.emplace_back(fuzz2113.value());
+                auto result = fuzz2113.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2114.has_value()) {
-                comp_batches.emplace_back(fuzz2114.value());
+                auto result = fuzz2114.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2115.has_value()) {
-                comp_batches.emplace_back(fuzz2115.value());
+                auto result = fuzz2115.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2116.has_value()) {
-                comp_batches.emplace_back(fuzz2116.value());
+                auto result = fuzz2116.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2117.has_value()) {
-                comp_batches.emplace_back(fuzz2117.value());
+                auto result = fuzz2117.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
             if (fuzz2118.has_value()) {
-                comp_batches.emplace_back(fuzz2118.value());
+                auto result = fuzz2118.value().serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
             }
-            comp_batches.emplace_back(AffixFuzzer4::indicator());
+            {
+                components::IndicatorComponent<AffixFuzzer4::INDICATOR_COMPONENT_NAME> indicator;
+                auto result = ComponentBatch(indicator).serialize();
+                RR_RETURN_NOT_OK(result.error);
+                cells.emplace_back(std::move(result.value));
+            }
 
-            return comp_batches;
+            return cells;
         }
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
@@ -7,108 +7,113 @@ namespace rerun {
     namespace archetypes {
         const char AffixFuzzer4::INDICATOR_COMPONENT_NAME[] =
             "rerun.testing.components.AffixFuzzer4Indicator";
+    }
 
-        Result<std::vector<SerializedComponentBatch>> AffixFuzzer4::serialize() const {
-            std::vector<SerializedComponentBatch> cells;
-            cells.reserve(18);
+    Result<std::vector<SerializedComponentBatch>> AsComponents<archetypes::AffixFuzzer4>::serialize(
+        const archetypes::AffixFuzzer4& archetype
+    ) const {
+        using namespace archetypes;
+        std::vector<SerializedComponentBatch> cells;
+        cells.reserve(18);
 
-            if (fuzz2101.has_value()) {
-                auto result = fuzz2101.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2102.has_value()) {
-                auto result = fuzz2102.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2103.has_value()) {
-                auto result = fuzz2103.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2104.has_value()) {
-                auto result = fuzz2104.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2105.has_value()) {
-                auto result = fuzz2105.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2106.has_value()) {
-                auto result = fuzz2106.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2107.has_value()) {
-                auto result = fuzz2107.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2108.has_value()) {
-                auto result = fuzz2108.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2109.has_value()) {
-                auto result = fuzz2109.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2110.has_value()) {
-                auto result = fuzz2110.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2111.has_value()) {
-                auto result = fuzz2111.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2112.has_value()) {
-                auto result = fuzz2112.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2113.has_value()) {
-                auto result = fuzz2113.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2114.has_value()) {
-                auto result = fuzz2114.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2115.has_value()) {
-                auto result = fuzz2115.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2116.has_value()) {
-                auto result = fuzz2116.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2117.has_value()) {
-                auto result = fuzz2117.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            if (fuzz2118.has_value()) {
-                auto result = fuzz2118.value().serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-            {
-                auto result = ComponentBatch<IndicatorComponent>(IndicatorComponent()).serialize();
-                RR_RETURN_NOT_OK(result.error);
-                cells.emplace_back(std::move(result.value));
-            }
-
-            return cells;
+        if (archetype.fuzz2101.has_value()) {
+            auto result = archetype.fuzz2101.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
         }
-    } // namespace archetypes
+        if (archetype.fuzz2102.has_value()) {
+            auto result = archetype.fuzz2102.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2103.has_value()) {
+            auto result = archetype.fuzz2103.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2104.has_value()) {
+            auto result = archetype.fuzz2104.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2105.has_value()) {
+            auto result = archetype.fuzz2105.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2106.has_value()) {
+            auto result = archetype.fuzz2106.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2107.has_value()) {
+            auto result = archetype.fuzz2107.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2108.has_value()) {
+            auto result = archetype.fuzz2108.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2109.has_value()) {
+            auto result = archetype.fuzz2109.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2110.has_value()) {
+            auto result = archetype.fuzz2110.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2111.has_value()) {
+            auto result = archetype.fuzz2111.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2112.has_value()) {
+            auto result = archetype.fuzz2112.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2113.has_value()) {
+            auto result = archetype.fuzz2113.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2114.has_value()) {
+            auto result = archetype.fuzz2114.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2115.has_value()) {
+            auto result = archetype.fuzz2115.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2116.has_value()) {
+            auto result = archetype.fuzz2116.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2117.has_value()) {
+            auto result = archetype.fuzz2117.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        if (archetype.fuzz2118.has_value()) {
+            auto result = archetype.fuzz2118.value().serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+        {
+            auto result =
+                ComponentBatch<AffixFuzzer4::IndicatorComponent>(AffixFuzzer4::IndicatorComponent())
+                    .serialize();
+            RR_RETURN_NOT_OK(result.error);
+            cells.emplace_back(std::move(result.value));
+        }
+
+        return cells;
+    }
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
@@ -17,92 +17,92 @@ namespace rerun {
         cells.reserve(18);
 
         if (archetype.fuzz2101.has_value()) {
-            auto result = archetype.fuzz2101.value().serialize();
+            auto result = (archetype.fuzz2101.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2102.has_value()) {
-            auto result = archetype.fuzz2102.value().serialize();
+            auto result = (archetype.fuzz2102.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2103.has_value()) {
-            auto result = archetype.fuzz2103.value().serialize();
+            auto result = (archetype.fuzz2103.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2104.has_value()) {
-            auto result = archetype.fuzz2104.value().serialize();
+            auto result = (archetype.fuzz2104.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2105.has_value()) {
-            auto result = archetype.fuzz2105.value().serialize();
+            auto result = (archetype.fuzz2105.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2106.has_value()) {
-            auto result = archetype.fuzz2106.value().serialize();
+            auto result = (archetype.fuzz2106.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2107.has_value()) {
-            auto result = archetype.fuzz2107.value().serialize();
+            auto result = (archetype.fuzz2107.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2108.has_value()) {
-            auto result = archetype.fuzz2108.value().serialize();
+            auto result = (archetype.fuzz2108.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2109.has_value()) {
-            auto result = archetype.fuzz2109.value().serialize();
+            auto result = (archetype.fuzz2109.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2110.has_value()) {
-            auto result = archetype.fuzz2110.value().serialize();
+            auto result = (archetype.fuzz2110.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2111.has_value()) {
-            auto result = archetype.fuzz2111.value().serialize();
+            auto result = (archetype.fuzz2111.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2112.has_value()) {
-            auto result = archetype.fuzz2112.value().serialize();
+            auto result = (archetype.fuzz2112.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2113.has_value()) {
-            auto result = archetype.fuzz2113.value().serialize();
+            auto result = (archetype.fuzz2113.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2114.has_value()) {
-            auto result = archetype.fuzz2114.value().serialize();
+            auto result = (archetype.fuzz2114.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2115.has_value()) {
-            auto result = archetype.fuzz2115.value().serialize();
+            auto result = (archetype.fuzz2115.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2116.has_value()) {
-            auto result = archetype.fuzz2116.value().serialize();
+            auto result = (archetype.fuzz2116.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2117.has_value()) {
-            auto result = archetype.fuzz2117.value().serialize();
+            auto result = (archetype.fuzz2117.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2118.has_value()) {
-            auto result = archetype.fuzz2118.value().serialize();
+            auto result = (archetype.fuzz2118.value()).serialize();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -34,41 +34,41 @@
 namespace rerun {
     namespace archetypes {
         struct AffixFuzzer4 {
-            std::optional<std::vector<rerun::components::AffixFuzzer1>> fuzz2101;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer1>> fuzz2101;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer2>> fuzz2102;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer2>> fuzz2102;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer3>> fuzz2103;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer3>> fuzz2103;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer4>> fuzz2104;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer4>> fuzz2104;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer5>> fuzz2105;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer5>> fuzz2105;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer6>> fuzz2106;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer6>> fuzz2106;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer7>> fuzz2107;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer7>> fuzz2107;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer8>> fuzz2108;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer8>> fuzz2108;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer9>> fuzz2109;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer9>> fuzz2109;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer10>> fuzz2110;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer10>> fuzz2110;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer11>> fuzz2111;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer11>> fuzz2111;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer12>> fuzz2112;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer12>> fuzz2112;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer13>> fuzz2113;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer13>> fuzz2113;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer14>> fuzz2114;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer14>> fuzz2114;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer15>> fuzz2115;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer15>> fuzz2115;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer16>> fuzz2116;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer16>> fuzz2116;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer17>> fuzz2117;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer17>> fuzz2117;
 
-            std::optional<std::vector<rerun::components::AffixFuzzer18>> fuzz2118;
+            std::optional<ComponentBatch<rerun::components::AffixFuzzer18>> fuzz2118;
 
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
@@ -76,185 +76,114 @@ namespace rerun {
 
           public:
             AffixFuzzer4() = default;
+            AffixFuzzer4(AffixFuzzer4&& other) = default;
 
-            AffixFuzzer4& with_fuzz2101(std::vector<rerun::components::AffixFuzzer1> _fuzz2101) {
+            AffixFuzzer4 with_fuzz2101(ComponentBatch<rerun::components::AffixFuzzer1> _fuzz2101
+            ) && {
                 fuzz2101 = std::move(_fuzz2101);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2101(rerun::components::AffixFuzzer1 _fuzz2101) {
-                fuzz2101 = std::vector(1, std::move(_fuzz2101));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2102(std::vector<rerun::components::AffixFuzzer2> _fuzz2102) {
+            AffixFuzzer4 with_fuzz2102(ComponentBatch<rerun::components::AffixFuzzer2> _fuzz2102
+            ) && {
                 fuzz2102 = std::move(_fuzz2102);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2102(rerun::components::AffixFuzzer2 _fuzz2102) {
-                fuzz2102 = std::vector(1, std::move(_fuzz2102));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2103(std::vector<rerun::components::AffixFuzzer3> _fuzz2103) {
+            AffixFuzzer4 with_fuzz2103(ComponentBatch<rerun::components::AffixFuzzer3> _fuzz2103
+            ) && {
                 fuzz2103 = std::move(_fuzz2103);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2103(rerun::components::AffixFuzzer3 _fuzz2103) {
-                fuzz2103 = std::vector(1, std::move(_fuzz2103));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2104(std::vector<rerun::components::AffixFuzzer4> _fuzz2104) {
+            AffixFuzzer4 with_fuzz2104(ComponentBatch<rerun::components::AffixFuzzer4> _fuzz2104
+            ) && {
                 fuzz2104 = std::move(_fuzz2104);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2104(rerun::components::AffixFuzzer4 _fuzz2104) {
-                fuzz2104 = std::vector(1, std::move(_fuzz2104));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2105(std::vector<rerun::components::AffixFuzzer5> _fuzz2105) {
+            AffixFuzzer4 with_fuzz2105(ComponentBatch<rerun::components::AffixFuzzer5> _fuzz2105
+            ) && {
                 fuzz2105 = std::move(_fuzz2105);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2105(rerun::components::AffixFuzzer5 _fuzz2105) {
-                fuzz2105 = std::vector(1, std::move(_fuzz2105));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2106(std::vector<rerun::components::AffixFuzzer6> _fuzz2106) {
+            AffixFuzzer4 with_fuzz2106(ComponentBatch<rerun::components::AffixFuzzer6> _fuzz2106
+            ) && {
                 fuzz2106 = std::move(_fuzz2106);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2106(rerun::components::AffixFuzzer6 _fuzz2106) {
-                fuzz2106 = std::vector(1, std::move(_fuzz2106));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2107(std::vector<rerun::components::AffixFuzzer7> _fuzz2107) {
+            AffixFuzzer4 with_fuzz2107(ComponentBatch<rerun::components::AffixFuzzer7> _fuzz2107
+            ) && {
                 fuzz2107 = std::move(_fuzz2107);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2107(rerun::components::AffixFuzzer7 _fuzz2107) {
-                fuzz2107 = std::vector(1, std::move(_fuzz2107));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2108(std::vector<rerun::components::AffixFuzzer8> _fuzz2108) {
+            AffixFuzzer4 with_fuzz2108(ComponentBatch<rerun::components::AffixFuzzer8> _fuzz2108
+            ) && {
                 fuzz2108 = std::move(_fuzz2108);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2108(rerun::components::AffixFuzzer8 _fuzz2108) {
-                fuzz2108 = std::vector(1, std::move(_fuzz2108));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2109(std::vector<rerun::components::AffixFuzzer9> _fuzz2109) {
+            AffixFuzzer4 with_fuzz2109(ComponentBatch<rerun::components::AffixFuzzer9> _fuzz2109
+            ) && {
                 fuzz2109 = std::move(_fuzz2109);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2109(rerun::components::AffixFuzzer9 _fuzz2109) {
-                fuzz2109 = std::vector(1, std::move(_fuzz2109));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2110(std::vector<rerun::components::AffixFuzzer10> _fuzz2110) {
+            AffixFuzzer4 with_fuzz2110(ComponentBatch<rerun::components::AffixFuzzer10> _fuzz2110
+            ) && {
                 fuzz2110 = std::move(_fuzz2110);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2110(rerun::components::AffixFuzzer10 _fuzz2110) {
-                fuzz2110 = std::vector(1, std::move(_fuzz2110));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2111(std::vector<rerun::components::AffixFuzzer11> _fuzz2111) {
+            AffixFuzzer4 with_fuzz2111(ComponentBatch<rerun::components::AffixFuzzer11> _fuzz2111
+            ) && {
                 fuzz2111 = std::move(_fuzz2111);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2111(rerun::components::AffixFuzzer11 _fuzz2111) {
-                fuzz2111 = std::vector(1, std::move(_fuzz2111));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2112(std::vector<rerun::components::AffixFuzzer12> _fuzz2112) {
+            AffixFuzzer4 with_fuzz2112(ComponentBatch<rerun::components::AffixFuzzer12> _fuzz2112
+            ) && {
                 fuzz2112 = std::move(_fuzz2112);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2112(rerun::components::AffixFuzzer12 _fuzz2112) {
-                fuzz2112 = std::vector(1, std::move(_fuzz2112));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2113(std::vector<rerun::components::AffixFuzzer13> _fuzz2113) {
+            AffixFuzzer4 with_fuzz2113(ComponentBatch<rerun::components::AffixFuzzer13> _fuzz2113
+            ) && {
                 fuzz2113 = std::move(_fuzz2113);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2113(rerun::components::AffixFuzzer13 _fuzz2113) {
-                fuzz2113 = std::vector(1, std::move(_fuzz2113));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2114(std::vector<rerun::components::AffixFuzzer14> _fuzz2114) {
+            AffixFuzzer4 with_fuzz2114(ComponentBatch<rerun::components::AffixFuzzer14> _fuzz2114
+            ) && {
                 fuzz2114 = std::move(_fuzz2114);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2114(rerun::components::AffixFuzzer14 _fuzz2114) {
-                fuzz2114 = std::vector(1, std::move(_fuzz2114));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2115(std::vector<rerun::components::AffixFuzzer15> _fuzz2115) {
+            AffixFuzzer4 with_fuzz2115(ComponentBatch<rerun::components::AffixFuzzer15> _fuzz2115
+            ) && {
                 fuzz2115 = std::move(_fuzz2115);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2115(rerun::components::AffixFuzzer15 _fuzz2115) {
-                fuzz2115 = std::vector(1, std::move(_fuzz2115));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2116(std::vector<rerun::components::AffixFuzzer16> _fuzz2116) {
+            AffixFuzzer4 with_fuzz2116(ComponentBatch<rerun::components::AffixFuzzer16> _fuzz2116
+            ) && {
                 fuzz2116 = std::move(_fuzz2116);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2116(rerun::components::AffixFuzzer16 _fuzz2116) {
-                fuzz2116 = std::vector(1, std::move(_fuzz2116));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2117(std::vector<rerun::components::AffixFuzzer17> _fuzz2117) {
+            AffixFuzzer4 with_fuzz2117(ComponentBatch<rerun::components::AffixFuzzer17> _fuzz2117
+            ) && {
                 fuzz2117 = std::move(_fuzz2117);
-                return *this;
+                return std::move(*this);
             }
 
-            AffixFuzzer4& with_fuzz2117(rerun::components::AffixFuzzer17 _fuzz2117) {
-                fuzz2117 = std::vector(1, std::move(_fuzz2117));
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2118(std::vector<rerun::components::AffixFuzzer18> _fuzz2118) {
+            AffixFuzzer4 with_fuzz2118(ComponentBatch<rerun::components::AffixFuzzer18> _fuzz2118
+            ) && {
                 fuzz2118 = std::move(_fuzz2118);
-                return *this;
-            }
-
-            AffixFuzzer4& with_fuzz2118(rerun::components::AffixFuzzer18 _fuzz2118) {
-                fuzz2118 = std::vector(1, std::move(_fuzz2118));
-                return *this;
+                return std::move(*this);
             }
 
             /// Returns the number of primary instances of this archetype.
@@ -262,16 +191,8 @@ namespace rerun {
                 return 0;
             }
 
-            /// Creates an `AnonymousComponentBatch` out of the associated indicator component. This
-            /// allows for associating arbitrary indicator components with arbitrary data. Check out
-            /// the `manual_indicator` API example to see what's possible.
-            static AnonymousComponentBatch indicator();
-
-            /// Collections all component lists into a list of component collections. *Attention:*
-            /// The returned vector references this instance and does not take ownership of any
-            /// data. Adding any new components to this archetype will invalidate the returned
-            /// component lists!
-            std::vector<AnonymousComponentBatch> as_component_batches() const;
+            /// TODO: move to trait
+            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
     } // namespace archetypes
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -27,6 +27,7 @@
 #include <rerun/arrow.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/data_cell.hpp>
+#include <rerun/indicator_component.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 #include <vector>
@@ -73,6 +74,7 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             AffixFuzzer4() = default;

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -196,6 +196,7 @@ namespace rerun {
         };
 
     } // namespace archetypes
+
     template <typename T>
     struct AsComponents;
 

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -73,6 +73,8 @@ namespace rerun {
             /// Name of the indicator component, used to identify the archetype when converting to a
             /// list of components.
             static const char INDICATOR_COMPONENT_NAME[];
+            /// Indicator component, used to identify the archetype when converting to a list of
+            /// components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -24,7 +24,6 @@
 
 #include <cstdint>
 #include <optional>
-#include <rerun/arrow.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/data_cell.hpp>
 #include <rerun/indicator_component.hpp>
@@ -195,14 +194,14 @@ namespace rerun {
         };
 
     } // namespace archetypes
-    template <typename TComponent>
+    template <typename T>
     struct AsComponents;
 
     template <>
     struct AsComponents<archetypes::AffixFuzzer4> {
         /// Serialize all set component batches.
-        Result<std::vector<SerializedComponentBatch>> serialize(
+        static Result<std::vector<SerializedComponentBatch>> serialize(
             const archetypes::AffixFuzzer4& archetype
-        ) const;
+        );
     };
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -192,9 +192,17 @@ namespace rerun {
             size_t num_instances() const {
                 return 0;
             }
-
-            /// TODO: move to trait
-            Result<std::vector<SerializedComponentBatch>> serialize() const;
         };
+
     } // namespace archetypes
+    template <typename TComponent>
+    struct AsComponents;
+
+    template <>
+    struct AsComponents<archetypes::AffixFuzzer4> {
+        /// Serialize all set component batches.
+        Result<std::vector<SerializedComponentBatch>> serialize(
+            const archetypes::AffixFuzzer4& archetype
+        ) const;
+    };
 } // namespace rerun

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -142,14 +142,17 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
             WHEN("creating a new stream") {
                 rr::RecordingStream stream("test", kind);
 
-                THEN("single components can be logged") {
-                    stream.log_component_batches(
-                        "single-components",
-                        2,
-                        rrc::Position2D{1.0, 2.0},
-                        rrc::Color(0x00FF00FF)
-                    );
-                }
+                // We can make single components work, but this would make error messages a lot
+                // worse since we'd have to implement the base `AsComponents` template for this.
+                //
+                // THEN("single components can be logged") {
+                //     stream.log_component_batches(
+                //         "single-components",
+                //         2,
+                //         rrc::Position2D{1.0, 2.0},
+                //         rrc::Color(0x00FF00FF)
+                //     );
+                // }
 
                 THEN("components as c-array can be logged") {
                     rrc::Position2D c_style_array[2] = {
@@ -209,7 +212,7 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                             rrc::Position2D(rr::datatypes::Vec2D{0.0, 0.0}),
                             rrc::Position2D(rr::datatypes::Vec2D{1.0, 3.0}),
                         },
-                        rrc::Color(0xFF0000FF)
+                        std::array{rrc::Color(0xFF0000FF)}
                     );
                 }
 

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -146,9 +146,8 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                 // worse since we'd have to implement the base `AsComponents` template for this.
                 //
                 // THEN("single components can be logged") {
-                //     stream.log_component_batches(
+                //     stream.log(
                 //         "single-components",
-                //         2,
                 //         rrc::Position2D{1.0, 2.0},
                 //         rrc::Color(0x00FF00FF)
                 //     );
@@ -172,9 +171,8 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                     );
                 }
                 THEN("components as std::vector can be logged") {
-                    stream.log_component_batches(
+                    stream.log(
                         "as-vector",
-                        2,
                         std::vector<rrc::Position2D>{
                             rr::datatypes::Vec2D{1.0, 2.0},
                             rr::datatypes::Vec2D{4.0, 5.0},
@@ -187,9 +185,8 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                         rrc::Text("friend"),
                         rrc::Text("yo"),
                     };
-                    stream.log_component_batches(
+                    stream.log(
                         "as-mix",
-                        3,
                         std::vector{
                             rrc::Position2D(rr::datatypes::Vec2D{0.0, 0.0}),
                             rrc::Position2D(rr::datatypes::Vec2D{1.0, 3.0}),
@@ -205,9 +202,8 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                 }
 
                 THEN("components with splatting some of them can be logged") {
-                    stream.log_component_batches(
-                        "log_component_batches-splat",
-                        2,
+                    stream.log(
+                        "log-splat",
                         std::vector{
                             rrc::Position2D(rr::datatypes::Vec2D{0.0, 0.0}),
                             rrc::Position2D(rr::datatypes::Vec2D{1.0, 3.0}),

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -39,8 +39,8 @@ struct BadArchetype {
         return 1;
     }
 
-    std::vector<rerun::AnonymousComponentBatch> as_component_batches() const {
-        return {BadComponent()};
+    rerun::Result<std::vector<rerun::SerializedComponentBatch>> serialize() const {
+        return BadComponent::error;
     }
 };
 
@@ -388,7 +388,7 @@ SCENARIO("Recording stream handles invalid logging gracefully", TEST_TAG) {
                 ),
             }));
             const auto [path, error] = variant;
-            auto v = rr::datatypes::Vec2D{1.0, 2.0};
+            auto v = rrc::Position2D{1.0, 2.0};
 
             THEN("try_log_data_row returns the correct error") {
                 CHECK(stream.try_log_data_row(path, 0, 0, nullptr).code == error);

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -43,9 +43,9 @@ struct BadArchetype {
 namespace rerun {
     template <>
     struct AsComponents<BadArchetype> {
-        rerun::Result<std::vector<rerun::SerializedComponentBatch>> serialize(
+        static rerun::Result<std::vector<rerun::SerializedComponentBatch>> serialize(
             const BadArchetype& archetype
-        ) const {
+        ) {
             return BadComponent::error;
         }
     };

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -222,6 +222,9 @@ def is_missing_blank_line_between(prev_line: str, line: str) -> bool:
         line = line.strip()
         prev_line = prev_line.strip()
 
+        if "template<" in prev_line:
+            return False  # C++ template in code generation code.
+
         if is_empty(prev_line) or prev_line.strip().startswith("```"):
             return False
 
@@ -297,6 +300,10 @@ def test_lint_vertical_spacing() -> None:
         type Response = Response<Body>;
         type Error = hyper::Error;
         """,
+        """
+        template<typename T>
+        struct AsComponents;
+        """,  # C++ template in code generation code.
     ]
 
     should_fail = [

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -223,7 +223,7 @@ def is_missing_blank_line_between(prev_line: str, line: str) -> bool:
         prev_line = prev_line.strip()
 
         if "template<" in prev_line:
-            return False  # C++ template in code generation code.
+            return False  # C++ template inside Rust code that generates C++ code.
 
         if is_empty(prev_line) or prev_line.strip().startswith("```"):
             return False
@@ -303,7 +303,7 @@ def test_lint_vertical_spacing() -> None:
         """
         template<typename T>
         struct AsComponents;
-        """,  # C++ template in code generation code.
+        """,  # C++ template inside Rust code that generates C++ code.
     ]
 
     should_fail = [


### PR DESCRIPTION
### What

* Fixes #3050 

This PR introduces two new concepts to our logging/serialization pipeline that make it much more extensible and make us able to avoid allocations for (simple) user types.
On top, it simplifies our logging pipelines and - despite template juggling - should lead to **better** error messages!

The whole thing works with two new trait classes:

* `ComponentBatch<TComponent>`
    * this is used wherever we previously used `std::vector<TComponent>` in archetypes
    * can be constructed for every `TInput` for which `ComponentBatchAdapater<TComponent, TInput>` exists
       * the generic implementations of this trait take over std::vector/array/etc. support which actually opens more ways of feeding an archetype
       * in order to keep it simple (it's free of SFINAE!) there's some slight usability compromises, check adjustments to examples and tests to learn more. In particular some type conversions from _constructor arguments_ of `TComponent` no longer work (you have to construct your component before passing now).
        * it's super easy for users to create their own non-generic adapters, check the unit test!
    * data is either owned (via an std::vector) or borrowed. Borrowed means it holds a pointer which is comes with a safety tradeoff. Behavior can be controlled explicitly (`borrow(ptr, len)` / `take_ownership(std::vector&&)`) but adapters typically decide
* `AsComponents<T>`
    * similar to the trait with the same name in Rust!
    * everything that is implemented for it can be logged -> There's only `log` and `try_log` now 🎉 
    * default implemented for `ComponentBatch`, vector/array/c-array of components and generated for all archetypes (-> serialization is no longer part of the archetype struct, but pushed to the trait impl)

Unlike typically with traits, the default of both traits IS implemented, containing a static_assert (thanks @ankeanke for the idea!!) which gives a (somewhat readable) error message when there's not batch adapter or component:

AsComponents failure:
```cpp
struct Foo {};
stream.log("test", Foo{});
```
leads to:
```
/Users/andreas/dev/rerun-io/rerun/rerun_cpp/src/rerun/as_components.hpp:18:9: error: static_assert failed due to requirement 'NoAsComponentsFor<Foo>::value' "AsComponents is not implemented for this type. It is implemented for all built-in archetypes as well as std::vector, std::array, and c-arrays of components. You can add your own implementation by specializing AsComponents<T> for your type T."
        static_assert(
        ^
/Users/andreas/dev/rerun-io/rerun/rerun_cpp/src/rerun/recording_stream.hpp:160:25: note: in instantiation of template class 'rerun::AsComponents<Foo>' requested here
                        AsComponents<Ts>().serialize(archetypes_or_component_batches);
                        ^
/Users/andreas/dev/rerun-io/rerun/rerun_cpp/src/rerun/recording_stream.hpp:137:13: note: in instantiation of function template specialization 'rerun::RecordingStream::try_log<Foo>' requested here
            try_log(entity_path, archetypes_or_component_batches...).log_on_failure();
            ^
/Users/andreas/dev/rerun-io/rerun/rerun_cpp/tests/recording_stream.cpp:527:16: note: in instantiation of function template specialization 'rerun::RecordingStream::log<Foo>' requested here
        stream.log("test", Foo{});
               ^
```

ComponentBatchAdapter failure:
```cpp
struct Foo {
} foo;
rerun::archetypes::Points2D test(foo);
```
```
/Users/andreas/dev/rerun-io/rerun/rerun_cpp/src/rerun/archetypes/../component_batch.hpp:32:9: error: static_assert failed due to requirement 'NoAdapterFor<rerun::components::Position2D, Foo>::value' "ComponentBatchAdapter is not implemented for this type. It is implemented for for single components as well as std::vector, std::array, and c-arrays of components. You can add your own implementation by specializing ComponentBatchAdapter<TComponent, T> for a given component and your input type T."
        static_assert(
        ^
/Users/andreas/dev/rerun-io/rerun/rerun_cpp/src/rerun/archetypes/../component_batch.hpp:95:52: note: in instantiation of template class 'rerun::ComponentBatchAdapter<rerun::components::Position2D, Foo>' requested here
        ComponentBatch(T&& input) : ComponentBatch(TAdapter<T>()(std::forward<T>(input))) {}
                                                   ^
/Users/andreas/dev/rerun-io/rerun/rerun_cpp/tests/recording_stream.cpp:528:42: note: in instantiation of function template specialization 'rerun::ComponentBatch<rerun::components::Position2D>::ComponentBatch<Foo &>' requested here
        rerun::archetypes::Points2D test(foo);
                                         ^
```

Future work:
* `MonoComponentBatch` for mono components - right now mono components (like transform, but also like MeshProperties which has all triangle indices 😞) are not adaptable and always full-copy
* ComponentBatch optimization for owned single components
* ComponentBatch stride adapter
* iterate on `to_data_cell` arrow serialization methods to make them fit better into the system. Since `ComponentBatch` should have strides etc. in the future, they will need to consume `ComponentBatches` which in turn need the ability to iterate.
* example demonstrating the new extensibility

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3791) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3791)
- [Docs preview](https://rerun.io/preview/ec9832449c3416410b9ca4df77cedc379ae85dbd/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ec9832449c3416410b9ca4df77cedc379ae85dbd/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)