### PR TITLE
Silence linkinator on speculative links

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -30,7 +30,8 @@ jobs:
       - uses: jprochazk/linkinator-action@main
         with:
           paths: "**/*.md"
-          linksToSkip: "https://crates.io/crates/.*, https://github.com/rerun-io/rerun/pull/.*, https://.*#new" # Avoid crates.io rate-limiting, and skip changelog PR links (so many)
+          # Avoid crates.io rate-limiting, skip changelog PR links (so many), and skip speculative links
+          linksToSkip: "https://crates.io/crates/.*, https://github.com/rerun-io/rerun/pull/.*, .*?speculative-link"
           retry: true
           retryErrors: true
           retryErrorsCount: 5

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: jprochazk/linkinator-action@main
         with:
           paths: "**/*.md"
-          linksToSkip: "https://crates.io/crates/.*, https://github.com/rerun-io/rerun/pull/.*" # Avoid crates.io rate-limiting, and skip changelog PR links (so many)
+          linksToSkip: "https://crates.io/crates/.*, https://github.com/rerun-io/rerun/pull/.*, https://.*#new" # Avoid crates.io rate-limiting, and skip changelog PR links (so many)
           retry: true
           retryErrors: true
           retryErrorsCount: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,28 @@ jobs:
   #   any wheels already uploaded.
   # - `build-and-publish-web` is re-entrant for the same reason as `build-and-publish-wheels`,
   #   except that uploads are done to GCS instead of PyPI.
+
+  checks:
+    name: "Checks"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - name: Check links
+        run: |
+          python3 scripts/ci/check_links.py
+
   version:
     name: "Versioning"
     runs-on: ubuntu-latest
-
+    needs: [checks]
     outputs:
       previous: ${{ steps.versioning.outputs.previous }}
       current: ${{ steps.versioning.outputs.current }}

--- a/README.md
+++ b/README.md
@@ -101,6 +101,3 @@ The commercial product targets the needs specific to teams that build and run co
 1. Download the correct `.whl` from [GitHub Releases](https://github.com/rerun-io/rerun/releases)
 2. Run `pip install rerun_sdk<…>.whl` (replace `<…>` with the actual filename)
 3. Test it: `rerun --version`
-
-
-[Test link](https://abcdefg-this-is-not-a-valid-link.net/#new)

--- a/README.md
+++ b/README.md
@@ -101,3 +101,6 @@ The commercial product targets the needs specific to teams that build and run co
 1. Download the correct `.whl` from [GitHub Releases](https://github.com/rerun-io/rerun/releases)
 2. Run `pip install rerun_sdk<…>.whl` (replace `<…>` with the actual filename)
 3. Test it: `rerun --version`
+
+
+[Test link](https://abcdefg-this-is-not-a-valid-link.net/#new)

--- a/crates/re_types/definitions/docs/attributes.fbs
+++ b/crates/re_types/definitions/docs/attributes.fbs
@@ -1,0 +1,6 @@
+namespace docs.attributes;
+
+/// Apply to a struct or table object to mark it as unreleased.
+///
+/// Any external links referencing this datatype will be given a speculative link marker.
+attribute "attr.docs.unreleased";

--- a/crates/re_types/definitions/docs/attributes.fbs
+++ b/crates/re_types/definitions/docs/attributes.fbs
@@ -3,4 +3,6 @@ namespace docs.attributes;
 /// Apply to a struct or table object to mark it as unreleased.
 ///
 /// Any external links referencing this datatype will be given a speculative link marker.
+/// Speculative links contain a `?speculative-link` query param. Any such links are ignored by linkinator,
+/// and we check for their absence as the first step in our release process.
 attribute "attr.docs.unreleased";

--- a/crates/re_types/definitions/rerun/datatypes/uint32.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/uint32.fbs
@@ -2,6 +2,7 @@ include "arrow/attributes.fbs";
 include "python/attributes.fbs";
 include "fbs/attributes.fbs";
 include "rust/attributes.fbs";
+include "docs/attributes.fbs";
 
 namespace rerun.datatypes;
 
@@ -10,7 +11,8 @@ struct UInt32 (
   "attr.arrow.transparent",
   "attr.rust.derive": "Copy, PartialEq, Eq, PartialOrd, Ord",
   "attr.rust.override_crate": "re_types_core",
-  "attr.rust.tuple_struct"
+  "attr.rust.tuple_struct",
+  "attr.docs.unreleased"
 ) {
   value: uint32 (order: 100);
 }

--- a/crates/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/re_types_builder/src/codegen/docs/mod.rs
@@ -121,6 +121,8 @@ fn index_page(kind: ObjectKind, order: u64, prelude: &str, objects: &[&Object]) 
 }
 
 fn object_page(reporter: &Reporter, object: &Object, object_map: &ObjectMap) -> String {
+    let is_unreleased = object.is_attr_set(crate::ATTR_DOCS_UNRELEASED);
+
     let top_level_docs = get_documentation(&object.docs, &[]);
 
     if top_level_docs.is_empty() {
@@ -154,24 +156,31 @@ fn object_page(reporter: &Reporter, object: &Object, object_map: &ObjectMap) -> 
     }
 
     {
+        let speculative_marker = if is_unreleased {
+            "?speculative-link"
+        } else {
+            ""
+        };
         putln!(page);
         putln!(page, "## Links");
         // TODO(#2919): link to C++ docs
         putln!(
             page,
-            " * 🐍 [Python API docs for `{}`](https://ref.rerun.io/docs/python/stable/common/{}#rerun.{}.{})",
+            " * 🐍 [Python API docs for `{}`](https://ref.rerun.io/docs/python/stable/common/{}{}#rerun.{}.{})",
             object.name,
             object.kind.plural_snake_case(),
+            speculative_marker,
             object.kind.plural_snake_case(),
             object.name
         );
         putln!(
             page,
-            " * 🦀 [Rust API docs for `{}`](https://docs.rs/rerun/latest/rerun/{}/{}.{}.html)",
+            " * 🦀 [Rust API docs for `{}`](https://docs.rs/rerun/latest/rerun/{}/{}.{}.html{})",
             object.name,
             object.kind.plural_snake_case(),
             if object.is_struct() { "struct" } else { "enum" },
-            object.name
+            object.name,
+            speculative_marker
         );
     }
 

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -185,6 +185,8 @@ pub const ATTR_RUST_TUPLE_STRUCT: &str = "attr.rust.tuple_struct";
 
 pub const ATTR_CPP_NO_FIELD_CTORS: &str = "attr.cpp.no_field_ctors";
 
+pub const ATTR_DOCS_UNRELEASED: &str = "attr.docs.unreleased";
+
 // --- Entrypoints ---
 
 use camino::{Utf8Path, Utf8PathBuf};

--- a/docs/content/reference/types/datatypes/uint32.md
+++ b/docs/content/reference/types/datatypes/uint32.md
@@ -7,6 +7,6 @@ A 32bit unsigned integer.
 
 ## Links
  * 🐍 [Python API docs for `UInt32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UInt32)
- * 🦀 [Rust API docs for `UInt32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt32.html?speculative-link)
+ * 🦀 [Rust API docs for `UInt32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt32.html?test=asdf&speculative-link)
 
 

--- a/docs/content/reference/types/datatypes/uint32.md
+++ b/docs/content/reference/types/datatypes/uint32.md
@@ -7,6 +7,6 @@ A 32bit unsigned integer.
 
 ## Links
  * 🐍 [Python API docs for `UInt32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UInt32)
- * 🦀 [Rust API docs for `UInt32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt32.html?test=asdf&speculative-link)
+ * 🦀 [Rust API docs for `UInt32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt32.html)
 
 

--- a/docs/content/reference/types/datatypes/uint32.md
+++ b/docs/content/reference/types/datatypes/uint32.md
@@ -7,6 +7,6 @@ A 32bit unsigned integer.
 
 ## Links
  * 🐍 [Python API docs for `UInt32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UInt32)
- * 🦀 [Rust API docs for `UInt32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt32.html)
+ * 🦀 [Rust API docs for `UInt32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt32.html?speculative-link)
 
 

--- a/docs/content/reference/types/datatypes/uint32.md
+++ b/docs/content/reference/types/datatypes/uint32.md
@@ -6,7 +6,7 @@ A 32bit unsigned integer.
 
 
 ## Links
- * 🐍 [Python API docs for `UInt32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UInt32)
- * 🦀 [Rust API docs for `UInt32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt32.html)
+ * 🐍 [Python API docs for `UInt32`](https://ref.rerun.io/docs/python/stable/common/datatypes?speculative-link#rerun.datatypes.UInt32)
+ * 🦀 [Rust API docs for `UInt32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt32.html?speculative-link)
 
 

--- a/scripts/ci/check_links.py
+++ b/scripts/ci/check_links.py
@@ -1,23 +1,26 @@
 #!/usr/bin/env python3
 
-"""Checks that no links with `#new` are present in any `.md` files."""
+"""Checks that no links with a speculative link marker are present in any `.md` files."""
 
 from __future__ import annotations
 
 import re
+import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from glob import glob
 
-NEW_LINK_HASH = "?speculative-link"
+NEW_LINK_MARKER = "speculative-link"
 
 
 def check_file(file_path: str) -> list[str] | None:
     links = []
     with open(file_path) as f:
         content = f.read()
-        for m in re.finditer("(https://.*)#new", content):
-            line_number = 1 + content[: m.start()].count("\n")
-            links.append(f"{m.group(0)} ({file_path}:{line_number})")
+        for m in re.finditer(f"(https://.*){NEW_LINK_MARKER}", content):
+            link = m.group(0)
+            if NEW_LINK_MARKER in urllib.parse.urlparse(link).query:
+                line_number = 1 + content[: m.start()].count("\n")
+                links.append(f"{link} ({file_path}:{line_number})")
 
     if len(links) > 0:
         return links
@@ -29,7 +32,7 @@ def main() -> None:
     with ThreadPoolExecutor() as e:
         bad_files = [v for v in e.map(check_file, glob("**/*.md", recursive=True)) if v is not None]
         if len(bad_files) > 0:
-            print("The following `#new` URLs were found:")
+            print(f"The following `?{NEW_LINK_MARKER}` URLs were found:")
             for file in bad_files:
                 for link in file:
                     print(link)

--- a/scripts/ci/check_links.py
+++ b/scripts/ci/check_links.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+"""Checks that no links with `#new` are present in any `.md` files."""
+
+from __future__ import annotations
+
+import re
+from concurrent.futures import ThreadPoolExecutor
+from glob import glob
+
+NEW_LINK_HASH = "#new"
+
+
+def check_file(file_path: str) -> list[str] | None:
+    links = []
+    with open(file_path) as f:
+        content = f.read()
+        for m in re.finditer("(https://.*)#new", content):
+            line_number = 1 + content[: m.start()].count("\n")
+            links.append(f"{m.group(0)} ({file_path}:{line_number})")
+
+    if len(links) > 0:
+        return links
+    else:
+        return None
+
+
+def main() -> None:
+    with ThreadPoolExecutor() as e:
+        bad_files = [v for v in e.map(check_file, glob("**/*.md", recursive=True)) if v is not None]
+        if len(bad_files) > 0:
+            print("The following `#new` URLs were found:")
+            for file in bad_files:
+                for link in file:
+                    print(link)
+            exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/check_links.py
+++ b/scripts/ci/check_links.py
@@ -8,7 +8,7 @@ import re
 from concurrent.futures import ThreadPoolExecutor
 from glob import glob
 
-NEW_LINK_HASH = "#new"
+NEW_LINK_HASH = "?speculative-link"
 
 
 def check_file(file_path: str) -> list[str] | None:


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

- Linkinator will now ignore any links with a `?speculative-link` query param
- We check for the absence of such links as the first step in the `release` workflow
- Added `attr.docs.unreleased` codegen attribute to mark types as "unreleased", which will add the speculative link marker to any HTTP links that reference the type

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3930) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3930)
- [Docs preview](https://rerun.io/preview/2712f30b4e6600b1dd901dfc60b9d1f8842de793/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2712f30b4e6600b1dd901dfc60b9d1f8842de793/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)