### PR TITLE
Remove mention of `rerun_sdk` in Python Quick Start guides

### DIFF
--- a/crates/re_viewer/data/quick_start_guides/how_does_it_work.md
+++ b/crates/re_viewer/data/quick_start_guides/how_does_it_work.md
@@ -4,6 +4,6 @@ Rerun's goal is to make handling and visualizing multimodal data streams easy an
 
 Rerun is made of two main building blocks: the SDK and the Viewer. The data provided by the user code is serialised by the SDK and transferred (via a log file, a TCP socket, a WebSocket, etc.) to the Viewer process for visualization. You can learn more about Rerun's operating modes [here](https://www.rerun.io/docs/reference/sdk-operating-modes).
 
-In the example above, the SDK connects via a TCP socket to the present viewer.
+In the example above, the SDK connects via a TCP socket to the viewer.
 
 The `log()` function logs _entities_ represented by the "entity path" provided as first argument. Entities are a collection of _components_, which hold the actual data such as position, color, or pixel data. _Archetypes_ such as `Points3D` are builder objects which help creating entities with a consistent set of components that are recognized by the Viewer (they can be entirely bypassed when required by advanced use-cases). You can learn more about Rerun's data model [here](https://www.rerun.io/docs/concepts/entity-component).

--- a/crates/re_viewer/data/quick_start_guides/python_connect.md
+++ b/crates/re_viewer/data/quick_start_guides/python_connect.md
@@ -12,26 +12,17 @@ Python package:
 pip install rerun-sdk
 ```
 
-### Try out the viewer
+### Logging your own data
 
-The Rerun SDK comes with a demo that can be used to try the viewer. You can send a demo recording
-to this viewer using the following command:
+Copy and paste the following snippet in a new Python file and execute it to create a new recording in this viewer:
 
-```sh
-python -m rerun_sdk --connect
+```python
+${EXAMPLE_CODE}
 ```
 
 This will open a new recording that looks like this:
 
 ![Demo recording](https://static.rerun.io/quickstart2_simple_cube/632a8f1c79f70a2355fad294fe085291fcf3a8ae/768w.png)
 
-
-### Logging your own data
-
-Instead of a pre-packaged demo, you can log your own data. Copy and paste the following snippet in a new Python file and execute it to create a new recording in this viewer:
-
-```python
-${EXAMPLE_CODE}
-```
 
 ${HOW_DOES_IT_WORK}

--- a/crates/re_viewer/data/quick_start_guides/python_spawn.md
+++ b/crates/re_viewer/data/quick_start_guides/python_spawn.md
@@ -12,25 +12,16 @@ Python package:
 pip install rerun-sdk
 ```
 
-### Try out the viewer
-
-The Rerun SDK comes with a demo that can be used to try the viewer. You can spawn a native viewer and load a demo using the following command:
-
-```sh
-python -m rerun_sdk
-```
-
-This will open a new recording that looks like this:
-
-![Demo recording](https://static.rerun.io/quickstart2_simple_cube/632a8f1c79f70a2355fad294fe085291fcf3a8ae/768w.png)
-
-
 ### Logging your own data
 
-Instead of a pre-packaged demo, you can log your own data. Copy and paste the following snippet in a new Python file and execute it to create a recording in a new viewer:
+Copy and paste the following snippet in a new Python file and execute it to create a recording in a new viewer:
 
 ```python
 ${EXAMPLE_CODE}
 ```
+
+This will spawn a new viewer and open a new recording that looks like this:
+
+![Demo recording](https://static.rerun.io/quickstart2_simple_cube/632a8f1c79f70a2355fad294fe085291fcf3a8ae/768w.png)
 
 ${HOW_DOES_IT_WORK}


### PR DESCRIPTION
### What

* Closes #3955

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
