### PR TITLE
Add easy way to dump out final wgsl shader

### DIFF
--- a/crates/re_renderer/README.md
+++ b/crates/re_renderer/README.md
@@ -24,3 +24,40 @@ Goals & philosophy:
 * Lazy loading whenever possible for best startup performance
 * Run great both on the desktop and web
 * No dependencies on `re_viewer` or rerun data store libraries
+
+
+## Debugging
+
+### Shader
+
+#### Iterating
+
+In debug mode shaders are live-reloaded.
+If a failure occurs during live-reload, an error is logged and the previous shader is kept.
+
+#### Inspecting final source
+
+If `RERUN_WGSL_SHADER_DUMP_PATH` is set, all readily stitched (import resolve) and patched
+wgsl shaders will be written to the specified directory.
+
+Often you're also interested in the Naga translated shader. This can be done easily from command line using
+```sh
+cargo install naga-cli --all-features
+```
+
+Example for translating a wgsl fragment shader to GL as used on WebGL:
+```sh
+naga ./wgsl_dump/rectangle_fs.wgsl ./wgsl_dump/rectangle_fs.frag --entry-point fs_main --profile es
+```
+Example for translating a wgsl vertex shader to GL as used on WebGL:
+```sh
+naga ./wgsl_dump/rectangle_vs.wgsl ./wgsl_dump/rectangle_vs.vert --entry-point vs_main --profile es
+```
+Note that a single shader entry point from wgsl maps to a single frag/vert file!
+
+Example for translating a wgsl to MSL as used on MacOS.
+Note that a single metal file maps to a single wgsl file.
+```sh
+naga ./wgsl_dump/rectangle_fs.wgsl ./wgsl_dump/rectangle_fs.metal
+```
+


### PR DESCRIPTION
### What

.. and document how to inspect translated shaders in an easy way.

* Fixes #3944
   * not exactly what I had in mind but actually good enough! 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
