### PR TITLE
Fix crash when using `RecordingStream::set_thread_local` on macOS 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5828,13 +5828,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "test_set_thread_local"
-version = "0.10.0-alpha.7+dev"
-dependencies = [
- "rerun",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5828,6 +5828,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_set_thread_local"
+version = "0.10.0-alpha.7+dev"
+dependencies = [
+ "rerun",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/re_sdk/src/global.rs
+++ b/crates/re_sdk/src/global.rs
@@ -52,7 +52,7 @@ impl Drop for ThreadLocalRecording {
             // Calling drop on `self.stream` will panic the calling thread.
             // But we want to make sure we don't loose the data in the stream.
             // So how?
-            re_log::warn!("Using thread-local RecordingStream on macOS can result in data loss because of https://github.com/rerun-io/rerun/issues/2889");
+            re_log::warn!("Using thread-local RecordingStream on macOS can result in data loss because of https://github.com/rerun-io/rerun/issues/3937");
 
             // Give the batcher and sink threads a chance to process the data.
             std::thread::sleep(std::time::Duration::from_millis(500));

--- a/crates/re_sdk/src/global.rs
+++ b/crates/re_sdk/src/global.rs
@@ -30,11 +30,11 @@ impl std::fmt::Display for RecordingScope {
 
 /// Required to work-around <https://github.com/rerun-io/rerun/issues/2889>
 #[derive(Default)]
-struct ThradLocalRecording {
+struct ThreadLocalRecording {
     stream: Option<RecordingStream>,
 }
 
-impl ThradLocalRecording {
+impl ThreadLocalRecording {
     fn replace(&mut self, stream: Option<RecordingStream>) -> Option<RecordingStream> {
         std::mem::replace(&mut self.stream, stream)
     }
@@ -45,7 +45,7 @@ impl ThradLocalRecording {
 }
 
 #[cfg(target_os = "macos")]
-impl Drop for ThradLocalRecording {
+impl Drop for ThreadLocalRecording {
     fn drop(&mut self) {
         if let Some(stream) = self.stream.take() {
             // Work-around for https://github.com/rerun-io/rerun/issues/2889
@@ -64,12 +64,12 @@ impl Drop for ThradLocalRecording {
 
 static GLOBAL_DATA_RECORDING: OnceCell<RwLock<Option<RecordingStream>>> = OnceCell::new();
 thread_local! {
-    static LOCAL_DATA_RECORDING: RefCell<ThradLocalRecording> = Default::default();
+    static LOCAL_DATA_RECORDING: RefCell<ThreadLocalRecording> = Default::default();
 }
 
 static GLOBAL_BLUEPRINT_RECORDING: OnceCell<RwLock<Option<RecordingStream>>> = OnceCell::new();
 thread_local! {
-    static LOCAL_BLUEPRINT_RECORDING: RefCell<ThradLocalRecording> = Default::default();
+    static LOCAL_BLUEPRINT_RECORDING: RefCell<ThreadLocalRecording> = Default::default();
 }
 
 /// Check whether we are the child of a fork.

--- a/crates/re_sdk/src/global.rs
+++ b/crates/re_sdk/src/global.rs
@@ -54,7 +54,7 @@ impl Drop for ThreadLocalRecording {
             // So how?
             re_log::warn!("Using thread-local RecordingStream on macOS can result in data loss because of https://github.com/rerun-io/rerun/issues/2889");
 
-            // Give the batchet and sink threads a chance to process the data.
+            // Give the batcher and sink threads a chance to process the data.
             std::thread::sleep(std::time::Duration::from_millis(500));
 
             #[allow(clippy::mem_forget)] // Intentionally not calling `drop`

--- a/crates/re_sdk/src/global.rs
+++ b/crates/re_sdk/src/global.rs
@@ -57,6 +57,7 @@ impl Drop for ThreadLocalRecording {
             // Give the batchet and sink threads a chance to process the data.
             std::thread::sleep(std::time::Duration::from_millis(500));
 
+            #[allow(clippy::mem_forget)] // Intentionally not calling `drop`
             std::mem::forget(stream);
         }
     }

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1622,10 +1622,9 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_os = "macos"))] // TODO(#2889): https://github.com/rerun-io/rerun/issues/2889
     fn test_set_thread_local() {
+        // Regression-test for https://github.com/rerun-io/rerun/issues/2889
         std::thread::spawn(|| {
-            // Regression-test for https://github.com/rerun-io/rerun/issues/2889
             let stream = RecordingStreamBuilder::new("rerun_example_test")
                 .buffered()
                 .unwrap();

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1624,13 +1624,16 @@ mod tests {
     #[test]
     fn test_set_thread_local() {
         // Regression-test for https://github.com/rerun-io/rerun/issues/2889
-        std::thread::spawn(|| {
-            let stream = RecordingStreamBuilder::new("rerun_example_test")
-                .buffered()
-                .unwrap();
-            RecordingStream::set_thread_local(StoreKind::Recording, Some(stream));
-        })
-        .join()
-        .unwrap();
+        std::thread::Builder::new()
+            .name("test_thead".to_owned())
+            .spawn(|| {
+                let stream = RecordingStreamBuilder::new("rerun_example_test")
+                    .buffered()
+                    .unwrap();
+                RecordingStream::set_thread_local(StoreKind::Recording, Some(stream));
+            })
+            .unwrap()
+            .join()
+            .unwrap();
     }
 }

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1620,4 +1620,18 @@ mod tests {
         // That's all.
         assert!(msgs.pop().is_none());
     }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))] // TODO(#2889): https://github.com/rerun-io/rerun/issues/2889
+    fn test_set_thread_local() {
+        std::thread::spawn(|| {
+            // Regression-test for https://github.com/rerun-io/rerun/issues/2889
+            let stream = RecordingStreamBuilder::new("rerun_example_test")
+                .buffered()
+                .unwrap();
+            RecordingStream::set_thread_local(StoreKind::Recording, Some(stream));
+        })
+        .join()
+        .unwrap();
+    }
 }


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/3558
* Closes https://github.com/rerun-io/rerun/issues/2889
* Opens https://github.com/rerun-io/rerun/issues/3937

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3929) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3929)
- [Docs preview](https://rerun.io/preview/2b1469294de742102f69f16f6ecb8dc0e3e3a0c5/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2b1469294de742102f69f16f6ecb8dc0e3e3a0c5/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)