### PR TITLE
Improve Python docstring codegen

### DIFF
--- a/crates/re_types/definitions/rerun/archetypes/segmentation_image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/segmentation_image.fbs
@@ -6,7 +6,7 @@ include "rerun/components.fbs";
 namespace rerun.archetypes;
 
 
-/// An image made up of integer class-ids
+/// An image made up of integer class-ids.
 ///
 /// The shape of the `TensorData` must be mappable to an `HxW` tensor.
 /// Each pixel corresponds to a depth value in units specified by meter.

--- a/crates/re_types/definitions/rerun/components/clear_is_recursive.fbs
+++ b/crates/re_types/definitions/rerun/components/clear_is_recursive.fbs
@@ -9,7 +9,7 @@ namespace rerun.components;
 
 // ---
 
-/// Configures how a clear operation should behave - recursive or not?
+/// Configures how a clear operation should behave - recursive or not.
 struct ClearIsRecursive (
   "attr.arrow.transparent",
   "attr.python.aliases": "bool",

--- a/crates/re_types/definitions/rerun/components/text.fbs
+++ b/crates/re_types/definitions/rerun/components/text.fbs
@@ -9,7 +9,7 @@ namespace rerun.components;
 
 // ---
 
-/// A string of text, e.g. for labels and text documents
+/// A string of text, e.g. for labels and text documents.
 table Text (
   "attr.arrow.transparent",
   "attr.python.aliases": "str",

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -21,7 +21,7 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Archetype**: An image made up of integer class-ids
+/// **Archetype**: An image made up of integer class-ids.
 ///
 /// The shape of the `TensorData` must be mappable to an `HxW` tensor.
 /// Each pixel corresponds to a depth value in units specified by meter.

--- a/crates/re_types/src/components/text.rs
+++ b/crates/re_types/src/components/text.rs
@@ -21,7 +21,7 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Component**: A string of text, e.g. for labels and text documents
+/// **Component**: A string of text, e.g. for labels and text documents.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Text(pub crate::datatypes::Utf8);

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -939,7 +939,7 @@ fn quote_doc_lines(lines: Vec<String>) -> String {
     if lines.len() == 1 {
         // single-line
         let line = &lines[0];
-        format!("\"\"\"{line}\"\"\"\n\n")
+        format!("\"\"\"{line}\"\"\"\n\n") // NOLINT
     } else {
         // multi-line
         format!("\"\"\"\n{}\n\"\"\"\n\n", lines.join("\n"))

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -663,7 +663,7 @@ fn code_for_struct(
             let doc_lines = lines_from_docs(&field.docs);
             if !doc_lines.is_empty() {
                 if show_fields_in_docs {
-                    code.push_text(quote_doc_lines(&doc_lines), 0, 4);
+                    code.push_text(quote_doc_lines(doc_lines), 0, 4);
                 } else {
                     // Still include it for those that are reading the source file:
                     for line in doc_lines {
@@ -893,6 +893,7 @@ fn quote_examples(examples: Vec<Example<'_>>, lines: &mut Vec<String>) {
     }
 }
 
+/// Ends with double newlines, unless empty.
 fn quote_obj_docs(obj: &Object) -> String {
     let mut lines = lines_from_docs(&obj.docs);
 
@@ -901,7 +902,7 @@ fn quote_obj_docs(obj: &Object) -> String {
         *first_line = format!("**{}**: {}", obj.kind.singular_name(), first_line);
     }
 
-    quote_doc_lines(&lines)
+    quote_doc_lines(lines)
 }
 
 fn lines_from_docs(docs: &Docs) -> Vec<String> {
@@ -923,18 +924,26 @@ fn lines_from_docs(docs: &Docs) -> Vec<String> {
     lines
 }
 
-fn quote_doc_lines(lines: &[String]) -> String {
+/// Ends with double newlines, unless empty.
+fn quote_doc_lines(lines: Vec<String>) -> String {
     if lines.is_empty() {
         return String::new();
     }
 
     // NOTE: Filter out docstrings within docstrings, it just gets crazy otherwise…
-    let doc = lines
-        .iter()
+    let lines: Vec<String> = lines
+        .into_iter()
         .filter(|line| !line.starts_with(r#"""""#))
-        .join("\n");
+        .collect();
 
-    format!("\"\"\"\n{doc}\n\"\"\"\n\n")
+    if lines.len() == 1 {
+        // single-line
+        let line = &lines[0];
+        format!("\"\"\"{line}\"\"\"\n\n")
+    } else {
+        // multi-line
+        format!("\"\"\"\n{}\n\"\"\"\n\n", lines.join("\n"))
+    }
 }
 
 fn quote_doc_from_fields(objects: &Objects, fields: &Vec<ObjectField>) -> String {
@@ -1635,10 +1644,11 @@ fn quote_init_method(
         ObjectKind::Component => "component",
         ObjectKind::Archetype => "archetype",
     };
-    let mut doc_string_lines = vec![
-        r#"""""#.to_owned(),
-        format!("Create a new instance of the {} {doc_typedesc}.", obj.name),
-    ];
+
+    let mut doc_string_lines = vec![format!(
+        "Create a new instance of the {} {doc_typedesc}.",
+        obj.name
+    )];
     if !parameter_docs.is_empty() {
         doc_string_lines.push("\n".to_owned());
         doc_string_lines.push("Parameters".to_owned());
@@ -1647,8 +1657,7 @@ fn quote_init_method(
             doc_string_lines.push(doc);
         }
     };
-    doc_string_lines.push(r#"""""#.to_owned());
-    let doc_block = doc_string_lines.join("\n");
+    let doc_block = quote_doc_lines(doc_string_lines);
 
     let custom_init_hint = format!(
         "# You can define your own __init__ function as a member of {} in {}",
@@ -1685,7 +1694,7 @@ fn quote_init_method(
         "{head}\n{}",
         indent::indent_all_by(
             4,
-            format!("{doc_block}\n\n{custom_init_hint}\n{forwarding_call}"),
+            format!("{doc_block}{custom_init_hint}\n{forwarding_call}"),
         )
     )
 }
@@ -1709,7 +1718,7 @@ fn quote_clear_methods(obj: &Object) -> String {
 
         @classmethod
         def _clear(cls) -> {classname}:
-            """Produce an empty {classname}, bypassing `__init__`"""
+            """Produce an empty {classname}, bypassing `__init__`."""
             inst = cls.__new__(cls)
             inst.__attrs_clear__()
             return inst

--- a/docs/content/reference/types/archetypes/segmentation_image.md
+++ b/docs/content/reference/types/archetypes/segmentation_image.md
@@ -2,7 +2,7 @@
 title: "SegmentationImage"
 ---
 
-An image made up of integer class-ids
+An image made up of integer class-ids.
 
 The shape of the `TensorData` must be mappable to an `HxW` tensor.
 Each pixel corresponds to a depth value in units specified by meter.

--- a/docs/content/reference/types/components/clear_is_recursive.md
+++ b/docs/content/reference/types/components/clear_is_recursive.md
@@ -2,7 +2,7 @@
 title: "ClearIsRecursive"
 ---
 
-Configures how a clear operation should behave - recursive or not?
+Configures how a clear operation should behave - recursive or not.
 
 
 ## Links

--- a/docs/content/reference/types/components/text.md
+++ b/docs/content/reference/types/components/text.md
@@ -2,7 +2,7 @@
 title: "Text"
 ---
 
-A string of text, e.g. for labels and text documents
+A string of text, e.g. for labels and text documents.
 
 ## Fields
 

--- a/rerun_py/tests/unit/test_tensor.py
+++ b/rerun_py/tests/unit/test_tensor.py
@@ -69,20 +69,20 @@ def test_bad_tensors() -> None:
 
     # No buffers
     with pytest.raises(ValueError):
-        TensorData(),
+        TensorData()
 
     # Buffer with no indication of shape
     with pytest.raises(ValueError):
         TensorData(
             buffer=RANDOM_TENSOR_SOURCE,
-        ),
+        )
 
     # Both array and buffer
     with pytest.raises(ValueError):
         TensorData(
             array=RANDOM_TENSOR_SOURCE,
             buffer=RANDOM_TENSOR_SOURCE,
-        ),
+        )
 
     # Wrong size buffer for dimensions
     with pytest.raises(ValueError):
@@ -94,7 +94,7 @@ def test_bad_tensors() -> None:
                 TensorDimension(4, name="d"),
             ],
             buffer=RANDOM_TENSOR_SOURCE,
-        ),
+        )
 
     # TODO(jleibs) send_warning bottoms out in TypeError but these ought to be ValueErrors
 
@@ -103,7 +103,7 @@ def test_bad_tensors() -> None:
         TensorData(
             dim_names=["a", "b", "c"],
             array=RANDOM_TENSOR_SOURCE,
-        ),
+        )
 
     # Shape disagrees with array
     with pytest.raises(ValueError):
@@ -115,4 +115,4 @@ def test_bad_tensors() -> None:
                 TensorDimension(3, name="d"),
             ],
             array=RANDOM_TENSOR_SOURCE,
-        ),
+        )


### PR DESCRIPTION
### What
This is a pre-requisite for switching to `ruff format`, which seems stricter about the formatting of our docstrings

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
