### PR TITLE
Allow c++ ComponentBatch to be constructed for Vec of types that can be used to construct the inner component

### DIFF
--- a/docs/code-examples/line_segments2d_simple.cpp
+++ b/docs/code-examples/line_segments2d_simple.cpp
@@ -6,7 +6,7 @@ int main() {
     auto rec = rerun::RecordingStream("rerun_example_line_segments2d");
     rec.connect().throw_on_failure();
 
-    std::vector < std::vector<std::array<float, 2>> points = {
+    std::vector<std::vector<std::array<float, 2>>> points = {
         {{0.f, 0.f}, {2.f, 1.f}},
         {{4.f, -1.f}, {6.f, 0.f}},
     };

--- a/docs/code-examples/line_segments2d_simple.cpp
+++ b/docs/code-examples/line_segments2d_simple.cpp
@@ -6,16 +6,11 @@ int main() {
     auto rec = rerun::RecordingStream("rerun_example_line_segments2d");
     rec.connect().throw_on_failure();
 
-    // TODO(#3202): I want to do this!
-    // std::vector<std::vector<rerun::datatypes::Vec2D>> points = {
-    //     {{0.f, 0.f}, {2.f, 1.f}},
-    //     {{4.f, -1.f}, {6.f, 0.f}},
-    // };
-    // rec.log("segments", rerun::LineStrips2D(points));
-
-    std::vector<rerun::datatypes::Vec2D> points1 = {{0.f, 0.f}, {2.f, 1.f}};
-    std::vector<rerun::datatypes::Vec2D> points2 = {{4.f, -1.f}, {6.f, 0.f}};
-    rec.log("segments", rerun::LineStrips2D({points1, points2}));
+    std::vector < std::vector<std::array<float, 2>> points = {
+        {{0.f, 0.f}, {2.f, 1.f}},
+        {{4.f, -1.f}, {6.f, 0.f}},
+    };
+    rec.log("segments", rerun::LineStrips2D(points));
 
     // Log an extra rect to set the view bounds
     rec.log("bounds", rerun::Boxes2D::from_centers_and_sizes({{3.0f, 0.0f}}, {{8.0f, 6.0f}}));

--- a/docs/code-examples/line_segments3d_simple.cpp
+++ b/docs/code-examples/line_segments3d_simple.cpp
@@ -6,18 +6,12 @@ int main() {
     auto rec = rerun::RecordingStream("rerun_example_line_segments3d");
     rec.connect().throw_on_failure();
 
-    // TODO(#3202): I want to do this!
-    // std::vector<std::vector<rerun::datatypes::Vec3D>> points = {
-    //     {{0.f, 0.f, 0.f}, {0.f, 0.f, 1.f}},
-    //     {{1.f, 0.f, 0.f}, {1.f, 0.f, 1.f}},
-    //     {{1.f, 1.f, 0.f}, {1.f, 1.f, 1.f}},
-    //     {{0.f, 1.f, 0.f}, {0.f, 1.f, 1.f}},
-    // };
-    // rec.log("segments", rerun::LineStrips3D(points));
+    std::vector<std::vector<std::array<float, 3>>> points = {
+        {{0.f, 0.f, 0.f}, {0.f, 0.f, 1.f}},
+        {{1.f, 0.f, 0.f}, {1.f, 0.f, 1.f}},
+        {{1.f, 1.f, 0.f}, {1.f, 1.f, 1.f}},
+        {{0.f, 1.f, 0.f}, {0.f, 1.f, 1.f}},
+    };
 
-    std::vector<rerun::datatypes::Vec3D> points1 = {{0.f, 0.f, 0.f}, {0.f, 0.f, 1.f}};
-    std::vector<rerun::datatypes::Vec3D> points2 = {{1.f, 0.f, 0.f}, {1.f, 0.f, 1.f}};
-    std::vector<rerun::datatypes::Vec3D> points3 = {{1.f, 1.f, 0.f}, {1.f, 1.f, 1.f}};
-    std::vector<rerun::datatypes::Vec3D> points4 = {{0.f, 1.f, 0.f}, {0.f, 1.f, 1.f}};
-    rec.log("segments", rerun::LineStrips3D({points1, points2, points3, points4}));
+    rec.log("segments", rerun::LineStrips3D(points));
 }

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -301,7 +301,7 @@ namespace rerun {
         ComponentBatch<TComponent> operator()(const std::vector<T>& input) {
             std::vector<TComponent> transformed(input.size());
 
-            std::transform(input.begin(), input.end(), transformed.begin(), [](auto datum) {
+            std::transform(input.begin(), input.end(), transformed.begin(), [](const T& datum) {
                 return TComponent(datum);
             });
 
@@ -311,9 +311,12 @@ namespace rerun {
         ComponentBatch<TComponent> operator()(std::vector<T>&& input) {
             std::vector<TComponent> transformed(input.size());
 
-            std::transform(input.begin(), input.end(), transformed.begin(), [](auto datum) {
-                return TComponent(datum);
-            });
+            std::transform(
+                std::make_move_iterator(input.begin()),
+                std::make_move_iterator(input.end()),
+                transformed.begin(),
+                [](T&& datum) { return TComponent(datum); }
+            );
 
             return ComponentBatch<TComponent>::take_ownership(std::move(transformed));
         }

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <utility>
 #include <vector>
@@ -98,6 +99,19 @@ namespace rerun {
         /// Construct using a `ComponentBatchAdapter`.
         template <typename T>
         ComponentBatch(T&& input) : ComponentBatch(TAdapter<T>()(std::forward<T>(input))) {}
+
+        // Construct using a vector
+        template <typename T>
+        ComponentBatch(std::vector<T>& input) : ownership(BatchOwnership::VectorOwned) {
+            new (&storage.vector_owned) std::vector<TComponent>(input.size());
+
+            std::transform(
+                input.begin(),
+                input.end(),
+                storage.vector_owned.begin(),
+                [](auto datum) { return TComponentType(datum); }
+            );
+        }
 
         /// Construct from a temporary list of components.
         ///

--- a/rerun_cpp/src/rerun/components/line_strip2d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d.hpp
@@ -7,6 +7,7 @@
 #include "../datatypes/vec2d.hpp"
 #include "../result.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -37,6 +38,16 @@ namespace rerun {
 
             /// Name of the component, used for serialization.
             static const char NAME[];
+
+          public:
+            // Extensions to generated type defined in 'line_strip2d_ext.cpp'
+
+            template <typename T>
+            LineStrip2D(const std::vector<T>& points_) : points(points_.size()) {
+                std::transform(points_.begin(), points_.end(), points.begin(), [](const T& pt) {
+                    return rerun::datatypes::Vec2D(pt);
+                });
+            }
 
           public:
             LineStrip2D() = default;

--- a/rerun_cpp/src/rerun/components/line_strip2d_ext.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d_ext.cpp
@@ -1,4 +1,4 @@
-#include "line_strip3d.hpp"
+#include "line_strip2d.hpp"
 
 #include <algorithm>
 
@@ -11,9 +11,9 @@ namespace rerun {
         // [CODEGEN COPY TO HEADER START]
 
         template <typename T>
-        LineStrip3D(const std::vector<T>& points_) : points(points_.size()) {
+        LineStrip2D(const std::vector<T>& points_) : points(points_.size()) {
             std::transform(points_.begin(), points_.end(), points.begin(), [](const T& pt) {
-                return rerun::datatypes::Vec3D(pt);
+                return rerun::datatypes::Vec2D(pt);
             });
         }
 

--- a/rerun_cpp/src/rerun/components/line_strip3d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.hpp
@@ -43,8 +43,8 @@ namespace rerun {
             // Extensions to generated type defined in 'line_strip3d_ext.cpp'
 
             template <typename T>
-            LineStrip3D(std::vector<T>& points_) : points(points_.size()) {
-                std::transform(points_.begin(), points_.end(), points.begin(), [](auto pt) {
+            LineStrip3D(const std::vector<T>& points_) : points(points_.size()) {
+                std::transform(points_.begin(), points_.end(), points.begin(), [](const T& pt) {
                     return rerun::datatypes::Vec3D(pt);
                 });
             }

--- a/rerun_cpp/src/rerun/components/line_strip3d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.hpp
@@ -7,6 +7,7 @@
 #include "../datatypes/vec3d.hpp"
 #include "../result.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -37,6 +38,16 @@ namespace rerun {
 
             /// Name of the component, used for serialization.
             static const char NAME[];
+
+          public:
+            // Extensions to generated type defined in 'line_strip3d_ext.cpp'
+
+            template <typename T>
+            LineStrip3D(std::vector<T>& points_) : points(points_.size()) {
+                std::transform(points_.begin(), points_.end(), points.begin(), [](auto pt) {
+                    return rerun::datatypes::Vec3D(pt);
+                });
+            }
 
           public:
             LineStrip3D() = default;

--- a/rerun_cpp/src/rerun/components/line_strip3d_ext.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d_ext.cpp
@@ -1,0 +1,23 @@
+#include "line_strip3d.hpp"
+
+#include <algorithm>
+
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+
+#ifdef EDIT_EXTENSION
+        // [CODEGEN COPY TO HEADER START]
+
+        template <typename T>
+        LineStrip3D(std::vector<T>& points_) : points(points_.size()) {
+            std::transform(points_.begin(), points_.end(), points.begin(), [](auto pt) {
+                return rerun::datatypes::Vec3D(pt);
+            });
+        }
+
+        // [CODEGEN COPY TO HEADER END]
+#endif
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/tests/component_batch.cpp
+++ b/rerun_cpp/tests/component_batch.cpp
@@ -229,4 +229,8 @@ SCENARIO("ComponentBatch move behavior", TEST_TAG) {
             CHECK(borrowed.get_ownership() == rerun::BatchOwnership::Borrowed);
         }
     }
+
+    // Uncomment to check if the error message for missing adapter is sane:
+    //std::vector<std::string> strings = {"a", "b", "c"};
+    //rerun::ComponentBatch<Position2D> batch(strings);
 }


### PR DESCRIPTION
### What

As an alternative (or in addition to) https://github.com/rerun-io/rerun/pull/3967 this introduces a pattern wherein any `ComponentBatch<C>` can be constructed from any `Vec<T>` where we have implemented an extension for constructing `C` from `T`. 

Additionally, this introduces a similar extension for constructing linestrips from vecs of Vec3-like things so that users don't event need to pick up a Vec3 dependency if they don't want to.

These two combine to allow:
```
    std::vector<std::vector<std::array<float, 3>>> points = {
        {{0.f, 0.f, 0.f}, {0.f, 0.f, 1.f}},
        {{1.f, 0.f, 0.f}, {1.f, 0.f, 1.f}},
        {{1.f, 1.f, 0.f}, {1.f, 1.f, 1.f}},
        {{0.f, 1.f, 0.f}, {0.f, 1.f, 1.f}},
    };

    rec.log("segments", rerun::LineStrips3D(points));
```

To do the correct thing.

I think this is important, relative to the variadic / initializer-list approach since it's more likely to match the kind of patterns users will encounter in the real-world, where they want to build a Vec of Vecs without needing to instantiate rerun types directly.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
