### PR TITLE
VSCode: migrate to the new Python extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,8 @@
     "gaborv.flatbuffers",
     "github.vscode-github-actions",
     "josetr.cmake-language-support-vscode",
+    "ms-python.black-formatter",
+    "ms-python.mypy-type-checker",
     "ms-python.python",
     "ms-vscode.cmake-tools",
     "ms-vscode.cpptools-extension-pack",
@@ -18,7 +20,7 @@
     "vadimcn.vscode-lldb",
     "wayou.vscode-todo-highlight",
     "webfreak.debug",
-    "xaver.clang-format",  // C++ formatter
+    "xaver.clang-format", // C++ formatter
     "zxh404.vscode-proto3",
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,13 +8,6 @@
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
     "files.autoGuessEncoding": true,
-    "python.formatting.provider": "black",
-    "python.formatting.blackArgs": [
-        "--config",
-        "rerun_py/pyproject.toml"
-    ],
-    "python.linting.mypyEnabled": true,
-    "python.linting.enabled": true,
     "cSpell.words": [
         "andreas",
         "bbox",
@@ -75,11 +68,19 @@
     "python.analysis.extraPaths": [
         "rerun_py/rerun_sdk"
     ],
-    "ruff.args": [
-        "--config",
-        "rerun_py/pyproject.toml"
+    "ruff.lint.arg": [
+        "--config=rerun_py/pyproject.toml"
     ],
     "cmake.buildDirectory": "${workspaceRoot}/build/",
     "C_Cpp.autoAddFileAssociations": false,
-    "rust-analyzer.showUnlinkedFileNotification": false
+    "rust-analyzer.showUnlinkedFileNotification": false,
+    "black-formatter.args": [
+        "--config=rerun_py/pyproject.toml"
+    ],
+    "ruff.format.args": [
+        "--config=rerun_py/pyproject.toml"
+    ],
+    "ruff.lint.args": [
+        "--config=rerun_py/pyproject.toml"
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,9 +68,6 @@
     "python.analysis.extraPaths": [
         "rerun_py/rerun_sdk"
     ],
-    "ruff.lint.arg": [
-        "--config=rerun_py/pyproject.toml"
-    ],
     "cmake.buildDirectory": "${workspaceRoot}/build/",
     "C_Cpp.autoAddFileAssociations": false,
     "rust-analyzer.showUnlinkedFileNotification": false,


### PR DESCRIPTION
The main `python` extension one is being broken up into parts:

https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3802) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3802)
- [Docs preview](https://rerun.io/preview/0d267f2056f06a5a4f6abf88d688b23010027183/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0d267f2056f06a5a4f6abf88d688b23010027183/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)