### PR TITLE
Python: remove unconditional sleep on `spawn`

### DIFF
--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -234,9 +234,14 @@ def spawn(
             start_new_session=True,
         )
 
-        # TODO(emilk): figure out a way to postpone connecting until the rerun viewer is listening.
-        # For example, wait until it prints "Hosting a SDK server over TCP at …"
-        sleep(0.5)  # almost as good as waiting the correct amount of time
+        # Give the newly spawned Rerun Viewer some time to bind.
+        #
+        # NOTE: The timeout only covers the TCP handshake: if no process is bound to that address
+        # at all, the connection will fail immediately, irrelevant of the timeout configuration.
+        # For that reason we use an extra loop.
+        for _ in range(0, 5):
+            _check_for_existing_viewer(port)
+            sleep(0.1)
 
     if connect:
         _connect(f"127.0.0.1:{port}", recording=recording)


### PR DESCRIPTION
Removes the unconditional `sleep(0.5)` on the spawn path in python, improving latency.

This mimics what happens in the new Rust/C/C++ spawn APIs:
https://github.com/rerun-io/rerun/blob/3f41c3b3906147a0b9a4f27f7fe55a8fa59532ef/crates/re_sdk/src/recording_stream.rs#L1309-L1321

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4010) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4010)
- [Docs preview](https://rerun.io/preview/3da1275a0380945f5eb692e8e0794243d764db88/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3da1275a0380945f5eb692e8e0794243d764db88/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)