### PR TITLE
Fix examples manifest version detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4780,7 +4780,6 @@ dependencies = [
  "arrow2",
  "arrow2_convert",
  "bytemuck",
- "cargo_metadata",
  "cfg-if",
  "eframe",
  "egui",
@@ -4829,7 +4828,6 @@ dependencies = [
  "web-sys",
  "web-time",
  "wgpu",
- "xshell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4780,6 +4780,7 @@ dependencies = [
  "arrow2",
  "arrow2_convert",
  "bytemuck",
+ "cargo_metadata",
  "cfg-if",
  "eframe",
  "egui",

--- a/crates/re_build_tools/src/git.rs
+++ b/crates/re_build_tools/src/git.rs
@@ -43,7 +43,8 @@ pub fn rebuild_if_branch_or_commit_changes() {
     }
 }
 
-pub fn commit_hash() -> anyhow::Result<String> {
+/// Get the full commit hash
+pub fn git_commit_hash() -> anyhow::Result<String> {
     let git_hash = run_command("git", &["rev-parse", "HEAD"])?;
     if git_hash.is_empty() {
         anyhow::bail!("empty commit hash");
@@ -51,7 +52,13 @@ pub fn commit_hash() -> anyhow::Result<String> {
     Ok(git_hash)
 }
 
-pub fn branch() -> anyhow::Result<String> {
+/// Get the first 7 characters of the commit hash
+pub fn git_commit_short_hash() -> anyhow::Result<String> {
+    Ok(git_commit_hash()?[0..7].to_string())
+}
+
+/// Get the current git branch name
+pub fn git_branch() -> anyhow::Result<String> {
     run_command("git", &["symbolic-ref", "--short", "HEAD"])
 }
 

--- a/crates/re_build_tools/src/lib.rs
+++ b/crates/re_build_tools/src/lib.rs
@@ -14,6 +14,7 @@ mod rebuild_detector;
 
 pub(crate) use self::rebuild_detector::Packages;
 
+pub use self::git::{git_branch, git_commit_hash, git_commit_short_hash};
 pub use self::hashing::{
     compute_crate_hash, compute_dir_filtered_hash, compute_dir_hash, compute_file_hash,
     compute_strings_hash, iter_dir, read_versioning_hash, write_versioning_hash,
@@ -142,8 +143,14 @@ pub fn export_build_info_vars_for_crate(crate_name: &str) {
     }
 
     if export_git_info {
-        set_env("RE_BUILD_GIT_HASH", &git::commit_hash().unwrap_or_default());
-        set_env("RE_BUILD_GIT_BRANCH", &git::branch().unwrap_or_default());
+        set_env(
+            "RE_BUILD_GIT_HASH",
+            &git::git_commit_hash().unwrap_or_default(),
+        );
+        set_env(
+            "RE_BUILD_GIT_BRANCH",
+            &git::git_branch().unwrap_or_default(),
+        );
 
         // Make sure the above are up-to-date
         git::rebuild_if_branch_or_commit_changes();
@@ -248,4 +255,9 @@ fn rust_llvm_versions() -> anyhow::Result<(String, String)> {
         rustc_version.unwrap_or_else(|| "unknown".to_owned()),
         llvm_version.unwrap_or_else(|| "unknown".to_owned()),
     ))
+}
+
+/// Returns info parsed from an invocation of the `cargo metadata` command
+pub fn cargo_metadata() -> anyhow::Result<cargo_metadata::Metadata> {
+    Ok(cargo_metadata::MetadataCommand::new().exec()?)
 }

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -104,11 +104,10 @@ wasm-bindgen-futures.workspace = true
 web-sys = { workspace = true, features = ["Window"] }
 
 [build-dependencies]
+anyhow.workspace = true
 re_build_tools.workspace = true
-cargo_metadata = "0.15"
 
 # External
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml.workspace = true
-xshell.workspace = true

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -105,6 +105,7 @@ web-sys = { workspace = true, features = ["Window"] }
 
 [build-dependencies]
 re_build_tools.workspace = true
+cargo_metadata = "0.15"
 
 # External
 serde = { workspace = true, features = ["derive"] }

--- a/crates/re_viewer/build.rs
+++ b/crates/re_viewer/build.rs
@@ -15,55 +15,6 @@
 
 use std::path::Path;
 
-use cargo_metadata::Metadata;
-use xshell::cmd;
-use xshell::Shell;
-
-type AnyError = Box<dyn std::error::Error + Send + Sync + 'static>;
-type Result<T, E = AnyError> = std::result::Result<T, E>;
-
-#[derive(Debug)]
-struct Error(String);
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl std::error::Error for Error {}
-
-macro_rules! error {
-    ($lit:literal) => (Error($lit.to_owned()));
-    ($($tt:tt)*) => (Error(format!($($tt)*)));
-}
-
-macro_rules! bail {
-    ($lit:literal) => (return Err(error!($lit)));
-    ($($tt:tt)*) => (return Err(error!($($tt)*).into()));
-}
-
-fn git_branch_name(sh: &Shell) -> Result<String> {
-    let mut branch_name =
-        String::from_utf8(cmd!(sh, "git branch --show-current").output()?.stdout)?;
-    branch_name.truncate(branch_name.trim_end().len()); // trim trailing whitespace in-place
-    Ok(branch_name)
-}
-
-fn git_short_hash(sh: &Shell) -> Result<String> {
-    let full_hash = String::from_utf8(cmd!(sh, "git rev-parse HEAD").output()?.stdout)?;
-    Ok(full_hash.trim()[0..7].to_string())
-}
-
-fn cargo_metadata(sh: &Shell) -> Result<Metadata> {
-    let metadata = String::from_utf8(
-        cmd!(sh, "cargo metadata --format-version 1")
-            .output()?
-            .stdout,
-    )?;
-    Ok(cargo_metadata::MetadataCommand::parse(metadata)?)
-}
-
 fn parse_release_version(branch: &str) -> Option<&str> {
     // release-\d+.\d+.\d+(-alpha.\d+)?
 
@@ -147,7 +98,7 @@ struct Example {
     readme: Frontmatter,
 }
 
-fn examples() -> Result<Vec<Example>> {
+fn examples() -> anyhow::Result<Vec<Example>> {
     let mut examples = vec![];
     let dir = "../../examples/python";
     assert!(std::path::Path::new(dir).exists(), "Failed to find {dir}");
@@ -179,7 +130,7 @@ fn examples() -> Result<Vec<Example>> {
     Ok(examples)
 }
 
-fn parse_frontmatter<P: AsRef<Path>>(path: P) -> Result<Option<Frontmatter>> {
+fn parse_frontmatter<P: AsRef<Path>>(path: P) -> anyhow::Result<Option<Frontmatter>> {
     let path = path.as_ref();
     let content = std::fs::read_to_string(path)?;
     let content = content.replace('\r', ""); // Windows, god damn you
@@ -188,11 +139,11 @@ fn parse_frontmatter<P: AsRef<Path>>(path: P) -> Result<Option<Frontmatter>> {
         return Ok(None);
     };
     let Some(end) = content.find("---") else {
-        bail!("{:?} has invalid frontmatter", path);
+        anyhow::bail!("{:?} has invalid frontmatter", path);
     };
     Ok(Some(serde_yaml::from_str(&content[..end]).map_err(
         |e| {
-            error!(
+            anyhow::anyhow!(
                 "failed to read {:?}: {e}",
                 path.parent().unwrap().file_name().unwrap()
             )
@@ -200,14 +151,13 @@ fn parse_frontmatter<P: AsRef<Path>>(path: P) -> Result<Option<Frontmatter>> {
     )?))
 }
 
-fn get_base_url() -> Result<String> {
+fn get_base_url() -> anyhow::Result<String> {
     if let Ok(base_url) = re_build_tools::get_and_track_env_var("EXAMPLES_MANIFEST_BASE_URL") {
         // override via env var
         return Ok(base_url);
     }
 
-    let sh = Shell::new()?;
-    let branch = git_branch_name(&sh)?;
+    let branch = re_build_tools::git_branch()?;
     if branch == "main" || !re_build_tools::is_on_ci() {
         // on `main` and local builds, use `version/nightly`
         // this will point to data uploaded by `.github/workflows/reusable_upload_web_demo.yml`
@@ -216,10 +166,10 @@ fn get_base_url() -> Result<String> {
     }
 
     if parse_release_version(&branch).is_some() {
-        let metadata = cargo_metadata(&sh)?;
+        let metadata = re_build_tools::cargo_metadata()?;
         let workspace_root = metadata
             .root_package()
-            .ok_or_else(|| error!("failed to find workspace root"))?;
+            .ok_or_else(|| anyhow::anyhow!("failed to find workspace root"))?;
 
         // on `release-x.y.z` builds, use `version/{crate_version}`
         // this will point to data uploaded by `.github/workflows/reusable_build_and_publish_web.yml`
@@ -231,13 +181,13 @@ fn get_base_url() -> Result<String> {
 
     // any other branch that is not `main`, use `commit/{sha}`
     // this will point to data uploaded by `.github/workflows/reusable_upload_web_demo.yml`
-    let sha = git_short_hash(&sh)?;
+    let sha = re_build_tools::git_commit_short_hash()?;
     Ok(format!("https://demo.rerun.io/commit/{sha}"))
 }
 
 const MANIFEST_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/data/examples_manifest.json");
 
-fn write_examples_manifest() -> Result<()> {
+fn write_examples_manifest() -> anyhow::Result<()> {
     let base_url = get_base_url()?;
 
     let mut manifest = vec![];


### PR DESCRIPTION
### What

Closes https://github.com/rerun-io/rerun/issues/3842

- CI `main` and non-CI -> `version/nightly`
- CI `release-x.y.z-alpha.N` -> `version/{root_crate_version}`
- CI any other branch -> `commit/{sha}`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3859) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3859)
- [Docs preview](https://rerun.io/preview/9e7cfa2eae2460e38983ffcfeb1bd46b07a4f715/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/9e7cfa2eae2460e38983ffcfeb1bd46b07a4f715/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)