### PR TITLE
Fix `rerun_demo` to stop using deprecated APIs

### DIFF
--- a/rerun_py/rerun_sdk/rerun_demo/__main__.py
+++ b/rerun_py/rerun_sdk/rerun_demo/__main__.py
@@ -21,7 +21,7 @@ def run_cube(args: argparse.Namespace):
     for t in range(STEPS):
         rr.set_time_sequence("step", t)
         cube = build_color_grid(10, 10, 10, twist=twists[t])
-        rr.log_points("cube", positions=cube.positions, colors=cube.colors, radii=0.5)
+        rr.log("cube", rr.Points3D(positions=cube.positions, colors=cube.colors, radii=0.5))
 
     rr.script_teardown(args)
 

--- a/rerun_py/tests/unit/test_rerun_demo.py
+++ b/rerun_py/tests/unit/test_rerun_demo.py
@@ -1,13 +1,14 @@
+from __future__ import annotations
+
 import sys
 
 import pytest
 from rerun_demo import __main__ as main
 
-
 # fail for any deprecation warning
 pytestmark = pytest.mark.filterwarnings("error")
 
 
-def test_run_cube():
+def test_run_cube() -> None:
     sys.argv = ["prog", "--cube", "--headless"]
     main.main()

--- a/rerun_py/tests/unit/test_rerun_demo.py
+++ b/rerun_py/tests/unit/test_rerun_demo.py
@@ -1,0 +1,13 @@
+import sys
+
+import pytest
+from rerun_demo import __main__ as main
+
+
+# fail for any deprecation warning
+pytestmark = pytest.mark.filterwarnings("error")
+
+
+def test_run_cube():
+    sys.argv = ["prog", "--cube", "--headless"]
+    main.main()


### PR DESCRIPTION
### What

`rerun_demo` was using deprecated APIs 🤦🏻  This PR fixes this and adds a quick test to ensure no warning is emitted by the demo.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3900) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3900)
- [Docs preview](https://rerun.io/preview/4410dd3f1f1bc9b36509c2bc516c685ec4b02676/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4410dd3f1f1bc9b36509c2bc516c685ec4b02676/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)