### PR TITLE
Fix issues for using C++ on Windows

### DIFF
--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -332,13 +332,13 @@ jobs:
             ## CMake fetch-content for C++ SDK
             ```
             include(FetchContent)
-            FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP URL https://build.rerun.io/commit/${{ env.SHORT_SHA }}/rerun_cpp_sdk.zip)
+            FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP ON URL https://build.rerun.io/commit/${{ env.SHORT_SHA }}/rerun_cpp_sdk.zip)
             FetchContent_MakeAvailable(rerun_sdk)
             ```
             or
             ```
             include(FetchContent)
-            FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip)
+            FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP ON URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip)
             FetchContent_MakeAvailable(rerun_sdk)
             ```
 

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -332,13 +332,13 @@ jobs:
             ## CMake fetch-content for C++ SDK
             ```
             include(FetchContent)
-            FetchContent_Declare(rerun_sdk URL https://build.rerun.io/commit/${{ env.SHORT_SHA }}/rerun_cpp_sdk.zip)
+            FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP URL https://build.rerun.io/commit/${{ env.SHORT_SHA }}/rerun_cpp_sdk.zip)
             FetchContent_MakeAvailable(rerun_sdk)
             ```
             or
             ```
             include(FetchContent)
-            FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip)
+            FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip)
             FetchContent_MakeAvailable(rerun_sdk)
             ```
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -67,10 +67,17 @@ If you want to build from source, use the following instructions.
 
 First, a local virtual environment must be created and the necessary dependencies installed (this needs to be done only once):
 
+Linux/Mac:
 ```sh
 just py-dev-env
 source venv/bin/activate
 ```
+Windows (powershell):
+```ps1
+just py-dev-env
+.\venv\Scripts\Activate.ps1
+```
+
 
 Then, the SDK can be compiled and installed in the virtual environment using the following command:
 
@@ -80,38 +87,22 @@ just py-build
 
 This needs to be repeated each time the Rust source code is updated, for example after updating your clone using `git pull`.
 
-Finally, the virtual environment must be activated to run Python examples:
-
+Now you can run the python examples from the repository, given that you're still in the virtual environment.
 ```sh
-source venv/bin/activate
 python examples/python/car/main.py
 ```
 
-### Windows (PowerShell)
+## Building and installing the Rerun C++ SDK
 
-The `justfile` currently doesn't support Windows, so each step must be run manually.
+On Windows you have to have a system install of Visual Studio 2022 in order to compile the SDK and samples.
 
-First, create and activate a local virtual environment and install the required dependencies using the following commands:
-
-```ps1
-python -m venv venv
-.\venv\Scripts\Activate.ps1
-python -m pip install --upgrade pip
-python -m pip install -r scripts/requirements-dev.txt
+All other dependencies are downloaded by Pixi! You can run tests with:
+```sh
+just cpp-test
 ```
-
-Then build and install the Rerun SDK with:
-
-```ps1
-maturin develop \
-    --manifest-path rerun_py/Cargo.toml \
-    --extras="tests"
-```
-
-You can then run the example using the following command:
-
-```ps1
-python examples/python/car/main.py
+and build all C++ artifacts with:
+```sh
+just cpp-build-all
 ```
 
 ## Building the docs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(rerun_cpp_proj LANGUAGES CXX)
 
 function(set_default_warning_settings target)
     if(MSVC)
-        target_compile_options(${target} PRIVATE /W4 /WX)
+        target_compile_options(${target} PRIVATE /W4)
     else()
         # Enabled warnings.
         target_compile_options(${target} PRIVATE
@@ -35,7 +35,7 @@ function(set_default_warning_settings target)
 
         # CMAKE_COMPILE_WARNING_AS_ERROR is only directly supported starting in CMake `3.24`
         # https://cmake.org/cmake/help/latest/prop_tgt/COMPILE_WARNING_AS_ERROR.html
-        if(${CMAKE_COMPILE_WARNING_AS_ERROR})
+        if(CMAKE_COMPILE_WARNING_AS_ERROR)
             target_compile_options(${target} PRIVATE -Werror)
         endif()
 
@@ -59,6 +59,7 @@ if(NOT DEFINED CMAKE_GENERATOR AND UNIX)
 endif()
 
 # If using MSVC, always enable multi-process compiling for all targets.
+# Note that this setting is repeated for rerun_sdk's CMakeLists.txt since it should also work stand-alone.
 if(MSVC)
     add_compile_options(/MP)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,12 @@ FetchContent_Declare(LoguruGitRepo
     GIT_TAG "master"
 )
 
-# set any loguru compile-time flags before calling MakeAvailable()
-set(LOGURU_STACKTRACES 1)
+# Set any loguru compile-time flags before calling MakeAvailable()
+# Stacktraces are not yet supported on Windows.
+if(NOT WIN32)
+    set(LOGURU_STACKTRACES 1)
+endif()
+
 FetchContent_MakeAvailable(LoguruGitRepo) # defines target 'loguru::loguru'
 
 # ------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ if(NOT DEFINED CMAKE_GENERATOR AND UNIX)
     set(CMAKE_GENERATOR "Unix Makefiles")
 endif()
 
+# If using MSVC, always enable multi-process compiling for all targets.
+if(MSVC)
+    add_compile_options(/MP)
+endif()
+
 # Arrow requires a C++17 compliant compiler.
 if(NOT DEFINED CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 17)

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1403,7 +1403,9 @@ fn quote_fill_arrow_array_builder(
             if field.is_nullable {
                 quote! {
                     (void)num_elements;
-                    return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+                    if (true) { // Works around unreachability compiler warning.
+                        return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+                    }
                 }
             } else {
                 // Trivial forwarding to inner type.

--- a/crates/re_viewer/data/quick_start_guides/cpp_connect.md
+++ b/crates/re_viewer/data/quick_start_guides/cpp_connect.md
@@ -24,7 +24,7 @@ If you're using CMake, you can add the following to your `CMakeLists.txt`:
 
 ```cmake
 include(FetchContent)
-FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip) # TODO(#3962): update link
+FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip) # TODO(#3962): update link
 FetchContent_MakeAvailable(rerun_sdk)
 ```
 

--- a/crates/re_viewer/data/quick_start_guides/cpp_connect.md
+++ b/crates/re_viewer/data/quick_start_guides/cpp_connect.md
@@ -24,7 +24,7 @@ If you're using CMake, you can add the following to your `CMakeLists.txt`:
 
 ```cmake
 include(FetchContent)
-FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip) # TODO(#3962): update link
+FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP ON URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip) # TODO(#3962): update link
 FetchContent_MakeAvailable(rerun_sdk)
 ```
 

--- a/docs/code-examples/annotation_context_segmentation.cpp
+++ b/docs/code-examples/annotation_context_segmentation.cpp
@@ -21,10 +21,10 @@ int main() {
     const int HEIGHT = 200;
     const int WIDTH = 300;
     std::vector<uint8_t> data(WIDTH * HEIGHT, 0);
-    for (uint8_t y = 50; y < 100; ++y) {
+    for (auto y = 50; y < 100; ++y) {
         std::fill_n(data.begin() + y * WIDTH + 50, 70, static_cast<uint8_t>(1));
     }
-    for (uint8_t y = 100; y < 180; ++y) {
+    for (auto y = 100; y < 180; ++y) {
         std::fill_n(data.begin() + y * WIDTH + 130, 150, static_cast<uint8_t>(2));
     }
 

--- a/docs/code-examples/annotation_context_segmentation.cpp
+++ b/docs/code-examples/annotation_context_segmentation.cpp
@@ -21,11 +21,11 @@ int main() {
     const int HEIGHT = 200;
     const int WIDTH = 300;
     std::vector<uint8_t> data(WIDTH * HEIGHT, 0);
-    for (auto y = 50; y < 100; ++y) {
-        std::fill_n(data.begin() + y * WIDTH + 50, 70, 1);
+    for (uint8_t y = 50; y < 100; ++y) {
+        std::fill_n(data.begin() + y * WIDTH + 50, 70, static_cast<uint8_t>(1));
     }
-    for (auto y = 100; y < 180; ++y) {
-        std::fill_n(data.begin() + y * WIDTH + 130, 150, 2);
+    for (uint8_t y = 100; y < 180; ++y) {
+        std::fill_n(data.begin() + y * WIDTH + 130, 150, static_cast<uint8_t>(2));
     }
 
     rec.log("segmentation/image", rerun::SegmentationImage({HEIGHT, WIDTH}, std::move(data)));

--- a/docs/code-examples/arrow3d_simple.cpp
+++ b/docs/code-examples/arrow3d_simple.cpp
@@ -3,9 +3,8 @@
 #include <rerun.hpp>
 
 #include <cmath>
-#include <numeric>
 
-const float TAU = static_cast<float>(2.0 * M_PI);
+constexpr float TAU = 6.28318530717958647692528676655900577f;
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_arrow3d");

--- a/docs/code-examples/depth_image_3d.cpp
+++ b/docs/code-examples/depth_image_3d.cpp
@@ -13,10 +13,10 @@ int main() {
     const int WIDTH = 300;
     std::vector<uint16_t> data(WIDTH * HEIGHT, 65535);
     for (auto y = 50; y < 150; ++y) {
-        std::fill_n(data.begin() + y * WIDTH + 50, 100, 20000);
+        std::fill_n(data.begin() + y * WIDTH + 50, 100, static_cast<uint16_t>(20000));
     }
     for (auto y = 130; y < 180; ++y) {
-        std::fill_n(data.begin() + y * WIDTH + 100, 180, 45000);
+        std::fill_n(data.begin() + y * WIDTH + 100, 180, static_cast<uint16_t>(45000));
     }
 
     // If we log a pinhole camera model, the depth gets automatically back-projected to 3D

--- a/docs/code-examples/depth_image_simple.cpp
+++ b/docs/code-examples/depth_image_simple.cpp
@@ -13,10 +13,10 @@ int main() {
     const int WIDTH = 300;
     std::vector<uint16_t> data(WIDTH * HEIGHT, 65535);
     for (auto y = 50; y < 150; ++y) {
-        std::fill_n(data.begin() + y * WIDTH + 50, 100, 20000);
+        std::fill_n(data.begin() + y * WIDTH + 50, 100, static_cast<uint16_t>(20000));
     }
     for (auto y = 130; y < 180; ++y) {
-        std::fill_n(data.begin() + y * WIDTH + 100, 180, 45000);
+        std::fill_n(data.begin() + y * WIDTH + 100, 180, static_cast<uint16_t>(45000));
     }
 
     rec.log("depth", rerun::DepthImage({HEIGHT, WIDTH}, std::move(data)).with_meter(10000.0));

--- a/docs/code-examples/pinhole_simple.cpp
+++ b/docs/code-examples/pinhole_simple.cpp
@@ -19,7 +19,9 @@ int main() {
     tensor.shape = {dim3, dim3, dim3};
     std::srand(static_cast<uint32_t>(std::time(nullptr)));
     std::vector<uint8_t> random_data(3 * 3 * 3);
-    std::generate(random_data.begin(), random_data.end(), []{ return static_cast<uint8_t>(std::rand()); });
+    std::generate(random_data.begin(), random_data.end(), [] {
+        return static_cast<uint8_t>(std::rand());
+    });
     tensor.buffer = rerun::datatypes::TensorBuffer::u8(random_data);
 
     rec.log("world/image", rerun::Image(tensor));

--- a/docs/code-examples/pinhole_simple.cpp
+++ b/docs/code-examples/pinhole_simple.cpp
@@ -19,7 +19,7 @@ int main() {
     tensor.shape = {dim3, dim3, dim3};
     std::srand(static_cast<uint32_t>(std::time(nullptr)));
     std::vector<uint8_t> random_data(3 * 3 * 3);
-    std::generate(random_data.begin(), random_data.end(), std::rand);
+    std::generate(random_data.begin(), random_data.end(), []{ return static_cast<uint8_t>(std::rand()); });
     tensor.buffer = rerun::datatypes::TensorBuffer::u8(random_data);
 
     rec.log("world/image", rerun::Image(tensor));

--- a/docs/code-examples/point2d_random.cpp
+++ b/docs/code-examples/point2d_random.cpp
@@ -12,7 +12,7 @@ int main() {
     std::default_random_engine gen;
     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);
     std::uniform_real_distribution<float> dist_radius(0.1f, 1.0f);
-    std::uniform_int_distribution<uint8_t> dist_color(0, 255);
+    std::uniform_int_distribution<int> dist_color(0, 255);  // On MSVC uint8_t distributions are not supported.
 
     std::vector<rerun::components::Position2D> points2d(10);
     std::generate(points2d.begin(), points2d.end(), [&] {
@@ -20,7 +20,7 @@ int main() {
     });
     std::vector<rerun::components::Color> colors(10);
     std::generate(colors.begin(), colors.end(), [&] {
-        return rerun::components::Color(dist_color(gen), dist_color(gen), dist_color(gen));
+        return rerun::components::Color(static_cast<uint8_t>(dist_color(gen)), static_cast<uint8_t>(dist_color(gen)), static_cast<uint8_t>(dist_color(gen)));
     });
     std::vector<rerun::components::Radius> radii(10);
     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });

--- a/docs/code-examples/point2d_random.cpp
+++ b/docs/code-examples/point2d_random.cpp
@@ -12,10 +12,8 @@ int main() {
     std::default_random_engine gen;
     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);
     std::uniform_real_distribution<float> dist_radius(0.1f, 1.0f);
-    std::uniform_int_distribution<int> dist_color(
-        0,
-        255
-    ); // On MSVC uint8_t distributions are not supported.
+    // On MSVC uint8_t distributions are not supported.
+    std::uniform_int_distribution<int> dist_color(0, 255);
 
     std::vector<rerun::components::Position2D> points2d(10);
     std::generate(points2d.begin(), points2d.end(), [&] {

--- a/docs/code-examples/point2d_random.cpp
+++ b/docs/code-examples/point2d_random.cpp
@@ -12,7 +12,10 @@ int main() {
     std::default_random_engine gen;
     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);
     std::uniform_real_distribution<float> dist_radius(0.1f, 1.0f);
-    std::uniform_int_distribution<int> dist_color(0, 255);  // On MSVC uint8_t distributions are not supported.
+    std::uniform_int_distribution<int> dist_color(
+        0,
+        255
+    ); // On MSVC uint8_t distributions are not supported.
 
     std::vector<rerun::components::Position2D> points2d(10);
     std::generate(points2d.begin(), points2d.end(), [&] {
@@ -20,7 +23,11 @@ int main() {
     });
     std::vector<rerun::components::Color> colors(10);
     std::generate(colors.begin(), colors.end(), [&] {
-        return rerun::components::Color(static_cast<uint8_t>(dist_color(gen)), static_cast<uint8_t>(dist_color(gen)), static_cast<uint8_t>(dist_color(gen)));
+        return rerun::components::Color(
+            static_cast<uint8_t>(dist_color(gen)),
+            static_cast<uint8_t>(dist_color(gen)),
+            static_cast<uint8_t>(dist_color(gen))
+        );
     });
     std::vector<rerun::components::Radius> radii(10);
     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });

--- a/docs/code-examples/point3d_random.cpp
+++ b/docs/code-examples/point3d_random.cpp
@@ -12,7 +12,10 @@ int main() {
     std::default_random_engine gen;
     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);
     std::uniform_real_distribution<float> dist_radius(0.1f, 1.0f);
-    std::uniform_int_distribution<int> dist_color(0, 255); // On MSVC uint8_t distributions are not supported.
+    std::uniform_int_distribution<int> dist_color(
+        0,
+        255
+    ); // On MSVC uint8_t distributions are not supported.
 
     std::vector<rerun::components::Position3D> points3d(10);
     std::generate(points3d.begin(), points3d.end(), [&] {
@@ -20,7 +23,11 @@ int main() {
     });
     std::vector<rerun::components::Color> colors(10);
     std::generate(colors.begin(), colors.end(), [&] {
-        return rerun::components::Color(static_cast<uint8_t>(dist_color(gen)), static_cast<uint8_t>(dist_color(gen)), static_cast<uint8_t>(dist_color(gen)));
+        return rerun::components::Color(
+            static_cast<uint8_t>(dist_color(gen)),
+            static_cast<uint8_t>(dist_color(gen)),
+            static_cast<uint8_t>(dist_color(gen))
+        );
     });
     std::vector<rerun::components::Radius> radii(10);
     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });

--- a/docs/code-examples/point3d_random.cpp
+++ b/docs/code-examples/point3d_random.cpp
@@ -12,10 +12,8 @@ int main() {
     std::default_random_engine gen;
     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);
     std::uniform_real_distribution<float> dist_radius(0.1f, 1.0f);
-    std::uniform_int_distribution<int> dist_color(
-        0,
-        255
-    ); // On MSVC uint8_t distributions are not supported.
+    // On MSVC uint8_t distributions are not supported.
+    std::uniform_int_distribution<int> dist_color(0, 255);
 
     std::vector<rerun::components::Position3D> points3d(10);
     std::generate(points3d.begin(), points3d.end(), [&] {

--- a/docs/code-examples/point3d_random.cpp
+++ b/docs/code-examples/point3d_random.cpp
@@ -12,7 +12,7 @@ int main() {
     std::default_random_engine gen;
     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);
     std::uniform_real_distribution<float> dist_radius(0.1f, 1.0f);
-    std::uniform_int_distribution<uint8_t> dist_color(0, 255);
+    std::uniform_int_distribution<int> dist_color(0, 255); // On MSVC uint8_t distributions are not supported.
 
     std::vector<rerun::components::Position3D> points3d(10);
     std::generate(points3d.begin(), points3d.end(), [&] {
@@ -20,7 +20,7 @@ int main() {
     });
     std::vector<rerun::components::Color> colors(10);
     std::generate(colors.begin(), colors.end(), [&] {
-        return rerun::components::Color(dist_color(gen), dist_color(gen), dist_color(gen));
+        return rerun::components::Color(static_cast<uint8_t>(dist_color(gen)), static_cast<uint8_t>(dist_color(gen)), static_cast<uint8_t>(dist_color(gen)));
     });
     std::vector<rerun::components::Radius> radii(10);
     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });

--- a/docs/code-examples/scalar_multiple_plots.cpp
+++ b/docs/code-examples/scalar_multiple_plots.cpp
@@ -1,11 +1,10 @@
 // Log a scalar over time.
 
-#include <rerun.hpp>
 
+#include <rerun.hpp>
 #include <cmath>
 
-#define TAU (M_PI * 2.0)
-
+constexpr float TAU = 6.28318530717958647692528676655900577f;
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_points3d_simple");
     rec.connect().throw_on_failure();

--- a/docs/code-examples/scalar_multiple_plots.cpp
+++ b/docs/code-examples/scalar_multiple_plots.cpp
@@ -1,10 +1,10 @@
 // Log a scalar over time.
 
-
-#include <rerun.hpp>
 #include <cmath>
+#include <rerun.hpp>
 
 constexpr float TAU = 6.28318530717958647692528676655900577f;
+
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_points3d_simple");
     rec.connect().throw_on_failure();

--- a/docs/code-examples/segmentation_image_simple.cpp
+++ b/docs/code-examples/segmentation_image_simple.cpp
@@ -13,10 +13,10 @@ int main() {
     const int WIDTH = 12;
     std::vector<uint8_t> data(WIDTH * HEIGHT, 0);
     for (auto y = 0; y < 4; ++y) {                   // top half
-        std::fill_n(data.begin() + y * WIDTH, 6, 1); // left half
+        std::fill_n(data.begin() + y * WIDTH, 6, static_cast<uint8_t>(1)); // left half
     }
     for (auto y = 4; y < 8; ++y) {                       // bottom half
-        std::fill_n(data.begin() + y * WIDTH + 6, 6, 2); // right half
+        std::fill_n(data.begin() + y * WIDTH + 6, 6, static_cast<uint8_t>(2)); // right half
     }
 
     // create an annotation context to describe the classes

--- a/docs/code-examples/segmentation_image_simple.cpp
+++ b/docs/code-examples/segmentation_image_simple.cpp
@@ -12,10 +12,10 @@ int main() {
     const int HEIGHT = 8;
     const int WIDTH = 12;
     std::vector<uint8_t> data(WIDTH * HEIGHT, 0);
-    for (auto y = 0; y < 4; ++y) {                   // top half
+    for (auto y = 0; y < 4; ++y) {                                         // top half
         std::fill_n(data.begin() + y * WIDTH, 6, static_cast<uint8_t>(1)); // left half
     }
-    for (auto y = 4; y < 8; ++y) {                       // bottom half
+    for (auto y = 4; y < 8; ++y) {                                             // bottom half
         std::fill_n(data.begin() + y * WIDTH + 6, 6, static_cast<uint8_t>(2)); // right half
     }
 

--- a/docs/code-examples/tensor_simple.cpp
+++ b/docs/code-examples/tensor_simple.cpp
@@ -9,10 +9,10 @@ int main() {
     rec.connect().throw_on_failure();
 
     std::default_random_engine gen;
-    std::uniform_int_distribution<uint8_t> dist(0, 255);
+    std::uniform_int_distribution<int> dist(0, 255); // On MSVC uint8_t distributions are not supported.
 
     std::vector<uint8_t> data(8 * 6 * 3 * 5);
-    std::generate(data.begin(), data.end(), [&] { return dist(gen); });
+    std::generate(data.begin(), data.end(), [&] { return static_cast<uint8_t>(dist(gen)); });
 
     rec.log(
         "tensor",

--- a/docs/code-examples/tensor_simple.cpp
+++ b/docs/code-examples/tensor_simple.cpp
@@ -9,10 +9,8 @@ int main() {
     rec.connect().throw_on_failure();
 
     std::default_random_engine gen;
-    std::uniform_int_distribution<int> dist(
-        0,
-        255
-    ); // On MSVC uint8_t distributions are not supported.
+    // On MSVC uint8_t distributions are not supported.
+    std::uniform_int_distribution<int> dist(0, 255);
 
     std::vector<uint8_t> data(8 * 6 * 3 * 5);
     std::generate(data.begin(), data.end(), [&] { return static_cast<uint8_t>(dist(gen)); });

--- a/docs/code-examples/tensor_simple.cpp
+++ b/docs/code-examples/tensor_simple.cpp
@@ -9,7 +9,10 @@ int main() {
     rec.connect().throw_on_failure();
 
     std::default_random_engine gen;
-    std::uniform_int_distribution<int> dist(0, 255); // On MSVC uint8_t distributions are not supported.
+    std::uniform_int_distribution<int> dist(
+        0,
+        255
+    ); // On MSVC uint8_t distributions are not supported.
 
     std::vector<uint8_t> data(8 * 6 * 3 * 5);
     std::generate(data.begin(), data.end(), [&] { return static_cast<uint8_t>(dist(gen)); });

--- a/docs/code-examples/transform3d_simple.cpp
+++ b/docs/code-examples/transform3d_simple.cpp
@@ -1,7 +1,7 @@
 // Log different transforms between three arrows.
 
-#include <rerun.hpp>
 #include <cmath>
+#include <rerun.hpp>
 
 constexpr float TAU = 6.28318530717958647692528676655900577f;
 

--- a/docs/code-examples/transform3d_simple.cpp
+++ b/docs/code-examples/transform3d_simple.cpp
@@ -1,12 +1,9 @@
 // Log different transforms between three arrows.
 
 #include <rerun.hpp>
-
 #include <cmath>
 
-namespace rrd = rerun::datatypes;
-
-const float TAU = static_cast<float>(2.0 * M_PI);
+constexpr float TAU = 6.28318530717958647692528676655900577f;
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_transform3d");
@@ -23,7 +20,7 @@ int main() {
     rec.log(
         "base/rotated_scaled",
         rerun::Transform3D(
-            rrd::RotationAxisAngle({0.0f, 0.0f, 1.0f}, rrd::Angle::radians(TAU / 8.0f)),
+            rerun::RotationAxisAngle({0.0f, 0.0f, 1.0f}, rerun::Angle::radians(TAU / 8.0f)),
             2.0f
         )
     );

--- a/docs/content/getting-started/cpp.md
+++ b/docs/content/getting-started/cpp.md
@@ -14,7 +14,7 @@ If you're using CMake, you can add the following to your `CMakeLists.txt`:
 
 ```cmake
 include(FetchContent)
-FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip) # TODO(#3962): update link
+FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP ON URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip) # TODO(#3962): update link
 FetchContent_MakeAvailable(rerun_sdk)
 ```
 
@@ -39,7 +39,7 @@ add_executable(example main.cpp)
 
 # Download the rerun_sdk
 include(FetchContent)
-FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip) # TODO(#3962): update link
+FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP ON URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip) # TODO(#3962): update link
 FetchContent_MakeAvailable(rerun_sdk)
 
 # Rerun requires at least C++17, but it should be compatible with newer versions.

--- a/docs/content/getting-started/cpp.md
+++ b/docs/content/getting-started/cpp.md
@@ -9,6 +9,8 @@ Before adding Rerun to your application, start by [installing the viewer](instal
 The Rerun C++ SDK depends on an install of the `arrow-cpp` library on your system using.
 If you are using [Pixi](https://prefix.dev/docs/pixi/overview), you can simply type `pixi global install arrow-cpp`.
 Find more information about other package managers at the official Arrow Apache [install guide](https://arrow.apache.org/install/).
+⚠️ On Windows this only downloads release binaries which are **not** compatible with debug builds, causing runtime crashes. For debug builds you have to build Arrow yourself, see [Building Arrow C++](https://arrow.apache.org/docs/developers/cpp/building.html).
+🚧 In the future we want to make this part of the setup easier.
 
 If you're using CMake, you can add the following to your `CMakeLists.txt`:
 

--- a/docs/content/getting-started/cpp.md
+++ b/docs/content/getting-started/cpp.md
@@ -7,14 +7,14 @@ order: 2
 Before adding Rerun to your application, start by [installing the viewer](installing-viewer.md).
 
 The Rerun C++ SDK depends on an install of the `arrow-cpp` library on your system using.
-If you are using [pixi], you can simply type `pixi global install arrow-cpp`.
+If you are using [Pixi](https://prefix.dev/docs/pixi/overview), you can simply type `pixi global install arrow-cpp`.
 Find more information about other package managers at the official Arrow Apache [install guide](https://arrow.apache.org/install/).
 
 If you're using CMake, you can add the following to your `CMakeLists.txt`:
 
 ```cmake
 include(FetchContent)
-FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip) # TODO(#3962): update link
+FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip) # TODO(#3962): update link
 FetchContent_MakeAvailable(rerun_sdk)
 ```
 
@@ -32,14 +32,14 @@ target_link_libraries(example PRIVATE rerun_sdk)
 
 Combining the above, a minimal self-contained `CMakeLists.txt` looks like:
 ```cmake
-project(example LANGUAGES CXX)
 cmake_minimum_required(VERSION 3.16)
+project(example LANGUAGES CXX)
 
 add_executable(example main.cpp)
 
 # Download the rerun_sdk
 include(FetchContent)
-FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip) # TODO(#3962): update link
+FetchContent_Declare(rerun_sdk DOWNLOAD_EXTRACT_TIMESTAMP URL https://github.com/rerun-io/rerun/releases/download/prerelease/rerun_cpp_sdk.zip) # TODO(#3962): update link
 FetchContent_MakeAvailable(rerun_sdk)
 
 # Rerun requires at least C++17, but it should be compatible with newer versions.

--- a/docs/content/getting-started/installing-viewer.md
+++ b/docs/content/getting-started/installing-viewer.md
@@ -14,7 +14,7 @@ There are many ways to install the viewer. Please pick whatever works best for y
 * Together with the Rerun [Python SDK](python.md):
   * `pip3 install rerun-sdk` - download it via pip
   * `conda install -c conda-forge rerun-sdk` - download via Conda
-  * `pixi global install rerun-sdk` - download it via [Pixi](https://prefix.dev/docs/pixi/overview
+  * `pixi global install rerun-sdk` - download it via [Pixi](https://prefix.dev/docs/pixi/overview)
 
 In any case you should be able to run `rerun` afterwards to start the Viewer.
 You'll be welcomed by an overview page that allows you to jump into some examples.

--- a/examples/cpp/clock/main.cpp
+++ b/examples/cpp/clock/main.cpp
@@ -2,7 +2,7 @@
 #include <cmath>
 #include <rerun.hpp>
 
-const float TAU = static_cast<float>(2.0 * M_PI);
+constexpr float TAU = 6.28318530717958647692528676655900577f;
 
 void log_hand(
     rerun::RecordingStream& rec, const char* name, int step, float angle, float length, float width,

--- a/pixi.lock
+++ b/pixi.lock
@@ -1938,25 +1938,6 @@ package:
   license: BSD
   size: 6269
   timestamp: 1689097851052
-- name: c-compiler
-  version: 1.6.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    vs2019_win-64: '*'
-  url: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.6.0-hcfcfb64_0.conda
-  hash:
-    md5: 9246624ea9ea636c9801b3279f88f3a4
-    sha256: 10d113359a3906d9eda66062ab3a36e0f21381c8448ec50c7a9e09e0a9bb4f21
-  optional: false
-  category: main
-  build: hcfcfb64_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD
-  size: 6381
-  timestamp: 1689097760340
 - name: ca-certificates
   version: 2023.7.22
   manager: conda
@@ -2205,32 +2186,6 @@ package:
   license_family: Apache
   size: 133018
   timestamp: 1690549798814
-- name: clang
-  version: 15.0.7
-  manager: conda
-  platform: win-64
-  dependencies:
-    clang-15: ==15.0.7 default_h66ee7f4_3
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/clang-15.0.7-h8e541a6_3.conda
-  hash:
-    md5: 22ceaf22487b0145a19c5bd61fbae126
-    sha256: beec8e1ebd4ee1722f7d3168ae0bef3b67bc5949071f0811d26808f0a75ab062
-  optional: false
-  category: main
-  build: h8e541a6_3
-  arch: x86_64
-  subdir: win-64
-  build_number: 3
-  constrains:
-  - clang-tools 15.0.7.*
-  - llvm 15.0.7.*
-  - llvm-tools 15.0.7.*
-  - llvmdev 15.0.7.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 85642361
-  timestamp: 1690552752505
 - name: clang-15
   version: 15.0.7
   manager: conda
@@ -2314,34 +2269,6 @@ package:
   license_family: Apache
   size: 795051
   timestamp: 1690549670667
-- name: clang-15
-  version: 15.0.7
-  manager: conda
-  platform: win-64
-  dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/clang-15-15.0.7-default_h66ee7f4_3.conda
-  hash:
-    md5: 5f127f81d123de0eb5795cf8436b035b
-    sha256: 839a0143214802f0f3b2d6295150e28754863021344b0c82719c60f379b09776
-  optional: false
-  category: main
-  build: default_h66ee7f4_3
-  arch: x86_64
-  subdir: win-64
-  build_number: 3
-  constrains:
-  - clangxx 15.0.7
-  - llvm-tools 15.0.7
-  - clangdev 15.0.7
-  - clang-tools 15.0.7
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 29291788
-  timestamp: 1690552522050
 - name: clang-format
   version: 15.0.7
   manager: conda
@@ -3202,25 +3129,6 @@ package:
   license: BSD
   size: 6301
   timestamp: 1689097905706
-- name: cxx-compiler
-  version: 1.6.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    vs2019_win-64: '*'
-  url: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.6.0-h91493d7_0.conda
-  hash:
-    md5: b1219f0b49bd243c7139cb9c42c4710c
-    sha256: 625af0fe202d3df70ba29bb6c80f3e45887b571a87dfd5bff94fa75577e2c417
-  optional: false
-  category: main
-  build: h91493d7_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD
-  size: 6421
-  timestamp: 1689097764951
 - name: exceptiongroup
   version: 1.1.3
   manager: conda
@@ -11768,47 +11676,6 @@ package:
   license_family: BSD
   size: 17207
   timestamp: 1688020635322
-- name: vs2019_win-64
-  version: 19.29.30139
-  manager: conda
-  platform: win-64
-  dependencies:
-    vswhere: '*'
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_17.conda
-  hash:
-    md5: 6351cac64b43c84c64bb6fe646d6acfe
-    sha256: 48ae2875083ef9e0b4dc2a3045154a4197e67f948dec44ae02c5348960445b93
-  optional: false
-  category: main
-  build: he1865b1_17
-  arch: x86_64
-  subdir: win-64
-  build_number: 17
-  track_features:
-  - vc14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19812
-  timestamp: 1688020390940
-- name: vswhere
-  version: 3.1.4
-  manager: conda
-  platform: win-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
-  hash:
-    md5: b1d1d6a1f874d8c93a57b5efece52f03
-    sha256: 553c41fc1a883415a39444313f8d99236685529776fdd04e8d97288b73496002
-  optional: false
-  category: main
-  build: h57928b3_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 218421
-  timestamp: 1682376911339
 - name: wheel
   version: 0.38.4
   manager: conda

--- a/pixi.lock
+++ b/pixi.lock
@@ -8517,28 +8517,6 @@ package:
   license_family: Apache
   size: 107047
   timestamp: 1676837935565
-- name: ninja
-  version: 1.11.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/ninja-1.11.1-h91493d7_0.conda
-  hash:
-    md5: 44a99ef26178ea98626ff8e027702795
-    sha256: 0ffb1912768af8354a930f482368ef170bf3d8217db328dfea1c8b09772c8c71
-  optional: false
-  category: main
-  build: h91493d7_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 279200
-  timestamp: 1676838681615
 - name: numpy
   version: 1.26.0
   manager: conda
@@ -11676,6 +11654,47 @@ package:
   license_family: BSD
   size: 17207
   timestamp: 1688020635322
+- name: vs2022_win-64
+  version: 19.37.32822
+  manager: conda
+  platform: win-64
+  dependencies:
+    vswhere: '*'
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.37.32822-h0123c8e_17.conda
+  hash:
+    md5: 8b02594cf497f7516a3ed20a164de75e
+    sha256: 259b5d4ac07b131bf15bf1a2d101eb9eb039e32cfef57de79061cb4c8f1889fe
+  optional: false
+  category: main
+  build: h0123c8e_17
+  arch: x86_64
+  subdir: win-64
+  build_number: 17
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19405
+  timestamp: 1694292390059
+- name: vswhere
+  version: 3.1.4
+  manager: conda
+  platform: win-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
+  hash:
+    md5: b1d1d6a1f874d8c93a57b5efece52f03
+    sha256: 553c41fc1a883415a39444313f8d99236685529776fdd04e8d97288b73496002
+  optional: false
+  category: main
+  build: h57928b3_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 218421
+  timestamp: 1682376911339
 - name: wheel
   version: 0.38.4
   manager: conda

--- a/pixi.toml
+++ b/pixi.toml
@@ -25,15 +25,27 @@ version = "0.1.0"                                                              #
 # Also, it's more likely that users are also going to use Visual Studio/MSBuild directly.
 [target.win-64.tasks]
 cpp-prepare = "cmake -G 'Visual Studio 17 2022' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
+cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/Debug/rerun_sdk_tests.exe", depends_on = [
+  "cpp-build-tests",
+] }
 
 [target.linux-64.tasks]
 cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
+cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
+  "cpp-build-tests",
+] }
 
 [target.osx-64.tasks]
 cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
+cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
+  "cpp-build-tests",
+] }
 
 [target.osx-arm64.tasks]
 cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
+cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
+  "cpp-build-tests",
+] }
 
 [tasks]
 # Note: extra CLI argument after `pixi run TASK` are passed to the task cmd.

--- a/pixi.toml
+++ b/pixi.toml
@@ -72,11 +72,8 @@ arrow-cpp = "10.0.1"
 attrs = ">=23.1.0"
 black = "23.3.0"
 blackdoc = "0.3.8"
-c-compiler = "1.6.0.*"
-clang = ">=15,<16"
 clang-tools = ">=15,<16"
 cmake = "3.27.6"
-cxx-compiler = "1.6.0.*"
 flatbuffers = ">=23"
 gitignore-parser = ">=0.1.9"
 gitpython = ">=3.1.40"
@@ -98,3 +95,19 @@ wheel = ">=0.38,<0.39"
 
 [target.linux-64.dependencies]
 patchelf = ">=0.17"
+clang = ">=15,<16"
+c-compiler = "1.6.0.*"
+cxx-compiler = "1.6.0.*"
+
+[target.osx-64.dependencies]
+clang = ">=15,<16"
+c-compiler = "1.6.0.*"
+cxx-compiler = "1.6.0.*"
+
+[target.osx-arm64.dependencies]
+clang = ">=15,<16"
+c-compiler = "1.6.0.*"
+cxx-compiler = "1.6.0.*"
+
+[target.win-64.dependecies]
+vs2022_win-64 = "19.37.32822"

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,6 +21,19 @@ readme = "README.md"
 repository = "https://github.com/rerun-io/rerun"
 version = "0.1.0"                                                              # TODO(emilk): sync version with `Cargo.toml` with help from `crates.py`
 
+# We could use Ninja on Windows as well, but this makes the compiler setup needlessly complicated.
+# Also, it's more likely that users are also going to use Visual Studio/MSBuild directly.
+[target.win-64.tasks]
+cpp-prepare = "cmake -G 'Visual Studio 17 2022' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
+
+[target.linux-64.tasks]
+cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
+
+[target.osx-64.tasks]
+cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
+
+[target.osx-arm64.tasks]
+cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
 
 [tasks]
 # Note: extra CLI argument after `pixi run TASK` are passed to the task cmd.
@@ -53,7 +66,6 @@ cpp-build-all = { depends_on = [
   "cpp-build-examples",
   "cpp-build-doc-examples",
 ] }
-cpp-prepare = "cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=Debug"
 cpp-build-tests = { cmd = "cmake --build build --config Debug --target rerun_sdk_tests", depends_on = [
   "cpp-prepare",
 ] }
@@ -80,7 +92,6 @@ gitpython = ">=3.1.40"
 just = ">=1.15.0"
 maturin = ">=0.14,<0.15"
 mypy = "1.4.1"
-ninja = "1.11.1"
 pip = ">=23"
 pyarrow = "10.0.1"
 pytest = ">=7"
@@ -98,16 +109,19 @@ patchelf = ">=0.17"
 clang = ">=15,<16"
 c-compiler = "1.6.0.*"
 cxx-compiler = "1.6.0.*"
+ninja = "1.11.1"
 
 [target.osx-64.dependencies]
 clang = ">=15,<16"
 c-compiler = "1.6.0.*"
 cxx-compiler = "1.6.0.*"
+ninja = "1.11.1"
 
 [target.osx-arm64.dependencies]
 clang = ">=15,<16"
 c-compiler = "1.6.0.*"
 cxx-compiler = "1.6.0.*"
+ninja = "1.11.1"
 
 [target.win-64.dependecies]
 vs2022_win-64 = "19.37.32822"

--- a/pixi.toml
+++ b/pixi.toml
@@ -135,5 +135,5 @@ c-compiler = "1.6.0.*"
 cxx-compiler = "1.6.0.*"
 ninja = "1.11.1"
 
-[target.win-64.dependecies]
+[target.win-64.dependencies]
 vs2022_win-64 = "19.37.32822"

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -50,6 +50,7 @@ if(DEFINED RERUN_REPOSITORY)
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/../crates/rerun_c/src/rerun.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/rerun/c/rerun.h"
+        NEWLINE_STYLE LF # Specify line endings, otherwise CMake wants to change them on Windows.
     )
 
     # Add tests!

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -104,6 +104,11 @@ if(RERUN_ARROW_LINK_SHARED)
     target_link_libraries(rerun_sdk PRIVATE Arrow::arrow_shared)
 else()
     message(STATUS "Arrow version: ${ARROW_VERSION}")
+
+    if(WIN32)
+        message(WARNING "As of writing static linking with libarrow is broken on Windows. See https://github.com/apache/arrow/issues/33145")
+    endif()
+
     target_link_libraries(rerun_sdk PRIVATE Arrow::arrow_static)
 endif()
 
@@ -114,5 +119,5 @@ if(APPLE)
 elseif(UNIX) # if(LINUX) # CMake 3.25
     target_link_libraries(rerun_sdk PRIVATE "-lm -ldl -pthread")
 elseif(WIN32)
-    target_link_libraries(rerun_sdk PUBLIC ws2_32.dll Bcrypt.dll Userenv.dll)
+    target_link_libraries(rerun_sdk PUBLIC ws2_32.dll Bcrypt.dll Userenv.dll ntdll.dll)
 endif()

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -76,7 +76,7 @@ if(NOT DEFINED RERUN_C_LIB_DEFAULT)
         set(RERUN_C_LIB_DEFAULT ${RERUN_C_DEFAULT_LIB_DIR}/librerun_c__linux_x64.a)
     elseif(WIN32)
         # TODO(andreas): Arm support.
-        set(RERUN_C_LIB_DEFAULT ${RERUN_C_DEFAULT_LIB_DIR}/librerun_c__win_x64.lib)
+        set(RERUN_C_LIB_DEFAULT ${RERUN_C_DEFAULT_LIB_DIR}/rerun_c__win_x64.lib)
     else()
         message(WARNING "Unsupported platform ${RERUN_C_LIB_DEFAULT}, can't find rerun_c library.")
     endif()

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -14,6 +14,11 @@ add_library(rerun_sdk ${rerun_sdk_SRC})
 # Rerun needs at least C++17.
 set_property(TARGET rerun_sdk PROPERTY CXX_STANDARD 17)
 
+# Do multithreaded compiling on MSVC.
+if(MSVC)
+    target_compile_options(rerun_sdk PRIVATE "/MP")
+endif()
+
 # ------------------------------------------------------------------------------
 # Rerun development setup only:
 if(DEFINED RERUN_REPOSITORY)

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -16,7 +16,7 @@ set_property(TARGET rerun_sdk PROPERTY CXX_STANDARD 17)
 
 # Do multithreaded compiling on MSVC.
 if(MSVC)
-    target_compile_options(rerun_sdk PRIVATE "/MP")
+    target_compile_options(rerun_sdk PRIVATE /MP)
 endif()
 
 # ------------------------------------------------------------------------------

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -49,10 +49,10 @@ namespace rerun {
         ///     const int WIDTH = 300;
         ///     std::vector<uint8_t> data(WIDTH * HEIGHT, 0);
         ///     for (auto y = 50; y <100; ++y) {
-        ///         std::fill_n(data.begin() + y * WIDTH + 50, 70, 1);
+        ///         std::fill_n(data.begin() + y * WIDTH + 50, 70, static_cast<uint8_t>(1));
         ///     }
         ///     for (auto y = 100; y <180; ++y) {
-        ///         std::fill_n(data.begin() + y * WIDTH + 130, 150, 2);
+        ///         std::fill_n(data.begin() + y * WIDTH + 130, 150, static_cast<uint8_t>(2));
         ///     }
         ///
         ///     rec.log("segmentation/image", rerun::SegmentationImage({HEIGHT, WIDTH}, std::move(data)));

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -31,9 +31,8 @@ namespace rerun {
         /// #include <rerun.hpp>
         ///
         /// #include <cmath>
-        /// #include <numeric>
         ///
-        /// const float TAU = static_cast<float>(2.0 * M_PI);
+        /// constexpr float TAU = 6.28318530717958647692528676655900577f;
         ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_arrow3d");

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -80,7 +80,7 @@ namespace rerun {
             // Extensions to generated type defined in 'asset3d_ext.cpp'
 
             static std::optional<rerun::components::MediaType> guess_media_type(
-                const std::filesystem::path& path
+                const std::string& path
             );
 
             /// Creates a new [`Asset3D`] from the file contents at `path`.

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -80,7 +80,7 @@ namespace rerun {
             // Extensions to generated type defined in 'asset3d_ext.cpp'
 
             static std::optional<rerun::components::MediaType> guess_media_type(
-                const std::string& path
+                const std::filesystem::path& path
             );
 
             /// Creates a new [`Asset3D`] from the file contents at `path`.

--- a/rerun_cpp/src/rerun/archetypes/asset3d_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d_ext.cpp
@@ -13,8 +13,7 @@ namespace rerun {
 #ifdef EDIT_EXTENSION
         // [CODEGEN COPY TO HEADER START]
 
-        static std::optional<rerun::components::MediaType> guess_media_type(const std::string& path
-        );
+        static std::optional<rerun::components::MediaType> guess_media_type(const std::filesystem::path& path);
 
         /// Creates a new [`Asset3D`] from the file contents at `path`.
         ///

--- a/rerun_cpp/src/rerun/archetypes/asset3d_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d_ext.cpp
@@ -1,6 +1,6 @@
 #include <algorithm>
-#include <filesystem> // TODO(andreas): Should not leak into public header.
-#include <fstream>    // TODO(andreas): Should not leak into public header.
+#include <filesystem> // TODO(#3991): Should not leak into public header.
+#include <fstream>    // TODO(#3991): Should not leak into public header.
 #include <string>
 
 #include "asset3d.hpp"
@@ -57,7 +57,7 @@ namespace rerun {
         }
 
         std::optional<rerun::components::MediaType> Asset3D::guess_media_type(
-            const std::string& path //
+            const std::filesystem::path& path
         ) {
             std::filesystem::path file_path(path);
             std::string ext = file_path.extension().string();

--- a/rerun_cpp/src/rerun/archetypes/asset3d_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d_ext.cpp
@@ -13,7 +13,9 @@ namespace rerun {
 #ifdef EDIT_EXTENSION
         // [CODEGEN COPY TO HEADER START]
 
-        static std::optional<rerun::components::MediaType> guess_media_type(const std::filesystem::path& path);
+        static std::optional<rerun::components::MediaType> guess_media_type(
+            const std::filesystem::path& path
+        );
 
         /// Creates a new [`Asset3D`] from the file contents at `path`.
         ///

--- a/rerun_cpp/src/rerun/archetypes/boxes2d_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d_ext.cpp
@@ -61,7 +61,7 @@ namespace rerun {
             std::vector<components::HalfSizes2D> half_sizes;
             half_sizes.reserve(sizes.size());
             for (const auto& size : sizes) {
-                half_sizes.emplace_back(size.x() / 2.0, size.y() / 2.0);
+                half_sizes.emplace_back(size.x() / 2.0f, size.y() / 2.0f);
             }
 
             // Move the vector into a component batch.

--- a/rerun_cpp/src/rerun/archetypes/boxes3d_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d_ext.cpp
@@ -64,7 +64,7 @@ namespace rerun {
             std::vector<components::HalfSizes3D> half_sizes;
             half_sizes.reserve(sizes.size());
             for (const auto& size : sizes) {
-                half_sizes.emplace_back(size.x() / 2.0, size.y() / 2.0, size.z() / 2.0);
+                half_sizes.emplace_back(size.x() / 2.0f, size.y() / 2.0f, size.z() / 2.0f);
             }
 
             // Move the vector into a component batch.

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -41,10 +41,10 @@ namespace rerun {
         ///     const int WIDTH = 300;
         ///     std::vector<uint16_t> data(WIDTH * HEIGHT, 65535);
         ///     for (auto y = 50; y <150; ++y) {
-        ///         std::fill_n(data.begin() + y * WIDTH + 50, 100, 20000);
+        ///         std::fill_n(data.begin() + y * WIDTH + 50, 100, static_cast<uint16_t>(20000));
         ///     }
         ///     for (auto y = 130; y <180; ++y) {
-        ///         std::fill_n(data.begin() + y * WIDTH + 100, 180, 45000);
+        ///         std::fill_n(data.begin() + y * WIDTH + 100, 180, static_cast<uint16_t>(45000));
         ///     }
         ///
         ///     // If we log a pinhole camera model, the depth gets automatically back-projected to 3D

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -43,7 +43,9 @@ namespace rerun {
         ///     tensor.shape = {dim3, dim3, dim3};
         ///     std::srand(static_cast<uint32_t>(std::time(nullptr)));
         ///     std::vector<uint8_t> random_data(3 * 3 * 3);
-        ///     std::generate(random_data.begin(), random_data.end(), std::rand);
+        ///     std::generate(random_data.begin(), random_data.end(), [] {
+        ///         return static_cast<uint8_t>(std::rand());
+        ///     });
         ///     tensor.buffer = rerun::datatypes::TensorBuffer::u8(random_data);
         ///
         ///     rec.log("world/image", rerun::Image(tensor));

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -41,7 +41,10 @@ namespace rerun {
         ///     std::default_random_engine gen;
         ///     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);
         ///     std::uniform_real_distribution<float> dist_radius(0.1f, 1.0f);
-        ///     std::uniform_int_distribution<uint8_t> dist_color(0, 255);
+        ///     std::uniform_int_distribution<int> dist_color(
+        ///         0,
+        ///         255
+        ///     ); // On MSVC uint8_t distributions are not supported.
         ///
         ///     std::vector<rerun::components::Position2D> points2d(10);
         ///     std::generate(points2d.begin(), points2d.end(), [&] {
@@ -49,7 +52,11 @@ namespace rerun {
         ///     });
         ///     std::vector<rerun::components::Color> colors(10);
         ///     std::generate(colors.begin(), colors.end(), [&] {
-        ///         return rerun::components::Color(dist_color(gen), dist_color(gen), dist_color(gen));
+        ///         return rerun::components::Color(
+        ///             static_cast<uint8_t>(dist_color(gen)),
+        ///             static_cast<uint8_t>(dist_color(gen)),
+        ///             static_cast<uint8_t>(dist_color(gen))
+        ///         );
         ///     });
         ///     std::vector<rerun::components::Radius> radii(10);
         ///     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -41,10 +41,8 @@ namespace rerun {
         ///     std::default_random_engine gen;
         ///     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);
         ///     std::uniform_real_distribution<float> dist_radius(0.1f, 1.0f);
-        ///     std::uniform_int_distribution<int> dist_color(
-        ///         0,
-        ///         255
-        ///     ); // On MSVC uint8_t distributions are not supported.
+        ///     // On MSVC uint8_t distributions are not supported.
+        ///     std::uniform_int_distribution<int> dist_color(0, 255);
         ///
         ///     std::vector<rerun::components::Position2D> points2d(10);
         ///     std::generate(points2d.begin(), points2d.end(), [&] {

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -40,10 +40,8 @@ namespace rerun {
         ///     std::default_random_engine gen;
         ///     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);
         ///     std::uniform_real_distribution<float> dist_radius(0.1f, 1.0f);
-        ///     std::uniform_int_distribution<int> dist_color(
-        ///         0,
-        ///         255
-        ///     ); // On MSVC uint8_t distributions are not supported.
+        ///     // On MSVC uint8_t distributions are not supported.
+        ///     std::uniform_int_distribution<int> dist_color(0, 255);
         ///
         ///     std::vector<rerun::components::Position3D> points3d(10);
         ///     std::generate(points3d.begin(), points3d.end(), [&] {

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -40,7 +40,10 @@ namespace rerun {
         ///     std::default_random_engine gen;
         ///     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);
         ///     std::uniform_real_distribution<float> dist_radius(0.1f, 1.0f);
-        ///     std::uniform_int_distribution<uint8_t> dist_color(0, 255);
+        ///     std::uniform_int_distribution<int> dist_color(
+        ///         0,
+        ///         255
+        ///     ); // On MSVC uint8_t distributions are not supported.
         ///
         ///     std::vector<rerun::components::Position3D> points3d(10);
         ///     std::generate(points3d.begin(), points3d.end(), [&] {
@@ -48,7 +51,11 @@ namespace rerun {
         ///     });
         ///     std::vector<rerun::components::Color> colors(10);
         ///     std::generate(colors.begin(), colors.end(), [&] {
-        ///         return rerun::components::Color(dist_color(gen), dist_color(gen), dist_color(gen));
+        ///         return rerun::components::Color(
+        ///             static_cast<uint8_t>(dist_color(gen)),
+        ///             static_cast<uint8_t>(dist_color(gen)),
+        ///             static_cast<uint8_t>(dist_color(gen))
+        ///         );
         ///     });
         ///     std::vector<rerun::components::Radius> radii(10);
         ///     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -42,11 +42,11 @@ namespace rerun {
         ///     const int HEIGHT = 8;
         ///     const int WIDTH = 12;
         ///     std::vector<uint8_t> data(WIDTH * HEIGHT, 0);
-        ///     for (auto y = 0; y <4; ++y) {                   // top half
-        ///         std::fill_n(data.begin() + y * WIDTH, 6, 1); // left half
+        ///     for (auto y = 0; y <4; ++y) {                                         // top half
+        ///         std::fill_n(data.begin() + y * WIDTH, 6, static_cast<uint8_t>(1)); // left half
         ///     }
-        ///     for (auto y = 4; y <8; ++y) {                       // bottom half
-        ///         std::fill_n(data.begin() + y * WIDTH + 6, 6, 2); // right half
+        ///     for (auto y = 4; y <8; ++y) {                                             // bottom half
+        ///         std::fill_n(data.begin() + y * WIDTH + 6, 6, static_cast<uint8_t>(2)); // right half
         ///     }
         ///
         ///     // create an annotation context to describe the classes

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -31,10 +31,8 @@ namespace rerun {
         ///     rec.connect().throw_on_failure();
         ///
         ///     std::default_random_engine gen;
-        ///     std::uniform_int_distribution<int> dist(
-        ///         0,
-        ///         255
-        ///     ); // On MSVC uint8_t distributions are not supported.
+        ///     // On MSVC uint8_t distributions are not supported.
+        ///     std::uniform_int_distribution<int> dist(0, 255);
         ///
         ///     std::vector<uint8_t> data(8 * 6 * 3 * 5);
         ///     std::generate(data.begin(), data.end(), [&] { return static_cast<uint8_t>(dist(gen)); });

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -31,10 +31,13 @@ namespace rerun {
         ///     rec.connect().throw_on_failure();
         ///
         ///     std::default_random_engine gen;
-        ///     std::uniform_int_distribution<uint8_t> dist(0, 255);
+        ///     std::uniform_int_distribution<int> dist(
+        ///         0,
+        ///         255
+        ///     ); // On MSVC uint8_t distributions are not supported.
         ///
         ///     std::vector<uint8_t> data(8 * 6 * 3 * 5);
-        ///     std::generate(data.begin(), data.end(), [&] { return dist(gen); });
+        ///     std::generate(data.begin(), data.end(), [&] { return static_cast<uint8_t>(dist(gen)); });
         ///
         ///     rec.log(
         ///         "tensor",

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -21,8 +21,8 @@ namespace rerun {
         ///
         /// ### Variety of 3D transforms
         /// ```cpp,ignore
-        /// #include <rerun.hpp>
         /// #include <cmath>
+        /// #include <rerun.hpp>
         ///
         /// constexpr float TAU = 6.28318530717958647692528676655900577f;
         ///

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -22,12 +22,9 @@ namespace rerun {
         /// ### Variety of 3D transforms
         /// ```cpp,ignore
         /// #include <rerun.hpp>
-        ///
         /// #include <cmath>
         ///
-        /// namespace rrd = rerun::datatypes;
-        ///
-        /// const float TAU = static_cast<float>(2.0 * M_PI);
+        /// constexpr float TAU = 6.28318530717958647692528676655900577f;
         ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_transform3d");
@@ -44,7 +41,7 @@ namespace rerun {
         ///     rec.log(
         ///         "base/rotated_scaled",
         ///         rerun::Transform3D(
-        ///             rrd::RotationAxisAngle({0.0f, 0.0f, 1.0f}, rrd::Angle::radians(TAU / 8.0f)),
+        ///             rerun::RotationAxisAngle({0.0f, 0.0f, 1.0f}, rerun::Angle::radians(TAU / 8.0f)),
         ///             2.0f
         ///         )
         ///     );

--- a/rerun_cpp/src/rerun/demo_utils.hpp
+++ b/rerun_cpp/src/rerun/demo_utils.hpp
@@ -9,7 +9,8 @@
 
 namespace rerun {
     namespace demo {
-        constexpr float TAU = static_cast<float>(M_PI * 2.0);
+        constexpr float PI = 3.14159265358979323846264338327950288f;
+        constexpr float TAU = 6.28318530717958647692528676655900577f;
 
         /// A linear interpolator that bounces between `a` and `b` as `t` goes above `1.0`.
         inline float bounce_lerp(float a, float b, float t) {

--- a/rerun_cpp/src/rerun/demo_utils.hpp
+++ b/rerun_cpp/src/rerun/demo_utils.hpp
@@ -28,7 +28,7 @@ namespace rerun {
         inline std::vector<T> linspace(T start, T end, size_t num) {
             std::vector<T> linspaced(num);
             std::generate(linspaced.begin(), linspaced.end(), [&, i = 0]() mutable {
-                return start + i++ * (end - start) / static_cast<T>(num - 1);
+                return static_cast<T>(start + i++ * (end - start) / static_cast<T>(num - 1));
             });
             return linspaced;
         }
@@ -41,7 +41,7 @@ namespace rerun {
             for (Elem z : linspace(from[0], to[0], n)) {
                 for (Elem y : linspace(from[1], to[1], n)) {
                     for (Elem x : linspace(from[2], to[2], n)) {
-                        output.emplace_back(x, y, z);
+                        output.emplace_back(static_cast<Elem>(x), static_cast<Elem>(y), static_cast<Elem>(z));
                     }
                 }
             }

--- a/rerun_cpp/src/rerun/demo_utils.hpp
+++ b/rerun_cpp/src/rerun/demo_utils.hpp
@@ -41,7 +41,11 @@ namespace rerun {
             for (Elem z : linspace(from[0], to[0], n)) {
                 for (Elem y : linspace(from[1], to[1], n)) {
                     for (Elem x : linspace(from[2], to[2], n)) {
-                        output.emplace_back(static_cast<Elem>(x), static_cast<Elem>(y), static_cast<Elem>(z));
+                        output.emplace_back(
+                            static_cast<Elem>(x),
+                            static_cast<Elem>(y),
+                            static_cast<Elem>(z)
+                        );
                     }
                 }
             }

--- a/rerun_cpp/src/rerun/error.cpp
+++ b/rerun_cpp/src/rerun/error.cpp
@@ -9,11 +9,20 @@
 
 namespace rerun {
     bool is_strict_mode() {
+        // MSVC warns if the older `getenv` is used.
+        // The new C11 getenv_s on the other hand isn't supported by all C++ compilers.
+    #ifdef _MSC_VER
         char env[512] = {};
         size_t env_length = 0;
         if (getenv_s(&env_length, env,  sizeof(env), "RERUN_STRICT") != 0) {
             return false;
         }
+    #else
+        const char* env = std::getenv("RERUN_STRICT");
+        if (env == nullptr) {
+            return false;
+        }
+    #endif
 
         std::string v = env;
         std::transform(v.begin(), v.end(), v.begin(), [](char c) { return std::tolower(c); });

--- a/rerun_cpp/src/rerun/error.cpp
+++ b/rerun_cpp/src/rerun/error.cpp
@@ -11,18 +11,18 @@ namespace rerun {
     bool is_strict_mode() {
         // MSVC warns if the older `getenv` is used.
         // The new C11 getenv_s on the other hand isn't supported by all C++ compilers.
-    #ifdef _MSC_VER
+#ifdef _MSC_VER
         char env[512] = {};
         size_t env_length = 0;
-        if (getenv_s(&env_length, env,  sizeof(env), "RERUN_STRICT") != 0) {
+        if (getenv_s(&env_length, env, sizeof(env), "RERUN_STRICT") != 0) {
             return false;
         }
-    #else
+#else
         const char* env = std::getenv("RERUN_STRICT");
         if (env == nullptr) {
             return false;
         }
-    #endif
+#endif
 
         std::string v = env;
         std::transform(v.begin(), v.end(), v.begin(), [](char c) { return std::tolower(c); });

--- a/rerun_cpp/src/rerun/error.cpp
+++ b/rerun_cpp/src/rerun/error.cpp
@@ -9,8 +9,9 @@
 
 namespace rerun {
     bool is_strict_mode() {
-        const char* env = getenv("RERUN_STRICT");
-        if (env == nullptr) {
+        char env[512] = {};
+        size_t env_length = 0;
+        if (getenv_s(&env_length, env,  sizeof(env), "RERUN_STRICT") != 0) {
             return false;
         }
 

--- a/rerun_cpp/tests/archetypes/lines_strips2d.cpp
+++ b/rerun_cpp/tests/archetypes/lines_strips2d.cpp
@@ -34,7 +34,7 @@ SCENARIO(
         from_manual.labels = {"hello", "friend"};
         from_manual.class_ids = {126, 127};
         from_manual.instance_keys = {123ull, 124ull};
-        from_manual.draw_order = 123;
+        from_manual.draw_order = 123.0f;
 
         test_compare_archetype_serialization(from_manual, from_builder);
     }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer15.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer15.cpp
@@ -42,7 +42,9 @@ namespace rerun {
             }
 
             (void)num_elements;
-            return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+            if (true) {
+                return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+            }
 
             return Error::ok();
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer4.cpp
@@ -42,7 +42,9 @@ namespace rerun {
             }
 
             (void)num_elements;
-            return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+            if (true) {
+                return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+            }
 
             return Error::ok();
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer5.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer5.cpp
@@ -42,7 +42,9 @@ namespace rerun {
             }
 
             (void)num_elements;
-            return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+            if (true) {
+                return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+            }
 
             return Error::ok();
         }

--- a/rerun_cpp/tests/generated/components/affix_fuzzer6.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer6.cpp
@@ -42,7 +42,9 @@ namespace rerun {
             }
 
             (void)num_elements;
-            return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+            if (true) {
+                return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+            }
 
             return Error::ok();
         }

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -1,10 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <arrow/buffer.h>
-#pragma GCC diagnostic pop
 
 #include "error_check.hpp"
 

--- a/scripts/ci/bundle_and_upload_rerun_cpp.py
+++ b/scripts/ci/bundle_and_upload_rerun_cpp.py
@@ -34,7 +34,7 @@ def download_rerun_c(target_dir: str, git_hash: str, platform_filter: str = None
         ("linux/librerun_c.a", "librerun_c__linux_x64.a"),
         ("macos-arm/librerun_c.a", "librerun_c__macos_arm64.a"),
         ("macos-intel/librerun_c.a", "librerun_c__macos_x64.a"),
-        ("windows/librerun_c.a", "librerun_c__win_x64.a"),
+        ("windows/rerun_c.lib", "rerun_c__win_x64.lib"),
     ]:
         if platform_filter is not None and src.startswith(platform_filter) is False:
             continue

--- a/tests/cpp/roundtrips/transform3d/main.cpp
+++ b/tests/cpp/roundtrips/transform3d/main.cpp
@@ -3,7 +3,7 @@
 #include <rerun/archetypes/transform3d.hpp>
 #include <rerun/recording_stream.hpp>
 
-#include <cmath>
+constexpr float PI = 3.14159265358979323846264338327950288f;
 
 int main(int, char** argv) {
     auto rec = rerun::RecordingStream("rerun_example_roundtrip_transform3d");
@@ -50,7 +50,7 @@ int main(int, char** argv) {
             {1.0f, 2.0f, 3.0f},
             rerun::datatypes::RotationAxisAngle(
                 {0.2f, 0.2f, 0.8f},
-                rerun::datatypes::Angle::radians(static_cast<float>(M_PI))
+                rerun::datatypes::Angle::radians(PI)
             )
         )
     );
@@ -61,7 +61,7 @@ int main(int, char** argv) {
             {1.0f, 2.0f, 3.0f},
             rerun::datatypes::RotationAxisAngle(
                 {0.2f, 0.2f, 0.8f},
-                rerun::datatypes::Angle::radians(static_cast<float>(M_PI))
+                rerun::datatypes::Angle::radians(PI)
             ),
             42.0f,
             true


### PR DESCRIPTION
### What

A wild mix between:
* improve CMake script
* fix CMake warnings
* improve documentation
* fix windows artifact bundling
* fix compile errors & warnings
* fix Rerun pixi setup for windows

Unless I tainted my system environment to much, this PR will make `pixi run cpp-build-all` work out of the box on Windows given that there is a VS2022 install present.

Fixes a big chunk of:
* #3756

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4011) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4011)
- [Docs preview](https://rerun.io/preview/2e9215adee8737f2ef27803185f996364513c8fd/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2e9215adee8737f2ef27803185f996364513c8fd/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)