### PR TITLE
`RecordingStream`: introduce `connect_opts`

### DIFF
--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -258,6 +258,21 @@ impl RecordingStreamBuilder {
     /// Creates a new [`RecordingStream`] that is pre-configured to stream the data through to a
     /// remote Rerun instance.
     ///
+    /// See also [`Self::connect_opts`] if you wish to configure the TCP connection.
+    ///
+    /// ## Example
+    ///
+    /// ```no_run
+    /// let rec = re_sdk::RecordingStreamBuilder::new("rerun_example_app").connect()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn connect(self) -> RecordingStreamResult<RecordingStream> {
+        self.connect_opts(crate::default_server_addr(), crate::default_flush_timeout())
+    }
+
+    /// Creates a new [`RecordingStream`] that is pre-configured to stream the data through to a
+    /// remote Rerun instance.
+    ///
     /// `flush_timeout` is the minimum time the [`TcpSink`][`crate::log_sink::TcpSink`] will
     /// wait during a flush before potentially dropping data.  Note: Passing `None` here can cause a
     /// call to `flush` to block indefinitely if a connection cannot be established.
@@ -266,10 +281,10 @@ impl RecordingStreamBuilder {
     ///
     /// ```no_run
     /// let rec = re_sdk::RecordingStreamBuilder::new("rerun_example_app")
-    ///     .connect(re_sdk::default_server_addr(), re_sdk::default_flush_timeout())?;
+    ///     .connect_opts(re_sdk::default_server_addr(), re_sdk::default_flush_timeout())?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn connect(
+    pub fn connect_opts(
         self,
         addr: std::net::SocketAddr,
         flush_timeout: Option<std::time::Duration>,
@@ -321,21 +336,17 @@ impl RecordingStreamBuilder {
     /// If a Rerun Viewer is already listening on this TCP port, the stream will be redirected to
     /// that viewer instead of starting a new one.
     ///
-    /// `flush_timeout` is the minimum time the [`TcpSink`][`crate::log_sink::TcpSink`] will
-    /// wait during a flush before potentially dropping data.  Note: Passing `None` here can cause a
-    /// call to `flush` to block indefinitely if a connection cannot be established.
+    /// See also [`Self::spawn_opts`] if you wish to configure the behavior of thew Rerun process
+    /// as well as the underlying TCP connection.
     ///
     /// ## Example
     ///
     /// ```no_run
-    /// let rec = re_sdk::RecordingStreamBuilder::new("rerun_example_app").spawn(re_sdk::default_flush_timeout())?;
+    /// let rec = re_sdk::RecordingStreamBuilder::new("rerun_example_app").spawn()?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn spawn(
-        self,
-        flush_timeout: Option<std::time::Duration>,
-    ) -> RecordingStreamResult<RecordingStream> {
-        self.spawn_opts(&Default::default(), flush_timeout)
+    pub fn spawn(self) -> RecordingStreamResult<RecordingStream> {
+        self.spawn_opts(&Default::default(), crate::default_flush_timeout())
     }
 
     /// Spawns a new Rerun Viewer process from an executable available in PATH, then creates a new
@@ -368,12 +379,12 @@ impl RecordingStreamBuilder {
         // NOTE: If `_RERUN_TEST_FORCE_SAVE` is set, all recording streams will write to disk no matter
         // what, thus spawning a viewer is pointless (and probably not intended).
         if forced_sink_path().is_some() {
-            return self.connect(connect_addr, flush_timeout);
+            return self.connect_opts(connect_addr, flush_timeout);
         }
 
         spawn(opts)?;
 
-        self.connect(connect_addr, flush_timeout)
+        self.connect_opts(connect_addr, flush_timeout)
     }
 
     /// Creates a new [`RecordingStream`] that is pre-configured to stream the data through to a
@@ -1153,6 +1164,18 @@ impl RecordingStream {
     /// Swaps the underlying sink for a [`crate::log_sink::TcpSink`] sink pre-configured to use
     /// the specified address.
     ///
+    /// See also [`Self::connect_opts`] if you wish to configure the TCP connection.
+    ///
+    /// This is a convenience wrapper for [`Self::set_sink`] that upholds the same guarantees in
+    /// terms of data durability and ordering.
+    /// See [`Self::set_sink`] for more information.
+    pub fn connect(&self) {
+        self.connect_opts(crate::default_server_addr(), crate::default_flush_timeout())
+    }
+
+    /// Swaps the underlying sink for a [`crate::log_sink::TcpSink`] sink pre-configured to use
+    /// the specified address.
+    ///
     /// `flush_timeout` is the minimum time the [`TcpSink`][`crate::log_sink::TcpSink`] will
     /// wait during a flush before potentially dropping data.  Note: Passing `None` here can cause a
     /// call to `flush` to block indefinitely if a connection cannot be established.
@@ -1160,7 +1183,11 @@ impl RecordingStream {
     /// This is a convenience wrapper for [`Self::set_sink`] that upholds the same guarantees in
     /// terms of data durability and ordering.
     /// See [`Self::set_sink`] for more information.
-    pub fn connect(&self, addr: std::net::SocketAddr, flush_timeout: Option<std::time::Duration>) {
+    pub fn connect_opts(
+        &self,
+        addr: std::net::SocketAddr,
+        flush_timeout: Option<std::time::Duration>,
+    ) {
         if forced_sink_path().is_some() {
             re_log::debug!("Ignored setting new TcpSink since _RERUN_FORCE_SINK is set");
             return;
@@ -1176,15 +1203,14 @@ impl RecordingStream {
     /// If a Rerun Viewer is already listening on this TCP port, the stream will be redirected to
     /// that viewer instead of starting a new one.
     ///
-    /// `flush_timeout` is the minimum time the [`TcpSink`][`crate::log_sink::TcpSink`] will
-    /// wait during a flush before potentially dropping data.  Note: Passing `None` here can cause a
-    /// call to `flush` to block indefinitely if a connection cannot be established.
+    /// See also [`Self::spawn_opts`] if you wish to configure the behavior of thew Rerun process
+    /// as well as the underlying TCP connection.
     ///
     /// This is a convenience wrapper for [`Self::set_sink`] that upholds the same guarantees in
     /// terms of data durability and ordering.
     /// See [`Self::set_sink`] for more information.
-    pub fn spawn(&self, flush_timeout: Option<std::time::Duration>) -> RecordingStreamResult<()> {
-        self.spawn_opts(&Default::default(), flush_timeout)
+    pub fn spawn(&self) -> RecordingStreamResult<()> {
+        self.spawn_opts(&Default::default(), crate::default_flush_timeout())
     }
 
     /// Spawns a new Rerun Viewer process from an executable available in PATH, then swaps the
@@ -1216,7 +1242,7 @@ impl RecordingStream {
 
         spawn(opts)?;
 
-        self.connect(opts.connect_addr(), flush_timeout);
+        self.connect_opts(opts.connect_addr(), flush_timeout);
 
         Ok(())
     }

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1170,7 +1170,7 @@ impl RecordingStream {
     /// terms of data durability and ordering.
     /// See [`Self::set_sink`] for more information.
     pub fn connect(&self) {
-        self.connect_opts(crate::default_server_addr(), crate::default_flush_timeout())
+        self.connect_opts(crate::default_server_addr(), crate::default_flush_timeout());
     }
 
     /// Swaps the underlying sink for a [`crate::log_sink::TcpSink`] sink pre-configured to use

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -39,7 +39,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_segmentation")
-///         .spawn(rerun::default_flush_timeout())?;
+///         .spawn()?;
 ///
 ///     // create an annotation context to describe the classes
 ///     rec.log_timeless(

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use std::f32::consts::TAU;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d").spawn()?;
 ///
 ///     let origins = vec![rerun::Position3D::ZERO; 100];
 ///     let (vectors, colors): (Vec<_>, Vec<_>) = (0..100)

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -37,8 +37,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj]>", args[0]);
 ///     };
 ///
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple").spawn()?;
 ///
 ///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;

--- a/crates/re_types/src/archetypes/bar_chart.rs
+++ b/crates/re_types/src/archetypes/bar_chart.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple bar chart
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart").spawn()?;
 ///
 ///     rec.log(
 ///         "bar_chart",

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -28,8 +28,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple 2D boxes
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d").spawn()?;
 ///
 ///     rec.log(
 ///         "simple",

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -28,8 +28,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Batch of 3D boxes
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").spawn()?;
 ///
 ///     rec.log(
 ///         "batch",

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -33,8 +33,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn()?;
 ///
 ///     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
 ///     image.slice_mut(s![50..150, 50..150]).fill(20000);

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -33,8 +33,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Disconnected Space
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").spawn()?;
 ///
 ///     // These two points can be projected into the same space..
 ///     rec.log(

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -38,8 +38,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple").spawn()?;
 ///
 ///     let mut image = Array::<u8, _>::zeros((200, 300, 3).f());
 ///     image.slice_mut(s![.., .., 0]).fill(255);

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -28,8 +28,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### `line_strip2d_batch`:
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn()?;
 ///
 ///     let strip1 = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
 ///     #[rustfmt::skip]

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -28,8 +28,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Many strips
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn()?;
 ///
 ///     let strip1 = [[0., 0., 2.], [1., 0., 2.], [1., 1., 2.], [0., 1., 2.]];
 ///     let strip2 = [

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple indexed 3D mesh
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").spawn()?;
 ///
 ///     rec.log(
 ///         "triangle",

--- a/crates/re_types/src/archetypes/pinhole.rs
+++ b/crates/re_types/src/archetypes/pinhole.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").spawn()?;
 ///
 ///     let mut image = Array::<u8, _>::default((3, 3, 3).f());
 ///     image.map_inplace(|x| *x = rand::random());

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use rand::{distributions::Uniform, Rng as _};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn()?;
 ///
 ///     let mut rng = rand::thread_rng();
 ///     let dist = Uniform::new(-3., 3.);

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use rand::{distributions::Uniform, Rng as _};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").spawn()?;
 ///
 ///     let mut rng = rand::thread_rng();
 ///     let dist = Uniform::new(-5., 5.);

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -38,8 +38,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{s, Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image").spawn()?;
 ///
 ///     // create a segmentation image
 ///     let mut image = Array::<u8, _>::zeros((8, 12).f());

--- a/crates/re_types/src/archetypes/tensor.rs
+++ b/crates/re_types/src/archetypes/tensor.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use ndarray::{Array, ShapeBuilder};
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple").spawn()?;
 ///
 ///     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
 ///     data.map_inplace(|x| *x = rand::random());

--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Markdown text document
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document").spawn()?;
 ///
 ///     rec.log(
 ///         "text_document",

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use rerun::external::log;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration").spawn()?;
 ///
 ///     // Log a text entry directly:
 ///     rec.log(

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -31,8 +31,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple line plot
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn()?;
 ///
 ///     for step in 0..64 {
 ///         rec.set_time_sequence("step", step);

--- a/crates/re_types/src/archetypes/transform3d.rs
+++ b/crates/re_types/src/archetypes/transform3d.rs
@@ -30,8 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// use std::f32::consts::TAU;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d").spawn()?;
 ///
 ///     let arrow = rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]);
 ///

--- a/crates/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/re_types/src/archetypes/view_coordinates.rs
@@ -35,8 +35,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### View coordinates for adjusting the eye camera
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").spawn()?;
 ///
 ///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log(

--- a/crates/re_types_core/src/archetypes/clear.rs
+++ b/crates/re_types_core/src/archetypes/clear.rs
@@ -30,8 +30,7 @@ use crate::{DeserializationError, DeserializationResult};
 /// use rerun::external::glam;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple")
-///         .spawn(rerun::default_flush_timeout())?;
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple").spawn()?;
 ///
 ///     #[rustfmt::skip]
 ///     let (vectors, origins, colors) = (

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -91,7 +91,7 @@ impl RerunArgs {
         match self.to_behavior()? {
             RerunBehavior::Connect(addr) => Ok((
                 RecordingStreamBuilder::new(application_id)
-                    .connect(addr, crate::default_flush_timeout())?,
+                    .connect_opts(addr, crate::default_flush_timeout())?,
                 Default::default(),
             )),
 
@@ -101,7 +101,7 @@ impl RerunArgs {
             )),
 
             RerunBehavior::Spawn => Ok((
-                RecordingStreamBuilder::new(application_id).spawn(crate::default_flush_timeout())?,
+                RecordingStreamBuilder::new(application_id).spawn()?,
                 Default::default(),
             )),
 

--- a/crates/rerun/src/lib.rs
+++ b/crates/rerun/src/lib.rs
@@ -55,8 +55,7 @@
 //! # fn positions() -> Vec<rerun::Position3D> { Default::default() }
 //! # fn colors() -> Vec<rerun::Color> { Default::default() }
 //! // Stream log data to an awaiting `rerun` process.
-//! let rec = rerun::RecordingStreamBuilder::new("rerun_example_app")
-//!     .connect(rerun::default_server_addr(), rerun::default_flush_timeout())?;
+//! let rec = rerun::RecordingStreamBuilder::new("rerun_example_app").connect()?;
 //!
 //! let points: Vec<rerun::Position3D> = positions();
 //! let colors: Vec<rerun::Color> = colors();

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -370,7 +370,7 @@ fn rr_recording_stream_connect_impl(
     } else {
         None
     };
-    stream.connect(tcp_addr, flush_timeout);
+    stream.connect_opts(tcp_addr, flush_timeout);
 
     Ok(())
 }

--- a/docs/code-examples/annotation_context_connections.rs
+++ b/docs/code-examples/annotation_context_connections.rs
@@ -2,7 +2,7 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_connections")
-        .spawn(rerun::default_flush_timeout())?;
+        .spawn()?;
 
     // Log an annotation context to assign a label and color to each class
     // Create a class description with labels and color for each keypoint ID as well as some

--- a/docs/code-examples/annotation_context_rects.rs
+++ b/docs/code-examples/annotation_context_rects.rs
@@ -1,8 +1,8 @@
 //! Log rectangles with different colors and labels using annotation context
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_rects")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec =
+        rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_rects").spawn()?;
 
     // Log an annotation context to assign a label and color to each class
     rec.log_timeless(

--- a/docs/code-examples/annotation_context_segmentation.rs
+++ b/docs/code-examples/annotation_context_segmentation.rs
@@ -4,7 +4,7 @@ use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_segmentation")
-        .spawn(rerun::default_flush_timeout())?;
+        .spawn()?;
 
     // create an annotation context to describe the classes
     rec.log_timeless(

--- a/docs/code-examples/arrow3d_simple.rs
+++ b/docs/code-examples/arrow3d_simple.rs
@@ -3,8 +3,7 @@
 use std::f32::consts::TAU;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_arrow3d").spawn()?;
 
     let origins = vec![rerun::Position3D::ZERO; 100];
     let (vectors, colors): (Vec<_>, Vec<_>) = (0..100)

--- a/docs/code-examples/asset3d_out_of_tree.rs
+++ b/docs/code-examples/asset3d_out_of_tree.rs
@@ -11,8 +11,7 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb]>", args[0]);
     };
 
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree").spawn()?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 

--- a/docs/code-examples/asset3d_simple.rs
+++ b/docs/code-examples/asset3d_simple.rs
@@ -8,8 +8,7 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj]>", args[0]);
     };
 
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_simple").spawn()?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;

--- a/docs/code-examples/bar_chart.rs
+++ b/docs/code-examples/bar_chart.rs
@@ -1,8 +1,7 @@
 //! Create and log a bar chart
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_bar_chart").spawn()?;
 
     rec.log(
         "bar_chart",

--- a/docs/code-examples/box2d_simple.rs
+++ b/docs/code-examples/box2d_simple.rs
@@ -1,8 +1,7 @@
 //! Log some very simple 2D boxes.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box2d").spawn()?;
 
     rec.log(
         "simple",

--- a/docs/code-examples/box3d_batch.rs
+++ b/docs/code-examples/box3d_batch.rs
@@ -1,8 +1,7 @@
 //! Log a batch of oriented bounding boxes.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d_batch").spawn()?;
 
     rec.log(
         "batch",

--- a/docs/code-examples/box3d_simple.rs
+++ b/docs/code-examples/box3d_simple.rs
@@ -1,8 +1,7 @@
 //! Log a single 3D box.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_box3d").spawn()?;
 
     rec.log(
         "simple",

--- a/docs/code-examples/clear_recursive.rs
+++ b/docs/code-examples/clear_recursive.rs
@@ -3,8 +3,7 @@
 use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_recursive")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_recursive").spawn()?;
 
     #[rustfmt::skip]
     let (vectors, origins, colors) = (

--- a/docs/code-examples/clear_simple.rs
+++ b/docs/code-examples/clear_simple.rs
@@ -3,8 +3,7 @@
 use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_clear_simple").spawn()?;
 
     #[rustfmt::skip]
     let (vectors, origins, colors) = (

--- a/docs/code-examples/custom_data.rs
+++ b/docs/code-examples/custom_data.rs
@@ -72,8 +72,7 @@ impl rerun::Loggable for Confidence {
 // ---
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_custom_data")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_custom_data").spawn()?;
 
     rec.log(
         "left/my_confident_point_cloud",

--- a/docs/code-examples/depth_image_3d.rs
+++ b/docs/code-examples/depth_image_3d.rs
@@ -2,8 +2,7 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn()?;
 
     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
     image.slice_mut(s![50..150, 50..150]).fill(20000);

--- a/docs/code-examples/depth_image_simple.rs
+++ b/docs/code-examples/depth_image_simple.rs
@@ -3,8 +3,7 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_depth_image").spawn()?;
 
     let mut image = Array::<u16, _>::from_elem((200, 300).f(), 65535);
     image.slice_mut(s![50..150, 50..150]).fill(20000);

--- a/docs/code-examples/disconnected_space.rs
+++ b/docs/code-examples/disconnected_space.rs
@@ -1,8 +1,7 @@
 //! Disconnect two spaces.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").spawn()?;
 
     // These two points can be projected into the same space..
     rec.log(

--- a/docs/code-examples/image_simple.rs
+++ b/docs/code-examples/image_simple.rs
@@ -3,8 +3,7 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_simple").spawn()?;
 
     let mut image = Array::<u8, _>::zeros((200, 300, 3).f());
     image.slice_mut(s![.., .., 0]).fill(255);

--- a/docs/code-examples/line_segments2d_simple.rs
+++ b/docs/code-examples/line_segments2d_simple.rs
@@ -1,8 +1,7 @@
 //! Log a couple 2D line segments using 2D line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments2d")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments2d").spawn()?;
 
     let points = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     rec.log("segments", &rerun::LineStrips2D::new(points.chunks(2)))?;

--- a/docs/code-examples/line_segments3d_simple.rs
+++ b/docs/code-examples/line_segments3d_simple.rs
@@ -1,8 +1,7 @@
 //! Log a simple set of line segments.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments3d")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_segments3d").spawn()?;
 
     let points = [
         [0., 0., 0.],

--- a/docs/code-examples/line_strip2d_batch.rs
+++ b/docs/code-examples/line_strip2d_batch.rs
@@ -1,8 +1,7 @@
 //! Log a batch of 2d line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn()?;
 
     let strip1 = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     #[rustfmt::skip]

--- a/docs/code-examples/line_strip2d_simple.rs
+++ b/docs/code-examples/line_strip2d_simple.rs
@@ -1,8 +1,7 @@
 //! Log a simple line strip.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip2d").spawn()?;
 
     let points = [[0., 0.], [2., 1.], [4., -1.], [6., 0.]];
     rec.log("strip", &rerun::LineStrips2D::new([points]))?;

--- a/docs/code-examples/line_strip3d_batch.rs
+++ b/docs/code-examples/line_strip3d_batch.rs
@@ -1,8 +1,7 @@
 //! Log a batch of 2d line strips.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn()?;
 
     let strip1 = [[0., 0., 2.], [1., 0., 2.], [1., 1., 2.], [0., 1., 2.]];
     let strip2 = [

--- a/docs/code-examples/line_strip3d_simple.rs
+++ b/docs/code-examples/line_strip3d_simple.rs
@@ -1,8 +1,7 @@
 //! Log a simple line strip.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_line_strip3d").spawn()?;
 
     let points = [
         [0., 0., 0.],

--- a/docs/code-examples/manual_indicator.rs
+++ b/docs/code-examples/manual_indicator.rs
@@ -3,8 +3,7 @@
 use rerun::Archetype as _;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_manual_indicator")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_manual_indicator").spawn()?;
 
     // Specify both a Mesh3D and a Points3D indicator component so that the data is shown as both a
     // 3D mesh _and_ a point cloud by default.

--- a/docs/code-examples/mesh3d_indexed.rs
+++ b/docs/code-examples/mesh3d_indexed.rs
@@ -1,8 +1,7 @@
 //! Log a simple colored triangle with indexed drawing.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_indexed").spawn()?;
 
     rec.log(
         "triangle",

--- a/docs/code-examples/mesh3d_partial_updates.rs
+++ b/docs/code-examples/mesh3d_partial_updates.rs
@@ -3,8 +3,7 @@
 use rerun::external::glam;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_partial_updates")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_partial_updates").spawn()?;
 
     let vertex_positions = [[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
 

--- a/docs/code-examples/mesh3d_simple.rs
+++ b/docs/code-examples/mesh3d_simple.rs
@@ -1,8 +1,7 @@
 //! Log a simple colored triangle.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_simple")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_mesh3d_simple").spawn()?;
 
     rec.log(
         "triangle",

--- a/docs/code-examples/pinhole_simple.rs
+++ b/docs/code-examples/pinhole_simple.rs
@@ -3,8 +3,7 @@
 use ndarray::{Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").spawn()?;
 
     let mut image = Array::<u8, _>::default((3, 3, 3).f());
     image.map_inplace(|x| *x = rand::random());

--- a/docs/code-examples/point2d_random.rs
+++ b/docs/code-examples/point2d_random.rs
@@ -3,8 +3,7 @@
 use rand::{distributions::Uniform, Rng as _};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn()?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-3., 3.);

--- a/docs/code-examples/point2d_simple.rs
+++ b/docs/code-examples/point2d_simple.rs
@@ -1,8 +1,7 @@
 //! Log some very simple points.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d").spawn()?;
 
     rec.log("points", &rerun::Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?;
 

--- a/docs/code-examples/point3d_random.rs
+++ b/docs/code-examples/point3d_random.rs
@@ -3,8 +3,7 @@
 use rand::{distributions::Uniform, Rng as _};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").spawn()?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-5., 5.);

--- a/docs/code-examples/point3d_simple.rs
+++ b/docs/code-examples/point3d_simple.rs
@@ -1,8 +1,7 @@
 //! Log some very simple points.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_simple")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_simple").spawn()?;
 
     rec.log(
         "points",

--- a/docs/code-examples/quick_start_connect.rs
+++ b/docs/code-examples/quick_start_connect.rs
@@ -4,8 +4,7 @@ use rerun::{demo_util::grid, external::glam};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new `RecordingStream` which sends data over TCP to the viewer process.
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_demo")
-        .connect("127.0.0.1:9876".parse()?, None)?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_demo").connect()?;
 
     // Create some data using the `grid` utility function.
     let points = grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10);

--- a/docs/code-examples/quick_start_spawn.rs
+++ b/docs/code-examples/quick_start_spawn.rs
@@ -4,8 +4,7 @@ use rerun::{demo_util::grid, external::glam};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new `RecordingStream` which stores data in memory.
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal").spawn()?;
 
     // Create some data using the `grid` utility function.
     let points = grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10);

--- a/docs/code-examples/scalar_multiple_plots.rs
+++ b/docs/code-examples/scalar_multiple_plots.rs
@@ -1,8 +1,7 @@
 //! Log a scalar over time.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots").spawn()?;
     let mut lcg_state = 0_i64;
 
     for t in 0..((std::f32::consts::TAU * 2.0 * 100.0) as i64) {

--- a/docs/code-examples/scalar_simple.rs
+++ b/docs/code-examples/scalar_simple.rs
@@ -1,8 +1,7 @@
 //! Log a scalar over time.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn()?;
 
     for step in 0..64 {
         rec.set_time_sequence("step", step);

--- a/docs/code-examples/segmentation_image_simple.rs
+++ b/docs/code-examples/segmentation_image_simple.rs
@@ -3,8 +3,7 @@
 use ndarray::{s, Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_segmentation_image").spawn()?;
 
     // create a segmentation image
     let mut image = Array::<u8, _>::zeros((8, 12).f());

--- a/docs/code-examples/tensor_simple.rs
+++ b/docs/code-examples/tensor_simple.rs
@@ -3,8 +3,7 @@
 use ndarray::{Array, ShapeBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor_simple").spawn()?;
 
     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
     data.map_inplace(|x| *x = rand::random());

--- a/docs/code-examples/text_document.rs
+++ b/docs/code-examples/text_document.rs
@@ -1,8 +1,7 @@
 //! Log a `TextDocument`
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document").spawn()?;
 
     rec.log(
         "text_document",

--- a/docs/code-examples/text_log.rs
+++ b/docs/code-examples/text_log.rs
@@ -1,8 +1,7 @@
 //! Log a `TextLog`
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log").spawn()?;
 
     rec.log(
         "log",

--- a/docs/code-examples/text_log_integration.rs
+++ b/docs/code-examples/text_log_integration.rs
@@ -3,8 +3,7 @@
 use rerun::external::log;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_log_integration").spawn()?;
 
     // Log a text entry directly:
     rec.log(

--- a/docs/code-examples/transform3d_simple.rs
+++ b/docs/code-examples/transform3d_simple.rs
@@ -3,8 +3,7 @@
 use std::f32::consts::TAU;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d").spawn()?;
 
     let arrow = rerun::Arrows3D::from_vectors([(0.0, 1.0, 0.0)]).with_origins([(0.0, 0.0, 0.0)]);
 

--- a/docs/code-examples/view_coordinates_simple.rs
+++ b/docs/code-examples/view_coordinates_simple.rs
@@ -1,8 +1,7 @@
 //! Change the view coordinates for the scene.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").spawn()?;
 
     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log(

--- a/docs/content/getting-started/logging-rust.md
+++ b/docs/content/getting-started/logging-rust.md
@@ -339,7 +339,7 @@ If an external viewer was already running, `spawn` will connect to that one inst
 ```rust
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_dna_abacus")
-        .spawn(rerun::default_flush_timeout())?;
+        .spawn()?;
 
     // … log data to `rec` …
 

--- a/examples/rust/dna/src/main.rs
+++ b/examples/rust/dna/src/main.rs
@@ -12,8 +12,7 @@ use rerun::{
 const NUM_POINTS: usize = 100;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_dna_abacus")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_dna_abacus").spawn()?;
 
     let (points1, colors1) = color_spiral(NUM_POINTS, 2.0, 0.02, 0.0, 0.1);
     let (points2, colors2) = color_spiral(NUM_POINTS, 2.0, 0.02, TAU * 0.5, 0.1);

--- a/examples/rust/minimal/src/main.rs
+++ b/examples/rust/minimal/src/main.rs
@@ -3,8 +3,7 @@
 use rerun::{demo_util::grid, external::glam};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal").spawn()?;
 
     let points = grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10);
     let colors = grid(glam::Vec3::ZERO, glam::Vec3::splat(255.0), 10)

--- a/examples/rust/template/src/main.rs
+++ b/examples/rust/template/src/main.rs
@@ -1,8 +1,7 @@
 //! Example template.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_my_example_name")
-        .spawn(rerun::default_flush_timeout())?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_my_example_name").spawn()?;
 
     // … example code
     _ = rec;

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -486,14 +486,14 @@ fn connect(
     py.allow_threads(|| {
         if let Some(recording) = recording {
             // If the user passed in a recording, use it
-            recording.connect(addr, flush_timeout);
+            recording.connect_opts(addr, flush_timeout);
         } else {
             // Otherwise, connect both global defaults
             if let Some(recording) = get_data_recording(None) {
-                recording.connect(addr, flush_timeout);
+                recording.connect_opts(addr, flush_timeout);
             };
             if let Some(blueprint) = get_blueprint_recording(None) {
-                blueprint.connect(addr, flush_timeout);
+                blueprint.connect_opts(addr, flush_timeout);
             };
         }
     });

--- a/tests/rust/test_image_memory/src/main.rs
+++ b/tests/rust/test_image_memory/src/main.rs
@@ -15,7 +15,7 @@ static GLOBAL: AccountingAllocator<MiMalloc> = AccountingAllocator::new(MiMalloc
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     re_memory::accounting_allocator::turn_on_tracking_if_env_var("RERUN_TRACK_ALLOCATIONS");
 
-    let rec = rerun::RecordingStreamBuilder::new("test_image_memory_rs").spawn(None)?;
+    let rec = rerun::RecordingStreamBuilder::new("test_image_memory").spawn()?;
     log_images(&rec).unwrap();
 
     Ok(())


### PR DESCRIPTION
Promised follow up after the addition of `spawn_opts`.

This simplifies a bunch of things and greatly improve DX while we wait for Rust to unlock the default parameter skill :sparkles: 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4042) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4042)
- [Docs preview](https://rerun.io/preview/ea9f3b4dd931377c36d88a3fdcd9b99d01f1503b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ea9f3b4dd931377c36d88a3fdcd9b99d01f1503b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)