### PR TITLE
Fix typo in the python logging tutorial

### DIFF
--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -158,7 +158,7 @@ We can represent the scaffolding using a batch of 3D line strips:
 ```python
 rr.log(
     "dna/structure/scaffolding",
-    rr.LineStrips3D(np.stack(points1, points2, axis=1), colors=[128, 128, 128])
+    rr.LineStrips3D(np.stack((points1, points2), axis=1), colors=[128, 128, 128])
 )
 ```
 


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What
Fix log statement in tutorial using [numpy stack](https://github.com/rerun-io/rerun/pull/3856)

Coping the code from the tutorial got me this error:
```
Traceback (most recent call last):
  File "/home/rarts/development/pixi/examples/rerun/dna_example.py", line 24, in <module>
    rr.LineStrips3D(np.stack(points1, points2, axis=1), colors=[128, 128, 128])
TypeError: stack() got multiple values for argument 'axis'
```
Putting the points in a tuple fixed the issue. 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3856) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3856)
- [Docs preview](https://rerun.io/preview/5aaded5d75667d6435cc3d0b0924d4418b64da3b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5aaded5d75667d6435cc3d0b0924d4418b64da3b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)