### PR TITLE
Fix jpeg returning None for image_height_width_channels

### DIFF
--- a/crates/re_types/src/datatypes/tensor_data_ext.rs
+++ b/crates/re_types/src/datatypes/tensor_data_ext.rs
@@ -55,7 +55,8 @@ impl TensorData {
                     _ => None,
                 }
             }
-            TensorBuffer::U8(_)
+            TensorBuffer::Jpeg(_)
+            | TensorBuffer::U8(_)
             | TensorBuffer::U16(_)
             | TensorBuffer::U32(_)
             | TensorBuffer::U64(_)
@@ -89,7 +90,6 @@ impl TensorData {
                     _ => None,
                 }
             }
-            TensorBuffer::Jpeg(_) => None,
         }
     }
 


### PR DESCRIPTION
### What

Small mistake (maybe merge error) that slipped into #3541 


before:
![image](https://github.com/rerun-io/rerun/assets/1220815/0d3e94d7-6a8d-4171-9ddf-4924f61ce5a1)

After:
<img width="488" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/00cb7c3f-46be-437d-b4ec-d67e7ee5819b">
(actually curious it says depth 4 here; that must be a bug on the logging side though. Same behavior [as before](https://demo.rerun.io/pr/3838/examples/structure_from_motion/)!)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3885) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3885)
- [Docs preview](https://rerun.io/preview/d99315e47a273c4dfef158a34fc806005c2f51e8/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d99315e47a273c4dfef158a34fc806005c2f51e8/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)