### PR TITLE
C++ fix failure to serialize empty component arrays / archetypes

### DIFF
--- a/rerun_cpp/src/rerun/arrow.cpp
+++ b/rerun_cpp/src/rerun/arrow.cpp
@@ -19,22 +19,4 @@ namespace rerun {
             return result.status();
         }
     }
-
-    Result<rerun::DataCell> create_indicator_component(const char* indicator_fqname) {
-        arrow::MemoryPool* pool = arrow::default_memory_pool();
-        auto builder = std::make_shared<arrow::NullBuilder>(pool);
-        ARROW_RETURN_NOT_OK(builder->AppendNulls(1));
-        std::shared_ptr<arrow::Array> array;
-        ARROW_RETURN_NOT_OK(builder->Finish(&array));
-
-        auto schema = arrow::schema({arrow::field(indicator_fqname, arrow::null(), false)});
-
-        rerun::DataCell cell;
-        cell.component_name = indicator_fqname;
-        const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-        RR_RETURN_NOT_OK(ipc_result.error);
-        cell.buffer = std::move(ipc_result.value);
-
-        return cell;
-    }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/arrow.hpp
+++ b/rerun_cpp/src/rerun/arrow.hpp
@@ -2,7 +2,6 @@
 #pragma once
 
 #include <memory>
-#include "data_cell.hpp"
 #include "result.hpp"
 
 namespace arrow {
@@ -16,6 +15,4 @@ namespace rerun {
     /// * <https://arrow.apache.org/docs/format/Columnar.html#format-ipc>
     /// * <https://wesm.github.io/arrow-site-test/format/IPC.html#encapsulated-message-format>
     Result<std::shared_ptr<arrow::Buffer>> ipc_from_table(const arrow::Table& table);
-
-    Result<rerun::DataCell> create_indicator_component(const char* arch_name);
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/space_view_component.cpp
+++ b/rerun_cpp/src/rerun/blueprint/space_view_component.cpp
@@ -8,7 +8,7 @@
 
 namespace rerun {
     namespace blueprint {
-        const std::shared_ptr<arrow::DataType> &SpaceViewComponent::arrow_datatype() {
+        const std::shared_ptr<arrow::DataType>& SpaceViewComponent::arrow_datatype() {
             static const auto datatype = arrow::struct_({
                 arrow::field(
                     "space_view",
@@ -20,7 +20,7 @@ namespace rerun {
         }
 
         Result<std::shared_ptr<arrow::StructBuilder>> SpaceViewComponent::new_arrow_array_builder(
-            arrow::MemoryPool *memory_pool
+            arrow::MemoryPool* memory_pool
         ) {
             if (!memory_pool) {
                 return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
@@ -39,7 +39,7 @@ namespace rerun {
         }
 
         Error SpaceViewComponent::fill_arrow_array_builder(
-            arrow::StructBuilder *builder, const SpaceViewComponent *elements, size_t num_elements
+            arrow::StructBuilder* builder, const SpaceViewComponent* elements, size_t num_elements
         ) {
             if (!builder) {
                 return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -52,14 +52,14 @@ namespace rerun {
             }
 
             {
-                auto field_builder = static_cast<arrow::ListBuilder *>(builder->field_builder(0));
+                auto field_builder = static_cast<arrow::ListBuilder*>(builder->field_builder(0));
                 auto value_builder =
-                    static_cast<arrow::UInt8Builder *>(field_builder->value_builder());
+                    static_cast<arrow::UInt8Builder*>(field_builder->value_builder());
                 ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
                 ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 2)));
 
                 for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                    const auto &element = elements[elem_idx];
+                    const auto& element = elements[elem_idx];
                     ARROW_RETURN_NOT_OK(field_builder->Append());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
                         element.space_view.data(),

--- a/rerun_cpp/src/rerun/components/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.cpp
@@ -3,11 +3,9 @@
 
 #include "annotation_context.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/class_description_map_elem.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -90,17 +88,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AnnotationContext::NAME, AnnotationContext::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AnnotationContext::NAME,
+                AnnotationContext::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AnnotationContext::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/blob.cpp
+++ b/rerun_cpp/src/rerun/components/blob.cpp
@@ -3,10 +3,7 @@
 
 #include "blob.hpp"
 
-#include "../arrow.hpp"
-
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -76,15 +73,7 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema({arrow::field(Blob::NAME, Blob::arrow_datatype(), false)});
-
-            rerun::DataCell cell;
-            cell.component_name = Blob::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(Blob::NAME, Blob::arrow_datatype(), std::move(array));
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/class_id.cpp
+++ b/rerun_cpp/src/rerun/components/class_id.cpp
@@ -3,11 +3,9 @@
 
 #include "class_id.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/class_id.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,16 +67,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(ClassId::NAME, ClassId::arrow_datatype(), false)});
-
-            rerun::DataCell cell;
-            cell.component_name = ClassId::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(
+                ClassId::NAME,
+                ClassId::arrow_datatype(),
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/clear_is_recursive.cpp
+++ b/rerun_cpp/src/rerun/components/clear_is_recursive.cpp
@@ -3,10 +3,7 @@
 
 #include "clear_is_recursive.hpp"
 
-#include "../arrow.hpp"
-
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,17 +66,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(ClearIsRecursive::NAME, ClearIsRecursive::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                ClearIsRecursive::NAME,
+                ClearIsRecursive::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = ClearIsRecursive::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/color.cpp
+++ b/rerun_cpp/src/rerun/components/color.cpp
@@ -3,11 +3,9 @@
 
 #include "color.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/rgba32.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -67,16 +65,7 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(Color::NAME, Color::arrow_datatype(), false)});
-
-            rerun::DataCell cell;
-            cell.component_name = Color::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(Color::NAME, Color::arrow_datatype(), std::move(array));
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/depth_meter.cpp
+++ b/rerun_cpp/src/rerun/components/depth_meter.cpp
@@ -3,10 +3,7 @@
 
 #include "depth_meter.hpp"
 
-#include "../arrow.hpp"
-
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -66,17 +63,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(DepthMeter::NAME, DepthMeter::arrow_datatype(), false)}
-                );
-
-            rerun::DataCell cell;
-            cell.component_name = DepthMeter::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(
+                DepthMeter::NAME,
+                DepthMeter::arrow_datatype(),
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.cpp
@@ -3,10 +3,7 @@
 
 #include "disconnected_space.hpp"
 
-#include "../arrow.hpp"
-
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,17 +66,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(DisconnectedSpace::NAME, DisconnectedSpace::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                DisconnectedSpace::NAME,
+                DisconnectedSpace::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = DisconnectedSpace::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/draw_order.cpp
+++ b/rerun_cpp/src/rerun/components/draw_order.cpp
@@ -3,10 +3,7 @@
 
 #include "draw_order.hpp"
 
-#include "../arrow.hpp"
-
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -66,16 +63,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(DrawOrder::NAME, DrawOrder::arrow_datatype(), false)});
-
-            rerun::DataCell cell;
-            cell.component_name = DrawOrder::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(
+                DrawOrder::NAME,
+                DrawOrder::arrow_datatype(),
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/half_sizes2d.cpp
+++ b/rerun_cpp/src/rerun/components/half_sizes2d.cpp
@@ -3,11 +3,9 @@
 
 #include "half_sizes2d.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/vec2d.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,17 +67,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(HalfSizes2D::NAME, HalfSizes2D::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                HalfSizes2D::NAME,
+                HalfSizes2D::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = HalfSizes2D::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/half_sizes3d.cpp
+++ b/rerun_cpp/src/rerun/components/half_sizes3d.cpp
@@ -3,11 +3,9 @@
 
 #include "half_sizes3d.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/vec3d.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,17 +67,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(HalfSizes3D::NAME, HalfSizes3D::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                HalfSizes3D::NAME,
+                HalfSizes3D::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = HalfSizes3D::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/instance_key.cpp
+++ b/rerun_cpp/src/rerun/components/instance_key.cpp
@@ -3,10 +3,7 @@
 
 #include "instance_key.hpp"
 
-#include "../arrow.hpp"
-
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -66,17 +63,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(InstanceKey::NAME, InstanceKey::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                InstanceKey::NAME,
+                InstanceKey::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = InstanceKey::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/keypoint_id.cpp
+++ b/rerun_cpp/src/rerun/components/keypoint_id.cpp
@@ -3,11 +3,9 @@
 
 #include "keypoint_id.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/keypoint_id.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,17 +67,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(KeypointId::NAME, KeypointId::arrow_datatype(), false)}
-                );
-
-            rerun::DataCell cell;
-            cell.component_name = KeypointId::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(
+                KeypointId::NAME,
+                KeypointId::arrow_datatype(),
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/line_strip2d.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d.cpp
@@ -3,11 +3,9 @@
 
 #include "line_strip2d.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/vec2d.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -83,17 +81,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(LineStrip2D::NAME, LineStrip2D::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                LineStrip2D::NAME,
+                LineStrip2D::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = LineStrip2D::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/line_strip3d.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.cpp
@@ -3,11 +3,9 @@
 
 #include "line_strip3d.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/vec3d.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -83,17 +81,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(LineStrip3D::NAME, LineStrip3D::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                LineStrip3D::NAME,
+                LineStrip3D::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = LineStrip3D::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/material.cpp
+++ b/rerun_cpp/src/rerun/components/material.cpp
@@ -3,11 +3,9 @@
 
 #include "material.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/material.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,16 +67,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(Material::NAME, Material::arrow_datatype(), false)});
-
-            rerun::DataCell cell;
-            cell.component_name = Material::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(
+                Material::NAME,
+                Material::arrow_datatype(),
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/media_type.cpp
+++ b/rerun_cpp/src/rerun/components/media_type.cpp
@@ -3,11 +3,9 @@
 
 #include "media_type.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/utf8.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,16 +67,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(MediaType::NAME, MediaType::arrow_datatype(), false)});
-
-            rerun::DataCell cell;
-            cell.component_name = MediaType::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(
+                MediaType::NAME,
+                MediaType::arrow_datatype(),
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/mesh_properties.cpp
+++ b/rerun_cpp/src/rerun/components/mesh_properties.cpp
@@ -3,11 +3,9 @@
 
 #include "mesh_properties.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/mesh_properties.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -73,17 +71,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(MeshProperties::NAME, MeshProperties::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                MeshProperties::NAME,
+                MeshProperties::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = MeshProperties::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/out_of_tree_transform3d.cpp
+++ b/rerun_cpp/src/rerun/components/out_of_tree_transform3d.cpp
@@ -3,11 +3,9 @@
 
 #include "out_of_tree_transform3d.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/transform3d.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -72,19 +70,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema({arrow::field(
+            return rerun::DataCell::create(
                 OutOfTreeTransform3D::NAME,
                 OutOfTreeTransform3D::arrow_datatype(),
-                false
-            )});
-
-            rerun::DataCell cell;
-            cell.component_name = OutOfTreeTransform3D::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/pinhole_projection.cpp
+++ b/rerun_cpp/src/rerun/components/pinhole_projection.cpp
@@ -3,11 +3,9 @@
 
 #include "pinhole_projection.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/mat3x3.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -71,17 +69,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(PinholeProjection::NAME, PinholeProjection::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                PinholeProjection::NAME,
+                PinholeProjection::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = PinholeProjection::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/position2d.cpp
+++ b/rerun_cpp/src/rerun/components/position2d.cpp
@@ -3,11 +3,9 @@
 
 #include "position2d.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/vec2d.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,17 +67,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(Position2D::NAME, Position2D::arrow_datatype(), false)}
-                );
-
-            rerun::DataCell cell;
-            cell.component_name = Position2D::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(
+                Position2D::NAME,
+                Position2D::arrow_datatype(),
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/position3d.cpp
+++ b/rerun_cpp/src/rerun/components/position3d.cpp
@@ -3,11 +3,9 @@
 
 #include "position3d.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/vec3d.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,17 +67,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(Position3D::NAME, Position3D::arrow_datatype(), false)}
-                );
-
-            rerun::DataCell cell;
-            cell.component_name = Position3D::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(
+                Position3D::NAME,
+                Position3D::arrow_datatype(),
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/radius.cpp
+++ b/rerun_cpp/src/rerun/components/radius.cpp
@@ -3,10 +3,7 @@
 
 #include "radius.hpp"
 
-#include "../arrow.hpp"
-
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -66,16 +63,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(Radius::NAME, Radius::arrow_datatype(), false)});
-
-            rerun::DataCell cell;
-            cell.component_name = Radius::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(
+                Radius::NAME,
+                Radius::arrow_datatype(),
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/resolution.cpp
+++ b/rerun_cpp/src/rerun/components/resolution.cpp
@@ -3,11 +3,9 @@
 
 #include "resolution.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/vec2d.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,17 +67,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(Resolution::NAME, Resolution::arrow_datatype(), false)}
-                );
-
-            rerun::DataCell cell;
-            cell.component_name = Resolution::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(
+                Resolution::NAME,
+                Resolution::arrow_datatype(),
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/rotation3d.cpp
+++ b/rerun_cpp/src/rerun/components/rotation3d.cpp
@@ -3,11 +3,9 @@
 
 #include "rotation3d.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/rotation3d.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,17 +67,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(Rotation3D::NAME, Rotation3D::arrow_datatype(), false)}
-                );
-
-            rerun::DataCell cell;
-            cell.component_name = Rotation3D::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(
+                Rotation3D::NAME,
+                Rotation3D::arrow_datatype(),
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/scalar.cpp
+++ b/rerun_cpp/src/rerun/components/scalar.cpp
@@ -3,10 +3,7 @@
 
 #include "scalar.hpp"
 
-#include "../arrow.hpp"
-
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -66,16 +63,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(Scalar::NAME, Scalar::arrow_datatype(), false)});
-
-            rerun::DataCell cell;
-            cell.component_name = Scalar::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(
+                Scalar::NAME,
+                Scalar::arrow_datatype(),
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/scalar_scattering.cpp
+++ b/rerun_cpp/src/rerun/components/scalar_scattering.cpp
@@ -3,10 +3,7 @@
 
 #include "scalar_scattering.hpp"
 
-#include "../arrow.hpp"
-
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,17 +66,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(ScalarScattering::NAME, ScalarScattering::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                ScalarScattering::NAME,
+                ScalarScattering::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = ScalarScattering::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/tensor_data.cpp
+++ b/rerun_cpp/src/rerun/components/tensor_data.cpp
@@ -3,11 +3,9 @@
 
 #include "tensor_data.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/tensor_data.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,17 +67,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(TensorData::NAME, TensorData::arrow_datatype(), false)}
-                );
-
-            rerun::DataCell cell;
-            cell.component_name = TensorData::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(
+                TensorData::NAME,
+                TensorData::arrow_datatype(),
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/text.cpp
+++ b/rerun_cpp/src/rerun/components/text.cpp
@@ -3,11 +3,9 @@
 
 #include "text.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/utf8.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -67,15 +65,7 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema({arrow::field(Text::NAME, Text::arrow_datatype(), false)});
-
-            rerun::DataCell cell;
-            cell.component_name = Text::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(Text::NAME, Text::arrow_datatype(), std::move(array));
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/text_log_level.cpp
+++ b/rerun_cpp/src/rerun/components/text_log_level.cpp
@@ -3,11 +3,9 @@
 
 #include "text_log_level.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/utf8.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,17 +67,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(TextLogLevel::NAME, TextLogLevel::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                TextLogLevel::NAME,
+                TextLogLevel::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = TextLogLevel::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/transform3d.cpp
+++ b/rerun_cpp/src/rerun/components/transform3d.cpp
@@ -3,11 +3,9 @@
 
 #include "transform3d.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/transform3d.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -70,17 +68,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(Transform3D::NAME, Transform3D::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                Transform3D::NAME,
+                Transform3D::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = Transform3D::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/vector3d.cpp
+++ b/rerun_cpp/src/rerun/components/vector3d.cpp
@@ -3,11 +3,9 @@
 
 #include "vector3d.hpp"
 
-#include "../arrow.hpp"
 #include "../datatypes/vec3d.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -69,16 +67,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema =
-                arrow::schema({arrow::field(Vector3D::NAME, Vector3D::arrow_datatype(), false)});
-
-            rerun::DataCell cell;
-            cell.component_name = Vector3D::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
+            return rerun::DataCell::create(
+                Vector3D::NAME,
+                Vector3D::arrow_datatype(),
+                std::move(array)
+            );
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/view_coordinates.cpp
+++ b/rerun_cpp/src/rerun/components/view_coordinates.cpp
@@ -3,10 +3,7 @@
 
 #include "view_coordinates.hpp"
 
-#include "../arrow.hpp"
-
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
 
 namespace rerun {
@@ -78,17 +75,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(ViewCoordinates::NAME, ViewCoordinates::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                ViewCoordinates::NAME,
+                ViewCoordinates::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = ViewCoordinates::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/data_cell.cpp
+++ b/rerun_cpp/src/rerun/data_cell.cpp
@@ -1,0 +1,34 @@
+#include "data_cell.hpp"
+#include "arrow.hpp"
+
+#include <arrow/api.h>
+
+namespace rerun {
+
+    Result<DataCell> DataCell::create(
+        const char* name, const std::shared_ptr<arrow::DataType>& datatype,
+        std::shared_ptr<arrow::Array> array
+    ) {
+        // TODO(andreas): This should be lazily created once just like datatypes are right now, saving repeated allocations.
+        auto schema = arrow::schema({arrow::field(name, datatype, false)});
+
+        const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
+        RR_RETURN_NOT_OK(ipc_result.error);
+
+        rerun::DataCell cell;
+        cell.component_name = name;
+        cell.buffer = std::move(ipc_result.value);
+
+        return cell;
+    }
+
+    Result<rerun::DataCell> DataCell::create_indicator_component(const char* indicator_fqname) {
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto builder = std::make_shared<arrow::NullBuilder>(pool);
+        ARROW_RETURN_NOT_OK(builder->AppendNulls(1));
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        return create(indicator_fqname, arrow::null(), std::move(array));
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/data_cell.hpp
+++ b/rerun_cpp/src/rerun/data_cell.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <memory> // shared_ptr
+#include "result.hpp"
 
 namespace arrow {
     class Buffer;
-}
+    class Array;
+    class DataType;
+} // namespace arrow
 
 namespace rerun {
     /// Equivalent to `rr_data_cell` from the C API.
@@ -19,5 +22,14 @@ namespace rerun {
         /// * <https://arrow.apache.org/docs/format/Columnar.html#format-ipc>
         /// * <https://wesm.github.io/arrow-site-test/format/IPC.html#encapsulated-message-format>
         std::shared_ptr<arrow::Buffer> buffer;
+
+        /// Create a new data cell from an arrow array.
+        static Result<DataCell> create(
+            const char* name, const std::shared_ptr<arrow::DataType>& datatype,
+            std::shared_ptr<arrow::Array> array
+        );
+
+        /// Create a data cell for an indicator component.
+        static Result<rerun::DataCell> create_indicator_component(const char* arch_name);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/indicator_component.hpp
+++ b/rerun_cpp/src/rerun/indicator_component.hpp
@@ -17,7 +17,7 @@ namespace rerun {
             static Result<rerun::DataCell> to_data_cell(
                 const IndicatorComponent<Name>*, size_t _num_instances
             ) {
-                return rerun::create_indicator_component(Name);
+                return rerun::DataCell::create_indicator_component(Name);
             }
         };
     } // namespace components

--- a/rerun_cpp/tests/generated/components/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer1.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -70,17 +68,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer1::NAME, AffixFuzzer1::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer1::NAME,
+                AffixFuzzer1::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer1::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer10.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer10.cpp
@@ -4,9 +4,7 @@
 #include "affix_fuzzer10.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -70,17 +68,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer10::NAME, AffixFuzzer10::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer10::NAME,
+                AffixFuzzer10::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer10::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer11.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer11.cpp
@@ -4,9 +4,7 @@
 #include "affix_fuzzer11.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -81,17 +79,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer11::NAME, AffixFuzzer11::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer11::NAME,
+                AffixFuzzer11::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer11::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer12.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer12.cpp
@@ -4,9 +4,7 @@
 #include "affix_fuzzer12.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -78,17 +76,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer12::NAME, AffixFuzzer12::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer12::NAME,
+                AffixFuzzer12::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer12::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer13.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer13.cpp
@@ -4,9 +4,7 @@
 #include "affix_fuzzer13.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -83,17 +81,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer13::NAME, AffixFuzzer13::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer13::NAME,
+                AffixFuzzer13::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer13::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer14.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer14.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer3.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -70,17 +68,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer14::NAME, AffixFuzzer14::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer14::NAME,
+                AffixFuzzer14::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer14::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer15.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer15.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer3.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -66,17 +64,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer15::NAME, AffixFuzzer15::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer15::NAME,
+                AffixFuzzer15::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer15::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer16.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer16.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer3.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -83,17 +81,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer16::NAME, AffixFuzzer16::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer16::NAME,
+                AffixFuzzer16::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer16::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer17.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer17.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer3.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -87,17 +85,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer17::NAME, AffixFuzzer17::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer17::NAME,
+                AffixFuzzer17::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer17::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer18.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer18.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer4.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -87,17 +85,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer18::NAME, AffixFuzzer18::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer18::NAME,
+                AffixFuzzer18::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer18::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer19.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer19.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer5.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -70,17 +68,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer19::NAME, AffixFuzzer19::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer19::NAME,
+                AffixFuzzer19::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer19::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer2.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -70,17 +68,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer2::NAME, AffixFuzzer2::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer2::NAME,
+                AffixFuzzer2::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer2::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer20.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer20.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer20.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -71,17 +69,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer20::NAME, AffixFuzzer20::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer20::NAME,
+                AffixFuzzer20::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer20::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer21.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer21.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer21.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -71,17 +69,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer21::NAME, AffixFuzzer21::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer21::NAME,
+                AffixFuzzer21::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer21::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer3.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -70,17 +68,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer3::NAME, AffixFuzzer3::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer3::NAME,
+                AffixFuzzer3::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer3::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer4.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -66,17 +64,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer4::NAME, AffixFuzzer4::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer4::NAME,
+                AffixFuzzer4::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer4::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer5.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer5.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -66,17 +64,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer5::NAME, AffixFuzzer5::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer5::NAME,
+                AffixFuzzer5::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer5::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer6.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer6.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -66,17 +64,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer6::NAME, AffixFuzzer6::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer6::NAME,
+                AffixFuzzer6::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer6::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer7.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer7.cpp
@@ -6,9 +6,7 @@
 #include "../datatypes/affix_fuzzer1.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -87,17 +85,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer7::NAME, AffixFuzzer7::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer7::NAME,
+                AffixFuzzer7::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer7::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer8.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer8.cpp
@@ -4,9 +4,7 @@
 #include "affix_fuzzer8.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -70,17 +68,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer8::NAME, AffixFuzzer8::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer8::NAME,
+                AffixFuzzer8::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer8::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer9.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer9.cpp
@@ -4,9 +4,7 @@
 #include "affix_fuzzer9.hpp"
 
 #include <arrow/builder.h>
-#include <arrow/table.h>
 #include <arrow/type_fwd.h>
-#include <rerun/arrow.hpp>
 
 namespace rerun {
     namespace components {
@@ -65,17 +63,11 @@ namespace rerun {
             std::shared_ptr<arrow::Array> array;
             ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
-            auto schema = arrow::schema(
-                {arrow::field(AffixFuzzer9::NAME, AffixFuzzer9::arrow_datatype(), false)}
+            return rerun::DataCell::create(
+                AffixFuzzer9::NAME,
+                AffixFuzzer9::arrow_datatype(),
+                std::move(array)
             );
-
-            rerun::DataCell cell;
-            cell.component_name = AffixFuzzer9::NAME;
-            const auto ipc_result = rerun::ipc_from_table(*arrow::Table::Make(schema, {array}));
-            RR_RETURN_NOT_OK(ipc_result.error);
-            cell.buffer = std::move(ipc_result.value);
-
-            return cell;
         }
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/tests/log_empty.cpp
+++ b/rerun_cpp/tests/log_empty.cpp
@@ -1,0 +1,21 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <rerun.hpp>
+
+#include "error_check.hpp"
+
+#define TEST_TAG "[log_empty][archetypes]"
+
+// Regression test for #3840
+SCENARIO("Log empty data", TEST_TAG) {
+    rerun::RecordingStream stream("empty archetype");
+
+    SECTION("Using an existing archetype") {
+        check_logged_error([&] {
+            stream.log("empty", rerun::Points3D(std::vector<rerun::Position3D>{}));
+        });
+    }
+    SECTION("Using an empty component vector") {
+        check_logged_error([&] { stream.log("empty", std::vector<rerun::Position3D>{}); });
+    }
+}


### PR DESCRIPTION
### What

* Fixes #3840

The actual fix is isolated to the second commit (c34e168d9e88b7a9cbd693c9bc10a9cf5187ec36).

The first makes serialization code nicer and it's what's left of my attempt to solve it on the C++ side which I gave upon eventually (but it was very obviously worth keeping)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3919) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3919)
- [Docs preview](https://rerun.io/preview/daf52e6864d771cd8ca9f312284c555bd76b5f46/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/daf52e6864d771cd8ca9f312284c555bd76b5f46/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)