### PR TITLE
Remove unsued `EntityPathOpMsg`

### DIFF
--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -1,4 +1,4 @@
-use re_log_types::{ArrowMsg, DataTable, EntityPathOpMsg, LogMsg, SetStoreInfo, StoreInfo};
+use re_log_types::{ArrowMsg, DataTable, LogMsg, SetStoreInfo, StoreInfo};
 use re_viewer_context::{UiVerbosity, ViewerContext};
 
 use super::DataUi;
@@ -14,7 +14,6 @@ impl DataUi for LogMsg {
     ) {
         match self {
             LogMsg::SetStoreInfo(msg) => msg.data_ui(ctx, ui, verbosity, query),
-            LogMsg::EntityPathOpMsg(_, msg) => msg.data_ui(ctx, ui, verbosity, query),
             LogMsg::ArrowMsg(_, msg) => msg.data_ui(ctx, ui, verbosity, query),
         }
     }
@@ -62,32 +61,6 @@ impl DataUi for SetStoreInfo {
 
             ui.monospace("store_kind:");
             ui.label(format!("{store_kind}"));
-            ui.end_row();
-        });
-    }
-}
-
-impl DataUi for EntityPathOpMsg {
-    fn data_ui(
-        &self,
-        ctx: &mut ViewerContext<'_>,
-        ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
-        query: &re_arrow_store::LatestAtQuery,
-    ) {
-        let EntityPathOpMsg {
-            row_id: _,
-            time_point,
-            path_op,
-        } = self;
-
-        egui::Grid::new("fields").num_columns(2).show(ui, |ui| {
-            ui.monospace("time_point:");
-            time_point.data_ui(ctx, ui, verbosity, query);
-            ui.end_row();
-
-            ui.monospace("path_op:");
-            path_op.data_ui(ctx, ui, verbosity, query);
             ui.end_row();
         });
     }

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -228,9 +228,6 @@ pub enum LogMsg {
     /// Should usually be the first message sent.
     SetStoreInfo(SetStoreInfo),
 
-    /// Server-backed operation on an [`EntityPath`].
-    EntityPathOpMsg(StoreId, EntityPathOpMsg),
-
     /// Log an entity using an [`ArrowMsg`].
     ArrowMsg(StoreId, ArrowMsg),
 }
@@ -239,7 +236,7 @@ impl LogMsg {
     pub fn store_id(&self) -> &StoreId {
         match self {
             Self::SetStoreInfo(msg) => &msg.info.store_id,
-            Self::EntityPathOpMsg(store_id, _) | Self::ArrowMsg(store_id, _) => store_id,
+            Self::ArrowMsg(store_id, _) => store_id,
         }
     }
 }
@@ -371,24 +368,6 @@ impl std::fmt::Display for StoreSource {
 }
 
 // ----------------------------------------------------------------------------
-
-/// An operation (like a 'clear') on an [`EntityPath`].
-#[must_use]
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct EntityPathOpMsg {
-    /// A unique id per [`EntityPathOpMsg`].
-    pub row_id: RowId,
-
-    /// Time information (when it was logged, when it was received, …).
-    ///
-    /// If this is empty, no operation will be performed as we
-    /// cannot be timeless in a meaningful way.
-    pub time_point: TimePoint,
-
-    /// What operation.
-    pub path_op: PathOp,
-}
 
 /// Operation to perform on an [`EntityPath`], e.g. clearing all components.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1423,7 +1423,7 @@ mod tests {
                 assert!(msg.row_id != RowId::ZERO);
                 similar_asserts::assert_eq!(store_info, msg.info);
             }
-            _ => panic!("expected SetStoreInfo"),
+            LogMsg::ArrowMsg { .. } => panic!("expected SetStoreInfo"),
         }
 
         // Second message should be a set_store_info resulting from the later sink swap from
@@ -1434,7 +1434,7 @@ mod tests {
                 assert!(msg.row_id != RowId::ZERO);
                 similar_asserts::assert_eq!(store_info, msg.info);
             }
-            _ => panic!("expected SetStoreInfo"),
+            LogMsg::ArrowMsg { .. } => panic!("expected SetStoreInfo"),
         }
 
         // Third message is the batched table itself, which was sent as a result of the implicit
@@ -1451,7 +1451,7 @@ mod tests {
 
                 similar_asserts::assert_eq!(table, got);
             }
-            _ => panic!("expected ArrowMsg"),
+            LogMsg::SetStoreInfo { .. } => panic!("expected ArrowMsg"),
         }
 
         // That's all.
@@ -1490,7 +1490,7 @@ mod tests {
                 assert!(msg.row_id != RowId::ZERO);
                 similar_asserts::assert_eq!(store_info, msg.info);
             }
-            _ => panic!("expected SetStoreInfo"),
+            LogMsg::ArrowMsg { .. } => panic!("expected SetStoreInfo"),
         }
 
         // Second message should be a set_store_info resulting from the later sink swap from
@@ -1501,7 +1501,7 @@ mod tests {
                 assert!(msg.row_id != RowId::ZERO);
                 similar_asserts::assert_eq!(store_info, msg.info);
             }
-            _ => panic!("expected SetStoreInfo"),
+            LogMsg::ArrowMsg { .. } => panic!("expected SetStoreInfo"),
         }
 
         let mut rows = {
@@ -1525,7 +1525,7 @@ mod tests {
 
                     similar_asserts::assert_eq!(expected, got);
                 }
-                _ => panic!("expected ArrowMsg"),
+                LogMsg::SetStoreInfo { .. } => panic!("expected ArrowMsg"),
             }
         };
 
@@ -1570,7 +1570,7 @@ mod tests {
                     assert!(msg.row_id != RowId::ZERO);
                     similar_asserts::assert_eq!(store_info, msg.info);
                 }
-                _ => panic!("expected SetStoreInfo"),
+                LogMsg::ArrowMsg { .. } => panic!("expected SetStoreInfo"),
             }
 
             // MemorySinkStorage transparently handles flushing during `take()`!
@@ -1588,7 +1588,7 @@ mod tests {
 
                     similar_asserts::assert_eq!(table, got);
                 }
-                _ => panic!("expected ArrowMsg"),
+                LogMsg::SetStoreInfo { .. } => panic!("expected ArrowMsg"),
             }
 
             // That's all.

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -249,7 +249,7 @@ impl CongestionManager {
         #[allow(clippy::match_same_arms)]
         match msg {
             // we don't want to drop any of these
-            LogMsg::SetStoreInfo(_) | LogMsg::EntityPathOpMsg(_, _) => true,
+            LogMsg::SetStoreInfo(_) => true,
 
             LogMsg::ArrowMsg(_, arrow_msg) => self.should_send_time_point(&arrow_msg.timepoint_max),
         }

--- a/crates/re_viewer/src/saving.rs
+++ b/crates/re_viewer/src/saving.rs
@@ -81,7 +81,6 @@ pub fn save_database_to_file(
     path: std::path::PathBuf,
     time_selection: Option<(re_data_store::Timeline, re_log_types::TimeRangeF)>,
 ) -> anyhow::Result<impl FnOnce() -> anyhow::Result<std::path::PathBuf>> {
-    use itertools::Itertools as _;
     use re_arrow_store::TimeRange;
 
     re_tracing::profile_function!();
@@ -89,11 +88,6 @@ pub fn save_database_to_file(
     let set_store_info_msg = store_db
         .store_info_msg()
         .map(|msg| LogMsg::SetStoreInfo(msg.clone()));
-
-    let ent_op_msgs = store_db
-        .iter_entity_op_msgs()
-        .map(|msg| LogMsg::EntityPathOpMsg(store_db.store_id().clone(), msg.clone()))
-        .collect_vec();
 
     let time_filter = time_selection.map(|(timeline, range)| {
         (
@@ -117,7 +111,6 @@ pub fn save_database_to_file(
 
     let msgs = std::iter::once(set_store_info_msg)
         .flatten() // option
-        .chain(ent_op_msgs)
         .chain(data_msgs);
 
     Ok(move || {


### PR DESCRIPTION
### What
We now have a `Clear` component.

* Blocked on https://github.com/rerun-io/rerun/pull/3832

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3833) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3833)
- [Docs preview](https://rerun.io/preview/a39e2fa7d5ea311739b060d294491d89a3329826/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a39e2fa7d5ea311739b060d294491d89a3329826/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)