### PR TITLE
Include origin of cameras that are part of scene when computing view bounds

### DIFF
--- a/crates/re_space_view_spatial/src/parts/cameras.rs
+++ b/crates/re_space_view_spatial/src/parts/cameras.rs
@@ -85,7 +85,7 @@ impl CamerasPart {
         // There's one wrinkle with using the parent transform though:
         // The entity itself may have a 3D transform which (by convention!) we apply *before* the pinhole camera.
         // Let's add that if it exists.
-        if let Some(transform_at_entity) = transform_at_entity {
+        if let Some(transform_at_entity) = transform_at_entity.clone() {
             world_from_camera =
                 world_from_camera * transform_at_entity.into_parent_from_child_transform();
         }
@@ -171,6 +171,13 @@ impl CamerasPart {
         if let Some(outline_mask_ids) = entity_highlight.instances.get(&instance_key) {
             lines.outline_mask_ids(*outline_mask_ids);
         }
+
+        self.data.extend_bounding_box_with_points(
+            std::iter::once(glam::Vec3::ZERO),
+            transform_at_entity
+                .unwrap_or(Transform3D::IDENTITY)
+                .into_parent_from_child_transform(),
+        );
     }
 }
 


### PR DESCRIPTION
### What
Although we decided not to generally include the camera frustum in the view bounds. Having the origin included in the view bounds makes it much harder to totally "lose" the camera.

Consider:
```
import numpy as np
import rerun as rr

rr.init("rerun_example_pinhole", spawn=True)
rng = np.random.default_rng(12345)

rr.log("world/camera", rr.Pinhole(focal_length=300, width=300, height=300))
rr.log("world/points", rr.Points3D(rng.uniform(0, 1, size=[10, 3]) + [-0.5, -0.5, 1]))
```

Before:
![image](https://github.com/rerun-io/rerun/assets/3312232/2cd1ae2b-8737-48a9-be73-8f624c53f97c)


After:
![image](https://github.com/rerun-io/rerun/assets/3312232/f5215042-947b-41d7-896e-fffaa68a69da)

I still, personally find the default frustum a little small, but that's another issue:
 - https://github.com/rerun-io/rerun/issues/3810

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3811) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3811)
- [Docs preview](https://rerun.io/preview/a35edd098b40d7b23665a2bf8746f4e50c72828e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a35edd098b40d7b23665a2bf8746f4e50c72828e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)