### PR TITLE
Fix selection history right-click menu not working

### DIFF
--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -45,10 +45,11 @@ impl SelectionHistoryUi {
             let mut return_current = false;
             let response = response.context_menu(|ui| {
                 // undo: newest on top, oldest on bottom
+                let cur = history.current;
                 for i in (0..history.current).rev() {
                     self.history_item_ui(blueprint, ui, i, history);
                 }
-                return_current = true;
+                return_current = cur != history.current;
             });
             if return_current {
                 return history.current().map(|sel| sel.selection);
@@ -94,10 +95,11 @@ impl SelectionHistoryUi {
             let mut return_current = false;
             let response = response.context_menu(|ui| {
                 // redo: oldest on top, most recent on bottom
+                let cur = history.current;
                 for i in (history.current + 1)..history.stack.len() {
                     self.history_item_ui(blueprint, ui, i, history);
                 }
-                return_current = true;
+                return_current = cur != history.current;
             });
             if return_current {
                 return history.current().map(|sel| sel.selection);

--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -42,12 +42,17 @@ impl SelectionHistoryUi {
                     item_collection_to_string(blueprint, &previous.selection),
                 ));
 
+            let mut return_current = false;
             let response = response.context_menu(|ui| {
                 // undo: newest on top, oldest on bottom
                 for i in (0..history.current).rev() {
                     self.history_item_ui(blueprint, ui, i, history);
                 }
+                return_current = true;
             });
+            if return_current {
+                return history.current().map(|sel| sel.selection);
+            }
 
             // TODO(cmc): using the keyboard shortcut should highlight the associated
             // button or something (but then again it, it'd make more sense to do that
@@ -86,12 +91,17 @@ impl SelectionHistoryUi {
                     item_collection_to_string(blueprint, &next.selection),
                 ));
 
+            let mut return_current = false;
             let response = response.context_menu(|ui| {
                 // redo: oldest on top, most recent on bottom
                 for i in (history.current + 1)..history.stack.len() {
                     self.history_item_ui(blueprint, ui, i, history);
                 }
+                return_current = true;
             });
+            if return_current {
+                return history.current().map(|sel| sel.selection);
+            }
 
             // TODO(cmc): using the keyboard shortcut should highlight the associated
             // button or something (but then again it, it'd make more sense to do that


### PR DESCRIPTION
https://github.com/rerun-io/rerun/assets/2910679/733bffef-5f52-4152-9e82-1b570af66a0e


- Fixes #1639

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3819) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3819)
- [Docs preview](https://rerun.io/preview/7fa62f8319321b10df31d39de3d294ba946cc20a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7fa62f8319321b10df31d39de3d294ba946cc20a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)