### PR TITLE
Add missing include for <optional> in recording_stream.hpp

### DIFF
--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint> // uint32_t etc.
+#include <optional>
 #include <string_view>
 #include <vector>
 


### PR DESCRIPTION
### What
Doesn't seem to be required on all platforms, but it's in the interface of spawn so we should have it here.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
