### PR TITLE
Add a new build Environment option for CondaBuild to improve conda-built artifacts

### DIFF
--- a/crates/re_build_tools/src/lib.rs
+++ b/crates/re_build_tools/src/lib.rs
@@ -72,7 +72,7 @@ pub enum Environment {
     /// from the conda feed-stock and the build happens via source downloaded from the
     /// github-hosted tgz.
     ///
-    /// See: https://github.com/conda-forge/rerun-sdk-feedstock
+    /// See <https://github.com/conda-forge/rerun-sdk-feedstock>.
     CondaBuild,
 
     /// Are we a developer running inside the workspace of <https://github.com/rerun-io/rerun> ?

--- a/crates/re_build_tools/src/lib.rs
+++ b/crates/re_build_tools/src/lib.rs
@@ -66,7 +66,13 @@ pub enum Environment {
     /// We are running on CI, but NOT publishing crates
     CI,
 
-    /// We are running in the conda build environment
+    /// We are running in the conda build environment.
+    ///
+    /// This is a particularly special build environment because the branch checked out is
+    /// from the conda feed-stock and the build happens via source downloaded from the
+    /// github-hosted tgz.
+    ///
+    /// See: https://github.com/conda-forge/rerun-sdk-feedstock
     CondaBuild,
 
     /// Are we a developer running inside the workspace of <https://github.com/rerun-io/rerun> ?

--- a/crates/re_build_tools/src/rebuild_detector.rs
+++ b/crates/re_build_tools/src/rebuild_detector.rs
@@ -17,7 +17,7 @@ fn should_run() -> bool {
         // We cannot run this during publishing,
         // we don't need to,
         // and it can also can cause a Cargo.lock file to be generated.
-        Environment::PublishingCrates => false,
+        Environment::PublishingCrates | Environment::CondaBuild => false,
 
         // Dependencies shouldn't change on CI, but who knows 🤷‍♂️
         Environment::CI => true,

--- a/crates/re_renderer/build.rs
+++ b/crates/re_renderer/build.rs
@@ -110,7 +110,7 @@ fn should_run() -> bool {
         Environment::PublishingCrates => false,
 
         // The code we're generating here is actual source code that gets committed into the repository.
-        Environment::CI => false,
+        Environment::CI | Environment::CondaBuild => false,
 
         Environment::DeveloperInWorkspace => true,
 

--- a/crates/re_types_builder/build.rs
+++ b/crates/re_types_builder/build.rs
@@ -22,7 +22,7 @@ fn should_run() -> bool {
         Environment::PublishingCrates => false,
 
         // The code we're generating here is actual source code that gets committed into the repository.
-        Environment::CI => false,
+        Environment::CI | Environment::CondaBuild => false,
 
         Environment::DeveloperInWorkspace => {
             // This `build.rs` depends on having `flatc` installed,

--- a/crates/re_viewer/build.rs
+++ b/crates/re_viewer/build.rs
@@ -159,6 +159,9 @@ fn get_base_url(build_env: Environment) -> anyhow::Result<String> {
         return Ok(base_url);
     }
 
+    // In the CondaBuild environment we can't trust the git_branch name -- if it exists
+    // at all it's going to be the feedstock branch-name, not our Rerun branch. However
+    // conda should ONLY be building released versions, so we want to version the manifest.
     let versioned_manifest = matches!(build_env, Environment::CondaBuild) || {
         let branch = re_build_tools::git_branch()?;
         if branch == "main" || !re_build_tools::is_on_ci() {

--- a/crates/re_viewer/build.rs
+++ b/crates/re_viewer/build.rs
@@ -15,6 +15,8 @@
 
 use std::path::Path;
 
+use re_build_tools::Environment;
+
 fn parse_release_version(branch: &str) -> Option<&str> {
     // release-\d+.\d+.\d+(-alpha.\d+)?
 
@@ -151,21 +153,24 @@ fn parse_frontmatter<P: AsRef<Path>>(path: P) -> anyhow::Result<Option<Frontmatt
     )?))
 }
 
-fn get_base_url() -> anyhow::Result<String> {
+fn get_base_url(build_env: Environment) -> anyhow::Result<String> {
     if let Ok(base_url) = re_build_tools::get_and_track_env_var("EXAMPLES_MANIFEST_BASE_URL") {
         // override via env var
         return Ok(base_url);
     }
 
-    let branch = re_build_tools::git_branch()?;
-    if branch == "main" || !re_build_tools::is_on_ci() {
-        // on `main` and local builds, use `version/nightly`
-        // this will point to data uploaded by `.github/workflows/reusable_upload_web_demo.yml`
-        // on every commit to the `main` branch
-        return Ok("https://demo.rerun.io/version/nightly".into());
-    }
+    let versioned_manifest = matches!(build_env, Environment::CondaBuild) || {
+        let branch = re_build_tools::git_branch()?;
+        if branch == "main" || !re_build_tools::is_on_ci() {
+            // on `main` and local builds, use `version/nightly`
+            // this will point to data uploaded by `.github/workflows/reusable_upload_web_demo.yml`
+            // on every commit to the `main` branch
+            return Ok("https://demo.rerun.io/version/nightly".into());
+        }
+        parse_release_version(&branch).is_some()
+    };
 
-    if parse_release_version(&branch).is_some() {
+    if versioned_manifest {
         let metadata = re_build_tools::cargo_metadata()?;
         let workspace_root = metadata
             .root_package()
@@ -187,8 +192,8 @@ fn get_base_url() -> anyhow::Result<String> {
 
 const MANIFEST_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/data/examples_manifest.json");
 
-fn write_examples_manifest() -> anyhow::Result<()> {
-    let base_url = get_base_url()?;
+fn write_examples_manifest(build_env: Environment) -> anyhow::Result<()> {
+    let base_url = get_base_url(build_env)?;
 
     let mut manifest = vec![];
     for example in examples()? {
@@ -203,18 +208,19 @@ fn write_examples_manifest() -> anyhow::Result<()> {
 }
 
 fn write_examples_manifest_if_necessary() {
-    use re_build_tools::Environment;
-    let should_run = match Environment::detect() {
+    let build_env = Environment::detect();
+
+    let should_run = match build_env {
         // Can't run in thsese situations, because we can't find `examples/python`.
         Environment::PublishingCrates | Environment::UsedAsDependency => false,
 
         // Make sure the manifest reflects what is in `examples/python`.
-        Environment::CI | Environment::DeveloperInWorkspace => true,
+        Environment::CI | Environment::CondaBuild | Environment::DeveloperInWorkspace => true,
     };
 
     if should_run {
         re_build_tools::rerun_if_changed_or_doesnt_exist(MANIFEST_PATH);
-        if let Err(err) = write_examples_manifest() {
+        if let Err(err) = write_examples_manifest(build_env) {
             panic!("{err}");
         }
     }

--- a/crates/re_web_viewer_server/build.rs
+++ b/crates/re_web_viewer_server/build.rs
@@ -20,7 +20,7 @@ fn should_run() -> bool {
         Environment::PublishingCrates => false,
 
         // TODO(emilk): only build the web viewer explicitly on CI
-        Environment::CI => true,
+        Environment::CI | Environment::CondaBuild => true,
 
         Environment::DeveloperInWorkspace => true,
 

--- a/examples/rust/objectron/build.rs
+++ b/examples/rust/objectron/build.rs
@@ -12,7 +12,7 @@ fn should_run() -> bool {
 
         // No need to run this on CI (which means setting up `protoc` etc)
         // since the code is committed anyway.
-        Environment::CI => false,
+        Environment::CI | Environment::CondaBuild => false,
 
         // Sure - let's keep it up-to-date.
         Environment::DeveloperInWorkspace => true,


### PR DESCRIPTION
### What
Resolves:
 - https://github.com/rerun-io/rerun/issues/3908

The main issue is that the conda environment dind't realize it was building a released version.

The conda build environment is special. The feedstock recipe downloads the source from the published artifact, so many of our checks related to things like branch-name aren't correct. Otherwise it's very close to the CI build environment.

This detects the environment and attempts to do more reasonable things where relevant.

### Testing
- I created a temporary branch in the rerun feedstock repository pointing to the source `https://github.com/rerun-io/rerun/archive/refs/heads/jleibs/conda_examples.zip`
- I built using `python build-locally.py linux_64_python3.10.____cpython`
- I ran the `rerun` version from the channel with `RUST_LOG=debug`
- Confirmed correct attempted download location based on version:
  - `Downloading .rrd file from "https://demo.rerun.io/version/0.10.0-alpha.7+dev/examples/plots/data.rrd"…`

Related, I also need to remove RERUN_IS_PUBLISHING from the conda recipe. See:
 - https://github.com/conda-forge/rerun-sdk-feedstock/pull/17

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4015) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4015)
- [Docs preview](https://rerun.io/preview/88368c2fa735ba44cb811e0f238c6274f8d32071/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/88368c2fa735ba44cb811e0f238c6274f8d32071/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)