### PR TITLE
Spawn via `$PATH` 4: Updated docs & misc clean up

### DIFF
--- a/crates/re_viewer/data/quick_start_guides/rust_spawn.md
+++ b/crates/re_viewer/data/quick_start_guides/rust_spawn.md
@@ -4,12 +4,12 @@ ${SAFARI_WARNING}
 
 ### Installing Rerun
 
-To use the Rerun SDK in your project, you need the [rerun crate](https://crates.io/crates/rerun) which you can add with `cargo add rerun`.
+After you have [installed the viewer](https://www.rerun.io/docs/getting-started/installing-viewer?speculative-link) you can simply add [the rerun crate](https://crates.io/crates/rerun) to your project with `cargo add rerun`.
 
 Let's try it out in a brand-new Rust project:
 
 ```sh
-cargo init cube && cd cube && cargo add rerun --features native_viewer
+cargo init cube && cd cube && cargo add rerun
 ```
 
 Note that the Rerun SDK requires a working installation of Rust 1.72+.

--- a/docs/code-examples/Cargo.toml
+++ b/docs/code-examples/Cargo.toml
@@ -182,4 +182,4 @@ path = "view_coordinates_simple.rs"
 [dependencies]
 ndarray.workspace = true
 rand.workspace = true
-rerun = { path = "../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../crates/rerun" }

--- a/docs/code-examples/quick_start_spawn.rs
+++ b/docs/code-examples/quick_start_spawn.rs
@@ -4,7 +4,7 @@ use rerun::{demo_util::grid, external::glam};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new `RecordingStream` which stores data in memory.
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal_rs")
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal")
         .spawn(rerun::default_flush_timeout())?;
 
     // Create some data using the `grid` utility function.

--- a/docs/content/getting-started/logging-rust.md
+++ b/docs/content/getting-started/logging-rust.md
@@ -333,45 +333,39 @@ You can also save a recording (or a portion of it) as you're visualizing it, dir
 
 ### Spawning the Viewer from your process
 
-Instead of connecting to an external Viewer process, you can also spawn it from your own process.
-The main advantage of this is that you no longer need to open up the viewer as a separate process.
+If the Rerun Viewer is [installed](installing-viewer.md) and available in your `PATH`, you can use [`RecordingStream::spawn`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.spawn?speculative-link) to automatically start a viewer in a new process and connect to it over TCP.
+If an external viewer was already running, `spawn` will connect to that one instead of spawning a new one.
 
+```rust
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_dna_abacus")
+        .spawn(rerun::default_flush_timeout())?;
+
+    // … log data to `rec` …
+
+    Ok(())
+}
+```
+
+Alternatively, you can use [`rerun::native_viewer::show`](https://docs.rs/rerun/latest/rerun/native_viewer/fn.show.html) to start a viewer on the main thread (for platform-compatibility reasons) and feed it data from memory.
 This requires the `native_viewer` feature to be enabled in `Cargo.toml`:
 ```toml
 rerun = { version = "0.9", features = ["native_viewer"] }
 ```
 Doing so means you're building the Rerun Viewer itself as part of your project, meaning compilation will take a bit longer the first time.
 
-You can now use [`rerun::native_viewer::spawn`](https://docs.rs/rerun/latest/rerun/native_viewer/fn.spawn.html) to spawn
-the native Rerun viewer.
-Since the Viewer's UI thread must be the main thread, this method call will take it over and spawn a new thread for you:
+Unlike `spawn` however, this expects a complete recording instead of being fed in real-time:
 ```rust
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let store_info = rerun::new_store_info("DNA Abacus");
-    rerun::native_viewer::spawn(store_info, Default::default(), |rec| {
-        run(&rec).unwrap();
-    })?;
-    Ok(())
-}
-
-fn run(rec: &rerun::RecordingStream) -> rerun::RecordingStreamResult<()> {
-    // All your code (logging and otherwise) goes in here.
-}
-```
-
-Another way to spawn the native viewer is [`rerun::native_viewer::show`](https://docs.rs/rerun/latest/rerun/native_viewer/fn.show.html). Again, like [`rerun::native_viewer::spawn`](https://docs.rs/rerun/latest/rerun/native_viewer/fn.spawn.html) this has to be called from the main thread and the method call will only return once the Viewer is closed.
-Unlike `spawn` however, it expects a in-memory recording and sends it to the viewer instead of being fed in real-time:
-```rust
-let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_minimal_rs").memory()?;
+let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_dna_abacus").memory()?;
 
 // … log data to `rec` …
 
 rerun::native_viewer::show(storage.take())?;
 ```
+The viewer will block the main thread until it is closed.
 
 ### Closing
 
 This closes our whirlwind tour of Rerun. We've barely scratched the surface of what's possible, but this should have hopefully given you plenty pointers to start experimenting.
 
 As a next step, browse through our [example gallery](/examples) for some more realistic example use-cases, or browse the [Types](../reference/types.md) section for more simple examples of how to use the main data types.
-

--- a/docs/content/getting-started/rust.md
+++ b/docs/content/getting-started/rust.md
@@ -10,7 +10,7 @@ After you have [installed the viewer](installing-viewer.md) you can simply add [
 
 Let's try it out in a brand new Rust project:
 ```bash
-$ cargo init cube && cd cube && cargo add rerun --features native_viewer
+$ cargo init cube && cd cube && cargo add rerun
 ```
 
 ## Logging some data
@@ -20,7 +20,7 @@ Add the following code to your `main.rs`
 use rerun::{demo_util::grid, external::glam};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_minimal_rs").memory()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal").spawn(None)?;
 
     let points = grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10);
     let colors = grid(glam::Vec3::ZERO, glam::Vec3::splat(255.0), 10)
@@ -33,7 +33,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_radii([0.5]),
     )?;
 
-    rerun::native_viewer::show(storage.take())?;
     Ok(())
 }
 ```

--- a/docs/content/reference/sdk-operating-modes.md
+++ b/docs/content/reference/sdk-operating-modes.md
@@ -16,7 +16,7 @@ All four of them are optional: when none of these modes are active, the client w
 
 ### Spawn
 
-This is the default behavior you get when running all of our Python & Rust examples, and is generally the most convenient when you're experimenting.
+This is the default behavior you get when running all of our Python/Rust/C++ examples, and is generally the most convenient when you're experimenting.
 
 #### Python
 
@@ -24,7 +24,11 @@ Call [`rr.spawn`](https://ref.rerun.io/docs/python/stable/common/initialization_
 
 #### Rust
 
-[`rerun::native_viewer::spawn`](https://docs.rs/rerun/latest/rerun/native_viewer/fn.spawn.html) spawns a new viewer on the main thread (for platform compatibility reasons) and continues executing user code on a new thread, streaming data between the two in real-time using an in-memory channel.
+[`RecordingStream::spawn`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.spawn?speculative-link) spawns a new Rerun Viewer process using an executable available in your PATH, then streams all the data to it via TCP. If an external viewer was already running, `spawn` will connect to that one instead of spawning a new one.
+
+#### C++
+
+`RecordingStream::spawn` spawns a new Rerun Viewer process using an executable available in your PATH, then streams all the data to it via TCP. If an external viewer was already running, `spawn` will connect to that one instead of spawning a new one.
 
 ## Connect
 
@@ -40,6 +44,10 @@ You will need to start a stand-alone viewer first by typing `rerun` in your term
 
 [`RecordingStream::connect`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.connect)
 
+#### C++
+
+`RecordingStream::connect`
+
 ## Serve
 
 This starts the web version of the Rerun Viewer in your browser, and streams data to it in real-time using WebSockets.
@@ -51,6 +59,10 @@ Use [`rr.serve`](https://ref.rerun.io/docs/python/stable/common/initialization_f
 #### Rust
 
 [`RecordingStream::serve`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.serve)
+
+#### C++
+
+Not available yet.
 
 ## Save
 
@@ -67,6 +79,10 @@ Use [`rr.save`](https://ref.rerun.io/docs/python/stable/common/initialization_fu
 #### Rust
 
 Use [`RecordingStream::save`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.save).
+
+#### C++
+
+Use `RecordingStream::save`.
 
 ## Adding the standard flags to your programs
 

--- a/tests/rust/roundtrips/annotation_context/Cargo.toml
+++ b/tests/rust/roundtrips/annotation_context/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/arrows3d/Cargo.toml
+++ b/tests/rust/roundtrips/arrows3d/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/boxes2d/Cargo.toml
+++ b/tests/rust/roundtrips/boxes2d/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/boxes3d/Cargo.toml
+++ b/tests/rust/roundtrips/boxes3d/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/depth_image/Cargo.toml
+++ b/tests/rust/roundtrips/depth_image/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/disconnected_space/Cargo.toml
+++ b/tests/rust/roundtrips/disconnected_space/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/image/Cargo.toml
+++ b/tests/rust/roundtrips/image/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/line_strips2d/Cargo.toml
+++ b/tests/rust/roundtrips/line_strips2d/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/line_strips3d/Cargo.toml
+++ b/tests/rust/roundtrips/line_strips3d/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/pinhole/Cargo.toml
+++ b/tests/rust/roundtrips/pinhole/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/points2d/Cargo.toml
+++ b/tests/rust/roundtrips/points2d/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/points3d/Cargo.toml
+++ b/tests/rust/roundtrips/points3d/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/segmentation_image/Cargo.toml
+++ b/tests/rust/roundtrips/segmentation_image/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/tensor/Cargo.toml
+++ b/tests/rust/roundtrips/tensor/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/text_document/Cargo.toml
+++ b/tests/rust/roundtrips/text_document/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/text_log/Cargo.toml
+++ b/tests/rust/roundtrips/text_log/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/transform3d/Cargo.toml
+++ b/tests/rust/roundtrips/transform3d/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/roundtrips/view_coordinates/Cargo.toml
+++ b/tests/rust/roundtrips/view_coordinates/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-rerun = { path = "../../../../crates/rerun", features = ["native_viewer"] }
+rerun = { path = "../../../../crates/rerun" }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/tests/rust/test_api/Cargo.toml
+++ b/tests/rust/test_api/Cargo.toml
@@ -7,10 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = [
-  "native_viewer",
-  "web_viewer",
-] }
+rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }


### PR DESCRIPTION
Last one.

Spawn via `$PATH` series:
- #3996
- #3997
- #3998
- #4013

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4013) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4013)
- [Docs preview](https://rerun.io/preview/47899be3833d585ac5703ec2ffe8398fdfab1a10/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/47899be3833d585ac5703ec2ffe8398fdfab1a10/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)