### PR TITLE
Fix C++ check commands in contrib CI and readme

### DIFF
--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -282,15 +282,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build and run C++ minimal example
-        shell: bash
-        run: ./examples/cpp/minimal/build_and_run.sh --werror
-
       - name: Build and run rerun_cpp tests
         shell: bash
         run: ./rerun_cpp/build_and_run_tests.sh --werror
 
-      - name: Build code examples
+      - name: Build examples
         shell: bash
-        run: ./docs/code-examples/build_all.sh --werror
+        run: ./examples/cpp/build_all.sh --werror
 
+      - name: Build doc-code examples
+        shell: bash
+        run: ./docs/code-examples/cpp_build_all.sh --werror

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -337,6 +337,7 @@
     "webgpu",
     "webm",
     "webpki",
+    "werror",
     "wgpu",
     "wgsl",
     "whele",

--- a/rerun_cpp/README.md
+++ b/rerun_cpp/README.md
@@ -6,7 +6,7 @@ This is not yet ready to be used.
 Run `scripts/setup.sh`.
 
 ## Test it
-`examples/cpp/minimal/build_and_run.sh`
+`./rerun_cpp/build_and_run_tests.sh --werror`
 
 # To do:
 * CI

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -17,7 +17,7 @@ typos
 cargo fmt --all -- --check
 ./scripts/lint.py
 ./scripts/ci/cargo_deny.sh
-./examples/cpp/minimal/build_and_run.sh --werror
+./rerun_cpp/build_and_run_tests.sh --werror
 just py-lint
 
 cargo check --all-targets --all-features


### PR DESCRIPTION
### What

I removed the minimal build all script but didn't fix up some places in CI and readme!

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3858) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3858)
- [Docs preview](https://rerun.io/preview/4324c222d490f7f7c0abdb56e3967a8e4670557f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4324c222d490f7f7c0abdb56e3967a8e4670557f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)