### PR TITLE
C++: turn on `-fsanatize=address` in our debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,13 @@ function(set_default_warning_settings target)
         if(${CMAKE_COMPILE_WARNING_AS_ERROR})
             target_compile_options(${target} PRIVATE -Werror)
         endif()
+
+        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+            # Debug build with fsanatize:
+            target_compile_options(${target} PRIVATE -g -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fno-optimize-sibling-calls)
+            target_compile_options(${target} PRIVATE -fsanitize=address)
+            target_link_options(${target} PRIVATE -fsanitize=address)
+        endif()
     endif()
 endfunction()
 

--- a/crates/re_types/src/archetypes/transform3d_ext.rs
+++ b/crates/re_types/src/archetypes/transform3d_ext.rs
@@ -16,6 +16,18 @@ impl Transform3D {
         Self::new(TranslationRotationScale3D::from_translation(translation))
     }
 
+    /// From a rotation
+    #[inline]
+    pub fn from_rotation(rotation: impl Into<Rotation3D>) -> Self {
+        Self::new(TranslationRotationScale3D::from_rotation(rotation))
+    }
+
+    /// From a scale
+    #[inline]
+    pub fn from_scale(scale: impl Into<Scale3D>) -> Self {
+        Self::new(TranslationRotationScale3D::from_scale(scale))
+    }
+
     /// From a translation applied after a rotation, known as a rigid transformation.
     #[inline]
     pub fn from_translation_rotation(

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d_ext.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d_ext.rs
@@ -21,6 +21,28 @@ impl TranslationRotationScale3D {
         }
     }
 
+    /// From a rotation
+    #[inline]
+    pub fn from_rotation(rotation: impl Into<Rotation3D>) -> Self {
+        Self {
+            translation: None,
+            rotation: Some(rotation.into()),
+            scale: None,
+            from_parent: false,
+        }
+    }
+
+    /// From a rotation & scale
+    #[inline]
+    pub fn from_scale(scale: impl Into<Scale3D>) -> Self {
+        Self {
+            translation: None,
+            rotation: None,
+            scale: Some(scale.into()),
+            from_parent: false,
+        }
+    }
+
     /// From a translation applied after a rotation, known as a rigid transformation.
     #[inline]
     pub fn from_translation_rotation(


### PR DESCRIPTION
This will maybe help find the next segfault before it happens.

I also added a couple of smaller improvements (see commit history)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3910) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3910)
- [Docs preview](https://rerun.io/preview/6ef15455dc3d2cd88bf2c205b972bb2a6d251d5b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/6ef15455dc3d2cd88bf2c205b972bb2a6d251d5b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)