### PR TITLE
docs: remove scipy from python_logging example

### DIFF
--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -19,8 +19,6 @@ At any time, you can checkout the complete code listing for this tutorial [here]
 
 We assume you have working Python and `rerun-sdk` installations. If not, check out the [setup page](python.md).
 
-For this tutorial you will also need to `pip install numpy scipy`.
-
 ## Initializing the SDK
 
 Start by opening your editor of choice and creating a new file called `dna_example.py`.
@@ -73,7 +71,6 @@ from math import tau
 import numpy as np
 from rerun_demo.data import build_color_spiral
 from rerun_demo.util import bounce_lerp
-from scipy.spatial.transform import Rotation
 ```
 ---
 
@@ -278,9 +275,6 @@ Now it's just a matter of combining the two: we need to log the transform of the
 Either expand the previous loop to include logging transforms or
 simply add a second loop like this:
 ```python
-# new imports
-from scipy.spatial.transform import Rotation
-
 for i in range(400):
     time = i * 0.01
     rr.set_time_seconds("stable_time", time)


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What
From my understanding is the `scipy` include not needed anymore. In my test it works without it and I can't find a need for it. 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
