### PR TITLE
Expand C++ style guide

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -129,7 +129,7 @@ Use `re_error::format(err)` when displaying an error.
 We use `clang-format` to enforce most style choices (see [`.clang-format`](.clang-format)).
 
 ### Initialization
-Always use `const` unless you plan on mutating it.
+Always use `const` unless you plan on mutating it, with the exception of function paramers (because that is just too much noise).
 
 We use `const auto x = …` for declaration because that gives symmetric code for normal constructors and static constructors:
 

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -126,6 +126,25 @@ Use `re_error::format(err)` when displaying an error.
 
 
 ## C++
+For compatibility reasons we use C++11 (and nothing newer).
+We use `clang-format` to enforce most style choices (see [`.clang-format`](.clang-format)).
+
+### Initialization
+Always use `const` unless you plan on mutating it.
+
+We use `const auto x = …` for declaration because that gives symmetric code for normal constructors and static constructors:
+
+```C++
+const auto foo = SomeClass{…};
+const auto bar = SomeClass::new_xyzw(…);
+```
+
+We use `{}` for constructors (`Foo{…}` instead of `Foo(…)`).
+
+### Misc
+We don't add `inline ` before class/struct methods.
+
+### Members
 We prefix _private_ member variables with a `_`:
 
 ```C++

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -142,7 +142,7 @@ const auto bar = SomeClass::new_xyzw(…);
 We use `{}` for constructors (`Foo{…}` instead of `Foo(…)`).
 
 ### Misc
-We don't add `inline ` before class/struct methods.
+We don't add `inline ` before class/struct member functions if they are inlined in the class/struct definition.
 
 ### Members
 We prefix _private_ member variables with a `_`:

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -129,7 +129,7 @@ Use `re_error::format(err)` when displaying an error.
 We use `clang-format` to enforce most style choices (see [`.clang-format`](.clang-format)).
 
 ### Initialization
-Always use `const` unless you plan on mutating it, with the exception of function paramers (because that is just too much noise).
+Always use `const` unless you plan on mutating it, with the exception of function parameters (because that is just too much noise).
 
 We use `const auto x = …` for declaration because that gives symmetric code for normal constructors and static constructors:
 

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -126,7 +126,6 @@ Use `re_error::format(err)` when displaying an error.
 
 
 ## C++
-For compatibility reasons we use C++11 (and nothing newer).
 We use `clang-format` to enforce most style choices (see [`.clang-format`](.clang-format)).
 
 ### Initialization
@@ -142,7 +141,7 @@ const auto bar = SomeClass::new_xyzw(…);
 We use `{}` for constructors (`Foo{…}` instead of `Foo(…)`).
 
 ### Misc
-We don't add `inline ` before class/struct member functions if they are inlined in the class/struct definition.
+We don't add `inline` before class/struct member functions if they are inlined in the class/struct definition.
 
 ### Members
 We prefix _private_ member variables with a `_`:

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -138,7 +138,7 @@ const auto foo = SomeClass{…};
 const auto bar = SomeClass::new_xyzw(…);
 ```
 
-We use `{}` for constructors (`Foo{…}` instead of `Foo(…)`).
+We prefer `{}` for constructors (`Foo{…}` instead of `Foo(…)`), though there are exceptions (`std::vector{2, 3}` is different from `std::vector(2, 3)`).
 
 ### Misc
 We don't add `inline` before class/struct member functions if they are inlined in the class/struct definition.


### PR DESCRIPTION
### What
Expand C++ style guide with even more style choices.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3851) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3851)
- [Docs preview](https://rerun.io/preview/01ad11ac921c4acd81c8be09266c16b0aa5db58e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/01ad11ac921c4acd81c8be09266c16b0aa5db58e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)