### PR TITLE
`--max-frame` support for tracking examples

### DIFF
--- a/examples/python/detect_and_track_objects/main.py
+++ b/examples/python/detect_and_track_objects/main.py
@@ -363,7 +363,7 @@ def update_trackers_with_detections(
     return updated_trackers
 
 
-def track_objects(video_path: str) -> None:
+def track_objects(video_path: str, max_frame_count: int | None) -> None:
     with open(COCO_CATEGORIES_PATH) as f:
         coco_categories = json.load(f)
     class_descriptions = [
@@ -380,6 +380,9 @@ def track_objects(video_path: str) -> None:
     label_strs = [cat["name"] or str(cat["id"]) for cat in coco_categories]
     trackers: list[Tracker] = []
     while cap.isOpened():
+        if max_frame_count is not None and frame_idx >= max_frame_count:
+            break
+
         ret, bgr = cap.read()
         rr.set_time_sequence("frame", frame_idx)
 
@@ -445,6 +448,11 @@ def main() -> None:
     )
     parser.add_argument("--dataset_dir", type=Path, default=DATASET_DIR, help="Directory to save example videos to.")
     parser.add_argument("--video_path", type=str, default="", help="Full path to video to run on. Overrides `--video`.")
+    parser.add_argument(
+        "--max-frame",
+        type=int,
+        help="Stop after processing this many frames. If not specified, will run until interrupted.",
+    )
     rr.script_add_args(parser)
     args = parser.parse_args()
 
@@ -458,7 +466,7 @@ def main() -> None:
     if not video_path:
         video_path = get_downloaded_path(args.dataset_dir, args.video)
 
-    track_objects(video_path)
+    track_objects(video_path, max_frame_count=args.max_frame)
 
     rr.script_teardown(args)
 

--- a/examples/python/detect_and_track_objects/main.py
+++ b/examples/python/detect_and_track_objects/main.py
@@ -363,7 +363,7 @@ def update_trackers_with_detections(
     return updated_trackers
 
 
-def track_objects(video_path: str, max_frame_count: int | None) -> None:
+def track_objects(video_path: str, *, max_frame_count: int | None) -> None:
     with open(COCO_CATEGORIES_PATH) as f:
         coco_categories = json.load(f)
     class_descriptions = [

--- a/examples/python/human_pose_tracking/main.py
+++ b/examples/python/human_pose_tracking/main.py
@@ -60,7 +60,7 @@ nd 3D as [rr.Points2D](https://www.rerun.io/docs/reference/types/archetypes/poin
 """.strip()
 
 
-def track_pose(video_path: str, segment: bool, max_frame_count: int | None) -> None:
+def track_pose(video_path: str, *, segment: bool, max_frame_count: int | None) -> None:
     mp_pose = mp.solutions.pose
 
     rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -18,6 +18,8 @@ EXTRA_ARGS = {
     "examples/python/clock": ["--steps=200"],  # Make it faster
     "examples/python/live_camera_edge_detection": ["--num-frames=30"],  # Make sure it finishes
     "examples/python/face_tracking": ["--max-frame=30"],  # Make sure it finishes
+    "examples/python/human_pose_tracking": ["--max-frame=10"],  # Make it faster
+    "examples/python/detect_and_track_objects": ["--max-frame=10"],  # Make it faster
 }
 
 HAS_NO_RERUN_ARGS = {

--- a/scripts/run_all.py
+++ b/scripts/run_all.py
@@ -16,10 +16,10 @@ from typing import Any
 
 EXTRA_ARGS = {
     "examples/python/clock": ["--steps=200"],  # Make it faster
-    "examples/python/live_camera_edge_detection": ["--num-frames=30"],  # Make sure it finishes
+    "examples/python/detect_and_track_objects": ["--max-frame=10"],  # Make it faster
     "examples/python/face_tracking": ["--max-frame=30"],  # Make sure it finishes
     "examples/python/human_pose_tracking": ["--max-frame=10"],  # Make it faster
-    "examples/python/detect_and_track_objects": ["--max-frame=10"],  # Make it faster
+    "examples/python/live_camera_edge_detection": ["--num-frames=30"],  # Make sure it finishes
 }
 
 HAS_NO_RERUN_ARGS = {


### PR DESCRIPTION
- Fixes #1930

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3835) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3835)
- [Docs preview](https://rerun.io/preview/8b844151475fa466bc51d752749649ecc5ecec6e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8b844151475fa466bc51d752749649ecc5ecec6e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)