### PR TITLE
Fix inconsistent comments in code examples

### DIFF
--- a/docs/code-examples/asset3d_simple.cpp
+++ b/docs/code-examples/asset3d_simple.cpp
@@ -1,4 +1,4 @@
-// Log a batch of 3D arrows.
+// Log a a simple 3D asset.
 
 #include <rerun.hpp>
 

--- a/docs/code-examples/bar_chart.cpp
+++ b/docs/code-examples/bar_chart.cpp
@@ -1,4 +1,4 @@
-// Log a batch of 3D arrows.
+// Create and log a bar chart.
 
 #include <rerun.hpp>
 

--- a/docs/code-examples/clear_recursive.cpp
+++ b/docs/code-examples/clear_recursive.cpp
@@ -1,4 +1,4 @@
-// Log a batch of 3D arrows.
+// Log and then clear data recursively.
 
 #include <rerun.hpp>
 

--- a/docs/code-examples/clear_recursive.py
+++ b/docs/code-examples/clear_recursive.py
@@ -1,4 +1,4 @@
-"""Log a batch of 3D arrows."""
+"""Log and then clear data recursively."""
 
 import rerun as rr
 

--- a/docs/code-examples/clear_recursive.rs
+++ b/docs/code-examples/clear_recursive.rs
@@ -1,4 +1,4 @@
-//! Log a batch of 3D arrows.
+//! Log and then clear data recursively.
 
 use rerun::external::glam;
 

--- a/docs/code-examples/clear_simple.cpp
+++ b/docs/code-examples/clear_simple.cpp
@@ -1,4 +1,4 @@
-// Log a batch of 3D arrows.
+// Log and then clear data.
 
 #include <rerun.hpp>
 

--- a/docs/code-examples/clear_simple.py
+++ b/docs/code-examples/clear_simple.py
@@ -1,4 +1,4 @@
-"""Log a batch of 3D arrows."""
+"""Log and then clear data."""
 
 import rerun as rr
 

--- a/docs/code-examples/clear_simple.rs
+++ b/docs/code-examples/clear_simple.rs
@@ -1,4 +1,4 @@
-//! Log a batch of 3D arrows.
+//! Log and then clear data.
 
 use rerun::external::glam;
 

--- a/docs/code-examples/depth_image_3d.cpp
+++ b/docs/code-examples/depth_image_3d.cpp
@@ -1,4 +1,4 @@
-// Create and log a depth image.
+// Create and log a depth image and pinhole camera.
 
 #include <rerun.hpp>
 

--- a/docs/code-examples/disconnected_space.py
+++ b/docs/code-examples/disconnected_space.py
@@ -1,4 +1,4 @@
-"""Log some very simple points."""
+"""Disconnect two spaces."""
 import rerun as rr
 
 rr.init("rerun_example_disconnect_space", spawn=True)

--- a/docs/code-examples/line_segments2d_simple.py
+++ b/docs/code-examples/line_segments2d_simple.py
@@ -1,4 +1,4 @@
-"""Log a simple set of line segments."""
+"""Log a couple 2D line segments using 2D line strips."""
 import numpy as np
 import rerun as rr
 

--- a/docs/code-examples/point2d_random.cpp
+++ b/docs/code-examples/point2d_random.cpp
@@ -1,4 +1,4 @@
-// Log some very simple points.
+// Log some random points with color and radii.
 
 #include <rerun.hpp>
 

--- a/docs/code-examples/scalar_simple.cpp
+++ b/docs/code-examples/scalar_simple.cpp
@@ -1,3 +1,5 @@
+//! Log a scalar over time.
+
 #include <rerun.hpp>
 
 #include <cmath>

--- a/docs/code-examples/scalar_simple.cpp
+++ b/docs/code-examples/scalar_simple.cpp
@@ -1,4 +1,4 @@
-//! Log a scalar over time.
+// Log a scalar over time.
 
 #include <rerun.hpp>
 

--- a/docs/code-examples/transform3d_simple.cpp
+++ b/docs/code-examples/transform3d_simple.cpp
@@ -1,4 +1,4 @@
-// Log some transforms.
+// Log different transforms between three arrows.
 
 #include <rerun.hpp>
 

--- a/docs/code-examples/transform3d_simple.rs
+++ b/docs/code-examples/transform3d_simple.rs
@@ -1,4 +1,4 @@
-//! Log some transforms.
+//! Log different transforms between three arrows.
 
 use std::f32::consts::TAU;
 


### PR DESCRIPTION
### What
Mostly copy-paste errors.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3965) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3965)
- [Docs preview](https://rerun.io/preview/8a9175da0e35702cd337fb543b349ec37a26fd0e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8a9175da0e35702cd337fb543b349ec37a26fd0e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)