### PR TITLE
Implement scalar multiple plots example for C++

### DIFF
--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -27,7 +27,6 @@ opt_out_run = {
     "image_advanced": ["cpp", "rust"], # Missing examples
     "log_line": ["cpp", "rust", "py"], # Not a complete example -- just a single log line
     "quick_start_connect": ["cpp"], # TODO(#3870): Not yet implemented in C++
-    "scalar_multiple_plots": ["cpp"], # TODO(#2919): Not yet implemented in C++
     "text_log_integration": ["cpp"], # TODO(#2919): Not yet implemented in C++
 
     # This is this script, it's not an example.
@@ -46,6 +45,7 @@ opt_out_compare = {
     "point2d_random": ["cpp", "py", "rust"], # TODO(#3206): examples use different RNGs
     "point3d_random": ["cpp", "py", "rust"], # TODO(#3206): examples use different RNGs
     "quick_start_connect":  ["cpp", "py", "rust"], # These example don't have exactly the same implementation.
+    "scalar_multiple_plots": ["cpp"], # trigonometric functions have slightly different outcomes
     "tensor_simple": ["cpp", "py", "rust"], # TODO(#3206): examples use different RNGs
     "transform3d_simple": ["cpp"], # TODO(#2919): Something broken in the C++ SDK
 }

--- a/docs/code-examples/scalar_multiple_plots.cpp
+++ b/docs/code-examples/scalar_multiple_plots.cpp
@@ -1,0 +1,38 @@
+// Log a scalar over time.
+
+#include <rerun.hpp>
+
+#include <cmath>
+
+#define TAU (M_PI * 2.0)
+
+int main() {
+    auto rec = rerun::RecordingStream("rerun_example_points3d_simple");
+    rec.connect("127.0.0.1:9876").throw_on_failure();
+
+    int64_t lcg_state = 0;
+
+    for (int t = 0; t < static_cast<int>(TAU * 2.0 * 100.0); ++t) {
+        rec.set_time_sequence("step", t);
+
+        // Log two time series under a shared root so that they show in the same plot by default.
+        rec.log(
+            "trig/sin",
+            rerun::TimeSeriesScalar(sin(t / 100.0)).with_label("sin(0.01t)").with_color({255, 0, 0})
+        );
+        rec.log(
+            "trig/cos",
+            rerun::TimeSeriesScalar(cos(t / 100.0f))
+                .with_label("cos(0.01t)")
+                .with_color({0, 255, 0})
+        );
+
+        // Log scattered points under a different root so that it shows in a different plot by default.
+        lcg_state =
+            1140671485 * lcg_state + 128201163 % 16777216; // simple linear congruency generator
+        rec.log(
+            "scatter/lcg",
+            rerun::TimeSeriesScalar(static_cast<float>(lcg_state)).with_scattered(true)
+        );
+    }
+}


### PR DESCRIPTION
### What

* part of  #3751

What it says on the tin!
Tried using `sin` + cast instead of `sinf`, but still couldn't get the results to match with Rust sadly 🤷 

<img width="1232" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/4bd7d025-3945-45b8-8215-5196c085d0fd">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3914) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3914)
- [Docs preview](https://rerun.io/preview/81044e7460bf76c1c3093e929e55b7a499c9f24f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/81044e7460bf76c1c3093e929e55b7a499c9f24f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)