### PR TITLE
Small release workflow fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,13 +244,15 @@ jobs:
       - name: Update version
         id: update-version
         run: |
-          if [ ${{ inputs.release-type }} = "final" ]; then
-            # After a final release, we bump the minor version and append `+dev`.
+          latest=$(python3 scripts/ci/crates.py get-version --from=cio)
+          latest_finalized=$(python3 scripts/ci/crates.py get-version --from=cio --finalize)
+          if [ $latest_published = $latest_finalized ]; then
+            # Latest published is a non-prerelease (e.g. 0.9.1), bump minor and add alpha+dev
+            python3 scripts/ci/crates.py version --bump minor
             python3 scripts/ci/crates.py version --bump prerelease --dev --pre-id=alpha
             echo "version=$(python3 scripts/ci/crates.py get-version)" >> "$GITHUB_OUTPUT"
           else
-            # After an alpha release, we bump the prerelease version and append `+dev`.
-            python3 scripts/ci/crates.py version --bump minor
+            # Latest published is a pre-release (e.g. 0.10.0-alpha.5), bump prerelease
             python3 scripts/ci/crates.py version --bump prerelease --dev --pre-id=alpha
             echo "version=$(python3 scripts/ci/crates.py get-version)" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/reusable_build_and_publish_web.yml
+++ b/.github/workflows/reusable_build_and_publish_web.yml
@@ -61,6 +61,11 @@ jobs:
           workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+        with:
+          version: ">= 363.0.0"
+
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:


### PR DESCRIPTION
### What

- `reusable_build_and_publish_web.yml` was not setting up correct version of gcloud sdk, resulting in `gsutil` not being authenticated, because it used an ancient GHA runner pre-installed version that did not yet support WIF
- The post-release version bump step now bumps according to the _latest published version_, as opposed to bumping on top of what we just released. This means:
  - If we publish `0.9.1`, and that is the latest published version according to semver ordering, then it will bump to `0.10.0-alpha.1+dev`
  - If we publish `0.9.1`, and that is _not_ the latest published version according to semver ordering, because we previously published `0.10.0-alpha.5`, then it will bump to `0.10.0-alpha.6+dev`.
  - If we publish `0.10.0-alpha.1`, and that is the latest published version according to semver ordering, then it will bump to `0.10.0-alpha.2+dev`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
