### PR TITLE
Make release asset sync'ing shenanigan-proof

### DIFF
--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -364,4 +364,10 @@ jobs:
     with:
       CONCURRENCY: push-${{ github.ref_name }}
       RELEASE_VERSION: prerelease
+      # The google-cloud-storage update action doesn't seem to have any kind of read-your-writes
+      # semantics, so make sure to wait for a bit before we start to sync stuff.
+      #
+      # 15 seconds might seem long, but the prerelease workflow takes about 40 minutes, so a drop in
+      # the ocean really... and I'd rather be on the safe side.
+      WAIT_TIME_SECS: 15
     secrets: inherit

--- a/.github/workflows/reusable_sync_release_assets.yml
+++ b/.github/workflows/reusable_sync_release_assets.yml
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
         default: ""
+      WAIT_TIME_SECS:
+        required: false
+        type: number
+        default: 0
 
 concurrency:
   group: ${{ inputs.CONCURRENCY }}-sync-assets
@@ -55,4 +59,5 @@ jobs:
           python ./scripts/ci/sync_release_assets.py \
             --github-release ${{ inputs.RELEASE_VERSION }} \
             --github-token ${{ secrets.GITHUB_TOKEN }} \
+            --wait ${{ inputs.WAIT_TIME_SECS }} \
             --remove --update

--- a/scripts/ci/sync_release_assets.py
+++ b/scripts/ci/sync_release_assets.py
@@ -216,6 +216,10 @@ def main() -> None:
     if args.update:
         update_release_assets(release, assets)
 
+    if release.draft:
+        print(f"Detected mistakenly drafted release, undrafting…")
+        release.update_release(release.title, release.body, draft=False)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/ci/sync_release_assets.py
+++ b/scripts/ci/sync_release_assets.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 from typing import Dict
+import time
 
 from github import Github
 from github.GitRelease import GitRelease
@@ -169,6 +170,7 @@ def main() -> None:
         "--github-release", required=True, help="ID of the Github (pre)release (e.g. `prerelease` or `0.9.0`)"
     )
     parser.add_argument("--github-timeout", default=120, help="Timeout for Github related operations")
+    parser.add_argument("--wait", default=0, help="Sleep a bit before doing anything")
     parser.add_argument("--remove", action="store_true", help="Remove existing assets from the specified release")
     parser.add_argument("--update", action="store_true", help="Update new assets to the specified release")
     parser.add_argument("--no-wheels", action="store_true", help="Don't upload Python wheels")
@@ -177,6 +179,9 @@ def main() -> None:
     parser.add_argument("--no-rerun-cli", action="store_true", help="Don't upload CLI")
     args = parser.parse_args()
 
+    # Wait for a bit before doing anything.
+    # Useful on CI because the google-cloud-storage upload action doesn't guarantee to read-your-writes.
+    time.sleep(args.wait)
     gh = Github(args.github_token, timeout=args.github_timeout)
     repo = gh.get_repo(args.github_repository)
     release = repo.get_release(args.github_release)

--- a/scripts/ci/sync_release_assets.py
+++ b/scripts/ci/sync_release_assets.py
@@ -16,14 +16,23 @@ Requires the following packages:
 from __future__ import annotations
 
 import argparse
-from typing import Dict
 import time
+from typing import cast, Dict
 
 from github import Github
 from github.GitRelease import GitRelease
+from github.Repository import Repository
 from google.cloud import storage
 
 Assets = Dict[str, storage.Blob]
+
+
+def get_any_release(repo: Repository, tag_name: str) -> GitRelease | None:
+    """
+    Fetch any release from a Github repository, even drafts.
+    """
+    # Do _not_ use `repo.get_release`, it silently ignores drafts.
+    return next(rel for rel in repo.get_releases() if rel.tag_name == tag_name)
 
 
 def fetch_binary_assets(
@@ -182,13 +191,14 @@ def main() -> None:
     # Wait for a bit before doing anything.
     # Useful on CI because the google-cloud-storage upload action doesn't guarantee to read-your-writes.
     time.sleep(args.wait)
+
     gh = Github(args.github_token, timeout=args.github_timeout)
     repo = gh.get_repo(args.github_repository)
-    release = repo.get_release(args.github_release)
+    release = cast(GitRelease, get_any_release(repo, args.github_release))
     commit = dict([(tag.name, tag.commit) for tag in repo.get_tags()])[args.github_release]
 
     print(
-        f'Syncing binary assets for release `{release.tag_name}` ("{release.title}" @{release.published_at}) #{commit.sha[:7]}…'
+        f'Syncing binary assets for release `{release.tag_name}` ("{release.title}" @{release.published_at} draft={release.draft}) #{commit.sha[:7]}…'
     )
 
     assets = fetch_binary_assets(

--- a/scripts/ci/sync_release_assets.py
+++ b/scripts/ci/sync_release_assets.py
@@ -219,6 +219,13 @@ def main() -> None:
     if args.update:
         update_release_assets(release, assets)
 
+    # Github will unconditionally draft a release in some cases (e.g. because the branch it has
+    # originated from has been modified since). This is beyond our control.
+    #
+    # Draft releases are not accessible through any of the expected ways, so we make sure to fix
+    # that.
+    #
+    # See e.g. <https://github.com/ncipollo/release-action/issues/317>.
     if release.draft:
         print(f"Detected mistakenly drafted release, undrafting…")
         release.update_release(release.title, release.body, draft=False)

--- a/scripts/ci/sync_release_assets.py
+++ b/scripts/ci/sync_release_assets.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import argparse
 import time
-from typing import cast, Dict
+from typing import Dict, cast
 
 from github import Github
 from github.GitRelease import GitRelease
@@ -28,9 +28,7 @@ Assets = Dict[str, storage.Blob]
 
 
 def get_any_release(repo: Repository, tag_name: str) -> GitRelease | None:
-    """
-    Fetch any release from a Github repository, even drafts.
-    """
+    """Fetch any release from a Github repository, even drafts."""
     # Do _not_ use `repo.get_release`, it silently ignores drafts.
     return next(rel for rel in repo.get_releases() if rel.tag_name == tag_name)
 
@@ -227,7 +225,7 @@ def main() -> None:
     #
     # See e.g. <https://github.com/ncipollo/release-action/issues/317>.
     if release.draft:
-        print(f"Detected mistakenly drafted release, undrafting…")
+        print("Detected mistakenly drafted release, undrafting…")
         release.update_release(release.title, release.body, draft=False)
 
 

--- a/scripts/ci/sync_release_assets.py
+++ b/scripts/ci/sync_release_assets.py
@@ -226,7 +226,7 @@ def main() -> None:
     # See e.g. <https://github.com/ncipollo/release-action/issues/317>.
     if release.draft:
         print("Detected mistakenly drafted release, undrafting…")
-        release.update_release(release.title, release.body, draft=False)
+        release.update_release(release.title, release.body, draft=False, prerelease=release.prerelease)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/sync_release_assets.py
+++ b/scripts/ci/sync_release_assets.py
@@ -190,7 +190,10 @@ def main() -> None:
 
     # Wait for a bit before doing anything.
     # Useful on CI because the google-cloud-storage upload action doesn't guarantee to read-your-writes.
-    time.sleep(args.wait)
+    wait_time_secs = float(args.wait)
+    if wait_time_secs > 0.0:
+        print(f"Waiting for {wait_time_secs}s…")
+        time.sleep(wait_time_secs)
 
     gh = Github(args.github_token, timeout=args.github_timeout)
     repo = gh.get_repo(args.github_repository)


### PR DESCRIPTION
There are two main issues at the moment:
- The action we're using to upload to GCS doesn't seem to provide read-your-write semantics, so we're always missing a couple assets.
- Github will mark releases as drafts for reasons beyond our control, and drafts basically break all APIs.

This PR works around both of those.

Tested on the latest broken `prerelease` from my machine, working like a charm:
![image](https://github.com/rerun-io/rerun/assets/2910679/8f37614e-1321-4b3e-b6c1-a8c9b3a0837f)


### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
