### PR TITLE
Replace `--strict` flag with `RERUN_PANIC_ON_WARN` env-var

### DIFF
--- a/crates/re_log/src/setup.rs
+++ b/crates/re_log/src/setup.rs
@@ -49,6 +49,26 @@ pub fn setup_native_logging() {
     let mut stderr_logger = env_logger::Builder::new();
     stderr_logger.parse_filters(&log_filter);
     crate::add_boxed_logger(Box::new(stderr_logger.build())).expect("Failed to install logger");
+
+    if env_var_bool("RERUN_PANIC_ON_WARN") == Some(true) {
+        crate::add_boxed_logger(Box::new(PanicOnWarn {}))
+            .expect("Failed to enable RERUN_PANIC_ON_WARN");
+        crate::info!("RERUN_PANIC_ON_WARN: any warning or error will cause Rerun to panic.");
+    }
+}
+
+fn env_var_bool(name: &str) -> Option<bool> {
+    std::env::var(name).ok()
+        .and_then(|s| match s.to_lowercase().as_str() {
+            "0" | "false" | "off" | "no" => Some(false),
+            "1" | "true" | "on" | "yes" => Some(true),
+            _ => {
+                crate::warn!(
+                    "Invalid value for environment variable {name}={s:?}. Expected 'on' or 'off'. It will be ignored"
+                );
+                None
+            }
+        })
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -59,4 +79,29 @@ pub fn setup_web_logging() {
         log::LevelFilter::Debug,
     )))
     .expect("Failed to install logger");
+}
+
+// ----------------------------------------------------------------------------
+
+struct PanicOnWarn {}
+
+impl log::Log for PanicOnWarn {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        match metadata.level() {
+            log::Level::Error | log::Level::Warn => true,
+            log::Level::Info | log::Level::Debug | log::Level::Trace => false,
+        }
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        let level = match record.level() {
+            log::Level::Error => "error",
+            log::Level::Warn => "warning",
+            log::Level::Info | log::Level::Debug | log::Level::Trace => return,
+        };
+
+        panic!("{level} logged with RERUN_PANIC_ON_WARN: {}", record.args());
+    }
+
+    fn flush(&self) {}
 }

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -219,6 +219,9 @@ def roundtrip_env(*, save_path: str | None = None) -> dict[str, str]:
     # Turn on strict mode to catch errors early
     env["RERUN_STRICT"] = "1"
 
+    # Treat any warning as panics
+    env["RERUN_PANIC_ON_WARN"] = "1"
+
     if save_path:
         # NOTE: Force the recording stream to write to disk!
         env["_RERUN_TEST_FORCE_SAVE"] = save_path

--- a/scripts/run_python_e2e_test.py
+++ b/scripts/run_python_e2e_test.py
@@ -87,15 +87,16 @@ def run_example(example: str, extra_args: list[str]) -> None:
     if python_executable is None:
         python_executable = "python3"
 
-    rerun_process = subprocess.Popen(
-        [python_executable, "-m", "rerun", "--port", str(PORT), "--strict", "--test-receive"]
-    )
-    time.sleep(0.3)  # Wait for rerun server to start to remove a logged warning
+    env = os.environ.copy()
+    env["RERUN_STRICT"] = "1"
+    env["RERUN_PANIC_ON_WARN"] = "1"
 
-    run_env = os.environ.copy()
-    run_env["RERUN_STRICT"] = "1"
+    cmd = [python_executable, "-m", "rerun", "--port", str(PORT), "--test-receive"]
+    rerun_process = subprocess.Popen(cmd, env=env)
+    time.sleep(0.5)  # Wait for rerun server to start to remove a logged warning
+
     cmd = [python_executable, example, "--connect", "--addr", f"127.0.0.1:{PORT}"] + extra_args
-    python_process = subprocess.Popen(cmd, env=run_env)
+    python_process = subprocess.Popen(cmd, env=env)
 
     print("Waiting for python process to finish…")
     returncode = python_process.wait(timeout=30)

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -164,6 +164,9 @@ def roundtrip_env() -> dict[str, str]:
     # Turn on strict mode to catch errors early
     env["RERUN_STRICT"] = "1"
 
+    # Treat any warning as panics
+    env["RERUN_PANIC_ON_WARN"] = "1"
+
     return env
 
 


### PR DESCRIPTION
`--strict` was an ill-chosen name, as it clashes with the SDK-side strict-modes for user errors.

By making it an environment variable it is now also works anywhere `setup_native_logging` is called.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
