### PR TITLE
Fixes to installing-viewer docs

### DIFF
--- a/docs/content/getting-started/installing-viewer.md
+++ b/docs/content/getting-started/installing-viewer.md
@@ -10,7 +10,7 @@ There are many ways to install the viewer. Please pick whatever works best for y
 
 * `cargo binstall rerun-cli` - download binaries via [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall)
 * `cargo install rerun-cli` - build it from source (this requires Rust 1.72+)
-* Download it from the [GitHub Release artifacts](https://github.com/rerun-io/rerun/releases/)
+* Download it from the [GitHub Release artifacts](https://github.com/rerun-io/rerun/releases/latest/)
 * Together with the Rerun [Python SDK](python.md):
   * `pip3 install rerun-sdk` - download it via pip
   * `conda install -c conda-forge rerun-sdk` - download via Conda

--- a/docs/content/getting-started/installing-viewer.md
+++ b/docs/content/getting-started/installing-viewer.md
@@ -14,7 +14,7 @@ There are many ways to install the viewer. Please pick whatever works best for y
 * Together with the Rerun [Python SDK](python.md):
   * `pip3 install rerun-sdk` - download it via pip
   * `conda install -c conda-forge rerun-sdk` - download via Conda
-  * `pixi global install rerun-sdk` - download it via [Pixi](https://prefix.dev/docs/pixi/overview
+  * `pixi global install rerun-sdk` - download it via [Pixi](https://prefix.dev/docs/pixi/overview)
 
 In any case you should be able to run `rerun` afterwards to start the Viewer.
 You'll be welcomed by an overview page that allows you to jump into some examples.
@@ -23,5 +23,5 @@ If you're facing any difficulties, don't hesitate to [open an issue](https://git
 
 To start getting your own data logged & visualized in the viewer check one of the respective getting started guides:
 * [Python](python.md)
-* [C++]cpp.md)
+* [C++](cpp.md)
 * [Rust](python.md)


### PR DESCRIPTION
- Point to latest release to A) be consistent with other commands and B) because the release index is a really unfriendly page that is dominated by pre-releases
- Fix broken links

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4006) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4006)
- [Docs preview](https://rerun.io/preview/ecc8cdf63b62da842fc409cb51e8ab6e4df6e0bc/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ecc8cdf63b62da842fc409cb51e8ab6e4df6e0bc/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)