### PR TITLE
Improve pre-push git hook

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -5,7 +5,7 @@
 repo_root=$(git rev-parse --show-toplevel)
 pre_push_hook=$repo_root/scripts/pre-push.sh
 if [ -f "$pre_push_hook" ]; then
-    exec $pre_push_hook $@
+    exec $pre_push_hook
 else
     echo "The pre-push hook appears to be missing from: $pre_push_hook -- Skipping."
     exit 0

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -5,7 +5,7 @@
 repo_root=$(git rev-parse --show-toplevel)
 pre_push_hook=$repo_root/scripts/pre-push.sh
 if [ -f "$pre_push_hook" ]; then
-    exec $pre_push_hook
+    exec $pre_push_hook # --skip lint-codegen
 else
     echo "The pre-push hook appears to be missing from: $pre_push_hook -- Skipping."
     exit 0

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -5,7 +5,7 @@
 repo_root=$(git rev-parse --show-toplevel)
 pre_push_hook=$repo_root/scripts/pre-push.sh
 if [ -f "$pre_push_hook" ]; then
-    exec $pre_push_hook "$@"
+    exec $pre_push_hook $@
 else
     echo "The pre-push hook appears to be missing from: $pre_push_hook -- Skipping."
     exit 0

--- a/scripts/fast_lint.py
+++ b/scripts/fast_lint.py
@@ -61,15 +61,16 @@ class LintJob:
 
         cmd_arr = ["pixi", "run", cmd]
 
-        cmd_preview = " ".join(cmd_arr) + " <FILES>" if files else ""
+        cmd_preview = subprocess.list2cmdline(cmd_arr + ["<FILES>"]) if files else subprocess.list2cmdline(cmd_arr)
 
-        proc = subprocess.run(cmd_arr + files, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        full_cmd = cmd_arr + files
+        proc = subprocess.run(full_cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         if proc.returncode == 0:
             logging.info(f"PASS: {cmd} in {time.time() - start:.2f}s")
             logging.debug(f"----------\n{cmd_preview}\n{proc.stdout}\n----------")
         else:
             logging.info(
-                f"FAIL: {cmd} in {time.time() - start:.2f}s \n----------\n{cmd_preview}\n{proc.stdout}\n----------"
+                f"FAIL: {cmd} in {time.time() - start:.2f}s \n----------\n{subprocess.list2cmdline(full_cmd)}\n{proc.stdout}\n----------"
             )
 
         return proc.returncode == 0

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -18,7 +18,7 @@ while read local_ref local_sha remote_ref remote_sha; do
 
     # Check if the pushed branch matches the active branch
     if [ "$branch_name" = "$active_branch" ]; then
-        exec pixi run fast-lint
+        exec pixi run fast-lint $@
     else
         echo "Skipping fast-lint because the pushed branch ($branch_name) does not match the active branch ($active_branch)."
     fi


### PR DESCRIPTION
### What
I made it easier to disable the slowest step in the "fast" lint with `--skip lint-codegen`. Why? Because codegen can be very slow if you haven't compiled in a while:

```
❯ pixi run fast-lint
fast-lint(INFO): SKIP: lint-cpp-files (no modified files)
fast-lint(INFO): SKIP: lint-rerun (no modified files)
fast-lint(INFO): SKIP: lint-rs-files (no modified files)
fast-lint(INFO): SKIP: lint-py-black (no modified files)
fast-lint(INFO): SKIP: lint-py-blackdoc (no modified files)
fast-lint(INFO): SKIP: lint-py-mypy (no modified files)
fast-lint(INFO): SKIP: lint-py-ruff (no modified files)
fast-lint(INFO): SKIP: lint-taplo (no modified files)
fast-lint(INFO): SKIP: lint-typos (no modified files)
fast-lint(INFO): PASS: lint-codegen in 59.72s
fast-lint(INFO): All lints passed in 59.80s
```

Not very fast.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3979) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3979)
- [Docs preview](https://rerun.io/preview/8fd5ceb4f083eeb1e5fe50e3d9c84849b2b55631/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8fd5ceb4f083eeb1e5fe50e3d9c84849b2b55631/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)