### PR TITLE
Enable C++ code-tests & improve docstring codegen

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,7 +21,7 @@ InsertTrailingCommas: Wrapped
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All
 PointerAlignment: Left
-ReflowComments: true
+ReflowComments: false # This can break example code in docstrings
 SeparateDefinitionBlocks: Always
 SpacesBeforeTrailingComments: 1
 

--- a/crates/re_types/definitions/rerun/components/view_coordinates.fbs
+++ b/crates/re_types/definitions/rerun/components/view_coordinates.fbs
@@ -28,13 +28,13 @@ enum ViewDir: byte {
 /// For example [Right, Down, Forward] means that the X axis points to the right, the Y axis points
 /// down, and the Z axis points forward.
 ///
-/// The following constants are used to represent the different directions.
-///  Up = 1
-///  Down = 2
-///  Right = 3
-///  Left = 4
-///  Forward = 5
-///  Back = 6
+/// The following constants are used to represent the different directions:
+///  * Up = 1
+///  * Down = 2
+///  * Right = 3
+///  * Left = 4
+///  * Forward = 5
+///  * Back = 6
 struct ViewCoordinates (
   "attr.python.aliases": "npt.ArrayLike",
   "attr.python.array_aliases": "npt.ArrayLike",

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -41,8 +41,8 @@
 ///     rec.log_timeless(
 ///         "segmentation",
 ///         &rerun::AnnotationContext::new([
-///             (1, "red", rerun::Rgba32::from(0xFF0000FF)),
-///             (2, "green", rerun::Rgba32::from(0x00FF00FF)),
+///             (1, "red", rerun::Rgba32::from_rgb(255, 0, 0)),
+///             (2, "green", rerun::Rgba32::from_rgb(0, 255, 0)),
 ///         ]),
 ///     )?;
 ///

--- a/crates/re_types/src/archetypes/bar_chart.rs
+++ b/crates/re_types/src/archetypes/bar_chart.rs
@@ -29,7 +29,7 @@
 ///
 ///     rec.log(
 ///         "bar_chart",
-///         &rerun::BarChart::new(vec![8_i64, 4, 0, 9, 1, 4, 1, 6, 9, 0]),
+///         &rerun::BarChart::new([8_i64, 4, 0, 9, 1, 4, 1, 6, 9, 0].as_slice()),
 ///     )?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -43,8 +43,8 @@
 ///
 ///     // create an annotation context to describe the classes
 ///     let annotation = rerun::AnnotationContext::new([
-///         (1, "red", rerun::Rgba32::from(0xFF0000FF)),
-///         (2, "green", rerun::Rgba32::from(0x00FF00FF)),
+///         (1, "red", rerun::Rgba32::from_rgb(255, 0, 0)),
+///         (2, "green", rerun::Rgba32::from_rgb(0, 255, 0)),
 ///     ]);
 ///
 ///     // log the annotation and the image

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -28,20 +28,16 @@
 ///     let (rec, storage) =
 ///         rerun::RecordingStreamBuilder::new("rerun_example_transform3d").memory()?;
 ///
-///     rec.log(
-///         "base",
-///         &rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
-///     )?;
+///     let arrow = rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]);
+///
+///     rec.log("base", &arrow)?;
 ///
 ///     rec.log(
 ///         "base/translated",
 ///         &rerun::Transform3D::from_translation([1.0, 0.0, 0.0]),
 ///     )?;
 ///
-///     rec.log(
-///         "base/translated",
-///         &rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
-///     )?;
+///     rec.log("base/translated", &arrow)?;
 ///
 ///     rec.log(
 ///         "base/rotated_scaled",
@@ -51,10 +47,7 @@
 ///         ),
 ///     )?;
 ///
-///     rec.log(
-///         "base/rotated_scaled",
-///         &rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
-///     )?;
+///     rec.log("base/rotated_scaled", &arrow)?;
 ///
 ///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())

--- a/crates/re_types/src/arrow_buffer.rs
+++ b/crates/re_types/src/arrow_buffer.rs
@@ -69,7 +69,7 @@ impl<T> From<Vec<T>> for ArrowBuffer<T> {
 impl<T: Clone> From<&[T]> for ArrowBuffer<T> {
     #[inline]
     fn from(value: &[T]) -> Self {
-        Self(Buffer::from_iter(value.iter().cloned())) // TODO(emilk): avoid extra clones
+        Self(value.iter().cloned().collect()) // TODO(emilk): avoid extra clones
     }
 }
 

--- a/crates/re_types/src/arrow_buffer.rs
+++ b/crates/re_types/src/arrow_buffer.rs
@@ -66,9 +66,16 @@ impl<T> From<Vec<T>> for ArrowBuffer<T> {
     }
 }
 
+impl<T: Clone> From<&[T]> for ArrowBuffer<T> {
+    #[inline]
+    fn from(value: &[T]) -> Self {
+        Self(Buffer::from_iter(value.iter().cloned())) // TODO(emilk): avoid extra clones
+    }
+}
+
 impl<T> FromIterator<T> for ArrowBuffer<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        iter.into_iter().collect::<Vec<_>>().into()
+        Self(Buffer::from_iter(iter))
     }
 }
 

--- a/crates/re_types/src/components/view_coordinates.rs
+++ b/crates/re_types/src/components/view_coordinates.rs
@@ -23,13 +23,13 @@
 /// For example [Right, Down, Forward] means that the X axis points to the right, the Y axis points
 /// down, and the Z axis points forward.
 ///
-/// The following constants are used to represent the different directions.
-///  Up = 1
-///  Down = 2
-///  Right = 3
-///  Left = 4
-///  Forward = 5
-///  Back = 6
+/// The following constants are used to represent the different directions:
+///  * Up = 1
+///  * Down = 2
+///  * Right = 3
+///  * Left = 4
+///  * Forward = 5
+///  * Back = 6
 #[derive(Clone, Debug, Copy, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(transparent)]
 pub struct ViewCoordinates(

--- a/crates/re_types/src/datatypes/tensor_data_ext.rs
+++ b/crates/re_types/src/datatypes/tensor_data_ext.rs
@@ -241,10 +241,19 @@ macro_rules! tensor_type {
         }
 
         impl From<Vec<$type>> for TensorData {
-            fn from(value: Vec<$type>) -> Self {
+            fn from(vec: Vec<$type>) -> Self {
                 TensorData {
-                    shape: vec![TensorDimension::unnamed(value.len() as u64)],
-                    buffer: TensorBuffer::$variant(value.into()),
+                    shape: vec![TensorDimension::unnamed(vec.len() as u64)],
+                    buffer: TensorBuffer::$variant(vec.into()),
+                }
+            }
+        }
+
+        impl From<&[$type]> for TensorData {
+            fn from(slice: &[$type]) -> Self {
+                TensorData {
+                    shape: vec![TensorDimension::unnamed(slice.len() as u64)],
+                    buffer: TensorBuffer::$variant(slice.into()),
                 }
             }
         }

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -64,9 +64,9 @@ fn string_from_token_stream(token_stream: &TokenStream, source_path: Option<&Utf
         .to_string()
         .replace(&format!("{NEWLINE_TOKEN:?}"), "\n")
         .replace(NEWLINE_TOKEN, "\n") // Should only happen inside header extensions.
-        .replace(&format!("{NORMAL_COMMENT_PREFIX_TOKEN:?} \""), "//")
+        .replace(&format!("{NORMAL_COMMENT_PREFIX_TOKEN:?} \""), "// ")
         .replace(&format!("\" {NORMAL_COMMENT_SUFFIX_TOKEN:?}"), "\n")
-        .replace(&format!("{DOC_COMMENT_PREFIX_TOKEN:?} \""), "///")
+        .replace(&format!("{DOC_COMMENT_PREFIX_TOKEN:?} \""), "/// ")
         .replace(&format!("\" {DOC_COMMENT_SUFFIX_TOKEN:?}"), "\n")
         .replace(&format!("{ANGLE_BRACKET_LEFT_TOKEN:?} \""), "<")
         .replace(&format!("\" {ANGLE_BRACKET_RIGHT_TOKEN:?}"), ">")
@@ -2019,7 +2019,7 @@ fn quote_obj_docs(obj: &Object) -> TokenStream {
 
     if let Some(first_line) = lines.first_mut() {
         // Prefix with object kind:
-        *first_line = format!(" **{}**:{}", obj.kind.singular_name(), first_line);
+        *first_line = format!("**{}**: {}", obj.kind.singular_name(), first_line);
     }
 
     quote_doc_lines(&lines)
@@ -2054,13 +2054,13 @@ fn lines_from_docs(docs: &Docs) -> Vec<String> {
             } = &example.base;
 
             if let Some(title) = title {
-                lines.push(format!(" ### {title}"));
+                lines.push(format!("### {title}"));
             } else {
                 lines.push(format!("### `{name}`:"));
             }
-            lines.push(" ```cpp,ignore".into());
-            lines.extend(example.lines.iter().map(|line| format!(" {line}")));
-            lines.push(" ```".into());
+            lines.push("```cpp,ignore".into());
+            lines.extend(example.lines.iter().map(|line| format!("{line}")));
+            lines.push("```".into());
             if examples.peek().is_some() {
                 // blank line between examples
                 lines.push(String::new());

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1427,9 +1427,10 @@ fn quote_fill_arrow_array_builder(
                     let variant_name = format_ident!("{}", variant.name);
 
                     let variant_append = if variant.typ.is_plural() {
+                        let error = format!("Failed to serialize {}: list types in unions not yet implemented", obj.name); // TODO(#2919)
                         quote! {
                             (void)#variant_builder;
-                            return Error(ErrorCode::NotImplemented, "TODO(andreas): list types in unions are not yet supported");
+                            return Error(ErrorCode::NotImplemented, #error);
                         }
                     } else {
                         let variant_accessor = quote!(union_instance._data);

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -2059,7 +2059,7 @@ fn lines_from_docs(docs: &Docs) -> Vec<String> {
                 lines.push(format!("### `{name}`:"));
             }
             lines.push("```cpp,ignore".into());
-            lines.extend(example.lines.iter().map(|line| format!("{line}")));
+            lines.extend(example.lines.iter().cloned());
             lines.push("```".into());
             if examples.peek().is_some() {
                 // blank line between examples

--- a/crates/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/re_types_builder/src/codegen/docs/mod.rs
@@ -141,10 +141,7 @@ fn object_page(reporter: &Reporter, object: &Object, object_map: &ObjectMap) -> 
 
     write_frontmatter(&mut page, &object.name, None);
     putln!(page);
-    for mut line in top_level_docs {
-        if line.starts_with(char::is_whitespace) {
-            line.remove(0);
-        }
+    for line in top_level_docs {
         putln!(page, "{line}");
     }
     putln!(page);

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -963,11 +963,6 @@ fn quote_obj_docs(obj: &Object) -> String {
 
 fn lines_from_docs(docs: &Docs) -> Vec<String> {
     let mut lines = crate::codegen::get_documentation(docs, &["py", "python"]);
-    for line in &mut lines {
-        if line.starts_with(char::is_whitespace) {
-            line.remove(0);
-        }
-    }
 
     let examples = collect_examples_for_api_docs(docs, "py", true).unwrap();
     if !examples.is_empty() {

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -529,7 +529,7 @@ fn doc_as_lines(reporter: &Reporter, virtpath: &str, fqname: &str, docs: &Docs) 
         } else {
             "Examples"
         };
-        lines.push(format!(" ## {section_title}"));
+        lines.push(format!("## {section_title}"));
         lines.push(Default::default());
         let mut examples = examples.into_iter().peekable();
         while let Some(example) = examples.next() {
@@ -538,20 +538,15 @@ fn doc_as_lines(reporter: &Reporter, virtpath: &str, fqname: &str, docs: &Docs) 
             } = &example.base;
 
             if let Some(title) = title {
-                lines.push(format!(" ### {title}"));
+                lines.push(format!("### {title}"));
             } else {
                 lines.push(format!("### `{name}`:"));
             }
-            lines.push(" ```ignore".into());
-            lines.extend(example.lines.into_iter().map(|line| format!(" {line}")));
-            lines.push(" ```".into());
+            lines.push("```ignore".into());
+            lines.extend(example.lines.into_iter());
+            lines.push("```".into());
             if let Some(image) = &image {
-                lines.extend(
-                    image
-                        .image_stack()
-                        .into_iter()
-                        .map(|line| format!(" {line}")),
-                );
+                lines.extend(image.image_stack().into_iter());
             }
             if examples.peek().is_some() {
                 // blank line between examples
@@ -580,7 +575,10 @@ fn quote_doc_lines(lines: &[String]) -> TokenStream {
 
     impl quote::ToTokens for DocCommentTokenizer<'_> {
         fn to_tokens(&self, tokens: &mut TokenStream) {
-            tokens.extend(self.0.iter().map(|line| quote!(# [doc = #line])));
+            tokens.extend(self.0.iter().map(|line| {
+                let line = format!(" {line}"); // add space between `///` and comment
+                quote!(# [doc = #line])
+            }));
         }
     }
 

--- a/docs/code-examples/annotation_context_connections.rs
+++ b/docs/code-examples/annotation_context_connections.rs
@@ -13,10 +13,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &rerun::AnnotationContext::new([rerun::ClassDescription {
             info: 0.into(),
             keypoint_annotations: vec![
-                (0, "zero", rerun::Rgba32::from(0xFF0000FF)).into(),
-                (1, "one", rerun::Rgba32::from(0x00FF00FF)).into(),
-                (2, "two", rerun::Rgba32::from(0x0000FFFF)).into(),
-                (3, "three", rerun::Rgba32::from(0xFFFF00FF)).into(),
+                (0, "zero", rerun::Rgba32::from_rgb(255, 0, 0)).into(),
+                (1, "one", rerun::Rgba32::from_rgb(0, 255, 0)).into(),
+                (2, "two", rerun::Rgba32::from_rgb(0, 0, 255)).into(),
+                (3, "three", rerun::Rgba32::from_rgb(255, 255, 0)).into(),
             ],
             keypoint_connections: rerun::KeypointPair::vec_from([(0, 2), (1, 2), (2, 3)]),
         }]),

--- a/docs/code-examples/annotation_context_rects.cpp
+++ b/docs/code-examples/annotation_context_rects.cpp
@@ -7,7 +7,7 @@ int main() {
     rec.connect("127.0.0.1:9876").throw_on_failure();
 
     // Log an annotation context to assign a label and color to each class
-    rec.log(
+    rec.log_timeless(
         "/",
         rerun::AnnotationContext({
             rerun::datatypes::AnnotationInfo(1, "red", rerun::datatypes::Rgba32(255, 0, 0)),

--- a/docs/code-examples/annotation_context_rects.rs
+++ b/docs/code-examples/annotation_context_rects.rs
@@ -8,8 +8,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     rec.log_timeless(
         "/",
         &rerun::AnnotationContext::new([
-            (1, "red", rerun::Rgba32::from(0xFF0000FF)),
-            (2, "green", rerun::Rgba32::from(0x00FF00FF)),
+            (1, "red", rerun::Rgba32::from_rgb(255, 0, 0)),
+            (2, "green", rerun::Rgba32::from_rgb(0, 255, 0)),
         ]),
     )?;
 

--- a/docs/code-examples/annotation_context_segmentation.rs
+++ b/docs/code-examples/annotation_context_segmentation.rs
@@ -11,8 +11,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     rec.log_timeless(
         "segmentation",
         &rerun::AnnotationContext::new([
-            (1, "red", rerun::Rgba32::from(0xFF0000FF)),
-            (2, "green", rerun::Rgba32::from(0x00FF00FF)),
+            (1, "red", rerun::Rgba32::from_rgb(255, 0, 0)),
+            (2, "green", rerun::Rgba32::from_rgb(0, 255, 0)),
         ]),
     )?;
 

--- a/docs/code-examples/arrow3d_simple.cpp
+++ b/docs/code-examples/arrow3d_simple.cpp
@@ -18,8 +18,8 @@ int main() {
     for (int i = 0; i < 100; ++i) {
         origins.push_back({0, 0, 0});
 
-        float angle = TAU * i * 0.01f;
-        float length = log2f(i + 1);
+        float angle = TAU * static_cast<float>(i) * 0.01f;
+        float length = log2f(static_cast<float>(i + 1));
         vectors.push_back({length * sinf(angle), 0.0, length * cosf(angle)});
 
         uint8_t c = static_cast<uint8_t>(round(angle / TAU * 255.0f));

--- a/docs/code-examples/arrow3d_simple.cpp
+++ b/docs/code-examples/arrow3d_simple.cpp
@@ -5,7 +5,7 @@
 #include <cmath>
 #include <numeric>
 
-#define TAU (static_cast<float>(M_PI) * 2.0f)
+const float TAU = static_cast<float>(2.0 * M_PI);
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_arrow3d");

--- a/docs/code-examples/asset3d_simple.cpp
+++ b/docs/code-examples/asset3d_simple.cpp
@@ -20,6 +20,6 @@ int main(int argc, char* argv[]) {
     auto rec = rerun::RecordingStream("rerun_example_asset3d_simple");
     rec.connect("127.0.0.1:9876").throw_on_failure();
 
-    rec.log("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
+    rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
     rec.log("world/asset", rerun::Asset3D::from_file(path));
 }

--- a/docs/code-examples/bar_chart.rs
+++ b/docs/code-examples/bar_chart.rs
@@ -5,7 +5,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rec.log(
         "bar_chart",
-        &rerun::BarChart::new(vec![8_i64, 4, 0, 9, 1, 4, 1, 6, 9, 0]),
+        &rerun::BarChart::new([8_i64, 4, 0, 9, 1, 4, 1, 6, 9, 0].as_slice()),
     )?;
 
     rerun::native_viewer::show(storage.take())?;

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -26,7 +26,7 @@ opt_out_entirely = {
     "any_values": ["cpp", "rust"], # Only implemented for Python
     "asset3d_out_of_tree": ["cpp"], # TODO(cmc): cannot set recording clock in cpp at the moment
     "asset3d_simple": [],
-    "bar_chart": [],
+    "bar_chart": ["cpp"], # Serializing tensors not yet implemented in C++
     "custom_data": ["cpp"], # Not yet implemented in C++
     "depth_image_3d": ["cpp"], # Not yet implemented in C++
     "depth_image_simple": ["cpp"],  # Not yet implemented in C++

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -150,7 +150,7 @@ def main() -> None:
     examples.sort()
 
     print("----------------------------------------------------------")
-    print(f"Building {len(examples)} examples…")
+    print(f"Running {len(examples)} examples…")
 
     with multiprocessing.Pool() as pool:
         jobs = []
@@ -159,9 +159,9 @@ def main() -> None:
             for language in ["cpp", "py", "rust"]:
                 if language in example_opt_out_entirely:
                     continue
-                job = pool.apply_async(build_example, (example, language, args))
+                job = pool.apply_async(run_example, (example, language, args))
                 jobs.append(job)
-        print(f"Waiting for {len(jobs)} build jobs to finish…")
+        print(f"Waiting for {len(jobs)} runs to finish…")
         for job in jobs:
             job.get()
 
@@ -194,7 +194,7 @@ def main() -> None:
     print("All tests passed!")
 
 
-def build_example(example: str, language: str, args: argparse.Namespace) -> None:
+def run_example(example: str, language: str, args: argparse.Namespace) -> None:
     if language == "cpp":
         cpp_output_path = run_roundtrip_cpp(example, args.release)
         check_non_empty_rrd(cpp_output_path)

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -19,28 +19,28 @@ from os.path import isfile, join
 #
 # You should only ever use this if the test isn't implemented and cannot yet be implemented
 # for one or more specific SDKs.
-opt_out_entirely = {
-    "annotation_context_connections": ["cpp"], # Not yet implemented in C++
-    "annotation_context_segmentation": ["cpp"], # Not yet implemented in C++
+opt_out_run = {
+    "annotation_context_connections": ["cpp"], # TODO(#2919): Not yet implemented in C++
+    "annotation_context_segmentation": ["cpp"], # TODO(#2919): Not yet implemented in C++
     "annotation_context_rects": [],
-    "any_values": ["cpp", "rust"], # Only implemented for Python
-    "asset3d_out_of_tree": ["cpp"], # TODO(cmc): cannot set recording clock in cpp at the moment
+    "any_values": ["cpp", "rust"], # Not yet implemented
+    "asset3d_out_of_tree": ["cpp"], # TODO(#2919): Not yet implemented in C++
     "asset3d_simple": [],
-    "bar_chart": ["cpp"], # Serializing tensors not yet implemented in C++
-    "custom_data": ["cpp"], # Not yet implemented in C++
-    "depth_image_3d": ["cpp"], # Not yet implemented in C++
-    "depth_image_simple": ["cpp"],  # Not yet implemented in C++
-    "extra_values": ["cpp", "rust"], # Only implemented for Python
-    "image_advanced": ["cpp", "rust"], # Missing example for Rust
-    "image_simple": ["cpp"], # Not yet implemented in C++
+    "bar_chart": ["cpp"], # TODO(#2919): Serializing tensors not yet implemented in C++
+    "custom_data": ["cpp"], # TODO(#2919): Not yet implemented in C++
+    "depth_image_3d": ["cpp"], # TODO(#2919): Not yet implemented in C++
+    "depth_image_simple": ["cpp"],  # TODO(#2919): Not yet implemented in C++
+    "extra_values": ["cpp", "rust"], # Missing examples
+    "image_advanced": ["cpp", "rust"], # Missing examples
+    "image_simple": ["cpp"], # TODO(#2919): Not yet implemented in C++
     "log_line": ["cpp", "rust", "py"], # Not a complete example -- just a single log line
     "mesh3d_partial_updates": ["cpp"], # TODO(cmc): cannot set recording clock in cpp at the moment
-    "pinhole_simple": ["cpp"], # Seg-faults in C++
-    "scalar_multiple_plots": ["cpp"], # Not yet implemented in C++
-    "scalar_simple": ["cpp"], # Not yet implemented in C++
-    "segmentation_image_simple": ["cpp"], # Not yet implemented in C++
-    "tensor_simple": ["cpp"], # Not yet implemented in C++
-    "text_log_integration": ["cpp"], # Not yet implemented in C++
+    "pinhole_simple": ["cpp"], # TODO(#2919): Seg-faults in C++
+    "scalar_multiple_plots": ["cpp"], # TODO(#2919): Not yet implemented in C++
+    "scalar_simple": ["cpp"], # TODO(#2919): Not yet implemented in C++
+    "segmentation_image_simple": ["cpp"], # TODO(#2919): Not yet implemented in C++
+    "tensor_simple": ["cpp"], # TODO(#2919): Not yet implemented in C++
+    "text_log_integration": ["cpp"], # TODO(#2919): Not yet implemented in C++
     "view_coordinates_simple": [],
 
     # This is this script, it's not an example.
@@ -156,7 +156,7 @@ def main() -> None:
     with multiprocessing.Pool() as pool:
         jobs = []
         for example in examples:
-            example_opt_out_entirely = opt_out_entirely.get(example, [])
+            example_opt_out_entirely = opt_out_run.get(example, [])
             for language in ["cpp", "py", "rust"]:
                 if language in example_opt_out_entirely:
                     continue
@@ -174,7 +174,7 @@ def main() -> None:
         print("----------------------------------------------------------")
         print(f"Comparing example '{example}'…")
 
-        example_opt_out_entirely = opt_out_entirely.get(example, [])
+        example_opt_out_entirely = opt_out_run.get(example, [])
         example_opt_out_compare = opt_out_compare.get(example, [])
 
         if "rust" in example_opt_out_entirely:

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -20,28 +20,28 @@ from os.path import isfile, join
 # You should only ever use this if the test isn't implemented and cannot yet be implemented
 # for one or more specific SDKs.
 opt_out_entirely = {
-    "annotation_context_connections": ["cpp"],
-    "annotation_context_segmentation": ["cpp"],
-    "annotation_context_rects": ["cpp"], # TODO(#2919): Needs support for log_timeless
+    "annotation_context_connections": ["cpp"], # Not yet implemented in C++
+    "annotation_context_segmentation": ["cpp"], # Not yet implemented in C++
+    "annotation_context_rects": [],
     "any_values": ["cpp", "rust"], # Only implemented for Python
     "asset3d_out_of_tree": ["cpp"], # TODO(cmc): cannot set recording clock in cpp at the moment
-    "asset3d_simple": ["cpp"], # TODO(#2919): Need log_timeless for C++
-    "bar_chart": ["cpp"],
-    "custom_data": ["cpp"],
-    "depth_image_3d": ["cpp"],
-    "depth_image_simple": ["cpp"],
+    "asset3d_simple": [],
+    "bar_chart": [],
+    "custom_data": ["cpp"], # Not yet implemented in C++
+    "depth_image_3d": ["cpp"], # Not yet implemented in C++
+    "depth_image_simple": ["cpp"],  # Not yet implemented in C++
     "extra_values": ["cpp", "rust"], # Only implemented for Python
     "image_advanced": ["cpp", "rust"], # Missing example for Rust
-    "image_simple": ["cpp"],
+    "image_simple": ["cpp"], # Not yet implemented in C++
     "log_line": ["cpp", "rust", "py"], # Not a complete example -- just a single log line
     "mesh3d_partial_updates": ["cpp"], # TODO(cmc): cannot set recording clock in cpp at the moment
-    "pinhole_simple": ["cpp"],
-    "scalar_multiple_plots": ["cpp"], # TODO(#3394): Need to implement time in C++ first.
-    "scalar_simple": ["cpp"], # TODO(#3394): Need to implement time in C++ first.
-    "segmentation_image_simple": ["cpp"],
-    "tensor_simple": ["cpp"],
-    "text_log_integration": ["cpp"],
-    "view_coordinates_simple": ["cpp"], # TODO(#2919): Need log_timeless for C++
+    "pinhole_simple": [],
+    "scalar_multiple_plots": ["cpp"], # Not yet implemented in C++
+    "scalar_simple": ["cpp"], # Not yet implemented in C++
+    "segmentation_image_simple": ["cpp"], # Not yet implemented in C++
+    "tensor_simple": ["cpp"], # Not yet implemented in C++
+    "text_log_integration": ["cpp"], # Not yet implemented in C++
+    "view_coordinates_simple": [],
 
     # This is this script, it's not an example.
     "roundtrips": ["cpp", "py", "rust"],

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -35,7 +35,7 @@ opt_out_entirely = {
     "image_simple": ["cpp"], # Not yet implemented in C++
     "log_line": ["cpp", "rust", "py"], # Not a complete example -- just a single log line
     "mesh3d_partial_updates": ["cpp"], # TODO(cmc): cannot set recording clock in cpp at the moment
-    "pinhole_simple": [],
+    "pinhole_simple": ["cpp"], # Seg-faults in C++
     "scalar_multiple_plots": ["cpp"], # Not yet implemented in C++
     "scalar_simple": ["cpp"], # Not yet implemented in C++
     "segmentation_image_simple": ["cpp"], # Not yet implemented in C++
@@ -59,6 +59,7 @@ opt_out_compare = {
     "point2d_random": ["cpp", "py", "rust"], # TODO(#3206): need to align everything to use PCG64 in the same order etc... don't have time for that.
     "point3d_random": ["cpp", "py", "rust"], # TODO(#3206): need to align everything to use PCG64 in the same order etc... don't have time for that.
     "tensor_simple": ["cpp", "py", "rust"], # TODO(#3206): need to align everything to use PCG64 in the same order etc... don't have time for that.
+    "transform3d_simple": ["cpp"], # TODO(#2919): Something broken in the C++ SDK
 }
 
 extra_args = {

--- a/docs/code-examples/segmentation_image_simple.rs
+++ b/docs/code-examples/segmentation_image_simple.rs
@@ -13,8 +13,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // create an annotation context to describe the classes
     let annotation = rerun::AnnotationContext::new([
-        (1, "red", rerun::Rgba32::from(0xFF0000FF)),
-        (2, "green", rerun::Rgba32::from(0x00FF00FF)),
+        (1, "red", rerun::Rgba32::from_rgb(255, 0, 0)),
+        (2, "green", rerun::Rgba32::from_rgb(0, 255, 0)),
     ]);
 
     // log the annotation and the image

--- a/docs/code-examples/transform3d_simple.cpp
+++ b/docs/code-examples/transform3d_simple.cpp
@@ -6,7 +6,7 @@
 
 namespace rrd = rerun::datatypes;
 
-const float pi = static_cast<float>(M_PI);
+const float TAU = static_cast<float>(2.0 * M_PI);
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_transform3d");
@@ -23,7 +23,7 @@ int main() {
     rec.log(
         "base/rotated_scaled",
         rerun::Transform3D(
-            rrd::RotationAxisAngle({0.0f, 0.0f, 1.0f}, rrd::Angle::radians(pi / 4.0f)),
+            rrd::RotationAxisAngle({0.0f, 0.0f, 1.0f}, rrd::Angle::radians(TAU / 8.0f)),
             2.0f
         )
     );

--- a/docs/code-examples/transform3d_simple.py
+++ b/docs/code-examples/transform3d_simple.py
@@ -6,10 +6,12 @@ from rerun.datatypes import Angle, RotationAxisAngle
 
 rr.init("rerun_example_transform3d", spawn=True)
 
-rr.log("base", rr.Arrows3D(origins=[0, 0, 0], vectors=[0, 1, 0]))
+arrow = rr.Arrows3D(origins=[0, 0, 0], vectors=[0, 1, 0])
+
+rr.log("base", arrow)
 
 rr.log("base/translated", rr.Transform3D(translation=[1, 0, 0]))
-rr.log("base/translated", rr.Arrows3D(origins=[0, 0, 0], vectors=[0, 1, 0]))
+rr.log("base/translated", arrow)
 
 rr.log(
     "base/rotated_scaled",
@@ -18,4 +20,4 @@ rr.log(
         scale=2,
     ),
 )
-rr.log("base/rotated_scaled", rr.Arrows3D(origins=[0, 0, 0], vectors=[0, 1, 0]))
+rr.log("base/rotated_scaled", arrow)

--- a/docs/code-examples/transform3d_simple.rs
+++ b/docs/code-examples/transform3d_simple.rs
@@ -6,20 +6,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rec, storage) =
         rerun::RecordingStreamBuilder::new("rerun_example_transform3d").memory()?;
 
-    rec.log(
-        "base",
-        &rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
-    )?;
+    let arrow = rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]);
+
+    rec.log("base", &arrow)?;
 
     rec.log(
         "base/translated",
         &rerun::Transform3D::from_translation([1.0, 0.0, 0.0]),
     )?;
 
-    rec.log(
-        "base/translated",
-        &rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
-    )?;
+    rec.log("base/translated", &arrow)?;
 
     rec.log(
         "base/rotated_scaled",
@@ -29,10 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ),
     )?;
 
-    rec.log(
-        "base/rotated_scaled",
-        &rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]),
-    )?;
+    rec.log("base/rotated_scaled", &arrow)?;
 
     rerun::native_viewer::show(storage.take())?;
     Ok(())

--- a/docs/code-examples/view_coordinates_simple.cpp
+++ b/docs/code-examples/view_coordinates_simple.cpp
@@ -9,7 +9,7 @@ int main() {
     auto rec = rerun::RecordingStream("rerun_example_view_coordinates");
     rec.connect("127.0.0.1:9876").throw_on_failure();
 
-    rec.log("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
+    rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
     rec.log(
         "world/xyz",
         rerun::Arrows3D::from_vectors({{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}

--- a/docs/content/reference/types/components/view_coordinates.md
+++ b/docs/content/reference/types/components/view_coordinates.md
@@ -11,13 +11,13 @@ The three coordinates are always ordered as [x, y, z].
 For example [Right, Down, Forward] means that the X axis points to the right, the Y axis points
 down, and the Z axis points forward.
 
-The following constants are used to represent the different directions.
- Up = 1
- Down = 2
- Right = 3
- Left = 4
- Forward = 5
- Back = 6
+The following constants are used to represent the different directions:
+ * Up = 1
+ * Down = 2
+ * Right = 3
+ * Left = 4
+ * Forward = 5
+ * Back = 6
 
 
 ## Links

--- a/examples/cpp/clock/main.cpp
+++ b/examples/cpp/clock/main.cpp
@@ -2,7 +2,7 @@
 #include <cmath>
 #include <rerun.hpp>
 
-#define TAU (static_cast<float>(M_PI) * 2.0f)
+const float TAU = static_cast<float>(2.0 * M_PI);
 
 void log_hand(
     rerun::RecordingStream& rec, const char* name, int step, float angle, float length, float width,
@@ -14,7 +14,8 @@ void log_hand(
         static_cast<uint8_t>(255 - c),
         c,
         blue,
-        std::max<uint8_t>(128, blue)};
+        std::max<uint8_t>(128, blue)
+    };
 
     rec.set_time_seconds("sim_time", step);
 

--- a/examples/cpp/clock/main.cpp
+++ b/examples/cpp/clock/main.cpp
@@ -14,8 +14,7 @@ void log_hand(
         static_cast<uint8_t>(255 - c),
         c,
         blue,
-        std::max<uint8_t>(128, blue)
-    };
+        std::max<uint8_t>(128, blue)};
 
     rec.set_time_seconds("sim_time", step);
 

--- a/justfile
+++ b/justfile
@@ -148,6 +148,10 @@ rerun-web *ARGS:
 codegen *ARGS:
     pixi run codegen {{ARGS}}
 
+# Print the contents of an .rrd file
+print *ARGS:
+    just rerun print {{ARGS}}
+
 # To easily run examples on the web, see https://github.com/rukai/cargo-run-wasm.
 # Temporary solution while we wait for our own xtasks!
 run-wasm *ARGS:

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -15,8 +15,7 @@
 
 namespace rerun {
     namespace archetypes {
-        /// **Archetype**: The `AnnotationContext` provides additional information on how to display
-        /// entities.
+        /// **Archetype**: The `AnnotationContext` provides additional information on how to display entities.
         ///
         /// Entities can use `ClassId`s and `KeypointId`s to provide annotations, and
         /// the labels and colors will be looked up in the appropriate
@@ -27,11 +26,9 @@ namespace rerun {
             /// List of class descriptions, mapping class indices to class names, colors etc.
             rerun::components::AnnotationContext context;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -48,8 +48,8 @@ namespace rerun {
         ///     for (int i = 0; i <100; ++i) {
         ///         origins.push_back({0, 0, 0});
         ///
-        ///         float angle = TAU * i * 0.01f;
-        ///         float length = log2f(i + 1);
+        ///         float angle = TAU * static_cast<float>(i) * 0.01f;
+        ///         float length = log2f(static_cast<float>(i + 1));
         ///         vectors.push_back({length * sinf(angle), 0.0, length * cosf(angle)});
         ///
         ///         uint8_t c = static_cast<uint8_t>(round(angle / TAU * 255.0f));

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -35,7 +35,7 @@ namespace rerun {
         /// #include <cmath>
         /// #include <numeric>
         ///
-        /// #define TAU (static_cast<float>(M_PI) * 2.0f)
+        /// const float TAU = static_cast<float>(2.0 * M_PI);
         ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_arrow3d");

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -91,18 +91,16 @@ namespace rerun {
             /// Unique identifiers for each individual point in the batch.
             std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             // Extensions to generated type defined in 'arrows3d_ext.cpp'
 
-            /// Creates new 3D arrows pointing in the given directions, with a base at the origin
-            /// (0, 0, 0).
+            /// Creates new 3D arrows pointing in the given directions, with a base at the origin (0, 0,
+            /// 0).
             static Arrows3D from_vectors(ComponentBatch<components::Vector3D> vectors_) {
                 Arrows3D arrows;
                 arrows.vectors = std::move(vectors_);

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -50,7 +50,7 @@ namespace rerun {
         ///     auto rec = rerun::RecordingStream("rerun_example_asset3d_simple");
         ///     rec.connect("127.0.0.1:9876").throw_on_failure();
         ///
-        ///     rec.log("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
+        ///     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
         ///     rec.log("world/asset", rerun::Asset3D::from_file(path));
         /// }
         /// ```
@@ -62,8 +62,7 @@ namespace rerun {
             ///
             /// Supported values:
             /// * `model/gltf-binary`
-            /// * `model/obj` (.mtl material files are not supported yet, references are silently
-            /// ignored)
+            /// * `model/obj` (.mtl material files are not supported yet, references are silently ignored)
             ///
             /// If omitted, the viewer will try to guess from the data blob.
             /// If it cannot guess, it won't be able to render the asset.
@@ -74,11 +73,9 @@ namespace rerun {
             /// Applies a transformation to the asset itself without impacting its children.
             std::optional<rerun::components::OutOfTreeTransform3D> transform;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
@@ -106,8 +103,8 @@ namespace rerun {
             ///
             /// The [`MediaType`] will be guessed from the file extension.
             ///
-            /// If no [`MediaType`] can be guessed at the moment, the Rerun Viewer will try to guess
-            /// one from the data at render-time. If it can't, rendering will fail with an error.
+            /// If no [`MediaType`] can be guessed at the moment, the Rerun Viewer will try to guess one
+            /// from the data at render-time. If it can't, rendering will fail with an error.
             static Asset3D from_file(const std::filesystem::path& path) {
                 std::ifstream file(path, std::ios::binary);
                 if (!file) {
@@ -126,8 +123,8 @@ namespace rerun {
 
             /// Creates a new [`Asset3D`] from the given `bytes`.
             ///
-            /// If no [`MediaType`] is specified, the Rerun Viewer will try to guess one from the
-            /// data at render-time. If it can't, rendering will fail with an error.
+            /// If no [`MediaType`] is specified, the Rerun Viewer will try to guess one from the data
+            /// at render-time. If it can't, rendering will fail with an error.
             static Asset3D from_bytes(
                 const std::vector<uint8_t> bytes,
                 std::optional<rerun::components::MediaType> media_type
@@ -148,8 +145,7 @@ namespace rerun {
             ///
             /// Supported values:
             /// * `model/gltf-binary`
-            /// * `model/obj` (.mtl material files are not supported yet, references are silently
-            /// ignored)
+            /// * `model/obj` (.mtl material files are not supported yet, references are silently ignored)
             ///
             /// If omitted, the viewer will try to guess from the data blob.
             /// If it cannot guess, it won't be able to render the asset.

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -18,8 +18,7 @@ namespace rerun {
     namespace archetypes {
         /// **Archetype**: A bar chart.
         ///
-        /// The x values will be the indices of the array, and the bar heights will be the provided
-        /// values.
+        /// The x values will be the indices of the array, and the bar heights will be the provided values.
         ///
         /// ## Example
         ///
@@ -40,11 +39,9 @@ namespace rerun {
             /// The values. Should always be a rank-1 tensor.
             rerun::components::TensorData values;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -23,8 +23,7 @@
 
 namespace rerun {
     namespace archetypes {
-        /// **Archetype**: 2D boxes with half-extents and optional center, rotations, rotations,
-        /// colors etc.
+        /// **Archetype**: 2D boxes with half-extents and optional center, rotations, rotations, colors etc.
         ///
         /// ## Example
         ///
@@ -38,8 +37,7 @@ namespace rerun {
         ///     auto rec = rerun::RecordingStream("rerun_example_box2d");
         ///     rec.connect("127.0.0.1:9876").throw_on_failure();
         ///
-        ///     rec.log("simple", rerun::Boxes2D::from_mins_and_sizes({{-1.f, -1.f}},
-        ///     {{2.f, 2.f}}));
+        ///     rec.log("simple", rerun::Boxes2D::from_mins_and_sizes({{-1.f, -1.f}}, {{2.f, 2.f}}));
         ///
         ///     // Log an extra rect to set the view bounds
         ///     rec.log("bounds", rerun::Boxes2D::from_sizes({{4.f, 3.f}}));
@@ -76,11 +74,9 @@ namespace rerun {
             /// Unique identifiers for each individual boxes in the batch.
             std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
@@ -110,11 +106,11 @@ namespace rerun {
             /// input data.
             static Boxes2D from_sizes(const std::vector<datatypes::Vec2D>& sizes);
 
-            /// Creates new `Boxes2D` with `centers` and `half_sizes` created from centers and
-            /// (full) sizes.
+            /// Creates new `Boxes2D` with `centers` and `half_sizes` created from centers and (full)
+            /// sizes.
             ///
-            /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and
-            /// half-sizes from the input data.
+            /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and half-sizes
+            /// from the input data.
             static Boxes2D from_centers_and_sizes(
                 ComponentBatch<components::Position2D> centers,
                 const std::vector<datatypes::Vec2D>& sizes
@@ -124,11 +120,11 @@ namespace rerun {
                 return boxes;
             }
 
-            /// Creates new `Boxes2D` with `half_sizes` and `centers` created from minimums and
-            /// (full) sizes.
+            /// Creates new `Boxes2D` with `half_sizes` and `centers` created from minimums and (full)
+            /// sizes.
             ///
-            /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and
-            /// half-sizes from the input data.
+            /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and half-sizes
+            /// from the input data.
             static Boxes2D from_mins_and_sizes(
                 const std::vector<datatypes::Vec2D>& mins,
                 const std::vector<datatypes::Vec2D>& sizes

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -23,8 +23,7 @@
 
 namespace rerun {
     namespace archetypes {
-        /// **Archetype**: 3D boxes with half-extents and optional center, rotations, rotations,
-        /// colors etc.
+        /// **Archetype**: 3D boxes with half-extents and optional center, rotations, rotations, colors etc.
         ///
         /// ## Example
         ///
@@ -89,11 +88,9 @@ namespace rerun {
             /// Unique identifiers for each individual boxes in the batch.
             std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
@@ -124,11 +121,11 @@ namespace rerun {
             /// TODO(#3794): This should not take an std::vector.
             static Boxes3D from_sizes(const std::vector<datatypes::Vec3D>& sizes);
 
-            /// Creates new `Boxes3D` with `centers` and `half_sizes` created from centers and
-            /// (full) sizes.
+            /// Creates new `Boxes3D` with `centers` and `half_sizes` created from centers and (full)
+            /// sizes.
             ///
-            /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and
-            /// half-sizes from the input data.
+            /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and half-sizes
+            /// from the input data.
             /// TODO(#3794): This should not take an std::vector.
             static Boxes3D from_centers_and_sizes(
                 ComponentBatch<components::Position3D> centers,
@@ -139,11 +136,11 @@ namespace rerun {
                 return boxes;
             }
 
-            /// Creates new `Boxes3D` with `half_sizes` and `centers` created from minimums and
-            /// (full) sizes.
+            /// Creates new `Boxes3D` with `half_sizes` and `centers` created from minimums and (full)
+            /// sizes.
             ///
-            /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and
-            /// half-sizes from the input data.
+            /// TODO(#3285): Does *not* preserve data as-is and instead creates centers and half-sizes
+            /// from the input data.
             /// TODO(#3794): This should not take an std::vector.
             static Boxes3D from_mins_and_sizes(
                 const std::vector<datatypes::Vec3D>& mins,

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -72,11 +72,9 @@ namespace rerun {
         struct Clear {
             rerun::components::ClearIsRecursive is_recursive;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -26,11 +26,10 @@ namespace rerun {
             /// The depth-image data. Should always be a rank-2 tensor.
             rerun::components::TensorData data;
 
-            /// An optional floating point value that specifies how long a meter is in the native
-            /// depth units.
+            /// An optional floating point value that specifies how long a meter is in the native depth units.
             ///
-            /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter
-            /// precision and a range of up to ~65 meters (2^16 / 1000).
+            /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
+            /// and a range of up to ~65 meters (2^16 / 1000).
             std::optional<rerun::components::DepthMeter> meter;
 
             /// An optional floating point value that specifies the 2D drawing order.
@@ -38,11 +37,9 @@ namespace rerun {
             /// Objects with higher values are drawn on top of those with lower values.
             std::optional<rerun::components::DrawOrder> draw_order;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
@@ -51,11 +48,10 @@ namespace rerun {
 
             explicit DepthImage(rerun::components::TensorData _data) : data(std::move(_data)) {}
 
-            /// An optional floating point value that specifies how long a meter is in the native
-            /// depth units.
+            /// An optional floating point value that specifies how long a meter is in the native depth units.
             ///
-            /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter
-            /// precision and a range of up to ~65 meters (2^16 / 1000).
+            /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
+            /// and a range of up to ~65 meters (2^16 / 1000).
             DepthImage with_meter(rerun::components::DepthMeter _meter) && {
                 meter = std::move(_meter);
                 return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -15,8 +15,7 @@
 
 namespace rerun {
     namespace archetypes {
-        /// **Archetype**: Specifies that the entity path at which this is logged is disconnected
-        /// from its parent.
+        /// **Archetype**: Specifies that the entity path at which this is logged is disconnected from its parent.
         ///
         /// This is useful for specifying that a subgraph is independent of the rest of the scene.
         ///
@@ -47,11 +46,9 @@ namespace rerun {
         struct DisconnectedSpace {
             rerun::components::DisconnectedSpace disconnected_space;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -35,11 +35,9 @@ namespace rerun {
             /// Objects with higher values are drawn on top of those with lower values.
             std::optional<rerun::components::DrawOrder> draw_order;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -36,10 +36,9 @@ namespace rerun {
         ///     auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
         ///     rec.connect("127.0.0.1:9876").throw_on_failure();
         ///
-        ///     std::vector<rerun::datatypes::Vec2D> strip1 = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f},
-        ///     {6.f, 0.f}}; std::vector<rerun::datatypes::Vec2D> strip2 =
-        ///         {{0.f, 3.f}, {1.f, 4.f}, {2.f, 2.f}, {3.f, 4.f}, {4.f, 2.f}, {5.f, 4.f},
-        ///         {6.f, 3.f}};
+        ///     std::vector<rerun::datatypes::Vec2D> strip1 = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}};
+        ///     std::vector<rerun::datatypes::Vec2D> strip2 =
+        ///         {{0.f, 3.f}, {1.f, 4.f}, {2.f, 2.f}, {3.f, 4.f}, {4.f, 2.f}, {5.f, 4.f}, {6.f, 3.f}};
         ///     rec.log(
         ///         "strips",
         ///         rerun::LineStrips2D({strip1, strip2})
@@ -49,8 +48,7 @@ namespace rerun {
         ///     );
         ///
         ///     // Log an extra rect to set the view bounds
-        ///     rec.log("bounds", rerun::Boxes2D::from_centers_and_sizes({{3.0f, 1.5f}},
-        ///     {{8.0f, 9.0f}}));
+        ///     rec.log("bounds", rerun::Boxes2D::from_centers_and_sizes({{3.0f, 1.5f}}, {{8.0f, 9.0f}}));
         /// }
         /// ```
         struct LineStrips2D {
@@ -66,8 +64,7 @@ namespace rerun {
             /// Optional text labels for the line strips.
             std::optional<ComponentBatch<rerun::components::Text>> labels;
 
-            /// An optional floating point value that specifies the 2D drawing order of each line
-            /// strip.
+            /// An optional floating point value that specifies the 2D drawing order of each line strip.
             ///
             /// Objects with higher values are drawn on top of those with lower values.
             std::optional<rerun::components::DrawOrder> draw_order;
@@ -80,11 +77,9 @@ namespace rerun {
             /// Unique identifiers for each individual line strip in the batch.
             std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
@@ -112,8 +107,7 @@ namespace rerun {
                 return std::move(*this);
             }
 
-            /// An optional floating point value that specifies the 2D drawing order of each line
-            /// strip.
+            /// An optional floating point value that specifies the 2D drawing order of each line strip.
             ///
             /// Objects with higher values are drawn on top of those with lower values.
             LineStrips2D with_draw_order(rerun::components::DrawOrder _draw_order) && {

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -81,11 +81,9 @@ namespace rerun {
             /// Unique identifiers for each individual line strip in the batch.
             std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -22,8 +22,7 @@
 
 namespace rerun {
     namespace archetypes {
-        /// **Archetype**: A 3D triangle mesh as specified by its per-mesh and per-vertex
-        /// properties.
+        /// **Archetype**: A 3D triangle mesh as specified by its per-mesh and per-vertex properties.
         ///
         /// ## Example
         ///
@@ -67,8 +66,7 @@ namespace rerun {
         struct Mesh3D {
             /// The positions of each vertex.
             ///
-            /// If no `indices` are specified, then each triplet of positions is interpreted as a
-            /// triangle.
+            /// If no `indices` are specified, then each triplet of positions is interpreted as a triangle.
             ComponentBatch<rerun::components::Position3D> vertex_positions;
 
             /// Optional properties for the mesh as a whole (including indexed drawing).
@@ -93,11 +91,9 @@ namespace rerun {
             /// Unique identifiers for each individual vertex in the mesh.
             std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -36,8 +36,7 @@ namespace rerun {
         ///     auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
         ///     rec.connect("127.0.0.1:9876").throw_on_failure();
         ///
-        ///     rec.log("world/image", rerun::Pinhole::focal_length_and_resolution({3.0f, 3.0f},
-        ///     {3.0f, 3.0f}));
+        ///     rec.log("world/image", rerun::Pinhole::focal_length_and_resolution({3.0f, 3.0f}, {3.0f, 3.0f}));
         ///
         ///     // TODO(andreas): Improve ergonomics.
         ///     rerun::datatypes::TensorData tensor;
@@ -68,54 +67,46 @@ namespace rerun {
 
             /// Sets the view coordinates for the camera.
             ///
-            /// All common values are available as constants on the `components.ViewCoordinates`
-            /// class.
+            /// All common values are available as constants on the `components.ViewCoordinates` class.
             ///
-            /// The default is `ViewCoordinates::RDF`, i.e. X=Right, Y=Down, Z=Forward, and this is
-            /// also the recommended setting. This means that the camera frustum will point along
-            /// the positive Z axis of the parent space, and the cameras "up" direction will be
-            /// along the negative Y axis of the parent space.
+            /// The default is `ViewCoordinates::RDF`, i.e. X=Right, Y=Down, Z=Forward, and this is also the recommended setting.
+            /// This means that the camera frustum will point along the positive Z axis of the parent space,
+            /// and the cameras "up" direction will be along the negative Y axis of the parent space.
             ///
             /// The camera frustum will point whichever axis is set to `F` (or the opposite of `B`).
-            /// When logging a depth image under this entity, this is the direction the point cloud
-            /// will be projected. With `RDF`, the default forward is +Z.
+            /// When logging a depth image under this entity, this is the direction the point cloud will be projected.
+            /// With `RDF`, the default forward is +Z.
             ///
-            /// The frustum's "up" direction will be whichever axis is set to `U` (or the opposite
-            /// of `D`). This will match the negative Y direction of pixel space (all images are
-            /// assumed to have xyz=RDF). With `RDF`, the default is up is -Y.
+            /// The frustum's "up" direction will be whichever axis is set to `U` (or the opposite of `D`).
+            /// This will match the negative Y direction of pixel space (all images are assumed to have xyz=RDF).
+            /// With `RDF`, the default is up is -Y.
             ///
-            /// The frustum's "right" direction will be whichever axis is set to `R` (or the
-            /// opposite of `L`). This will match the positive X direction of pixel space (all
-            /// images are assumed to have xyz=RDF). With `RDF`, the default right is +x.
+            /// The frustum's "right" direction will be whichever axis is set to `R` (or the opposite of `L`).
+            /// This will match the positive X direction of pixel space (all images are assumed to have xyz=RDF).
+            /// With `RDF`, the default right is +x.
             ///
-            /// Other common formats are `RUB` (X=Right, Y=Up, Z=Back) and `FLU` (X=Forward, Y=Left,
-            /// Z=Up).
+            /// Other common formats are `RUB` (X=Right, Y=Up, Z=Back) and `FLU` (X=Forward, Y=Left, Z=Up).
             ///
-            /// NOTE: setting this to something else than `RDF` (the default) will change the
-            /// orientation of the camera frustum, and make the pinhole matrix not match up with the
-            /// coordinate system of the pinhole entity.
+            /// NOTE: setting this to something else than `RDF` (the default) will change the orientation of the camera frustum,
+            /// and make the pinhole matrix not match up with the coordinate system of the pinhole entity.
             ///
-            /// The pinhole matrix (the `image_from_camera` argument) always project along the third
-            /// (Z) axis, but will be re-oriented to project along the forward axis of the
-            /// `camera_xyz` argument.
+            /// The pinhole matrix (the `image_from_camera` argument) always project along the third (Z) axis,
+            /// but will be re-oriented to project along the forward axis of the `camera_xyz` argument.
             std::optional<rerun::components::ViewCoordinates> camera_xyz;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
             // Extensions to generated type defined in 'pinhole_ext.cpp'
 
-            /// Creates a pinhole from the camera focal length and resolution, both specified in
-            /// pixels.
+            /// Creates a pinhole from the camera focal length and resolution, both specified in pixels.
             ///
             /// The focal length is the diagonal of the projection matrix.
-            /// Set the same value for x & y value for symmetric cameras, or two values for
-            /// anamorphic cameras.
+            /// Set the same value for x & y value for symmetric cameras, or two values for anamorphic
+            /// cameras.
             ///
             /// Assumes the principal point to be in the middle of the sensor.
             static Pinhole focal_length_and_resolution(
@@ -144,36 +135,31 @@ namespace rerun {
 
             /// Sets the view coordinates for the camera.
             ///
-            /// All common values are available as constants on the `components.ViewCoordinates`
-            /// class.
+            /// All common values are available as constants on the `components.ViewCoordinates` class.
             ///
-            /// The default is `ViewCoordinates::RDF`, i.e. X=Right, Y=Down, Z=Forward, and this is
-            /// also the recommended setting. This means that the camera frustum will point along
-            /// the positive Z axis of the parent space, and the cameras "up" direction will be
-            /// along the negative Y axis of the parent space.
+            /// The default is `ViewCoordinates::RDF`, i.e. X=Right, Y=Down, Z=Forward, and this is also the recommended setting.
+            /// This means that the camera frustum will point along the positive Z axis of the parent space,
+            /// and the cameras "up" direction will be along the negative Y axis of the parent space.
             ///
             /// The camera frustum will point whichever axis is set to `F` (or the opposite of `B`).
-            /// When logging a depth image under this entity, this is the direction the point cloud
-            /// will be projected. With `RDF`, the default forward is +Z.
+            /// When logging a depth image under this entity, this is the direction the point cloud will be projected.
+            /// With `RDF`, the default forward is +Z.
             ///
-            /// The frustum's "up" direction will be whichever axis is set to `U` (or the opposite
-            /// of `D`). This will match the negative Y direction of pixel space (all images are
-            /// assumed to have xyz=RDF). With `RDF`, the default is up is -Y.
+            /// The frustum's "up" direction will be whichever axis is set to `U` (or the opposite of `D`).
+            /// This will match the negative Y direction of pixel space (all images are assumed to have xyz=RDF).
+            /// With `RDF`, the default is up is -Y.
             ///
-            /// The frustum's "right" direction will be whichever axis is set to `R` (or the
-            /// opposite of `L`). This will match the positive X direction of pixel space (all
-            /// images are assumed to have xyz=RDF). With `RDF`, the default right is +x.
+            /// The frustum's "right" direction will be whichever axis is set to `R` (or the opposite of `L`).
+            /// This will match the positive X direction of pixel space (all images are assumed to have xyz=RDF).
+            /// With `RDF`, the default right is +x.
             ///
-            /// Other common formats are `RUB` (X=Right, Y=Up, Z=Back) and `FLU` (X=Forward, Y=Left,
-            /// Z=Up).
+            /// Other common formats are `RUB` (X=Right, Y=Up, Z=Back) and `FLU` (X=Forward, Y=Left, Z=Up).
             ///
-            /// NOTE: setting this to something else than `RDF` (the default) will change the
-            /// orientation of the camera frustum, and make the pinhole matrix not match up with the
-            /// coordinate system of the pinhole entity.
+            /// NOTE: setting this to something else than `RDF` (the default) will change the orientation of the camera frustum,
+            /// and make the pinhole matrix not match up with the coordinate system of the pinhole entity.
             ///
-            /// The pinhole matrix (the `image_from_camera` argument) always project along the third
-            /// (Z) axis, but will be re-oriented to project along the forward axis of the
-            /// `camera_xyz` argument.
+            /// The pinhole matrix (the `image_from_camera` argument) always project along the third (Z) axis,
+            /// but will be re-oriented to project along the forward axis of the `camera_xyz` argument.
             Pinhole with_camera_xyz(rerun::components::ViewCoordinates _camera_xyz) && {
                 camera_xyz = std::move(_camera_xyz);
                 return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -51,8 +51,7 @@ namespace rerun {
         ///     });
         ///     std::vector<rerun::components::Color> colors(10);
         ///     std::generate(colors.begin(), colors.end(), [&] {
-        ///         return rerun::components::Color(dist_color(gen), dist_color(gen),
-        ///         dist_color(gen));
+        ///         return rerun::components::Color(dist_color(gen), dist_color(gen), dist_color(gen));
         ///     });
         ///     std::vector<rerun::components::Radius> radii(10);
         ///     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });
@@ -90,19 +89,18 @@ namespace rerun {
             ///
             /// If keypoint IDs are passed in but no class IDs were specified, the class ID will
             /// default to 0.
-            /// This is useful to identify points within a single classification (which is
-            /// identified with `class_id`). E.g. the classification might be 'Person' and the
-            /// keypoints refer to joints on a detected skeleton.
+            /// This is useful to identify points within a single classification (which is identified
+            /// with `class_id`).
+            /// E.g. the classification might be 'Person' and the keypoints refer to joints on a
+            /// detected skeleton.
             std::optional<ComponentBatch<rerun::components::KeypointId>> keypoint_ids;
 
             /// Unique identifiers for each individual point in the batch.
             std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
@@ -150,9 +148,10 @@ namespace rerun {
             ///
             /// If keypoint IDs are passed in but no class IDs were specified, the class ID will
             /// default to 0.
-            /// This is useful to identify points within a single classification (which is
-            /// identified with `class_id`). E.g. the classification might be 'Person' and the
-            /// keypoints refer to joints on a detected skeleton.
+            /// This is useful to identify points within a single classification (which is identified
+            /// with `class_id`).
+            /// E.g. the classification might be 'Person' and the keypoints refer to joints on a
+            /// detected skeleton.
             Points2D with_keypoint_ids(ComponentBatch<rerun::components::KeypointId> _keypoint_ids
             ) && {
                 keypoint_ids = std::move(_keypoint_ids);

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -46,13 +46,11 @@ namespace rerun {
         ///
         ///     std::vector<rerun::components::Position3D> points3d(10);
         ///     std::generate(points3d.begin(), points3d.end(), [&] {
-        ///         return rerun::components::Position3D(dist_pos(gen), dist_pos(gen),
-        ///         dist_pos(gen));
+        ///         return rerun::components::Position3D(dist_pos(gen), dist_pos(gen), dist_pos(gen));
         ///     });
         ///     std::vector<rerun::components::Color> colors(10);
         ///     std::generate(colors.begin(), colors.end(), [&] {
-        ///         return rerun::components::Color(dist_color(gen), dist_color(gen),
-        ///         dist_color(gen));
+        ///         return rerun::components::Color(dist_color(gen), dist_color(gen), dist_color(gen));
         ///     });
         ///     std::vector<rerun::components::Radius> radii(10);
         ///     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });
@@ -82,19 +80,18 @@ namespace rerun {
             ///
             /// If keypoint IDs are passed in but no class IDs were specified, the class ID will
             /// default to 0.
-            /// This is useful to identify points within a single classification (which is
-            /// identified with `class_id`). E.g. the classification might be 'Person' and the
-            /// keypoints refer to joints on a detected skeleton.
+            /// This is useful to identify points within a single classification (which is identified
+            /// with `class_id`).
+            /// E.g. the classification might be 'Person' and the keypoints refer to joints on a
+            /// detected skeleton.
             std::optional<ComponentBatch<rerun::components::KeypointId>> keypoint_ids;
 
             /// Unique identifiers for each individual point in the batch.
             std::optional<ComponentBatch<rerun::components::InstanceKey>> instance_keys;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:
@@ -134,9 +131,10 @@ namespace rerun {
             ///
             /// If keypoint IDs are passed in but no class IDs were specified, the class ID will
             /// default to 0.
-            /// This is useful to identify points within a single classification (which is
-            /// identified with `class_id`). E.g. the classification might be 'Person' and the
-            /// keypoints refer to joints on a detected skeleton.
+            /// This is useful to identify points within a single classification (which is identified
+            /// with `class_id`).
+            /// E.g. the classification might be 'Person' and the keypoints refer to joints on a
+            /// detected skeleton.
             Points3D with_keypoint_ids(ComponentBatch<rerun::components::KeypointId> _keypoint_ids
             ) && {
                 keypoint_ids = std::move(_keypoint_ids);

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -33,11 +33,9 @@ namespace rerun {
             /// Objects with higher values are drawn on top of those with lower values.
             std::optional<rerun::components::DrawOrder> draw_order;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -20,11 +20,9 @@ namespace rerun {
             /// The tensor data
             rerun::components::TensorData data;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -33,11 +33,9 @@ namespace rerun {
             /// If omitted, `text/plain` is assumed.
             std::optional<rerun::components::MediaType> media_type;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -31,11 +31,9 @@ namespace rerun {
             /// Optional color to use for the log line in the Rerun Viewer.
             std::optional<rerun::components::Color> color;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -20,8 +20,7 @@
 
 namespace rerun {
     namespace archetypes {
-        /// **Archetype**: Log a double-precision scalar that will be visualized as a time-series
-        /// plot.
+        /// **Archetype**: Log a double-precision scalar that will be visualized as a time-series plot.
         ///
         /// The current simulation time will be used for the time/X-axis, hence scalars
         /// cannot be timeless!
@@ -71,11 +70,9 @@ namespace rerun {
             /// required.
             std::optional<rerun::components::ScalarScattering> scattered;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -36,8 +36,7 @@ namespace rerun {
         ///     rec.connect("127.0.0.1:9876").throw_on_failure();
         ///
         ///     auto arrow =
-        ///         rerun::Arrows3D::from_vectors({{0.0f, 1.0f, 0.0f}}).with_origins({{0.0f, 0.0f,
-        ///         0.0f}});
+        ///         rerun::Arrows3D::from_vectors({{0.0f, 1.0f, 0.0f}}).with_origins({{0.0f, 0.0f, 0.0f}});
         ///
         ///     rec.log("base", arrow);
         ///
@@ -58,11 +57,9 @@ namespace rerun {
             /// The transform
             rerun::components::Transform3D transform;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -29,7 +29,7 @@ namespace rerun {
         ///
         /// namespace rrd = rerun::datatypes;
         ///
-        /// const float pi = static_cast<float>(M_PI);
+        /// const float TAU = static_cast<float>(2.0 * M_PI);
         ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_transform3d");
@@ -46,7 +46,7 @@ namespace rerun {
         ///     rec.log(
         ///         "base/rotated_scaled",
         ///         rerun::Transform3D(
-        ///             rrd::RotationAxisAngle({0.0f, 0.0f, 1.0f}, rrd::Angle::radians(pi / 4.0f)),
+        ///             rrd::RotationAxisAngle({0.0f, 0.0f, 1.0f}, rrd::Angle::radians(TAU / 8.0f)),
         ///             2.0f
         ///         )
         ///     );

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -17,13 +17,12 @@ namespace rerun {
     namespace archetypes {
         /// **Archetype**: How we interpret the coordinate system of an entity/space.
         ///
-        /// For instance: What is "up"? What does the Z axis mean? Is this right-handed or
-        /// left-handed?
+        /// For instance: What is "up"? What does the Z axis mean? Is this right-handed or left-handed?
         ///
         /// The three coordinates are always ordered as [x, y, z].
         ///
-        /// For example [Right, Down, Forward] means that the X axis points to the right, the Y axis
-        /// points down, and the Z axis points forward.
+        /// For example [Right, Down, Forward] means that the X axis points to the right, the Y axis points
+        /// down, and the Z axis points forward.
         ///
         /// ## Example
         ///
@@ -40,11 +39,10 @@ namespace rerun {
         ///     auto rec = rerun::RecordingStream("rerun_example_view_coordinates");
         ///     rec.connect("127.0.0.1:9876").throw_on_failure();
         ///
-        ///     rec.log("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
+        ///     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
         ///     rec.log(
         ///         "world/xyz",
-        ///         rerun::Arrows3D::from_vectors({{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0,
-        ///         0.0, 1.0}}
+        ///         rerun::Arrows3D::from_vectors({{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}
         ///         ).with_colors({{255, 0, 0}, {0, 255, 0}, {0, 0, 255}})
         ///     );
         /// }
@@ -52,11 +50,9 @@ namespace rerun {
         struct ViewCoordinates {
             rerun::components::ViewCoordinates xyz;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/src/rerun/components/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.hpp
@@ -20,8 +20,7 @@ namespace arrow {
 
 namespace rerun {
     namespace components {
-        /// **Component**: The `AnnotationContext` provides additional information on how to display
-        /// entities.
+        /// **Component**: The `AnnotationContext` provides additional information on how to display entities.
         ///
         /// Entities can use `ClassId`s and `KeypointId`s to provide annotations, and
         /// the labels and colors will be looked up in the appropriate

--- a/rerun_cpp/src/rerun/components/color.hpp
+++ b/rerun_cpp/src/rerun/components/color.hpp
@@ -23,8 +23,7 @@ namespace arrow {
 
 namespace rerun {
     namespace components {
-        /// **Component**: An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with
-        /// linear alpha.
+        /// **Component**: An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
         ///
         /// The color is stored as a 32-bit integer, where the most significant
         /// byte is `R` and the least significant byte is `A`.

--- a/rerun_cpp/src/rerun/components/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.hpp
@@ -18,8 +18,7 @@ namespace arrow {
 
 namespace rerun {
     namespace components {
-        /// **Component**: Specifies that the entity path at which this is logged is disconnected
-        /// from its parent.
+        /// **Component**: Specifies that the entity path at which this is logged is disconnected from its parent.
         ///
         /// This is useful for specifying that a subgraph is independent of the rest of the scene.
         ///

--- a/rerun_cpp/src/rerun/components/half_sizes2d.hpp
+++ b/rerun_cpp/src/rerun/components/half_sizes2d.hpp
@@ -19,12 +19,10 @@ namespace arrow {
 
 namespace rerun {
     namespace components {
-        /// **Component**: Half-sizes (extents) of a 2D box along its local axis, starting at its
-        /// local origin/center.
+        /// **Component**: Half-sizes (extents) of a 2D box along its local axis, starting at its local origin/center.
         ///
         /// The box extends both in negative and positive direction along each axis.
-        /// Negative sizes indicate that the box is flipped along the respective axis, but this has
-        /// no effect on how it is displayed.
+        /// Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
         struct HalfSizes2D {
             rerun::datatypes::Vec2D xy;
 

--- a/rerun_cpp/src/rerun/components/half_sizes3d.hpp
+++ b/rerun_cpp/src/rerun/components/half_sizes3d.hpp
@@ -19,12 +19,10 @@ namespace arrow {
 
 namespace rerun {
     namespace components {
-        /// **Component**: Half-sizes (extents) of a 3D box along its local axis, starting at its
-        /// local origin/center.
+        /// **Component**: Half-sizes (extents) of a 3D box along its local axis, starting at its local origin/center.
         ///
         /// The box extends both in negative and positive direction along each axis.
-        /// Negative sizes indicate that the box is flipped along the respective axis, but this has
-        /// no effect on how it is displayed.
+        /// Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
         struct HalfSizes3D {
             rerun::datatypes::Vec3D xyz;
 

--- a/rerun_cpp/src/rerun/components/media_type.hpp
+++ b/rerun_cpp/src/rerun/components/media_type.hpp
@@ -20,12 +20,10 @@ namespace arrow {
 
 namespace rerun {
     namespace components {
-        /// **Component**: A standardized media type (RFC2046, formerly known as MIME types),
-        /// encoded as a utf8 string.
+        /// **Component**: A standardized media type (RFC2046, formerly known as MIME types), encoded as a utf8 string.
         ///
-        /// The complete reference of officially registered media types is maintained by the IANA
-        /// and can be consulted at
-        /// <https://www.iana.org/assignments/media-types/media-types.xhtml>.
+        /// The complete reference of officially registered media types is maintained by the IANA and can be
+        /// consulted at <https://www.iana.org/assignments/media-types/media-types.xhtml>.
         struct MediaType {
             rerun::datatypes::Utf8 value;
 

--- a/rerun_cpp/src/rerun/components/out_of_tree_transform3d.hpp
+++ b/rerun_cpp/src/rerun/components/out_of_tree_transform3d.hpp
@@ -19,11 +19,9 @@ namespace arrow {
 
 namespace rerun {
     namespace components {
-        /// **Component**: An out-of-tree affine transform between two 3D spaces, represented in a
-        /// given direction.
+        /// **Component**: An out-of-tree affine transform between two 3D spaces, represented in a given direction.
         ///
-        /// "Out-of-tree" means that the transform only affects its own entity: children don't
-        /// inherit from it.
+        /// "Out-of-tree" means that the transform only affects its own entity: children don't inherit from it.
         struct OutOfTreeTransform3D {
             /// Representation of the transform.
             rerun::datatypes::Transform3D repr;

--- a/rerun_cpp/src/rerun/components/rotation3d.hpp
+++ b/rerun_cpp/src/rerun/components/rotation3d.hpp
@@ -19,8 +19,7 @@ namespace arrow {
 
 namespace rerun {
     namespace components {
-        /// **Component**: A 3D rotation, represented either by a quaternion or a rotation around
-        /// axis.
+        /// **Component**: A 3D rotation, represented either by a quaternion or a rotation around axis.
         struct Rotation3D {
             /// Representation of the rotation.
             rerun::datatypes::Rotation3D repr;

--- a/rerun_cpp/src/rerun/components/transform3d.hpp
+++ b/rerun_cpp/src/rerun/components/transform3d.hpp
@@ -19,8 +19,7 @@ namespace arrow {
 
 namespace rerun {
     namespace components {
-        /// **Component**: An affine transform between two 3D spaces, represented in a given
-        /// direction.
+        /// **Component**: An affine transform between two 3D spaces, represented in a given direction.
         struct Transform3D {
             /// Representation of the transform.
             rerun::datatypes::Transform3D repr;

--- a/rerun_cpp/src/rerun/components/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/components/view_coordinates.hpp
@@ -19,21 +19,20 @@ namespace rerun {
     namespace components {
         /// **Component**: How we interpret the coordinate system of an entity/space.
         ///
-        /// For instance: What is "up"? What does the Z axis mean? Is this right-handed or
-        /// left-handed?
+        /// For instance: What is "up"? What does the Z axis mean? Is this right-handed or left-handed?
         ///
         /// The three coordinates are always ordered as [x, y, z].
         ///
-        /// For example [Right, Down, Forward] means that the X axis points to the right, the Y axis
-        /// points down, and the Z axis points forward.
+        /// For example [Right, Down, Forward] means that the X axis points to the right, the Y axis points
+        /// down, and the Z axis points forward.
         ///
-        /// The following constants are used to represent the different directions.
-        ///  Up = 1
-        ///  Down = 2
-        ///  Right = 3
-        ///  Left = 4
-        ///  Forward = 5
-        ///  Back = 6
+        /// The following constants are used to represent the different directions:
+        ///  * Up = 1
+        ///  * Down = 2
+        ///  * Right = 3
+        ///  * Left = 4
+        ///  * Forward = 5
+        ///  * Back = 6
         struct ViewCoordinates {
             /// The directions of the [x, y, z] axes.
             uint8_t coordinates[3];

--- a/rerun_cpp/src/rerun/datatypes/angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.hpp
@@ -20,9 +20,7 @@ namespace rerun {
     namespace datatypes {
         namespace detail {
             enum class AngleTag : uint8_t {
-                /// Having a special empty state makes it possible to implement move-semantics. We
-                /// need to be able to leave the object in a state which we can run the destructor
-                /// on.
+                /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
                 NONE = 0,
                 Radians,
                 Degrees,
@@ -38,8 +36,7 @@ namespace rerun {
                 ~AngleData() {}
 
                 void swap(AngleData &other) noexcept {
-                    // This bitwise swap would fail for self-referential types, but we don't have
-                    // any of those.
+                    // This bitwise swap would fail for self-referential types, but we don't have any of those.
                     char temp[sizeof(AngleData)];
                     void *otherbytes = reinterpret_cast<void *>(&other);
                     void *thisbytes = reinterpret_cast<void *>(this);

--- a/rerun_cpp/src/rerun/datatypes/rgba32.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rgba32.hpp
@@ -21,8 +21,7 @@ namespace arrow {
 
 namespace rerun {
     namespace datatypes {
-        /// **Datatype**: An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with
-        /// linear alpha.
+        /// **Datatype**: An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
         ///
         /// The color is stored as a 32-bit integer, where the most significant
         /// byte is `R` and the least significant byte is `A`.

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
@@ -22,9 +22,7 @@ namespace rerun {
     namespace datatypes {
         namespace detail {
             enum class Rotation3DTag : uint8_t {
-                /// Having a special empty state makes it possible to implement move-semantics. We
-                /// need to be able to leave the object in a state which we can run the destructor
-                /// on.
+                /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
                 NONE = 0,
                 Quaternion,
                 AxisAngle,
@@ -42,8 +40,7 @@ namespace rerun {
                 ~Rotation3DData() {}
 
                 void swap(Rotation3DData &other) noexcept {
-                    // This bitwise swap would fail for self-referential types, but we don't have
-                    // any of those.
+                    // This bitwise swap would fail for self-referential types, but we don't have any of those.
                     char temp[sizeof(Rotation3DData)];
                     void *otherbytes = reinterpret_cast<void *>(&other);
                     void *thisbytes = reinterpret_cast<void *>(this);

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
@@ -23,8 +23,8 @@ namespace rerun {
             /// Axis to rotate around.
             ///
             /// This is not required to be normalized.
-            /// If normalization fails (typically because the vector is length zero), the rotation
-            /// is silently ignored.
+            /// If normalization fails (typically because the vector is length zero), the rotation is silently
+            /// ignored.
             rerun::datatypes::Vec3D axis;
 
             /// How much to rotate around the axis.

--- a/rerun_cpp/src/rerun/datatypes/scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.hpp
@@ -21,9 +21,7 @@ namespace rerun {
     namespace datatypes {
         namespace detail {
             enum class Scale3DTag : uint8_t {
-                /// Having a special empty state makes it possible to implement move-semantics. We
-                /// need to be able to leave the object in a state which we can run the destructor
-                /// on.
+                /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
                 NONE = 0,
                 ThreeD,
                 Uniform,
@@ -41,8 +39,7 @@ namespace rerun {
                 ~Scale3DData() {}
 
                 void swap(Scale3DData &other) noexcept {
-                    // This bitwise swap would fail for self-referential types, but we don't have
-                    // any of those.
+                    // This bitwise swap would fail for self-referential types, but we don't have any of those.
                     char temp[sizeof(Scale3DData)];
                     void *otherbytes = reinterpret_cast<void *>(&other);
                     void *thisbytes = reinterpret_cast<void *>(this);

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer.cpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer.cpp
@@ -163,7 +163,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize TensorBuffer: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }
@@ -173,7 +174,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize TensorBuffer: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }
@@ -183,7 +185,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize TensorBuffer: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }
@@ -193,7 +196,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize TensorBuffer: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }
@@ -203,7 +207,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize TensorBuffer: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }
@@ -213,7 +218,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize TensorBuffer: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }
@@ -223,7 +229,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize TensorBuffer: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }
@@ -233,7 +240,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize TensorBuffer: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }
@@ -243,7 +251,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize TensorBuffer: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }
@@ -253,7 +262,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize TensorBuffer: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }
@@ -263,7 +273,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize TensorBuffer: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }
@@ -273,7 +284,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize TensorBuffer: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
@@ -24,9 +24,7 @@ namespace rerun {
     namespace datatypes {
         namespace detail {
             enum class TensorBufferTag : uint8_t {
-                /// Having a special empty state makes it possible to implement move-semantics. We
-                /// need to be able to leave the object in a state which we can run the destructor
-                /// on.
+                /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
                 NONE = 0,
                 U8,
                 U16,
@@ -72,8 +70,7 @@ namespace rerun {
                 ~TensorBufferData() {}
 
                 void swap(TensorBufferData &other) noexcept {
-                    // This bitwise swap would fail for self-referential types, but we don't have
-                    // any of those.
+                    // This bitwise swap would fail for self-referential types, but we don't have any of those.
                     char temp[sizeof(TensorBufferData)];
                     void *otherbytes = reinterpret_cast<void *>(&other);
                     void *thisbytes = reinterpret_cast<void *>(this);

--- a/rerun_cpp/src/rerun/datatypes/tensor_data.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_data.hpp
@@ -22,8 +22,8 @@ namespace rerun {
         /// **Datatype**: A multi-dimensional `Tensor` of data.
         ///
         /// The number of dimensions and their respective lengths is specified by the `shape` field.
-        /// The dimensions are ordered from outermost to innermost. For example, in the common case
-        /// of a 2D RGB Image, the shape would be `[height, width, channel]`.
+        /// The dimensions are ordered from outermost to innermost. For example, in the common case of
+        /// a 2D RGB Image, the shape would be `[height, width, channel]`.
         ///
         /// These dimensions are combined with an index to look up values from the `buffer` field,
         /// which stores a contiguous array of typed values.

--- a/rerun_cpp/src/rerun/datatypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.hpp
@@ -22,9 +22,7 @@ namespace rerun {
     namespace datatypes {
         namespace detail {
             enum class Transform3DTag : uint8_t {
-                /// Having a special empty state makes it possible to implement move-semantics. We
-                /// need to be able to leave the object in a state which we can run the destructor
-                /// on.
+                /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
                 NONE = 0,
                 TranslationAndMat3x3,
                 TranslationRotationScale,
@@ -40,8 +38,7 @@ namespace rerun {
                 ~Transform3DData() {}
 
                 void swap(Transform3DData &other) noexcept {
-                    // This bitwise swap would fail for self-referential types, but we don't have
-                    // any of those.
+                    // This bitwise swap would fail for self-referential types, but we don't have any of those.
                     char temp[sizeof(Transform3DData)];
                     void *otherbytes = reinterpret_cast<void *>(&other);
                     void *thisbytes = reinterpret_cast<void *>(this);

--- a/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.hpp
@@ -19,8 +19,7 @@ namespace arrow {
 
 namespace rerun {
     namespace datatypes {
-        /// **Datatype**: Representation of an affine transform via a 3x3 affine matrix paired with
-        /// a translation.
+        /// **Datatype**: Representation of an affine transform via a 3x3 affine matrix paired with a translation.
         ///
         /// First applies the matrix, then the translation.
         struct TranslationAndMat3x3 {
@@ -30,8 +29,7 @@ namespace rerun {
             /// 3x3 matrix for scale, rotation & shear.
             std::optional<rerun::datatypes::Mat3x3> mat3x3;
 
-            /// If true, this transform is from the parent space to the space where the transform
-            /// was logged.
+            /// If true, this transform is from the parent space to the space where the transform was logged.
             ///
             /// If false (default), the transform maps from this space to its parent,
             /// i.e. the translation is the position in the parent space.

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
@@ -20,8 +20,7 @@ namespace arrow {
 
 namespace rerun {
     namespace datatypes {
-        /// **Datatype**: Representation of an affine transform via separate translation, rotation &
-        /// scale.
+        /// **Datatype**: Representation of an affine transform via separate translation, rotation & scale.
         struct TranslationRotationScale3D {
             /// 3D translation vector, applied last.
             std::optional<rerun::datatypes::Vec3D> translation;
@@ -32,8 +31,7 @@ namespace rerun {
             /// 3D scale, applied first.
             std::optional<rerun::datatypes::Scale3D> scale;
 
-            /// If true, this transform is from the parent space to the space where the transform
-            /// was logged.
+            /// If true, this transform is from the parent space to the space where the transform was logged.
             ///
             /// If false (default), the transform maps from this space to its parent,
             /// i.e. the translation is the position in the parent space.

--- a/rerun_cpp/src/rerun/error.cpp
+++ b/rerun_cpp/src/rerun/error.cpp
@@ -79,7 +79,7 @@ namespace rerun {
         if (global_log_handler) {
             global_log_handler(*this, global_log_handler_user_data);
         } else {
-            fprintf(stderr, "%s\n", description.c_str());
+            fprintf(stderr, "ERROR: %s\n", description.c_str());
         }
     }
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -78,11 +78,9 @@ namespace rerun {
 
             rerun::components::AffixFuzzer21 fuzz1021;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
@@ -69,11 +69,9 @@ namespace rerun {
 
             ComponentBatch<rerun::components::AffixFuzzer18> fuzz1118;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -70,11 +70,9 @@ namespace rerun {
 
             std::optional<rerun::components::AffixFuzzer18> fuzz2018;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -70,11 +70,9 @@ namespace rerun {
 
             std::optional<ComponentBatch<rerun::components::AffixFuzzer18>> fuzz2118;
 
-            /// Name of the indicator component, used to identify the archetype when converting to a
-            /// list of components.
+            /// Name of the indicator component, used to identify the archetype when converting to a list of components.
             static const char INDICATOR_COMPONENT_NAME[];
-            /// Indicator component, used to identify the archetype when converting to a list of
-            /// components.
+            /// Indicator component, used to identify the archetype when converting to a list of components.
             using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
 
           public:

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
@@ -109,7 +109,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize AffixFuzzer3: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }
@@ -119,7 +120,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize AffixFuzzer3: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
@@ -24,9 +24,7 @@ namespace rerun {
     namespace datatypes {
         namespace detail {
             enum class AffixFuzzer3Tag : uint8_t {
-                /// Having a special empty state makes it possible to implement move-semantics. We
-                /// need to be able to leave the object in a state which we can run the destructor
-                /// on.
+                /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
                 NONE = 0,
                 degrees,
                 radians,
@@ -48,8 +46,7 @@ namespace rerun {
                 ~AffixFuzzer3Data() {}
 
                 void swap(AffixFuzzer3Data &other) noexcept {
-                    // This bitwise swap would fail for self-referential types, but we don't have
-                    // any of those.
+                    // This bitwise swap would fail for self-referential types, but we don't have any of those.
                     char temp[sizeof(AffixFuzzer3Data)];
                     void *otherbytes = reinterpret_cast<void *>(&other);
                     void *thisbytes = reinterpret_cast<void *>(this);

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
@@ -107,7 +107,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize AffixFuzzer4: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }
@@ -117,7 +118,8 @@ namespace rerun {
                         (void)variant_builder;
                         return Error(
                             ErrorCode::NotImplemented,
-                            "TODO(andreas): list types in unions are not yet supported"
+                            "Failed to serialize AffixFuzzer4: list types in unions not yet "
+                            "implemented"
                         );
                         break;
                     }

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
@@ -24,9 +24,7 @@ namespace rerun {
     namespace datatypes {
         namespace detail {
             enum class AffixFuzzer4Tag : uint8_t {
-                /// Having a special empty state makes it possible to implement move-semantics. We
-                /// need to be able to leave the object in a state which we can run the destructor
-                /// on.
+                /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
                 NONE = 0,
                 single_required,
                 many_required,
@@ -45,8 +43,7 @@ namespace rerun {
                 ~AffixFuzzer4Data() {}
 
                 void swap(AffixFuzzer4Data &other) noexcept {
-                    // This bitwise swap would fail for self-referential types, but we don't have
-                    // any of those.
+                    // This bitwise swap would fail for self-referential types, but we don't have any of those.
                     char temp[sizeof(AffixFuzzer4Data)];
                     void *otherbytes = reinterpret_cast<void *>(&other);
                     void *thisbytes = reinterpret_cast<void *>(this);

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -66,7 +66,7 @@ class AnnotationContext(Archetype):
         Parameters
         ----------
         context:
-             List of class descriptions, mapping class indices to class names, colors etc.
+            List of class descriptions, mapping class indices to class names, colors etc.
         """
 
         # You can define your own __init__ function as a member of AnnotationContextExt in annotation_context_ext.py

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -52,7 +52,7 @@ class BarChart(BarChartExt, Archetype):
         Parameters
         ----------
         values:
-             The values. Should always be a rank-1 tensor.
+            The values. Should always be a rank-1 tensor.
         """
 
         # You can define your own __init__ function as a member of BarChartExt in bar_chart_ext.py

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -76,16 +76,16 @@ class DepthImage(DepthImageExt, Archetype):
         Parameters
         ----------
         data:
-             The depth-image data. Should always be a rank-2 tensor.
+            The depth-image data. Should always be a rank-2 tensor.
         meter:
-             An optional floating point value that specifies how long a meter is in the native depth units.
+            An optional floating point value that specifies how long a meter is in the native depth units.
 
-             For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
-             and a range of up to ~65 meters (2^16 / 1000).
+            For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
+            and a range of up to ~65 meters (2^16 / 1000).
         draw_order:
-             An optional floating point value that specifies the 2D drawing order.
+            An optional floating point value that specifies the 2D drawing order.
 
-             Objects with higher values are drawn on top of those with lower values.
+            Objects with higher values are drawn on top of those with lower values.
         """
 
         # You can define your own __init__ function as a member of DepthImageExt in depth_image_ext.py

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -65,11 +65,11 @@ class Image(ImageExt, Archetype):
         Parameters
         ----------
         data:
-             The image data. Should always be a rank-2 or rank-3 tensor.
+            The image data. Should always be a rank-2 or rank-3 tensor.
         draw_order:
-             An optional floating point value that specifies the 2D drawing order.
+            An optional floating point value that specifies the 2D drawing order.
 
-             Objects with higher values are drawn on top of those with lower values.
+            Objects with higher values are drawn on top of those with lower values.
         """
 
         # You can define your own __init__ function as a member of ImageExt in image_ext.py

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -73,23 +73,23 @@ class LineStrips2D(Archetype):
         Parameters
         ----------
         strips:
-             All the actual 2D line strips that make up the batch.
+            All the actual 2D line strips that make up the batch.
         radii:
-             Optional radii for the line strips.
+            Optional radii for the line strips.
         colors:
-             Optional colors for the line strips.
+            Optional colors for the line strips.
         labels:
-             Optional text labels for the line strips.
+            Optional text labels for the line strips.
         draw_order:
-             An optional floating point value that specifies the 2D drawing order of each line strip.
+            An optional floating point value that specifies the 2D drawing order of each line strip.
 
-             Objects with higher values are drawn on top of those with lower values.
+            Objects with higher values are drawn on top of those with lower values.
         class_ids:
-             Optional `ClassId`s for the lines.
+            Optional `ClassId`s for the lines.
 
-             The class ID provides colors and labels if not specified explicitly.
+            The class ID provides colors and labels if not specified explicitly.
         instance_keys:
-             Unique identifiers for each individual line strip in the batch.
+            Unique identifiers for each individual line strip in the batch.
         """
 
         # You can define your own __init__ function as a member of LineStrips2DExt in line_strips2d_ext.py

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -83,19 +83,19 @@ class LineStrips3D(Archetype):
         Parameters
         ----------
         strips:
-             All the actual 3D line strips that make up the batch.
+            All the actual 3D line strips that make up the batch.
         radii:
-             Optional radii for the line strips.
+            Optional radii for the line strips.
         colors:
-             Optional colors for the line strips.
+            Optional colors for the line strips.
         labels:
-             Optional text labels for the line strips.
+            Optional text labels for the line strips.
         class_ids:
-             Optional `ClassId`s for the lines.
+            Optional `ClassId`s for the lines.
 
-             The class ID provides colors and labels if not specified explicitly.
+            The class ID provides colors and labels if not specified explicitly.
         instance_keys:
-             Unique identifiers for each individual line strip in the batch.
+            Unique identifiers for each individual line strip in the batch.
         """
 
         # You can define your own __init__ function as a member of LineStrips3DExt in line_strips3d_ext.py

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -68,11 +68,11 @@ class SegmentationImage(SegmentationImageExt, Archetype):
         Parameters
         ----------
         data:
-             The image data. Should always be a rank-2 tensor.
+            The image data. Should always be a rank-2 tensor.
         draw_order:
-             An optional floating point value that specifies the 2D drawing order.
+            An optional floating point value that specifies the 2D drawing order.
 
-             Objects with higher values are drawn on top of those with lower values.
+            Objects with higher values are drawn on top of those with lower values.
         """
 
         # You can define your own __init__ function as a member of SegmentationImageExt in segmentation_image_ext.py

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -31,15 +31,15 @@ class TextDocument(Archetype):
         Parameters
         ----------
         text:
-             Contents of the text document.
+            Contents of the text document.
         media_type:
-             The Media Type of the text.
+            The Media Type of the text.
 
-             For instance:
-             * `text/plain`
-             * `text/markdown`
+            For instance:
+            * `text/plain`
+            * `text/markdown`
 
-             If omitted, `text/plain` is assumed.
+            If omitted, `text/plain` is assumed.
         """
 
         # You can define your own __init__ function as a member of TextDocumentExt in text_document_ext.py

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -63,13 +63,13 @@ class TextLog(Archetype):
         Parameters
         ----------
         text:
-             The body of the message.
+            The body of the message.
         level:
-             The verbosity level of the message.
+            The verbosity level of the message.
 
-             This can be used to filter the log messages in the Rerun Viewer.
+            This can be used to filter the log messages in the Rerun Viewer.
         color:
-             Optional color to use for the log line in the Rerun Viewer.
+            Optional color to use for the log line in the Rerun Viewer.
         """
 
         # You can define your own __init__ function as a member of TextLogExt in text_log_ext.py

--- a/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
@@ -64,45 +64,45 @@ class TimeSeriesScalar(Archetype):
         Parameters
         ----------
         scalar:
-             The scalar value to log.
+            The scalar value to log.
         radius:
-             An optional radius for the point.
+            An optional radius for the point.
 
-             Points within a single line do not have to share the same radius, the line
-             will have differently sized segments as appropriate.
+            Points within a single line do not have to share the same radius, the line
+            will have differently sized segments as appropriate.
 
-             If all points within a single entity path (i.e. a line) share the same
-             radius, then this radius will be used as the line width too. Otherwise, the
-             line will use the default width of `1.0`.
+            If all points within a single entity path (i.e. a line) share the same
+            radius, then this radius will be used as the line width too. Otherwise, the
+            line will use the default width of `1.0`.
         color:
-             Optional color for the scalar entry.
+            Optional color for the scalar entry.
 
-             If left unspecified, a pseudo-random color will be used instead. That
-             same color will apply to all points residing in the same entity path
-             that don't have a color specified.
+            If left unspecified, a pseudo-random color will be used instead. That
+            same color will apply to all points residing in the same entity path
+            that don't have a color specified.
 
-             Points within a single line do not have to share the same color, the line
-             will have differently colored segments as appropriate.
-             If all points within a single entity path (i.e. a line) share the same
-             color, then this color will be used as the line color in the plot legend.
-             Otherwise, the line will appear gray in the legend.
+            Points within a single line do not have to share the same color, the line
+            will have differently colored segments as appropriate.
+            If all points within a single entity path (i.e. a line) share the same
+            color, then this color will be used as the line color in the plot legend.
+            Otherwise, the line will appear gray in the legend.
         label:
-             An optional label for the point.
+            An optional label for the point.
 
-             TODO(#1289): This won't show up on points at the moment, as our plots don't yet
-             support displaying labels for individual points.
-             If all points within a single entity path (i.e. a line) share the same label, then
-             this label will be used as the label for the line itself. Otherwise, the
-             line will be named after the entity path. The plot itself is named after
-             the space it's in.
+            TODO(#1289): This won't show up on points at the moment, as our plots don't yet
+            support displaying labels for individual points.
+            If all points within a single entity path (i.e. a line) share the same label, then
+            this label will be used as the label for the line itself. Otherwise, the
+            line will be named after the entity path. The plot itself is named after
+            the space it's in.
         scattered:
-             Specifies whether a point in a scatter plot should form a continuous line.
+            Specifies whether a point in a scatter plot should form a continuous line.
 
-             If set to true, this scalar will be drawn as a point, akin to a scatterplot.
-             Otherwise, it will form a continuous line with its neighbors.
-             Points within a single line do not have to all share the same scatteredness:
-             the line will switch between a scattered and a continuous representation as
-             required.
+            If set to true, this scalar will be drawn as a point, akin to a scatterplot.
+            Otherwise, it will form a continuous line with its neighbors.
+            Points within a single line do not have to all share the same scatteredness:
+            the line will switch between a scattered and a continuous representation as
+            required.
         """
 
         # You can define your own __init__ function as a member of TimeSeriesScalarExt in time_series_scalar_ext.py

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -30,10 +30,12 @@ class Transform3D(Transform3DExt, Archetype):
 
     rr.init("rerun_example_transform3d", spawn=True)
 
-    rr.log("base", rr.Arrows3D(origins=[0, 0, 0], vectors=[0, 1, 0]))
+    arrow = rr.Arrows3D(origins=[0, 0, 0], vectors=[0, 1, 0])
+
+    rr.log("base", arrow)
 
     rr.log("base/translated", rr.Transform3D(translation=[1, 0, 0]))
-    rr.log("base/translated", rr.Arrows3D(origins=[0, 0, 0], vectors=[0, 1, 0]))
+    rr.log("base/translated", arrow)
 
     rr.log(
         "base/rotated_scaled",
@@ -42,7 +44,7 @@ class Transform3D(Transform3DExt, Archetype):
             scale=2,
         ),
     )
-    rr.log("base/rotated_scaled", rr.Arrows3D(origins=[0, 0, 0], vectors=[0, 1, 0]))
+    rr.log("base/rotated_scaled", arrow)
     ```
     <center>
     <picture>

--- a/rerun_py/rerun_sdk/rerun/components/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/components/annotation_context.py
@@ -42,7 +42,7 @@ class AnnotationContext(AnnotationContextExt):
         Parameters
         ----------
         class_map:
-             List of class descriptions, mapping class indices to class names, colors etc.
+            List of class descriptions, mapping class indices to class names, colors etc.
         """
 
         # You can define your own __init__ function as a member of AnnotationContextExt in annotation_context_ext.py

--- a/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
+++ b/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
@@ -35,7 +35,7 @@ class ClearIsRecursive(ClearIsRecursiveExt):
         Parameters
         ----------
         recursive:
-             If true, also clears all recursive children entities.
+            If true, also clears all recursive children entities.
         """
 
         # You can define your own __init__ function as a member of ClearIsRecursiveExt in clear_is_recursive_ext.py

--- a/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
@@ -36,13 +36,13 @@ class ViewCoordinates(ViewCoordinatesExt):
     For example [Right, Down, Forward] means that the X axis points to the right, the Y axis points
     down, and the Z axis points forward.
 
-    The following constants are used to represent the different directions.
-     Up = 1
-     Down = 2
-     Right = 3
-     Left = 4
-     Forward = 5
-     Back = 6
+    The following constants are used to represent the different directions:
+     * Up = 1
+     * Down = 2
+     * Right = 3
+     * Left = 4
+     * Forward = 5
+     * Back = 6
     """
 
     def __init__(self: Any, coordinates: ViewCoordinatesLike):
@@ -52,7 +52,7 @@ class ViewCoordinates(ViewCoordinatesExt):
         Parameters
         ----------
         coordinates:
-             The directions of the [x, y, z] axes.
+            The directions of the [x, y, z] axes.
         """
 
         # You can define your own __init__ function as a member of ViewCoordinatesExt in view_coordinates_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
@@ -61,11 +61,11 @@ class AnnotationInfo(AnnotationInfoExt):
         Parameters
         ----------
         id:
-             `ClassId` or `KeypointId` to which this annotation info belongs.
+            `ClassId` or `KeypointId` to which this annotation info belongs.
         label:
-             The label that will be shown in the UI.
+            The label that will be shown in the UI.
         color:
-             The color that will be applied to the annotated entity.
+            The color that will be applied to the annotated entity.
         """
 
         # You can define your own __init__ function as a member of AnnotationInfoExt in annotation_info_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem.py
@@ -47,9 +47,9 @@ class ClassDescriptionMapElem(ClassDescriptionMapElemExt):
         Parameters
         ----------
         class_id:
-             The key: the class ID.
+            The key: the class ID.
         class_description:
-             The value: class name, color, etc.
+            The value: class name, color, etc.
         """
 
         # You can define your own __init__ function as a member of ClassDescriptionMapElemExt in class_description_map_elem_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair.py
@@ -42,9 +42,9 @@ class KeypointPair(KeypointPairExt):
         Parameters
         ----------
         keypoint0:
-             The first point of the pair.
+            The first point of the pair.
         keypoint1:
-             The second point of the pair.
+            The second point of the pair.
         """
 
         # You can define your own __init__ function as a member of KeypointPairExt in keypoint_pair_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/material.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/material.py
@@ -39,7 +39,7 @@ class Material(MaterialExt):
         Parameters
         ----------
         albedo_factor:
-             Optional color multiplier.
+            Optional color multiplier.
         """
 
         # You can define your own __init__ function as a member of MaterialExt in material_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/mesh_properties.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mesh_properties.py
@@ -38,9 +38,9 @@ class MeshProperties(MeshPropertiesExt):
         Parameters
         ----------
         indices:
-             A flattened array of vertex indices that describe the mesh's triangles.
+            A flattened array of vertex indices that describe the mesh's triangles.
 
-             Its length must be divisible by 3.
+            Its length must be divisible by 3.
         """
 
         # You can define your own __init__ function as a member of MeshPropertiesExt in mesh_properties_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension.py
@@ -35,9 +35,9 @@ class TensorDimension:
         Parameters
         ----------
         size:
-             The length of this dimension.
+            The length of this dimension.
         name:
-             The name of this dimension, e.g. "width", "height", "channel", "batch', ….
+            The name of this dimension, e.g. "width", "height", "channel", "batch', ….
         """
 
         # You can define your own __init__ function as a member of TensorDimensionExt in tensor_dimension_ext.py

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -17,7 +17,7 @@ typos
 cargo fmt --all -- --check
 ./scripts/lint.py
 ./scripts/ci/cargo_deny.sh
-./examples/cpp/minimal/build_and_run.sh --werror
+./rerun_cpp/build_and_run_tests.sh --werror
 just py-lint
 
 cargo check --all-targets --all-features

--- a/tests/cpp/roundtrips/view_coordinates/main.cpp
+++ b/tests/cpp/roundtrips/view_coordinates/main.cpp
@@ -3,5 +3,5 @@
 int main(int argc, char** argv) {
     auto rec = rerun::RecordingStream("rerun_example_roundtrip_view_coordinates");
     rec.save(argv[1]).throw_on_failure();
-    rec.log("/", rerun::archetypes::ViewCoordinates::RDF);
+    rec.log_timeless("/", rerun::archetypes::ViewCoordinates::RDF);
 }

--- a/tests/python/roundtrips/view_coordinates/main.py
+++ b/tests/python/roundtrips/view_coordinates/main.py
@@ -16,7 +16,7 @@ def main() -> None:
 
     rr.script_setup(args, "rerun_example_roundtrip_view_coordinates")
 
-    rr.log("/", rr.ViewCoordinates.RDF)
+    rr.log("/", rr.ViewCoordinates.RDF, timeless=True)
 
     rr.script_teardown(args)
 

--- a/tests/rust/roundtrips/view_coordinates/src/main.rs
+++ b/tests/rust/roundtrips/view_coordinates/src/main.rs
@@ -10,7 +10,7 @@ struct Args {
 }
 
 fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
-    rec.log("/", &ViewCoordinates::RDF)?;
+    rec.log_timeless("/", &ViewCoordinates::RDF)?;
     Ok(())
 }
 


### PR DESCRIPTION
### What
* Turn on some of the `code-example` roundtrip tests, and document why the others aren't turned on yet.
* Turned off `RefloatComments` for C++, since it messed up example code in docstrings
* Cleaned up how docstring hare handled by the codegen, so it works the same everywhere.
   * This fixed the indentation for parameter-comments in Python, which was five spaces instead of four
* Some other small cleanups

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3854) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3854)
- [Docs preview](https://rerun.io/preview/52305429f0f4d011666492aef740cecba13d388e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/52305429f0f4d011666492aef740cecba13d388e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)