### PR TITLE
Rust SDK: expose clap in externals

### DIFF
--- a/crates/rerun/src/lib.rs
+++ b/crates/rerun/src/lib.rs
@@ -123,8 +123,12 @@ pub use re_sdk::*;
 pub mod external {
     pub use anyhow;
 
+    #[cfg(all(feature = "sdk", not(target_arch = "wasm32")))]
+    pub use clap;
+
     #[cfg(feature = "native_viewer")]
     pub use re_viewer;
+
     #[cfg(feature = "native_viewer")]
     pub use re_viewer::external::*;
 


### PR DESCRIPTION
Very annoying to have to manually `cargo add clap` when using our `clap` integration :man_facepalming: 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4040) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4040)
- [Docs preview](https://rerun.io/preview/b1da00a9e8b5437e2e9f5fec7dac2513fe736ab1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b1da00a9e8b5437e2e9f5fec7dac2513fe736ab1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)