### PR TITLE
Use formatting in Blueprint and Streams tree UI to indicate that no data is logged in the current timeline

### DIFF
--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -443,6 +443,12 @@ impl TimePanel {
         clip_rect.max.x = tree_max_y;
         ui.set_clip_rect(clip_rect);
 
+        // style the item to provide feedback on whether it has data in the current timeline
+        let mut text = egui::RichText::new(text);
+        if !tree_has_data_in_current_timeline {
+            text = text.italics();
+        }
+
         let re_ui::list_item::ShowCollapsingResponse {
             item_response: response,
             body_response,
@@ -551,9 +557,14 @@ impl TimePanel {
                 clip_rect.max.x = tree_max_y;
                 ui.set_clip_rect(clip_rect);
 
+                // style the item to provide feedback on whether it has data in the current timeline
+                let mut text = egui::RichText::new(short_component_name);
+                if !component_has_data_in_current_timeline {
+                    text = text.italics();
+                }
                 let response =
                     re_data_ui::temporary_style_ui_for_component(ui, component_name, |ui| {
-                        ListItem::new(ctx.re_ui, short_component_name)
+                        ListItem::new(ctx.re_ui, text)
                             .selected(ctx.selection().contains(&item))
                             .width_allocation_mode(WidthAllocationMode::Compact)
                             .force_hovered(

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -92,19 +92,38 @@ impl<'a> ViewerContext<'a> {
         self.rec_cfg.time_ctrl.current_query()
     }
 
-    /// Returns whether the given tree has any data logged in the current timeline.
+    /// Returns whether the given tree has any timeless data or data logged in the current timeline.
     pub fn tree_has_data_in_current_timeline(&self, tree: &EntityTree) -> bool {
         tree.prefix_times
             .has_timeline(self.rec_cfg.time_ctrl.timeline())
             || tree.num_timeless_messages() > 0
     }
 
-    /// Returns whether the given component has any data logged in the current timeline.
+    /// Returns whether the given component has any timeless data or data logged in the current
+    /// timeline.
     pub fn component_has_data_in_current_timeline(&self, component_stat: &ComponentStats) -> bool {
         component_stat
             .times
             .has_timeline(self.rec_cfg.time_ctrl.timeline())
             || component_stat.num_timeless_messages() > 0
+    }
+
+    /// Returns whether the given component has any timeless data or data logged in the current
+    /// timeline.
+    ///
+    /// Returns `None` if the entity is not found in the current recording.
+    pub fn entity_has_data_in_selected_timeline(
+        &self,
+        entity_path: &re_log_types::EntityPath,
+    ) -> Option<bool> {
+        self.store_context
+            .recording
+            .and_then(|recording| recording.entity_db.tree.subtree(entity_path))
+            .map(|tree| {
+                tree.prefix_times
+                    .has_timeline(self.rec_cfg.time_ctrl.timeline())
+                    || tree.num_timeless_messages() > 0
+            })
     }
 }
 


### PR DESCRIPTION
### What

This PR implements the logic to apply specific highlighting for items in the Blueprint and Stream trees that _don't_ have any data logged to the current timeline (nor any timeless data). Currently, the formatting takes the form of italics.

It is however unclear whether this PR should go through or not, see https://github.com/rerun-io/rerun/issues/3733#issuecomment-1757713161.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3792) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3792)
- [Docs preview](https://rerun.io/preview/c2e57c2fcf769d0ed540c095a3b05c5653484bc5/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c2e57c2fcf769d0ed540c095a3b05c5653484bc5/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)