### PR TITLE
`CODE_STYLE.md`: add section about C++

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -7,12 +7,14 @@
 * [`CONTRIBUTING.md`](CONTRIBUTING.md)
 * [`RELEASES.md`](RELEASES.md)
 
+
 ## Languages
 We prefer Rust.
 
 We have a bunch of Bash and Python scripts that [we want to replace with Rust](https://github.com/rerun-io/rerun/issues/3349).
 
 For configs we like JSON and TOML, and [dislike YAML](https://ruudvanasseldonk.com/2023/01/11/the-yaml-document-from-hell).
+
 
 ## Rust code
 
@@ -121,6 +123,38 @@ You can also use the `todo()!` macro during development, but again it won't pass
 Use debug-formatting (`{:?}`) when logging strings in logs and error messages. This will surround the string with quotes and escape newlines, tabs, etc. For instance: `re_log::warn!("Unknown key: {key:?}");`.
 
 Use `re_error::format(err)` when displaying an error.
+
+
+## C++
+We prefix _private_ member variables with a `_`:
+
+```C++
+class Thing {
+  public:
+    …
+
+    void set_value(uint32_t value) {
+        _value = value;
+    }
+
+  private:
+    uint32_t _value;
+}
+```
+
+Public member variables has no prefix.
+When necessary use a `_` suffix on parameter names to avoid name conflicts:
+
+```C++
+struct Thing {
+    uint32_t value;
+
+    void set_value(uint32_t value_) {
+        value = value_;
+    }
+}
+```
+
 
 ## Naming
 We prefer `snake_case` to `kebab-case` for most things (e.g. crate names, crate features, …). `snake_case` is a valid identifier in almost any programming language, while `kebab-case` is not. This means one can use the same `snake_case` identifier everywhere, and not think about whether it needs to be written as `snake_case` in some circumstances.


### PR DESCRIPTION
### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3796) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3796)
- [Docs preview](https://rerun.io/preview/a9111c7364668e8a87cd8ead59b5974867c8dc4d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a9111c7364668e8a87cd8ead59b5974867c8dc4d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)