### PR TITLE
Add `RERUN_STRICT` environment variable

### DIFF
--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -210,10 +210,14 @@ def run_example(example: str, language: str, args: argparse.Namespace) -> None:
 
 
 def roundtrip_env(*, save_path: str | None = None) -> dict[str, str]:
+    env = os.environ.copy()
+
     # NOTE: Make sure to disable batching, otherwise the Arrow concatenation logic within
     # the batcher will happily insert uninitialized padding bytes as needed!
-    env = os.environ.copy()
     env["RERUN_FLUSH_NUM_ROWS"] = "0"
+
+    # Turn on strict mode to catch errors early
+    env["RERUN_STRICT"] = "1"
 
     if save_path:
         # NOTE: Force the recording stream to write to disk!

--- a/pixi.toml
+++ b/pixi.toml
@@ -37,7 +37,7 @@ cpp-prepare = "cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=Debug"
 cpp-build = { cmd = "cmake --build build --config Debug --target rerun_sdk_tests", depends_on = [
   "cpp-prepare",
 ] }
-cpp-test = { cmd = "./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
+cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
   "cpp-build",
 ] }
 

--- a/rerun_cpp/src/rerun/error.cpp
+++ b/rerun_cpp/src/rerun/error.cpp
@@ -3,7 +3,8 @@
 #include <arrow/status.h>
 #include <rerun.h>
 
-#include <cstdlib> // For getenv
+#include <algorithm> // For std::transform
+#include <cstdlib>   // For getenv
 #include <string>
 
 namespace rerun {

--- a/rerun_cpp/src/rerun/error.cpp
+++ b/rerun_cpp/src/rerun/error.cpp
@@ -13,7 +13,8 @@ namespace rerun {
             return false;
         }
 
-        const std::string v = env; // so we can compare string with operator ==, 21st centry style
+        std::string v = env;
+        std::transform(v.begin(), v.end(), v.begin(), [](char c) { return std::tolower(c); });
 
         if (v == "1" || v == "true" || v == "yes" || v == "on") {
             return true;

--- a/rerun_cpp/src/rerun/error.hpp
+++ b/rerun_cpp/src/rerun/error.hpp
@@ -14,12 +14,12 @@ namespace arrow {
 struct rr_error;
 
 /// Return error if a given rerun::Error producing expression is not rerun::ErrorCode::Ok.
-#define RR_RETURN_NOT_OK(status_expr)      \
-    do {                                   \
-        const auto _status_ = status_expr; \
-        if (_status_.is_err()) {           \
-            return _status_;               \
-        }                                  \
+#define RR_RETURN_NOT_OK(status_expr)              \
+    do {                                           \
+        const rerun::Error _status_ = status_expr; \
+        if (_status_.is_err()) {                   \
+            return _status_;                       \
+        }                                          \
     } while (false)
 
 namespace rerun {
@@ -115,9 +115,9 @@ namespace rerun {
             return code != ErrorCode::Ok;
         }
 
-        /// Sets global log handler called for `log` and `log_on_failure`.
+        /// Sets global log handler called for `handle`.
         ///
-        /// The default will log to stderr.
+        /// The default will log to stderr, unless `RERUN_STRICT` is set to something truthy.
         ///
         /// @param handler The handler to call, or `nullptr` to reset to the default.
         /// @param userdata Userdata pointer that will be passed to each invocation of the handler.
@@ -125,19 +125,18 @@ namespace rerun {
         /// @see log, log_on_failure
         static void set_log_handler(StatusLogHandler handler, void* userdata = nullptr);
 
-        /// Logs this status via the global log handler.
+        /// Handle this error based on the set log handler.
         ///
-        /// @see set_log_handler
-        void log() const;
-
-        /// Logs this status if failed via the global log handler.
+        /// If there is no error, nothing happens.
         ///
-        /// @see set_log_handler
-        void log_on_failure() const {
-            if (is_err()) {
-                log();
-            }
-        }
+        /// If you have set a log handler with `set_log_handler`, it will be called.
+        /// Else if the `RERUN_STRICT` env-var is set to something truthy,
+        /// an exception will be thrown (if `__cpp_exceptions` are enabled),
+        /// or the program will abort.
+        ///
+        /// If no log handler is installed, and we are not in strict mode,
+        /// the error will be logged to stderr.
+        void handle() const;
 
 #ifdef __cpp_exceptions
         /// Throws a `std::runtime_error` if the status is not `Ok`.

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -32,7 +32,7 @@ namespace rerun {
 
         rr_error status = {};
         this->_id = rr_recording_stream_new(&store_info, &status);
-        Error(status).log_on_failure();
+        Error(status).handle();
     }
 
     RecordingStream::RecordingStream(RecordingStream&& other)
@@ -97,25 +97,25 @@ namespace rerun {
     void RecordingStream::set_time_sequence(const char* timeline_name, int64_t sequence_nr) {
         rr_error status = {};
         rr_recording_stream_set_time_sequence(_id, timeline_name, sequence_nr, &status);
-        Error(status).log_on_failure(); // Too unlikely to fail to make it worth forwarding.
+        Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
     }
 
     void RecordingStream::set_time_seconds(const char* timeline_name, double seconds) {
         rr_error status = {};
         rr_recording_stream_set_time_seconds(_id, timeline_name, seconds, &status);
-        Error(status).log_on_failure(); // Too unlikely to fail to make it worth forwarding.
+        Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
     }
 
     void RecordingStream::set_time_nanos(const char* timeline_name, int64_t nanos) {
         rr_error status = {};
         rr_recording_stream_set_time_nanos(_id, timeline_name, nanos, &status);
-        Error(status).log_on_failure(); // Too unlikely to fail to make it worth forwarding.
+        Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
     }
 
     void RecordingStream::disable_timeline(const char* timeline_name) {
         rr_error status = {};
         rr_recording_stream_disable_timeline(_id, timeline_name, &status);
-        Error(status).log_on_failure(); // Too unlikely to fail to make it worth forwarding.
+        Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
     }
 
     void RecordingStream::reset_time() {

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -179,7 +179,7 @@ namespace rerun {
 
         /// Logs one or more archetype and/or component batches.
         ///
-        /// Logs any failure via `Error::log_on_failure`
+        /// Failures are handled with `Error::handle`.
         ///
         /// @param archetypes_or_component_batches
         /// Any type for which the `AsComponents<T>` trait is implemented.
@@ -188,8 +188,7 @@ namespace rerun {
         /// @see try_log
         template <typename... Ts>
         void log(const char* entity_path, const Ts&... archetypes_or_component_batches) {
-            try_log_with_timeless(entity_path, false, archetypes_or_component_batches...)
-                .log_on_failure();
+            try_log_with_timeless(entity_path, false, archetypes_or_component_batches...).handle();
         }
 
         /// Logs one or more archetype and/or component batches as timeless data.
@@ -198,7 +197,7 @@ namespace rerun {
         /// far into the past. All timestamp data associated with this message will be dropped right
         /// before sending it to Rerun.
         ///
-        /// Logs any failure via `Error::log_on_failure`
+        /// Failures are handled with `Error::handle`.
         ///
         /// @param archetypes_or_component_batches
         /// Any type for which the `AsComponents<T>` trait is implemented.
@@ -207,8 +206,7 @@ namespace rerun {
         /// @see try_log
         template <typename... Ts>
         void log_timeless(const char* entity_path, const Ts&... archetypes_or_component_batches) {
-            try_log_with_timeless(entity_path, true, archetypes_or_component_batches...)
-                .log_on_failure();
+            try_log_with_timeless(entity_path, true, archetypes_or_component_batches...).handle();
         }
 
         /// Logs one or more archetype and/or component batches.

--- a/scripts/run_python_e2e_test.py
+++ b/scripts/run_python_e2e_test.py
@@ -81,7 +81,7 @@ def main() -> None:
     print("All tests passed successfully!")
 
 
-def run_example(example: str, args: list[str]) -> None:
+def run_example(example: str, extra_args: list[str]) -> None:
     # sys.executable: the absolute path of the executable binary for the Python interpreter
     python_executable = sys.executable
     if python_executable is None:
@@ -92,7 +92,10 @@ def run_example(example: str, args: list[str]) -> None:
     )
     time.sleep(0.3)  # Wait for rerun server to start to remove a logged warning
 
-    python_process = subprocess.Popen([python_executable, example, "--connect", "--addr", f"127.0.0.1:{PORT}"] + args)
+    run_env = os.environ.copy()
+    run_env["RERUN_STRICT"] = "1"
+    cmd = [python_executable, example, "--connect", "--addr", f"127.0.0.1:{PORT}"] + extra_args
+    python_process = subprocess.Popen(cmd, env=run_env)
 
     print("Waiting for python process to finish…")
     returncode = python_process.wait(timeout=30)

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -155,10 +155,15 @@ def main() -> None:
 
 
 def roundtrip_env() -> dict[str, str]:
+    env = os.environ.copy()
+
     # NOTE: Make sure to disable batching, otherwise the Arrow concatenation logic within
     # the batcher will happily insert uninitialized padding bytes as needed!
-    env = os.environ.copy()
     env["RERUN_FLUSH_NUM_ROWS"] = "0"
+
+    # Turn on strict mode to catch errors early
+    env["RERUN_STRICT"] = "1"
+
     return env
 
 


### PR DESCRIPTION
### What
If `RERUN_STRICT` is set to a truthy value (`1, ON, YES, TRUE`), then errors in C++ and Python will be handled by throwing an exception.

We enabled this for our tests.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3861) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3861)
- [Docs preview](https://rerun.io/preview/80b86b08a4aa0ea8f6e68ce37fd92ce0b4512e22/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/80b86b08a4aa0ea8f6e68ce37fd92ce0b4512e22/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)