### PR TITLE
Python codegen: use `|` for union types

### DIFF
--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -1067,11 +1067,11 @@ fn quote_aliases_from_object(obj: &Object) -> String {
 
     let mut code = String::new();
 
-    if aliases.is_empty() {
-        code.push_unindented_text(&format!("{name}Like = {name}"), 1);
-    } else {
-        code.push_unindented_text(
-            &format!(
+    code.push_unindented_text(
+        &if aliases.is_empty() {
+            format!("{name}Like = {name}")
+        } else {
+            format!(
                 r#"
                 if TYPE_CHECKING:
                     {name}Like = {name} | {}
@@ -1079,25 +1079,22 @@ fn quote_aliases_from_object(obj: &Object) -> String {
                     {name}Like = Any
                 "#,
                 aliases.iter().join(" | ")
-            ),
-            1,
-        );
-    }
+            )
+        },
+        1,
+    );
 
-    if array_aliases.is_empty() {
-        code.push_unindented_text(
-            format!("{name}ArrayLike = {name} | Sequence[{name}Like]"),
-            0,
-        );
-    } else {
-        code.push_unindented_text(
+    code.push_unindented_text(
+        if array_aliases.is_empty() {
+            format!("{name}ArrayLike = {name} | Sequence[{name}Like]")
+        } else {
             format!(
                 "{name}ArrayLike = {name} | Sequence[{name}Like] | {}",
                 array_aliases.iter().join(" | ")
-            ),
-            0,
-        );
-    }
+            )
+        },
+        0,
+    );
 
     code
 }

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -612,6 +612,16 @@ impl Object {
         self.attrs.try_get(self.fqname.as_str(), name)
     }
 
+    pub fn get_attr_list(&self, name: &str) -> Vec<String> {
+        self.attrs
+            .try_get::<String>(self.fqname.as_str(), name)
+            .unwrap_or_default()
+            .split(", ")
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_owned())
+            .collect()
+    }
+
     pub fn is_attr_set(&self, name: impl AsRef<str>) -> bool {
         self.attrs.has(name)
     }

--- a/crates/re_types_core/src/components/clear_is_recursive.rs
+++ b/crates/re_types_core/src/components/clear_is_recursive.rs
@@ -21,7 +21,7 @@ use crate::SerializationResult;
 use crate::{ComponentBatch, MaybeOwnedComponentBatch};
 use crate::{DeserializationError, DeserializationResult};
 
-/// **Component**: Configures how a clear operation should behave - recursive or not.
+/// **Component**: Configures how a clear operation should behave - recursive or not?
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub struct ClearIsRecursive(
     /// If true, also clears all recursive children entities.

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -18,7 +18,7 @@
 
 namespace rerun {
     namespace archetypes {
-        /// **Archetype**: An image made up of integer class-ids.
+        /// **Archetype**: An image made up of integer class-ids
         ///
         /// The shape of the `TensorData` must be mappable to an `HxW` tensor.
         /// Each pixel corresponds to a depth value in units specified by meter.

--- a/rerun_cpp/src/rerun/components/clear_is_recursive.hpp
+++ b/rerun_cpp/src/rerun/components/clear_is_recursive.hpp
@@ -17,7 +17,7 @@ namespace arrow {
 
 namespace rerun {
     namespace components {
-        /// **Component**: Configures how a clear operation should behave - recursive or not.
+        /// **Component**: Configures how a clear operation should behave - recursive or not?
         struct ClearIsRecursive {
             /// If true, also clears all recursive children entities.
             bool recursive;

--- a/rerun_cpp/src/rerun/components/text.hpp
+++ b/rerun_cpp/src/rerun/components/text.hpp
@@ -20,7 +20,7 @@ namespace arrow {
 
 namespace rerun {
     namespace components {
-        /// **Component**: A string of text, e.g. for labels and text documents.
+        /// **Component**: A string of text, e.g. for labels and text documents
         struct Text {
             rerun::datatypes::Utf8 value;
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/auto_space_views.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/auto_space_views.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 from attrs import define, field
 
@@ -38,10 +38,7 @@ class AutoSpaceViews:
 
 
 AutoSpaceViewsLike = AutoSpaceViews
-AutoSpaceViewsArrayLike = Union[
-    AutoSpaceViews,
-    Sequence[AutoSpaceViewsLike],
-]
+AutoSpaceViewsArrayLike = AutoSpaceViews | Sequence[AutoSpaceViewsLike]
 
 
 class AutoSpaceViewsType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/blueprint/panel_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/panel_view.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 from attrs import define, field
 
@@ -32,10 +32,7 @@ class PanelView:
 
 
 PanelViewLike = PanelView
-PanelViewArrayLike = Union[
-    PanelView,
-    Sequence[PanelViewLike],
-]
+PanelViewArrayLike = PanelView | Sequence[PanelViewLike]
 
 
 class PanelViewType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/blueprint/space_view_component.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/space_view_component.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -47,10 +47,7 @@ class SpaceViewComponent:
 
 
 SpaceViewComponentLike = SpaceViewComponent
-SpaceViewComponentArrayLike = Union[
-    SpaceViewComponent,
-    Sequence[SpaceViewComponentLike],
-]
+SpaceViewComponentArrayLike = SpaceViewComponent | Sequence[SpaceViewComponentLike]
 
 
 class SpaceViewComponentType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/blueprint/space_view_maximized.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/space_view_maximized.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -47,10 +47,7 @@ class SpaceViewMaximized:
 
 
 SpaceViewMaximizedLike = SpaceViewMaximized
-SpaceViewMaximizedArrayLike = Union[
-    SpaceViewMaximized,
-    Sequence[SpaceViewMaximizedLike],
-]
+SpaceViewMaximizedArrayLike = SpaceViewMaximized | Sequence[SpaceViewMaximizedLike]
 
 
 class SpaceViewMaximizedType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/blueprint/viewport_layout.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/viewport_layout.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -67,10 +67,7 @@ class ViewportLayout:
 
 
 ViewportLayoutLike = ViewportLayout
-ViewportLayoutArrayLike = Union[
-    ViewportLayout,
-    Sequence[ViewportLayoutLike],
-]
+ViewportLayoutArrayLike = ViewportLayout | Sequence[ViewportLayoutLike]
 
 
 class ViewportLayoutType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/components/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/components/annotation_context.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -57,16 +57,13 @@ class AnnotationContext(AnnotationContextExt):
 
 
 if TYPE_CHECKING:
-    AnnotationContextLike = Union[
-        AnnotationContext, datatypes.ClassDescriptionArrayLike, Sequence[datatypes.ClassDescriptionMapElemLike]
-    ]
+    AnnotationContextLike = (
+        AnnotationContext | datatypes.ClassDescriptionArrayLike | Sequence[datatypes.ClassDescriptionMapElemLike]
+    )
 else:
     AnnotationContextLike = Any
 
-AnnotationContextArrayLike = Union[
-    AnnotationContext,
-    Sequence[AnnotationContextLike],
-]
+AnnotationContextArrayLike = AnnotationContext | Sequence[AnnotationContextLike]
 
 
 class AnnotationContextType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/components/blob.py
+++ b/rerun_py/rerun_sdk/rerun/components/blob.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -39,11 +39,11 @@ class Blob(BlobExt):
 
 
 if TYPE_CHECKING:
-    BlobLike = Union[Blob, bytes, npt.NDArray[np.uint8]]
+    BlobLike = Blob | bytes | npt.NDArray[np.uint8]
 else:
     BlobLike = Any
 
-BlobArrayLike = Union[Blob, Sequence[BlobLike], bytes, npt.NDArray[np.uint8]]
+BlobArrayLike = Blob | Sequence[BlobLike] | bytes | npt.NDArray[np.uint8]
 
 
 class BlobType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
+++ b/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -48,11 +48,11 @@ class ClearIsRecursive(ClearIsRecursiveExt):
 
 
 if TYPE_CHECKING:
-    ClearIsRecursiveLike = Union[ClearIsRecursive, bool]
+    ClearIsRecursiveLike = ClearIsRecursive | bool
 else:
     ClearIsRecursiveLike = Any
 
-ClearIsRecursiveArrayLike = Union[ClearIsRecursive, Sequence[ClearIsRecursiveLike], bool, npt.NDArray[np.bool_]]
+ClearIsRecursiveArrayLike = ClearIsRecursive | Sequence[ClearIsRecursiveLike] | bool | npt.NDArray[np.bool_]
 
 
 class ClearIsRecursiveType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
+++ b/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
@@ -26,7 +26,7 @@ __all__ = [
 
 @define(init=False)
 class ClearIsRecursive(ClearIsRecursiveExt):
-    """**Component**: Configures how a clear operation should behave - recursive or not."""
+    """**Component**: Configures how a clear operation should behave - recursive or not?."""
 
     def __init__(self: Any, recursive: ClearIsRecursiveLike):
         """

--- a/rerun_py/rerun_sdk/rerun/components/depth_meter.py
+++ b/rerun_py/rerun_sdk/rerun/components/depth_meter.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -39,11 +39,11 @@ class DepthMeter(DepthMeterExt):
 
 
 if TYPE_CHECKING:
-    DepthMeterLike = Union[DepthMeter, float]
+    DepthMeterLike = DepthMeter | float
 else:
     DepthMeterLike = Any
 
-DepthMeterArrayLike = Union[DepthMeter, Sequence[DepthMeterLike], float, npt.NDArray[np.float32]]
+DepthMeterArrayLike = DepthMeter | Sequence[DepthMeterLike] | float | npt.NDArray[np.float32]
 
 
 class DepthMeterType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -43,11 +43,11 @@ class DisconnectedSpace(DisconnectedSpaceExt):
 
 
 if TYPE_CHECKING:
-    DisconnectedSpaceLike = Union[DisconnectedSpace, bool]
+    DisconnectedSpaceLike = DisconnectedSpace | bool
 else:
     DisconnectedSpaceLike = Any
 
-DisconnectedSpaceArrayLike = Union[DisconnectedSpace, Sequence[DisconnectedSpaceLike], bool, npt.NDArray[np.bool_]]
+DisconnectedSpaceArrayLike = DisconnectedSpace | Sequence[DisconnectedSpaceLike] | bool | npt.NDArray[np.bool_]
 
 
 class DisconnectedSpaceType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/components/draw_order.py
+++ b/rerun_py/rerun_sdk/rerun/components/draw_order.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -47,11 +47,11 @@ class DrawOrder(DrawOrderExt):
 
 
 if TYPE_CHECKING:
-    DrawOrderLike = Union[DrawOrder, float]
+    DrawOrderLike = DrawOrder | float
 else:
     DrawOrderLike = Any
 
-DrawOrderArrayLike = Union[DrawOrder, Sequence[DrawOrderLike], float, npt.NDArray[np.float32]]
+DrawOrderArrayLike = DrawOrder | Sequence[DrawOrderLike] | float | npt.NDArray[np.float32]
 
 
 class DrawOrderType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/components/instance_key.py
+++ b/rerun_py/rerun_sdk/rerun/components/instance_key.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -39,11 +39,11 @@ class InstanceKey(InstanceKeyExt):
 
 
 if TYPE_CHECKING:
-    InstanceKeyLike = Union[InstanceKey, int]
+    InstanceKeyLike = InstanceKey | int
 else:
     InstanceKeyLike = Any
 
-InstanceKeyArrayLike = Union[InstanceKey, Sequence[InstanceKeyLike], int, npt.NDArray[np.uint64]]
+InstanceKeyArrayLike = InstanceKey | Sequence[InstanceKeyLike] | int | npt.NDArray[np.uint64]
 
 
 class InstanceKeyType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -46,11 +46,11 @@ class LineStrip2D(LineStrip2DExt):
 
 
 if TYPE_CHECKING:
-    LineStrip2DLike = Union[LineStrip2D, datatypes.Vec2DArrayLike, npt.NDArray[np.float32]]
+    LineStrip2DLike = LineStrip2D | datatypes.Vec2DArrayLike | npt.NDArray[np.float32]
 else:
     LineStrip2DLike = Any
 
-LineStrip2DArrayLike = Union[LineStrip2D, Sequence[LineStrip2DLike], npt.NDArray[np.float32]]
+LineStrip2DArrayLike = LineStrip2D | Sequence[LineStrip2DLike] | npt.NDArray[np.float32]
 
 
 class LineStrip2DType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -46,11 +46,11 @@ class LineStrip3D(LineStrip3DExt):
 
 
 if TYPE_CHECKING:
-    LineStrip3DLike = Union[LineStrip3D, datatypes.Vec3DArrayLike, npt.NDArray[np.float32]]
+    LineStrip3DLike = LineStrip3D | datatypes.Vec3DArrayLike | npt.NDArray[np.float32]
 else:
     LineStrip3DLike = Any
 
-LineStrip3DArrayLike = Union[LineStrip3D, Sequence[LineStrip3DLike], npt.NDArray[np.float32]]
+LineStrip3DArrayLike = LineStrip3D | Sequence[LineStrip3DLike] | npt.NDArray[np.float32]
 
 
 class LineStrip3DType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/components/radius.py
+++ b/rerun_py/rerun_sdk/rerun/components/radius.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -39,11 +39,11 @@ class Radius(RadiusExt):
 
 
 if TYPE_CHECKING:
-    RadiusLike = Union[Radius, float]
+    RadiusLike = Radius | float
 else:
     RadiusLike = Any
 
-RadiusArrayLike = Union[Radius, Sequence[RadiusLike], float, npt.ArrayLike]
+RadiusArrayLike = Radius | Sequence[RadiusLike] | float | npt.ArrayLike
 
 
 class RadiusType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/components/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/components/scalar.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -43,11 +43,11 @@ class Scalar(ScalarExt):
 
 
 if TYPE_CHECKING:
-    ScalarLike = Union[Scalar, float]
+    ScalarLike = Scalar | float
 else:
     ScalarLike = Any
 
-ScalarArrayLike = Union[Scalar, Sequence[ScalarLike], float, npt.NDArray[np.float64]]
+ScalarArrayLike = Scalar | Sequence[ScalarLike] | float | npt.NDArray[np.float64]
 
 
 class ScalarType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/components/scalar_scattering.py
+++ b/rerun_py/rerun_sdk/rerun/components/scalar_scattering.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -38,11 +38,11 @@ class ScalarScattering(ScalarScatteringExt):
 
 
 if TYPE_CHECKING:
-    ScalarScatteringLike = Union[ScalarScattering, bool]
+    ScalarScatteringLike = ScalarScattering | bool
 else:
     ScalarScatteringLike = Any
 
-ScalarScatteringArrayLike = Union[ScalarScattering, Sequence[ScalarScatteringLike], bool, npt.NDArray[np.bool_]]
+ScalarScatteringArrayLike = ScalarScattering | Sequence[ScalarScatteringLike] | bool | npt.NDArray[np.bool_]
 
 
 class ScalarScatteringType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -71,11 +71,11 @@ class ViewCoordinates(ViewCoordinatesExt):
 
 
 if TYPE_CHECKING:
-    ViewCoordinatesLike = Union[ViewCoordinates, npt.ArrayLike]
+    ViewCoordinatesLike = ViewCoordinates | npt.ArrayLike
 else:
     ViewCoordinatesLike = Any
 
-ViewCoordinatesArrayLike = Union[ViewCoordinates, Sequence[ViewCoordinatesLike], npt.ArrayLike]
+ViewCoordinatesArrayLike = ViewCoordinates | Sequence[ViewCoordinatesLike] | npt.ArrayLike
 
 
 class ViewCoordinatesType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/angle.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/angle.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Sequence, Union
+from typing import TYPE_CHECKING, Any, Literal, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -35,15 +35,8 @@ class Angle(AngleExt):
 
 
 if TYPE_CHECKING:
-    AngleLike = Union[
-        Angle,
-        float,
-    ]
-    AngleArrayLike = Union[
-        Angle,
-        float,
-        Sequence[AngleLike],
-    ]
+    AngleLike = Angle | float
+    AngleArrayLike = Angle | float | Sequence[AngleLike]
 else:
     AngleLike = Any
     AngleArrayLike = Any

--- a/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
@@ -33,7 +33,7 @@ def _annotation_info__label__special_field_converter_override(x: datatypes.Utf8L
 
 
 def _annotation_info__color__special_field_converter_override(
-    x: datatypes.Rgba32Like | None
+    x: datatypes.Rgba32Like | None,
 ) -> datatypes.Rgba32 | None:
     if x is None:
         return None

--- a/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Sequence, Tuple
 
 import pyarrow as pa
 from attrs import define, field
@@ -33,7 +33,7 @@ def _annotation_info__label__special_field_converter_override(x: datatypes.Utf8L
 
 
 def _annotation_info__color__special_field_converter_override(
-    x: datatypes.Rgba32Like | None,
+    x: datatypes.Rgba32Like | None
 ) -> datatypes.Rgba32 | None:
     if x is None:
         return None
@@ -92,14 +92,11 @@ class AnnotationInfo(AnnotationInfoExt):
 
 
 if TYPE_CHECKING:
-    AnnotationInfoLike = Union[AnnotationInfo, int, Tuple[int, str], Tuple[int, str, datatypes.Rgba32Like]]
+    AnnotationInfoLike = AnnotationInfo | int | Tuple[int | str] | Tuple[int | str | datatypes.Rgba32Like]
 else:
     AnnotationInfoLike = Any
 
-AnnotationInfoArrayLike = Union[
-    AnnotationInfo,
-    Sequence[AnnotationInfoLike],
-]
+AnnotationInfoArrayLike = AnnotationInfo | Sequence[AnnotationInfoLike]
 
 
 class AnnotationInfoType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
@@ -92,7 +92,7 @@ class AnnotationInfo(AnnotationInfoExt):
 
 
 if TYPE_CHECKING:
-    AnnotationInfoLike = AnnotationInfo | int | Tuple[int | str] | Tuple[int | str | datatypes.Rgba32Like]
+    AnnotationInfoLike = AnnotationInfo | int | Tuple[int, str] | Tuple[int, str, datatypes.Rgba32Like]
 else:
     AnnotationInfoLike = Any
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -71,14 +71,11 @@ class ClassDescription(ClassDescriptionExt):
 
 
 if TYPE_CHECKING:
-    ClassDescriptionLike = Union[ClassDescription, datatypes.AnnotationInfoLike]
+    ClassDescriptionLike = ClassDescription | datatypes.AnnotationInfoLike
 else:
     ClassDescriptionLike = Any
 
-ClassDescriptionArrayLike = Union[
-    ClassDescription,
-    Sequence[ClassDescriptionLike],
-]
+ClassDescriptionArrayLike = ClassDescription | Sequence[ClassDescriptionLike]
 
 
 class ClassDescriptionType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem.py
@@ -24,7 +24,7 @@ __all__ = [
 
 
 def _class_description_map_elem__class_id__special_field_converter_override(
-    x: datatypes.ClassIdLike
+    x: datatypes.ClassIdLike,
 ) -> datatypes.ClassId:
     if isinstance(x, datatypes.ClassId):
         return x

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -24,7 +24,7 @@ __all__ = [
 
 
 def _class_description_map_elem__class_id__special_field_converter_override(
-    x: datatypes.ClassIdLike,
+    x: datatypes.ClassIdLike
 ) -> datatypes.ClassId:
     if isinstance(x, datatypes.ClassId):
         return x
@@ -69,14 +69,11 @@ class ClassDescriptionMapElem(ClassDescriptionMapElemExt):
 
 
 if TYPE_CHECKING:
-    ClassDescriptionMapElemLike = Union[ClassDescriptionMapElem, datatypes.ClassDescriptionLike]
+    ClassDescriptionMapElemLike = ClassDescriptionMapElem | datatypes.ClassDescriptionLike
 else:
     ClassDescriptionMapElemLike = Any
 
-ClassDescriptionMapElemArrayLike = Union[
-    ClassDescriptionMapElem,
-    Sequence[ClassDescriptionMapElemLike],
-]
+ClassDescriptionMapElemArrayLike = ClassDescriptionMapElem | Sequence[ClassDescriptionMapElemLike]
 
 
 class ClassDescriptionMapElemType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_id.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_id.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -39,11 +39,11 @@ class ClassId(ClassIdExt):
 
 
 if TYPE_CHECKING:
-    ClassIdLike = Union[ClassId, int]
+    ClassIdLike = ClassId | int
 else:
     ClassIdLike = Any
 
-ClassIdArrayLike = Union[ClassId, Sequence[ClassIdLike], int, npt.ArrayLike]
+ClassIdArrayLike = ClassId | Sequence[ClassIdLike] | int | npt.ArrayLike
 
 
 class ClassIdType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/float32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/float32.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -38,10 +38,7 @@ class Float32:
 
 
 Float32Like = Float32
-Float32ArrayLike = Union[
-    Float32,
-    Sequence[Float32Like],
-]
+Float32ArrayLike = Float32 | Sequence[Float32Like]
 
 
 class Float32Type(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_id.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_id.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -46,11 +46,11 @@ class KeypointId(KeypointIdExt):
 
 
 if TYPE_CHECKING:
-    KeypointIdLike = Union[KeypointId, int]
+    KeypointIdLike = KeypointId | int
 else:
     KeypointIdLike = Any
 
-KeypointIdArrayLike = Union[KeypointId, Sequence[KeypointIdLike], int, npt.ArrayLike]
+KeypointIdArrayLike = KeypointId | Sequence[KeypointIdLike] | int | npt.ArrayLike
 
 
 class KeypointIdType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -62,14 +62,11 @@ class KeypointPair(KeypointPairExt):
 
 
 if TYPE_CHECKING:
-    KeypointPairLike = Union[KeypointPair, Sequence[datatypes.KeypointIdLike]]
+    KeypointPairLike = KeypointPair | Sequence[datatypes.KeypointIdLike]
 else:
     KeypointPairLike = Any
 
-KeypointPairArrayLike = Union[
-    KeypointPair,
-    Sequence[KeypointPairLike],
-]
+KeypointPairArrayLike = KeypointPair | Sequence[KeypointPairLike]
 
 
 class KeypointPairType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -71,14 +71,11 @@ class Mat3x3(Mat3x3Ext):
 
 
 if TYPE_CHECKING:
-    Mat3x3Like = Union[Mat3x3, npt.ArrayLike]
+    Mat3x3Like = Mat3x3 | npt.ArrayLike
 else:
     Mat3x3Like = Any
 
-Mat3x3ArrayLike = Union[
-    Mat3x3,
-    Sequence[Mat3x3Like],
-]
+Mat3x3ArrayLike = Mat3x3 | Sequence[Mat3x3Like]
 
 
 class Mat3x3Type(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -73,14 +73,11 @@ class Mat4x4(Mat4x4Ext):
 
 
 if TYPE_CHECKING:
-    Mat4x4Like = Union[Mat4x4, npt.ArrayLike]
+    Mat4x4Like = Mat4x4 | npt.ArrayLike
 else:
     Mat4x4Like = Any
 
-Mat4x4ArrayLike = Union[
-    Mat4x4,
-    Sequence[Mat4x4Like],
-]
+Mat4x4ArrayLike = Mat4x4 | Sequence[Mat4x4Like]
 
 
 class Mat4x4Type(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/material.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/material.py
@@ -18,7 +18,7 @@ __all__ = ["Material", "MaterialArrayLike", "MaterialBatch", "MaterialLike", "Ma
 
 
 def _material__albedo_factor__special_field_converter_override(
-    x: datatypes.Rgba32Like | None
+    x: datatypes.Rgba32Like | None,
 ) -> datatypes.Rgba32 | None:
     if x is None:
         return None

--- a/rerun_py/rerun_sdk/rerun/datatypes/material.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/material.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -18,7 +18,7 @@ __all__ = ["Material", "MaterialArrayLike", "MaterialBatch", "MaterialLike", "Ma
 
 
 def _material__albedo_factor__special_field_converter_override(
-    x: datatypes.Rgba32Like | None,
+    x: datatypes.Rgba32Like | None
 ) -> datatypes.Rgba32 | None:
     if x is None:
         return None
@@ -54,10 +54,7 @@ class Material(MaterialExt):
 
 
 MaterialLike = Material
-MaterialArrayLike = Union[
-    Material,
-    Sequence[MaterialLike],
-]
+MaterialArrayLike = Material | Sequence[MaterialLike]
 
 
 class MaterialType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/mesh_properties.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mesh_properties.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -59,10 +59,7 @@ class MeshProperties(MeshPropertiesExt):
 
 
 MeshPropertiesLike = MeshProperties
-MeshPropertiesArrayLike = Union[
-    MeshProperties,
-    Sequence[MeshPropertiesLike],
-]
+MeshPropertiesArrayLike = MeshProperties | Sequence[MeshPropertiesLike]
 
 
 class MeshPropertiesType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -40,10 +40,7 @@ class Quaternion(QuaternionExt):
 
 
 QuaternionLike = Quaternion
-QuaternionArrayLike = Union[
-    Quaternion,
-    Sequence[QuaternionLike],
-]
+QuaternionArrayLike = Quaternion | Sequence[QuaternionLike]
 
 
 class QuaternionType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/rgba32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rgba32.py
@@ -50,7 +50,7 @@ class Rgba32(Rgba32Ext):
 
 
 if TYPE_CHECKING:
-    Rgba32Like = Rgba32 | int | Sequence[Union[int | float]] | npt.NDArray[Union[np.uint8 | np.float32 | np.float64]]
+    Rgba32Like = Rgba32 | int | Sequence[Union[int, float]] | npt.NDArray[Union[np.uint8, np.float32, np.float64]]
 else:
     Rgba32Like = Any
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/rgba32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rgba32.py
@@ -50,11 +50,11 @@ class Rgba32(Rgba32Ext):
 
 
 if TYPE_CHECKING:
-    Rgba32Like = Union[Rgba32, int, Sequence[Union[int, float]], npt.NDArray[Union[np.uint8, np.float32, np.float64]]]
+    Rgba32Like = Rgba32 | int | Sequence[Union[int | float]] | npt.NDArray[Union[np.uint8 | np.float32 | np.float64]]
 else:
     Rgba32Like = Any
 
-Rgba32ArrayLike = Union[Rgba32, Sequence[Rgba32Like], int, npt.ArrayLike]
+Rgba32ArrayLike = Rgba32 | Sequence[Rgba32Like] | int | npt.ArrayLike
 
 
 class Rgba32Type(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/rotation3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rotation3d.py
@@ -23,9 +23,7 @@ class Rotation3D(Rotation3DExt):
 
     # You can define your own __init__ function as a member of Rotation3DExt in rotation3d_ext.py
 
-    inner: datatypes.Quaternion | datatypes.RotationAxisAngle = field(
-        converter=Rotation3DExt.inner__field_converter_override
-    )  # type: ignore[misc]
+    inner: datatypes.Quaternion | datatypes.RotationAxisAngle = field(converter=Rotation3DExt.inner__field_converter_override)  # type: ignore[misc]
     """
     Quaternion (datatypes.Quaternion):
         Rotation defined by a quaternion.

--- a/rerun_py/rerun_sdk/rerun/datatypes/rotation3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rotation3d.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, SupportsFloat, Union
+from typing import TYPE_CHECKING, Any, Sequence, SupportsFloat
 
 import pyarrow as pa
 from attrs import define, field
@@ -23,7 +23,9 @@ class Rotation3D(Rotation3DExt):
 
     # You can define your own __init__ function as a member of Rotation3DExt in rotation3d_ext.py
 
-    inner: datatypes.Quaternion | datatypes.RotationAxisAngle = field(converter=Rotation3DExt.inner__field_converter_override)  # type: ignore[misc]
+    inner: datatypes.Quaternion | datatypes.RotationAxisAngle = field(
+        converter=Rotation3DExt.inner__field_converter_override
+    )  # type: ignore[misc]
     """
     Quaternion (datatypes.Quaternion):
         Rotation defined by a quaternion.
@@ -34,13 +36,8 @@ class Rotation3D(Rotation3DExt):
 
 
 if TYPE_CHECKING:
-    Rotation3DLike = Union[Rotation3D, datatypes.Quaternion, datatypes.RotationAxisAngle, Sequence[SupportsFloat]]
-    Rotation3DArrayLike = Union[
-        Rotation3D,
-        datatypes.Quaternion,
-        datatypes.RotationAxisAngle,
-        Sequence[Rotation3DLike],
-    ]
+    Rotation3DLike = Rotation3D | datatypes.Quaternion | datatypes.RotationAxisAngle | Sequence[SupportsFloat]
+    Rotation3DArrayLike = Rotation3D | datatypes.Quaternion | datatypes.RotationAxisAngle | Sequence[Rotation3DLike]
 else:
     Rotation3DLike = Any
     Rotation3DArrayLike = Any

--- a/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence, Union
+from typing import Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -54,10 +54,7 @@ class RotationAxisAngle(RotationAxisAngleExt):
 
 
 RotationAxisAngleLike = RotationAxisAngle
-RotationAxisAngleArrayLike = Union[
-    RotationAxisAngle,
-    Sequence[RotationAxisAngleLike],
-]
+RotationAxisAngleArrayLike = RotationAxisAngle | Sequence[RotationAxisAngleLike]
 
 
 class RotationAxisAngleType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/scale3d.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -47,13 +47,8 @@ class Scale3D(Scale3DExt):
 
 
 if TYPE_CHECKING:
-    Scale3DLike = Union[Scale3D, datatypes.Vec3D, float, datatypes.Vec3DLike]
-    Scale3DArrayLike = Union[
-        Scale3D,
-        datatypes.Vec3D,
-        float,
-        Sequence[Scale3DLike],
-    ]
+    Scale3DLike = Scale3D | datatypes.Vec3D | float | datatypes.Vec3DLike
+    Scale3DArrayLike = Scale3D | datatypes.Vec3D | float | Sequence[Scale3DLike]
 else:
     Scale3DLike = Any
     Scale3DArrayLike = Any

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
@@ -28,19 +28,7 @@ class TensorBuffer(TensorBufferExt):
 
     # You can define your own __init__ function as a member of TensorBufferExt in tensor_buffer_ext.py
 
-    inner: (
-        npt.NDArray[np.float16]
-        | npt.NDArray[np.float32]
-        | npt.NDArray[np.float64]
-        | npt.NDArray[np.int16]
-        | npt.NDArray[np.int32]
-        | npt.NDArray[np.int64]
-        | npt.NDArray[np.int8]
-        | npt.NDArray[np.uint16]
-        | npt.NDArray[np.uint32]
-        | npt.NDArray[np.uint64]
-        | npt.NDArray[np.uint8]
-    ) = field(converter=TensorBufferExt.inner__field_converter_override)  # type: ignore[misc]
+    inner: npt.NDArray[np.float16] | npt.NDArray[np.float32] | npt.NDArray[np.float64] | npt.NDArray[np.int16] | npt.NDArray[np.int32] | npt.NDArray[np.int64] | npt.NDArray[np.int8] | npt.NDArray[np.uint16] | npt.NDArray[np.uint32] | npt.NDArray[np.uint64] | npt.NDArray[np.uint8] = field(converter=TensorBufferExt.inner__field_converter_override)  # type: ignore[misc]
     """
     U8 (npt.NDArray[np.uint8]):
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Sequence, Union
+from typing import TYPE_CHECKING, Any, Literal, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -28,7 +28,19 @@ class TensorBuffer(TensorBufferExt):
 
     # You can define your own __init__ function as a member of TensorBufferExt in tensor_buffer_ext.py
 
-    inner: npt.NDArray[np.float16] | npt.NDArray[np.float32] | npt.NDArray[np.float64] | npt.NDArray[np.int16] | npt.NDArray[np.int32] | npt.NDArray[np.int64] | npt.NDArray[np.int8] | npt.NDArray[np.uint16] | npt.NDArray[np.uint32] | npt.NDArray[np.uint64] | npt.NDArray[np.uint8] = field(converter=TensorBufferExt.inner__field_converter_override)  # type: ignore[misc]
+    inner: (
+        npt.NDArray[np.float16]
+        | npt.NDArray[np.float32]
+        | npt.NDArray[np.float64]
+        | npt.NDArray[np.int16]
+        | npt.NDArray[np.int32]
+        | npt.NDArray[np.int64]
+        | npt.NDArray[np.int8]
+        | npt.NDArray[np.uint16]
+        | npt.NDArray[np.uint32]
+        | npt.NDArray[np.uint64]
+        | npt.NDArray[np.uint8]
+    ) = field(converter=TensorBufferExt.inner__field_converter_override)  # type: ignore[misc]
     """
     U8 (npt.NDArray[np.uint8]):
 
@@ -63,35 +75,35 @@ class TensorBuffer(TensorBufferExt):
 
 
 if TYPE_CHECKING:
-    TensorBufferLike = Union[
-        TensorBuffer,
-        npt.NDArray[np.float16],
-        npt.NDArray[np.float32],
-        npt.NDArray[np.float64],
-        npt.NDArray[np.int16],
-        npt.NDArray[np.int32],
-        npt.NDArray[np.int64],
-        npt.NDArray[np.int8],
-        npt.NDArray[np.uint16],
-        npt.NDArray[np.uint32],
-        npt.NDArray[np.uint64],
-        npt.NDArray[np.uint8],
-    ]
-    TensorBufferArrayLike = Union[
-        TensorBuffer,
-        npt.NDArray[np.float16],
-        npt.NDArray[np.float32],
-        npt.NDArray[np.float64],
-        npt.NDArray[np.int16],
-        npt.NDArray[np.int32],
-        npt.NDArray[np.int64],
-        npt.NDArray[np.int8],
-        npt.NDArray[np.uint16],
-        npt.NDArray[np.uint32],
-        npt.NDArray[np.uint64],
-        npt.NDArray[np.uint8],
-        Sequence[TensorBufferLike],
-    ]
+    TensorBufferLike = (
+        TensorBuffer
+        | npt.NDArray[np.float16]
+        | npt.NDArray[np.float32]
+        | npt.NDArray[np.float64]
+        | npt.NDArray[np.int16]
+        | npt.NDArray[np.int32]
+        | npt.NDArray[np.int64]
+        | npt.NDArray[np.int8]
+        | npt.NDArray[np.uint16]
+        | npt.NDArray[np.uint32]
+        | npt.NDArray[np.uint64]
+        | npt.NDArray[np.uint8]
+    )
+    TensorBufferArrayLike = (
+        TensorBuffer
+        | npt.NDArray[np.float16]
+        | npt.NDArray[np.float32]
+        | npt.NDArray[np.float64]
+        | npt.NDArray[np.int16]
+        | npt.NDArray[np.int32]
+        | npt.NDArray[np.int64]
+        | npt.NDArray[np.int8]
+        | npt.NDArray[np.uint16]
+        | npt.NDArray[np.uint32]
+        | npt.NDArray[np.uint64]
+        | npt.NDArray[np.uint8]
+        | Sequence[TensorBufferLike]
+    )
 else:
     TensorBufferLike = Any
     TensorBufferArrayLike = Any

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy.typing as npt
 import pyarrow as pa
@@ -45,11 +45,11 @@ class TensorData(TensorDataExt):
 
 
 if TYPE_CHECKING:
-    TensorDataLike = Union[TensorData, npt.ArrayLike]
+    TensorDataLike = TensorData | npt.ArrayLike
 else:
     TensorDataLike = Any
 
-TensorDataArrayLike = Union[TensorData, Sequence[TensorDataLike], npt.ArrayLike]
+TensorDataArrayLike = TensorData | Sequence[TensorDataLike] | npt.ArrayLike
 
 
 class TensorDataType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -55,10 +55,7 @@ class TensorDimension:
 
 
 TensorDimensionLike = TensorDimension
-TensorDimensionArrayLike = Union[
-    TensorDimension,
-    Sequence[TensorDimensionLike],
-]
+TensorDimensionArrayLike = TensorDimension | Sequence[TensorDimensionLike]
 
 
 class TensorDimensionType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/transform3d.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -32,17 +32,10 @@ class Transform3D(Transform3DExt):
 
 
 if TYPE_CHECKING:
-    Transform3DLike = Union[
-        Transform3D,
-        datatypes.TranslationAndMat3x3,
-        datatypes.TranslationRotationScale3D,
-    ]
-    Transform3DArrayLike = Union[
-        Transform3D,
-        datatypes.TranslationAndMat3x3,
-        datatypes.TranslationRotationScale3D,
-        Sequence[Transform3DLike],
-    ]
+    Transform3DLike = Transform3D | datatypes.TranslationAndMat3x3 | datatypes.TranslationRotationScale3D
+    Transform3DArrayLike = (
+        Transform3D | datatypes.TranslationAndMat3x3 | datatypes.TranslationRotationScale3D | Sequence[Transform3DLike]
+    )
 else:
     Transform3DLike = Any
     Transform3DArrayLike = Any

--- a/rerun_py/rerun_sdk/rerun/datatypes/translation_and_mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/translation_and_mat3x3.py
@@ -24,7 +24,7 @@ __all__ = [
 
 
 def _translation_and_mat3x3__translation__special_field_converter_override(
-    x: datatypes.Vec3DLike | None
+    x: datatypes.Vec3DLike | None,
 ) -> datatypes.Vec3D | None:
     if x is None:
         return None
@@ -35,7 +35,7 @@ def _translation_and_mat3x3__translation__special_field_converter_override(
 
 
 def _translation_and_mat3x3__mat3x3__special_field_converter_override(
-    x: datatypes.Mat3x3Like | None
+    x: datatypes.Mat3x3Like | None,
 ) -> datatypes.Mat3x3 | None:
     if x is None:
         return None

--- a/rerun_py/rerun_sdk/rerun/datatypes/translation_and_mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/translation_and_mat3x3.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence, Union
+from typing import Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -24,7 +24,7 @@ __all__ = [
 
 
 def _translation_and_mat3x3__translation__special_field_converter_override(
-    x: datatypes.Vec3DLike | None,
+    x: datatypes.Vec3DLike | None
 ) -> datatypes.Vec3D | None:
     if x is None:
         return None
@@ -35,7 +35,7 @@ def _translation_and_mat3x3__translation__special_field_converter_override(
 
 
 def _translation_and_mat3x3__mat3x3__special_field_converter_override(
-    x: datatypes.Mat3x3Like | None,
+    x: datatypes.Mat3x3Like | None
 ) -> datatypes.Mat3x3 | None:
     if x is None:
         return None
@@ -79,10 +79,7 @@ class TranslationAndMat3x3(TranslationAndMat3x3Ext):
 
 
 TranslationAndMat3x3Like = TranslationAndMat3x3
-TranslationAndMat3x3ArrayLike = Union[
-    TranslationAndMat3x3,
-    Sequence[TranslationAndMat3x3Like],
-]
+TranslationAndMat3x3ArrayLike = TranslationAndMat3x3 | Sequence[TranslationAndMat3x3Like]
 
 
 class TranslationAndMat3x3Type(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/translation_rotation_scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/translation_rotation_scale3d.py
@@ -24,7 +24,7 @@ __all__ = [
 
 
 def _translation_rotation_scale3d__rotation__special_field_converter_override(
-    x: datatypes.Rotation3DLike | None
+    x: datatypes.Rotation3DLike | None,
 ) -> datatypes.Rotation3D | None:
     if x is None:
         return None
@@ -35,7 +35,7 @@ def _translation_rotation_scale3d__rotation__special_field_converter_override(
 
 
 def _translation_rotation_scale3d__scale__special_field_converter_override(
-    x: datatypes.Scale3DLike | None
+    x: datatypes.Scale3DLike | None,
 ) -> datatypes.Scale3D | None:
     if x is None:
         return None

--- a/rerun_py/rerun_sdk/rerun/datatypes/translation_rotation_scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/translation_rotation_scale3d.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence, Union
+from typing import Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -24,7 +24,7 @@ __all__ = [
 
 
 def _translation_rotation_scale3d__rotation__special_field_converter_override(
-    x: datatypes.Rotation3DLike | None,
+    x: datatypes.Rotation3DLike | None
 ) -> datatypes.Rotation3D | None:
     if x is None:
         return None
@@ -35,7 +35,7 @@ def _translation_rotation_scale3d__rotation__special_field_converter_override(
 
 
 def _translation_rotation_scale3d__scale__special_field_converter_override(
-    x: datatypes.Scale3DLike | None,
+    x: datatypes.Scale3DLike | None
 ) -> datatypes.Scale3D | None:
     if x is None:
         return None
@@ -83,10 +83,7 @@ class TranslationRotationScale3D(TranslationRotationScale3DExt):
 
 
 TranslationRotationScale3DLike = TranslationRotationScale3D
-TranslationRotationScale3DArrayLike = Union[
-    TranslationRotationScale3D,
-    Sequence[TranslationRotationScale3DLike],
-]
+TranslationRotationScale3DArrayLike = TranslationRotationScale3D | Sequence[TranslationRotationScale3DLike]
 
 
 class TranslationRotationScale3DType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/uint32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uint32.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -38,10 +38,7 @@ class UInt32:
 
 
 UInt32Like = UInt32
-UInt32ArrayLike = Union[
-    UInt32,
-    Sequence[UInt32Like],
-]
+UInt32ArrayLike = UInt32 | Sequence[UInt32Like]
 
 
 class UInt32Type(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/utf8.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/utf8.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -33,11 +33,11 @@ class Utf8(Utf8Ext):
 
 
 if TYPE_CHECKING:
-    Utf8Like = Union[Utf8, str]
+    Utf8Like = Utf8 | str
 else:
     Utf8Like = Any
 
-Utf8ArrayLike = Union[Utf8, Sequence[Utf8Like], str, Sequence[str]]
+Utf8ArrayLike = Utf8 | Sequence[Utf8Like] | str | Sequence[str]
 
 
 class Utf8Type(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec2d.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -38,13 +38,13 @@ class UVec2D:
 
 
 if TYPE_CHECKING:
-    UVec2DLike = Union[UVec2D, npt.NDArray[Any], npt.ArrayLike, Sequence[int]]
+    UVec2DLike = UVec2D | npt.NDArray[Any] | npt.ArrayLike | Sequence[int]
 else:
     UVec2DLike = Any
 
-UVec2DArrayLike = Union[
-    UVec2D, Sequence[UVec2DLike], npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[int]], Sequence[int]
-]
+UVec2DArrayLike = (
+    UVec2D | Sequence[UVec2DLike] | npt.NDArray[Any] | npt.ArrayLike | Sequence[Sequence[int]] | Sequence[int]
+)
 
 
 class UVec2DType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec3d.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -38,13 +38,13 @@ class UVec3D:
 
 
 if TYPE_CHECKING:
-    UVec3DLike = Union[UVec3D, npt.NDArray[Any], npt.ArrayLike, Sequence[int]]
+    UVec3DLike = UVec3D | npt.NDArray[Any] | npt.ArrayLike | Sequence[int]
 else:
     UVec3DLike = Any
 
-UVec3DArrayLike = Union[
-    UVec3D, Sequence[UVec3DLike], npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[int]], Sequence[int]
-]
+UVec3DArrayLike = (
+    UVec3D | Sequence[UVec3DLike] | npt.NDArray[Any] | npt.ArrayLike | Sequence[Sequence[int]] | Sequence[int]
+)
 
 
 class UVec3DType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec4d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec4d.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -38,13 +38,13 @@ class UVec4D:
 
 
 if TYPE_CHECKING:
-    UVec4DLike = Union[UVec4D, npt.NDArray[Any], npt.ArrayLike, Sequence[int]]
+    UVec4DLike = UVec4D | npt.NDArray[Any] | npt.ArrayLike | Sequence[int]
 else:
     UVec4DLike = Any
 
-UVec4DArrayLike = Union[
-    UVec4D, Sequence[UVec4DLike], npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[int]], Sequence[int]
-]
+UVec4DArrayLike = (
+    UVec4D | Sequence[UVec4DLike] | npt.NDArray[Any] | npt.ArrayLike | Sequence[Sequence[int]] | Sequence[int]
+)
 
 
 class UVec4DType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec2d.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -39,13 +39,13 @@ class Vec2D(Vec2DExt):
 
 
 if TYPE_CHECKING:
-    Vec2DLike = Union[Vec2D, npt.NDArray[Any], npt.ArrayLike, Sequence[float]]
+    Vec2DLike = Vec2D | npt.NDArray[Any] | npt.ArrayLike | Sequence[float]
 else:
     Vec2DLike = Any
 
-Vec2DArrayLike = Union[
-    Vec2D, Sequence[Vec2DLike], npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[float]], Sequence[float]
-]
+Vec2DArrayLike = (
+    Vec2D | Sequence[Vec2DLike] | npt.NDArray[Any] | npt.ArrayLike | Sequence[Sequence[float]] | Sequence[float]
+)
 
 
 class Vec2DType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec3d.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -39,13 +39,13 @@ class Vec3D(Vec3DExt):
 
 
 if TYPE_CHECKING:
-    Vec3DLike = Union[Vec3D, npt.NDArray[Any], npt.ArrayLike, Sequence[float]]
+    Vec3DLike = Vec3D | npt.NDArray[Any] | npt.ArrayLike | Sequence[float]
 else:
     Vec3DLike = Any
 
-Vec3DArrayLike = Union[
-    Vec3D, Sequence[Vec3DLike], npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[float]], Sequence[float]
-]
+Vec3DArrayLike = (
+    Vec3D | Sequence[Vec3DLike] | npt.NDArray[Any] | npt.ArrayLike | Sequence[Sequence[float]] | Sequence[float]
+)
 
 
 class Vec3DType(BaseExtensionType):

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec4d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec4d.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -39,13 +39,13 @@ class Vec4D(Vec4DExt):
 
 
 if TYPE_CHECKING:
-    Vec4DLike = Union[Vec4D, npt.NDArray[Any], npt.ArrayLike, Sequence[float]]
+    Vec4DLike = Vec4D | npt.NDArray[Any] | npt.ArrayLike | Sequence[float]
 else:
     Vec4DLike = Any
 
-Vec4DArrayLike = Union[
-    Vec4D, Sequence[Vec4DLike], npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[float]], Sequence[float]
-]
+Vec4DArrayLike = (
+    Vec4D | Sequence[Vec4DLike] | npt.NDArray[Any] | npt.ArrayLike | Sequence[Sequence[float]] | Sequence[float]
+)
 
 
 class Vec4DType(BaseExtensionType):

--- a/rerun_py/tests/test_types/components/affix_fuzzer10.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer10.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -29,10 +29,7 @@ class AffixFuzzer10:
 
 
 AffixFuzzer10Like = AffixFuzzer10
-AffixFuzzer10ArrayLike = Union[
-    AffixFuzzer10,
-    Sequence[AffixFuzzer10Like],
-]
+AffixFuzzer10ArrayLike = AffixFuzzer10 | Sequence[AffixFuzzer10Like]
 
 
 class AffixFuzzer10Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/components/affix_fuzzer11.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer11.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -35,10 +35,7 @@ class AffixFuzzer11:
 
 
 AffixFuzzer11Like = AffixFuzzer11
-AffixFuzzer11ArrayLike = Union[
-    AffixFuzzer11,
-    Sequence[AffixFuzzer11Like],
-]
+AffixFuzzer11ArrayLike = AffixFuzzer11 | Sequence[AffixFuzzer11Like]
 
 
 class AffixFuzzer11Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/components/affix_fuzzer12.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer12.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -26,10 +26,7 @@ class AffixFuzzer12:
 
 
 AffixFuzzer12Like = AffixFuzzer12
-AffixFuzzer12ArrayLike = Union[
-    AffixFuzzer12,
-    Sequence[AffixFuzzer12Like],
-]
+AffixFuzzer12ArrayLike = AffixFuzzer12 | Sequence[AffixFuzzer12Like]
 
 
 class AffixFuzzer12Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/components/affix_fuzzer13.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer13.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -26,10 +26,7 @@ class AffixFuzzer13:
 
 
 AffixFuzzer13Like = AffixFuzzer13
-AffixFuzzer13ArrayLike = Union[
-    AffixFuzzer13,
-    Sequence[AffixFuzzer13Like],
-]
+AffixFuzzer13ArrayLike = AffixFuzzer13 | Sequence[AffixFuzzer13Like]
 
 
 class AffixFuzzer13Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/components/affix_fuzzer16.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer16.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -28,10 +28,7 @@ class AffixFuzzer16:
 
 
 AffixFuzzer16Like = AffixFuzzer16
-AffixFuzzer16ArrayLike = Union[
-    AffixFuzzer16,
-    Sequence[AffixFuzzer16Like],
-]
+AffixFuzzer16ArrayLike = AffixFuzzer16 | Sequence[AffixFuzzer16Like]
 
 
 class AffixFuzzer16Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/components/affix_fuzzer17.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer17.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -28,10 +28,7 @@ class AffixFuzzer17:
 
 
 AffixFuzzer17Like = AffixFuzzer17
-AffixFuzzer17ArrayLike = Union[
-    AffixFuzzer17,
-    Sequence[AffixFuzzer17Like],
-]
+AffixFuzzer17ArrayLike = AffixFuzzer17 | Sequence[AffixFuzzer17Like]
 
 
 class AffixFuzzer17Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/components/affix_fuzzer18.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer18.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -28,10 +28,7 @@ class AffixFuzzer18:
 
 
 AffixFuzzer18Like = AffixFuzzer18
-AffixFuzzer18ArrayLike = Union[
-    AffixFuzzer18,
-    Sequence[AffixFuzzer18Like],
-]
+AffixFuzzer18ArrayLike = AffixFuzzer18 | Sequence[AffixFuzzer18Like]
 
 
 class AffixFuzzer18Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/components/affix_fuzzer7.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer7.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -28,10 +28,7 @@ class AffixFuzzer7:
 
 
 AffixFuzzer7Like = AffixFuzzer7
-AffixFuzzer7ArrayLike = Union[
-    AffixFuzzer7,
-    Sequence[AffixFuzzer7Like],
-]
+AffixFuzzer7ArrayLike = AffixFuzzer7 | Sequence[AffixFuzzer7Like]
 
 
 class AffixFuzzer7Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/components/affix_fuzzer8.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer8.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -35,10 +35,7 @@ class AffixFuzzer8:
 
 
 AffixFuzzer8Like = AffixFuzzer8
-AffixFuzzer8ArrayLike = Union[
-    AffixFuzzer8,
-    Sequence[AffixFuzzer8Like],
-]
+AffixFuzzer8ArrayLike = AffixFuzzer8 | Sequence[AffixFuzzer8Like]
 
 
 class AffixFuzzer8Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/components/affix_fuzzer9.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer9.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -29,10 +29,7 @@ class AffixFuzzer9:
 
 
 AffixFuzzer9Like = AffixFuzzer9
-AffixFuzzer9ArrayLike = Union[
-    AffixFuzzer9,
-    Sequence[AffixFuzzer9Like],
-]
+AffixFuzzer9ArrayLike = AffixFuzzer9 | Sequence[AffixFuzzer9Like]
 
 
 class AffixFuzzer9Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer1.py
@@ -25,7 +25,7 @@ __all__ = ["AffixFuzzer1", "AffixFuzzer1ArrayLike", "AffixFuzzer1Batch", "AffixF
 
 
 def _affix_fuzzer1__almost_flattened_scalar__special_field_converter_override(
-    x: datatypes.FlattenedScalarLike
+    x: datatypes.FlattenedScalarLike,
 ) -> datatypes.FlattenedScalar:
     if isinstance(x, datatypes.FlattenedScalar):
         return x

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer1.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -25,7 +25,7 @@ __all__ = ["AffixFuzzer1", "AffixFuzzer1ArrayLike", "AffixFuzzer1Batch", "AffixF
 
 
 def _affix_fuzzer1__almost_flattened_scalar__special_field_converter_override(
-    x: datatypes.FlattenedScalarLike,
+    x: datatypes.FlattenedScalarLike
 ) -> datatypes.FlattenedScalar:
     if isinstance(x, datatypes.FlattenedScalar):
         return x
@@ -76,10 +76,7 @@ class AffixFuzzer1:
 
 
 AffixFuzzer1Like = AffixFuzzer1
-AffixFuzzer1ArrayLike = Union[
-    AffixFuzzer1,
-    Sequence[AffixFuzzer1Like],
-]
+AffixFuzzer1ArrayLike = AffixFuzzer1 | Sequence[AffixFuzzer1Like]
 
 
 class AffixFuzzer1Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer2.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -35,10 +35,7 @@ class AffixFuzzer2:
 
 
 AffixFuzzer2Like = AffixFuzzer2
-AffixFuzzer2ArrayLike = Union[
-    AffixFuzzer2,
-    Sequence[AffixFuzzer2Like],
-]
+AffixFuzzer2ArrayLike = AffixFuzzer2 | Sequence[AffixFuzzer2Like]
 
 
 class AffixFuzzer2Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer20.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer20.py
@@ -17,7 +17,7 @@ __all__ = ["AffixFuzzer20", "AffixFuzzer20ArrayLike", "AffixFuzzer20Batch", "Aff
 
 
 def _affix_fuzzer20__p__special_field_converter_override(
-    x: datatypes.PrimitiveComponentLike
+    x: datatypes.PrimitiveComponentLike,
 ) -> datatypes.PrimitiveComponent:
     if isinstance(x, datatypes.PrimitiveComponent):
         return x

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer20.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer20.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -17,7 +17,7 @@ __all__ = ["AffixFuzzer20", "AffixFuzzer20ArrayLike", "AffixFuzzer20Batch", "Aff
 
 
 def _affix_fuzzer20__p__special_field_converter_override(
-    x: datatypes.PrimitiveComponentLike,
+    x: datatypes.PrimitiveComponentLike
 ) -> datatypes.PrimitiveComponent:
     if isinstance(x, datatypes.PrimitiveComponent):
         return x
@@ -45,10 +45,7 @@ class AffixFuzzer20:
 
 
 AffixFuzzer20Like = AffixFuzzer20
-AffixFuzzer20ArrayLike = Union[
-    AffixFuzzer20,
-    Sequence[AffixFuzzer20Like],
-]
+AffixFuzzer20ArrayLike = AffixFuzzer20 | Sequence[AffixFuzzer20Like]
 
 
 class AffixFuzzer20Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer21.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer21.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -32,10 +32,7 @@ class AffixFuzzer21:
 
 
 AffixFuzzer21Like = AffixFuzzer21
-AffixFuzzer21ArrayLike = Union[
-    AffixFuzzer21,
-    Sequence[AffixFuzzer21Like],
-]
+AffixFuzzer21ArrayLike = AffixFuzzer21 | Sequence[AffixFuzzer21Like]
 
 
 class AffixFuzzer21Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Sequence, Union
+from typing import TYPE_CHECKING, Any, Literal, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -37,19 +37,10 @@ class AffixFuzzer3:
 
 
 if TYPE_CHECKING:
-    AffixFuzzer3Like = Union[
-        AffixFuzzer3,
-        float,
-        list[datatypes.AffixFuzzer1],
-        npt.NDArray[np.float32],
-    ]
-    AffixFuzzer3ArrayLike = Union[
-        AffixFuzzer3,
-        float,
-        list[datatypes.AffixFuzzer1],
-        npt.NDArray[np.float32],
-        Sequence[AffixFuzzer3Like],
-    ]
+    AffixFuzzer3Like = AffixFuzzer3 | float | list[datatypes.AffixFuzzer1] | npt.NDArray[np.float32]
+    AffixFuzzer3ArrayLike = (
+        AffixFuzzer3 | float | list[datatypes.AffixFuzzer1] | npt.NDArray[np.float32] | Sequence[AffixFuzzer3Like]
+    )
 else:
     AffixFuzzer3Like = Any
     AffixFuzzer3ArrayLike = Any

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer4.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Sequence, Union
+from typing import TYPE_CHECKING, Any, Literal, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -33,17 +33,10 @@ class AffixFuzzer4:
 
 
 if TYPE_CHECKING:
-    AffixFuzzer4Like = Union[
-        AffixFuzzer4,
-        datatypes.AffixFuzzer3,
-        list[datatypes.AffixFuzzer3],
-    ]
-    AffixFuzzer4ArrayLike = Union[
-        AffixFuzzer4,
-        datatypes.AffixFuzzer3,
-        list[datatypes.AffixFuzzer3],
-        Sequence[AffixFuzzer4Like],
-    ]
+    AffixFuzzer4Like = AffixFuzzer4 | datatypes.AffixFuzzer3 | list[datatypes.AffixFuzzer3]
+    AffixFuzzer4ArrayLike = (
+        AffixFuzzer4 | datatypes.AffixFuzzer3 | list[datatypes.AffixFuzzer3] | Sequence[AffixFuzzer4Like]
+    )
 else:
     AffixFuzzer4Like = Any
     AffixFuzzer4ArrayLike = Any

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer5.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer5.py
@@ -17,7 +17,7 @@ __all__ = ["AffixFuzzer5", "AffixFuzzer5ArrayLike", "AffixFuzzer5Batch", "AffixF
 
 
 def _affix_fuzzer5__single_optional_union__special_field_converter_override(
-    x: datatypes.AffixFuzzer4Like | None
+    x: datatypes.AffixFuzzer4Like | None,
 ) -> datatypes.AffixFuzzer4 | None:
     if x is None:
         return None

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer5.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer5.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -17,7 +17,7 @@ __all__ = ["AffixFuzzer5", "AffixFuzzer5ArrayLike", "AffixFuzzer5Batch", "AffixF
 
 
 def _affix_fuzzer5__single_optional_union__special_field_converter_override(
-    x: datatypes.AffixFuzzer4Like | None,
+    x: datatypes.AffixFuzzer4Like | None
 ) -> datatypes.AffixFuzzer4 | None:
     if x is None:
         return None
@@ -41,10 +41,7 @@ class AffixFuzzer5:
 
 
 AffixFuzzer5Like = AffixFuzzer5
-AffixFuzzer5ArrayLike = Union[
-    AffixFuzzer5,
-    Sequence[AffixFuzzer5Like],
-]
+AffixFuzzer5ArrayLike = AffixFuzzer5 | Sequence[AffixFuzzer5Like]
 
 
 class AffixFuzzer5Type(BaseExtensionType):

--- a/rerun_py/tests/test_types/datatypes/flattened_scalar.py
+++ b/rerun_py/tests/test_types/datatypes/flattened_scalar.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -41,10 +41,7 @@ class FlattenedScalar:
 
 
 FlattenedScalarLike = FlattenedScalar
-FlattenedScalarArrayLike = Union[
-    FlattenedScalar,
-    Sequence[FlattenedScalarLike],
-]
+FlattenedScalarArrayLike = FlattenedScalar | Sequence[FlattenedScalarLike]
 
 
 class FlattenedScalarType(BaseExtensionType):

--- a/rerun_py/tests/test_types/datatypes/primitive_component.py
+++ b/rerun_py/tests/test_types/datatypes/primitive_component.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -41,10 +41,7 @@ class PrimitiveComponent:
 
 
 PrimitiveComponentLike = PrimitiveComponent
-PrimitiveComponentArrayLike = Union[
-    PrimitiveComponent,
-    Sequence[PrimitiveComponentLike],
-]
+PrimitiveComponentArrayLike = PrimitiveComponent | Sequence[PrimitiveComponentLike]
 
 
 class PrimitiveComponentType(BaseExtensionType):

--- a/rerun_py/tests/test_types/datatypes/string_component.py
+++ b/rerun_py/tests/test_types/datatypes/string_component.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import pyarrow as pa
 from attrs import define, field
@@ -35,10 +35,7 @@ class StringComponent:
 
 
 StringComponentLike = StringComponent
-StringComponentArrayLike = Union[
-    StringComponent,
-    Sequence[StringComponentLike],
-]
+StringComponentArrayLike = StringComponent | Sequence[StringComponentLike]
 
 
 class StringComponentType(BaseExtensionType):


### PR DESCRIPTION
### What
This replaces `Union[A, B, C]` with `A | B | C` in our generated Python code.


* cherry-picked from https://github.com/rerun-io/rerun/pull/3839

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3956) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3956)
- [Docs preview](https://rerun.io/preview/7c243da63d8f77fc83ff2303d072683e6e8e2bf4/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7c243da63d8f77fc83ff2303d072683e6e8e2bf4/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)