### PR TITLE
Update egui_commonmark to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ffd5501495ea79117103bcb0ed0480eacf96967837662516ecd629580596262"
+checksum = "3423cc4ae1cb068e3aff8c6b33eb9bab2a79c5563e8e3979dac3d56c92f00a2f"
 dependencies = [
  "egui",
  "egui_extras",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ egui = { version = "0.23.0", features = [
   "log",
   "puffin",
 ] }
-egui_commonmark = { version = "0.8", default-features = false }
+egui_commonmark = { version = "0.9", default-features = false }
 egui_extras = { version = "0.23.0", features = ["http", "image", "puffin"] }
 egui_plot = "0.23.0"
 egui_tiles = "0.3.1"


### PR DESCRIPTION
### What

Gives us copy button in code blocks:

<img width="1190" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/b6c30e4c-9e0b-4312-a908-652cc6d424e2">

Note: copy/paste seems to not work from web/Safari https://github.com/emilk/egui/issues/3480.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3882) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3882)
- [Docs preview](https://rerun.io/preview/79bc94fd4e913f5f2c6eb185c08089f2d2d654ee/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/79bc94fd4e913f5f2c6eb185c08089f2d2d654ee/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)