### PR TITLE
Less automatic `build.rs` shenanigans

### DIFF
--- a/crates/re_build_info/src/build_info.rs
+++ b/crates/re_build_info/src/build_info.rs
@@ -42,6 +42,8 @@ pub struct BuildInfo {
     /// ISO 8601 / RFC 3339 build time.
     ///
     /// Example: `"2023-02-23T19:33:26Z"`
+    ///
+    /// Empty if unknown.
     pub datetime: &'static str,
 }
 
@@ -83,7 +85,9 @@ impl std::fmt::Display for BuildInfo {
             write!(f, "]")?;
         }
 
-        write!(f, " {target_triple}")?;
+        if !target_triple.is_empty() {
+            write!(f, " {target_triple}")?;
+        }
 
         if !git_branch.is_empty() {
             write!(f, " {git_branch}")?;
@@ -93,7 +97,9 @@ impl std::fmt::Display for BuildInfo {
             write!(f, " {git_hash}")?;
         }
 
-        write!(f, ", built {datetime}")?;
+        if !datetime.is_empty() {
+            write!(f, ", built {datetime}")?;
+        }
 
         Ok(())
     }

--- a/crates/re_build_tools/src/git.rs
+++ b/crates/re_build_tools/src/git.rs
@@ -1,0 +1,65 @@
+//! # Situations to consider regarding git
+//!
+//! ## Using the published crate
+//!
+//! The published crate carries its version around, which in turns gives us the git tag, which makes
+//! the commit hash irrelevant.
+//! We still need to compute _something_ so that we can actually build, but that value will be
+//! ignored when the crate is built by the end user anyhow.
+//!
+//! ## Working directly within the workspace
+//!
+//! When working within the workspace, we can simply try and call `git` and we're done.
+//!
+//! ## Using an unpublished crate (e.g. `path = "…"` or `git = "…"` or `[patch.crates-io]`)
+//!
+//! In these cases we may or may not have access to the workspace (e.g. a `path = …` import likely
+//! will, while a crate patch won't).
+//!
+//! This is not an issue however, as we can simply try and see what we get.
+//! If we manage to compute a commit hash, great, otherwise we still have the crate version to
+//! fallback on.
+
+use std::path::PathBuf;
+
+use crate::{rerun_if_changed, run_command};
+
+pub fn rebuild_if_branch_or_commit_changes() {
+    if let Ok(head_path) = git_path("HEAD") {
+        rerun_if_changed(&head_path); // Track changes to branch
+        if let Ok(head) = std::fs::read_to_string(&head_path) {
+            if let Some(git_file) = head.strip_prefix("ref: ") {
+                if let Ok(path) = git_path(git_file) {
+                    if path.exists() {
+                        rerun_if_changed(path); // Track changes to commit hash
+                    } else {
+                        // Weird that it doesn't exist. Maybe we will miss a git hash change,
+                        // but that is better that tracking a non-existing files (which leads to constant rebuilds).
+                        // See https://github.com/rerun-io/rerun/issues/2380 for more
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub fn commit_hash() -> anyhow::Result<String> {
+    let git_hash = run_command("git", &["rev-parse", "HEAD"])?;
+    if git_hash.is_empty() {
+        anyhow::bail!("empty commit hash");
+    }
+    Ok(git_hash)
+}
+
+pub fn branch() -> anyhow::Result<String> {
+    run_command("git", &["symbolic-ref", "--short", "HEAD"])
+}
+
+/// From <https://git-scm.com/docs/git-rev-parse>:
+///
+/// Resolve `$GIT_DIR/<path>` and takes other path relocation variables such as `$GIT_OBJECT_DIRECTORY`, `$GIT_INDEX_FILE…​` into account.
+/// For example, if `$GIT_OBJECT_DIRECTORY` is set to /foo/bar then `git rev-parse --git-path objects/abc` returns `/foo/bar/abc`.
+fn git_path(path: &str) -> anyhow::Result<PathBuf> {
+    let path = run_command("git", &["rev-parse", "--git-path", path])?;
+    Ok(path.into())
+}

--- a/crates/re_build_tools/src/lib.rs
+++ b/crates/re_build_tools/src/lib.rs
@@ -157,7 +157,7 @@ pub fn export_build_info_vars_for_crate(crate_name: &str) {
         set_env("RE_BUILD_TARGET_TRIPLE", &std::env::var("TARGET").unwrap());
 
         // rust version
-        let (rustc, llvm) = rust_version().unwrap_or_default();
+        let (rustc, llvm) = rust_llvm_versions().unwrap_or_default();
         set_env("RE_BUILD_RUSTC_VERSION", &rustc);
         set_env("RE_BUILD_LLVM_VERSION", &llvm);
 
@@ -214,7 +214,7 @@ fn run_command(cmd: &str, args: &[&str]) -> anyhow::Result<String> {
 ///
 /// Defaults to `"unknown"` if, for whatever reason, the output from `rustc -vV` did not contain
 /// version information and/or the output format underwent breaking changes.
-fn rust_version() -> anyhow::Result<(String, String)> {
+fn rust_llvm_versions() -> anyhow::Result<(String, String)> {
     let cmd = std::env::var("RUSTC").unwrap_or("rustc".into());
     let args = &["-vV"];
 

--- a/crates/re_build_tools/src/lib.rs
+++ b/crates/re_build_tools/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+#![warn(missing_docs)]
 
 //! This crate is to be used from `build.rs` build scripts.
 

--- a/crates/re_build_tools/src/lib.rs
+++ b/crates/re_build_tools/src/lib.rs
@@ -4,9 +4,10 @@
 
 use anyhow::Context as _;
 
+use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::{path::PathBuf, process::Command};
 
+mod git;
 mod hashing;
 mod rebuild_detector;
 
@@ -87,79 +88,66 @@ pub fn is_on_ci() -> bool {
 ///
 /// Use this crate together with the `re_build_info` crate.
 pub fn export_build_info_vars_for_crate(crate_name: &str) {
-    rebuild_if_crate_changed(crate_name);
-    export_build_info_env_vars();
-}
+    let export_datetime = true; // TODO(emilk): make configurable
+    let export_git_info = true; // TODO(emilk): make configurable
 
-/// # Situations to consider regarding git
-///
-/// ## Using the published crate
-///
-/// The published crate carries its version around, which in turns gives us the git tag, which makes
-/// the commit hash irrelevant.
-/// We still need to compute _something_ so that we can actually build, but that value will be
-/// ignored when the crate is built by the end user anyhow.
-///
-/// ## Working directly within the workspace
-///
-/// When working within the workspace, we can simply try and call `git` and we're done.
-///
-/// ## Using an unpublished crate (e.g. `path = "…"` or `git = "…"` or `[patch.crates-io]`)
-///
-/// In these cases we may or may not have access to the workspace (e.g. a `path = …` import likely
-/// will, while a crate patch won't).
-///
-/// This is not an issue however, as we can simply try and see what we get.
-/// If we manage to compute a commit hash, great, otherwise we still have the crate version to
-/// fallback on.
-fn export_build_info_env_vars() {
-    // target triple
-    set_env("RE_BUILD_TARGET_TRIPLE", &std::env::var("TARGET").unwrap());
-    set_env("RE_BUILD_GIT_HASH", &git_hash().unwrap_or_default());
-    set_env("RE_BUILD_GIT_BRANCH", &git_branch().unwrap_or_default());
+    if export_datetime {
+        set_env("RE_BUILD_DATETIME", &date_time());
 
-    // rust version
-    let (rustc, llvm) = rust_version().unwrap_or_default();
-    set_env("RE_BUILD_RUSTC_VERSION", &rustc);
-    set_env("RE_BUILD_LLVM_VERSION", &llvm);
-
-    // We need to check `IS_IN_RERUN_WORKSPACE` in the build-script (here),
-    // because otherwise it won't show up when compiling through maturin.
-    // We must also make an exception for when we build actual wheels (on CI) for release.
-    if is_on_ci() {
-        // e.g. building wheels on CI.
-        set_env("RE_BUILD_IS_IN_RERUN_WORKSPACE", "no");
+        // The only way to make sure the build datetime is up-to-date is to run
+        // `build.rs` on every build, and there is really no good way of doing
+        // so except to manually check if any files have changed:
+        rebuild_if_crate_changed(crate_name);
     } else {
-        set_env(
-            "RE_BUILD_IS_IN_RERUN_WORKSPACE",
-            &std::env::var("IS_IN_RERUN_WORKSPACE").unwrap_or_default(),
-        );
+        set_env("RE_BUILD_DATETIME", "");
     }
 
-    let time_format =
-        time::format_description::parse("[year]-[month]-[day]T[hour]:[minute]:[second]Z").unwrap();
-    let date_time = time::OffsetDateTime::now_utc()
-        .format(&time_format)
-        .unwrap();
-    set_env("RE_BUILD_DATETIME", &date_time);
+    if export_git_info {
+        set_env("RE_BUILD_GIT_HASH", &git::commit_hash().unwrap_or_default());
+        set_env("RE_BUILD_GIT_BRANCH", &git::branch().unwrap_or_default());
 
-    // Make sure we re-run the build script if the branch or commit changes:
-    if let Ok(head_path) = git_path("HEAD") {
-        rerun_if_changed(&head_path); // Track changes to branch
-        if let Ok(head) = std::fs::read_to_string(&head_path) {
-            if let Some(git_file) = head.strip_prefix("ref: ") {
-                if let Ok(path) = git_path(git_file) {
-                    if path.exists() {
-                        rerun_if_changed(path); // Track changes to commit hash
-                    } else {
-                        // Weird that it doesn't exist. Maybe we will miss a git hash change,
-                        // but that is better that tracking a non-existing files (which leads to constant rebuilds).
-                        // See https://github.com/rerun-io/rerun/issues/2380 for more
-                    }
-                }
-            }
+        // Make sure the above are up-to-date
+        git::rebuild_if_branch_or_commit_changes();
+    } else {
+        set_env("RE_BUILD_GIT_HASH", "");
+        set_env("RE_BUILD_GIT_BRANCH", "");
+    }
+
+    // Stuff that doesn't change, so doesn't need rebuilding:
+    {
+        // target triple
+        set_env("RE_BUILD_TARGET_TRIPLE", &std::env::var("TARGET").unwrap());
+
+        // rust version
+        let (rustc, llvm) = rust_version().unwrap_or_default();
+        set_env("RE_BUILD_RUSTC_VERSION", &rustc);
+        set_env("RE_BUILD_LLVM_VERSION", &llvm);
+
+        // We need to check `IS_IN_RERUN_WORKSPACE` in the build-script (here),
+        // because otherwise it won't show up when compiling through maturin.
+        // We must also make an exception for when we build actual wheels (on CI) for release.
+        if is_on_ci() {
+            // e.g. building wheels on CI.
+            set_env("RE_BUILD_IS_IN_RERUN_WORKSPACE", "no");
+        } else {
+            set_env(
+                "RE_BUILD_IS_IN_RERUN_WORKSPACE",
+                &std::env::var("IS_IN_RERUN_WORKSPACE").unwrap_or_default(),
+            );
         }
     }
+}
+
+/// ISO 8601 / RFC 3339 build time.
+///
+/// Example: `"2023-02-23T19:33:26Z"`
+fn date_time() -> String {
+    let time_format =
+        time::format_description::parse("[year]-[month]-[day]T[hour]:[minute]:[second]Z").unwrap();
+
+    time::OffsetDateTime::now_utc()
+        .format(&time_format)
+        .unwrap()
 }
 
 fn set_env(name: &str, value: &str) {
@@ -182,27 +170,6 @@ fn run_command(cmd: &str, args: &[&str]) -> anyhow::Result<String> {
     );
 
     Ok(String::from_utf8(output.stdout)?.trim().to_owned())
-}
-
-fn git_hash() -> anyhow::Result<String> {
-    let git_hash = run_command("git", &["rev-parse", "HEAD"])?;
-    if git_hash.is_empty() {
-        anyhow::bail!("empty commit hash");
-    }
-    Ok(git_hash)
-}
-
-fn git_branch() -> anyhow::Result<String> {
-    run_command("git", &["symbolic-ref", "--short", "HEAD"])
-}
-
-/// From <https://git-scm.com/docs/git-rev-parse>:
-///
-/// Resolve `$GIT_DIR/<path>` and takes other path relocation variables such as `$GIT_OBJECT_DIRECTORY`, `$GIT_INDEX_FILE…​` into account.
-/// For example, if `$GIT_OBJECT_DIRECTORY` is set to /foo/bar then `git rev-parse --git-path objects/abc` returns `/foo/bar/abc`.
-fn git_path(path: &str) -> anyhow::Result<PathBuf> {
-    let path = run_command("git", &["rev-parse", "--git-path", path])?;
-    Ok(path.into())
 }
 
 /// Returns `(rustc, LLVM)` versions.

--- a/crates/re_build_tools/src/rebuild_detector.rs
+++ b/crates/re_build_tools/src/rebuild_detector.rs
@@ -36,7 +36,7 @@ fn should_run() -> bool {
 /// This will work even if the package depends on crates that are outside of the workspace,
 /// included with `path = …`
 ///
-/// However, this is a complex things, and may have bugs in it.
+/// However, this is a complex beast, and may have bugs in it.
 /// Maybe it is even causing spurious re-compiles (<https://github.com/rerun-io/rerun/issues/3266>).
 pub fn rebuild_if_crate_changed(pkg_name: &str) {
     if !should_run() {

--- a/crates/re_build_tools/src/rebuild_detector.rs
+++ b/crates/re_build_tools/src/rebuild_detector.rs
@@ -35,6 +35,9 @@ fn should_run() -> bool {
 ///
 /// This will work even if the package depends on crates that are outside of the workspace,
 /// included with `path = …`
+///
+/// However, this is a complex things, and may have bugs in it.
+/// Maybe it is even causing spurious re-compiles (<https://github.com/rerun-io/rerun/issues/3266>).
 pub fn rebuild_if_crate_changed(pkg_name: &str) {
     if !should_run() {
         return;

--- a/crates/re_build_tools/src/rebuild_detector.rs
+++ b/crates/re_build_tools/src/rebuild_detector.rs
@@ -22,6 +22,7 @@ fn should_run() -> bool {
         // Dependencies shouldn't change on CI, but who knows 🤷‍♂️
         Environment::CI => true,
 
+        // Yes - this is what we want tracking for.
         Environment::DeveloperInWorkspace => true,
 
         // Definitely not

--- a/crates/re_types/Cargo.toml
+++ b/crates/re_types/Cargo.toml
@@ -45,6 +45,14 @@ serde = ["dep:serde", "re_string_interner/serde"]
 ## Only useful for testing purposes.
 testing = []
 
+## Special hack!
+##
+## If you configure rust-analyzer to set `--all-features,
+## then this feature will be set and that will ensure that
+## `rust-analyzer` won't run the (expensive) `build.rs`!
+__opt_out_of_auto_rebuild = []
+
+
 [dependencies]
 # Rerun
 re_error.workspace = true

--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -38,6 +38,11 @@ fn should_run() -> bool {
         return false;
     }
 
+    if re_build_tools::get_and_track_env_var("CARGO_FEATURE___OPT_OUT_OF_AUTO_REBUILD").is_ok() {
+        eprintln!("__opt_out_of_auto_rebuild feature detected: Skipping re_types/build.rs");
+        return false;
+    }
+
     match Environment::detect() {
         // we should have been run before publishing
         Environment::PublishingCrates => false,
@@ -67,11 +72,6 @@ fn should_run() -> bool {
 
 fn main() {
     if !should_run() {
-        return;
-    }
-
-    if re_build_tools::get_and_track_env_var("CARGO_FEATURE___OPT_OUT_OF_AUTO_REBUILD").is_ok() {
-        eprintln!("__opt_out_of_auto_rebuild feature detected: Skipping re_types/build.rs");
         return;
     }
 

--- a/crates/re_types/build.rs
+++ b/crates/re_types/build.rs
@@ -70,6 +70,11 @@ fn main() {
         return;
     }
 
+    if re_build_tools::get_and_track_env_var("CARGO_FEATURE___OPT_OUT_OF_AUTO_REBUILD").is_ok() {
+        eprintln!("__opt_out_of_auto_rebuild feature detected: Skipping re_types/build.rs");
+        return;
+    }
+
     rerun_if_changed(SOURCE_HASH_PATH);
     for path in iter_dir(DEFINITIONS_DIR_PATH, Some(&["fbs"])) {
         rerun_if_changed(&path);

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -191,7 +191,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 ///     "definitions/rerun/archetypes.fbs",
 /// );
 /// ```
-pub fn compile_binary_schemas(
+fn compile_binary_schemas(
     include_dir_path: impl AsRef<Utf8Path>,
     output_dir_path: impl AsRef<Utf8Path>,
     entrypoint_path: impl AsRef<Utf8Path>,
@@ -266,7 +266,7 @@ pub fn generate_lang_agnostic(
 }
 
 /// Generates a .gitattributes file that marks up all generated files as generated
-pub fn generate_gitattributes_for_generated_files(
+fn generate_gitattributes_for_generated_files(
     output_path: &impl AsRef<Utf8Path>,
     files: impl Iterator<Item = Utf8PathBuf>,
 ) {
@@ -292,6 +292,7 @@ pub fn generate_gitattributes_for_generated_files(
     codegen::write_file(&path, &content);
 }
 
+/// This will automatically emit a `rerun-if-changed` clause for all the files that were hashed.
 pub fn compute_re_types_builder_hash() -> String {
     compute_crate_hash("re_types_builder")
 }
@@ -303,6 +304,7 @@ pub struct SourceLocations<'a> {
     pub cpp_output_dir: &'a str,
 }
 
+/// Also triggers a re-build if anything that affects the hash changes.
 pub fn compute_re_types_hash(locations: &SourceLocations<'_>) -> String {
     // NOTE: We need to hash both the flatbuffers definitions as well as the source code of the
     // code generator itself!

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -191,7 +191,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 ///     "definitions/rerun/archetypes.fbs",
 /// );
 /// ```
-fn compile_binary_schemas(
+pub fn compile_binary_schemas(
     include_dir_path: impl AsRef<Utf8Path>,
     output_dir_path: impl AsRef<Utf8Path>,
     entrypoint_path: impl AsRef<Utf8Path>,

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -138,15 +138,25 @@ impl App {
             llvm_version
         };
 
-        let short_git_hash = &git_hash[..std::cmp::min(git_hash.len(), 7)];
+        let git_hash_suffix = if git_hash.is_empty() {
+            "".to_owned()
+        } else {
+            let short_git_hash = &git_hash[..std::cmp::min(git_hash.len(), 7)];
+            format!("({short_git_hash})")
+        };
 
-        ui.label(format!(
-            "{crate_name} {version} ({short_git_hash})\n\
-        {target_triple}\n\
-        rustc {rustc_version}\n\
-        LLVM {llvm_version}\n\
-        Built {datetime}",
-        ));
+        let mut label = format!(
+            "{crate_name} {version} {git_hash_suffix}\n\
+            {target_triple}\n\
+            rustc {rustc_version}\n\
+            LLVM {llvm_version}"
+        );
+
+        if !datetime.is_empty() {
+            label += &format!("\nBuilt {datetime}");
+        }
+
+        ui.label(label);
     }
 
     fn options_menu_ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -126,20 +126,8 @@ impl App {
 
         ui.style_mut().wrap = Some(false);
 
-        let rustc_version = if rustc_version.is_empty() {
-            "unknown"
-        } else {
-            rustc_version
-        };
-
-        let llvm_version = if llvm_version.is_empty() {
-            "unknown"
-        } else {
-            llvm_version
-        };
-
         let git_hash_suffix = if git_hash.is_empty() {
-            "".to_owned()
+            String::new()
         } else {
             let short_git_hash = &git_hash[..std::cmp::min(git_hash.len(), 7)];
             format!("({short_git_hash})")
@@ -147,13 +135,18 @@ impl App {
 
         let mut label = format!(
             "{crate_name} {version} {git_hash_suffix}\n\
-            {target_triple}\n\
-            rustc {rustc_version}\n\
-            LLVM {llvm_version}"
+            {target_triple}"
         );
 
+        if !rustc_version.is_empty() {
+            label += &format!("\nrustc {rustc_version}");
+            if !llvm_version.is_empty() {
+                label += &format!(", LLVM {llvm_version}");
+            }
+        }
+
         if !datetime.is_empty() {
-            label += &format!("\nBuilt {datetime}");
+            label += &format!("\nbuilt {datetime}");
         }
 
         ui.label(label);

--- a/crates/re_web_viewer_server/Cargo.toml
+++ b/crates/re_web_viewer_server/Cargo.toml
@@ -34,7 +34,10 @@ all-features = true
 ##
 ## When set: will skip building the Web Viewer Wasm.
 ## This makes the CI much faster, but the resulting web server
-## will crash if you rey to run it!
+## will crash if you try to run it!
+##
+## BONUS: If you configure rust-analyzer to use `--all-features,
+## you will also have rust-analyzer opting-out of building wasm!
 __ci = []
 
 ## Enable telemetry using our analytics SDK.


### PR DESCRIPTION
* Part of https://github.com/rerun-io/rerun/issues/3266

### What
#### `rust-analyzer` will no longer run codegen
…if you configure `rust-analyzer` to use `--all-features`, which you should, and which we do in `.vscode/settings.json`

Same is true for stuff like `bacon` too.

#### No build-time and git branch/commit for local developers
I've removed the build-time and git branch/commit from:

* `rerun --version`
* Viewer Rerun Menu -> About
* analytics

for local developers (that means you), who has cloned our repository.

This is to save us from annoying re-builds using complex detection code.

#### No build-time and git branch/commit for crate users
Users of our crates (i.e. users who put `rerun` in their `Cargo.toml` or build `rerun` using `cargo install rerun`) will also no longer see the build-time and git branch/commit in these places. Previously we would try to get the git branch/commit hash for whatever folder they happened to be in (😬 ), which was not a great idea. So that's a bug fix.

The build time is a bit sadder to let go, but it was always unreliable: if you ran `cargo update` for instance, the build time would not update even if the rerun crate was being rebuilt. So instead of showing an unreliable built-time, I think it is better to just remove it.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3814) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3814)
- [Docs preview](https://rerun.io/preview/b6822d26484951599b89cd0c06b607cb88d2c4ec/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b6822d26484951599b89cd0c06b607cb88d2c4ec/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)