### PR TITLE
Auto-approve workflow run fixes

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -13,7 +13,9 @@ jobs:
   approve-workflow-runs:
     name: "Check for approval"
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request_target' || github.event.issue.pull_request }}
+    if: |
+      github.event.pull_request.head.repo.owner.login != 'rerun-io' &&
+      (github.event_name == 'pull_request_target' || github.event.issue.pull_request)
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Pull requests from external contributors require approval for CI runs. This can 
 
 Members of the `rerun-io` organization and collaborators in the `rerun-io/rerun` repository may enable auto-approval of workflow runs for a single PR by commenting with `@rerun-bot approve`:
 
-![PR comment by jprochazk with the text `@rerun-bot approve`](https://github.com/rerun-io/rerun/assets/1665677/b5f07f3f-ea95-44a4-8eb7-f07c905f96c3)
+![PR comment with the text `@rerun-bot approve`](https://github.com/rerun-io/rerun/assets/1665677/b5f07f3f-ea95-44a4-8eb7-f07c905f96c3)
 
 ### Adding dependencies
 Be thoughtful when adding dependencies. Each new dependency is a liability which lead to increased compile times, a bigger binary, more code that can break, a larger attack surface, etc. Sometimes it is better to write a hundred lines of code than to add a new dependency.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,14 @@ All PR:s are merged with [`Squash and Merge`](https://docs.github.com/en/pull-re
 
 Our CI will run benchmarks on each merged PR. The results can be found at <https://rerun-io.github.io/rerun/dev/bench/>.
 
+Pull requests from external contributors require approval for CI runs. This can be done manually, by clicking the `Approve and run` button:
+
+![Image showing the approve and run button](https://github.com/rerun-io/rerun/assets/1665677/ead5c04f-df02-4f20-9093-37cfce097b44)
+
+Members of the `rerun-io` organization and collaborators in the `rerun-io/rerun` repository may enable auto-approval of workflow runs for a single PR by commenting with `@rerun-bot approve`:
+
+![PR comment by jprochazk with the text `@rerun-bot approve`](https://github.com/rerun-io/rerun/assets/1665677/b5f07f3f-ea95-44a4-8eb7-f07c905f96c3)
+
 ### Adding dependencies
 Be thoughtful when adding dependencies. Each new dependency is a liability which lead to increased compile times, a bigger binary, more code that can break, a larger attack surface, etc. Sometimes it is better to write a hundred lines of code than to add a new dependency.
 


### PR DESCRIPTION
### What

- Document `@rerun-bot approve` in `CONTRIBUTING.md`
- Skip the approval workflow entirely for PRs in the `rerun-io` org

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3911) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3911)
- [Docs preview](https://rerun.io/preview/50d3bc6c32945c627d077e0894362ca9ea199c97/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/50d3bc6c32945c627d077e0894362ca9ea199c97/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)