### PR TITLE
Improve `taplo` output on failure

### DIFF
--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -205,7 +205,7 @@ jobs:
 
       - name: Taplo check
         run: |
-          taplo fmt --check
+          taplo fmt --check --diff
 
   misc-rerun-lints:
     name: Rerun lints

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -277,7 +277,7 @@ jobs:
 
       - name: Taplo check
         run: |
-          taplo fmt --check
+          taplo fmt --check --diff
 
   # ---------------------------------------------------------------------------
 

--- a/justfile
+++ b/justfile
@@ -187,7 +187,7 @@ toml-format:
 
 # Lint .toml files
 toml-lint:
-    taplo fmt --check
+    taplo fmt --check --diff
 
 
 ### Misc


### PR DESCRIPTION
### What

When taplo fails on CI or with `just toml-lint`, it tells us very little about what is wrong. The PR adds the `--diff` option so we can directly see the fix that needs to be done.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
