### PR TITLE
Fix `just codegen --profile`

### DIFF
--- a/crates/re_types_builder/src/bin/build_re_types.rs
+++ b/crates/re_types_builder/src/bin/build_re_types.rs
@@ -34,15 +34,11 @@ macro_rules! join {
 fn main() {
     re_log::setup_native_logging();
 
-    // This isn't a build.rs script, so opt out of cargo build instrctinsr
+    let mut profiler = re_tracing::Profiler::default(); // must be started early and dropped late to catch everything
+
+    // This isn't a build.rs script, so opt out of cargo build instructions
     set_output_cargo_build_instructions(false);
 
-    rayon::ThreadPoolBuilder::new()
-        .thread_name(|i| format!("rayon-{i}"))
-        .build_global()
-        .unwrap();
-
-    let mut profiler = re_tracing::Profiler::default();
     let mut always_run = false;
     let mut check = false;
 
@@ -64,6 +60,11 @@ fn main() {
             }
         }
     }
+
+    rayon::ThreadPoolBuilder::new()
+        .thread_name(|i| format!("rayon-{i}"))
+        .build_global()
+        .unwrap();
 
     let workspace_dir = Utf8Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -245,6 +245,7 @@ pub fn generate_lang_agnostic(
     entrypoint_path: impl AsRef<Utf8Path>,
 ) -> (Objects, ArrowRegistry) {
     re_tracing::profile_function!();
+
     use xshell::Shell;
 
     let sh = Shell::new().unwrap();
@@ -324,6 +325,8 @@ fn generate_gitattributes_for_generated_files(files_to_write: &mut GeneratedFile
 
 /// This will automatically emit a `rerun-if-changed` clause for all the files that were hashed.
 pub fn compute_re_types_builder_hash() -> String {
+    re_tracing::profile_function!();
+
     compute_crate_hash("re_types_builder")
 }
 
@@ -336,6 +339,8 @@ pub struct SourceLocations<'a> {
 
 /// Also triggers a re-build if anything that affects the hash changes.
 pub fn compute_re_types_hash(locations: &SourceLocations<'_>) -> String {
+    re_tracing::profile_function!();
+
     // NOTE: We need to hash both the flatbuffers definitions as well as the source code of the
     // code generator itself!
     let re_types_builder_hash = compute_re_types_builder_hash();


### PR DESCRIPTION
### What
Fixes up `just codegen --profile` so it works again to show what is slow (it is `rust-fmt`):

![image](https://github.com/rerun-io/rerun/assets/1148717/1e011980-e7a3-4da2-a5a3-d2df12ae2a73)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3951) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3951)
- [Docs preview](https://rerun.io/preview/5f06a2fd89aa50e1f62f7ba40fc834bd7d4b859d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5f06a2fd89aa50e1f62f7ba40fc834bd7d4b859d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)