### PR TITLE
Refactor the rectangle fragment shader to work around a suspected angle/mesa bug

### DIFF
--- a/crates/re_renderer/shader/rectangle_fs.wgsl
+++ b/crates/re_renderer/shader/rectangle_fs.wgsl
@@ -3,6 +3,10 @@
 #import <./utils/srgb.wgsl>
 #import <./decodings.wgsl>
 
+// WARNING! Adding anything else to this shader is very likely to push us over a size threshold that
+// causes the failure reported in: https://github.com/rerun-io/rerun/issues/3931
+// Make sure any changes are tested in Chrome on Linux.
+
 fn is_magnifying(pixel_coord: Vec2) -> bool {
     return fwidth(pixel_coord.x) < 1.0;
 }

--- a/crates/re_renderer/shader/rectangle_fs.wgsl
+++ b/crates/re_renderer/shader/rectangle_fs.wgsl
@@ -5,7 +5,7 @@
 
 // WARNING! Adding anything else to this shader is very likely to push us over a size threshold that
 // causes the failure reported in: https://github.com/rerun-io/rerun/issues/3931
-// Make sure any changes are tested in Chrome on Linux.
+// Make sure any changes are tested in Chrome on Linux using the Intel Mesa driver.
 
 fn is_magnifying(pixel_coord: Vec2) -> bool {
     return fwidth(pixel_coord.x) < 1.0;
@@ -129,10 +129,10 @@ fn fs_main(in: VertexOut) -> @location(0) Vec4 {
             normalized_value = decode_color(Vec4(decode_nv12(texture_uint, clamped_coord)));
         } else {
             // bilinear
-            let v00 = Vec4(decode_nv12(texture_uint, v00_coord));
-            let v01 = Vec4(decode_nv12(texture_uint, v01_coord));
-            let v10 = Vec4(decode_nv12(texture_uint, v10_coord));
-            let v11 = Vec4(decode_nv12(texture_uint, v11_coord));
+            let v00 = decode_nv12(texture_uint, v00_coord);
+            let v01 = decode_nv12(texture_uint, v01_coord);
+            let v10 = decode_nv12(texture_uint, v10_coord);
+            let v11 = decode_nv12(texture_uint, v11_coord);
             normalized_value = decode_color_and_filter_bilinear(coord, v00, v01, v10, v11);
         }
     }


### PR DESCRIPTION
### What
:see_no_evil: 

This mitigates the crash reported in:
* https://github.com/rerun-io/rerun/issues/3931
but should be considered a workaround, rather than a proper fix.

After a fair bit of shooting in the dark, our best working theory is that the there is a magic size threshold at which shaders fail to link on angle+mesa.

On that hunch, I refactored this shader and am no longer seeing the crash. 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3948) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3948)
- [Docs preview](https://rerun.io/preview/aae3dae91c18d6697fc5be06d84e0f9ca16d0ba9/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/aae3dae91c18d6697fc5be06d84e0f9ca16d0ba9/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)