### PR TITLE
Spawn via `$PATH` 1: Rust implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5655,6 +5655,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "spawn_viewer"
+version = "0.10.0-alpha.7+dev"
+dependencies = [
+ "rerun",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -26,7 +26,7 @@ mod log_integration;
 // -------------
 // Public items:
 
-pub use spawn::{spawn, SpawnOptions};
+pub use spawn::{spawn, SpawnError, SpawnOptions};
 
 pub use self::recording_stream::{
     RecordingStream, RecordingStreamBuilder, RecordingStreamError, RecordingStreamResult,

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -18,12 +18,15 @@
 mod global;
 mod log_sink;
 mod recording_stream;
+mod spawn;
 
 #[cfg(feature = "log")]
 mod log_integration;
 
 // -------------
 // Public items:
+
+pub use spawn::{spawn, SpawnOptions};
 
 pub use self::recording_stream::{
     RecordingStream, RecordingStreamBuilder, RecordingStreamError, RecordingStreamResult,

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1300,6 +1300,7 @@ fn spawn(opts: &crate::SpawnOptions) -> RecordingStreamResult<()> {
 
     let connect_addr = opts.connect_addr();
 
+    // TODO(#4019): application-level handshake
     if TcpStream::connect_timeout(&connect_addr, Duration::from_secs(1)).is_ok() {
         re_log::info!(
             addr = %opts.listen_addr(),

--- a/crates/re_sdk/src/spawn.rs
+++ b/crates/re_sdk/src/spawn.rs
@@ -1,0 +1,166 @@
+/// Options to control the behavior of [`spawn`].
+///
+/// Refer to the field-level documentation for more information about each individual options.
+///
+/// The defaults are ok for most use cases: `SpawnOptions::default()`.
+/// Use the builder pattern to customize them further:
+/// ```no_run
+/// let opts = re_sdk::SpawnOptions::default().with_port(1234u16).with_memory_limit("25%");
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct SpawnOptions {
+    /// The port to listen on.
+    ///
+    /// Defaults to `9876` if unspecified.
+    pub port: Option<u16>,
+
+    /// An upper limit on how much memory the Rerun Viewer should use.
+    /// When this limit is reached, Rerun will drop the oldest data.
+    /// Example: `16GB` or `50%` (of system total).
+    ///
+    /// Defaults to `75%` if unspecified.
+    pub memory_limit: Option<String>,
+
+    /// Specifies the name of the Rerun executable.
+    ///
+    /// You can omit the `.exe` suffix on Windows.
+    ///
+    /// Defaults to `rerun` if unspecified.
+    pub executable_name: Option<String>,
+
+    /// Enforce a specific executable to use instead of searching though PATH
+    /// for [`Self::executable_name`].
+    ///
+    /// Unspecified by default.
+    pub executable_path: Option<String>,
+}
+
+impl SpawnOptions {
+    /// Refer to field-level documentation.
+    pub fn with_port(mut self, port: impl Into<u16>) -> Self {
+        self.port = Some(port.into());
+        self
+    }
+
+    /// Refer to field-level documentation.
+    pub fn with_memory_limit(mut self, memory_limit: impl AsRef<str>) -> Self {
+        self.memory_limit = Some(memory_limit.as_ref().to_owned());
+        self
+    }
+
+    /// Refer to field-level documentation.
+    pub fn with_executable_name(mut self, executable_name: impl AsRef<str>) -> Self {
+        self.executable_name = Some(executable_name.as_ref().to_owned());
+        self
+    }
+
+    /// Refer to field-level documentation.
+    pub fn with_executable_path(mut self, executable_path: impl AsRef<str>) -> Self {
+        self.executable_path = Some(executable_path.as_ref().to_owned());
+        self
+    }
+}
+
+impl SpawnOptions {
+    /// Resolves the final port value.
+    pub fn port(&self) -> u16 {
+        self.port.unwrap_or(9876)
+    }
+
+    /// Resolves the final connect address value.
+    pub fn connect_addr(&self) -> std::net::SocketAddr {
+        std::net::SocketAddr::new("127.0.0.1".parse().unwrap(), self.port())
+    }
+
+    /// Resolves the final listen address value.
+    pub fn listen_addr(&self) -> std::net::SocketAddr {
+        std::net::SocketAddr::new("0.0.0.0".parse().unwrap(), self.port())
+    }
+
+    /// Resolves the final memory limit value.
+    pub fn memory_limit(&self) -> String {
+        self.memory_limit.as_deref().unwrap_or("75%").to_owned()
+    }
+
+    /// Resolves the final executable path.
+    pub fn executable_path(&self) -> String {
+        // NOTE: No need for .exe extension on windows.
+        const RERUN_BINARY: &str = "rerun";
+
+        if let Some(path) = self.executable_path.as_deref() {
+            return path.to_owned();
+        }
+
+        self.executable_name
+            .as_deref()
+            .unwrap_or(RERUN_BINARY)
+            .to_owned()
+    }
+}
+
+/// Spawns a new Rerun Viewer process ready to listen for TCP connections.
+///
+/// Refer to [`SpawnOptions`]'s documentation for configuration options.
+///
+/// This only starts a Viewer process: if you'd like to connect to it and start sending data, refer
+/// to [`crate::RecordingStream::connect`] or use [`crate::RecordingStream::spawn`] directly.
+pub fn spawn(opts: &SpawnOptions) -> std::io::Result<()> {
+    use std::{net::TcpStream, process::Command, time::Duration};
+
+    // NOTE: It's indented on purpose, it just looks better and reads easier.
+    const EXECUTABLE_NOT_FOUND: &str = //
+    "
+    Couldn't find the Rerun Viewer executable in your PATH.
+
+    You can install binary releases of the Rerun Viewer using any of the following methods:
+    * Binary download with `cargo`: `cargo binstall rerun-cli` (see https://github.com/cargo-bins/cargo-binstall)
+    * Build from source with `cargo`: `cargo install rerun-cli` (requires Rust 1.72+)
+    * Direct download from our release assets: https://github.com/rerun-io/rerun/releases/latest/
+    * Or together with the Rerun Python SDK:
+      * Pip: `pip3 install rerun-sdk`
+      * Conda: `conda install -c conda-forge rerun-sdk`
+      * Binary download with `pixi`: `pixi global install rerun-sdk` (see https://prefix.dev/docs/pixi/overview)
+
+    If your platform and/or architecture is not available, you can refer to
+    https://github.com/rerun-io/rerun/blob/main/BUILD.md for instructions on how to build from source.
+
+    Otherwise, feel free to open an issue at https://github.com/rerun-io/rerun/issues if you'd like to
+    request binary releases for your specific platform.
+    ";
+
+    let port = opts.port();
+    let connect_addr = opts.connect_addr();
+    let memory_limit = opts.memory_limit();
+    let executable_path = opts.executable_path();
+
+    if TcpStream::connect_timeout(&connect_addr, Duration::from_millis(1)).is_ok() {
+        re_log::info!(
+            addr = %opts.listen_addr(),
+            "A process is already listening at this address. Assuming it's a Rerun Viewer."
+        );
+        return Ok(());
+    }
+
+    let res = Command::new(executable_path)
+        .arg(format!("--port={port}"))
+        .arg(format!("--memory-limit={memory_limit}"))
+        .arg("--skip-welcome-screen")
+        .spawn();
+
+    let rerun_bin = match res {
+        Ok(rerun_bin) => rerun_bin,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!("{EXECUTABLE_NOT_FOUND}");
+            return Err(err);
+        }
+        Err(err) => {
+            re_log::info!(%err, "Failed to spawn Rerun Viewer");
+            return Err(err);
+        }
+    };
+
+    // Simply forget about the child process, we want it to outlive the parent process if needed.
+    _ = rerun_bin;
+
+    Ok(())
+}

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -38,9 +38,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_segmentation")
-///             .memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_segmentation")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     // create an annotation context to describe the classes
 ///     rec.log_timeless(
@@ -61,7 +60,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         &rerun::SegmentationImage::try_from(data)?,
 ///     )?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -39,7 +39,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_segmentation")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///         .spawn(None)?;
 ///
 ///     // create an annotation context to describe the classes
 ///     rec.log_timeless(

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -39,7 +39,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_segmentation")
-///         .spawn(None)?;
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     // create an annotation context to describe the classes
 ///     rec.log_timeless(

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -30,7 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use std::f32::consts::TAU;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d").spawn(rerun::default_flush_timeout())?;
 ///
 ///     let origins = vec![rerun::Position3D::ZERO; 100];
 ///     let (vectors, colors): (Vec<_>, Vec<_>) = (0..100)

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -30,7 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use std::f32::consts::TAU;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     let origins = vec![rerun::Position3D::ZERO; 100];
 ///     let (vectors, colors): (Vec<_>, Vec<_>) = (0..100)

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -30,7 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use std::f32::consts::TAU;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     let origins = vec![rerun::Position3D::ZERO; 100];
 ///     let (vectors, colors): (Vec<_>, Vec<_>) = (0..100)
@@ -52,7 +53,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///             .with_colors(colors),
 ///     )?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use std::f32::consts::TAU;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d").spawn(None)?;
 ///
 ///     let origins = vec![rerun::Position3D::ZERO; 100];
 ///     let (vectors, colors): (Vec<_>, Vec<_>) = (0..100)

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -37,7 +37,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj]>", args[0]);
 ///     };
 ///
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -37,8 +37,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj]>", args[0]);
 ///     };
 ///
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple").spawn(None)?;
 ///
 ///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -37,7 +37,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj]>", args[0]);
 ///     };
 ///
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple").spawn(rerun::default_flush_timeout())?;
 ///
 ///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -37,13 +37,12 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj]>", args[0]);
 ///     };
 ///
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/bar_chart.rs
+++ b/crates/re_types/src/archetypes/bar_chart.rs
@@ -30,14 +30,14 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple bar chart
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     rec.log(
 ///         "bar_chart",
 ///         &rerun::BarChart::new([8_i64, 4, 0, 9, 1, 4, 1, 6, 9, 0].as_slice()),
 ///     )?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/bar_chart.rs
+++ b/crates/re_types/src/archetypes/bar_chart.rs
@@ -30,7 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple bar chart
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart").spawn(rerun::default_flush_timeout())?;
 ///
 ///     rec.log(
 ///         "bar_chart",

--- a/crates/re_types/src/archetypes/bar_chart.rs
+++ b/crates/re_types/src/archetypes/bar_chart.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple bar chart
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart").spawn(None)?;
 ///
 ///     rec.log(
 ///         "bar_chart",

--- a/crates/re_types/src/archetypes/bar_chart.rs
+++ b/crates/re_types/src/archetypes/bar_chart.rs
@@ -30,7 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple bar chart
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     rec.log(
 ///         "bar_chart",

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -28,7 +28,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple 2D boxes
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     rec.log(
 ///         "simple",

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -28,7 +28,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple 2D boxes
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d").spawn(rerun::default_flush_timeout())?;
 ///
 ///     rec.log(
 ///         "simple",

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -28,7 +28,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple 2D boxes
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_box2d").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     rec.log(
 ///         "simple",
@@ -38,7 +39,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///     // Log an extra rect to set the view bounds
 ///     rec.log("bounds", &rerun::Boxes2D::from_sizes([(4., 3.)]))?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -28,8 +28,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple 2D boxes
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d").spawn(None)?;
 ///
 ///     rec.log(
 ///         "simple",

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -28,8 +28,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Batch of 3D boxes
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").spawn(None)?;
 ///
 ///     rec.log(
 ///         "batch",

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -28,7 +28,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Batch of 3D boxes
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     rec.log(
 ///         "batch",

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -28,7 +28,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Batch of 3D boxes
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").spawn(rerun::default_flush_timeout())?;
 ///
 ///     rec.log(
 ///         "batch",

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -28,8 +28,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Batch of 3D boxes
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     rec.log(
 ///         "batch",
@@ -51,7 +51,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         .with_labels(["red", "green", "blue"]),
 ///     )?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -33,8 +33,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_depth_image").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
 ///     image.slice_mut(s![50..150, 50..150]).fill(20000);
@@ -53,7 +53,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     rec.log("world/camera/depth", &depth_image)?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -33,7 +33,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn(rerun::default_flush_timeout())?;
 ///
 ///     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
 ///     image.slice_mut(s![50..150, 50..150]).fill(20000);

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -33,8 +33,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn(None)?;
 ///
 ///     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
 ///     image.slice_mut(s![50..150, 50..150]).fill(20000);

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -33,7 +33,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
 ///     image.slice_mut(s![50..150, 50..150]).fill(20000);

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -33,7 +33,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Disconnected Space
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     // These two points can be projected into the same space..
 ///     rec.log(

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -33,8 +33,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Disconnected Space
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     // These two points can be projected into the same space..
 ///     rec.log(
@@ -53,7 +53,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         &rerun::Points3D::new([(2.0, 2.0, 2.0)]),
 ///     )?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -33,7 +33,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Disconnected Space
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").spawn(rerun::default_flush_timeout())?;
 ///
 ///     // These two points can be projected into the same space..
 ///     rec.log(

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -33,8 +33,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Disconnected Space
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").spawn(None)?;
 ///
 ///     // These two points can be projected into the same space..
 ///     rec.log(

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -38,7 +38,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     let mut image = Array::<u8, _>::zeros((200, 300, 3).f());
 ///     image.slice_mut(s![.., .., 0]).fill(255);

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -38,8 +38,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_image_simple").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     let mut image = Array::<u8, _>::zeros((200, 300, 3).f());
 ///     image.slice_mut(s![.., .., 0]).fill(255);
@@ -48,7 +48,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     rec.log("image", &rerun::Image::try_from(image)?)?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -38,8 +38,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple").spawn(None)?;
 ///
 ///     let mut image = Array::<u8, _>::zeros((200, 300, 3).f());
 ///     image.slice_mut(s![.., .., 0]).fill(255);

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -38,7 +38,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple").spawn(rerun::default_flush_timeout())?;
 ///
 ///     let mut image = Array::<u8, _>::zeros((200, 300, 3).f());
 ///     image.slice_mut(s![.., .., 0]).fill(255);

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -28,8 +28,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### `line_strip2d_batch`:
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     let strip1 = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
 ///     #[rustfmt::skip]
@@ -48,7 +48,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         &rerun::Boxes2D::from_centers_and_sizes([(3.0, 1.5)], [(8.0, 9.0)]),
 ///     )?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -28,7 +28,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### `line_strip2d_batch`:
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     let strip1 = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
 ///     #[rustfmt::skip]

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -28,8 +28,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### `line_strip2d_batch`:
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn(None)?;
 ///
 ///     let strip1 = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
 ///     #[rustfmt::skip]

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -28,7 +28,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### `line_strip2d_batch`:
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn(rerun::default_flush_timeout())?;
 ///
 ///     let strip1 = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
 ///     #[rustfmt::skip]

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -28,7 +28,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Many strips
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     let strip1 = [[0., 0., 2.], [1., 0., 2.], [1., 1., 2.], [0., 1., 2.]];
 ///     let strip2 = [

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -28,7 +28,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Many strips
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn(rerun::default_flush_timeout())?;
 ///
 ///     let strip1 = [[0., 0., 2.], [1., 0., 2.], [1., 1., 2.], [0., 1., 2.]];
 ///     let strip2 = [

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -28,8 +28,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Many strips
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn(None)?;
 ///
 ///     let strip1 = [[0., 0., 2.], [1., 0., 2.], [1., 1., 2.], [0., 1., 2.]];
 ///     let strip2 = [

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -28,8 +28,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Many strips
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     let strip1 = [[0., 0., 2.], [1., 0., 2.], [1., 1., 2.], [0., 1., 2.]];
 ///     let strip2 = [
@@ -50,7 +50,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///             .with_labels(["one strip here", "and one strip there"]),
 ///     )?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple indexed 3D mesh
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").spawn(None)?;
 ///
 ///     rec.log(
 ///         "triangle",

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -30,8 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple indexed 3D mesh
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     rec.log(
 ///         "triangle",
@@ -42,7 +42,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///             .with_mesh_material(rerun::Material::from_albedo_factor(0xCC00CCFF)),
 ///     )?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -30,7 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple indexed 3D mesh
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").spawn(rerun::default_flush_timeout())?;
 ///
 ///     rec.log(
 ///         "triangle",

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -30,7 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple indexed 3D mesh
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     rec.log(
 ///         "triangle",

--- a/crates/re_types/src/archetypes/pinhole.rs
+++ b/crates/re_types/src/archetypes/pinhole.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").spawn(None)?;
 ///
 ///     let mut image = Array::<u8, _>::default((3, 3, 3).f());
 ///     image.map_inplace(|x| *x = rand::random());

--- a/crates/re_types/src/archetypes/pinhole.rs
+++ b/crates/re_types/src/archetypes/pinhole.rs
@@ -30,7 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     let mut image = Array::<u8, _>::default((3, 3, 3).f());
 ///     image.map_inplace(|x| *x = rand::random());

--- a/crates/re_types/src/archetypes/pinhole.rs
+++ b/crates/re_types/src/archetypes/pinhole.rs
@@ -30,7 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").spawn(rerun::default_flush_timeout())?;
 ///
 ///     let mut image = Array::<u8, _>::default((3, 3, 3).f());
 ///     image.map_inplace(|x| *x = rand::random());

--- a/crates/re_types/src/archetypes/pinhole.rs
+++ b/crates/re_types/src/archetypes/pinhole.rs
@@ -30,7 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     let mut image = Array::<u8, _>::default((3, 3, 3).f());
 ///     image.map_inplace(|x| *x = rand::random());
@@ -41,7 +42,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///     )?;
 ///     rec.log("world/image", &rerun::Image::try_from(image)?)?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use rand::{distributions::Uniform, Rng as _};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn(None)?;
 ///
 ///     let mut rng = rand::thread_rng();
 ///     let dist = Uniform::new(-3., 3.);

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -30,7 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use rand::{distributions::Uniform, Rng as _};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     let mut rng = rand::thread_rng();
 ///     let dist = Uniform::new(-3., 3.);

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -30,7 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use rand::{distributions::Uniform, Rng as _};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn(rerun::default_flush_timeout())?;
 ///
 ///     let mut rng = rand::thread_rng();
 ///     let dist = Uniform::new(-3., 3.);

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -30,7 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use rand::{distributions::Uniform, Rng as _};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_points2d").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     let mut rng = rand::thread_rng();
 ///     let dist = Uniform::new(-3., 3.);
@@ -45,7 +46,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///     // Log an extra rect to set the view bounds
 ///     rec.log("bounds", &rerun::Boxes2D::from_half_sizes([(4., 3.)]))?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -30,7 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use rand::{distributions::Uniform, Rng as _};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").spawn(rerun::default_flush_timeout())?;
 ///
 ///     let mut rng = rand::thread_rng();
 ///     let dist = Uniform::new(-5., 5.);

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use rand::{distributions::Uniform, Rng as _};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").spawn(None)?;
 ///
 ///     let mut rng = rand::thread_rng();
 ///     let dist = Uniform::new(-5., 5.);

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -30,8 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use rand::{distributions::Uniform, Rng as _};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     let mut rng = rand::thread_rng();
 ///     let dist = Uniform::new(-5., 5.);
@@ -45,7 +45,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         .with_radii((0..10).map(|_| rng.gen::<f32>())),
 ///     )?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -30,7 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use rand::{distributions::Uniform, Rng as _};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     let mut rng = rand::thread_rng();
 ///     let dist = Uniform::new(-5., 5.);

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -38,8 +38,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image").spawn(None)?;
 ///
 ///     // create a segmentation image
 ///     let mut image = Array::<u8, _>::zeros((8, 12).f());

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -38,7 +38,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     // create a segmentation image
 ///     let mut image = Array::<u8, _>::zeros((8, 12).f());

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -38,8 +38,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     // create a segmentation image
 ///     let mut image = Array::<u8, _>::zeros((8, 12).f());
@@ -57,7 +57,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     rec.log("image", &rerun::SegmentationImage::try_from(image)?)?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -38,7 +38,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image").spawn(rerun::default_flush_timeout())?;
 ///
 ///     // create a segmentation image
 ///     let mut image = Array::<u8, _>::zeros((8, 12).f());

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -30,7 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
 ///     data.map_inplace(|x| *x = rand::random());

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple").spawn(None)?;
 ///
 ///     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
 ///     data.map_inplace(|x| *x = rand::random());

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -30,7 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple").spawn(rerun::default_flush_timeout())?;
 ///
 ///     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
 ///     data.map_inplace(|x| *x = rand::random());

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -30,8 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
 ///     data.map_inplace(|x| *x = rand::random());
@@ -40,7 +40,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         rerun::Tensor::try_from(data)?.with_dim_names(["batch", "channel", "height", "width"]);
 ///     rec.log("tensor", &tensor)?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -31,7 +31,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec =
-///         rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration").spawn(None)?;
+///         rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration").spawn(rerun::default_flush_timeout())?;
 ///
 ///     // Log a text entry directly:
 ///     rec.log(

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -30,8 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use rerun::external::log;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec =
+///         rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration").spawn(None)?;
 ///
 ///     // Log a text entry directly:
 ///     rec.log(

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -30,8 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use rerun::external::log;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec =
-///         rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     // Log a text entry directly:
 ///     rec.log(

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -30,8 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use rerun::external::log;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     // Log a text entry directly:
 ///     rec.log(
@@ -48,7 +48,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         .init()?;
 ///     log::info!("This INFO log got added through the standard logging interface");
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -48,6 +48,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         .init()?;
 ///     log::info!("This INFO log got added through the standard logging interface");
 ///
+///     log::logger().flush();
+///
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -31,7 +31,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple line plot
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn(rerun::default_flush_timeout())?;
 ///
 ///     for step in 0..64 {
 ///         rec.set_time_sequence("step", step);

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -31,7 +31,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple line plot
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     for step in 0..64 {
 ///         rec.set_time_sequence("step", step);

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -31,8 +31,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple line plot
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn(None)?;
 ///
 ///     for step in 0..64 {
 ///         rec.set_time_sequence("step", step);

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -31,7 +31,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple line plot
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_scalar").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     for step in 0..64 {
 ///         rec.set_time_sequence("step", step);
@@ -41,7 +42,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         )?;
 ///     }
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -30,8 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use std::f32::consts::TAU;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_transform3d").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     let arrow = rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]);
 ///
@@ -54,7 +54,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     rec.log("base/rotated_scaled", &arrow)?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use std::f32::consts::TAU;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d").spawn(None)?;
 ///
 ///     let arrow = rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]);
 ///

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -30,7 +30,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use std::f32::consts::TAU;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     let arrow = rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]);
 ///

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -30,7 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use std::f32::consts::TAU;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d").spawn(rerun::default_flush_timeout())?;
 ///
 ///     let arrow = rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]);
 ///

--- a/crates/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/re_types/src/archetypes/view_coordinates.rs
@@ -35,8 +35,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### View coordinates for adjusting the eye camera
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").spawn(None)?;
 ///
 ///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log(

--- a/crates/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/re_types/src/archetypes/view_coordinates.rs
@@ -35,7 +35,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### View coordinates for adjusting the eye camera
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log(

--- a/crates/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/re_types/src/archetypes/view_coordinates.rs
@@ -35,7 +35,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### View coordinates for adjusting the eye camera
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").spawn(rerun::default_flush_timeout())?;
 ///
 ///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log(

--- a/crates/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/re_types/src/archetypes/view_coordinates.rs
@@ -35,8 +35,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### View coordinates for adjusting the eye camera
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log(
@@ -47,7 +47,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         .with_colors([[255, 0, 0], [0, 255, 0], [0, 0, 255]]),
 ///     )?;
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/crates/re_types_core/src/archetypes/clear.rs
+++ b/crates/re_types_core/src/archetypes/clear.rs
@@ -30,8 +30,7 @@ use crate::{DeserializationError, DeserializationResult};
 /// use rerun::external::glam;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple")
-///         .spawn(&rerun::SpawnOptions::default(), None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple").spawn(None)?;
 ///
 ///     #[rustfmt::skip]
 ///     let (vectors, origins, colors) = (

--- a/crates/re_types_core/src/archetypes/clear.rs
+++ b/crates/re_types_core/src/archetypes/clear.rs
@@ -30,7 +30,8 @@ use crate::{DeserializationError, DeserializationResult};
 /// use rerun::external::glam;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple").spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple")
+///         .spawn(rerun::default_flush_timeout())?;
 ///
 ///     #[rustfmt::skip]
 ///     let (vectors, origins, colors) = (

--- a/crates/re_types_core/src/archetypes/clear.rs
+++ b/crates/re_types_core/src/archetypes/clear.rs
@@ -30,7 +30,7 @@ use crate::{DeserializationError, DeserializationResult};
 /// use rerun::external::glam;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple").spawn(None)?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple").spawn(rerun::default_flush_timeout())?;
 ///
 ///     #[rustfmt::skip]
 ///     let (vectors, origins, colors) = (

--- a/crates/re_types_core/src/archetypes/clear.rs
+++ b/crates/re_types_core/src/archetypes/clear.rs
@@ -30,8 +30,8 @@ use crate::{DeserializationError, DeserializationResult};
 /// use rerun::external::glam;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (rec, storage) =
-///         rerun::RecordingStreamBuilder::new("rerun_example_clear_simple").memory()?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple")
+///         .spawn(&rerun::SpawnOptions::default(), None)?;
 ///
 ///     #[rustfmt::skip]
 ///     let (vectors, origins, colors) = (
@@ -55,7 +55,6 @@ use crate::{DeserializationError, DeserializationResult};
 ///         rec.log(format!("arrows/{i}"), &rerun::Clear::flat())?;
 ///     }
 ///
-///     rerun::native_viewer::show(storage.take())?;
 ///     Ok(())
 /// }
 /// ```

--- a/docs/code-examples/annotation_context_connections.rs
+++ b/docs/code-examples/annotation_context_connections.rs
@@ -1,9 +1,8 @@
 //! Log annotation context with connections between keypoints.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_connections")
-            .memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_connections")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     // Log an annotation context to assign a label and color to each class
     // Create a class description with labels and color for each keypoint ID as well as some
@@ -35,6 +34,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_class_ids([0]),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/annotation_context_connections.rs
+++ b/docs/code-examples/annotation_context_connections.rs
@@ -2,7 +2,7 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_connections")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+        .spawn(None)?;
 
     // Log an annotation context to assign a label and color to each class
     // Create a class description with labels and color for each keypoint ID as well as some

--- a/docs/code-examples/annotation_context_connections.rs
+++ b/docs/code-examples/annotation_context_connections.rs
@@ -2,7 +2,7 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_connections")
-        .spawn(None)?;
+        .spawn(rerun::default_flush_timeout())?;
 
     // Log an annotation context to assign a label and color to each class
     // Create a class description with labels and color for each keypoint ID as well as some

--- a/docs/code-examples/annotation_context_rects.rs
+++ b/docs/code-examples/annotation_context_rects.rs
@@ -2,7 +2,7 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec =
-        rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_rects").spawn(None)?;
+        rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_rects").spawn(rerun::default_flush_timeout())?;
 
     // Log an annotation context to assign a label and color to each class
     rec.log_timeless(

--- a/docs/code-examples/annotation_context_rects.rs
+++ b/docs/code-examples/annotation_context_rects.rs
@@ -1,8 +1,8 @@
 //! Log rectangles with different colors and labels using annotation context
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_rects")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec =
+        rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_rects").spawn(None)?;
 
     // Log an annotation context to assign a label and color to each class
     rec.log_timeless(

--- a/docs/code-examples/annotation_context_rects.rs
+++ b/docs/code-examples/annotation_context_rects.rs
@@ -1,8 +1,8 @@
 //! Log rectangles with different colors and labels using annotation context
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_rects").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_rects")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     // Log an annotation context to assign a label and color to each class
     rec.log_timeless(
@@ -23,6 +23,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log an extra rect to set the view bounds
     rec.log("bounds", &rerun::Boxes2D::from_half_sizes([(2.5, 2.5)]))?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/annotation_context_rects.rs
+++ b/docs/code-examples/annotation_context_rects.rs
@@ -1,8 +1,8 @@
 //! Log rectangles with different colors and labels using annotation context
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec =
-        rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_rects").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_rects")
+        .spawn(rerun::default_flush_timeout())?;
 
     // Log an annotation context to assign a label and color to each class
     rec.log_timeless(

--- a/docs/code-examples/annotation_context_segmentation.rs
+++ b/docs/code-examples/annotation_context_segmentation.rs
@@ -3,9 +3,8 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_segmentation")
-            .memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_segmentation")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     // create an annotation context to describe the classes
     rec.log_timeless(
@@ -26,6 +25,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &rerun::SegmentationImage::try_from(data)?,
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/annotation_context_segmentation.rs
+++ b/docs/code-examples/annotation_context_segmentation.rs
@@ -4,7 +4,7 @@ use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_segmentation")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+        .spawn(None)?;
 
     // create an annotation context to describe the classes
     rec.log_timeless(

--- a/docs/code-examples/annotation_context_segmentation.rs
+++ b/docs/code-examples/annotation_context_segmentation.rs
@@ -4,7 +4,7 @@ use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_segmentation")
-        .spawn(None)?;
+        .spawn(rerun::default_flush_timeout())?;
 
     // create an annotation context to describe the classes
     rec.log_timeless(

--- a/docs/code-examples/arrow3d_simple.rs
+++ b/docs/code-examples/arrow3d_simple.rs
@@ -3,7 +3,7 @@
 use std::f32::consts::TAU;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d").spawn(rerun::default_flush_timeout())?;
 
     let origins = vec![rerun::Position3D::ZERO; 100];
     let (vectors, colors): (Vec<_>, Vec<_>) = (0..100)

--- a/docs/code-examples/arrow3d_simple.rs
+++ b/docs/code-examples/arrow3d_simple.rs
@@ -3,7 +3,8 @@
 use std::f32::consts::TAU;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let origins = vec![rerun::Position3D::ZERO; 100];
     let (vectors, colors): (Vec<_>, Vec<_>) = (0..100)
@@ -25,6 +26,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_colors(colors),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/arrow3d_simple.rs
+++ b/docs/code-examples/arrow3d_simple.rs
@@ -3,7 +3,8 @@
 use std::f32::consts::TAU;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d")
+        .spawn(rerun::default_flush_timeout())?;
 
     let origins = vec![rerun::Position3D::ZERO; 100];
     let (vectors, colors): (Vec<_>, Vec<_>) = (0..100)

--- a/docs/code-examples/arrow3d_simple.rs
+++ b/docs/code-examples/arrow3d_simple.rs
@@ -3,8 +3,7 @@
 use std::f32::consts::TAU;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d").spawn(None)?;
 
     let origins = vec![rerun::Position3D::ZERO; 100];
     let (vectors, colors): (Vec<_>, Vec<_>) = (0..100)

--- a/docs/code-examples/asset3d_out_of_tree.rs
+++ b/docs/code-examples/asset3d_out_of_tree.rs
@@ -11,8 +11,8 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb]>", args[0]);
     };
 
-    let rec =
-        rerun::RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree")
+        .spawn(rerun::default_flush_timeout())?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 

--- a/docs/code-examples/asset3d_out_of_tree.rs
+++ b/docs/code-examples/asset3d_out_of_tree.rs
@@ -11,8 +11,8 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb]>", args[0]);
     };
 
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec =
+        rerun::RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree").spawn(None)?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 

--- a/docs/code-examples/asset3d_out_of_tree.rs
+++ b/docs/code-examples/asset3d_out_of_tree.rs
@@ -11,8 +11,8 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb]>", args[0]);
     };
 
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 
@@ -37,6 +37,5 @@ fn main() -> anyhow::Result<()> {
         )?;
     }
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/asset3d_out_of_tree.rs
+++ b/docs/code-examples/asset3d_out_of_tree.rs
@@ -12,7 +12,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     let rec =
-        rerun::RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree").spawn(None)?;
+        rerun::RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree").spawn(rerun::default_flush_timeout())?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 

--- a/docs/code-examples/asset3d_simple.rs
+++ b/docs/code-examples/asset3d_simple.rs
@@ -8,7 +8,7 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj]>", args[0]);
     };
 
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple").spawn(rerun::default_flush_timeout())?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;

--- a/docs/code-examples/asset3d_simple.rs
+++ b/docs/code-examples/asset3d_simple.rs
@@ -8,8 +8,7 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj]>", args[0]);
     };
 
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple").spawn(None)?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;

--- a/docs/code-examples/asset3d_simple.rs
+++ b/docs/code-examples/asset3d_simple.rs
@@ -8,12 +8,11 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj]>", args[0]);
     };
 
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/asset3d_simple.rs
+++ b/docs/code-examples/asset3d_simple.rs
@@ -8,7 +8,8 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj]>", args[0]);
     };
 
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple")
+        .spawn(rerun::default_flush_timeout())?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;

--- a/docs/code-examples/bar_chart.rs
+++ b/docs/code-examples/bar_chart.rs
@@ -1,7 +1,8 @@
 //! Create and log a bar chart
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart")
+        .spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "bar_chart",

--- a/docs/code-examples/bar_chart.rs
+++ b/docs/code-examples/bar_chart.rs
@@ -1,7 +1,7 @@
 //! Create and log a bar chart
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart").spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "bar_chart",

--- a/docs/code-examples/bar_chart.rs
+++ b/docs/code-examples/bar_chart.rs
@@ -1,8 +1,7 @@
 //! Create and log a bar chart
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart").spawn(None)?;
 
     rec.log(
         "bar_chart",

--- a/docs/code-examples/bar_chart.rs
+++ b/docs/code-examples/bar_chart.rs
@@ -1,13 +1,13 @@
 //! Create and log a bar chart
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     rec.log(
         "bar_chart",
         &rerun::BarChart::new([8_i64, 4, 0, 9, 1, 4, 1, 6, 9, 0].as_slice()),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/box2d_simple.rs
+++ b/docs/code-examples/box2d_simple.rs
@@ -1,7 +1,8 @@
 //! Log some very simple 2D boxes.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_box2d").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     rec.log(
         "simple",
@@ -11,6 +12,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log an extra rect to set the view bounds
     rec.log("bounds", &rerun::Boxes2D::from_sizes([(4., 3.)]))?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/box2d_simple.rs
+++ b/docs/code-examples/box2d_simple.rs
@@ -1,7 +1,8 @@
 //! Log some very simple 2D boxes.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d")
+        .spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "simple",

--- a/docs/code-examples/box2d_simple.rs
+++ b/docs/code-examples/box2d_simple.rs
@@ -1,8 +1,7 @@
 //! Log some very simple 2D boxes.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d").spawn(None)?;
 
     rec.log(
         "simple",

--- a/docs/code-examples/box2d_simple.rs
+++ b/docs/code-examples/box2d_simple.rs
@@ -1,7 +1,7 @@
 //! Log some very simple 2D boxes.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d").spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "simple",

--- a/docs/code-examples/box3d_batch.rs
+++ b/docs/code-examples/box3d_batch.rs
@@ -1,7 +1,7 @@
 //! Log a batch of oriented bounding boxes.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "batch",

--- a/docs/code-examples/box3d_batch.rs
+++ b/docs/code-examples/box3d_batch.rs
@@ -1,8 +1,7 @@
 //! Log a batch of oriented bounding boxes.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").spawn(None)?;
 
     rec.log(
         "batch",

--- a/docs/code-examples/box3d_batch.rs
+++ b/docs/code-examples/box3d_batch.rs
@@ -1,8 +1,8 @@
 //! Log a batch of oriented bounding boxes.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     rec.log(
         "batch",
@@ -24,6 +24,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_labels(["red", "green", "blue"]),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/box3d_batch.rs
+++ b/docs/code-examples/box3d_batch.rs
@@ -1,7 +1,8 @@
 //! Log a batch of oriented bounding boxes.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch")
+        .spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "batch",

--- a/docs/code-examples/box3d_simple.rs
+++ b/docs/code-examples/box3d_simple.rs
@@ -1,7 +1,7 @@
 //! Log a single 3D box.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d").spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "simple",

--- a/docs/code-examples/box3d_simple.rs
+++ b/docs/code-examples/box3d_simple.rs
@@ -1,7 +1,8 @@
 //! Log a single 3D box.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d")
+        .spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "simple",

--- a/docs/code-examples/box3d_simple.rs
+++ b/docs/code-examples/box3d_simple.rs
@@ -1,8 +1,7 @@
 //! Log a single 3D box.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d").spawn(None)?;
 
     rec.log(
         "simple",

--- a/docs/code-examples/box3d_simple.rs
+++ b/docs/code-examples/box3d_simple.rs
@@ -1,13 +1,13 @@
 //! Log a single 3D box.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_box3d").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     rec.log(
         "simple",
         &rerun::Boxes3D::from_half_sizes([(2.0, 2.0, 1.0)]),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/clear_recursive.rs
+++ b/docs/code-examples/clear_recursive.rs
@@ -3,7 +3,7 @@
 use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_recursive").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_recursive").spawn(rerun::default_flush_timeout())?;
 
     #[rustfmt::skip]
     let (vectors, origins, colors) = (

--- a/docs/code-examples/clear_recursive.rs
+++ b/docs/code-examples/clear_recursive.rs
@@ -3,8 +3,8 @@
 use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_clear_recursive").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_recursive")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     #[rustfmt::skip]
     let (vectors, origins, colors) = (
@@ -26,6 +26,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Now clear all of them at once.
     rec.log("arrows", &rerun::Clear::recursive())?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/clear_recursive.rs
+++ b/docs/code-examples/clear_recursive.rs
@@ -3,7 +3,8 @@
 use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_recursive").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_recursive")
+        .spawn(rerun::default_flush_timeout())?;
 
     #[rustfmt::skip]
     let (vectors, origins, colors) = (

--- a/docs/code-examples/clear_recursive.rs
+++ b/docs/code-examples/clear_recursive.rs
@@ -3,8 +3,7 @@
 use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_recursive")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_recursive").spawn(None)?;
 
     #[rustfmt::skip]
     let (vectors, origins, colors) = (

--- a/docs/code-examples/clear_simple.rs
+++ b/docs/code-examples/clear_simple.rs
@@ -3,7 +3,8 @@
 use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple")
+        .spawn(rerun::default_flush_timeout())?;
 
     #[rustfmt::skip]
     let (vectors, origins, colors) = (

--- a/docs/code-examples/clear_simple.rs
+++ b/docs/code-examples/clear_simple.rs
@@ -3,8 +3,8 @@
 use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_clear_simple").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     #[rustfmt::skip]
     let (vectors, origins, colors) = (
@@ -28,6 +28,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rec.log(format!("arrows/{i}"), &rerun::Clear::flat())?;
     }
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/clear_simple.rs
+++ b/docs/code-examples/clear_simple.rs
@@ -3,7 +3,7 @@
 use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple").spawn(rerun::default_flush_timeout())?;
 
     #[rustfmt::skip]
     let (vectors, origins, colors) = (

--- a/docs/code-examples/clear_simple.rs
+++ b/docs/code-examples/clear_simple.rs
@@ -3,8 +3,7 @@
 use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple").spawn(None)?;
 
     #[rustfmt::skip]
     let (vectors, origins, colors) = (

--- a/docs/code-examples/custom_data.rs
+++ b/docs/code-examples/custom_data.rs
@@ -72,8 +72,7 @@ impl rerun::Loggable for Confidence {
 // ---
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_custom_data")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_custom_data").spawn(None)?;
 
     rec.log(
         "left/my_confident_point_cloud",

--- a/docs/code-examples/custom_data.rs
+++ b/docs/code-examples/custom_data.rs
@@ -72,7 +72,7 @@ impl rerun::Loggable for Confidence {
 // ---
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_custom_data").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_custom_data").spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "left/my_confident_point_cloud",

--- a/docs/code-examples/custom_data.rs
+++ b/docs/code-examples/custom_data.rs
@@ -72,8 +72,8 @@ impl rerun::Loggable for Confidence {
 // ---
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_custom_data").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_custom_data")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     rec.log(
         "left/my_confident_point_cloud",
@@ -99,6 +99,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/custom_data.rs
+++ b/docs/code-examples/custom_data.rs
@@ -72,7 +72,8 @@ impl rerun::Loggable for Confidence {
 // ---
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_custom_data").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_custom_data")
+        .spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "left/my_confident_point_cloud",

--- a/docs/code-examples/depth_image_3d.rs
+++ b/docs/code-examples/depth_image_3d.rs
@@ -2,7 +2,8 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image")
+        .spawn(rerun::default_flush_timeout())?;
 
     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
     image.slice_mut(s![50..150, 50..150]).fill(20000);

--- a/docs/code-examples/depth_image_3d.rs
+++ b/docs/code-examples/depth_image_3d.rs
@@ -2,8 +2,7 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn(None)?;
 
     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
     image.slice_mut(s![50..150, 50..150]).fill(20000);

--- a/docs/code-examples/depth_image_3d.rs
+++ b/docs/code-examples/depth_image_3d.rs
@@ -2,8 +2,8 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_depth_image").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
     image.slice_mut(s![50..150, 50..150]).fill(20000);
@@ -22,6 +22,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rec.log("world/camera/depth", &depth_image)?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/depth_image_3d.rs
+++ b/docs/code-examples/depth_image_3d.rs
@@ -2,7 +2,7 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn(rerun::default_flush_timeout())?;
 
     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
     image.slice_mut(s![50..150, 50..150]).fill(20000);

--- a/docs/code-examples/depth_image_simple.rs
+++ b/docs/code-examples/depth_image_simple.rs
@@ -3,8 +3,8 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_depth_image").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
     image.slice_mut(s![50..150, 50..150]).fill(20000);
@@ -14,6 +14,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rec.log("depth", &depth_image)?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/depth_image_simple.rs
+++ b/docs/code-examples/depth_image_simple.rs
@@ -3,7 +3,8 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image")
+        .spawn(rerun::default_flush_timeout())?;
 
     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
     image.slice_mut(s![50..150, 50..150]).fill(20000);

--- a/docs/code-examples/depth_image_simple.rs
+++ b/docs/code-examples/depth_image_simple.rs
@@ -3,8 +3,7 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn(None)?;
 
     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
     image.slice_mut(s![50..150, 50..150]).fill(20000);

--- a/docs/code-examples/depth_image_simple.rs
+++ b/docs/code-examples/depth_image_simple.rs
@@ -3,7 +3,7 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn(rerun::default_flush_timeout())?;
 
     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
     image.slice_mut(s![50..150, 50..150]).fill(20000);

--- a/docs/code-examples/disconnected_space.rs
+++ b/docs/code-examples/disconnected_space.rs
@@ -1,7 +1,8 @@
 //! Disconnect two spaces.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space")
+        .spawn(rerun::default_flush_timeout())?;
 
     // These two points can be projected into the same space..
     rec.log(

--- a/docs/code-examples/disconnected_space.rs
+++ b/docs/code-examples/disconnected_space.rs
@@ -1,8 +1,7 @@
 //! Disconnect two spaces.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").spawn(None)?;
 
     // These two points can be projected into the same space..
     rec.log(

--- a/docs/code-examples/disconnected_space.rs
+++ b/docs/code-examples/disconnected_space.rs
@@ -1,8 +1,8 @@
 //! Disconnect two spaces.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     // These two points can be projected into the same space..
     rec.log(
@@ -21,6 +21,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &rerun::Points3D::new([(2.0, 2.0, 2.0)]),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/disconnected_space.rs
+++ b/docs/code-examples/disconnected_space.rs
@@ -1,7 +1,7 @@
 //! Disconnect two spaces.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").spawn(rerun::default_flush_timeout())?;
 
     // These two points can be projected into the same space..
     rec.log(

--- a/docs/code-examples/image_simple.rs
+++ b/docs/code-examples/image_simple.rs
@@ -3,8 +3,7 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple").spawn(None)?;
 
     let mut image = Array::<u8, _>::zeros((200, 300, 3).f());
     image.slice_mut(s![.., .., 0]).fill(255);

--- a/docs/code-examples/image_simple.rs
+++ b/docs/code-examples/image_simple.rs
@@ -3,7 +3,8 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple")
+        .spawn(rerun::default_flush_timeout())?;
 
     let mut image = Array::<u8, _>::zeros((200, 300, 3).f());
     image.slice_mut(s![.., .., 0]).fill(255);

--- a/docs/code-examples/image_simple.rs
+++ b/docs/code-examples/image_simple.rs
@@ -3,7 +3,7 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple").spawn(rerun::default_flush_timeout())?;
 
     let mut image = Array::<u8, _>::zeros((200, 300, 3).f());
     image.slice_mut(s![.., .., 0]).fill(255);

--- a/docs/code-examples/image_simple.rs
+++ b/docs/code-examples/image_simple.rs
@@ -3,8 +3,8 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_image_simple").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let mut image = Array::<u8, _>::zeros((200, 300, 3).f());
     image.slice_mut(s![.., .., 0]).fill(255);
@@ -13,6 +13,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rec.log("image", &rerun::Image::try_from(image)?)?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/line_segments2d_simple.rs
+++ b/docs/code-examples/line_segments2d_simple.rs
@@ -1,8 +1,8 @@
 //! Log a couple 2D line segments using 2D line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_line_segments2d").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments2d")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let points = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     rec.log("segments", &rerun::LineStrips2D::new(points.chunks(2)))?;
@@ -13,6 +13,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &rerun::Boxes2D::from_centers_and_sizes([(3.0, 0.0)], [(8.0, 6.0)]),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/line_segments2d_simple.rs
+++ b/docs/code-examples/line_segments2d_simple.rs
@@ -1,8 +1,7 @@
 //! Log a couple 2D line segments using 2D line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments2d")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments2d").spawn(None)?;
 
     let points = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     rec.log("segments", &rerun::LineStrips2D::new(points.chunks(2)))?;

--- a/docs/code-examples/line_segments2d_simple.rs
+++ b/docs/code-examples/line_segments2d_simple.rs
@@ -1,7 +1,7 @@
 //! Log a couple 2D line segments using 2D line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments2d").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments2d").spawn(rerun::default_flush_timeout())?;
 
     let points = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     rec.log("segments", &rerun::LineStrips2D::new(points.chunks(2)))?;

--- a/docs/code-examples/line_segments2d_simple.rs
+++ b/docs/code-examples/line_segments2d_simple.rs
@@ -1,7 +1,8 @@
 //! Log a couple 2D line segments using 2D line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments2d").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments2d")
+        .spawn(rerun::default_flush_timeout())?;
 
     let points = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     rec.log("segments", &rerun::LineStrips2D::new(points.chunks(2)))?;

--- a/docs/code-examples/line_segments3d_simple.rs
+++ b/docs/code-examples/line_segments3d_simple.rs
@@ -1,7 +1,8 @@
 //! Log a simple set of line segments.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments3d").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments3d")
+        .spawn(rerun::default_flush_timeout())?;
 
     let points = [
         [0., 0., 0.],

--- a/docs/code-examples/line_segments3d_simple.rs
+++ b/docs/code-examples/line_segments3d_simple.rs
@@ -1,8 +1,8 @@
 //! Log a simple set of line segments.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_line_segments3d").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments3d")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let points = [
         [0., 0., 0.],
@@ -16,6 +16,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
     rec.log("segments", &rerun::LineStrips3D::new(points.chunks(2)))?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/line_segments3d_simple.rs
+++ b/docs/code-examples/line_segments3d_simple.rs
@@ -1,8 +1,7 @@
 //! Log a simple set of line segments.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments3d")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments3d").spawn(None)?;
 
     let points = [
         [0., 0., 0.],

--- a/docs/code-examples/line_segments3d_simple.rs
+++ b/docs/code-examples/line_segments3d_simple.rs
@@ -1,7 +1,7 @@
 //! Log a simple set of line segments.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments3d").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments3d").spawn(rerun::default_flush_timeout())?;
 
     let points = [
         [0., 0., 0.],

--- a/docs/code-examples/line_strip2d_batch.rs
+++ b/docs/code-examples/line_strip2d_batch.rs
@@ -1,7 +1,7 @@
 //! Log a batch of 2d line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn(rerun::default_flush_timeout())?;
 
     let strip1 = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     #[rustfmt::skip]

--- a/docs/code-examples/line_strip2d_batch.rs
+++ b/docs/code-examples/line_strip2d_batch.rs
@@ -1,8 +1,8 @@
 //! Log a batch of 2d line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let strip1 = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     #[rustfmt::skip]
@@ -21,6 +21,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &rerun::Boxes2D::from_centers_and_sizes([(3.0, 1.5)], [(8.0, 9.0)]),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/line_strip2d_batch.rs
+++ b/docs/code-examples/line_strip2d_batch.rs
@@ -1,8 +1,7 @@
 //! Log a batch of 2d line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn(None)?;
 
     let strip1 = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     #[rustfmt::skip]

--- a/docs/code-examples/line_strip2d_batch.rs
+++ b/docs/code-examples/line_strip2d_batch.rs
@@ -1,7 +1,8 @@
 //! Log a batch of 2d line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d")
+        .spawn(rerun::default_flush_timeout())?;
 
     let strip1 = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     #[rustfmt::skip]

--- a/docs/code-examples/line_strip2d_simple.rs
+++ b/docs/code-examples/line_strip2d_simple.rs
@@ -1,7 +1,8 @@
 //! Log a simple line strip.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d")
+        .spawn(rerun::default_flush_timeout())?;
 
     let points = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     rec.log("strip", &rerun::LineStrips2D::new([points]))?;

--- a/docs/code-examples/line_strip2d_simple.rs
+++ b/docs/code-examples/line_strip2d_simple.rs
@@ -1,7 +1,7 @@
 //! Log a simple line strip.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn(rerun::default_flush_timeout())?;
 
     let points = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     rec.log("strip", &rerun::LineStrips2D::new([points]))?;

--- a/docs/code-examples/line_strip2d_simple.rs
+++ b/docs/code-examples/line_strip2d_simple.rs
@@ -1,8 +1,8 @@
 //! Log a simple line strip.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let points = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     rec.log("strip", &rerun::LineStrips2D::new([points]))?;
@@ -13,6 +13,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &rerun::Boxes2D::from_centers_and_sizes([(3., 0.)], [(8., 6.)]),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/line_strip2d_simple.rs
+++ b/docs/code-examples/line_strip2d_simple.rs
@@ -1,8 +1,7 @@
 //! Log a simple line strip.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn(None)?;
 
     let points = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     rec.log("strip", &rerun::LineStrips2D::new([points]))?;

--- a/docs/code-examples/line_strip3d_batch.rs
+++ b/docs/code-examples/line_strip3d_batch.rs
@@ -1,8 +1,8 @@
 //! Log a batch of 2d line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let strip1 = [[0., 0., 2.], [1., 0., 2.], [1., 1., 2.], [0., 1., 2.]];
     let strip2 = [
@@ -23,6 +23,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_labels(["one strip here", "and one strip there"]),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/line_strip3d_batch.rs
+++ b/docs/code-examples/line_strip3d_batch.rs
@@ -1,7 +1,8 @@
 //! Log a batch of 2d line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d")
+        .spawn(rerun::default_flush_timeout())?;
 
     let strip1 = [[0., 0., 2.], [1., 0., 2.], [1., 1., 2.], [0., 1., 2.]];
     let strip2 = [

--- a/docs/code-examples/line_strip3d_batch.rs
+++ b/docs/code-examples/line_strip3d_batch.rs
@@ -1,8 +1,7 @@
 //! Log a batch of 2d line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn(None)?;
 
     let strip1 = [[0., 0., 2.], [1., 0., 2.], [1., 1., 2.], [0., 1., 2.]];
     let strip2 = [

--- a/docs/code-examples/line_strip3d_batch.rs
+++ b/docs/code-examples/line_strip3d_batch.rs
@@ -1,7 +1,7 @@
 //! Log a batch of 2d line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn(rerun::default_flush_timeout())?;
 
     let strip1 = [[0., 0., 2.], [1., 0., 2.], [1., 1., 2.], [0., 1., 2.]];
     let strip2 = [

--- a/docs/code-examples/line_strip3d_simple.rs
+++ b/docs/code-examples/line_strip3d_simple.rs
@@ -1,7 +1,7 @@
 //! Log a simple line strip.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn(rerun::default_flush_timeout())?;
 
     let points = [
         [0., 0., 0.],

--- a/docs/code-examples/line_strip3d_simple.rs
+++ b/docs/code-examples/line_strip3d_simple.rs
@@ -1,7 +1,8 @@
 //! Log a simple line strip.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d")
+        .spawn(rerun::default_flush_timeout())?;
 
     let points = [
         [0., 0., 0.],

--- a/docs/code-examples/line_strip3d_simple.rs
+++ b/docs/code-examples/line_strip3d_simple.rs
@@ -1,8 +1,8 @@
 //! Log a simple line strip.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let points = [
         [0., 0., 0.],
@@ -16,6 +16,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
     rec.log("strip", &rerun::LineStrips3D::new([points]))?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/line_strip3d_simple.rs
+++ b/docs/code-examples/line_strip3d_simple.rs
@@ -1,8 +1,7 @@
 //! Log a simple line strip.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn(None)?;
 
     let points = [
         [0., 0., 0.],

--- a/docs/code-examples/manual_indicator.rs
+++ b/docs/code-examples/manual_indicator.rs
@@ -3,8 +3,8 @@
 use rerun::Archetype as _;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_manual_indicator").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_manual_indicator")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     // Specify both a Mesh3D and a Points3D indicator component so that the data is shown as both a
     // 3D mesh _and_ a point cloud by default.
@@ -21,6 +21,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ],
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/manual_indicator.rs
+++ b/docs/code-examples/manual_indicator.rs
@@ -3,7 +3,7 @@
 use rerun::Archetype as _;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_manual_indicator").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_manual_indicator").spawn(rerun::default_flush_timeout())?;
 
     // Specify both a Mesh3D and a Points3D indicator component so that the data is shown as both a
     // 3D mesh _and_ a point cloud by default.

--- a/docs/code-examples/manual_indicator.rs
+++ b/docs/code-examples/manual_indicator.rs
@@ -3,7 +3,8 @@
 use rerun::Archetype as _;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_manual_indicator").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_manual_indicator")
+        .spawn(rerun::default_flush_timeout())?;
 
     // Specify both a Mesh3D and a Points3D indicator component so that the data is shown as both a
     // 3D mesh _and_ a point cloud by default.

--- a/docs/code-examples/manual_indicator.rs
+++ b/docs/code-examples/manual_indicator.rs
@@ -3,8 +3,7 @@
 use rerun::Archetype as _;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_manual_indicator")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_manual_indicator").spawn(None)?;
 
     // Specify both a Mesh3D and a Points3D indicator component so that the data is shown as both a
     // 3D mesh _and_ a point cloud by default.

--- a/docs/code-examples/mesh3d_indexed.rs
+++ b/docs/code-examples/mesh3d_indexed.rs
@@ -1,8 +1,7 @@
 //! Log a simple colored triangle with indexed drawing.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").spawn(None)?;
 
     rec.log(
         "triangle",

--- a/docs/code-examples/mesh3d_indexed.rs
+++ b/docs/code-examples/mesh3d_indexed.rs
@@ -1,8 +1,8 @@
 //! Log a simple colored triangle with indexed drawing.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     rec.log(
         "triangle",
@@ -13,6 +13,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_mesh_material(rerun::Material::from_albedo_factor(0xCC00CCFF)),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/mesh3d_indexed.rs
+++ b/docs/code-examples/mesh3d_indexed.rs
@@ -1,7 +1,7 @@
 //! Log a simple colored triangle with indexed drawing.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "triangle",

--- a/docs/code-examples/mesh3d_indexed.rs
+++ b/docs/code-examples/mesh3d_indexed.rs
@@ -1,7 +1,8 @@
 //! Log a simple colored triangle with indexed drawing.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed")
+        .spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "triangle",

--- a/docs/code-examples/mesh3d_partial_updates.rs
+++ b/docs/code-examples/mesh3d_partial_updates.rs
@@ -4,7 +4,7 @@ use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec =
-        rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_partial_updates").spawn(None)?;
+        rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_partial_updates").spawn(rerun::default_flush_timeout())?;
 
     let vertex_positions = [[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
 

--- a/docs/code-examples/mesh3d_partial_updates.rs
+++ b/docs/code-examples/mesh3d_partial_updates.rs
@@ -3,8 +3,8 @@
 use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_partial_updates").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_partial_updates")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let vertex_positions = [[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
 
@@ -30,6 +30,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rec.log_component_batches("triangle", false, [&vertex_positions as _])?;
     }
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/mesh3d_partial_updates.rs
+++ b/docs/code-examples/mesh3d_partial_updates.rs
@@ -3,8 +3,8 @@
 use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec =
-        rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_partial_updates").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_partial_updates")
+        .spawn(rerun::default_flush_timeout())?;
 
     let vertex_positions = [[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
 

--- a/docs/code-examples/mesh3d_partial_updates.rs
+++ b/docs/code-examples/mesh3d_partial_updates.rs
@@ -3,8 +3,8 @@
 use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_partial_updates")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec =
+        rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_partial_updates").spawn(None)?;
 
     let vertex_positions = [[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
 

--- a/docs/code-examples/mesh3d_simple.rs
+++ b/docs/code-examples/mesh3d_simple.rs
@@ -1,8 +1,7 @@
 //! Log a simple colored triangle.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_simple")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_simple").spawn(None)?;
 
     rec.log(
         "triangle",

--- a/docs/code-examples/mesh3d_simple.rs
+++ b/docs/code-examples/mesh3d_simple.rs
@@ -1,7 +1,8 @@
 //! Log a simple colored triangle.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_simple").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_simple")
+        .spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "triangle",

--- a/docs/code-examples/mesh3d_simple.rs
+++ b/docs/code-examples/mesh3d_simple.rs
@@ -1,7 +1,7 @@
 //! Log a simple colored triangle.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_simple").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_simple").spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "triangle",

--- a/docs/code-examples/mesh3d_simple.rs
+++ b/docs/code-examples/mesh3d_simple.rs
@@ -1,8 +1,8 @@
 //! Log a simple colored triangle.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_simple").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_simple")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     rec.log(
         "triangle",
@@ -11,6 +11,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_vertex_colors([0xFF0000FF, 0x00FF00FF, 0x0000FFFF]),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/pinhole_simple.rs
+++ b/docs/code-examples/pinhole_simple.rs
@@ -3,7 +3,8 @@
 use ndarray::{Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole")
+        .spawn(rerun::default_flush_timeout())?;
 
     let mut image = Array::<u8, _>::default((3, 3, 3).f());
     image.map_inplace(|x| *x = rand::random());

--- a/docs/code-examples/pinhole_simple.rs
+++ b/docs/code-examples/pinhole_simple.rs
@@ -3,7 +3,8 @@
 use ndarray::{Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let mut image = Array::<u8, _>::default((3, 3, 3).f());
     image.map_inplace(|x| *x = rand::random());
@@ -14,6 +15,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
     rec.log("world/image", &rerun::Image::try_from(image)?)?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/pinhole_simple.rs
+++ b/docs/code-examples/pinhole_simple.rs
@@ -3,7 +3,7 @@
 use ndarray::{Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").spawn(rerun::default_flush_timeout())?;
 
     let mut image = Array::<u8, _>::default((3, 3, 3).f());
     image.map_inplace(|x| *x = rand::random());

--- a/docs/code-examples/pinhole_simple.rs
+++ b/docs/code-examples/pinhole_simple.rs
@@ -3,8 +3,7 @@
 use ndarray::{Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").spawn(None)?;
 
     let mut image = Array::<u8, _>::default((3, 3, 3).f());
     image.map_inplace(|x| *x = rand::random());

--- a/docs/code-examples/point2d_random.rs
+++ b/docs/code-examples/point2d_random.rs
@@ -3,7 +3,7 @@
 use rand::{distributions::Uniform, Rng as _};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn(rerun::default_flush_timeout())?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-3., 3.);

--- a/docs/code-examples/point2d_random.rs
+++ b/docs/code-examples/point2d_random.rs
@@ -3,7 +3,8 @@
 use rand::{distributions::Uniform, Rng as _};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d")
+        .spawn(rerun::default_flush_timeout())?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-3., 3.);

--- a/docs/code-examples/point2d_random.rs
+++ b/docs/code-examples/point2d_random.rs
@@ -3,8 +3,7 @@
 use rand::{distributions::Uniform, Rng as _};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn(None)?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-3., 3.);

--- a/docs/code-examples/point2d_random.rs
+++ b/docs/code-examples/point2d_random.rs
@@ -3,7 +3,8 @@
 use rand::{distributions::Uniform, Rng as _};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_points2d").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-3., 3.);
@@ -18,6 +19,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log an extra rect to set the view bounds
     rec.log("bounds", &rerun::Boxes2D::from_half_sizes([(4., 3.)]))?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/point2d_simple.rs
+++ b/docs/code-examples/point2d_simple.rs
@@ -1,7 +1,7 @@
 //! Log some very simple points.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn(rerun::default_flush_timeout())?;
 
     rec.log("points", &rerun::Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?;
 

--- a/docs/code-examples/point2d_simple.rs
+++ b/docs/code-examples/point2d_simple.rs
@@ -1,13 +1,13 @@
 //! Log some very simple points.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_points2d").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     rec.log("points", &rerun::Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?;
 
     // Log an extra rect to set the view bounds
     rec.log("bounds", &rerun::Boxes2D::from_half_sizes([(2.0, 1.5)]))?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/point2d_simple.rs
+++ b/docs/code-examples/point2d_simple.rs
@@ -1,7 +1,8 @@
 //! Log some very simple points.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d")
+        .spawn(rerun::default_flush_timeout())?;
 
     rec.log("points", &rerun::Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?;
 

--- a/docs/code-examples/point2d_simple.rs
+++ b/docs/code-examples/point2d_simple.rs
@@ -1,8 +1,7 @@
 //! Log some very simple points.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn(None)?;
 
     rec.log("points", &rerun::Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?;
 

--- a/docs/code-examples/point3d_random.rs
+++ b/docs/code-examples/point3d_random.rs
@@ -3,7 +3,8 @@
 use rand::{distributions::Uniform, Rng as _};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random")
+        .spawn(rerun::default_flush_timeout())?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-5., 5.);

--- a/docs/code-examples/point3d_random.rs
+++ b/docs/code-examples/point3d_random.rs
@@ -3,8 +3,8 @@
 use rand::{distributions::Uniform, Rng as _};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-5., 5.);
@@ -18,6 +18,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_radii((0..10).map(|_| rng.gen::<f32>())),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/point3d_random.rs
+++ b/docs/code-examples/point3d_random.rs
@@ -3,7 +3,7 @@
 use rand::{distributions::Uniform, Rng as _};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").spawn(rerun::default_flush_timeout())?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-5., 5.);

--- a/docs/code-examples/point3d_random.rs
+++ b/docs/code-examples/point3d_random.rs
@@ -3,8 +3,7 @@
 use rand::{distributions::Uniform, Rng as _};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").spawn(None)?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-5., 5.);

--- a/docs/code-examples/point3d_simple.rs
+++ b/docs/code-examples/point3d_simple.rs
@@ -1,14 +1,13 @@
 //! Log some very simple points.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_points3d_simple").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_simple")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     rec.log(
         "points",
         &rerun::Points3D::new([(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/point3d_simple.rs
+++ b/docs/code-examples/point3d_simple.rs
@@ -1,7 +1,7 @@
 //! Log some very simple points.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_simple").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_simple").spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "points",

--- a/docs/code-examples/point3d_simple.rs
+++ b/docs/code-examples/point3d_simple.rs
@@ -1,7 +1,8 @@
 //! Log some very simple points.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_simple").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_simple")
+        .spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "points",

--- a/docs/code-examples/point3d_simple.rs
+++ b/docs/code-examples/point3d_simple.rs
@@ -1,8 +1,7 @@
 //! Log some very simple points.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_simple")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_simple").spawn(None)?;
 
     rec.log(
         "points",

--- a/docs/code-examples/quick_start_spawn.rs
+++ b/docs/code-examples/quick_start_spawn.rs
@@ -4,7 +4,7 @@ use rerun::{demo_util::grid, external::glam};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new `RecordingStream` which stores data in memory.
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal_rs").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal_rs").spawn(rerun::default_flush_timeout())?;
 
     // Create some data using the `grid` utility function.
     let points = grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10);

--- a/docs/code-examples/quick_start_spawn.rs
+++ b/docs/code-examples/quick_start_spawn.rs
@@ -4,7 +4,8 @@ use rerun::{demo_util::grid, external::glam};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new `RecordingStream` which stores data in memory.
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal_rs").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal_rs")
+        .spawn(rerun::default_flush_timeout())?;
 
     // Create some data using the `grid` utility function.
     let points = grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10);

--- a/docs/code-examples/quick_start_spawn.rs
+++ b/docs/code-examples/quick_start_spawn.rs
@@ -4,7 +4,8 @@ use rerun::{demo_util::grid, external::glam};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new `RecordingStream` which stores data in memory.
-    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_minimal_rs").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal_rs")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     // Create some data using the `grid` utility function.
     let points = grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10);
@@ -20,7 +21,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // Show the viewer with the recorded data.
-    rerun::native_viewer::show(storage.take())?;
 
     Ok(())
 }

--- a/docs/code-examples/quick_start_spawn.rs
+++ b/docs/code-examples/quick_start_spawn.rs
@@ -4,8 +4,7 @@ use rerun::{demo_util::grid, external::glam};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new `RecordingStream` which stores data in memory.
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal_rs")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal_rs").spawn(None)?;
 
     // Create some data using the `grid` utility function.
     let points = grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10);

--- a/docs/code-examples/scalar_multiple_plots.rs
+++ b/docs/code-examples/scalar_multiple_plots.rs
@@ -1,8 +1,8 @@
 //! Log a scalar over time.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
     let mut lcg_state = 0_i64;
 
     for t in 0..((std::f32::consts::TAU * 2.0 * 100.0) as i64) {
@@ -33,6 +33,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )?;
     }
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/scalar_multiple_plots.rs
+++ b/docs/code-examples/scalar_multiple_plots.rs
@@ -1,8 +1,8 @@
 //! Log a scalar over time.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec =
-        rerun::RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots")
+        .spawn(rerun::default_flush_timeout())?;
     let mut lcg_state = 0_i64;
 
     for t in 0..((std::f32::consts::TAU * 2.0 * 100.0) as i64) {

--- a/docs/code-examples/scalar_multiple_plots.rs
+++ b/docs/code-examples/scalar_multiple_plots.rs
@@ -2,7 +2,7 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec =
-        rerun::RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots").spawn(None)?;
+        rerun::RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots").spawn(rerun::default_flush_timeout())?;
     let mut lcg_state = 0_i64;
 
     for t in 0..((std::f32::consts::TAU * 2.0 * 100.0) as i64) {

--- a/docs/code-examples/scalar_multiple_plots.rs
+++ b/docs/code-examples/scalar_multiple_plots.rs
@@ -1,8 +1,8 @@
 //! Log a scalar over time.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec =
+        rerun::RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots").spawn(None)?;
     let mut lcg_state = 0_i64;
 
     for t in 0..((std::f32::consts::TAU * 2.0 * 100.0) as i64) {

--- a/docs/code-examples/scalar_simple.rs
+++ b/docs/code-examples/scalar_simple.rs
@@ -1,8 +1,7 @@
 //! Log a scalar over time.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn(None)?;
 
     for step in 0..64 {
         rec.set_time_sequence("step", step);

--- a/docs/code-examples/scalar_simple.rs
+++ b/docs/code-examples/scalar_simple.rs
@@ -1,7 +1,7 @@
 //! Log a scalar over time.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn(rerun::default_flush_timeout())?;
 
     for step in 0..64 {
         rec.set_time_sequence("step", step);

--- a/docs/code-examples/scalar_simple.rs
+++ b/docs/code-examples/scalar_simple.rs
@@ -1,7 +1,8 @@
 //! Log a scalar over time.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar")
+        .spawn(rerun::default_flush_timeout())?;
 
     for step in 0..64 {
         rec.set_time_sequence("step", step);

--- a/docs/code-examples/scalar_simple.rs
+++ b/docs/code-examples/scalar_simple.rs
@@ -1,7 +1,8 @@
 //! Log a scalar over time.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_scalar").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     for step in 0..64 {
         rec.set_time_sequence("step", step);
@@ -11,6 +12,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )?;
     }
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/segmentation_image_simple.rs
+++ b/docs/code-examples/segmentation_image_simple.rs
@@ -3,7 +3,8 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image")
+        .spawn(rerun::default_flush_timeout())?;
 
     // create a segmentation image
     let mut image = Array::<u8, _>::zeros((8, 12).f());

--- a/docs/code-examples/segmentation_image_simple.rs
+++ b/docs/code-examples/segmentation_image_simple.rs
@@ -3,8 +3,8 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     // create a segmentation image
     let mut image = Array::<u8, _>::zeros((8, 12).f());
@@ -22,6 +22,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rec.log("image", &rerun::SegmentationImage::try_from(image)?)?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/segmentation_image_simple.rs
+++ b/docs/code-examples/segmentation_image_simple.rs
@@ -3,8 +3,7 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image").spawn(None)?;
 
     // create a segmentation image
     let mut image = Array::<u8, _>::zeros((8, 12).f());

--- a/docs/code-examples/segmentation_image_simple.rs
+++ b/docs/code-examples/segmentation_image_simple.rs
@@ -3,7 +3,7 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image").spawn(rerun::default_flush_timeout())?;
 
     // create a segmentation image
     let mut image = Array::<u8, _>::zeros((8, 12).f());

--- a/docs/code-examples/tensor_simple.rs
+++ b/docs/code-examples/tensor_simple.rs
@@ -3,7 +3,7 @@
 use ndarray::{Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple").spawn(rerun::default_flush_timeout())?;
 
     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
     data.map_inplace(|x| *x = rand::random());

--- a/docs/code-examples/tensor_simple.rs
+++ b/docs/code-examples/tensor_simple.rs
@@ -3,8 +3,7 @@
 use ndarray::{Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple").spawn(None)?;
 
     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
     data.map_inplace(|x| *x = rand::random());

--- a/docs/code-examples/tensor_simple.rs
+++ b/docs/code-examples/tensor_simple.rs
@@ -3,7 +3,8 @@
 use ndarray::{Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple")
+        .spawn(rerun::default_flush_timeout())?;
 
     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
     data.map_inplace(|x| *x = rand::random());

--- a/docs/code-examples/tensor_simple.rs
+++ b/docs/code-examples/tensor_simple.rs
@@ -3,8 +3,8 @@
 use ndarray::{Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
     data.map_inplace(|x| *x = rand::random());
@@ -13,6 +13,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rerun::Tensor::try_from(data)?.with_dim_names(["batch", "channel", "height", "width"]);
     rec.log("tensor", &tensor)?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/text_document.rs
+++ b/docs/code-examples/text_document.rs
@@ -1,8 +1,8 @@
 //! Log a `TextDocument`
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_text_document").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     rec.log(
         "text_document",
@@ -58,6 +58,5 @@ Of course you can also have [normal https links](https://github.com/rerun-io/rer
         .with_media_type(rerun::MediaType::markdown()),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/text_document.rs
+++ b/docs/code-examples/text_document.rs
@@ -1,7 +1,7 @@
 //! Log a `TextDocument`
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document").spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "text_document",

--- a/docs/code-examples/text_document.rs
+++ b/docs/code-examples/text_document.rs
@@ -1,7 +1,8 @@
 //! Log a `TextDocument`
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document")
+        .spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "text_document",

--- a/docs/code-examples/text_document.rs
+++ b/docs/code-examples/text_document.rs
@@ -1,8 +1,7 @@
 //! Log a `TextDocument`
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document").spawn(None)?;
 
     rec.log(
         "text_document",

--- a/docs/code-examples/text_log.rs
+++ b/docs/code-examples/text_log.rs
@@ -1,13 +1,13 @@
 //! Log a `TextLog`
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_text_log").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     rec.log(
         "log",
         &rerun::TextLog::new("Application started.").with_level("INFO"),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/text_log.rs
+++ b/docs/code-examples/text_log.rs
@@ -1,7 +1,8 @@
 //! Log a `TextLog`
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log")
+        .spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "log",

--- a/docs/code-examples/text_log.rs
+++ b/docs/code-examples/text_log.rs
@@ -1,7 +1,7 @@
 //! Log a `TextLog`
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log").spawn(rerun::default_flush_timeout())?;
 
     rec.log(
         "log",

--- a/docs/code-examples/text_log.rs
+++ b/docs/code-examples/text_log.rs
@@ -1,8 +1,7 @@
 //! Log a `TextLog`
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log").spawn(None)?;
 
     rec.log(
         "log",

--- a/docs/code-examples/text_log_integration.rs
+++ b/docs/code-examples/text_log_integration.rs
@@ -3,8 +3,8 @@
 use rerun::external::log;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec =
-        rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration")
+        .spawn(rerun::default_flush_timeout())?;
 
     // Log a text entry directly:
     rec.log(

--- a/docs/code-examples/text_log_integration.rs
+++ b/docs/code-examples/text_log_integration.rs
@@ -3,8 +3,8 @@
 use rerun::external::log;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec =
+        rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration").spawn(None)?;
 
     // Log a text entry directly:
     rec.log(

--- a/docs/code-examples/text_log_integration.rs
+++ b/docs/code-examples/text_log_integration.rs
@@ -21,5 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .init()?;
     log::info!("This INFO log got added through the standard logging interface");
 
+    log::logger().flush();
+
     Ok(())
 }

--- a/docs/code-examples/text_log_integration.rs
+++ b/docs/code-examples/text_log_integration.rs
@@ -3,8 +3,8 @@
 use rerun::external::log;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     // Log a text entry directly:
     rec.log(
@@ -21,6 +21,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .init()?;
     log::info!("This INFO log got added through the standard logging interface");
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/text_log_integration.rs
+++ b/docs/code-examples/text_log_integration.rs
@@ -4,7 +4,7 @@ use rerun::external::log;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec =
-        rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration").spawn(None)?;
+        rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration").spawn(rerun::default_flush_timeout())?;
 
     // Log a text entry directly:
     rec.log(

--- a/docs/code-examples/transform3d_simple.rs
+++ b/docs/code-examples/transform3d_simple.rs
@@ -3,7 +3,8 @@
 use std::f32::consts::TAU;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d")
+        .spawn(rerun::default_flush_timeout())?;
 
     let arrow = rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]);
 

--- a/docs/code-examples/transform3d_simple.rs
+++ b/docs/code-examples/transform3d_simple.rs
@@ -3,7 +3,7 @@
 use std::f32::consts::TAU;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d").spawn(rerun::default_flush_timeout())?;
 
     let arrow = rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]);
 

--- a/docs/code-examples/transform3d_simple.rs
+++ b/docs/code-examples/transform3d_simple.rs
@@ -3,8 +3,8 @@
 use std::f32::consts::TAU;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_transform3d").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     let arrow = rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]);
 
@@ -27,6 +27,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rec.log("base/rotated_scaled", &arrow)?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/docs/code-examples/transform3d_simple.rs
+++ b/docs/code-examples/transform3d_simple.rs
@@ -3,8 +3,7 @@
 use std::f32::consts::TAU;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d").spawn(None)?;
 
     let arrow = rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]);
 

--- a/docs/code-examples/view_coordinates_simple.rs
+++ b/docs/code-examples/view_coordinates_simple.rs
@@ -1,7 +1,8 @@
 //! Change the view coordinates for the scene.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates")
+        .spawn(rerun::default_flush_timeout())?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log(

--- a/docs/code-examples/view_coordinates_simple.rs
+++ b/docs/code-examples/view_coordinates_simple.rs
@@ -1,8 +1,7 @@
 //! Change the view coordinates for the scene.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").spawn(None)?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log(

--- a/docs/code-examples/view_coordinates_simple.rs
+++ b/docs/code-examples/view_coordinates_simple.rs
@@ -1,7 +1,7 @@
 //! Change the view coordinates for the scene.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").spawn(rerun::default_flush_timeout())?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log(

--- a/docs/code-examples/view_coordinates_simple.rs
+++ b/docs/code-examples/view_coordinates_simple.rs
@@ -1,8 +1,8 @@
 //! Change the view coordinates for the scene.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log(
@@ -13,6 +13,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_colors([[255, 0, 0], [0, 255, 0], [0, 0, 255]]),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }

--- a/examples/rust/spawn_viewer/Cargo.toml
+++ b/examples/rust/spawn_viewer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "spawn_viewer"
+version = "0.10.0-alpha.7+dev"
+edition = "2021"
+rust-version = "1.72"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+rerun = { path = "../../../crates/rerun" }

--- a/examples/rust/spawn_viewer/README.md
+++ b/examples/rust/spawn_viewer/README.md
@@ -1,7 +1,7 @@
 ---
 title: Spawn Viewer
 tags: [spawn]
-rust: https://github.com/rerun-io/rerun/tree/latest/examples/rust/spawn_viewer/src/main.rs
+rust: https://github.com/rerun-io/rerun/tree/latest/examples/rust/spawn_viewer/src/main.rs?speculative-link
 ---
 
 Shows how to spawn a new Rerun Viewer process ready to listen for TCP connections using an executable available in PATH.

--- a/examples/rust/spawn_viewer/README.md
+++ b/examples/rust/spawn_viewer/README.md
@@ -1,0 +1,11 @@
+---
+title: Spawn Viewer
+tags: [spawn]
+rust: https://github.com/rerun-io/rerun/tree/latest/examples/rust/spawn_viewer/src/main.rs
+---
+
+Shows how to spawn a new Rerun Viewer process ready to listen for TCP connections using an executable available in PATH.
+
+```bash
+cargo run --release -p spawn_viewer
+```

--- a/examples/rust/spawn_viewer/src/main.rs
+++ b/examples/rust/spawn_viewer/src/main.rs
@@ -1,0 +1,6 @@
+//! Spawn a new Rerun Viewer process ready to listen for TCP connections.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    rerun::spawn(&rerun::SpawnOptions::default())?;
+    Ok(())
+}

--- a/examples/rust/template/src/main.rs
+++ b/examples/rust/template/src/main.rs
@@ -1,8 +1,7 @@
 //! Example template.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_my_example_name")
-        .spawn(&rerun::SpawnOptions::default(), None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_my_example_name").spawn(None)?;
 
     // … example code
     _ = rec;

--- a/examples/rust/template/src/main.rs
+++ b/examples/rust/template/src/main.rs
@@ -1,7 +1,7 @@
 //! Example template.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_my_example_name").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_my_example_name").spawn(rerun::default_flush_timeout())?;
 
     // … example code
     _ = rec;

--- a/examples/rust/template/src/main.rs
+++ b/examples/rust/template/src/main.rs
@@ -1,7 +1,8 @@
 //! Example template.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_my_example_name").spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_my_example_name")
+        .spawn(rerun::default_flush_timeout())?;
 
     // … example code
     _ = rec;

--- a/examples/rust/template/src/main.rs
+++ b/examples/rust/template/src/main.rs
@@ -1,14 +1,11 @@
 //! Example template.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_my_example_name").memory()?;
-
-    let _ = rec;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_my_example_name")
+        .spawn(&rerun::SpawnOptions::default(), None)?;
 
     // … example code
-
-    rerun::native_viewer::show(storage.take())?;
+    _ = rec;
 
     Ok(())
 }

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -145,8 +145,7 @@ def serve(
     bindings.serve(open_browser, web_port, ws_port, recording=recording)
 
 
-# TODO(jleibs): Ideally this would include a quick handshake that we're not talking
-# to some other random process holding the port.
+# TODO(#4019): application-level handshake
 def _check_for_existing_viewer(port: int) -> bool:
     try:
         # Try opening a connection to the port to see if something is there


### PR DESCRIPTION
Introduces standalone `rerun::spawn(SpawnOptions)` API that allows one to start a Rerun Viewer process ready to listen for TCP connections, as well as the associated `RecordingStream` integration.


https://github.com/rerun-io/rerun/assets/2910679/24eb5647-38c1-4049-b249-dc6e00e4ff54



---

Spawn via `$PATH` series:
- #3996
- #3997
- #3998

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/3996) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/3996)
- [Docs preview](https://rerun.io/preview/eff9ed593701c38c0b5cbe030e1ad3b4b820b4cc/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/eff9ed593701c38c0b5cbe030e1ad3b4b820b4cc/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)