### PR TITLE
re_renderer: detect badly sized texture buffers before handing to wgpu

### DIFF
--- a/crates/re_renderer/src/resource_managers/texture_manager.rs
+++ b/crates/re_renderer/src/resource_managers/texture_manager.rs
@@ -433,7 +433,6 @@ impl TextureManager2D {
         let data: &[u8] = data.as_ref();
 
         // TODO(andreas): temp allocator for staging data?
-        // We don't do any further validation of the buffer here as wgpu does so extensively.
         re_tracing::profile_scope!("write_texture");
         queue.write_texture(
             wgpu::ImageCopyTexture {


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/3927

wgpu does no validation right away, but defer it to a background thread, leading to lack of good error messages, and sometimes panics.

So we need to do the best we can up-front!

I tested this with:

```diff
--- a/docs/code-examples/image_simple.cpp
+++ b/docs/code-examples/image_simple.cpp
@@ -21,5 +21,5 @@ int main() {
         }
     }
 
-    rec.log("image", rerun::Image({HEIGHT, WIDTH, 3}, std::move(data)));
+    rec.log("image", rerun::Image({HEIGHT + 100, WIDTH, 3}, std::move(data)));
 }
```

Result:

> [2023-10-25T13:10:56Z ERROR re_space_view_spatial::parts::images] Failed to create texture for "image": Wrong number of bytes in the texture data buffer - expected 300x300x4=360000, got 240000



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4005) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4005)
- [Docs preview](https://rerun.io/preview/d94937b6991a03e998e9106bdf51e7390263b4ff/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d94937b6991a03e998e9106bdf51e7390263b4ff/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)