### PR TITLE
`arrow2-convert` migration 1: `TUID`, `RowId`, `TableId`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,6 @@ name = "re_tuid"
 version = "0.10.0-alpha.7+dev"
 dependencies = [
  "arrow2",
- "arrow2_convert",
  "criterion",
  "document-features",
  "getrandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4686,6 +4686,7 @@ dependencies = [
  "document-features",
  "getrandom",
  "once_cell",
+ "re_types",
  "serde",
  "thiserror",
  "web-time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4689,6 +4689,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "serde",
+ "thiserror",
  "web-time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4237,7 +4237,6 @@ name = "re_format"
 version = "0.10.0-alpha.7+dev"
 dependencies = [
  "arrow2",
- "arrow2_convert",
  "comfy-table",
  "re_tuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4699,7 +4699,6 @@ dependencies = [
  "anyhow",
  "array-init",
  "arrow2",
- "arrow2_convert",
  "backtrace",
  "bytemuck",
  "document-features",

--- a/crates/re_arrow_store/src/store_arrow.rs
+++ b/crates/re_arrow_store/src/store_arrow.rs
@@ -4,7 +4,7 @@ use arrow2::{array::Array, chunk::Chunk, datatypes::Schema};
 use nohash_hasher::IntMap;
 use re_log_types::{
     DataCellColumn, DataTable, DataTableResult, RowId, Timeline, COLUMN_INSERT_ID,
-    COLUMN_NUM_INSTANCES, COLUMN_ROW_ID,
+    COLUMN_NUM_INSTANCES,
 };
 use re_types::ComponentName;
 
@@ -149,8 +149,7 @@ fn serialize_control_columns(
         columns.push(insert_id_column);
     }
 
-    let (row_id_field, row_id_column) =
-        DataTable::serialize_control_column(COLUMN_ROW_ID, col_row_id)?;
+    let (row_id_field, row_id_column) = DataTable::serialize_control_column(col_row_id)?;
     schema.fields.push(row_id_field);
     columns.push(row_id_column);
 

--- a/crates/re_arrow_store/src/store_sanity.rs
+++ b/crates/re_arrow_store/src/store_sanity.rs
@@ -1,8 +1,7 @@
 use re_log_types::{
-    DataCellColumn, SizeBytes as _, TimeRange, COLUMN_NUM_INSTANCES, COLUMN_ROW_ID,
-    COLUMN_TIMEPOINT,
+    DataCellColumn, RowId, SizeBytes as _, TimeRange, COLUMN_NUM_INSTANCES, COLUMN_TIMEPOINT,
 };
-use re_types::ComponentName;
+use re_types::{ComponentName, Loggable};
 
 use crate::{DataStore, IndexedBucket, IndexedBucketInner, IndexedTable, PersistentIndexedTable};
 
@@ -193,7 +192,7 @@ impl IndexedBucket {
                     (!col_insert_id.is_empty())
                         .then(|| (DataStore::insert_id_key(), col_insert_id.len())), //
                     Some((COLUMN_TIMEPOINT.into(), col_time.len())),
-                    Some((COLUMN_ROW_ID.into(), col_row_id.len())),
+                    Some((RowId::name(), col_row_id.len())),
                     Some((COLUMN_NUM_INSTANCES.into(), col_num_instances.len())),
                 ]
                 .into_iter()
@@ -274,7 +273,7 @@ impl PersistentIndexedTable {
             let column_lengths = [
                 (!col_insert_id.is_empty())
                     .then(|| (DataStore::insert_id_key(), col_insert_id.len())), //
-                Some((COLUMN_ROW_ID.into(), col_row_id.len())),
+                Some((RowId::name(), col_row_id.len())),
                 Some((COLUMN_NUM_INSTANCES.into(), col_num_instances.len())),
             ]
             .into_iter()

--- a/crates/re_format/Cargo.toml
+++ b/crates/re_format/Cargo.toml
@@ -19,4 +19,4 @@ all-features = true
 arrow2.workspace = true
 arrow2_convert.workspace = true
 comfy-table.workspace = true
-re_tuid = { workspace = true, features = ["arrow2_convert"] }
+re_tuid = { workspace = true, features = ["arrow"] }

--- a/crates/re_format/Cargo.toml
+++ b/crates/re_format/Cargo.toml
@@ -17,6 +17,5 @@ all-features = true
 
 [dependencies]
 arrow2.workspace = true
-arrow2_convert.workspace = true
 comfy-table.workspace = true
 re_tuid = { workspace = true, features = ["arrow"] }

--- a/crates/re_format/src/arrow.rs
+++ b/crates/re_format/src/arrow.rs
@@ -3,10 +3,9 @@
 use std::fmt::Formatter;
 
 use arrow2::{
-    array::{get_display, Array, ListArray, StructArray},
+    array::{get_display, Array, ListArray},
     datatypes::{DataType, IntervalUnit, TimeUnit},
 };
-use arrow2_convert::deserialize::TryIntoCollection;
 use comfy_table::{presets, Cell, Table};
 
 use re_tuid::Tuid;
@@ -68,9 +67,8 @@ fn parse_tuid(array: &dyn Array, index: usize) -> Option<Tuid> {
         // New control columns: it's not a list to begin with!
         _ => (array.to_boxed(), index),
     };
-    let array = array.as_any().downcast_ref::<StructArray>()?;
 
-    let tuids: Vec<Tuid> = TryIntoCollection::try_into_collection(array.to_boxed()).ok()?;
+    let tuids = Tuid::from_arrow(array.as_ref()).ok()?;
     tuids.get(index).copied()
 }
 

--- a/crates/re_format/src/arrow.rs
+++ b/crates/re_format/src/arrow.rs
@@ -38,8 +38,7 @@ pub fn get_custom_display<'a, F: std::fmt::Write + 'a>(
 
     if let Some(DataType::Extension(name, _, _)) = datatype {
         // TODO(#1775): This should be registered dynamically.
-        // NOTE: Can't call `Tuid::name()`, `Component` lives in `re_log_types`.
-        if name.as_str() == "rerun.tuid" {
+        if name.as_str() == Tuid::name() {
             return Box::new(|w, index| {
                 if let Some(tuid) = parse_tuid(array, index) {
                     w.write_fmt(format_args!("{tuid}"))
@@ -226,7 +225,11 @@ where
         .map(|(name, data_type)| {
             Cell::new(format!(
                 "{}\n---\n{}",
-                name.replace("rerun.components.", "").replace("rerun.", ""),
+                name.replace("rerun.archetypes.", "")
+                    .replace("rerun.components.", "")
+                    .replace("rerun.datatypes.", "")
+                    .replace("rerun.controls.", "")
+                    .replace("rerun.", ""),
                 DisplayDataType(data_type.clone())
             ))
         });

--- a/crates/re_format/src/arrow.rs
+++ b/crates/re_format/src/arrow.rs
@@ -225,11 +225,11 @@ where
         .map(|(name, data_type)| {
             Cell::new(format!(
                 "{}\n---\n{}",
-                name.replace("rerun.archetypes.", "")
-                    .replace("rerun.components.", "")
-                    .replace("rerun.datatypes.", "")
-                    .replace("rerun.controls.", "")
-                    .replace("rerun.", ""),
+                name.trim_start_matches("rerun.archetypes.")
+                    .trim_start_matches("rerun.components.")
+                    .trim_start_matches("rerun.datatypes.")
+                    .trim_start_matches("rerun.controls.")
+                    .trim_start_matches("rerun."),
                 DisplayDataType(data_type.clone())
             ))
         });

--- a/crates/re_format/src/arrow.rs
+++ b/crates/re_format/src/arrow.rs
@@ -8,7 +8,7 @@ use arrow2::{
 };
 use comfy_table::{presets, Cell, Table};
 
-use re_tuid::Tuid;
+use re_tuid::{external::re_types::Loggable as _, Tuid};
 
 // ---
 

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -37,7 +37,7 @@ re_format.workspace = true
 re_log.workspace = true
 re_string_interner.workspace = true
 re_tracing.workspace = true
-re_tuid = { workspace = true, features = ["arrow2_convert"] }
+re_tuid = { workspace = true, features = ["arrow"] }
 re_types = { workspace = true, features = ["image"] }
 
 # External

--- a/crates/re_log_types/src/data_row.rs
+++ b/crates/re_log_types/src/data_row.rs
@@ -157,7 +157,7 @@ impl std::ops::DerefMut for RowId {
     }
 }
 
-re_tuid::delegate_arrow_tuid!(RowId as "rerun.control.RowId");
+re_tuid::delegate_arrow_tuid!(RowId as "rerun.controls.RowId");
 
 /// A row's worth of data, i.e. an event: a list of [`DataCell`]s associated with an auto-generated
 /// `RowId`, a user-specified [`TimePoint`] and [`EntityPath`], and an expected number of

--- a/crates/re_log_types/src/data_row.rs
+++ b/crates/re_log_types/src/data_row.rs
@@ -106,21 +106,8 @@ impl SizeBytes for DataCellRow {
 // ---
 
 /// A unique ID for a [`DataRow`].
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    arrow2_convert::ArrowField,
-    arrow2_convert::ArrowSerialize,
-    arrow2_convert::ArrowDeserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[arrow_field(transparent)]
 pub struct RowId(pub(crate) re_tuid::Tuid);
 
 impl std::fmt::Display for RowId {
@@ -169,6 +156,8 @@ impl std::ops::DerefMut for RowId {
         &mut self.0
     }
 }
+
+re_tuid::delegate_arrow_tuid!(RowId as "rerun.control.RowId");
 
 /// A row's worth of data, i.e. an event: a list of [`DataCell`]s associated with an auto-generated
 /// `RowId`, a user-specified [`TimePoint`] and [`EntityPath`], and an expected number of

--- a/crates/re_log_types/src/data_table.rs
+++ b/crates/re_log_types/src/data_table.rs
@@ -176,7 +176,7 @@ impl std::ops::DerefMut for TableId {
     }
 }
 
-re_tuid::delegate_arrow_tuid!(TableId as "rerun.control.TableId");
+re_tuid::delegate_arrow_tuid!(TableId as "rerun.controls.TableId");
 
 /// A sparse table's worth of data, i.e. a batch of events: a collection of [`DataRow`]s.
 /// This is the top-level layer in our data model.

--- a/crates/re_log_types/src/data_table.rs
+++ b/crates/re_log_types/src/data_table.rs
@@ -128,21 +128,8 @@ impl SizeBytes for DataCellColumn {
 // ---
 
 /// A unique ID for a [`DataTable`].
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    arrow2_convert::ArrowField,
-    arrow2_convert::ArrowSerialize,
-    arrow2_convert::ArrowDeserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[arrow_field(transparent)]
 pub struct TableId(pub(crate) re_tuid::Tuid);
 
 impl std::fmt::Display for TableId {
@@ -182,6 +169,8 @@ impl std::ops::DerefMut for TableId {
         &mut self.0
     }
 }
+
+re_tuid::delegate_arrow_tuid!(TableId as "rerun.control.TableId");
 
 /// A sparse table's worth of data, i.e. a batch of events: a collection of [`DataRow`]s.
 /// This is the top-level layer in our data model.

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -47,8 +47,8 @@ pub use self::data_row::{
 pub use self::data_table::{
     DataCellColumn, DataCellOptVec, DataTable, DataTableError, DataTableResult, EntityPathVec,
     ErasedTimeVec, NumInstancesVec, RowIdVec, TableId, TimePointVec, COLUMN_ENTITY_PATH,
-    COLUMN_INSERT_ID, COLUMN_NUM_INSTANCES, COLUMN_ROW_ID, COLUMN_TIMEPOINT, METADATA_KIND,
-    METADATA_KIND_CONTROL, METADATA_KIND_DATA,
+    COLUMN_INSERT_ID, COLUMN_NUM_INSTANCES, COLUMN_TIMEPOINT, METADATA_KIND, METADATA_KIND_CONTROL,
+    METADATA_KIND_DATA,
 };
 pub use self::index::*;
 pub use self::path::*;

--- a/crates/re_tuid/Cargo.toml
+++ b/crates/re_tuid/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 default = []
 
 ## Enable (de)serialization using Arrow.
-arrow = ["dep:arrow2"]
+arrow = ["dep:arrow2", "dep:thiserror"]
 
 ## Enable (de)serialization using serde.
 serde = ["dep:serde"]

--- a/crates/re_tuid/Cargo.toml
+++ b/crates/re_tuid/Cargo.toml
@@ -27,6 +27,8 @@ serde = ["dep:serde"]
 
 
 [dependencies]
+re_types.workspace = true # TODO
+
 document-features.workspace = true
 getrandom = "0.2"
 once_cell.workspace = true

--- a/crates/re_tuid/Cargo.toml
+++ b/crates/re_tuid/Cargo.toml
@@ -19,8 +19,8 @@ all-features = true
 [features]
 default = []
 
-## Enable converting Tuid to arrow2
-arrow2_convert = ["dep:arrow2", "dep:arrow2_convert"]
+## Enable (de)serialization using Arrow.
+arrow = ["dep:arrow2"]
 
 ## Enable (de)serialization using serde.
 serde = ["dep:serde"]
@@ -33,8 +33,7 @@ once_cell.workspace = true
 web-time.workspace = true
 
 # Optional dependencies:
-arrow2 = { workspace = true, optional = true }                    # used by arrow2_convert
-arrow2_convert = { workspace = true, optional = true }
+arrow2 = { workspace = true, optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 thiserror = { workspace = true, optional = true }
 

--- a/crates/re_tuid/Cargo.toml
+++ b/crates/re_tuid/Cargo.toml
@@ -20,21 +20,22 @@ all-features = true
 default = []
 
 ## Enable (de)serialization using Arrow.
-arrow = ["dep:arrow2", "dep:thiserror"]
+arrow = ["dep:re_types", "dep:arrow2", "dep:thiserror"]
 
 ## Enable (de)serialization using serde.
 serde = ["dep:serde"]
 
 
 [dependencies]
-re_types.workspace = true # TODO
-
 document-features.workspace = true
 getrandom = "0.2"
 once_cell.workspace = true
 web-time.workspace = true
 
-# Optional dependencies:
+# Optional dependencies
+
+re_types = { workspace = true, optional = true }
+
 arrow2 = { workspace = true, optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 thiserror = { workspace = true, optional = true }

--- a/crates/re_tuid/Cargo.toml
+++ b/crates/re_tuid/Cargo.toml
@@ -36,6 +36,7 @@ web-time.workspace = true
 arrow2 = { workspace = true, optional = true }                    # used by arrow2_convert
 arrow2_convert = { workspace = true, optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
+thiserror = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/crates/re_tuid/benches/bench_tuid.rs
+++ b/crates/re_tuid/benches/bench_tuid.rs
@@ -8,23 +8,15 @@ fn bench_tuid(c: &mut Criterion) {
     });
 }
 
-#[cfg(feature = "arrow2_convert")]
+#[cfg(feature = "arrow")]
 fn bench_arrow(c: &mut Criterion) {
     use arrow2::array::Array;
-    use arrow2_convert::{deserialize::TryIntoCollection, serialize::TryIntoArrow};
 
     {
         let mut group = c.benchmark_group("arrow/serialize");
         group.throughput(criterion::Throughput::Elements(1));
 
         let tuid = re_tuid::Tuid::random();
-
-        group.bench_function("arrow2_convert", |b| {
-            b.iter(|| {
-                let data: Box<dyn Array> = vec![tuid].try_into_arrow().unwrap();
-                criterion::black_box(data)
-            });
-        });
 
         group.bench_function("arrow2", |b| {
             b.iter(|| {
@@ -38,14 +30,7 @@ fn bench_arrow(c: &mut Criterion) {
         let mut group = c.benchmark_group("arrow/deserialize");
         group.throughput(criterion::Throughput::Elements(1));
 
-        let data: Box<dyn Array> = vec![re_tuid::Tuid::random()].try_into_arrow().unwrap();
-
-        group.bench_function("arrow2_convert", |b| {
-            b.iter(|| {
-                let tuids: Vec<re_tuid::Tuid> = data.as_ref().try_into_collection().unwrap();
-                criterion::black_box(tuids)
-            });
-        });
+        let data: Box<dyn Array> = re_tuid::Tuid::random().as_arrow();
 
         group.bench_function("arrow2", |b| {
             b.iter(|| {

--- a/crates/re_tuid/benches/bench_tuid.rs
+++ b/crates/re_tuid/benches/bench_tuid.rs
@@ -18,9 +18,17 @@ fn bench_arrow(c: &mut Criterion) {
         group.throughput(criterion::Throughput::Elements(1));
 
         let tuid = re_tuid::Tuid::random();
+
         group.bench_function("arrow2_convert", |b| {
             b.iter(|| {
                 let data: Box<dyn Array> = vec![tuid].try_into_arrow().unwrap();
+                criterion::black_box(data)
+            });
+        });
+
+        group.bench_function("arrow2", |b| {
+            b.iter(|| {
+                let data: Box<dyn Array> = tuid.as_arrow();
                 criterion::black_box(data)
             });
         });
@@ -31,10 +39,18 @@ fn bench_arrow(c: &mut Criterion) {
         group.throughput(criterion::Throughput::Elements(1));
 
         let data: Box<dyn Array> = vec![re_tuid::Tuid::random()].try_into_arrow().unwrap();
+
         group.bench_function("arrow2_convert", |b| {
             b.iter(|| {
                 let tuids: Vec<re_tuid::Tuid> = data.as_ref().try_into_collection().unwrap();
                 criterion::black_box(tuids)
+            });
+        });
+
+        group.bench_function("arrow2", |b| {
+            b.iter(|| {
+                let tuid = re_tuid::Tuid::from_arrow(data.as_ref()).unwrap();
+                criterion::black_box(tuid)
             });
         });
     }

--- a/crates/re_tuid/benches/bench_tuid.rs
+++ b/crates/re_tuid/benches/bench_tuid.rs
@@ -8,7 +8,7 @@ fn bench_tuid(c: &mut Criterion) {
     });
 }
 
-// #[cfg(feature = "arrow")]
+#[cfg(feature = "arrow")]
 fn bench_arrow(c: &mut Criterion) {
     use arrow2::array::Array;
 

--- a/crates/re_tuid/benches/bench_tuid.rs
+++ b/crates/re_tuid/benches/bench_tuid.rs
@@ -8,5 +8,37 @@ fn bench_tuid(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_tuid,);
+#[cfg(feature = "arrow2_convert")]
+fn bench_arrow(c: &mut Criterion) {
+    use arrow2::array::Array;
+    use arrow2_convert::{deserialize::TryIntoCollection, serialize::TryIntoArrow};
+
+    {
+        let mut group = c.benchmark_group("arrow/serialize");
+        group.throughput(criterion::Throughput::Elements(1));
+
+        let tuid = re_tuid::Tuid::random();
+        group.bench_function("arrow2_convert", |b| {
+            b.iter(|| {
+                let data: Box<dyn Array> = vec![tuid].try_into_arrow().unwrap();
+                criterion::black_box(data)
+            });
+        });
+    }
+
+    {
+        let mut group = c.benchmark_group("arrow/deserialize");
+        group.throughput(criterion::Throughput::Elements(1));
+
+        let data: Box<dyn Array> = vec![re_tuid::Tuid::random()].try_into_arrow().unwrap();
+        group.bench_function("arrow2_convert", |b| {
+            b.iter(|| {
+                let tuids: Vec<re_tuid::Tuid> = data.as_ref().try_into_collection().unwrap();
+                criterion::black_box(tuids)
+            });
+        });
+    }
+}
+
+criterion_group!(benches, bench_tuid, bench_arrow);
 criterion_main!(benches);

--- a/crates/re_tuid/benches/bench_tuid.rs
+++ b/crates/re_tuid/benches/bench_tuid.rs
@@ -11,6 +11,7 @@ fn bench_tuid(c: &mut Criterion) {
 #[cfg(feature = "arrow")]
 fn bench_arrow(c: &mut Criterion) {
     use arrow2::array::Array;
+    use re_types::Loggable as _;
 
     for nb_elems in [1, 1000] {
         {
@@ -21,7 +22,7 @@ fn bench_arrow(c: &mut Criterion) {
 
             group.bench_function("arrow2", |b| {
                 b.iter(|| {
-                    let data: Box<dyn Array> = re_tuid::Tuid::to_arrow(tuids.clone());
+                    let data: Box<dyn Array> = re_tuid::Tuid::to_arrow(tuids.clone()).unwrap();
                     criterion::black_box(data)
                 });
             });
@@ -32,7 +33,7 @@ fn bench_arrow(c: &mut Criterion) {
             group.throughput(criterion::Throughput::Elements(nb_elems));
 
             let data: Box<dyn Array> =
-                re_tuid::Tuid::to_arrow(vec![re_tuid::Tuid::random(); nb_elems as usize]);
+                re_tuid::Tuid::to_arrow(vec![re_tuid::Tuid::random(); nb_elems as usize]).unwrap();
 
             group.bench_function("arrow2", |b| {
                 b.iter(|| {

--- a/crates/re_tuid/benches/bench_tuid.rs
+++ b/crates/re_tuid/benches/bench_tuid.rs
@@ -13,12 +13,12 @@ fn bench_arrow(c: &mut Criterion) {
     use arrow2::array::Array;
     use re_types::Loggable as _;
 
-    for nb_elems in [1, 1000] {
+    for elem_count in [1, 1000] {
         {
-            let mut group = c.benchmark_group(format!("arrow/serialize/nb_elems={nb_elems}"));
-            group.throughput(criterion::Throughput::Elements(nb_elems));
+            let mut group = c.benchmark_group(format!("arrow/serialize/elem_count={elem_count}"));
+            group.throughput(criterion::Throughput::Elements(elem_count));
 
-            let tuids = vec![re_tuid::Tuid::random(); nb_elems as usize];
+            let tuids = vec![re_tuid::Tuid::random(); elem_count as usize];
 
             group.bench_function("arrow2", |b| {
                 b.iter(|| {
@@ -29,11 +29,12 @@ fn bench_arrow(c: &mut Criterion) {
         }
 
         {
-            let mut group = c.benchmark_group(format!("arrow/deserialize/nb_elems={nb_elems}"));
-            group.throughput(criterion::Throughput::Elements(nb_elems));
+            let mut group = c.benchmark_group(format!("arrow/deserialize/elem_count={elem_count}"));
+            group.throughput(criterion::Throughput::Elements(elem_count));
 
             let data: Box<dyn Array> =
-                re_tuid::Tuid::to_arrow(vec![re_tuid::Tuid::random(); nb_elems as usize]).unwrap();
+                re_tuid::Tuid::to_arrow(vec![re_tuid::Tuid::random(); elem_count as usize])
+                    .unwrap();
 
             group.bench_function("arrow2", |b| {
                 b.iter(|| {

--- a/crates/re_tuid/src/arrow.rs
+++ b/crates/re_tuid/src/arrow.rs
@@ -1,0 +1,103 @@
+use arrow2::{
+    array::{Array, StructArray, UInt64Array},
+    datatypes::{DataType, Field},
+};
+
+use crate::Tuid;
+
+// ---
+
+pub type DeserializationResult<T> = ::std::result::Result<T, DeserializationError>;
+
+#[derive(Debug, thiserror::Error, Clone)]
+pub enum DeserializationError {
+    #[error("Expected {expected:#?} but found {got:#?} instead")]
+    DatatypeMismatch {
+        expected: ::arrow2::datatypes::DataType,
+        got: ::arrow2::datatypes::DataType,
+    },
+
+    #[error("Expected field {field:#?} to be of unit-length but found {got} entries instead")]
+    InvalidLength { field: String, got: usize },
+}
+
+impl Tuid {
+    /// The underlying [`arrow2::datatypes::DataType`], excluding datatype extensions.
+    #[inline]
+    pub fn arrow_datatype() -> DataType {
+        DataType::Struct(vec![
+            Field::new("time_ns", DataType::UInt64, false),
+            Field::new("inc", DataType::UInt64, false),
+        ])
+    }
+
+    /// The underlying [`arrow2::datatypes::DataType`], including datatype extensions.
+    #[inline]
+    fn extended_arrow_datatype() -> arrow2::datatypes::DataType {
+        DataType::Extension("rerun.tuid".into(), Box::new(Self::arrow_datatype()), None)
+    }
+
+    #[inline]
+    pub fn as_arrow(&self) -> Box<dyn Array> {
+        let extended_datatype = Self::extended_arrow_datatype();
+        let values = vec![
+            UInt64Array::from_vec(vec![self.time_ns]).boxed(),
+            UInt64Array::from_vec(vec![self.inc]).boxed(),
+        ];
+        let validity = None;
+        StructArray::new(extended_datatype, values, validity).boxed()
+    }
+
+    #[inline]
+    pub fn from_arrow(array: &dyn Array) -> DeserializationResult<Self> {
+        let expected_datatype = Self::arrow_datatype();
+        let actual_datatype = array.data_type().to_logical_type();
+        if actual_datatype != &expected_datatype {
+            return Err(DeserializationError::DatatypeMismatch {
+                expected: expected_datatype,
+                got: actual_datatype.clone(),
+            });
+        }
+
+        // NOTE: Unwrap is safe everywhere below, datatype is checked above.
+        // NOTE: We don't even look at the validity, our datatype says we don't care.
+
+        let array = array.as_any().downcast_ref::<StructArray>().unwrap();
+
+        // TODO(cmc): Can we rely on the fields ordering from the datatype? I would assume not
+        // since we generally cannot rely on anything when it comes to arrow...
+        // If we could, that would also impact our codegen deserialization path.
+        let (time_ns_index, inc_index) = {
+            let mut time_ns_index = None;
+            let mut inc_index = None;
+            for (i, field) in array.fields().iter().enumerate() {
+                if field.name == "time_ns" {
+                    time_ns_index = Some(i);
+                } else if field.name == "inc" {
+                    inc_index = Some(i);
+                }
+            }
+            (time_ns_index.unwrap(), inc_index.unwrap())
+        };
+
+        let get_first_value = |field_name: &str, field_index: usize| {
+            let field_array = array.values()[field_index]
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .unwrap()
+                .values();
+            if field_array.len() != 1 {
+                return Err(DeserializationError::InvalidLength {
+                    field: field_name.into(),
+                    got: field_array.len(),
+                });
+            }
+            Ok(field_array[0])
+        };
+
+        Ok(Self {
+            time_ns: get_first_value("time_ns", time_ns_index)?,
+            inc: get_first_value("inc", inc_index)?,
+        })
+    }
+}

--- a/crates/re_tuid/src/arrow.rs
+++ b/crates/re_tuid/src/arrow.rs
@@ -27,7 +27,7 @@ impl Loggable for Tuid {
 
     #[inline]
     fn name() -> Self::Name {
-        "rerun.control.TUID".into()
+        "rerun.controls.TUID".into()
     }
 
     #[inline]
@@ -68,7 +68,9 @@ impl Loggable for Tuid {
             UInt64Array::from_vec(inc_values).boxed(),
         ];
         let validity = None;
-        Ok(StructArray::new(Self::arrow_datatype(), values, validity).boxed())
+
+        // TODO(#3360): We use the extended type here because we rely on it for formatting.
+        Ok(StructArray::new(Self::extended_arrow_datatype(), values, validity).boxed())
     }
 
     fn from_arrow(

--- a/crates/re_tuid/src/arrow.rs
+++ b/crates/re_tuid/src/arrow.rs
@@ -91,7 +91,7 @@ impl Loggable for Tuid {
         let array = array.as_any().downcast_ref::<StructArray>().unwrap();
 
         // TODO(cmc): Can we rely on the fields ordering from the datatype? I would assume not
-        // since we generally cannot rely on anything when it comes to arrow...
+        // since we generally cannot rely on anything when it comes to arrow…
         // If we could, that would also impact our codegen deserialization path.
         let (time_ns_index, inc_index) = {
             let mut time_ns_index = None;

--- a/crates/re_tuid/src/lib.rs
+++ b/crates/re_tuid/src/lib.rs
@@ -22,6 +22,9 @@ pub struct Tuid {
 }
 
 #[cfg(feature = "arrow2_convert")]
+mod arrow;
+
+#[cfg(feature = "arrow2_convert")]
 arrow2_convert::arrow_enable_vec_for_type!(Tuid);
 
 // TODO(#3741): shouldn't have to write this manually

--- a/crates/re_tuid/src/lib.rs
+++ b/crates/re_tuid/src/lib.rs
@@ -21,25 +21,8 @@ pub struct Tuid {
     inc: u64,
 }
 
-#[cfg(feature = "arrow2_convert")]
+#[cfg(feature = "arrow")]
 mod arrow;
-
-#[cfg(feature = "arrow2_convert")]
-arrow2_convert::arrow_enable_vec_for_type!(Tuid);
-
-// TODO(#3741): shouldn't have to write this manually
-#[cfg(feature = "arrow2_convert")]
-impl arrow2_convert::field::ArrowField for Tuid {
-    type Type = Self;
-
-    fn data_type() -> arrow2::datatypes::DataType {
-        let datatype = arrow2::datatypes::DataType::Struct(<[_]>::into_vec(Box::new([
-            <u64 as arrow2_convert::field::ArrowField>::field("time_ns"),
-            <u64 as arrow2_convert::field::ArrowField>::field("inc"),
-        ])));
-        arrow2::datatypes::DataType::Extension("rerun.tuid".into(), Box::new(datatype), None)
-    }
-}
 
 impl std::fmt::Display for Tuid {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/re_tuid/src/lib.rs
+++ b/crates/re_tuid/src/lib.rs
@@ -22,7 +22,12 @@ pub struct Tuid {
 }
 
 #[cfg(feature = "arrow")]
-mod arrow;
+pub mod arrow;
+
+pub mod external {
+    #[cfg(feature = "arrow")]
+    pub use re_types;
+}
 
 impl std::fmt::Display for Tuid {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/re_tuid/src/lib.rs
+++ b/crates/re_tuid/src/lib.rs
@@ -7,10 +7,6 @@
 //!
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(
-    feature = "arrow2_convert",
-    derive(arrow2_convert::ArrowSerialize, arrow2_convert::ArrowDeserialize)
-)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Tuid {
     /// Approximate nanoseconds since epoch.

--- a/crates/re_types/Cargo.toml
+++ b/crates/re_types/Cargo.toml
@@ -68,7 +68,6 @@ arrow2 = { workspace = true, features = [
   "io_print",
   "compute_concatenate",
 ] }
-arrow2_convert.workspace = true
 backtrace.workspace = true
 bytemuck = { workspace = true, features = ["derive", "extern_crate_alloc"] }
 document-features.workspace = true

--- a/crates/re_types/src/components/text_ext.rs
+++ b/crates/re_types/src/components/text_ext.rs
@@ -27,13 +27,3 @@ impl std::borrow::Borrow<str> for Text {
         self.as_str()
     }
 }
-
-// TODO(emilk): required to use with `range_entity_with_primary`. remove once the migration is over
-impl arrow2_convert::field::ArrowField for Text {
-    type Type = Self;
-
-    fn data_type() -> arrow2::datatypes::DataType {
-        use crate::Loggable as _;
-        Self::arrow_field().data_type
-    }
-}

--- a/crates/re_types/src/components/text_log_level_ext.rs
+++ b/crates/re_types/src/components/text_log_level_ext.rs
@@ -45,13 +45,3 @@ impl std::borrow::Borrow<str> for TextLogLevel {
         self.as_str()
     }
 }
-
-// TODO(emilk): required to use with `range_entity_with_primary`. remove once the migration is over
-impl arrow2_convert::field::ArrowField for TextLogLevel {
-    type Type = Self;
-
-    fn data_type() -> arrow2::datatypes::DataType {
-        use crate::Loggable as _;
-        Self::arrow_field().data_type
-    }
-}


### PR DESCRIPTION
This PR marks start of the migration away from `arrow2-convert`.

We start with our control columns, and more specifically our `TUID`-based control columns: `TUID`, `RowId`, `TableId`. 

This introduces a new convention: the `rerun.controls.` prefix (e.g. `rerun.controls.RowId`).
This likely means that this PR completely breaks old rrd files (I haven't tested, but that would make sense).

These control components now go through the same deserialization stack as everything else (`re_types::Loggable`).
A nice side-effect is that this is generally 2x to 3x faster than going through `arrow2-convert`:
```
arrow/serialize/arrow2_convert
                        time:   [428.60 ns 428.89 ns 429.29 ns]
                        thrpt:  [2.3294 Melem/s 2.3316 Melem/s 2.3332 Melem/s]
arrow/serialize/arrow2  
                        time:   [176.92 ns 177.03 ns 177.18 ns]
                        thrpt:  [5.6440 Melem/s 5.6486 Melem/s 5.6524 Melem/s]

arrow/deserialize/arrow2_convert
                        time:   [119.56 ns 119.75 ns 120.08 ns]
                        thrpt:  [8.3281 Melem/s 8.3506 Melem/s 8.3641 Melem/s]
arrow/deserialize/arrow2
                        time:   [70.062 ns 70.118 ns 70.200 ns]
                        thrpt:  [14.245 Melem/s 14.262 Melem/s 14.273 Melem/s]
```

---


`arrow2-convert` migration PR series:
- #3853 
- #3855


---

- Part of #3741


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3853) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3853)
- [Docs preview](https://rerun.io/preview/314e36e28b22ef7ad9c941e86bf3082f76e2790a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/314e36e28b22ef7ad9c941e86bf3082f76e2790a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)