### PR TITLE
Make RecordingStream calls in C++ no-op if the stream is disabled

### DIFF
--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -124,8 +124,10 @@ impl RecStreams {
 
     fn get(&self, id: CRecordingStream) -> Option<RecordingStream> {
         match id {
-            RERUN_REC_STREAM_CURRENT_RECORDING => RecordingStream::get(StoreKind::Recording, None),
-            RERUN_REC_STREAM_CURRENT_BLUEPRINT => RecordingStream::get(StoreKind::Blueprint, None),
+            RERUN_REC_STREAM_CURRENT_RECORDING => RecordingStream::get(StoreKind::Recording, None)
+                .or(Some(RecordingStream::disabled())),
+            RERUN_REC_STREAM_CURRENT_BLUEPRINT => RecordingStream::get(StoreKind::Blueprint, None)
+                .or(Some(RecordingStream::disabled())),
             _ => self.streams.get(&id).cloned(),
         }
     }

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -237,6 +237,26 @@ pub extern "C" fn rr_recording_stream_set_thread_local(
 
 #[allow(unsafe_code)]
 #[no_mangle]
+pub extern "C" fn rr_recording_stream_is_enabled(
+    stream: CRecordingStream,
+    error: *mut CError,
+) -> bool {
+    match rr_recording_stream_is_enabled_impl(stream) {
+        Ok(enabled) => enabled,
+        Err(err) => {
+            err.write_error(error);
+            false
+        }
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn rr_recording_stream_is_enabled_impl(id: CRecordingStream) -> Result<bool, CError> {
+    Ok(recording_stream(id)?.is_enabled())
+}
+
+#[allow(unsafe_code)]
+#[no_mangle]
 pub extern "C" fn rr_recording_stream_flush_blocking(id: CRecordingStream) {
     if let Some(stream) = RECORDING_STREAMS.lock().remove(id) {
         stream.flush_blocking();

--- a/crates/rerun_c/src/rerun.h
+++ b/crates/rerun_c/src/rerun.h
@@ -184,6 +184,9 @@ extern void rr_recording_stream_set_thread_local(
     rr_recording_stream stream, rr_store_kind store_kind
 );
 
+/// Check whether the recording stream is enabled.
+extern bool rr_recording_stream_is_enabled(rr_recording_stream stream, rr_error* error);
+
 /// Connect to a remote Rerun Viewer on the given ip:port.
 ///
 /// Requires that you first start a Rerun Viewer by typing 'rerun' in a terminal.

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -184,6 +184,9 @@ extern void rr_recording_stream_set_thread_local(
     rr_recording_stream stream, rr_store_kind store_kind
 );
 
+/// Check whether the recording stream is enabled.
+extern bool rr_recording_stream_is_enabled(rr_recording_stream stream, rr_error* error);
+
 /// Connect to a remote Rerun Viewer on the given ip:port.
 ///
 /// Requires that you first start a Rerun Viewer by typing 'rerun' in a terminal.

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -111,12 +111,18 @@ namespace rerun {
     }
 
     void RecordingStream::set_time_sequence(const char* timeline_name, int64_t sequence_nr) {
+        if (!is_enabled()) {
+            return;
+        }
         rr_error status = {};
         rr_recording_stream_set_time_sequence(_id, timeline_name, sequence_nr, &status);
         Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
     }
 
     void RecordingStream::set_time_seconds(const char* timeline_name, double seconds) {
+        if (!is_enabled()) {
+            return;
+        }
         rr_error status = {};
         rr_recording_stream_set_time_seconds(_id, timeline_name, seconds, &status);
         Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
@@ -141,6 +147,9 @@ namespace rerun {
     Error RecordingStream::try_log_serialized_batches(
         const char* entity_path, bool timeless, const std::vector<SerializedComponentBatch>& batches
     ) {
+        if (!is_enabled()) {
+            return Error::ok();
+        }
         size_t num_instances_max = 0;
         for (const auto& batch : batches) {
             num_instances_max = std::max(num_instances_max, batch.num_instances);
@@ -181,6 +190,9 @@ namespace rerun {
         const char* entity_path, size_t num_instances, size_t num_data_cells,
         const DataCell* data_cells, bool inject_time
     ) {
+        if (!is_enabled()) {
+            return Error::ok();
+        }
         // Map to C API:
         std::vector<rr_data_cell> c_data_cells(num_data_cells);
         for (size_t i = 0; i < num_data_cells; i++) {

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -52,9 +52,7 @@ namespace rerun {
         : _id(id), _store_kind(store_kind) {
         rr_error status = {};
         this->_enabled = rr_recording_stream_is_enabled(this->_id, &status);
-        // TODO(jleibs): Should we handle this error? This comes up if this comes up
-        // if we never set a thread-local or global recording stream.
-        //Error(status).handle();
+        Error(status).handle();
     }
 
     RecordingStream::~RecordingStream() {

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -71,6 +71,10 @@ namespace rerun {
             return _store_kind;
         }
 
+        bool is_enabled() const {
+            return _enabled;
+        }
+
         // -----------------------------------------------------------------------------------------
         // Controlling globally available instances of RecordingStream.
 
@@ -188,6 +192,9 @@ namespace rerun {
         /// @see try_log
         template <typename... Ts>
         void log(const char* entity_path, const Ts&... archetypes_or_component_batches) {
+            if (!is_enabled()) {
+                return;
+            }
             try_log_with_timeless(entity_path, false, archetypes_or_component_batches...).handle();
         }
 
@@ -206,6 +213,9 @@ namespace rerun {
         /// @see try_log
         template <typename... Ts>
         void log_timeless(const char* entity_path, const Ts&... archetypes_or_component_batches) {
+            if (!is_enabled()) {
+                return;
+            }
             try_log_with_timeless(entity_path, true, archetypes_or_component_batches...).handle();
         }
 
@@ -220,6 +230,9 @@ namespace rerun {
         /// @see try_log
         template <typename... Ts>
         Error try_log(const char* entity_path, const Ts&... archetypes_or_component_batches) {
+            if (!is_enabled()) {
+                return Error::ok();
+            }
             return try_log_with_timeless(entity_path, false, archetypes_or_component_batches...);
         }
 
@@ -240,6 +253,9 @@ namespace rerun {
         Error try_log_timeless(
             const char* entity_path, const Ts&... archetypes_or_component_batches
         ) {
+            if (!is_enabled()) {
+                return Error::ok();
+            }
             return try_log_with_timeless(entity_path, true, archetypes_or_component_batches...);
         }
 
@@ -256,6 +272,9 @@ namespace rerun {
         Error try_log_with_timeless(
             const char* entity_path, bool timeless, const Ts&... archetypes_or_component_batches
         ) {
+            if (!is_enabled()) {
+                return Error::ok();
+            }
             std::vector<SerializedComponentBatch> serialized_batches;
             Error err;
             (

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -313,9 +313,10 @@ namespace rerun {
         );
 
       private:
-        RecordingStream(uint32_t id, StoreKind store_kind) : _id(id), _store_kind(store_kind) {}
+        RecordingStream(uint32_t id, StoreKind store_kind);
 
         uint32_t _id;
         StoreKind _store_kind;
+        bool _enabled;
     };
 } // namespace rerun

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -112,6 +112,10 @@ SCENARIO("RecordingStream can be set as global and thread local", TEST_TAG) {
                 THEN("it reports the correct kind") {
                     CHECK(stream.kind() == kind);
                 }
+
+                THEN("it is not enabled") {
+                    CHECK(!stream.is_enabled());
+                }
             }
 
             WHEN("creating a new stream") {


### PR DESCRIPTION
### What
Part of:
 - https://github.com/rerun-io/rerun/issues/3754
 
This does not expose any new APIs for explicitly enabling or disabling recordings. Rather, it simply respects what the SDK says to do by retrieving the enabled flag and then using it as appropriate to noop any subsequent calls on this Stream.
 
 To disable logging you continue to use the environment variable which is already read and respected by the underlying rust implementation. e.g. `RERUN=0`
 
### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3993) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3993)
- [Docs preview](https://rerun.io/preview/60dd2fb1bc48ce395bfe4143a01ca4e2ddf8cb5c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/60dd2fb1bc48ce395bfe4143a01ca4e2ddf8cb5c/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)