### PR TITLE
Get rid of unreadable TODO-regex in `lint.py`

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -18,7 +18,6 @@ from gitignore_parser import parse_gitignore
 
 # -----------------------------------------------------------------------------
 
-todo_pattern = re.compile(r'TODO([^_"(]|$)')
 debug_format_of_err = re.compile(r"\{\:#?\?\}.*, err")
 error_match_name = re.compile(r"Err\((\w+)\)")
 error_map_err_name = re.compile(r"map_err\(\|(\w+)\|")
@@ -28,14 +27,21 @@ else_return = re.compile(r"else\s*{\s*return;?\s*};")
 explicit_quotes = re.compile(r'[^(]\\"\{\w*\}\\"')  # looks for: \"{foo}\"
 ellipsis = re.compile(r"[^.]\.\.\.([^\-.0-9a-zA-Z]|$)")
 
-any_todo_pattern = re.compile(r"TODO\(.*\)")
-legal_todo_inner_pattern = re.compile(
-    r"TODO\(((?:[a-zA-Z\-_/]+[a-zA-Z\-_/\d]+)?#\d+|[a-zA-Z]+)(?:,\s*((?:[a-zA-Z\-_/]+)?#\d+|[a-zA-Z]+))*\)"
-)
-
 anyhow_result = re.compile(r"Result<.*, anyhow::Error>")
 
 double_the = re.compile(r"\bthe the\b")
+
+
+def is_valid_todo_part(part: str) -> bool:
+    part = part.strip()
+
+    if re.match(r"^[\w/-]*#\d+$", part):
+        return True  # org/repo#42 or #42
+
+    if re.match(r"^[a-z][a-z0-9_]+$", part):
+        return True  # user-name
+
+    return False
 
 
 def lint_line(line: str, file_extension: str = "rs") -> str | None:
@@ -74,7 +80,12 @@ def lint_line(line: str, file_extension: str = "rs") -> str | None:
     if "todo!()" in line:
         return 'todo!() should be written as todo!("$details")'
 
-    if todo_pattern.search(line):
+    if m := re.search(r"TODO\(([^)]*)\)", line):
+        parts = m.group(1).split(",")
+        if len(parts) == 0 or not all(is_valid_todo_part(p) for p in parts):
+            return "TODOs should be formatted as either TODO(name), TODO(#42) or TODO(org/repo#42)"
+
+    if re.search(r'TODO([^_"(]|$)', line):
         return "TODO:s should be written as `TODO(yourname): what to do`"
 
     if "{err:?}" in line or "{err:#?}" in line or debug_format_of_err.search(line):
@@ -86,15 +97,13 @@ def lint_line(line: str, file_extension: str = "rs") -> str | None:
     if anyhow_result.search(line):
         return "Prefer using anyhow::Result<>"
 
-    m = re.search(error_map_err_name, line) or re.search(error_match_name, line)
-    if m:
+    if m := re.search(error_map_err_name, line) or re.search(error_match_name, line):
         name = m.group(1)
         # if name not in ("err", "_err", "_"):
         if name in ("e", "error"):
             return "Errors should be called 'err', '_err' or '_'"
 
-    m = re.search(else_return, line)
-    if m:
+    if m := re.search(else_return, line):
         match = m.group(0)
         if match != "else { return; };":
             # Because cargo fmt doesn't handle let-else
@@ -108,9 +117,6 @@ def lint_line(line: str, file_extension: str = "rs") -> str | None:
 
     if explicit_quotes.search(line):
         return "Prefer using {:?} - it will also escape newlines etc"
-
-    if any_todo_pattern.search(line) and not legal_todo_inner_pattern.search(line):
-        return "TODOs should be formatted as either TODO(name), TODO(#42) or TODO(org/repo#42)"
 
     if "rec_stream" in line or "rr_stream" in line:
         return "Instantiated RecordingStreams should be named `rec`"


### PR DESCRIPTION
yes, it is more code, but at least it is readable

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3818) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3818)
- [Docs preview](https://rerun.io/preview/63242db52cc23fadca7d4797413a2a52d970ce21/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/63242db52cc23fadca7d4797413a2a52d970ce21/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)