### PR TITLE
Resolve gcc compiler warnings

### DIFF
--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -768,7 +768,7 @@ impl QuotedObject {
                     methods.push(Method {
                         docs: obj_field.docs.clone().into(),
                         declaration: MethodDeclaration::constructor(
-                            quote!(#pascal_case_ident(#param_declaration)),
+                            quote!(#pascal_case_ident(#param_declaration) : #pascal_case_ident()),
                         ),
                         definition_body,
                         inline: true,
@@ -986,7 +986,10 @@ impl QuotedObject {
                         union #data_typename {
                             #(#enum_data_declarations;)*
 
-                            #data_typename() { } // Required by static constructors
+                            // Required by static constructors
+                            #data_typename() {
+                                std::memset(reinterpret_cast<void*>(this), 0, sizeof(#data_typename));
+                            }
                             ~#data_typename() { }
 
                             // Note that this type is *not* copyable unless all enum fields are trivially destructable.

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>
+
 #include <utility>
 #include <vector>
 
@@ -92,6 +94,7 @@ namespace rerun {
         /// batch: When you log an empty component batch at an entity that already has some
         /// components of the same type, it will clear out all components of that type.
         ComponentBatch() : ownership(BatchOwnership::Borrowed) {
+            memset(reinterpret_cast<void*>(&storage), 0, sizeof(storage));
             storage.borrowed.data = nullptr;
             storage.borrowed.num_instances = 0;
         }

--- a/rerun_cpp/src/rerun/components/rotation3d_ext.cpp
+++ b/rerun_cpp/src/rerun/components/rotation3d_ext.cpp
@@ -29,7 +29,6 @@ namespace rerun {
 #define Rotation3DExt Rotation3D
 #endif
 
-        const Rotation3D Rotation3D::IDENTITY =
-            rerun::datatypes::Rotation3D::quaternion(datatypes::Quaternion::IDENTITY);
+        const Rotation3D Rotation3D::IDENTITY = datatypes::Quaternion::IDENTITY;
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.hpp
@@ -32,7 +32,9 @@ namespace rerun {
 
                 float degrees;
 
-                AngleData() {}
+                AngleData() {
+                    std::memset(reinterpret_cast<void*>(this), 0, sizeof(AngleData));
+                }
 
                 ~AngleData() {}
 

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
@@ -36,7 +36,9 @@ namespace rerun {
                 /// Rotation defined with an axis and an angle.
                 rerun::datatypes::RotationAxisAngle axis_angle;
 
-                Rotation3DData() {}
+                Rotation3DData() {
+                    std::memset(reinterpret_cast<void*>(this), 0, sizeof(Rotation3DData));
+                }
 
                 ~Rotation3DData() {}
 
@@ -81,7 +83,7 @@ namespace rerun {
           public:
             // Extensions to generated type defined in 'rotation3d_ext.cpp'
 
-            // static const Rotation3D IDENTITY;
+            static const Rotation3D IDENTITY;
 
             void swap(Rotation3D& other) noexcept {
                 std::swap(this->_tag, other._tag);
@@ -89,12 +91,12 @@ namespace rerun {
             }
 
             /// Rotation defined by a quaternion.
-            Rotation3D(rerun::datatypes::Quaternion quaternion) {
+            Rotation3D(rerun::datatypes::Quaternion quaternion) : Rotation3D() {
                 *this = Rotation3D::quaternion(std::move(quaternion));
             }
 
             /// Rotation defined with an axis and an angle.
-            Rotation3D(rerun::datatypes::RotationAxisAngle axis_angle) {
+            Rotation3D(rerun::datatypes::RotationAxisAngle axis_angle) : Rotation3D() {
                 *this = Rotation3D::axis_angle(std::move(axis_angle));
             }
 

--- a/rerun_cpp/src/rerun/datatypes/rotation3d_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d_ext.cpp
@@ -12,7 +12,7 @@ namespace rerun {
 
             // [CODEGEN COPY TO HEADER START]
 
-            // static const Rotation3D IDENTITY;
+            static const Rotation3D IDENTITY;
 
             // [CODEGEN COPY TO HEADER END]
         };
@@ -22,10 +22,6 @@ namespace rerun {
 #define Rotation3DExt Rotation3D
 #endif
 
-        // TODO(andreas): This constant initialization does not work for unknown reasons!
-        //                On clang(-mac) this set the Rotation3D::IDENTITY to all zero instead of
-        //                the expected quaternion.
-        // Using the same code as a non-constant works fine.
-        // const Rotation3DExt Rotation3DExt::IDENTITY = Quaternion::IDENTITY;
+        const Rotation3D Rotation3D::IDENTITY = Quaternion::IDENTITY;
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.hpp
@@ -35,7 +35,9 @@ namespace rerun {
                 /// Uniform scaling factor along all axis.
                 float uniform;
 
-                Scale3DData() {}
+                Scale3DData() {
+                    std::memset(reinterpret_cast<void*>(this), 0, sizeof(Scale3DData));
+                }
 
                 ~Scale3DData() {}
 
@@ -83,12 +85,12 @@ namespace rerun {
             }
 
             /// Individual scaling factors for each axis, distorting the original object.
-            Scale3D(rerun::datatypes::Vec3D three_d) {
+            Scale3D(rerun::datatypes::Vec3D three_d) : Scale3D() {
                 *this = Scale3D::three_d(std::move(three_d));
             }
 
             /// Uniform scaling factor along all axis.
-            Scale3D(float uniform) {
+            Scale3D(float uniform) : Scale3D() {
                 *this = Scale3D::uniform(std::move(uniform));
             }
 

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
@@ -68,7 +68,9 @@ namespace rerun {
 
                 std::vector<uint8_t> nv12;
 
-                TensorBufferData() {}
+                TensorBufferData() {
+                    std::memset(reinterpret_cast<void*>(this), 0, sizeof(TensorBufferData));
+                }
 
                 ~TensorBufferData() {}
 

--- a/rerun_cpp/src/rerun/datatypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.hpp
@@ -34,7 +34,9 @@ namespace rerun {
 
                 rerun::datatypes::TranslationRotationScale3D translation_rotation_scale;
 
-                Transform3DData() {}
+                Transform3DData() {
+                    std::memset(reinterpret_cast<void*>(this), 0, sizeof(Transform3DData));
+                }
 
                 ~Transform3DData() {}
 
@@ -81,11 +83,13 @@ namespace rerun {
                 this->_data.swap(other._data);
             }
 
-            Transform3D(rerun::datatypes::TranslationAndMat3x3 translation_and_mat3x3) {
+            Transform3D(rerun::datatypes::TranslationAndMat3x3 translation_and_mat3x3)
+                : Transform3D() {
                 *this = Transform3D::translation_and_mat3x3(std::move(translation_and_mat3x3));
             }
 
-            Transform3D(rerun::datatypes::TranslationRotationScale3D translation_rotation_scale) {
+            Transform3D(rerun::datatypes::TranslationRotationScale3D translation_rotation_scale)
+                : Transform3D() {
                 *this =
                     Transform3D::translation_rotation_scale(std::move(translation_rotation_scale));
             }

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
@@ -42,7 +42,9 @@ namespace rerun {
 
                 std::array<float, 3> fixed_size_shenanigans;
 
-                AffixFuzzer3Data() {}
+                AffixFuzzer3Data() {
+                    std::memset(reinterpret_cast<void*>(this), 0, sizeof(AffixFuzzer3Data));
+                }
 
                 ~AffixFuzzer3Data() {}
 

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
@@ -38,7 +38,9 @@ namespace rerun {
 
                 std::optional<std::vector<rerun::datatypes::AffixFuzzer3>> many_optional;
 
-                AffixFuzzer4Data() {}
+                AffixFuzzer4Data() {
+                    std::memset(reinterpret_cast<void*>(this), 0, sizeof(AffixFuzzer4Data));
+                }
 
                 ~AffixFuzzer4Data() {}
 


### PR DESCRIPTION
### What
Add some constructors more explicitly and initialize memory of some unions.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4012) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4012)
- [Docs preview](https://rerun.io/preview/29cc3e82534dafc43b7a1feb796a2d08792c6022/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/29cc3e82534dafc43b7a1feb796a2d08792c6022/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)