### PR TITLE
C++ fix rotation serialization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,8 +69,9 @@
         "rerun_py/rerun_sdk"
     ],
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools", // Use cmake-tools to grab configs.
-    "cmake.buildDirectory": "${workspaceRoot}/build/",
     "C_Cpp.autoAddFileAssociations": false,
+    "cmake.buildDirectory": "${workspaceRoot}/build/",
+    "cmake.generator": "Ninja", // Use Ninja, just like we do in our just/pixi command.
     "rust-analyzer.showUnlinkedFileNotification": false,
     "black-formatter.args": [
         "--config=rerun_py/pyproject.toml"

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -48,7 +48,6 @@ opt_out_compare = {
     "quick_start_spawn":  ["cpp", "py", "rust"], # These example don't have exactly the same implementation.
     "scalar_multiple_plots": ["cpp"], # trigonometric functions have slightly different outcomes
     "tensor_simple": ["cpp", "py", "rust"], # TODO(#3206): examples use different RNGs
-    "transform3d_simple": ["cpp"], # TODO(#2919): Something broken in the C++ SDK
 }
 
 extra_args = {

--- a/rerun_cpp/src/rerun/datatypes/angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <new>
 #include <utility>
 
 namespace arrow {
@@ -81,14 +82,14 @@ namespace rerun {
             static Angle radians(float radians) {
                 Angle self;
                 self._tag = detail::AngleTag::Radians;
-                self._data.radians = std::move(radians);
+                new (&self._data.radians) float(std::move(radians));
                 return self;
             }
 
             static Angle degrees(float degrees) {
                 Angle self;
                 self._tag = detail::AngleTag::Degrees;
-                self._data.degrees = std::move(degrees);
+                new (&self._data.degrees) float(std::move(degrees));
                 return self;
             }
 

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <new>
 #include <utility>
 
 namespace arrow {
@@ -91,7 +92,7 @@ namespace rerun {
             static Rotation3D quaternion(rerun::datatypes::Quaternion quaternion) {
                 Rotation3D self;
                 self._tag = detail::Rotation3DTag::Quaternion;
-                self._data.quaternion = std::move(quaternion);
+                new (&self._data.quaternion) rerun::datatypes::Quaternion(std::move(quaternion));
                 return self;
             }
 
@@ -99,7 +100,8 @@ namespace rerun {
             static Rotation3D axis_angle(rerun::datatypes::RotationAxisAngle axis_angle) {
                 Rotation3D self;
                 self._tag = detail::Rotation3DTag::AxisAngle;
-                self._data.axis_angle = std::move(axis_angle);
+                new (&self._data.axis_angle)
+                    rerun::datatypes::RotationAxisAngle(std::move(axis_angle));
                 return self;
             }
 

--- a/rerun_cpp/src/rerun/datatypes/scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <new>
 #include <utility>
 
 namespace arrow {
@@ -85,7 +86,7 @@ namespace rerun {
             static Scale3D three_d(rerun::datatypes::Vec3D three_d) {
                 Scale3D self;
                 self._tag = detail::Scale3DTag::ThreeD;
-                self._data.three_d = std::move(three_d);
+                new (&self._data.three_d) rerun::datatypes::Vec3D(std::move(three_d));
                 return self;
             }
 
@@ -93,7 +94,7 @@ namespace rerun {
             static Scale3D uniform(float uniform) {
                 Scale3D self;
                 self._tag = detail::Scale3DTag::Uniform;
-                self._data.uniform = std::move(uniform);
+                new (&self._data.uniform) float(std::move(uniform));
                 return self;
             }
 

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
@@ -283,106 +283,93 @@ namespace rerun {
             }
 
             static TensorBuffer u8(std::vector<uint8_t> u8) {
-                using TypeAlias = std::vector<uint8_t>;
                 TensorBuffer self;
                 self._tag = detail::TensorBufferTag::U8;
-                new (&self._data.u8) TypeAlias(std::move(u8));
+                new (&self._data.u8) std::vector<uint8_t>(std::move(u8));
                 return self;
             }
 
             static TensorBuffer u16(std::vector<uint16_t> u16) {
-                using TypeAlias = std::vector<uint16_t>;
                 TensorBuffer self;
                 self._tag = detail::TensorBufferTag::U16;
-                new (&self._data.u16) TypeAlias(std::move(u16));
+                new (&self._data.u16) std::vector<uint16_t>(std::move(u16));
                 return self;
             }
 
             static TensorBuffer u32(std::vector<uint32_t> u32) {
-                using TypeAlias = std::vector<uint32_t>;
                 TensorBuffer self;
                 self._tag = detail::TensorBufferTag::U32;
-                new (&self._data.u32) TypeAlias(std::move(u32));
+                new (&self._data.u32) std::vector<uint32_t>(std::move(u32));
                 return self;
             }
 
             static TensorBuffer u64(std::vector<uint64_t> u64) {
-                using TypeAlias = std::vector<uint64_t>;
                 TensorBuffer self;
                 self._tag = detail::TensorBufferTag::U64;
-                new (&self._data.u64) TypeAlias(std::move(u64));
+                new (&self._data.u64) std::vector<uint64_t>(std::move(u64));
                 return self;
             }
 
             static TensorBuffer i8(std::vector<int8_t> i8) {
-                using TypeAlias = std::vector<int8_t>;
                 TensorBuffer self;
                 self._tag = detail::TensorBufferTag::I8;
-                new (&self._data.i8) TypeAlias(std::move(i8));
+                new (&self._data.i8) std::vector<int8_t>(std::move(i8));
                 return self;
             }
 
             static TensorBuffer i16(std::vector<int16_t> i16) {
-                using TypeAlias = std::vector<int16_t>;
                 TensorBuffer self;
                 self._tag = detail::TensorBufferTag::I16;
-                new (&self._data.i16) TypeAlias(std::move(i16));
+                new (&self._data.i16) std::vector<int16_t>(std::move(i16));
                 return self;
             }
 
             static TensorBuffer i32(std::vector<int32_t> i32) {
-                using TypeAlias = std::vector<int32_t>;
                 TensorBuffer self;
                 self._tag = detail::TensorBufferTag::I32;
-                new (&self._data.i32) TypeAlias(std::move(i32));
+                new (&self._data.i32) std::vector<int32_t>(std::move(i32));
                 return self;
             }
 
             static TensorBuffer i64(std::vector<int64_t> i64) {
-                using TypeAlias = std::vector<int64_t>;
                 TensorBuffer self;
                 self._tag = detail::TensorBufferTag::I64;
-                new (&self._data.i64) TypeAlias(std::move(i64));
+                new (&self._data.i64) std::vector<int64_t>(std::move(i64));
                 return self;
             }
 
             static TensorBuffer f16(std::vector<rerun::half> f16) {
-                using TypeAlias = std::vector<rerun::half>;
                 TensorBuffer self;
                 self._tag = detail::TensorBufferTag::F16;
-                new (&self._data.f16) TypeAlias(std::move(f16));
+                new (&self._data.f16) std::vector<rerun::half>(std::move(f16));
                 return self;
             }
 
             static TensorBuffer f32(std::vector<float> f32) {
-                using TypeAlias = std::vector<float>;
                 TensorBuffer self;
                 self._tag = detail::TensorBufferTag::F32;
-                new (&self._data.f32) TypeAlias(std::move(f32));
+                new (&self._data.f32) std::vector<float>(std::move(f32));
                 return self;
             }
 
             static TensorBuffer f64(std::vector<double> f64) {
-                using TypeAlias = std::vector<double>;
                 TensorBuffer self;
                 self._tag = detail::TensorBufferTag::F64;
-                new (&self._data.f64) TypeAlias(std::move(f64));
+                new (&self._data.f64) std::vector<double>(std::move(f64));
                 return self;
             }
 
             static TensorBuffer jpeg(std::vector<uint8_t> jpeg) {
-                using TypeAlias = std::vector<uint8_t>;
                 TensorBuffer self;
                 self._tag = detail::TensorBufferTag::JPEG;
-                new (&self._data.jpeg) TypeAlias(std::move(jpeg));
+                new (&self._data.jpeg) std::vector<uint8_t>(std::move(jpeg));
                 return self;
             }
 
             static TensorBuffer nv12(std::vector<uint8_t> nv12) {
-                using TypeAlias = std::vector<uint8_t>;
                 TensorBuffer self;
                 self._tag = detail::TensorBufferTag::NV12;
-                new (&self._data.nv12) TypeAlias(std::move(nv12));
+                new (&self._data.nv12) std::vector<uint8_t>(std::move(nv12));
                 return self;
             }
 

--- a/rerun_cpp/src/rerun/datatypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.hpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <new>
 #include <utility>
 
 namespace arrow {
@@ -85,7 +86,8 @@ namespace rerun {
             ) {
                 Transform3D self;
                 self._tag = detail::Transform3DTag::TranslationAndMat3x3;
-                self._data.translation_and_mat3x3 = std::move(translation_and_mat3x3);
+                new (&self._data.translation_and_mat3x3)
+                    rerun::datatypes::TranslationAndMat3x3(std::move(translation_and_mat3x3));
                 return self;
             }
 
@@ -94,7 +96,9 @@ namespace rerun {
             ) {
                 Transform3D self;
                 self._tag = detail::Transform3DTag::TranslationRotationScale;
-                self._data.translation_rotation_scale = std::move(translation_rotation_scale);
+                new (&self._data.translation_rotation_scale
+                ) rerun::datatypes::TranslationRotationScale3D(std::move(translation_rotation_scale)
+                );
                 return self;
             }
 

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
@@ -124,22 +124,22 @@ namespace rerun {
             static AffixFuzzer3 degrees(float degrees) {
                 AffixFuzzer3 self;
                 self._tag = detail::AffixFuzzer3Tag::degrees;
-                self._data.degrees = std::move(degrees);
+                new (&self._data.degrees) float(std::move(degrees));
                 return self;
             }
 
             static AffixFuzzer3 radians(std::optional<float> radians) {
                 AffixFuzzer3 self;
                 self._tag = detail::AffixFuzzer3Tag::radians;
-                self._data.radians = std::move(radians);
+                new (&self._data.radians) std::optional<float>(std::move(radians));
                 return self;
             }
 
             static AffixFuzzer3 craziness(std::vector<rerun::datatypes::AffixFuzzer1> craziness) {
-                using TypeAlias = std::vector<rerun::datatypes::AffixFuzzer1>;
                 AffixFuzzer3 self;
                 self._tag = detail::AffixFuzzer3Tag::craziness;
-                new (&self._data.craziness) TypeAlias(std::move(craziness));
+                new (&self._data.craziness)
+                    std::vector<rerun::datatypes::AffixFuzzer1>(std::move(craziness));
                 return self;
             }
 
@@ -147,9 +147,8 @@ namespace rerun {
             ) {
                 AffixFuzzer3 self;
                 self._tag = detail::AffixFuzzer3Tag::fixed_size_shenanigans;
-                for (size_t i = 0; i < 3; i += 1) {
-                    self._data.fixed_size_shenanigans[i] = std::move(fixed_size_shenanigans[i]);
-                }
+                new (&self._data.fixed_size_shenanigans)
+                    std::array<float, 3>(std::move(fixed_size_shenanigans));
                 return self;
             }
 

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
@@ -120,30 +120,31 @@ namespace rerun {
             }
 
             static AffixFuzzer4 single_required(rerun::datatypes::AffixFuzzer3 single_required) {
-                using TypeAlias = rerun::datatypes::AffixFuzzer3;
                 AffixFuzzer4 self;
                 self._tag = detail::AffixFuzzer4Tag::single_required;
-                new (&self._data.single_required) TypeAlias(std::move(single_required));
+                new (&self._data.single_required)
+                    rerun::datatypes::AffixFuzzer3(std::move(single_required));
                 return self;
             }
 
             static AffixFuzzer4 many_required(
                 std::vector<rerun::datatypes::AffixFuzzer3> many_required
             ) {
-                using TypeAlias = std::vector<rerun::datatypes::AffixFuzzer3>;
                 AffixFuzzer4 self;
                 self._tag = detail::AffixFuzzer4Tag::many_required;
-                new (&self._data.many_required) TypeAlias(std::move(many_required));
+                new (&self._data.many_required)
+                    std::vector<rerun::datatypes::AffixFuzzer3>(std::move(many_required));
                 return self;
             }
 
             static AffixFuzzer4 many_optional(
                 std::optional<std::vector<rerun::datatypes::AffixFuzzer3>> many_optional
             ) {
-                using TypeAlias = std::optional<std::vector<rerun::datatypes::AffixFuzzer3>>;
                 AffixFuzzer4 self;
                 self._tag = detail::AffixFuzzer4Tag::many_optional;
-                new (&self._data.many_optional) TypeAlias(std::move(many_optional));
+                new (&self._data.many_optional
+                ) std::optional<std::vector<rerun::datatypes::AffixFuzzer3>>(std::move(many_optional
+                ));
                 return self;
             }
 


### PR DESCRIPTION
### What

* Fixes #3865

It seems this was caused by undefined behavior via calling an assignment operator on uninitialized memory!

Bulldozered the entire responsible codegen section over to make it super simple :)
(which we can do now in part because recent std::array use - should have done so from the start, makes things way simpler!)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3935) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3935)
- [Docs preview](https://rerun.io/preview/b0a17e547eb59de9f2be8982e8ae1d01ca15afb5/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b0a17e547eb59de9f2be8982e8ae1d01ca15afb5/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)