### PR TITLE
Never include the pinhole / camera part in a 2D space view

### DIFF
--- a/crates/re_space_view_spatial/src/contexts/mod.rs
+++ b/crates/re_space_view_spatial/src/contexts/mod.rs
@@ -59,7 +59,7 @@ impl ViewContextSystem for PrimitiveCounter {
     }
 }
 
-pub fn register_contexts(
+pub fn register_spatial_contexts(
     system_registry: &mut re_viewer_context::SpaceViewSystemRegistry,
 ) -> Result<(), SpaceViewClassRegistryError> {
     system_registry.register_context_system::<TransformContext>()?;

--- a/crates/re_space_view_spatial/src/parts/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/parts/entity_iterator.rs
@@ -3,12 +3,16 @@ use re_query::{query_archetype_with_history, ArchetypeView, QueryError};
 use re_renderer::DepthOffset;
 use re_types::Archetype;
 use re_viewer_context::{
-    NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
+    NamedViewSystem, SpaceViewClass, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewQuery, ViewerContext,
 };
 
-use crate::contexts::{
-    AnnotationSceneContext, EntityDepthOffsets, PrimitiveCounter, SharedRenderBuilders,
-    SpatialSceneEntityContext, TransformContext,
+use crate::{
+    contexts::{
+        AnnotationSceneContext, EntityDepthOffsets, PrimitiveCounter, SharedRenderBuilders,
+        SpatialSceneEntityContext, TransformContext,
+    },
+    SpatialSpaceView3D,
 };
 
 /// Iterates through all entity views for a given archetype.
@@ -39,7 +43,18 @@ where
     let counter = view_ctx.get::<PrimitiveCounter>()?;
 
     for (ent_path, props) in query.iter_entities_for_system(System::name()) {
-        let Some(world_from_entity) = transforms.reference_from_entity(ent_path) else {
+        // The transform that considers pinholes only makes sense if this is a 3D space-view
+        let world_from_entity = if view_ctx.space_view_class_name() == SpatialSpaceView3D.name() {
+            transforms.reference_from_entity(ent_path)
+        } else {
+            transforms.reference_from_entity_ignoring_pinhole(
+                ent_path,
+                &ctx.store_db.entity_db.data_store,
+                &query.latest_at_query(),
+            )
+        };
+
+        let Some(world_from_entity) = world_from_entity else {
             continue;
         };
         let entity_context = SpatialSceneEntityContext {

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -30,7 +30,7 @@ use crate::{
     parts::SIZE_BOOST_IN_POINTS_FOR_POINT_OUTLINES,
     query_pinhole,
     view_kind::SpatialSpaceViewKind,
-    SpatialSpaceView2D,
+    SpatialSpaceView2D, SpatialSpaceView3D,
 };
 
 use super::{entity_iterator::process_archetype_views, SpatialViewPartData};
@@ -214,7 +214,13 @@ impl ImagesPart {
     ) -> Result<(), QueryError> {
         re_tracing::profile_function!();
 
-        let parent_pinhole_path = transforms.parent_pinhole(ent_path);
+        // Parent pinhole should only be relevant to 3D views
+        let parent_pinhole_path = if ent_context.space_view_class_name == SpatialSpaceView3D.name()
+        {
+            transforms.parent_pinhole(ent_path)
+        } else {
+            None
+        };
 
         // If this isn't an image, return
         // TODO(jleibs): The ArchetypeView should probably do this for us.
@@ -323,7 +329,13 @@ impl ImagesPart {
         }
         let meaning = TensorDataMeaning::Depth;
 
-        let parent_pinhole_path = transforms.parent_pinhole(ent_path);
+        // Parent pinhole should only be relevant to 3D views
+        let parent_pinhole_path = if ent_context.space_view_class_name == SpatialSpaceView3D.name()
+        {
+            transforms.parent_pinhole(ent_path)
+        } else {
+            None
+        };
 
         // Instance ids of tensors refer to entries inside the tensor.
         for (tensor, color, draw_order) in itertools::izip!(
@@ -439,7 +451,13 @@ impl ImagesPart {
     ) -> Result<(), QueryError> {
         re_tracing::profile_function!();
 
-        let parent_pinhole_path = transforms.parent_pinhole(ent_path);
+        // Parent pinhole should only be relevant to 3D views
+        let parent_pinhole_path = if ent_context.space_view_class_name == SpatialSpaceView3D.name()
+        {
+            transforms.parent_pinhole(ent_path)
+        } else {
+            None
+        };
 
         // If this isn't an image, return
         // TODO(jleibs): The ArchetypeView should probably to this for us.

--- a/crates/re_space_view_spatial/src/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/parts/mod.rs
@@ -43,7 +43,26 @@ pub type Keypoints = HashMap<(re_types::components::ClassId, i64), HashMap<Keypo
 pub const SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES: f32 = 1.5;
 pub const SIZE_BOOST_IN_POINTS_FOR_POINT_OUTLINES: f32 = 2.5;
 
-pub fn register_parts(
+pub fn register_2d_spatial_parts(
+    system_registry: &mut SpaceViewSystemRegistry,
+) -> Result<(), SpaceViewClassRegistryError> {
+    // Note: 2D spatial systems don't include cameras as this
+    // part only shows a 2D projection WITHIN a 3D view.
+    system_registry.register_part_system::<arrows3d::Arrows3DPart>()?;
+    system_registry.register_part_system::<assets3d::Asset3DPart>()?;
+    system_registry.register_part_system::<boxes2d::Boxes2DPart>()?;
+    system_registry.register_part_system::<boxes3d::Boxes3DPart>()?;
+    system_registry.register_part_system::<images::ImagesPart>()?;
+    system_registry.register_part_system::<lines2d::Lines2DPart>()?;
+    system_registry.register_part_system::<lines3d::Lines3DPart>()?;
+    system_registry.register_part_system::<meshes::Mesh3DPart>()?;
+    system_registry.register_part_system::<points2d::Points2DPart>()?;
+    system_registry.register_part_system::<points3d::Points3DPart>()?;
+    system_registry.register_part_system::<transform3d_arrows::Transform3DArrowsPart>()?;
+    Ok(())
+}
+
+pub fn register_3d_spatial_parts(
     system_registry: &mut SpaceViewSystemRegistry,
 ) -> Result<(), SpaceViewClassRegistryError> {
     system_registry.register_part_system::<arrows3d::Arrows3DPart>()?;

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -6,9 +6,9 @@ use re_viewer_context::{
 };
 
 use crate::{
-    contexts::{register_contexts, PrimitiveCounter},
+    contexts::{register_spatial_contexts, PrimitiveCounter},
     heuristics::{auto_spawn_heuristic, update_object_property_heuristics},
-    parts::{calculate_bounding_box, register_parts},
+    parts::{calculate_bounding_box, register_2d_spatial_parts},
     ui::SpatialSpaceViewState,
     view_kind::SpatialSpaceViewKind,
 };
@@ -35,8 +35,9 @@ impl SpaceViewClass for SpatialSpaceView2D {
         &self,
         system_registry: &mut re_viewer_context::SpaceViewSystemRegistry,
     ) -> Result<(), SpaceViewClassRegistryError> {
-        register_contexts(system_registry)?;
-        register_parts(system_registry)?;
+        register_spatial_contexts(system_registry)?;
+        register_2d_spatial_parts(system_registry)?;
+
         Ok(())
     }
 

--- a/crates/re_space_view_spatial/src/space_view_3d.rs
+++ b/crates/re_space_view_spatial/src/space_view_3d.rs
@@ -6,9 +6,9 @@ use re_viewer_context::{
 };
 
 use crate::{
-    contexts::{register_contexts, PrimitiveCounter},
+    contexts::{register_spatial_contexts, PrimitiveCounter},
     heuristics::{auto_spawn_heuristic, update_object_property_heuristics},
-    parts::{calculate_bounding_box, register_parts, CamerasPart},
+    parts::{calculate_bounding_box, register_3d_spatial_parts, CamerasPart},
     ui::SpatialSpaceViewState,
     view_kind::SpatialSpaceViewKind,
 };
@@ -35,8 +35,9 @@ impl SpaceViewClass for SpatialSpaceView3D {
         &self,
         system_registry: &mut re_viewer_context::SpaceViewSystemRegistry,
     ) -> Result<(), SpaceViewClassRegistryError> {
-        register_contexts(system_registry)?;
-        register_parts(system_registry)?;
+        register_spatial_contexts(system_registry)?;
+        register_3d_spatial_parts(system_registry)?;
+
         Ok(())
     }
 


### PR DESCRIPTION
### What
Resolves: https://github.com/rerun-io/rerun/issues/3806

Repro:
```
import numpy as np
import rerun as rr

rr.init("rerun_example_pinhole", spawn=True)
rng = np.random.default_rng(12345)

image = rng.uniform(0, 255, size=[3, 3, 3])
rr.log("world/image", rr.Image(image))
import time
time.sleep(3)
rr.log("world/image", rr.Pinhole(focal_length=3, width=3, height=3))
```

Before:
![image](https://github.com/rerun-io/rerun/assets/3312232/36bde4ae-6a67-47b4-b7e3-98df9187ed89)

After:
![image](https://github.com/rerun-io/rerun/assets/3312232/7fc37163-fdeb-4121-9b67-c6a15a613e86)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3815) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3815)
- [Docs preview](https://rerun.io/preview/f5020bc739982f843f6af085309dbcce498db323/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f5020bc739982f843f6af085309dbcce498db323/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)