### PR TITLE
Add scary warning that default recording_id = authkey

### DIFF
--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -247,6 +247,7 @@ def _init_recording_stream() -> None:
 _init_recording_stream()
 
 
+# TODO(#3793): defaulting recording_id to authkey should be opt-in
 def init(
     application_id: str,
     *,
@@ -265,6 +266,25 @@ def init(
     Without an active recording, all methods of the SDK will turn into no-ops.
 
     For more advanced use cases, e.g. multiple recordings setups, see [`rerun.new_recording`][].
+
+    !!! Warning
+        If you don't specify a `recording_id`, it will default to a random value that is generated once
+        at the start of the process.
+        That value will be kept around for the whole lifetime of the process, and even inherited by all
+        its subprocesses, if any.
+
+        This makes it trivial to log data to the same recording in a multiprocess setup, but it also means
+        that the following code will _not_ create two distinct recordings:
+        ```
+        rr.init("my_app")
+        rr.init("my_app")
+        ```
+
+        To create distinct recordings from the same process, specify distinct recording IDs:
+        ```
+        rr.init("my_app", recording_id="recording1")
+        rr.init("my_app", recording_id="recording2")
+        ```
 
     Parameters
     ----------
@@ -348,6 +368,7 @@ def init(
         _spawn()
 
 
+# TODO(#3793): defaulting recording_id to authkey should be opt-in
 def new_recording(
     *,
     application_id: str,
@@ -361,6 +382,25 @@ def new_recording(
     Creates a new recording with a user-chosen application id (name) that can be used to log data.
 
     If you only need a single global recording, [`rerun.init`][] might be simpler.
+
+    !!! Warning
+        If you don't specify a `recording_id`, it will default to a random value that is generated once
+        at the start of the process.
+        That value will be kept around for the whole lifetime of the process, and even inherited by all
+        its subprocesses, if any.
+
+        This makes it trivial to log data to the same recording in a multiprocess setup, but it also means
+        that the following code will _not_ create two distinct recordings:
+        ```
+        rr.init("my_app")
+        rr.init("my_app")
+        ```
+
+        To create distinct recordings from the same process, specify distinct recording IDs:
+        ```
+        rr.init("my_app", recording_id="recording1")
+        rr.init("my_app", recording_id="recording2")
+        ```
 
     Parameters
     ----------

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import random
 from typing import Any, Callable, TypeVar, cast
+from uuid import UUID
 
 import numpy as np
 
@@ -251,7 +252,7 @@ _init_recording_stream()
 def init(
     application_id: str,
     *,
-    recording_id: str | None = None,
+    recording_id: str | UUID | None = None,
     spawn: bool = False,
     init_logging: bool = True,
     default_enabled: bool = True,
@@ -282,8 +283,9 @@ def init(
 
         To create distinct recordings from the same process, specify distinct recording IDs:
         ```
-        rr.init("my_app", recording_id="recording1")
-        rr.init("my_app", recording_id="recording2")
+        from uuid import uuid4
+        rr.init("my_app", recording_id=uuid4())
+        rr.init("my_app", recording_id=uuid4())
         ```
 
     Parameters
@@ -342,6 +344,9 @@ def init(
     # via `_register_on_fork` but it's worth being conservative.
     cleanup_if_forked_child()
 
+    if recording_id is not None:
+        recording_id = str(recording_id)
+
     if init_logging:
         new_recording(
             application_id=application_id,
@@ -372,7 +377,7 @@ def init(
 def new_recording(
     *,
     application_id: str,
-    recording_id: str | None = None,
+    recording_id: str | UUID | None = None,
     make_default: bool = False,
     make_thread_default: bool = False,
     spawn: bool = False,
@@ -398,8 +403,9 @@ def new_recording(
 
         To create distinct recordings from the same process, specify distinct recording IDs:
         ```
-        rec1 = rr.new_recording("my_app", recording_id="recording1")
-        rec2 = rr.new_recording("my_app", recording_id="recording2")
+        from uuid import uuid4
+        rec = rr.new_recording(application_id="test", recording_id=uuid4())
+        rec = rr.new_recording(application_id="test", recording_id=uuid4())
         ```
 
     Parameters
@@ -471,6 +477,9 @@ def new_recording(
                 application_path = path
     except Exception:
         pass
+
+    if recording_id is not None:
+        recording_id = str(recording_id)
 
     recording = RecordingStream(
         bindings.new_recording(

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -398,8 +398,8 @@ def new_recording(
 
         To create distinct recordings from the same process, specify distinct recording IDs:
         ```
-        rr.init("my_app", recording_id="recording1")
-        rr.init("my_app", recording_id="recording2")
+        rec1 = rr.new_recording("my_app", recording_id="recording1")
+        rec2 = rr.new_recording("my_app", recording_id="recording2")
         ```
 
     Parameters


### PR DESCRIPTION
Rendered:
![image](https://github.com/rerun-io/rerun/assets/2910679/645c216b-488a-4ef5-9627-e476bb29e8e7)


- Fixes #3798 

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3799) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3799)
- [Docs preview](https://rerun.io/preview/026a603413bc0544bdbc1a23f875c2b75840dd85/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/026a603413bc0544bdbc1a23f875c2b75840dd85/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)