### PR TITLE
Improve heuristics around 2D vs 3D space-view creation

### DIFF
--- a/crates/re_space_view_bar_chart/src/view_part_system.rs
+++ b/crates/re_space_view_bar_chart/src/view_part_system.rs
@@ -8,8 +8,8 @@ use re_types::{
     Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
-    default_heuristic_filter, NamedViewSystem, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
+    default_heuristic_filter, HeuristicFilterContext, NamedViewSystem,
+    SpaceViewSystemExecutionError, ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 /// A bar chart system, with everything needed to render it.
@@ -45,6 +45,7 @@ impl ViewPartSystem for BarChartViewPartSystem {
         &self,
         store: &re_arrow_store::DataStore,
         ent_path: &EntityPath,
+        _ctx: HeuristicFilterContext,
         query: &LatestAtQuery,
         entity_components: &ComponentNameSet,
     ) -> bool {

--- a/crates/re_space_view_spatial/src/heuristics.rs
+++ b/crates/re_space_view_spatial/src/heuristics.rs
@@ -57,12 +57,16 @@ pub fn auto_spawn_heuristic(
         }
     }
 
-    if view_kind == SpatialSpaceViewKind::TwoD {
-        // Prefer 2D views over 3D views.
-        score += 0.1;
-    }
+    if score > 0.0 {
+        if view_kind == SpatialSpaceViewKind::TwoD {
+            // Prefer 2D views over 3D views.
+            score += 0.1;
+        }
 
-    AutoSpawnHeuristic::SpawnClassWithHighestScoreForRoot(score)
+        AutoSpawnHeuristic::SpawnClassWithHighestScoreForRoot(score)
+    } else {
+        AutoSpawnHeuristic::NeverSpawn
+    }
 }
 
 pub fn update_object_property_heuristics(

--- a/crates/re_space_view_spatial/src/heuristics.rs
+++ b/crates/re_space_view_spatial/src/heuristics.rs
@@ -57,16 +57,7 @@ pub fn auto_spawn_heuristic(
         }
     }
 
-    if score > 0.0 {
-        if view_kind == SpatialSpaceViewKind::TwoD {
-            // Prefer 2D views over 3D views.
-            score += 0.1;
-        }
-
-        AutoSpawnHeuristic::SpawnClassWithHighestScoreForRoot(score)
-    } else {
-        AutoSpawnHeuristic::NeverSpawn
-    }
+    AutoSpawnHeuristic::SpawnClassWithHighestScoreForRoot(score)
 }
 
 pub fn update_object_property_heuristics(

--- a/crates/re_space_view_spatial/src/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes2d.rs
@@ -191,7 +191,7 @@ impl ViewPartSystem for Boxes2DPart {
         }
 
         // If this is a 3D view and there's no parent pinhole, do not include this part.
-        if ctx.class == "3D" && !ctx.has_parent_pinhole {
+        if ctx.class == "3D" && !ctx.has_ancestor_pinhole {
             return false;
         }
 

--- a/crates/re_space_view_spatial/src/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes2d.rs
@@ -1,3 +1,4 @@
+use re_arrow_store::LatestAtQuery;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
@@ -6,8 +7,8 @@ use re_types::{
     Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
-    NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewPartSystem, ViewQuery, ViewerContext,
+    default_heuristic_filter, HeuristicFilterContext, NamedViewSystem, ResolvedAnnotationInfos,
+    SpaceViewSystemExecutionError, ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 use crate::{
@@ -175,6 +176,25 @@ impl ViewPartSystem for Boxes2DPart {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(Boxes2D::indicator().name()).collect()
+    }
+
+    fn heuristic_filter(
+        &self,
+        _store: &re_arrow_store::DataStore,
+        _ent_path: &EntityPath,
+        _ctx: HeuristicFilterContext,
+        _query: &LatestAtQuery,
+        entity_components: &ComponentNameSet,
+    ) -> bool {
+        if !default_heuristic_filter(entity_components, &self.indicator_components()) {
+            return false;
+        }
+
+        if _ctx.class == "3D" && !_ctx.has_parent_pinhole {
+            return false;
+        }
+
+        true
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes2d.rs
@@ -182,7 +182,7 @@ impl ViewPartSystem for Boxes2DPart {
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
-        _ctx: HeuristicFilterContext,
+        ctx: HeuristicFilterContext,
         _query: &LatestAtQuery,
         entity_components: &ComponentNameSet,
     ) -> bool {
@@ -190,7 +190,8 @@ impl ViewPartSystem for Boxes2DPart {
             return false;
         }
 
-        if _ctx.class == "3D" && !_ctx.has_parent_pinhole {
+        // If this is a 3D view and there's no parent pinhole, do not include this part.
+        if ctx.class == "3D" && !ctx.has_parent_pinhole {
             return false;
         }
 

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -19,7 +19,7 @@ use re_types::{
     Archetype as _, ComponentNameSet,
 };
 use re_viewer_context::{
-    default_heuristic_filter, gpu_bridge, DefaultColor, SpaceViewClass,
+    default_heuristic_filter, gpu_bridge, DefaultColor, HeuristicFilterContext, SpaceViewClass,
     SpaceViewSystemExecutionError, TensorDecodeCache, TensorStatsCache, ViewPartSystem, ViewQuery,
     ViewerContext,
 };
@@ -681,10 +681,15 @@ impl ViewPartSystem for ImagesPart {
         &self,
         store: &re_arrow_store::DataStore,
         ent_path: &EntityPath,
+        _ctx: HeuristicFilterContext,
         query: &LatestAtQuery,
         entity_components: &ComponentNameSet,
     ) -> bool {
         if !default_heuristic_filter(entity_components, &self.indicator_components()) {
+            return false;
+        }
+
+        if _ctx.class == "3D" && !_ctx.has_parent_pinhole {
             return false;
         }
 

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -681,7 +681,7 @@ impl ViewPartSystem for ImagesPart {
         &self,
         store: &re_arrow_store::DataStore,
         ent_path: &EntityPath,
-        _ctx: HeuristicFilterContext,
+        ctx: HeuristicFilterContext,
         query: &LatestAtQuery,
         entity_components: &ComponentNameSet,
     ) -> bool {
@@ -689,7 +689,8 @@ impl ViewPartSystem for ImagesPart {
             return false;
         }
 
-        if _ctx.class == "3D" && !_ctx.has_parent_pinhole {
+        // If this is a 3D view and there's no parent pinhole, do not include this part.
+        if ctx.class == "3D" && !ctx.has_parent_pinhole {
             return false;
         }
 

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -690,7 +690,7 @@ impl ViewPartSystem for ImagesPart {
         }
 
         // If this is a 3D view and there's no parent pinhole, do not include this part.
-        if ctx.class == "3D" && !ctx.has_parent_pinhole {
+        if ctx.class == "3D" && !ctx.has_ancestor_pinhole {
             return false;
         }
 

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -1,3 +1,4 @@
+use re_arrow_store::LatestAtQuery;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
@@ -6,8 +7,8 @@ use re_types::{
     Archetype as _, ComponentNameSet,
 };
 use re_viewer_context::{
-    NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewPartSystem, ViewQuery, ViewerContext,
+    default_heuristic_filter, HeuristicFilterContext, NamedViewSystem, ResolvedAnnotationInfos,
+    SpaceViewSystemExecutionError, ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 use crate::{
@@ -170,6 +171,25 @@ impl ViewPartSystem for Lines2DPart {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(LineStrips2D::indicator().name()).collect()
+    }
+
+    fn heuristic_filter(
+        &self,
+        _store: &re_arrow_store::DataStore,
+        _ent_path: &EntityPath,
+        _ctx: HeuristicFilterContext,
+        _query: &LatestAtQuery,
+        entity_components: &ComponentNameSet,
+    ) -> bool {
+        if !default_heuristic_filter(entity_components, &self.indicator_components()) {
+            return false;
+        }
+
+        if _ctx.class == "3D" && !_ctx.has_parent_pinhole {
+            return false;
+        }
+
+        true
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -177,7 +177,7 @@ impl ViewPartSystem for Lines2DPart {
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
-        _ctx: HeuristicFilterContext,
+        ctx: HeuristicFilterContext,
         _query: &LatestAtQuery,
         entity_components: &ComponentNameSet,
     ) -> bool {
@@ -185,7 +185,8 @@ impl ViewPartSystem for Lines2DPart {
             return false;
         }
 
-        if _ctx.class == "3D" && !_ctx.has_parent_pinhole {
+        // If this is a 3D view and there's no parent pinhole, do not include this part.
+        if ctx.class == "3D" && !ctx.has_parent_pinhole {
             return false;
         }
 

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -186,7 +186,7 @@ impl ViewPartSystem for Lines2DPart {
         }
 
         // If this is a 3D view and there's no parent pinhole, do not include this part.
-        if ctx.class == "3D" && !ctx.has_parent_pinhole {
+        if ctx.class == "3D" && !ctx.has_ancestor_pinhole {
             return false;
         }
 

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -1,3 +1,4 @@
+use re_arrow_store::LatestAtQuery;
 use re_data_store::{EntityPath, InstancePathHash};
 use re_query::{ArchetypeView, QueryError};
 use re_types::{
@@ -6,8 +7,8 @@ use re_types::{
     Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
-    NamedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewPartSystem, ViewQuery, ViewerContext,
+    default_heuristic_filter, HeuristicFilterContext, NamedViewSystem, ResolvedAnnotationInfos,
+    SpaceViewSystemExecutionError, ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
 };
 
 use crate::{
@@ -197,6 +198,25 @@ impl ViewPartSystem for Points2DPart {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(Points2D::indicator().name()).collect()
+    }
+
+    fn heuristic_filter(
+        &self,
+        _store: &re_arrow_store::DataStore,
+        _ent_path: &EntityPath,
+        _ctx: HeuristicFilterContext,
+        _query: &LatestAtQuery,
+        entity_components: &ComponentNameSet,
+    ) -> bool {
+        if !default_heuristic_filter(entity_components, &self.indicator_components()) {
+            return false;
+        }
+
+        if _ctx.class == "3D" && !_ctx.has_parent_pinhole {
+            return false;
+        }
+
+        true
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -204,7 +204,7 @@ impl ViewPartSystem for Points2DPart {
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
-        _ctx: HeuristicFilterContext,
+        ctx: HeuristicFilterContext,
         _query: &LatestAtQuery,
         entity_components: &ComponentNameSet,
     ) -> bool {
@@ -212,7 +212,8 @@ impl ViewPartSystem for Points2DPart {
             return false;
         }
 
-        if _ctx.class == "3D" && !_ctx.has_parent_pinhole {
+        // If this is a 3D view and there's no parent pinhole, do not include this part.
+        if ctx.class == "3D" && !ctx.has_parent_pinhole {
             return false;
         }
 

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -213,7 +213,7 @@ impl ViewPartSystem for Points2DPart {
         }
 
         // If this is a 3D view and there's no parent pinhole, do not include this part.
-        if ctx.class == "3D" && !ctx.has_parent_pinhole {
+        if ctx.class == "3D" && !ctx.has_ancestor_pinhole {
             return false;
         }
 

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -72,7 +72,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
         _space_origin: &EntityPath,
         per_system_entities: &PerSystemEntities,
     ) -> AutoSpawnHeuristic {
-        let score = auto_spawn_heuristic(
+        let mut score = auto_spawn_heuristic(
             &self.name(),
             ctx,
             per_system_entities,
@@ -100,6 +100,16 @@ impl SpaceViewClass for SpatialSpaceView2D {
                         }
                     }
                 }
+            }
+        }
+
+        if let AutoSpawnHeuristic::SpawnClassWithHighestScoreForRoot(score) = &mut score {
+            // If a 2D view contains nothing inherently 2D in nature, don't
+            // spawn it, though in all other cases default to 2D over 3D as a tie-breaker.
+            if *score == 0.0 {
+                return AutoSpawnHeuristic::NeverSpawn;
+            } else {
+                *score += 0.1;
             }
         }
 

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -69,7 +69,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
     fn auto_spawn_heuristic(
         &self,
         ctx: &ViewerContext<'_>,
-        _space_origin: &EntityPath,
+        space_origin: &EntityPath,
         per_system_entities: &PerSystemEntities,
     ) -> AutoSpawnHeuristic {
         let mut score = auto_spawn_heuristic(
@@ -83,7 +83,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
         // prefer to be 3D, don't spawn the 2D view. This is because it's never
         // possible to correctly project 3d objects to a root 2d view since the
         // the pinhole would go past the root.
-        if _space_origin.is_root() {
+        if space_origin.is_root() {
             let parts = ctx
                 .space_view_class_registry
                 .get_system_registry_or_log_error(&self.name())

--- a/crates/re_space_view_tensor/src/view_part_system.rs
+++ b/crates/re_space_view_tensor/src/view_part_system.rs
@@ -6,8 +6,9 @@ use re_types::{
     ComponentNameSet,
 };
 use re_viewer_context::{
-    default_heuristic_filter, NamedViewSystem, SpaceViewSystemExecutionError, TensorDecodeCache,
-    ViewContextCollection, ViewPartSystem, ViewQuery, ViewerContext,
+    default_heuristic_filter, HeuristicFilterContext, NamedViewSystem,
+    SpaceViewSystemExecutionError, TensorDecodeCache, ViewContextCollection, ViewPartSystem,
+    ViewQuery, ViewerContext,
 };
 
 #[derive(Default)]
@@ -37,6 +38,7 @@ impl ViewPartSystem for TensorSystem {
         &self,
         store: &re_arrow_store::DataStore,
         ent_path: &EntityPath,
+        _ctx: HeuristicFilterContext,
         query: &LatestAtQuery,
         entity_components: &ComponentNameSet,
     ) -> bool {

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -39,12 +39,12 @@ pub use selection_state::{
     HoverHighlight, HoveredSpace, InteractionHighlight, SelectionHighlight, SelectionState,
 };
 pub use space_view::{
-    default_heuristic_filter, AutoSpawnHeuristic, DynSpaceViewClass, NamedViewSystem,
-    PerSystemEntities, SpaceViewClass, SpaceViewClassLayoutPriority, SpaceViewClassName,
-    SpaceViewClassRegistry, SpaceViewClassRegistryError, SpaceViewEntityHighlight,
-    SpaceViewHighlights, SpaceViewOutlineMasks, SpaceViewState, SpaceViewSystemExecutionError,
-    SpaceViewSystemRegistry, ViewContextCollection, ViewContextSystem, ViewPartCollection,
-    ViewPartSystem, ViewQuery, ViewSystemName,
+    default_heuristic_filter, AutoSpawnHeuristic, DynSpaceViewClass, HeuristicFilterContext,
+    NamedViewSystem, PerSystemEntities, SpaceViewClass, SpaceViewClassLayoutPriority,
+    SpaceViewClassName, SpaceViewClassRegistry, SpaceViewClassRegistryError,
+    SpaceViewEntityHighlight, SpaceViewHighlights, SpaceViewOutlineMasks, SpaceViewState,
+    SpaceViewSystemExecutionError, SpaceViewSystemRegistry, ViewContextCollection,
+    ViewContextSystem, ViewPartCollection, ViewPartSystem, ViewQuery, ViewSystemName,
 };
 pub use store_context::StoreContext;
 pub use tensor::{TensorDecodeCache, TensorStats, TensorStatsCache};

--- a/crates/re_viewer_context/src/space_view/mod.rs
+++ b/crates/re_viewer_context/src/space_view/mod.rs
@@ -26,7 +26,9 @@ pub use space_view_class_registry::{
     SpaceViewClassRegistry, SpaceViewClassRegistryError, SpaceViewSystemRegistry,
 };
 pub use view_context_system::{ViewContextCollection, ViewContextSystem};
-pub use view_part_system::{default_heuristic_filter, ViewPartCollection, ViewPartSystem};
+pub use view_part_system::{
+    default_heuristic_filter, HeuristicFilterContext, ViewPartCollection, ViewPartSystem,
+};
 pub use view_query::ViewQuery;
 
 // ---------------------------------------------------------------------------

--- a/crates/re_viewer_context/src/space_view/view_part_system.rs
+++ b/crates/re_viewer_context/src/space_view/view_part_system.rs
@@ -16,14 +16,14 @@ use crate::{
 #[derive(Clone, Copy, Debug)]
 pub struct HeuristicFilterContext {
     pub class: SpaceViewClassName,
-    pub has_parent_pinhole: bool,
+    pub has_ancestor_pinhole: bool,
 }
 
 impl Default for HeuristicFilterContext {
     fn default() -> HeuristicFilterContext {
         Self {
             class: SpaceViewClassName::invalid(),
-            has_parent_pinhole: false,
+            has_ancestor_pinhole: false,
         }
     }
 }
@@ -32,7 +32,7 @@ impl HeuristicFilterContext {
     pub fn with_class(&self, class: SpaceViewClassName) -> Self {
         Self {
             class,
-            has_parent_pinhole: self.has_parent_pinhole,
+            has_ancestor_pinhole: self.has_ancestor_pinhole,
         }
     }
 }

--- a/crates/re_viewer_context/src/space_view/view_part_system.rs
+++ b/crates/re_viewer_context/src/space_view/view_part_system.rs
@@ -9,6 +9,10 @@ use crate::{
     ViewQuery, ViewSystemName, ViewerContext,
 };
 
+/// This is additional context made available to the `heuristic_filter`.
+/// It includes tree-context information such as whether certain components
+/// exist in the parent hierarchy which are better computed once than having
+/// each entity do their own tree-walk.
 #[derive(Clone, Copy, Debug)]
 pub struct HeuristicFilterContext {
     pub class: SpaceViewClassName,

--- a/crates/re_viewer_context/src/space_view/view_part_system.rs
+++ b/crates/re_viewer_context/src/space_view/view_part_system.rs
@@ -5,9 +5,33 @@ use re_log_types::EntityPath;
 use re_types::ComponentNameSet;
 
 use crate::{
-    NamedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery,
-    ViewSystemName, ViewerContext,
+    NamedViewSystem, SpaceViewClassName, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewQuery, ViewSystemName, ViewerContext,
 };
+
+#[derive(Clone, Copy, Debug)]
+pub struct HeuristicFilterContext {
+    pub class: SpaceViewClassName,
+    pub has_parent_pinhole: bool,
+}
+
+impl Default for HeuristicFilterContext {
+    fn default() -> HeuristicFilterContext {
+        Self {
+            class: SpaceViewClassName::invalid(),
+            has_parent_pinhole: false,
+        }
+    }
+}
+
+impl HeuristicFilterContext {
+    pub fn with_class(&self, class: SpaceViewClassName) -> Self {
+        Self {
+            class,
+            has_parent_pinhole: self.has_parent_pinhole,
+        }
+    }
+}
 
 /// Element of a scene derived from a single archetype query.
 ///
@@ -46,6 +70,7 @@ pub trait ViewPartSystem {
         &self,
         _store: &re_arrow_store::DataStore,
         _ent_path: &EntityPath,
+        _ctx: HeuristicFilterContext,
         _query: &LatestAtQuery,
         entity_components: &ComponentNameSet,
     ) -> bool {
@@ -80,7 +105,7 @@ pub trait ViewPartSystem {
 
 /// The default implementation for [`ViewPartSystem::heuristic_filter`].
 ///
-/// Returns true if eiher `indicator_components` is empty or `entity_components` contains at least one
+/// Returns true if either `indicator_components` is empty or `entity_components` contains at least one
 /// of these indicator components.
 ///
 /// Exported as a standalone function to simplify the implementation of custom filters.

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -9,7 +9,8 @@ use re_viewer_context::{
 use crate::{
     space_info::SpaceInfoCollection,
     space_view_heuristics::{
-        is_entity_processed_by_class, reachable_entities_from_root, EntitiesPerSystem,
+        compute_heuristic_context_for_entities, is_entity_processed_by_class,
+        reachable_entities_from_root, EntitiesPerSystem,
     },
 };
 
@@ -255,12 +256,18 @@ impl SpaceViewBlueprint {
     ) {
         re_tracing::profile_function!();
 
+        let heuristic_context = compute_heuristic_context_for_entities(ctx);
+
         let mut entities = Vec::new();
         tree.visit_children_recursively(&mut |entity_path: &EntityPath| {
             if is_entity_processed_by_class(
                 ctx,
                 &self.class_name,
                 entity_path,
+                heuristic_context
+                    .get(entity_path)
+                    .copied()
+                    .unwrap_or_default(),
                 &ctx.current_query(),
             ) && !self.contents.contains_entity(entity_path)
                 && spaces_info

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -3,15 +3,16 @@ use itertools::Itertools;
 use nohash_hasher::{IntMap, IntSet};
 
 use re_arrow_store::{LatestAtQuery, Timeline};
-use re_data_store::EntityPath;
+use re_data_store::{EntityPath, EntityTree};
+use re_log_types::TimeInt;
 use re_types::{
     archetypes::{Image, SegmentationImage},
     components::{DisconnectedSpace, TensorData},
     Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
-    AutoSpawnHeuristic, SpaceViewClassName, ViewContextCollection, ViewPartCollection,
-    ViewSystemName, ViewerContext,
+    AutoSpawnHeuristic, HeuristicFilterContext, SpaceViewClassName, ViewContextCollection,
+    ViewPartCollection, ViewSystemName, ViewerContext,
 };
 use tinyvec::TinyVec;
 
@@ -413,13 +414,20 @@ pub fn is_entity_processed_by_class(
     ctx: &ViewerContext<'_>,
     class: &SpaceViewClassName,
     ent_path: &EntityPath,
+    heuristic_ctx: HeuristicFilterContext,
     query: &LatestAtQuery,
 ) -> bool {
     let parts = ctx
         .space_view_class_registry
         .get_system_registry_or_log_error(class)
         .new_part_collection();
-    is_entity_processed_by_part_collection(ctx.store_db.store(), &parts, ent_path, query)
+    is_entity_processed_by_part_collection(
+        ctx.store_db.store(),
+        &parts,
+        ent_path,
+        heuristic_ctx.with_class(*class),
+        query,
+    )
 }
 
 /// Returns true if an entity is processed by any of the given [`re_viewer_context::ViewPartSystem`]s.
@@ -427,6 +435,7 @@ fn is_entity_processed_by_part_collection(
     store: &re_arrow_store::DataStore,
     parts: &ViewPartCollection,
     ent_path: &EntityPath,
+    ctx: HeuristicFilterContext,
     query: &LatestAtQuery,
 ) -> bool {
     let timeline = Timeline::log_time();
@@ -436,12 +445,59 @@ fn is_entity_processed_by_part_collection(
         .into_iter()
         .collect();
     for part in parts.iter() {
-        if part.heuristic_filter(store, ent_path, query, &components) {
+        if part.heuristic_filter(store, ent_path, ctx, query, &components) {
             return true;
         }
     }
 
     false
+}
+
+pub type HeuristicFilterContextPerEntity = IntMap<EntityPath, HeuristicFilterContext>;
+
+pub fn compute_heuristic_context_for_entities(
+    ctx: &ViewerContext<'_>,
+) -> HeuristicFilterContextPerEntity {
+    let mut heuristic_context = IntMap::default();
+
+    // Use "right most"/latest available data.
+    let timeline = Timeline::log_time();
+    let query_time = TimeInt::MAX;
+    let query = LatestAtQuery::new(timeline, query_time);
+
+    let tree = &ctx.store_db.entity_db.tree;
+
+    fn visit_children_recursively(
+        has_parent_pinhole: bool,
+        tree: &EntityTree,
+        store: &re_arrow_store::DataStore,
+        query: &LatestAtQuery,
+        heuristic_context: &mut HeuristicFilterContextPerEntity,
+    ) {
+        let has_parent_pinhole =
+            query_pinhole(store, query, &tree.path).is_some() || has_parent_pinhole;
+
+        heuristic_context.insert(
+            tree.path.clone(),
+            HeuristicFilterContext {
+                class: SpaceViewClassName::invalid(),
+                has_parent_pinhole,
+            },
+        );
+
+        for child in tree.children.values() {
+            visit_children_recursively(has_parent_pinhole, child, store, query, heuristic_context);
+        }
+    }
+
+    visit_children_recursively(
+        false,
+        tree,
+        &ctx.store_db.entity_db.data_store,
+        &query,
+        &mut heuristic_context,
+    );
+    heuristic_context
 }
 
 pub fn identify_entities_per_system_per_class(
@@ -498,6 +554,7 @@ pub fn identify_entities_per_system_per_class(
 
     let mut entities_per_system_per_class = EntitiesPerSystemPerClass::default();
 
+    let heuristic_context = compute_heuristic_context_for_entities(ctx);
     let store = ctx.store_db.store();
     for ent_path in ctx.store_db.entity_db.entity_paths() {
         let Some(components) = store.all_components(&re_log_types::Timeline::log_time(), ent_path)
@@ -522,6 +579,11 @@ pub fn identify_entities_per_system_per_class(
                         if !view_part_system.heuristic_filter(
                             store,
                             ent_path,
+                            heuristic_context
+                                .get(ent_path)
+                                .copied()
+                                .unwrap_or_default()
+                                .with_class(*class),
                             &ctx.current_query(),
                             &all_components,
                         ) {

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -475,13 +475,13 @@ pub fn compute_heuristic_context_for_entities(
         heuristic_context: &mut HeuristicFilterContextPerEntity,
     ) {
         let has_parent_pinhole =
-            query_pinhole(store, query, &tree.path).is_some() || has_parent_pinhole;
+            has_parent_pinhole || query_pinhole(store, query, &tree.path).is_some();
 
         heuristic_context.insert(
             tree.path.clone(),
             HeuristicFilterContext {
                 class: SpaceViewClassName::invalid(),
-                has_parent_pinhole,
+                has_ancestor_pinhole: has_parent_pinhole,
             },
         );
 


### PR DESCRIPTION
### What
Resolves:
 - https://github.com/rerun-io/rerun/issues/3712 and probably more

Against my better judgement I ended up with one more pile of compelling hacks.
I believe it addresses many of the existing annoyances with awkwardly mixed 2d/3d views without (to my knowledge) causing regressions on the existing examples, though I haven't thoroughly tested everything yet, SFM, Human Motion, Arkit, etc. all look good.

The very high level idea is to prevent including 2D data in 3D views when it can't be projected via a pinhole, and then in a few other common edge-cases, more aggressively force 3D views.

This is done through 3 heuristic changes:
 - In order for a 2D part to *ever* be part of a 3D view, there must be a Pinhole above it in the hierarchy.  Because this is something that can be inspected within the context of the tree without regard to any given space, we can evaluate this for each entity path as part of `identify_entities_per_system_per_class`.
   - To make the information available to the filter, we introduce a new `HeuristicFilterContext` that allows the heuristic filter to observe which class it is being evaluated for as well as other information about the tree.
- In the event that a 2d-space-view has a score of 0, we no longer spawn it. This should logically use 3d instead.
- In the event that a 2d-space-view at the root has any entities that would rather be 3D don't spawn it. Logically this follows from the fact that the only applicable pinhole in such a space would be at the root itself, and 3d data would need to transform past the root to be projected.

Some examples of the improved behavior:

As reported in https://github.com/rerun-io/rerun/issues/3712
```
rr.init("test", spawn=True)
rr.log("image/box", rr.Boxes2D(array=[10, 10, 50, 50], array_format=rr.Box2DFormat.XYXY))
rr.log("image", rr.Image(np.random.rand(100, 100, 3)))
rr.log("points", rr.Points3D(np.random.rand(100, 3)))
```

Before:
![image](https://github.com/rerun-io/rerun/assets/3312232/e018fcd8-7c98-428e-b5ff-cd49cefe800b)

After:
![image](https://github.com/rerun-io/rerun/assets/3312232/cf73a458-a1e1-43d9-abbd-91afe4b5d3b1)

And another particularly bad case I found while exploring:
```
rr.init("test", spawn=True)
rr.log("box", rr.Boxes3D(half_sizes=[1, 1, 1]))
rr.log("image", rr.Image(np.random.rand(100, 100, 3)))
rr.log("points", rr.Points3D(np.random.rand(100, 3)))
```

Before:
![image](https://github.com/rerun-io/rerun/assets/3312232/599407f1-d650-4ad7-b138-4594b8460b7b)

After:
![image](https://github.com/rerun-io/rerun/assets/3312232/94f5007b-40ba-4afb-974c-421984985f7d)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3822) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3822)
- [Docs preview](https://rerun.io/preview/680bf58b501d8b16d68caf6afab358e71c8aa013/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/680bf58b501d8b16d68caf6afab358e71c8aa013/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)