### PR TITLE
Fix release process (part 2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,11 +116,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RERUN_BOT_TOKEN }}
         run: |
-          pr=$(gh pr view --json headRefName 2>/dev/null)
+          set +e
+          pr=$(gh pr view --json headRefName 2>/dev/null || echo "no pull requests found")
           if echo "$pr" | jq '. | has("headRefName")' | grep -q 'true'; then
             echo "PR already exists"
             exit 0
           fi
+          set -e
 
           echo "PR does not exist, creating…"
 


### PR DESCRIPTION
### What

- `run` in CI runs with `bash -e`, so we have to unset it via `set +e`

https://github.com/rerun-io/rerun/actions/runs/6492940882/job/17632868304

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
