### PR TITLE
Add pragmas to hide additional gcc_warnings related to maybe-unitialized memory in std::optionals

### DIFF
--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -416,6 +416,7 @@ impl QuotedObject {
                 },
                 definition_body: quote! {
                     #field_ident = std::move(#parameter_ident);
+                    #NEWLINE_TOKEN
                     #gcc_ignore_comment
                     WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
                 },

--- a/pixi.toml
+++ b/pixi.toml
@@ -57,7 +57,7 @@ codegen = "cargo run --package re_types_builder -- "
 fast-lint = "python scripts/fast_lint.py"
 lint-codegen = "cargo run --package re_types_builder -- --check"
 # TODO(jleibs): implement lint-cpp-all
-lint-cpp-files = "clang-format --dry-run"
+lint-cpp-files = "clang-format --dry-run -Werror"
 lint-rerun = "python scripts/lint.py"
 lint-rs-files = "rustfmt --check"
 lint-rs-all = "cargo fmt --check"

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -8,6 +8,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <utility>

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -113,7 +113,15 @@ namespace rerun {
             /// If no origins are set, (0, 0, 0) is used as the origin for each arrow.
             Arrows3D with_origins(ComponentBatch<rerun::components::Position3D> _origins) && {
                 origins = std::move(_origins);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional radii for the arrows.
@@ -122,19 +130,43 @@ namespace rerun {
             /// The tip is rendered with `height = 2.0 * radius` and `radius = 1.0 * radius`.
             Arrows3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
                 radii = std::move(_radii);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional colors for the points.
             Arrows3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
                 colors = std::move(_colors);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional text labels for the arrows.
             Arrows3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
                 labels = std::move(_labels);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional class Ids for the points.
@@ -142,7 +174,15 @@ namespace rerun {
             /// The class ID provides colors and labels if not specified explicitly.
             Arrows3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Unique identifiers for each individual point in the batch.
@@ -150,7 +190,15 @@ namespace rerun {
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
                 instance_keys = std::move(_instance_keys);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -113,7 +113,8 @@ namespace rerun {
             ///
             /// If no origins are set, (0, 0, 0) is used as the origin for each arrow.
             Arrows3D with_origins(ComponentBatch<rerun::components::Position3D> _origins) && {
-                origins = std::move(_origins); // See: https://github.com/rerun-io/rerun/issues/4027
+                origins = std::move(_origins);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -122,19 +123,22 @@ namespace rerun {
             /// The shaft is rendered as a line with `radius = 0.5 * radius`.
             /// The tip is rendered with `height = 2.0 * radius` and `radius = 1.0 * radius`.
             Arrows3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
-                radii = std::move(_radii); // See: https://github.com/rerun-io/rerun/issues/4027
+                radii = std::move(_radii);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional colors for the points.
             Arrows3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
-                colors = std::move(_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                colors = std::move(_colors);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional text labels for the arrows.
             Arrows3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
-                labels = std::move(_labels); // See: https://github.com/rerun-io/rerun/issues/4027
+                labels = std::move(_labels);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -142,8 +146,8 @@ namespace rerun {
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Arrows3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids =
-                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                class_ids = std::move(_class_ids);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -151,8 +155,8 @@ namespace rerun {
             Arrows3D with_instance_keys(
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys =
-                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                instance_keys = std::move(_instance_keys);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -14,6 +14,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -112,16 +113,8 @@ namespace rerun {
             ///
             /// If no origins are set, (0, 0, 0) is used as the origin for each arrow.
             Arrows3D with_origins(ComponentBatch<rerun::components::Position3D> _origins) && {
-                origins = std::move(_origins);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                origins = std::move(_origins); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional radii for the arrows.
@@ -129,76 +122,38 @@ namespace rerun {
             /// The shaft is rendered as a line with `radius = 0.5 * radius`.
             /// The tip is rendered with `height = 2.0 * radius` and `radius = 1.0 * radius`.
             Arrows3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
-                radii = std::move(_radii);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                radii = std::move(_radii); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional colors for the points.
             Arrows3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
-                colors = std::move(_colors);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                colors = std::move(_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional text labels for the arrows.
             Arrows3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
-                labels = std::move(_labels);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                labels = std::move(_labels); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional class Ids for the points.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Arrows3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids = std::move(_class_ids);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                class_ids =
+                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Unique identifiers for each individual point in the batch.
             Arrows3D with_instance_keys(
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys = std::move(_instance_keys);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                instance_keys =
+                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -121,7 +121,15 @@ namespace rerun {
             /// If it cannot guess, it won't be able to render the asset.
             Asset3D with_media_type(rerun::components::MediaType _media_type) && {
                 media_type = std::move(_media_type);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// An out-of-tree transform.
@@ -129,7 +137,15 @@ namespace rerun {
             /// Applies a transformation to the asset itself without impacting its children.
             Asset3D with_transform(rerun::components::OutOfTreeTransform3D _transform) && {
                 transform = std::move(_transform);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -121,8 +121,8 @@ namespace rerun {
             /// If omitted, the viewer will try to guess from the data blob.
             /// If it cannot guess, it won't be able to render the asset.
             Asset3D with_media_type(rerun::components::MediaType _media_type) && {
-                media_type =
-                    std::move(_media_type); // See: https://github.com/rerun-io/rerun/issues/4027
+                media_type = std::move(_media_type);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -130,8 +130,8 @@ namespace rerun {
             ///
             /// Applies a transformation to the asset itself without impacting its children.
             Asset3D with_transform(rerun::components::OutOfTreeTransform3D _transform) && {
-                transform =
-                    std::move(_transform); // See: https://github.com/rerun-io/rerun/issues/4027
+                transform = std::move(_transform);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -10,6 +10,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <algorithm>
 #include <cstdint>
@@ -120,32 +121,18 @@ namespace rerun {
             /// If omitted, the viewer will try to guess from the data blob.
             /// If it cannot guess, it won't be able to render the asset.
             Asset3D with_media_type(rerun::components::MediaType _media_type) && {
-                media_type = std::move(_media_type);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                media_type =
+                    std::move(_media_type); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// An out-of-tree transform.
             ///
             /// Applies a transformation to the asset itself without impacting its children.
             Asset3D with_transform(rerun::components::OutOfTreeTransform3D _transform) && {
-                transform = std::move(_transform);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                transform =
+                    std::move(_transform); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -9,6 +9,7 @@
 #include "../half.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <utility>

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -135,25 +135,57 @@ namespace rerun {
             /// Optional center positions of the boxes.
             Boxes2D with_centers(ComponentBatch<rerun::components::Position2D> _centers) && {
                 centers = std::move(_centers);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional colors for the boxes.
             Boxes2D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
                 colors = std::move(_colors);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional radii for the lines that make up the boxes.
             Boxes2D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
                 radii = std::move(_radii);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional text labels for the boxes.
             Boxes2D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
                 labels = std::move(_labels);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// An optional floating point value that specifies the 2D drawing order.
@@ -163,7 +195,15 @@ namespace rerun {
             /// The default for 2D boxes is 10.0.
             Boxes2D with_draw_order(rerun::components::DrawOrder _draw_order) && {
                 draw_order = std::move(_draw_order);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional `ClassId`s for the boxes.
@@ -171,14 +211,30 @@ namespace rerun {
             /// The class ID provides colors and labels if not specified explicitly.
             Boxes2D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Unique identifiers for each individual boxes in the batch.
             Boxes2D with_instance_keys(ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
                 instance_keys = std::move(_instance_keys);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -135,25 +135,29 @@ namespace rerun {
 
             /// Optional center positions of the boxes.
             Boxes2D with_centers(ComponentBatch<rerun::components::Position2D> _centers) && {
-                centers = std::move(_centers); // See: https://github.com/rerun-io/rerun/issues/4027
+                centers = std::move(_centers);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional colors for the boxes.
             Boxes2D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
-                colors = std::move(_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                colors = std::move(_colors);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional radii for the lines that make up the boxes.
             Boxes2D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
-                radii = std::move(_radii); // See: https://github.com/rerun-io/rerun/issues/4027
+                radii = std::move(_radii);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional text labels for the boxes.
             Boxes2D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
-                labels = std::move(_labels); // See: https://github.com/rerun-io/rerun/issues/4027
+                labels = std::move(_labels);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -163,8 +167,8 @@ namespace rerun {
             ///
             /// The default for 2D boxes is 10.0.
             Boxes2D with_draw_order(rerun::components::DrawOrder _draw_order) && {
-                draw_order =
-                    std::move(_draw_order); // See: https://github.com/rerun-io/rerun/issues/4027
+                draw_order = std::move(_draw_order);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -172,16 +176,16 @@ namespace rerun {
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Boxes2D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids =
-                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                class_ids = std::move(_class_ids);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Unique identifiers for each individual boxes in the batch.
             Boxes2D with_instance_keys(ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys =
-                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                instance_keys = std::move(_instance_keys);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -15,6 +15,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -134,58 +135,26 @@ namespace rerun {
 
             /// Optional center positions of the boxes.
             Boxes2D with_centers(ComponentBatch<rerun::components::Position2D> _centers) && {
-                centers = std::move(_centers);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                centers = std::move(_centers); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional colors for the boxes.
             Boxes2D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
-                colors = std::move(_colors);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                colors = std::move(_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional radii for the lines that make up the boxes.
             Boxes2D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
-                radii = std::move(_radii);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                radii = std::move(_radii); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional text labels for the boxes.
             Boxes2D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
-                labels = std::move(_labels);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                labels = std::move(_labels); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// An optional floating point value that specifies the 2D drawing order.
@@ -194,47 +163,26 @@ namespace rerun {
             ///
             /// The default for 2D boxes is 10.0.
             Boxes2D with_draw_order(rerun::components::DrawOrder _draw_order) && {
-                draw_order = std::move(_draw_order);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                draw_order =
+                    std::move(_draw_order); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional `ClassId`s for the boxes.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Boxes2D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids = std::move(_class_ids);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                class_ids =
+                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Unique identifiers for each individual boxes in the batch.
             Boxes2D with_instance_keys(ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys = std::move(_instance_keys);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                instance_keys =
+                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -15,6 +15,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -151,102 +152,49 @@ namespace rerun {
 
             /// Optional center positions of the boxes.
             Boxes3D with_centers(ComponentBatch<rerun::components::Position3D> _centers) && {
-                centers = std::move(_centers);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                centers = std::move(_centers); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             Boxes3D with_rotations(ComponentBatch<rerun::components::Rotation3D> _rotations) && {
-                rotations = std::move(_rotations);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                rotations =
+                    std::move(_rotations); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional colors for the boxes.
             Boxes3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
-                colors = std::move(_colors);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                colors = std::move(_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional radii for the lines that make up the boxes.
             Boxes3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
-                radii = std::move(_radii);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                radii = std::move(_radii); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional text labels for the boxes.
             Boxes3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
-                labels = std::move(_labels);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                labels = std::move(_labels); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional `ClassId`s for the boxes.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Boxes3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids = std::move(_class_ids);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                class_ids =
+                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Unique identifiers for each individual boxes in the batch.
             Boxes3D with_instance_keys(ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys = std::move(_instance_keys);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                instance_keys =
+                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -152,31 +152,35 @@ namespace rerun {
 
             /// Optional center positions of the boxes.
             Boxes3D with_centers(ComponentBatch<rerun::components::Position3D> _centers) && {
-                centers = std::move(_centers); // See: https://github.com/rerun-io/rerun/issues/4027
+                centers = std::move(_centers);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             Boxes3D with_rotations(ComponentBatch<rerun::components::Rotation3D> _rotations) && {
-                rotations =
-                    std::move(_rotations); // See: https://github.com/rerun-io/rerun/issues/4027
+                rotations = std::move(_rotations);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional colors for the boxes.
             Boxes3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
-                colors = std::move(_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                colors = std::move(_colors);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional radii for the lines that make up the boxes.
             Boxes3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
-                radii = std::move(_radii); // See: https://github.com/rerun-io/rerun/issues/4027
+                radii = std::move(_radii);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional text labels for the boxes.
             Boxes3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
-                labels = std::move(_labels); // See: https://github.com/rerun-io/rerun/issues/4027
+                labels = std::move(_labels);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -184,16 +188,16 @@ namespace rerun {
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Boxes3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids =
-                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                class_ids = std::move(_class_ids);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Unique identifiers for each individual boxes in the batch.
             Boxes3D with_instance_keys(ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys =
-                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                instance_keys = std::move(_instance_keys);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -152,30 +152,70 @@ namespace rerun {
             /// Optional center positions of the boxes.
             Boxes3D with_centers(ComponentBatch<rerun::components::Position3D> _centers) && {
                 centers = std::move(_centers);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             Boxes3D with_rotations(ComponentBatch<rerun::components::Rotation3D> _rotations) && {
                 rotations = std::move(_rotations);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional colors for the boxes.
             Boxes3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
                 colors = std::move(_colors);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional radii for the lines that make up the boxes.
             Boxes3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
                 radii = std::move(_radii);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional text labels for the boxes.
             Boxes3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
                 labels = std::move(_labels);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional `ClassId`s for the boxes.
@@ -183,14 +223,30 @@ namespace rerun {
             /// The class ID provides colors and labels if not specified explicitly.
             Boxes3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Unique identifiers for each individual boxes in the batch.
             Boxes3D with_instance_keys(ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
                 instance_keys = std::move(_instance_keys);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -8,6 +8,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <utility>

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -110,7 +110,8 @@ namespace rerun {
             /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
             /// and a range of up to ~65 meters (2^16 / 1000).
             DepthImage with_meter(rerun::components::DepthMeter _meter) && {
-                meter = std::move(_meter); // See: https://github.com/rerun-io/rerun/issues/4027
+                meter = std::move(_meter);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -118,8 +119,8 @@ namespace rerun {
             ///
             /// Objects with higher values are drawn on top of those with lower values.
             DepthImage with_draw_order(rerun::components::DrawOrder _draw_order) && {
-                draw_order =
-                    std::move(_draw_order); // See: https://github.com/rerun-io/rerun/issues/4027
+                draw_order = std::move(_draw_order);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -110,7 +110,15 @@ namespace rerun {
             /// and a range of up to ~65 meters (2^16 / 1000).
             DepthImage with_meter(rerun::components::DepthMeter _meter) && {
                 meter = std::move(_meter);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// An optional floating point value that specifies the 2D drawing order.
@@ -118,7 +126,15 @@ namespace rerun {
             /// Objects with higher values are drawn on top of those with lower values.
             DepthImage with_draw_order(rerun::components::DrawOrder _draw_order) && {
                 draw_order = std::move(_draw_order);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -11,6 +11,7 @@
 #include "../error.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -109,32 +110,17 @@ namespace rerun {
             /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
             /// and a range of up to ~65 meters (2^16 / 1000).
             DepthImage with_meter(rerun::components::DepthMeter _meter) && {
-                meter = std::move(_meter);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                meter = std::move(_meter); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// An optional floating point value that specifies the 2D drawing order.
             ///
             /// Objects with higher values are drawn on top of those with lower values.
             DepthImage with_draw_order(rerun::components::DrawOrder _draw_order) && {
-                draw_order = std::move(_draw_order);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                draw_order =
+                    std::move(_draw_order); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -8,6 +8,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <utility>

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -95,7 +95,15 @@ namespace rerun {
             /// Objects with higher values are drawn on top of those with lower values.
             Image with_draw_order(rerun::components::DrawOrder _draw_order) && {
                 draw_order = std::move(_draw_order);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -10,6 +10,7 @@
 #include "../error.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -94,16 +95,9 @@ namespace rerun {
             ///
             /// Objects with higher values are drawn on top of those with lower values.
             Image with_draw_order(rerun::components::DrawOrder _draw_order) && {
-                draw_order = std::move(_draw_order);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                draw_order =
+                    std::move(_draw_order); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -95,8 +95,8 @@ namespace rerun {
             ///
             /// Objects with higher values are drawn on top of those with lower values.
             Image with_draw_order(rerun::components::DrawOrder _draw_order) && {
-                draw_order =
-                    std::move(_draw_order); // See: https://github.com/rerun-io/rerun/issues/4027
+                draw_order = std::move(_draw_order);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -90,19 +90,22 @@ namespace rerun {
 
             /// Optional radii for the line strips.
             LineStrips2D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
-                radii = std::move(_radii); // See: https://github.com/rerun-io/rerun/issues/4027
+                radii = std::move(_radii);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional colors for the line strips.
             LineStrips2D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
-                colors = std::move(_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                colors = std::move(_colors);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional text labels for the line strips.
             LineStrips2D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
-                labels = std::move(_labels); // See: https://github.com/rerun-io/rerun/issues/4027
+                labels = std::move(_labels);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -110,8 +113,8 @@ namespace rerun {
             ///
             /// Objects with higher values are drawn on top of those with lower values.
             LineStrips2D with_draw_order(rerun::components::DrawOrder _draw_order) && {
-                draw_order =
-                    std::move(_draw_order); // See: https://github.com/rerun-io/rerun/issues/4027
+                draw_order = std::move(_draw_order);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -119,8 +122,8 @@ namespace rerun {
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             LineStrips2D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids =
-                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                class_ids = std::move(_class_ids);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -128,8 +131,8 @@ namespace rerun {
             LineStrips2D with_instance_keys(
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys =
-                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                instance_keys = std::move(_instance_keys);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -14,6 +14,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -89,92 +90,47 @@ namespace rerun {
 
             /// Optional radii for the line strips.
             LineStrips2D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
-                radii = std::move(_radii);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                radii = std::move(_radii); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional colors for the line strips.
             LineStrips2D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
-                colors = std::move(_colors);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                colors = std::move(_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional text labels for the line strips.
             LineStrips2D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
-                labels = std::move(_labels);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                labels = std::move(_labels); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// An optional floating point value that specifies the 2D drawing order of each line strip.
             ///
             /// Objects with higher values are drawn on top of those with lower values.
             LineStrips2D with_draw_order(rerun::components::DrawOrder _draw_order) && {
-                draw_order = std::move(_draw_order);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                draw_order =
+                    std::move(_draw_order); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional `ClassId`s for the lines.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             LineStrips2D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids = std::move(_class_ids);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                class_ids =
+                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Unique identifiers for each individual line strip in the batch.
             LineStrips2D with_instance_keys(
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys = std::move(_instance_keys);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                instance_keys =
+                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -90,19 +90,43 @@ namespace rerun {
             /// Optional radii for the line strips.
             LineStrips2D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
                 radii = std::move(_radii);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional colors for the line strips.
             LineStrips2D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
                 colors = std::move(_colors);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional text labels for the line strips.
             LineStrips2D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
                 labels = std::move(_labels);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// An optional floating point value that specifies the 2D drawing order of each line strip.
@@ -110,7 +134,15 @@ namespace rerun {
             /// Objects with higher values are drawn on top of those with lower values.
             LineStrips2D with_draw_order(rerun::components::DrawOrder _draw_order) && {
                 draw_order = std::move(_draw_order);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional `ClassId`s for the lines.
@@ -118,7 +150,15 @@ namespace rerun {
             /// The class ID provides colors and labels if not specified explicitly.
             LineStrips2D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Unique identifiers for each individual line strip in the batch.
@@ -126,7 +166,15 @@ namespace rerun {
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
                 instance_keys = std::move(_instance_keys);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -94,19 +94,43 @@ namespace rerun {
             /// Optional radii for the line strips.
             LineStrips3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
                 radii = std::move(_radii);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional colors for the line strips.
             LineStrips3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
                 colors = std::move(_colors);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional text labels for the line strips.
             LineStrips3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
                 labels = std::move(_labels);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional `ClassId`s for the lines.
@@ -114,7 +138,15 @@ namespace rerun {
             /// The class ID provides colors and labels if not specified explicitly.
             LineStrips3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Unique identifiers for each individual line strip in the batch.
@@ -122,7 +154,15 @@ namespace rerun {
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
                 instance_keys = std::move(_instance_keys);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -13,6 +13,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -93,76 +94,38 @@ namespace rerun {
 
             /// Optional radii for the line strips.
             LineStrips3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
-                radii = std::move(_radii);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                radii = std::move(_radii); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional colors for the line strips.
             LineStrips3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
-                colors = std::move(_colors);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                colors = std::move(_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional text labels for the line strips.
             LineStrips3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
-                labels = std::move(_labels);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                labels = std::move(_labels); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional `ClassId`s for the lines.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             LineStrips3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids = std::move(_class_ids);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                class_ids =
+                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Unique identifiers for each individual line strip in the batch.
             LineStrips3D with_instance_keys(
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys = std::move(_instance_keys);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                instance_keys =
+                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -94,19 +94,22 @@ namespace rerun {
 
             /// Optional radii for the line strips.
             LineStrips3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
-                radii = std::move(_radii); // See: https://github.com/rerun-io/rerun/issues/4027
+                radii = std::move(_radii);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional colors for the line strips.
             LineStrips3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
-                colors = std::move(_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                colors = std::move(_colors);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional text labels for the line strips.
             LineStrips3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
-                labels = std::move(_labels); // See: https://github.com/rerun-io/rerun/issues/4027
+                labels = std::move(_labels);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -114,8 +117,8 @@ namespace rerun {
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             LineStrips3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids =
-                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                class_ids = std::move(_class_ids);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -123,8 +126,8 @@ namespace rerun {
             LineStrips3D with_instance_keys(
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys =
-                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                instance_keys = std::move(_instance_keys);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -102,7 +102,15 @@ namespace rerun {
             /// Optional properties for the mesh as a whole (including indexed drawing).
             Mesh3D with_mesh_properties(rerun::components::MeshProperties _mesh_properties) && {
                 mesh_properties = std::move(_mesh_properties);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// An optional normal for each vertex.
@@ -111,19 +119,43 @@ namespace rerun {
             Mesh3D with_vertex_normals(ComponentBatch<rerun::components::Vector3D> _vertex_normals
             ) && {
                 vertex_normals = std::move(_vertex_normals);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// An optional color for each vertex.
             Mesh3D with_vertex_colors(ComponentBatch<rerun::components::Color> _vertex_colors) && {
                 vertex_colors = std::move(_vertex_colors);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional material properties for the mesh as a whole.
             Mesh3D with_mesh_material(rerun::components::Material _mesh_material) && {
                 mesh_material = std::move(_mesh_material);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional class Ids for the vertices.
@@ -131,14 +163,30 @@ namespace rerun {
             /// The class ID provides colors and labels if not specified explicitly.
             Mesh3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Unique identifiers for each individual vertex in the mesh.
             Mesh3D with_instance_keys(ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
                 instance_keys = std::move(_instance_keys);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -102,8 +102,8 @@ namespace rerun {
 
             /// Optional properties for the mesh as a whole (including indexed drawing).
             Mesh3D with_mesh_properties(rerun::components::MeshProperties _mesh_properties) && {
-                mesh_properties = std::move(_mesh_properties
-                ); // See: https://github.com/rerun-io/rerun/issues/4027
+                mesh_properties = std::move(_mesh_properties);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -112,22 +112,22 @@ namespace rerun {
             /// If specified, this must have as many elements as `vertex_positions`.
             Mesh3D with_vertex_normals(ComponentBatch<rerun::components::Vector3D> _vertex_normals
             ) && {
-                vertex_normals = std::move(_vertex_normals
-                ); // See: https://github.com/rerun-io/rerun/issues/4027
+                vertex_normals = std::move(_vertex_normals);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// An optional color for each vertex.
             Mesh3D with_vertex_colors(ComponentBatch<rerun::components::Color> _vertex_colors) && {
-                vertex_colors =
-                    std::move(_vertex_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                vertex_colors = std::move(_vertex_colors);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional material properties for the mesh as a whole.
             Mesh3D with_mesh_material(rerun::components::Material _mesh_material) && {
-                mesh_material =
-                    std::move(_mesh_material); // See: https://github.com/rerun-io/rerun/issues/4027
+                mesh_material = std::move(_mesh_material);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -135,16 +135,16 @@ namespace rerun {
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Mesh3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids =
-                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                class_ids = std::move(_class_ids);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Unique identifiers for each individual vertex in the mesh.
             Mesh3D with_instance_keys(ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys =
-                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                instance_keys = std::move(_instance_keys);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -14,6 +14,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -101,16 +102,9 @@ namespace rerun {
 
             /// Optional properties for the mesh as a whole (including indexed drawing).
             Mesh3D with_mesh_properties(rerun::components::MeshProperties _mesh_properties) && {
-                mesh_properties = std::move(_mesh_properties);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                mesh_properties = std::move(_mesh_properties
+                ); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// An optional normal for each vertex.
@@ -118,75 +112,40 @@ namespace rerun {
             /// If specified, this must have as many elements as `vertex_positions`.
             Mesh3D with_vertex_normals(ComponentBatch<rerun::components::Vector3D> _vertex_normals
             ) && {
-                vertex_normals = std::move(_vertex_normals);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                vertex_normals = std::move(_vertex_normals
+                ); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// An optional color for each vertex.
             Mesh3D with_vertex_colors(ComponentBatch<rerun::components::Color> _vertex_colors) && {
-                vertex_colors = std::move(_vertex_colors);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                vertex_colors =
+                    std::move(_vertex_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional material properties for the mesh as a whole.
             Mesh3D with_mesh_material(rerun::components::Material _mesh_material) && {
-                mesh_material = std::move(_mesh_material);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                mesh_material =
+                    std::move(_mesh_material); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional class Ids for the vertices.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Mesh3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids = std::move(_class_ids);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                class_ids =
+                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Unique identifiers for each individual vertex in the mesh.
             Mesh3D with_instance_keys(ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys = std::move(_instance_keys);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                instance_keys =
+                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -10,6 +10,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -153,16 +154,9 @@ namespace rerun {
             ///
             /// `image_from_camera` project onto the space spanned by `(0,0)` and `resolution - 1`.
             Pinhole with_resolution(rerun::components::Resolution _resolution) && {
-                resolution = std::move(_resolution);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                resolution =
+                    std::move(_resolution); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Sets the view coordinates for the camera.
@@ -193,16 +187,9 @@ namespace rerun {
             /// The pinhole matrix (the `image_from_camera` argument) always project along the third (Z) axis,
             /// but will be re-oriented to project along the forward axis of the `camera_xyz` argument.
             Pinhole with_camera_xyz(rerun::components::ViewCoordinates _camera_xyz) && {
-                camera_xyz = std::move(_camera_xyz);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                camera_xyz =
+                    std::move(_camera_xyz); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -154,8 +154,8 @@ namespace rerun {
             ///
             /// `image_from_camera` project onto the space spanned by `(0,0)` and `resolution - 1`.
             Pinhole with_resolution(rerun::components::Resolution _resolution) && {
-                resolution =
-                    std::move(_resolution); // See: https://github.com/rerun-io/rerun/issues/4027
+                resolution = std::move(_resolution);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -187,8 +187,8 @@ namespace rerun {
             /// The pinhole matrix (the `image_from_camera` argument) always project along the third (Z) axis,
             /// but will be re-oriented to project along the forward axis of the `camera_xyz` argument.
             Pinhole with_camera_xyz(rerun::components::ViewCoordinates _camera_xyz) && {
-                camera_xyz =
-                    std::move(_camera_xyz); // See: https://github.com/rerun-io/rerun/issues/4027
+                camera_xyz = std::move(_camera_xyz);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -154,7 +154,15 @@ namespace rerun {
             /// `image_from_camera` project onto the space spanned by `(0,0)` and `resolution - 1`.
             Pinhole with_resolution(rerun::components::Resolution _resolution) && {
                 resolution = std::move(_resolution);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Sets the view coordinates for the camera.
@@ -186,7 +194,15 @@ namespace rerun {
             /// but will be re-oriented to project along the forward axis of the `camera_xyz` argument.
             Pinhole with_camera_xyz(rerun::components::ViewCoordinates _camera_xyz) && {
                 camera_xyz = std::move(_camera_xyz);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -116,19 +116,43 @@ namespace rerun {
             /// Optional radii for the points, effectively turning them into circles.
             Points2D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
                 radii = std::move(_radii);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional colors for the points.
             Points2D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
                 colors = std::move(_colors);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional text labels for the points.
             Points2D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
                 labels = std::move(_labels);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// An optional floating point value that specifies the 2D drawing order.
@@ -136,7 +160,15 @@ namespace rerun {
             /// Objects with higher values are drawn on top of those with lower values.
             Points2D with_draw_order(rerun::components::DrawOrder _draw_order) && {
                 draw_order = std::move(_draw_order);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional class Ids for the points.
@@ -144,7 +176,15 @@ namespace rerun {
             /// The class ID provides colors and labels if not specified explicitly.
             Points2D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional keypoint IDs for the points, identifying them within a class.
@@ -158,7 +198,15 @@ namespace rerun {
             Points2D with_keypoint_ids(ComponentBatch<rerun::components::KeypointId> _keypoint_ids
             ) && {
                 keypoint_ids = std::move(_keypoint_ids);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Unique identifiers for each individual point in the batch.
@@ -166,7 +214,15 @@ namespace rerun {
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
                 instance_keys = std::move(_instance_keys);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -116,19 +116,22 @@ namespace rerun {
 
             /// Optional radii for the points, effectively turning them into circles.
             Points2D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
-                radii = std::move(_radii); // See: https://github.com/rerun-io/rerun/issues/4027
+                radii = std::move(_radii);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional colors for the points.
             Points2D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
-                colors = std::move(_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                colors = std::move(_colors);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional text labels for the points.
             Points2D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
-                labels = std::move(_labels); // See: https://github.com/rerun-io/rerun/issues/4027
+                labels = std::move(_labels);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -136,8 +139,8 @@ namespace rerun {
             ///
             /// Objects with higher values are drawn on top of those with lower values.
             Points2D with_draw_order(rerun::components::DrawOrder _draw_order) && {
-                draw_order =
-                    std::move(_draw_order); // See: https://github.com/rerun-io/rerun/issues/4027
+                draw_order = std::move(_draw_order);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -145,8 +148,8 @@ namespace rerun {
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Points2D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids =
-                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                class_ids = std::move(_class_ids);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -160,8 +163,8 @@ namespace rerun {
             /// detected skeleton.
             Points2D with_keypoint_ids(ComponentBatch<rerun::components::KeypointId> _keypoint_ids
             ) && {
-                keypoint_ids =
-                    std::move(_keypoint_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                keypoint_ids = std::move(_keypoint_ids);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -169,8 +172,8 @@ namespace rerun {
             Points2D with_instance_keys(
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys =
-                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                instance_keys = std::move(_instance_keys);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -15,6 +15,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -115,76 +116,38 @@ namespace rerun {
 
             /// Optional radii for the points, effectively turning them into circles.
             Points2D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
-                radii = std::move(_radii);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                radii = std::move(_radii); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional colors for the points.
             Points2D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
-                colors = std::move(_colors);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                colors = std::move(_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional text labels for the points.
             Points2D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
-                labels = std::move(_labels);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                labels = std::move(_labels); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// An optional floating point value that specifies the 2D drawing order.
             ///
             /// Objects with higher values are drawn on top of those with lower values.
             Points2D with_draw_order(rerun::components::DrawOrder _draw_order) && {
-                draw_order = std::move(_draw_order);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                draw_order =
+                    std::move(_draw_order); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional class Ids for the points.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Points2D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids = std::move(_class_ids);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                class_ids =
+                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional keypoint IDs for the points, identifying them within a class.
@@ -197,32 +160,18 @@ namespace rerun {
             /// detected skeleton.
             Points2D with_keypoint_ids(ComponentBatch<rerun::components::KeypointId> _keypoint_ids
             ) && {
-                keypoint_ids = std::move(_keypoint_ids);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                keypoint_ids =
+                    std::move(_keypoint_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Unique identifiers for each individual point in the batch.
             Points2D with_instance_keys(
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys = std::move(_instance_keys);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                instance_keys =
+                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -107,19 +107,43 @@ namespace rerun {
             /// Optional radii for the points, effectively turning them into circles.
             Points3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
                 radii = std::move(_radii);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional colors for the points.
             Points3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
                 colors = std::move(_colors);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional text labels for the points.
             Points3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
                 labels = std::move(_labels);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional class Ids for the points.
@@ -127,7 +151,15 @@ namespace rerun {
             /// The class ID provides colors and labels if not specified explicitly.
             Points3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
                 class_ids = std::move(_class_ids);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional keypoint IDs for the points, identifying them within a class.
@@ -141,7 +173,15 @@ namespace rerun {
             Points3D with_keypoint_ids(ComponentBatch<rerun::components::KeypointId> _keypoint_ids
             ) && {
                 keypoint_ids = std::move(_keypoint_ids);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Unique identifiers for each individual point in the batch.
@@ -149,7 +189,15 @@ namespace rerun {
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
                 instance_keys = std::move(_instance_keys);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -14,6 +14,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -106,60 +107,29 @@ namespace rerun {
 
             /// Optional radii for the points, effectively turning them into circles.
             Points3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
-                radii = std::move(_radii);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                radii = std::move(_radii); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional colors for the points.
             Points3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
-                colors = std::move(_colors);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                colors = std::move(_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional text labels for the points.
             Points3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
-                labels = std::move(_labels);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                labels = std::move(_labels); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional class Ids for the points.
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Points3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids = std::move(_class_ids);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                class_ids =
+                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional keypoint IDs for the points, identifying them within a class.
@@ -172,32 +142,18 @@ namespace rerun {
             /// detected skeleton.
             Points3D with_keypoint_ids(ComponentBatch<rerun::components::KeypointId> _keypoint_ids
             ) && {
-                keypoint_ids = std::move(_keypoint_ids);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                keypoint_ids =
+                    std::move(_keypoint_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Unique identifiers for each individual point in the batch.
             Points3D with_instance_keys(
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys = std::move(_instance_keys);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                instance_keys =
+                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -107,19 +107,22 @@ namespace rerun {
 
             /// Optional radii for the points, effectively turning them into circles.
             Points3D with_radii(ComponentBatch<rerun::components::Radius> _radii) && {
-                radii = std::move(_radii); // See: https://github.com/rerun-io/rerun/issues/4027
+                radii = std::move(_radii);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional colors for the points.
             Points3D with_colors(ComponentBatch<rerun::components::Color> _colors) && {
-                colors = std::move(_colors); // See: https://github.com/rerun-io/rerun/issues/4027
+                colors = std::move(_colors);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional text labels for the points.
             Points3D with_labels(ComponentBatch<rerun::components::Text> _labels) && {
-                labels = std::move(_labels); // See: https://github.com/rerun-io/rerun/issues/4027
+                labels = std::move(_labels);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -127,8 +130,8 @@ namespace rerun {
             ///
             /// The class ID provides colors and labels if not specified explicitly.
             Points3D with_class_ids(ComponentBatch<rerun::components::ClassId> _class_ids) && {
-                class_ids =
-                    std::move(_class_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                class_ids = std::move(_class_ids);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -142,8 +145,8 @@ namespace rerun {
             /// detected skeleton.
             Points3D with_keypoint_ids(ComponentBatch<rerun::components::KeypointId> _keypoint_ids
             ) && {
-                keypoint_ids =
-                    std::move(_keypoint_ids); // See: https://github.com/rerun-io/rerun/issues/4027
+                keypoint_ids = std::move(_keypoint_ids);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -151,8 +154,8 @@ namespace rerun {
             Points3D with_instance_keys(
                 ComponentBatch<rerun::components::InstanceKey> _instance_keys
             ) && {
-                instance_keys =
-                    std::move(_instance_keys); // See: https://github.com/rerun-io/rerun/issues/4027
+                instance_keys = std::move(_instance_keys);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -10,6 +10,7 @@
 #include "../error.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -101,16 +102,9 @@ namespace rerun {
             ///
             /// Objects with higher values are drawn on top of those with lower values.
             SegmentationImage with_draw_order(rerun::components::DrawOrder _draw_order) && {
-                draw_order = std::move(_draw_order);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                draw_order =
+                    std::move(_draw_order); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -102,8 +102,8 @@ namespace rerun {
             ///
             /// Objects with higher values are drawn on top of those with lower values.
             SegmentationImage with_draw_order(rerun::components::DrawOrder _draw_order) && {
-                draw_order =
-                    std::move(_draw_order); // See: https://github.com/rerun-io/rerun/issues/4027
+                draw_order = std::move(_draw_order);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -102,7 +102,15 @@ namespace rerun {
             /// Objects with higher values are drawn on top of those with lower values.
             SegmentationImage with_draw_order(rerun::components::DrawOrder _draw_order) && {
                 draw_order = std::move(_draw_order);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -9,6 +9,7 @@
 #include "../error.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <utility>

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -109,8 +109,8 @@ namespace rerun {
             ///
             /// If omitted, `text/plain` is assumed.
             TextDocument with_media_type(rerun::components::MediaType _media_type) && {
-                media_type =
-                    std::move(_media_type); // See: https://github.com/rerun-io/rerun/issues/4027
+                media_type = std::move(_media_type);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -109,7 +109,15 @@ namespace rerun {
             /// If omitted, `text/plain` is assumed.
             TextDocument with_media_type(rerun::components::MediaType _media_type) && {
                 media_type = std::move(_media_type);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -9,6 +9,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -108,16 +109,9 @@ namespace rerun {
             ///
             /// If omitted, `text/plain` is assumed.
             TextDocument with_media_type(rerun::components::MediaType _media_type) && {
-                media_type = std::move(_media_type);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                media_type =
+                    std::move(_media_type); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -47,13 +47,15 @@ namespace rerun {
             ///
             /// This can be used to filter the log messages in the Rerun Viewer.
             TextLog with_level(rerun::components::TextLogLevel _level) && {
-                level = std::move(_level); // See: https://github.com/rerun-io/rerun/issues/4027
+                level = std::move(_level);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional color to use for the log line in the Rerun Viewer.
             TextLog with_color(rerun::components::Color _color) && {
-                color = std::move(_color); // See: https://github.com/rerun-io/rerun/issues/4027
+                color = std::move(_color);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -47,13 +47,29 @@ namespace rerun {
             /// This can be used to filter the log messages in the Rerun Viewer.
             TextLog with_level(rerun::components::TextLogLevel _level) && {
                 level = std::move(_level);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional color to use for the log line in the Rerun Viewer.
             TextLog with_color(rerun::components::Color _color) && {
                 color = std::move(_color);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -10,6 +10,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -46,30 +47,14 @@ namespace rerun {
             ///
             /// This can be used to filter the log messages in the Rerun Viewer.
             TextLog with_level(rerun::components::TextLogLevel _level) && {
-                level = std::move(_level);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                level = std::move(_level); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional color to use for the log line in the Rerun Viewer.
             TextLog with_color(rerun::components::Color _color) && {
-                color = std::move(_color);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                color = std::move(_color); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -111,7 +111,8 @@ namespace rerun {
             /// radius, then this radius will be used as the line width too. Otherwise, the
             /// line will use the default width of `1.0`.
             TimeSeriesScalar with_radius(rerun::components::Radius _radius) && {
-                radius = std::move(_radius); // See: https://github.com/rerun-io/rerun/issues/4027
+                radius = std::move(_radius);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -127,7 +128,8 @@ namespace rerun {
             /// color, then this color will be used as the line color in the plot legend.
             /// Otherwise, the line will appear gray in the legend.
             TimeSeriesScalar with_color(rerun::components::Color _color) && {
-                color = std::move(_color); // See: https://github.com/rerun-io/rerun/issues/4027
+                color = std::move(_color);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -140,7 +142,8 @@ namespace rerun {
             /// line will be named after the entity path. The plot itself is named after
             /// the space it's in.
             TimeSeriesScalar with_label(rerun::components::Text _label) && {
-                label = std::move(_label); // See: https://github.com/rerun-io/rerun/issues/4027
+                label = std::move(_label);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
@@ -152,8 +155,8 @@ namespace rerun {
             /// the line will switch between a scattered and a continuous representation as
             /// required.
             TimeSeriesScalar with_scattered(rerun::components::ScalarScattering _scattered) && {
-                scattered =
-                    std::move(_scattered); // See: https://github.com/rerun-io/rerun/issues/4027
+                scattered = std::move(_scattered);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -12,6 +12,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -110,16 +111,8 @@ namespace rerun {
             /// radius, then this radius will be used as the line width too. Otherwise, the
             /// line will use the default width of `1.0`.
             TimeSeriesScalar with_radius(rerun::components::Radius _radius) && {
-                radius = std::move(_radius);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                radius = std::move(_radius); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Optional color for the scalar entry.
@@ -134,16 +127,8 @@ namespace rerun {
             /// color, then this color will be used as the line color in the plot legend.
             /// Otherwise, the line will appear gray in the legend.
             TimeSeriesScalar with_color(rerun::components::Color _color) && {
-                color = std::move(_color);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                color = std::move(_color); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// An optional label for the point.
@@ -155,16 +140,8 @@ namespace rerun {
             /// line will be named after the entity path. The plot itself is named after
             /// the space it's in.
             TimeSeriesScalar with_label(rerun::components::Text _label) && {
-                label = std::move(_label);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                label = std::move(_label); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Specifies whether a point in a scatter plot should form a continuous line.
@@ -175,16 +152,9 @@ namespace rerun {
             /// the line will switch between a scattered and a continuous representation as
             /// required.
             TimeSeriesScalar with_scattered(rerun::components::ScalarScattering _scattered) && {
-                scattered = std::move(_scattered);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                scattered =
+                    std::move(_scattered); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -111,7 +111,15 @@ namespace rerun {
             /// line will use the default width of `1.0`.
             TimeSeriesScalar with_radius(rerun::components::Radius _radius) && {
                 radius = std::move(_radius);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Optional color for the scalar entry.
@@ -127,7 +135,15 @@ namespace rerun {
             /// Otherwise, the line will appear gray in the legend.
             TimeSeriesScalar with_color(rerun::components::Color _color) && {
                 color = std::move(_color);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// An optional label for the point.
@@ -140,7 +156,15 @@ namespace rerun {
             /// the space it's in.
             TimeSeriesScalar with_label(rerun::components::Text _label) && {
                 label = std::move(_label);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Specifies whether a point in a scatter plot should form a continuous line.
@@ -152,7 +176,15 @@ namespace rerun {
             /// required.
             TimeSeriesScalar with_scattered(rerun::components::ScalarScattering _scattered) && {
                 scattered = std::move(_scattered);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -8,6 +8,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <utility>

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -8,6 +8,7 @@
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
+#include "../util.hpp"
 
 #include <cstdint>
 #include <utility>

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -9,6 +9,7 @@
 
 #include "result.hpp"
 #include "serialized_component_batch.hpp"
+#include "util.hpp"
 
 namespace rerun {
     /// The ComponentBatchAdaptor trait is responsible for mapping an input argument to a
@@ -155,19 +156,12 @@ namespace rerun {
 
         /// Move assignment
         void operator=(ComponentBatch<TComponent>&& other) {
-// Need to disable the maybe-uninitialized here.  It seems like the compiler may be confused in situations where
-// we are assigning into an unused optional from a temporary. The fact that this hits the move-assignment without
-// having called the move constructor is suspicious though and hints of an actual bug.
-//
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-            this->swap(other);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+            // Need to disable the maybe-uninitialized here.  It seems like the compiler may be confused in situations where
+            // we are assigning into an unused optional from a temporary. The fact that this hits the move-assignment without
+            // having called the move constructor is suspicious though and hints of an actual bug.
+            //
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            WITH_MAYBE_UNINITIALIZED_DISABLED(this->swap(other);)
         }
 
         /// Swaps the content of this component batch with another.

--- a/rerun_cpp/src/rerun/components/rotation3d_ext.cpp
+++ b/rerun_cpp/src/rerun/components/rotation3d_ext.cpp
@@ -29,6 +29,6 @@ namespace rerun {
 #define Rotation3DExt Rotation3D
 #endif
 
-        const Rotation3D Rotation3D::IDENTITY = datatypes::Quaternion::IDENTITY;
+        const Rotation3DExt Rotation3DExt::IDENTITY = datatypes::Quaternion::IDENTITY;
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/rotation3d_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d_ext.cpp
@@ -22,6 +22,6 @@ namespace rerun {
 #define Rotation3DExt Rotation3D
 #endif
 
-        const Rotation3D Rotation3D::IDENTITY = Quaternion::IDENTITY;
+        const Rotation3DExt Rotation3DExt::IDENTITY = Quaternion::IDENTITY;
     } // namespace datatypes
 } // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
@@ -42,6 +42,23 @@ namespace rerun {
 
             static const TranslationRotationScale3D IDENTITY;
 
+// Need to disable the maybe-uninitialized here because the compiler gets confused by the combination
+// of union-types datatypes inside of an optional component.
+//
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+            TranslationRotationScale3D(const TranslationRotationScale3D& other)
+                : translation(other.translation),
+                  rotation(other.rotation),
+                  scale(other.scale),
+                  from_parent(other.from_parent){};
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
             /// Creates a new 3D transform from translation/rotation/scale.
             ///
             /// @param _from_parent If true, the transform maps from the parent space to the space

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../result.hpp"
+#include "../util.hpp"
 #include "rotation3d.hpp"
 #include "scale3d.hpp"
 #include "vec3d.hpp"
@@ -42,22 +43,17 @@ namespace rerun {
 
             static const TranslationRotationScale3D IDENTITY;
 
-// Need to disable the maybe-uninitialized here because the compiler gets confused by the combination
-// of union-types datatypes inside of an optional component.
-//
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
+            // Need to disable the maybe-uninitialized here because the compiler gets confused by the combination
+            // of union-types datatypes inside of an optional component.
+            //
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            DISABLE_MAYBE_UNINITIALIZED_PUSH
             TranslationRotationScale3D(const TranslationRotationScale3D& other)
                 : translation(other.translation),
                   rotation(other.rotation),
                   scale(other.scale),
                   from_parent(other.from_parent){};
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+            DISABLE_MAYBE_UNINITIALIZED_POP
 
             /// Creates a new 3D transform from translation/rotation/scale.
             ///

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d_ext.cpp
@@ -1,5 +1,5 @@
-#include "translation_rotation_scale3d.hpp"
 #include "../util.hpp"
+#include "translation_rotation_scale3d.hpp"
 
 // Uncomment for better auto-complete while editing the extension.
 // #define EDIT_EXTENSION
@@ -26,10 +26,9 @@ namespace rerun {
             DISABLE_MAYBE_UNINITIALIZED_PUSH
             TranslationRotationScale3D(const TranslationRotationScale3D& other)
                 : translation(other.translation),
-                rotation(other.rotation),
-                scale(other.scale),
-                from_parent(other.from_parent) {
-            };
+                  rotation(other.rotation),
+                  scale(other.scale),
+                  from_parent(other.from_parent){};
             DISABLE_MAYBE_UNINITIALIZED_POP
 
             /// Creates a new 3D transform from translation/rotation/scale.

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d_ext.cpp
@@ -18,6 +18,24 @@ namespace rerun {
 
             static const TranslationRotationScale3D IDENTITY;
 
+// Need to disable the maybe-uninitialized here because the compiler gets confused by the combination
+// of union-types datatypes inside of an optional component.
+//
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+            TranslationRotationScale3D(const TranslationRotationScale3D& other)
+                : translation(other.translation),
+                rotation(other.rotation),
+                scale(other.scale),
+                from_parent(other.from_parent) {
+            };
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
             /// Creates a new 3D transform from translation/rotation/scale.
             ///
             /// @param _from_parent If true, the transform maps from the parent space to the space

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d_ext.cpp
@@ -1,4 +1,5 @@
 #include "translation_rotation_scale3d.hpp"
+#include "../util.hpp"
 
 // Uncomment for better auto-complete while editing the extension.
 // #define EDIT_EXTENSION
@@ -18,23 +19,18 @@ namespace rerun {
 
             static const TranslationRotationScale3D IDENTITY;
 
-// Need to disable the maybe-uninitialized here because the compiler gets confused by the combination
-// of union-types datatypes inside of an optional component.
-//
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
+            // Need to disable the maybe-uninitialized here because the compiler gets confused by the combination
+            // of union-types datatypes inside of an optional component.
+            //
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            DISABLE_MAYBE_UNINITIALIZED_PUSH
             TranslationRotationScale3D(const TranslationRotationScale3D& other)
                 : translation(other.translation),
                 rotation(other.rotation),
                 scale(other.scale),
                 from_parent(other.from_parent) {
             };
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+            DISABLE_MAYBE_UNINITIALIZED_POP
 
             /// Creates a new 3D transform from translation/rotation/scale.
             ///

--- a/rerun_cpp/src/rerun/util.hpp
+++ b/rerun_cpp/src/rerun/util.hpp
@@ -15,8 +15,7 @@
 #endif
 
 #if defined(__GNUC__)
-#define DISABLE_MAYBE_UNINITIALIZED_POP \
-    _Pragma("GCC diagnostic pop")
+#define DISABLE_MAYBE_UNINITIALIZED_POP _Pragma("GCC diagnostic pop")
 #else
 #define DISABLE_MAYBE_UNINITIALIZED_WARNING
 #endif

--- a/rerun_cpp/src/rerun/util.hpp
+++ b/rerun_cpp/src/rerun/util.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+// Macro for enabling and disabling the "-Wmaybe-uninitialized" warning in GCC.
+// See: https://github.com/rerun-io/rerun/issues/4027
+
+#define WITH_MAYBE_UNINITIALIZED_DISABLED(expr) \
+    DISABLE_MAYBE_UNINITIALIZED_PUSH            \
+    expr DISABLE_MAYBE_UNINITIALIZED_POP
+
+#if defined(__GNUC__)
+#define DISABLE_MAYBE_UNINITIALIZED_PUSH \
+    _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+#else
+#define DISABLE_MAYBE_UNINITIALIZED_WARNING
+#endif
+
+#if defined(__GNUC__)
+#define DISABLE_MAYBE_UNINITIALIZED_POP \
+    _Pragma("GCC diagnostic pop")
+#else
+#define DISABLE_MAYBE_UNINITIALIZED_WARNING
+#endif

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -30,6 +30,7 @@
 #include <rerun/data_cell.hpp>
 #include <rerun/indicator_component.hpp>
 #include <rerun/result.hpp>
+#include <rerun/util.hpp>
 #include <utility>
 #include <vector>
 

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
@@ -27,6 +27,7 @@
 #include <rerun/data_cell.hpp>
 #include <rerun/indicator_component.hpp>
 #include <rerun/result.hpp>
+#include <rerun/util.hpp>
 #include <utility>
 #include <vector>
 

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -81,92 +81,236 @@ namespace rerun {
 
             AffixFuzzer3 with_fuzz2001(rerun::components::AffixFuzzer1 _fuzz2001) && {
                 fuzz2001 = std::move(_fuzz2001);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2002(rerun::components::AffixFuzzer2 _fuzz2002) && {
                 fuzz2002 = std::move(_fuzz2002);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2003(rerun::components::AffixFuzzer3 _fuzz2003) && {
                 fuzz2003 = std::move(_fuzz2003);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2004(rerun::components::AffixFuzzer4 _fuzz2004) && {
                 fuzz2004 = std::move(_fuzz2004);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2005(rerun::components::AffixFuzzer5 _fuzz2005) && {
                 fuzz2005 = std::move(_fuzz2005);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2006(rerun::components::AffixFuzzer6 _fuzz2006) && {
                 fuzz2006 = std::move(_fuzz2006);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2007(rerun::components::AffixFuzzer7 _fuzz2007) && {
                 fuzz2007 = std::move(_fuzz2007);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2008(rerun::components::AffixFuzzer8 _fuzz2008) && {
                 fuzz2008 = std::move(_fuzz2008);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2009(rerun::components::AffixFuzzer9 _fuzz2009) && {
                 fuzz2009 = std::move(_fuzz2009);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2010(rerun::components::AffixFuzzer10 _fuzz2010) && {
                 fuzz2010 = std::move(_fuzz2010);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2011(rerun::components::AffixFuzzer11 _fuzz2011) && {
                 fuzz2011 = std::move(_fuzz2011);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2012(rerun::components::AffixFuzzer12 _fuzz2012) && {
                 fuzz2012 = std::move(_fuzz2012);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2013(rerun::components::AffixFuzzer13 _fuzz2013) && {
                 fuzz2013 = std::move(_fuzz2013);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2014(rerun::components::AffixFuzzer14 _fuzz2014) && {
                 fuzz2014 = std::move(_fuzz2014);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2015(rerun::components::AffixFuzzer15 _fuzz2015) && {
                 fuzz2015 = std::move(_fuzz2015);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2016(rerun::components::AffixFuzzer16 _fuzz2016) && {
                 fuzz2016 = std::move(_fuzz2016);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2017(rerun::components::AffixFuzzer17 _fuzz2017) && {
                 fuzz2017 = std::move(_fuzz2017);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer3 with_fuzz2018(rerun::components::AffixFuzzer18 _fuzz2018) && {
                 fuzz2018 = std::move(_fuzz2018);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -28,6 +28,7 @@
 #include <rerun/data_cell.hpp>
 #include <rerun/indicator_component.hpp>
 #include <rerun/result.hpp>
+#include <rerun/util.hpp>
 #include <utility>
 #include <vector>
 
@@ -80,237 +81,111 @@ namespace rerun {
             AffixFuzzer3(AffixFuzzer3&& other) = default;
 
             AffixFuzzer3 with_fuzz2001(rerun::components::AffixFuzzer1 _fuzz2001) && {
-                fuzz2001 = std::move(_fuzz2001);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2001 =
+                    std::move(_fuzz2001); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2002(rerun::components::AffixFuzzer2 _fuzz2002) && {
-                fuzz2002 = std::move(_fuzz2002);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2002 =
+                    std::move(_fuzz2002); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2003(rerun::components::AffixFuzzer3 _fuzz2003) && {
-                fuzz2003 = std::move(_fuzz2003);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2003 =
+                    std::move(_fuzz2003); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2004(rerun::components::AffixFuzzer4 _fuzz2004) && {
-                fuzz2004 = std::move(_fuzz2004);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2004 =
+                    std::move(_fuzz2004); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2005(rerun::components::AffixFuzzer5 _fuzz2005) && {
-                fuzz2005 = std::move(_fuzz2005);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2005 =
+                    std::move(_fuzz2005); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2006(rerun::components::AffixFuzzer6 _fuzz2006) && {
-                fuzz2006 = std::move(_fuzz2006);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2006 =
+                    std::move(_fuzz2006); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2007(rerun::components::AffixFuzzer7 _fuzz2007) && {
-                fuzz2007 = std::move(_fuzz2007);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2007 =
+                    std::move(_fuzz2007); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2008(rerun::components::AffixFuzzer8 _fuzz2008) && {
-                fuzz2008 = std::move(_fuzz2008);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2008 =
+                    std::move(_fuzz2008); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2009(rerun::components::AffixFuzzer9 _fuzz2009) && {
-                fuzz2009 = std::move(_fuzz2009);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2009 =
+                    std::move(_fuzz2009); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2010(rerun::components::AffixFuzzer10 _fuzz2010) && {
-                fuzz2010 = std::move(_fuzz2010);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2010 =
+                    std::move(_fuzz2010); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2011(rerun::components::AffixFuzzer11 _fuzz2011) && {
-                fuzz2011 = std::move(_fuzz2011);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2011 =
+                    std::move(_fuzz2011); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2012(rerun::components::AffixFuzzer12 _fuzz2012) && {
-                fuzz2012 = std::move(_fuzz2012);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2012 =
+                    std::move(_fuzz2012); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2013(rerun::components::AffixFuzzer13 _fuzz2013) && {
-                fuzz2013 = std::move(_fuzz2013);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2013 =
+                    std::move(_fuzz2013); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2014(rerun::components::AffixFuzzer14 _fuzz2014) && {
-                fuzz2014 = std::move(_fuzz2014);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2014 =
+                    std::move(_fuzz2014); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2015(rerun::components::AffixFuzzer15 _fuzz2015) && {
-                fuzz2015 = std::move(_fuzz2015);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2015 =
+                    std::move(_fuzz2015); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2016(rerun::components::AffixFuzzer16 _fuzz2016) && {
-                fuzz2016 = std::move(_fuzz2016);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2016 =
+                    std::move(_fuzz2016); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2017(rerun::components::AffixFuzzer17 _fuzz2017) && {
-                fuzz2017 = std::move(_fuzz2017);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2017 =
+                    std::move(_fuzz2017); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2018(rerun::components::AffixFuzzer18 _fuzz2018) && {
-                fuzz2018 = std::move(_fuzz2018);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2018 =
+                    std::move(_fuzz2018); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -81,110 +81,110 @@ namespace rerun {
             AffixFuzzer3(AffixFuzzer3&& other) = default;
 
             AffixFuzzer3 with_fuzz2001(rerun::components::AffixFuzzer1 _fuzz2001) && {
-                fuzz2001 =
-                    std::move(_fuzz2001); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2001 = std::move(_fuzz2001);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2002(rerun::components::AffixFuzzer2 _fuzz2002) && {
-                fuzz2002 =
-                    std::move(_fuzz2002); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2002 = std::move(_fuzz2002);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2003(rerun::components::AffixFuzzer3 _fuzz2003) && {
-                fuzz2003 =
-                    std::move(_fuzz2003); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2003 = std::move(_fuzz2003);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2004(rerun::components::AffixFuzzer4 _fuzz2004) && {
-                fuzz2004 =
-                    std::move(_fuzz2004); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2004 = std::move(_fuzz2004);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2005(rerun::components::AffixFuzzer5 _fuzz2005) && {
-                fuzz2005 =
-                    std::move(_fuzz2005); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2005 = std::move(_fuzz2005);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2006(rerun::components::AffixFuzzer6 _fuzz2006) && {
-                fuzz2006 =
-                    std::move(_fuzz2006); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2006 = std::move(_fuzz2006);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2007(rerun::components::AffixFuzzer7 _fuzz2007) && {
-                fuzz2007 =
-                    std::move(_fuzz2007); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2007 = std::move(_fuzz2007);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2008(rerun::components::AffixFuzzer8 _fuzz2008) && {
-                fuzz2008 =
-                    std::move(_fuzz2008); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2008 = std::move(_fuzz2008);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2009(rerun::components::AffixFuzzer9 _fuzz2009) && {
-                fuzz2009 =
-                    std::move(_fuzz2009); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2009 = std::move(_fuzz2009);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2010(rerun::components::AffixFuzzer10 _fuzz2010) && {
-                fuzz2010 =
-                    std::move(_fuzz2010); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2010 = std::move(_fuzz2010);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2011(rerun::components::AffixFuzzer11 _fuzz2011) && {
-                fuzz2011 =
-                    std::move(_fuzz2011); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2011 = std::move(_fuzz2011);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2012(rerun::components::AffixFuzzer12 _fuzz2012) && {
-                fuzz2012 =
-                    std::move(_fuzz2012); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2012 = std::move(_fuzz2012);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2013(rerun::components::AffixFuzzer13 _fuzz2013) && {
-                fuzz2013 =
-                    std::move(_fuzz2013); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2013 = std::move(_fuzz2013);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2014(rerun::components::AffixFuzzer14 _fuzz2014) && {
-                fuzz2014 =
-                    std::move(_fuzz2014); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2014 = std::move(_fuzz2014);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2015(rerun::components::AffixFuzzer15 _fuzz2015) && {
-                fuzz2015 =
-                    std::move(_fuzz2015); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2015 = std::move(_fuzz2015);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2016(rerun::components::AffixFuzzer16 _fuzz2016) && {
-                fuzz2016 =
-                    std::move(_fuzz2016); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2016 = std::move(_fuzz2016);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2017(rerun::components::AffixFuzzer17 _fuzz2017) && {
-                fuzz2017 =
-                    std::move(_fuzz2017); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2017 = std::move(_fuzz2017);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer3 with_fuzz2018(rerun::components::AffixFuzzer18 _fuzz2018) && {
-                fuzz2018 =
-                    std::move(_fuzz2018); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2018 = std::move(_fuzz2018);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -82,109 +82,253 @@ namespace rerun {
             AffixFuzzer4 with_fuzz2101(ComponentBatch<rerun::components::AffixFuzzer1> _fuzz2101
             ) && {
                 fuzz2101 = std::move(_fuzz2101);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2102(ComponentBatch<rerun::components::AffixFuzzer2> _fuzz2102
             ) && {
                 fuzz2102 = std::move(_fuzz2102);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2103(ComponentBatch<rerun::components::AffixFuzzer3> _fuzz2103
             ) && {
                 fuzz2103 = std::move(_fuzz2103);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2104(ComponentBatch<rerun::components::AffixFuzzer4> _fuzz2104
             ) && {
                 fuzz2104 = std::move(_fuzz2104);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2105(ComponentBatch<rerun::components::AffixFuzzer5> _fuzz2105
             ) && {
                 fuzz2105 = std::move(_fuzz2105);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2106(ComponentBatch<rerun::components::AffixFuzzer6> _fuzz2106
             ) && {
                 fuzz2106 = std::move(_fuzz2106);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2107(ComponentBatch<rerun::components::AffixFuzzer7> _fuzz2107
             ) && {
                 fuzz2107 = std::move(_fuzz2107);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2108(ComponentBatch<rerun::components::AffixFuzzer8> _fuzz2108
             ) && {
                 fuzz2108 = std::move(_fuzz2108);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2109(ComponentBatch<rerun::components::AffixFuzzer9> _fuzz2109
             ) && {
                 fuzz2109 = std::move(_fuzz2109);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2110(ComponentBatch<rerun::components::AffixFuzzer10> _fuzz2110
             ) && {
                 fuzz2110 = std::move(_fuzz2110);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2111(ComponentBatch<rerun::components::AffixFuzzer11> _fuzz2111
             ) && {
                 fuzz2111 = std::move(_fuzz2111);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2112(ComponentBatch<rerun::components::AffixFuzzer12> _fuzz2112
             ) && {
                 fuzz2112 = std::move(_fuzz2112);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2113(ComponentBatch<rerun::components::AffixFuzzer13> _fuzz2113
             ) && {
                 fuzz2113 = std::move(_fuzz2113);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2114(ComponentBatch<rerun::components::AffixFuzzer14> _fuzz2114
             ) && {
                 fuzz2114 = std::move(_fuzz2114);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2115(ComponentBatch<rerun::components::AffixFuzzer15> _fuzz2115
             ) && {
                 fuzz2115 = std::move(_fuzz2115);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2116(ComponentBatch<rerun::components::AffixFuzzer16> _fuzz2116
             ) && {
                 fuzz2116 = std::move(_fuzz2116);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2117(ComponentBatch<rerun::components::AffixFuzzer17> _fuzz2117
             ) && {
                 fuzz2117 = std::move(_fuzz2117);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             AffixFuzzer4 with_fuzz2118(ComponentBatch<rerun::components::AffixFuzzer18> _fuzz2118
             ) && {
                 fuzz2118 = std::move(_fuzz2118);
+// See: https://github.com/rerun-io/rerun/issues/4027
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
                 return std::move(*this);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -28,6 +28,7 @@
 #include <rerun/data_cell.hpp>
 #include <rerun/indicator_component.hpp>
 #include <rerun/result.hpp>
+#include <rerun/util.hpp>
 #include <utility>
 #include <vector>
 
@@ -81,254 +82,128 @@ namespace rerun {
 
             AffixFuzzer4 with_fuzz2101(ComponentBatch<rerun::components::AffixFuzzer1> _fuzz2101
             ) && {
-                fuzz2101 = std::move(_fuzz2101);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2101 =
+                    std::move(_fuzz2101); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2102(ComponentBatch<rerun::components::AffixFuzzer2> _fuzz2102
             ) && {
-                fuzz2102 = std::move(_fuzz2102);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2102 =
+                    std::move(_fuzz2102); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2103(ComponentBatch<rerun::components::AffixFuzzer3> _fuzz2103
             ) && {
-                fuzz2103 = std::move(_fuzz2103);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2103 =
+                    std::move(_fuzz2103); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2104(ComponentBatch<rerun::components::AffixFuzzer4> _fuzz2104
             ) && {
-                fuzz2104 = std::move(_fuzz2104);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2104 =
+                    std::move(_fuzz2104); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2105(ComponentBatch<rerun::components::AffixFuzzer5> _fuzz2105
             ) && {
-                fuzz2105 = std::move(_fuzz2105);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2105 =
+                    std::move(_fuzz2105); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2106(ComponentBatch<rerun::components::AffixFuzzer6> _fuzz2106
             ) && {
-                fuzz2106 = std::move(_fuzz2106);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2106 =
+                    std::move(_fuzz2106); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2107(ComponentBatch<rerun::components::AffixFuzzer7> _fuzz2107
             ) && {
-                fuzz2107 = std::move(_fuzz2107);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2107 =
+                    std::move(_fuzz2107); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2108(ComponentBatch<rerun::components::AffixFuzzer8> _fuzz2108
             ) && {
-                fuzz2108 = std::move(_fuzz2108);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2108 =
+                    std::move(_fuzz2108); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2109(ComponentBatch<rerun::components::AffixFuzzer9> _fuzz2109
             ) && {
-                fuzz2109 = std::move(_fuzz2109);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2109 =
+                    std::move(_fuzz2109); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2110(ComponentBatch<rerun::components::AffixFuzzer10> _fuzz2110
             ) && {
-                fuzz2110 = std::move(_fuzz2110);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2110 =
+                    std::move(_fuzz2110); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2111(ComponentBatch<rerun::components::AffixFuzzer11> _fuzz2111
             ) && {
-                fuzz2111 = std::move(_fuzz2111);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2111 =
+                    std::move(_fuzz2111); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2112(ComponentBatch<rerun::components::AffixFuzzer12> _fuzz2112
             ) && {
-                fuzz2112 = std::move(_fuzz2112);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2112 =
+                    std::move(_fuzz2112); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2113(ComponentBatch<rerun::components::AffixFuzzer13> _fuzz2113
             ) && {
-                fuzz2113 = std::move(_fuzz2113);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2113 =
+                    std::move(_fuzz2113); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2114(ComponentBatch<rerun::components::AffixFuzzer14> _fuzz2114
             ) && {
-                fuzz2114 = std::move(_fuzz2114);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2114 =
+                    std::move(_fuzz2114); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2115(ComponentBatch<rerun::components::AffixFuzzer15> _fuzz2115
             ) && {
-                fuzz2115 = std::move(_fuzz2115);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2115 =
+                    std::move(_fuzz2115); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2116(ComponentBatch<rerun::components::AffixFuzzer16> _fuzz2116
             ) && {
-                fuzz2116 = std::move(_fuzz2116);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2116 =
+                    std::move(_fuzz2116); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2117(ComponentBatch<rerun::components::AffixFuzzer17> _fuzz2117
             ) && {
-                fuzz2117 = std::move(_fuzz2117);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2117 =
+                    std::move(_fuzz2117); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2118(ComponentBatch<rerun::components::AffixFuzzer18> _fuzz2118
             ) && {
-                fuzz2118 = std::move(_fuzz2118);
-// See: https://github.com/rerun-io/rerun/issues/4027
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-                return std::move(*this);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+                fuzz2118 =
+                    std::move(_fuzz2118); // See: https://github.com/rerun-io/rerun/issues/4027
+                WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             /// Returns the number of primary instances of this archetype.

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -82,127 +82,127 @@ namespace rerun {
 
             AffixFuzzer4 with_fuzz2101(ComponentBatch<rerun::components::AffixFuzzer1> _fuzz2101
             ) && {
-                fuzz2101 =
-                    std::move(_fuzz2101); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2101 = std::move(_fuzz2101);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2102(ComponentBatch<rerun::components::AffixFuzzer2> _fuzz2102
             ) && {
-                fuzz2102 =
-                    std::move(_fuzz2102); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2102 = std::move(_fuzz2102);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2103(ComponentBatch<rerun::components::AffixFuzzer3> _fuzz2103
             ) && {
-                fuzz2103 =
-                    std::move(_fuzz2103); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2103 = std::move(_fuzz2103);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2104(ComponentBatch<rerun::components::AffixFuzzer4> _fuzz2104
             ) && {
-                fuzz2104 =
-                    std::move(_fuzz2104); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2104 = std::move(_fuzz2104);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2105(ComponentBatch<rerun::components::AffixFuzzer5> _fuzz2105
             ) && {
-                fuzz2105 =
-                    std::move(_fuzz2105); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2105 = std::move(_fuzz2105);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2106(ComponentBatch<rerun::components::AffixFuzzer6> _fuzz2106
             ) && {
-                fuzz2106 =
-                    std::move(_fuzz2106); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2106 = std::move(_fuzz2106);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2107(ComponentBatch<rerun::components::AffixFuzzer7> _fuzz2107
             ) && {
-                fuzz2107 =
-                    std::move(_fuzz2107); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2107 = std::move(_fuzz2107);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2108(ComponentBatch<rerun::components::AffixFuzzer8> _fuzz2108
             ) && {
-                fuzz2108 =
-                    std::move(_fuzz2108); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2108 = std::move(_fuzz2108);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2109(ComponentBatch<rerun::components::AffixFuzzer9> _fuzz2109
             ) && {
-                fuzz2109 =
-                    std::move(_fuzz2109); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2109 = std::move(_fuzz2109);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2110(ComponentBatch<rerun::components::AffixFuzzer10> _fuzz2110
             ) && {
-                fuzz2110 =
-                    std::move(_fuzz2110); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2110 = std::move(_fuzz2110);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2111(ComponentBatch<rerun::components::AffixFuzzer11> _fuzz2111
             ) && {
-                fuzz2111 =
-                    std::move(_fuzz2111); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2111 = std::move(_fuzz2111);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2112(ComponentBatch<rerun::components::AffixFuzzer12> _fuzz2112
             ) && {
-                fuzz2112 =
-                    std::move(_fuzz2112); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2112 = std::move(_fuzz2112);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2113(ComponentBatch<rerun::components::AffixFuzzer13> _fuzz2113
             ) && {
-                fuzz2113 =
-                    std::move(_fuzz2113); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2113 = std::move(_fuzz2113);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2114(ComponentBatch<rerun::components::AffixFuzzer14> _fuzz2114
             ) && {
-                fuzz2114 =
-                    std::move(_fuzz2114); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2114 = std::move(_fuzz2114);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2115(ComponentBatch<rerun::components::AffixFuzzer15> _fuzz2115
             ) && {
-                fuzz2115 =
-                    std::move(_fuzz2115); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2115 = std::move(_fuzz2115);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2116(ComponentBatch<rerun::components::AffixFuzzer16> _fuzz2116
             ) && {
-                fuzz2116 =
-                    std::move(_fuzz2116); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2116 = std::move(_fuzz2116);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2117(ComponentBatch<rerun::components::AffixFuzzer17> _fuzz2117
             ) && {
-                fuzz2117 =
-                    std::move(_fuzz2117); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2117 = std::move(_fuzz2117);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 
             AffixFuzzer4 with_fuzz2118(ComponentBatch<rerun::components::AffixFuzzer18> _fuzz2118
             ) && {
-                fuzz2118 =
-                    std::move(_fuzz2118); // See: https://github.com/rerun-io/rerun/issues/4027
+                fuzz2118 = std::move(_fuzz2118);
+                // See: https://github.com/rerun-io/rerun/issues/4027
                 WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
             }
 


### PR DESCRIPTION
### What
We have a handful of places where we need to disable `-Wmaybe-uninitialized` primarily related to usage of `std::optional`.

It seems that move-assigning to the std::optional can lead to situations where gcc thinks we are using uninitialized-memory because the memory in the optional hasn't been initialized.

Tracking these now in: https://github.com/rerun-io/rerun/issues/4027

A few of these still make me uncomfortable, but seems better than having a pile of unusable warning spam.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4030) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4030)
- [Docs preview](https://rerun.io/preview/f7c01adf1874fed69c13f904d1c810da91e69b0a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f7c01adf1874fed69c13f904d1c810da91e69b0a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)