### PR TITLE
Allow torch >=2.0.1 instead of 2.1.0

### DIFF
--- a/rerun_py/requirements-lint.txt
+++ b/rerun_py/requirements-lint.txt
@@ -2,7 +2,7 @@ attrs>=23.1.0  # for mypy to work
 blackdoc==0.3.8
 mypy==1.4.1
 numpy>=1.24 # For mypy plugin
-torch>=2.1.0
+torch>=2.0.1
 pip-check-reqs==2.4.4 # Checks for missing deps in requirements.txt files
 pytest  # For mypy to work
 ruff==0.1.2


### PR DESCRIPTION
### What
PRs have started failing due to incompatible torch dep when installing CI requirements: https://github.com/rerun-io/rerun/actions/runs/6658351044/job/18095061609

I think we can relax this for now.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
