### PR TITLE
`spawn`: versioned links for missing executable too

### DIFF
--- a/crates/re_build_info/src/crate_version.rs
+++ b/crates/re_build_info/src/crate_version.rs
@@ -156,6 +156,13 @@ impl CrateVersion {
         }
     }
 
+    /// True is this version has no metadata at all (rc, dev, alpha, etc).
+    ///
+    /// I.e. it's an actual, final release.
+    pub fn is_release(&self) -> bool {
+        self.meta.is_none()
+    }
+
     /// Whether or not this build has a `+dev` suffix.
     ///
     /// This is used to identify builds which are not explicit releases,

--- a/crates/re_sdk/src/spawn.rs
+++ b/crates/re_sdk/src/spawn.rs
@@ -184,8 +184,15 @@ pub fn spawn(opts: &SpawnOptions) -> Result<(), SpawnError> {
                     executable_path: executable_path.clone(),
                 }
             } else {
+                let sdk_version = re_build_info::build_info!().version;
                 SpawnError::ExecutableNotFoundInPath {
-                    message: MSG_INSTALL_HOW_TO.to_owned(),
+                    // Only recommend a specific Viewer version for non-alpha/rc/dev SDKs.
+                    message: if sdk_version.meta.is_none() {
+                        MSG_INSTALL_HOW_TO_VERSIONED
+                            .replace("__VIEWER_VERSION__", &sdk_version.to_string())
+                    } else {
+                        MSG_INSTALL_HOW_TO.to_owned()
+                    },
                     executable_name: opts.executable_name.clone(),
                     search_path: std::env::var("PATH").unwrap_or_else(|_| String::new()),
                 }

--- a/crates/re_sdk/src/spawn.rs
+++ b/crates/re_sdk/src/spawn.rs
@@ -187,7 +187,7 @@ pub fn spawn(opts: &SpawnOptions) -> Result<(), SpawnError> {
                 let sdk_version = re_build_info::build_info!().version;
                 SpawnError::ExecutableNotFoundInPath {
                     // Only recommend a specific Viewer version for non-alpha/rc/dev SDKs.
-                    message: if sdk_version.meta.is_none() {
+                    message: if sdk_version.is_release() {
                         MSG_INSTALL_HOW_TO_VERSIONED
                             .replace("__VIEWER_VERSION__", &sdk_version.to_string())
                     } else {
@@ -226,7 +226,7 @@ pub fn spawn(opts: &SpawnOptions) -> Result<(), SpawnError> {
 
             // Don't recommend installing stuff through registries if the user is running some
             // weird version.
-            if sdk_version.meta.is_none() {
+            if sdk_version.is_release() {
                 eprintln!(
                     "{}",
                     MSG_INSTALL_HOW_TO_VERSIONED


### PR DESCRIPTION
Fixing an oversight from #4031: if the user doesn't have any executable at all on their PATH, don't just blindly tell them to download latest, it might not even be compatible! Use a versioned link in that case too, where possible.

```sh
$ which rerun
which: no rerun in (...)

$ RUST_LOG=off cargo r -p code_examples --bin point3d_simple

Error: SpawnViewer(Failed to find Rerun Viewer executable in PATH.

    You can install an appropriate version of the Rerun Viewer via binary releases:
    * Using `cargo`: `cargo binstall --force rerun-cli@0.10.0` (see https://github.com/cargo-bins/cargo-binstall)
    * Via direct download from our release assets: https://github.com/rerun-io/rerun/releases/0.10.0/
    * Using `pip`: `pip3 install rerun-sdk==0.10.0` (warning: pip version has slower start times!)

    For more information, refer to our complete install documentation over at:
    https://rerun.io/docs/getting-started/installing-viewer

PATH="...")
```
(This is using my local copy where everything is tagged as if `0.10.0` was released)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4041) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4041)
- [Docs preview](https://rerun.io/preview/40c1c7e4ea28f10dc0f186912fe637ae47c2d1e8/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/40c1c7e4ea28f10dc0f186912fe637ae47c2d1e8/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)