### PR TITLE
Fix incorrect markdown comment on troubleshooting page

### DIFF
--- a/docs/content/getting-started/troubleshooting.md
+++ b/docs/content/getting-started/troubleshooting.md
@@ -32,7 +32,7 @@ rerun reset
 ```
 
 ## Graphics issues
-<--! This section is linked to from `crates/re_viewer/src/native.rs` -->
+<!-- This section is linked to from `crates/re_viewer/src/native.rs` -->
 
 [Wgpu](https://github.com/gfx-rs/wgpu) (the graphics API we use) maintains a list of
 [known driver issues](https://github.com/gfx-rs/wgpu/wiki/Known-Driver-Issues) and workarounds for them.


### PR DESCRIPTION
### What
Incorrect markdown comment is rendered in:
https://www.rerun.io/docs/getting-started/troubleshooting#graphics-issues

![image](https://github.com/rerun-io/rerun/assets/3312232/a93cce83-6da0-450a-9b8d-4f6fe4a8c690)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4016) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4016)
- [Docs preview](https://rerun.io/preview/80c2d49e89c7de7ae76c8201e4bafd0095646989/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/80c2d49e89c7de7ae76c8201e4bafd0095646989/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)