### PR TITLE
Use pixi for all cpp test invocations on CI

### DIFF
--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -392,13 +392,12 @@ jobs:
 
       - name: Build and run rerun_cpp tests
         shell: bash
-        run: ./rerun_cpp/build_and_run_tests.sh --werror
+        run: just cpp-test
 
       - name: Build examples
         shell: bash
-        run: ./examples/cpp/build_all.sh --werror
+        run: just cpp-build-examples
 
       - name: Build doc-code examples
         shell: bash
-        run: ./docs/code-examples/cpp_build_all.sh --werror
-
+        run: just cpp-build-doc-examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,11 +52,6 @@ function(set_default_warning_settings target)
     endif()
 endfunction()
 
-# Use makefiles on linux, otherwise it might use Ninja which isn't installed by default.
-if(NOT DEFINED CMAKE_GENERATOR AND UNIX)
-    set(CMAKE_GENERATOR "Unix Makefiles")
-endif()
-
 # Arrow requires a C++17 compliant compiler.
 if(NOT DEFINED CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 17)

--- a/justfile
+++ b/justfile
@@ -34,6 +34,14 @@ cpp-format:
 cpp-build:
     pixi run cpp-build
 
+# Build all our C++ examples.
+cpp-build-examples:
+    pixi run cpp-build-examples
+
+# Build all our C++ api doc examples.
+cpp-build-doc-examples:
+    pixi run cpp-build-doc-examples
+
 # Run our C++ tests
 cpp-test:
     pixi run cpp-test

--- a/pixi.toml
+++ b/pixi.toml
@@ -33,8 +33,14 @@ py-test = { cmd = "python -m pytest -vv rerun_py/tests/unit", depends_on = [
   "py-build",
 ] }
 
-cpp-prepare = "cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=Debug"
+cpp-prepare = "cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
 cpp-build = { cmd = "cmake --build build --config Debug --target rerun_sdk_tests", depends_on = [
+  "cpp-prepare",
+] }
+cpp-build-examples = { cmd = "cmake --build build --config Debug --target examples", depends_on = [
+  "cpp-prepare",
+] }
+cpp-build-doc-examples = { cmd = "cmake --build build --config Debug --target doc_examples", depends_on = [
   "cpp-prepare",
 ] }
 cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [


### PR DESCRIPTION
### What

Unclear if that's a good idea as is.
Does it still use GCC? I want it to use GCC  to be on the safe side!

Locally this gives me a loot of warnings from Arrow - it seems the install of the compiler pixi uses goes to `/opt/homebrew/include/` without marking this as a system directory _and_ ignores the system directory that is set to the pixi folder. Very confusing. Lots of warnings

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3921) (if applicable)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3921)
- [Docs preview](https://rerun.io/preview/8d440f73232386a18e6faf6a79980583e19167e7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8d440f73232386a18e6faf6a79980583e19167e7/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)