### PR TITLE
Clean up C++ examples

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -197,7 +197,7 @@ To accommodate for this and other languages, strings on the C interface are almo
 ### Misc
 We don't add `inline` before class/struct member functions if they are inlined in the class/struct definition.
 
-Include what you use: if you use `std::vector`, then inlcude `<vector>` - don't depend on a transitive include.
+Include what you use: if you use `std::vector`, then include `<vector>` - don't depend on a transitive include.
 
 
 ## Naming

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -197,6 +197,8 @@ To accommodate for this and other languages, strings on the C interface are almo
 ### Misc
 We don't add `inline` before class/struct member functions if they are inlined in the class/struct definition.
 
+Include what you use: if you use `std::vector`, then inlcude `<vector>` - don't depend on a transitive include.
+
 
 ## Naming
 We prefer `snake_case` to `kebab-case` for most things (e.g. crate names, crate features, …). `snake_case` is a valid identifier in almost any programming language, while `kebab-case` is not. This means one can use the same `snake_case` identifier everywhere, and not think about whether it needs to be written as `snake_case` in some circumstances.

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -105,14 +105,16 @@ mod prelude {
     // the amount of typing for our users.
     pub use super::archetypes::*;
 
-    // Also import some select, often-used, datatypes and components:
+    // Also import any component or datatype that has a unique name:
     pub use super::components::{
-        Color, HalfSizes2D, HalfSizes3D, InstanceKey, Material, MediaType, MeshProperties,
-        OutOfTreeTransform3D, Position3D, Radius, TextLogLevel, Vector3D,
+        Color, HalfSizes2D, HalfSizes3D, InstanceKey, LineStrip2D, LineStrip3D, Material,
+        MediaType, MeshProperties, OutOfTreeTransform3D, Position2D, Position3D, Radius, Text,
+        TextLogLevel, Vector3D,
     };
     pub use super::datatypes::{
         Angle, ClassDescription, Float32, KeypointPair, Mat3x3, Quaternion, Rgba32, Rotation3D,
-        RotationAxisAngle, Scale3D, TranslationAndMat3x3, TranslationRotationScale3D,
+        RotationAxisAngle, Scale3D, TranslationAndMat3x3, TranslationRotationScale3D, Vec2D, Vec3D,
+        Vec4D,
     };
 
     pub use super::time::{Time, TimePoint, Timeline};

--- a/docs/code-examples/annotation_context_segmentation.cpp
+++ b/docs/code-examples/annotation_context_segmentation.cpp
@@ -2,7 +2,8 @@
 
 #include <rerun.hpp>
 
-#include <algorithm>
+#include <algorithm> // fill_n
+#include <vector>
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");

--- a/docs/code-examples/arrow3d_simple.cpp
+++ b/docs/code-examples/arrow3d_simple.cpp
@@ -3,6 +3,7 @@
 #include <rerun.hpp>
 
 #include <cmath>
+#include <vector>
 
 constexpr float TAU = 6.28318530717958647692528676655900577f;
 

--- a/docs/code-examples/arrow3d_simple.cpp
+++ b/docs/code-examples/arrow3d_simple.cpp
@@ -10,9 +10,9 @@ int main() {
     auto rec = rerun::RecordingStream("rerun_example_arrow3d");
     rec.spawn().throw_on_failure();
 
-    std::vector<rerun::components::Position3D> origins;
-    std::vector<rerun::components::Vector3D> vectors;
-    std::vector<rerun::components::Color> colors;
+    std::vector<rerun::Position3D> origins;
+    std::vector<rerun::Vector3D> vectors;
+    std::vector<rerun::Color> colors;
 
     for (int i = 0; i < 100; ++i) {
         origins.push_back({0, 0, 0});

--- a/docs/code-examples/asset3d_out_of_tree.cpp
+++ b/docs/code-examples/asset3d_out_of_tree.cpp
@@ -9,7 +9,7 @@ int main(int argc, char** argv) {
     if (argc < 2) {
         throw std::runtime_error("Usage: <path_to_asset.[gltf|glb]>");
     }
-    auto path = argv[1];
+    const auto path = argv[1];
 
     auto rec = rerun::RecordingStream("rerun_example_asset3d_out_of_tree");
     rec.spawn().throw_on_failure();
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
         rec.set_time_sequence("frame", i);
 
         // Modify the asset's out-of-tree transform: this will not affect its children (i.e. the points)!
-        auto translation =
+        const auto translation =
             rerun::TranslationRotationScale3D({0.0, 0.0, static_cast<float>(i) - 10.0f});
         rec.log(
             "world/asset",

--- a/docs/code-examples/asset3d_out_of_tree.cpp
+++ b/docs/code-examples/asset3d_out_of_tree.cpp
@@ -1,6 +1,7 @@
 // Log a simple 3D asset with an out-of-tree transform which will not affect its children.
 
 #include <exception>
+
 #include <rerun.hpp>
 #include <rerun/demo_utils.hpp>
 

--- a/docs/code-examples/asset3d_simple.cpp
+++ b/docs/code-examples/asset3d_simple.cpp
@@ -5,17 +5,14 @@
 #include <filesystem>
 #include <iostream>
 #include <string>
-#include <vector>
 
 int main(int argc, char* argv[]) {
-    std::vector<std::string> args(argv, argv + argc);
-
-    if (args.size() < 2) {
-        std::cerr << "Usage: " << args[0] << " <path_to_asset.[gltf|glb|obj]>" << std::endl;
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <path_to_asset.[gltf|glb|obj]>" << std::endl;
         return 1;
     }
 
-    std::string path = args[1];
+    const auto path = argv[1];
 
     auto rec = rerun::RecordingStream("rerun_example_asset3d_simple");
     rec.spawn().throw_on_failure();

--- a/docs/code-examples/box3d_batch.cpp
+++ b/docs/code-examples/box3d_batch.cpp
@@ -13,19 +13,16 @@ int main() {
             {{2.0f, 2.0f, 1.0f}, {1.0f, 1.0f, 0.5f}, {2.0f, 0.5f, 1.0f}}
         )
             .with_rotations({
-                rerun::datatypes::Quaternion::IDENTITY,
+                rerun::Quaternion::IDENTITY,
                 // 45 degrees around Z
-                rerun::datatypes::Quaternion::from_xyzw(0.0f, 0.0f, 0.382683f, 0.923880f),
-                rerun::datatypes::RotationAxisAngle(
-                    {0.0f, 1.0f, 0.0f},
-                    rerun::datatypes::Angle::degrees(30.0f)
-                ),
+                rerun::Quaternion::from_xyzw(0.0f, 0.0f, 0.382683f, 0.923880f),
+                rerun::RotationAxisAngle({0.0f, 1.0f, 0.0f}, rerun::Angle::degrees(30.0f)),
             })
             .with_radii({0.025f})
             .with_colors({
-                rerun::datatypes::Rgba32(255, 0, 0),
-                rerun::datatypes::Rgba32(0, 255, 0),
-                rerun::datatypes::Rgba32(0, 0, 255),
+                rerun::Rgba32(255, 0, 0),
+                rerun::Rgba32(0, 255, 0),
+                rerun::Rgba32(0, 0, 255),
             })
             .with_labels({"red", "green", "blue"})
     );

--- a/docs/code-examples/clear_recursive.cpp
+++ b/docs/code-examples/clear_recursive.cpp
@@ -9,19 +9,19 @@ int main() {
     auto rec = rerun::RecordingStream("rerun_example_clear_recursive");
     rec.spawn().throw_on_failure();
 
-    std::vector<rerun::components::Vector3D> vectors = {
+    std::vector<rerun::Vector3D> vectors = {
         {1.0, 0.0, 0.0},
         {0.0, -1.0, 0.0},
         {-1.0, 0.0, 0.0},
         {0.0, 1.0, 0.0},
     };
-    std::vector<rerun::components::Position3D> origins = {
+    std::vector<rerun::Position3D> origins = {
         {-0.5, 0.5, 0.0},
         {0.5, 0.5, 0.0},
         {0.5, -0.5, 0.0},
         {-0.5, -0.5, 0.0},
     };
-    std::vector<rerun::components::Color> colors = {
+    std::vector<rerun::Color> colors = {
         {200, 0, 0},
         {0, 200, 0},
         {0, 0, 200},

--- a/docs/code-examples/clear_recursive.cpp
+++ b/docs/code-examples/clear_recursive.cpp
@@ -4,6 +4,8 @@
 
 #include <cmath>
 #include <numeric>
+#include <string> // to_string
+#include <vector>
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_clear_recursive");

--- a/docs/code-examples/clear_simple.cpp
+++ b/docs/code-examples/clear_simple.cpp
@@ -9,19 +9,19 @@ int main() {
     auto rec = rerun::RecordingStream("rerun_example_clear_simple");
     rec.spawn().throw_on_failure();
 
-    std::vector<rerun::components::Vector3D> vectors = {
+    std::vector<rerun::Vector3D> vectors = {
         {1.0, 0.0, 0.0},
         {0.0, -1.0, 0.0},
         {-1.0, 0.0, 0.0},
         {0.0, 1.0, 0.0},
     };
-    std::vector<rerun::components::Position3D> origins = {
+    std::vector<rerun::Position3D> origins = {
         {-0.5, 0.5, 0.0},
         {0.5, 0.5, 0.0},
         {0.5, -0.5, 0.0},
         {-0.5, -0.5, 0.0},
     };
-    std::vector<rerun::components::Color> colors = {
+    std::vector<rerun::Color> colors = {
         {200, 0, 0},
         {0, 200, 0},
         {0, 0, 200},

--- a/docs/code-examples/clear_simple.cpp
+++ b/docs/code-examples/clear_simple.cpp
@@ -4,6 +4,8 @@
 
 #include <cmath>
 #include <numeric>
+#include <string> // to_string
+#include <vector>
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_clear_simple");

--- a/docs/code-examples/depth_image_3d.cpp
+++ b/docs/code-examples/depth_image_3d.cpp
@@ -2,7 +2,8 @@
 
 #include <rerun.hpp>
 
-#include <algorithm>
+#include <algorithm> // fill_n
+#include <vector>
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_depth_image");

--- a/docs/code-examples/depth_image_simple.cpp
+++ b/docs/code-examples/depth_image_simple.cpp
@@ -2,7 +2,8 @@
 
 #include <rerun.hpp>
 
-#include <algorithm>
+#include <algorithm> // fill_n
+#include <vector>
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_depth_image");

--- a/docs/code-examples/image_simple.cpp
+++ b/docs/code-examples/image_simple.cpp
@@ -2,6 +2,8 @@
 
 #include <rerun.hpp>
 
+#include <vector>
+
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_image_simple");
     rec.spawn().throw_on_failure();

--- a/docs/code-examples/line_segments3d_simple.cpp
+++ b/docs/code-examples/line_segments3d_simple.cpp
@@ -2,6 +2,9 @@
 
 #include <rerun.hpp>
 
+#include <array>
+#include <vector>
+
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_line_segments3d");
     rec.spawn().throw_on_failure();

--- a/docs/code-examples/line_strip2d_batch.cpp
+++ b/docs/code-examples/line_strip2d_batch.cpp
@@ -6,8 +6,8 @@ int main() {
     auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
     rec.spawn().throw_on_failure();
 
-    std::vector<rerun::datatypes::Vec2D> strip1 = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}};
-    std::vector<rerun::datatypes::Vec2D> strip2 =
+    std::vector<rerun::Vec2D> strip1 = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}};
+    std::vector<rerun::Vec2D> strip2 =
         {{0.f, 3.f}, {1.f, 4.f}, {2.f, 2.f}, {3.f, 4.f}, {4.f, 2.f}, {5.f, 4.f}, {6.f, 3.f}};
     rec.log(
         "strips",

--- a/docs/code-examples/line_strip2d_batch.cpp
+++ b/docs/code-examples/line_strip2d_batch.cpp
@@ -2,6 +2,8 @@
 
 #include <rerun.hpp>
 
+#include <vector>
+
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
     rec.spawn().throw_on_failure();

--- a/docs/code-examples/line_strip2d_simple.cpp
+++ b/docs/code-examples/line_strip2d_simple.cpp
@@ -6,7 +6,7 @@ int main() {
     auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
     rec.spawn().throw_on_failure();
 
-    rerun::components::LineStrip2D strip({{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}});
+    const auto strip = rerun::LineStrip2D({{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}});
     rec.log("strip", rerun::LineStrips2D(strip));
 
     // Log an extra rect to set the view bounds

--- a/docs/code-examples/line_strip3d_batch.cpp
+++ b/docs/code-examples/line_strip3d_batch.cpp
@@ -2,6 +2,8 @@
 
 #include <rerun.hpp>
 
+#include <vector>
+
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
     rec.spawn().throw_on_failure();

--- a/docs/code-examples/line_strip3d_batch.cpp
+++ b/docs/code-examples/line_strip3d_batch.cpp
@@ -6,13 +6,13 @@ int main() {
     auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
     rec.spawn().throw_on_failure();
 
-    std::vector<rerun::datatypes::Vec3D> strip1 = {
+    std::vector<rerun::Vec3D> strip1 = {
         {0.f, 0.f, 2.f},
         {1.f, 0.f, 2.f},
         {1.f, 1.f, 2.f},
         {0.f, 1.f, 2.f},
     };
-    std::vector<rerun::datatypes::Vec3D> strip2 = {
+    std::vector<rerun::Vec3D> strip2 = {
         {0.f, 0.f, 0.f},
         {0.f, 0.f, 1.f},
         {1.f, 0.f, 0.f},

--- a/docs/code-examples/line_strip3d_simple.cpp
+++ b/docs/code-examples/line_strip3d_simple.cpp
@@ -6,7 +6,7 @@ int main() {
     auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
     rec.spawn().throw_on_failure();
 
-    rerun::components::LineStrip3D linestrip({
+    rerun::LineStrip3D linestrip({
         {0.f, 0.f, 0.f},
         {0.f, 0.f, 1.f},
         {1.f, 0.f, 0.f},

--- a/docs/code-examples/manual_indicator.cpp
+++ b/docs/code-examples/manual_indicator.cpp
@@ -2,6 +2,8 @@
 
 #include <rerun.hpp>
 
+#include <vector>
+
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_manual_indicator");
     rec.spawn().throw_on_failure();

--- a/docs/code-examples/manual_indicator.cpp
+++ b/docs/code-examples/manual_indicator.cpp
@@ -6,17 +6,17 @@ int main() {
     auto rec = rerun::RecordingStream("rerun_example_manual_indicator");
     rec.spawn().throw_on_failure();
 
-    std::vector<rerun::components::Position3D> positions = {
+    std::vector<rerun::Position3D> positions = {
         {0.0, 0.0, 0.0},
         {10.0, 0.0, 0.0},
         {0.0, 10.0, 0.0},
     };
-    std::vector<rerun::components::Color> colors = {
+    std::vector<rerun::Color> colors = {
         {255, 0, 0},
         {0, 255, 0},
         {0, 0, 255},
     };
-    std::vector<rerun::components::Radius> radii = {1.0};
+    std::vector<rerun::Radius> radii = {1.0};
 
     // Specify both a Mesh3D and a Points3D indicator component so that the data is shown as both a
     // 3D mesh _and_ a point cloud by default.

--- a/docs/code-examples/mesh3d_indexed.cpp
+++ b/docs/code-examples/mesh3d_indexed.cpp
@@ -2,8 +2,7 @@
 
 #include <rerun.hpp>
 
-#include <cmath>
-#include <numeric>
+#include <vector>
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_mesh3d_indexed");

--- a/docs/code-examples/mesh3d_simple.cpp
+++ b/docs/code-examples/mesh3d_simple.cpp
@@ -2,9 +2,6 @@
 
 #include <rerun.hpp>
 
-#include <cmath>
-#include <numeric>
-
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_mesh3d_simple");
     rec.spawn().throw_on_failure();

--- a/docs/code-examples/pinhole_simple.cpp
+++ b/docs/code-examples/pinhole_simple.cpp
@@ -2,9 +2,9 @@
 
 #include <rerun.hpp>
 
-#include <algorithm>
-#include <cstdlib>
-#include <ctime>
+#include <algorithm> // std::generate
+#include <cstdlib>   // std::rand
+#include <vector>
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
@@ -12,7 +12,6 @@ int main() {
 
     rec.log("world/image", rerun::Pinhole::from_focal_length_and_resolution(3.0f, {3.0f, 3.0f}));
 
-    std::srand(static_cast<uint32_t>(std::time(nullptr)));
     std::vector<uint8_t> random_data(3 * 3 * 3);
     std::generate(random_data.begin(), random_data.end(), std::rand);
     std::generate(random_data.begin(), random_data.end(), [] {

--- a/docs/code-examples/point2d_random.cpp
+++ b/docs/code-examples/point2d_random.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <random>
+#include <vector>
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_points2d_simple");

--- a/docs/code-examples/point2d_random.cpp
+++ b/docs/code-examples/point2d_random.cpp
@@ -15,19 +15,19 @@ int main() {
     // On MSVC uint8_t distributions are not supported.
     std::uniform_int_distribution<int> dist_color(0, 255);
 
-    std::vector<rerun::components::Position2D> points2d(10);
+    std::vector<rerun::Position2D> points2d(10);
     std::generate(points2d.begin(), points2d.end(), [&] {
-        return rerun::components::Position2D(dist_pos(gen), dist_pos(gen));
+        return rerun::Position2D(dist_pos(gen), dist_pos(gen));
     });
-    std::vector<rerun::components::Color> colors(10);
+    std::vector<rerun::Color> colors(10);
     std::generate(colors.begin(), colors.end(), [&] {
-        return rerun::components::Color(
+        return rerun::Color(
             static_cast<uint8_t>(dist_color(gen)),
             static_cast<uint8_t>(dist_color(gen)),
             static_cast<uint8_t>(dist_color(gen))
         );
     });
-    std::vector<rerun::components::Radius> radii(10);
+    std::vector<rerun::Radius> radii(10);
     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });
 
     rec.log("random", rerun::Points2D(points2d).with_colors(colors).with_radii(radii));

--- a/docs/code-examples/point3d_random.cpp
+++ b/docs/code-examples/point3d_random.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <random>
+#include <vector>
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_points3d_random");

--- a/docs/code-examples/point3d_random.cpp
+++ b/docs/code-examples/point3d_random.cpp
@@ -15,19 +15,19 @@ int main() {
     // On MSVC uint8_t distributions are not supported.
     std::uniform_int_distribution<int> dist_color(0, 255);
 
-    std::vector<rerun::components::Position3D> points3d(10);
+    std::vector<rerun::Position3D> points3d(10);
     std::generate(points3d.begin(), points3d.end(), [&] {
-        return rerun::components::Position3D(dist_pos(gen), dist_pos(gen), dist_pos(gen));
+        return rerun::Position3D(dist_pos(gen), dist_pos(gen), dist_pos(gen));
     });
-    std::vector<rerun::components::Color> colors(10);
+    std::vector<rerun::Color> colors(10);
     std::generate(colors.begin(), colors.end(), [&] {
-        return rerun::components::Color(
+        return rerun::Color(
             static_cast<uint8_t>(dist_color(gen)),
             static_cast<uint8_t>(dist_color(gen)),
             static_cast<uint8_t>(dist_color(gen))
         );
     });
-    std::vector<rerun::components::Radius> radii(10);
+    std::vector<rerun::Radius> radii(10);
     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });
 
     rec.log("random", rerun::Points3D(points3d).with_colors(colors).with_radii(radii));

--- a/docs/code-examples/scalar_multiple_plots.cpp
+++ b/docs/code-examples/scalar_multiple_plots.cpp
@@ -1,7 +1,8 @@
 // Log a scalar over time.
 
-#include <cmath>
 #include <rerun.hpp>
+
+#include <cmath>
 
 constexpr float TAU = 6.28318530717958647692528676655900577f;
 

--- a/docs/code-examples/segmentation_image_simple.cpp
+++ b/docs/code-examples/segmentation_image_simple.cpp
@@ -2,7 +2,8 @@
 
 #include <rerun.hpp>
 
-#include <algorithm>
+#include <algorithm> // std::fill_n
+#include <vector>
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");

--- a/docs/code-examples/tensor_simple.cpp
+++ b/docs/code-examples/tensor_simple.cpp
@@ -2,7 +2,9 @@
 
 #include <rerun.hpp>
 
+#include <algorithm> // std::generate
 #include <random>
+#include <vector>
 
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_tensor_simple");

--- a/docs/code-examples/text_document.cpp
+++ b/docs/code-examples/text_document.cpp
@@ -10,11 +10,11 @@ int main() {
     auto rec = rerun::RecordingStream("rerun_example_text_document");
     rec.spawn().throw_on_failure();
 
-    rec.log("text_document", rerun::archetypes::TextDocument("Hello, TextDocument!"));
+    rec.log("text_document", rerun::TextDocument("Hello, TextDocument!"));
 
     rec.log(
         "markdown",
-        rerun::archetypes::TextDocument(R"#(# Hello Markdown!
+        rerun::TextDocument(R"#(# Hello Markdown!
 [Click here to see the raw text](recording://markdown.Text).
 
 Basic formatting:
@@ -47,6 +47,6 @@ Of course you can also have [normal https links](https://github.com/rerun-io/rer
 
 ## Image
 ![A random image](https://picsum.photos/640/480))#")
-            .with_media_type(rerun::components::MediaType::markdown())
+            .with_media_type(rerun::MediaType::markdown())
     );
 }

--- a/docs/code-examples/text_document.cpp
+++ b/docs/code-examples/text_document.cpp
@@ -2,10 +2,6 @@
 
 #include <rerun.hpp>
 
-#include <cmath>
-
-namespace rrd = rerun::datatypes;
-
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_text_document");
     rec.spawn().throw_on_failure();

--- a/docs/code-examples/text_log.cpp
+++ b/docs/code-examples/text_log.cpp
@@ -4,15 +4,9 @@
 
 #include <cmath>
 
-namespace rrd = rerun::datatypes;
-
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_text_log");
     rec.spawn().throw_on_failure();
 
-    rec.log(
-        "log",
-        rerun::archetypes::TextLog("Application started.")
-            .with_level(rerun::components::TextLogLevel::INFO)
-    );
+    rec.log("log", rerun::TextLog("Application started.").with_level(rerun::TextLogLevel::INFO));
 }

--- a/docs/code-examples/text_log.cpp
+++ b/docs/code-examples/text_log.cpp
@@ -2,8 +2,6 @@
 
 #include <rerun.hpp>
 
-#include <cmath>
-
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_text_log");
     rec.spawn().throw_on_failure();

--- a/docs/code-examples/transform3d_simple.cpp
+++ b/docs/code-examples/transform3d_simple.cpp
@@ -1,6 +1,5 @@
 // Log different transforms between three arrows.
 
-#include <cmath>
 #include <rerun.hpp>
 
 constexpr float TAU = 6.28318530717958647692528676655900577f;

--- a/docs/code-examples/view_coordinates_simple.cpp
+++ b/docs/code-examples/view_coordinates_simple.cpp
@@ -2,9 +2,6 @@
 
 #include <rerun.hpp>
 
-#include <cmath>
-#include <numeric>
-
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_view_coordinates");
     rec.spawn().throw_on_failure();

--- a/examples/cpp/clock/main.cpp
+++ b/examples/cpp/clock/main.cpp
@@ -1,6 +1,8 @@
-#include <algorithm>
-#include <cmath>
 #include <rerun.hpp>
+
+#include <algorithm> // std::max
+#include <cmath>
+#include <string>
 
 constexpr float TAU = 6.28318530717958647692528676655900577f;
 
@@ -8,23 +10,20 @@ void log_hand(
     rerun::RecordingStream& rec, const char* name, int step, float angle, float length, float width,
     uint8_t blue
 ) {
-    rerun::datatypes::Vec3D tip{length * sinf(angle * TAU), length * cosf(angle * TAU), 0.0f};
-    uint8_t c = static_cast<uint8_t>(angle * 255.0f);
-    rerun::components::Color color{
-        static_cast<uint8_t>(255 - c),
-        c,
-        blue,
-        std::max<uint8_t>(128, blue)};
+    const auto tip = rerun::Vec3D{length * sinf(angle * TAU), length * cosf(angle * TAU), 0.0f};
+    const auto c = static_cast<uint8_t>(angle * 255.0f);
+    const auto color =
+        rerun::Color{static_cast<uint8_t>(255 - c), c, blue, std::max<uint8_t>(128, blue)};
 
     rec.set_time_seconds("sim_time", step);
 
     rec.log(
         std::string("world/") + name + "_pt",
-        rerun::Points3D(rerun::components::Position3D(tip)).with_colors(color)
+        rerun::Points3D(rerun::Position3D(tip)).with_colors(color)
     );
     rec.log(
         std::string("world/") + name + "hand",
-        rerun::Arrows3D::from_vectors(rerun::components::Vector3D(tip))
+        rerun::Arrows3D::from_vectors(rerun::Vector3D(tip))
             .with_origins({{0.0f, 0.0f, 0.0f}})
             .with_colors(color)
             .with_radii({width * 0.5f})

--- a/examples/cpp/dna/main.cpp
+++ b/examples/cpp/dna/main.cpp
@@ -1,7 +1,9 @@
 #include <rerun.hpp>
 #include <rerun/demo_utils.hpp>
 
+#include <algorithm> // std::generate
 #include <random>
+#include <vector>
 
 using namespace rerun::demo;
 

--- a/rerun_cpp/src/rerun.hpp
+++ b/rerun_cpp/src/rerun.hpp
@@ -26,18 +26,21 @@
 namespace rerun {
     using namespace archetypes;
 
-    // Also import some select, often-used, datatypes and components:
+    // Also import any component or datatype that has a unique name:
     using components::Color;
     using components::HalfSizes2D;
     using components::HalfSizes3D;
     using components::InstanceKey;
+    using components::LineStrip2D;
     using components::LineStrip3D;
     using components::Material;
     using components::MediaType;
     using components::MeshProperties;
     using components::OutOfTreeTransform3D;
+    using components::Position2D;
     using components::Position3D;
     using components::Radius;
+    using components::Text;
     using components::TextLogLevel;
     using components::Vector3D;
 
@@ -55,4 +58,7 @@ namespace rerun {
     using datatypes::TensorData;
     using datatypes::TranslationAndMat3x3;
     using datatypes::TranslationRotationScale3D;
+    using datatypes::Vec2D;
+    using datatypes::Vec3D;
+    using datatypes::Vec4D;
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -29,7 +29,8 @@ namespace rerun {
         /// ```cpp,ignore
         /// #include <rerun.hpp>
         ///
-        /// #include <algorithm>
+        /// #include <algorithm> // fill_n
+        /// #include <vector>
         ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -32,6 +32,7 @@ namespace rerun {
         /// #include <rerun.hpp>
         ///
         /// #include <cmath>
+        /// #include <vector>
         ///
         /// constexpr float TAU = 6.28318530717958647692528676655900577f;
         ///
@@ -39,9 +40,9 @@ namespace rerun {
         ///     auto rec = rerun::RecordingStream("rerun_example_arrow3d");
         ///     rec.spawn().throw_on_failure();
         ///
-        ///     std::vector<rerun::components::Position3D> origins;
-        ///     std::vector<rerun::components::Vector3D> vectors;
-        ///     std::vector<rerun::components::Color> colors;
+        ///     std::vector<rerun::Position3D> origins;
+        ///     std::vector<rerun::Vector3D> vectors;
+        ///     std::vector<rerun::Color> colors;
         ///
         ///     for (int i = 0; i <100; ++i) {
         ///         origins.push_back({0, 0, 0});

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -34,17 +34,14 @@ namespace rerun {
         /// #include <filesystem>
         /// #include <iostream>
         /// #include <string>
-        /// #include <vector>
         ///
         /// int main(int argc, char* argv[]) {
-        ///     std::vector<std::string> args(argv, argv + argc);
-        ///
-        ///     if (args.size() <2) {
-        ///         std::cerr <<"Usage: " <<args[0] <<" <path_to_asset.[gltf|glb|obj]>" <<std::endl;
+        ///     if (argc <2) {
+        ///         std::cerr <<"Usage: " <<argv[0] <<" <path_to_asset.[gltf|glb|obj]>" <<std::endl;
         ///         return 1;
         ///     }
         ///
-        ///     std::string path = args[1];
+        ///     const auto path = argv[1];
         ///
         ///     auto rec = rerun::RecordingStream("rerun_example_asset3d_simple");
         ///     rec.spawn().throw_on_failure();

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -44,19 +44,16 @@ namespace rerun {
         ///             {{2.0f, 2.0f, 1.0f}, {1.0f, 1.0f, 0.5f}, {2.0f, 0.5f, 1.0f}}
         ///         )
         ///             .with_rotations({
-        ///                 rerun::datatypes::Quaternion::IDENTITY,
+        ///                 rerun::Quaternion::IDENTITY,
         ///                 // 45 degrees around Z
-        ///                 rerun::datatypes::Quaternion::from_xyzw(0.0f, 0.0f, 0.382683f, 0.923880f),
-        ///                 rerun::datatypes::RotationAxisAngle(
-        ///                     {0.0f, 1.0f, 0.0f},
-        ///                     rerun::datatypes::Angle::degrees(30.0f)
-        ///                 ),
+        ///                 rerun::Quaternion::from_xyzw(0.0f, 0.0f, 0.382683f, 0.923880f),
+        ///                 rerun::RotationAxisAngle({0.0f, 1.0f, 0.0f}, rerun::Angle::degrees(30.0f)),
         ///             })
         ///             .with_radii({0.025f})
         ///             .with_colors({
-        ///                 rerun::datatypes::Rgba32(255, 0, 0),
-        ///                 rerun::datatypes::Rgba32(0, 255, 0),
-        ///                 rerun::datatypes::Rgba32(0, 0, 255),
+        ///                 rerun::Rgba32(255, 0, 0),
+        ///                 rerun::Rgba32(0, 255, 0),
+        ///                 rerun::Rgba32(0, 0, 255),
         ///             })
         ///             .with_labels({"red", "green", "blue"})
         ///     );

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -25,24 +25,26 @@ namespace rerun {
         ///
         /// #include <cmath>
         /// #include <numeric>
+        /// #include <string> // to_string
+        /// #include <vector>
         ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_clear_simple");
         ///     rec.spawn().throw_on_failure();
         ///
-        ///     std::vector<rerun::components::Vector3D> vectors = {
+        ///     std::vector<rerun::Vector3D> vectors = {
         ///         {1.0, 0.0, 0.0},
         ///         {0.0, -1.0, 0.0},
         ///         {-1.0, 0.0, 0.0},
         ///         {0.0, 1.0, 0.0},
         ///     };
-        ///     std::vector<rerun::components::Position3D> origins = {
+        ///     std::vector<rerun::Position3D> origins = {
         ///         {-0.5, 0.5, 0.0},
         ///         {0.5, 0.5, 0.0},
         ///         {0.5, -0.5, 0.0},
         ///         {-0.5, -0.5, 0.0},
         ///     };
-        ///     std::vector<rerun::components::Color> colors = {
+        ///     std::vector<rerun::Color> colors = {
         ///         {200, 0, 0},
         ///         {0, 200, 0},
         ///         {0, 0, 200},

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -31,7 +31,8 @@ namespace rerun {
         /// ```cpp,ignore
         /// #include <rerun.hpp>
         ///
-        /// #include <algorithm>
+        /// #include <algorithm> // fill_n
+        /// #include <vector>
         ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_depth_image");

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -35,6 +35,8 @@ namespace rerun {
         /// ```cpp,ignore
         /// #include <rerun.hpp>
         ///
+        /// #include <vector>
+        ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_image_simple");
         ///     rec.spawn().throw_on_failure();

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -31,12 +31,14 @@ namespace rerun {
         /// ```cpp,ignore
         /// #include <rerun.hpp>
         ///
+        /// #include <vector>
+        ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
         ///     rec.spawn().throw_on_failure();
         ///
-        ///     std::vector<rerun::datatypes::Vec2D> strip1 = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}};
-        ///     std::vector<rerun::datatypes::Vec2D> strip2 =
+        ///     std::vector<rerun::Vec2D> strip1 = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}};
+        ///     std::vector<rerun::Vec2D> strip2 =
         ///         {{0.f, 3.f}, {1.f, 4.f}, {2.f, 2.f}, {3.f, 4.f}, {4.f, 2.f}, {5.f, 4.f}, {6.f, 3.f}};
         ///     rec.log(
         ///         "strips",

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -30,17 +30,19 @@ namespace rerun {
         /// ```cpp,ignore
         /// #include <rerun.hpp>
         ///
+        /// #include <vector>
+        ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
         ///     rec.spawn().throw_on_failure();
         ///
-        ///     std::vector<rerun::datatypes::Vec3D> strip1 = {
+        ///     std::vector<rerun::Vec3D> strip1 = {
         ///         {0.f, 0.f, 2.f},
         ///         {1.f, 0.f, 2.f},
         ///         {1.f, 1.f, 2.f},
         ///         {0.f, 1.f, 2.f},
         ///     };
-        ///     std::vector<rerun::datatypes::Vec3D> strip2 = {
+        ///     std::vector<rerun::Vec3D> strip2 = {
         ///         {0.f, 0.f, 0.f},
         ///         {0.f, 0.f, 1.f},
         ///         {1.f, 0.f, 0.f},

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -31,8 +31,7 @@ namespace rerun {
         /// ```cpp,ignore
         /// #include <rerun.hpp>
         ///
-        /// #include <cmath>
-        /// #include <numeric>
+        /// #include <vector>
         ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_mesh3d_indexed");

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -27,9 +27,9 @@ namespace rerun {
         /// ```cpp,ignore
         /// #include <rerun.hpp>
         ///
-        /// #include <algorithm>
-        /// #include <cstdlib>
-        /// #include <ctime>
+        /// #include <algorithm> // std::generate
+        /// #include <cstdlib>   // std::rand
+        /// #include <vector>
         ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
@@ -37,7 +37,6 @@ namespace rerun {
         ///
         ///     rec.log("world/image", rerun::Pinhole::from_focal_length_and_resolution(3.0f, {3.0f, 3.0f}));
         ///
-        ///     std::srand(static_cast<uint32_t>(std::time(nullptr)));
         ///     std::vector<uint8_t> random_data(3 * 3 * 3);
         ///     std::generate(random_data.begin(), random_data.end(), std::rand);
         ///     std::generate(random_data.begin(), random_data.end(), [] {

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -34,6 +34,7 @@ namespace rerun {
         ///
         /// #include <algorithm>
         /// #include <random>
+        /// #include <vector>
         ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_points2d_simple");
@@ -45,19 +46,19 @@ namespace rerun {
         ///     // On MSVC uint8_t distributions are not supported.
         ///     std::uniform_int_distribution<int> dist_color(0, 255);
         ///
-        ///     std::vector<rerun::components::Position2D> points2d(10);
+        ///     std::vector<rerun::Position2D> points2d(10);
         ///     std::generate(points2d.begin(), points2d.end(), [&] {
-        ///         return rerun::components::Position2D(dist_pos(gen), dist_pos(gen));
+        ///         return rerun::Position2D(dist_pos(gen), dist_pos(gen));
         ///     });
-        ///     std::vector<rerun::components::Color> colors(10);
+        ///     std::vector<rerun::Color> colors(10);
         ///     std::generate(colors.begin(), colors.end(), [&] {
-        ///         return rerun::components::Color(
+        ///         return rerun::Color(
         ///             static_cast<uint8_t>(dist_color(gen)),
         ///             static_cast<uint8_t>(dist_color(gen)),
         ///             static_cast<uint8_t>(dist_color(gen))
         ///         );
         ///     });
-        ///     std::vector<rerun::components::Radius> radii(10);
+        ///     std::vector<rerun::Radius> radii(10);
         ///     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });
         ///
         ///     rec.log("random", rerun::Points2D(points2d).with_colors(colors).with_radii(radii));

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -33,6 +33,7 @@ namespace rerun {
         ///
         /// #include <algorithm>
         /// #include <random>
+        /// #include <vector>
         ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_points3d_random");
@@ -44,19 +45,19 @@ namespace rerun {
         ///     // On MSVC uint8_t distributions are not supported.
         ///     std::uniform_int_distribution<int> dist_color(0, 255);
         ///
-        ///     std::vector<rerun::components::Position3D> points3d(10);
+        ///     std::vector<rerun::Position3D> points3d(10);
         ///     std::generate(points3d.begin(), points3d.end(), [&] {
-        ///         return rerun::components::Position3D(dist_pos(gen), dist_pos(gen), dist_pos(gen));
+        ///         return rerun::Position3D(dist_pos(gen), dist_pos(gen), dist_pos(gen));
         ///     });
-        ///     std::vector<rerun::components::Color> colors(10);
+        ///     std::vector<rerun::Color> colors(10);
         ///     std::generate(colors.begin(), colors.end(), [&] {
-        ///         return rerun::components::Color(
+        ///         return rerun::Color(
         ///             static_cast<uint8_t>(dist_color(gen)),
         ///             static_cast<uint8_t>(dist_color(gen)),
         ///             static_cast<uint8_t>(dist_color(gen))
         ///         );
         ///     });
-        ///     std::vector<rerun::components::Radius> radii(10);
+        ///     std::vector<rerun::Radius> radii(10);
         ///     std::generate(radii.begin(), radii.end(), [&] { return dist_radius(gen); });
         ///
         ///     rec.log("random", rerun::Points3D(points3d).with_colors(colors).with_radii(radii));

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -33,7 +33,8 @@ namespace rerun {
         /// ```cpp,ignore
         /// #include <rerun.hpp>
         ///
-        /// #include <algorithm>
+        /// #include <algorithm> // std::fill_n
+        /// #include <vector>
         ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -10,7 +10,9 @@
 #include "../indicator_component.hpp"
 #include "../result.hpp"
 
+#include <algorithm>
 #include <cstdint>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -24,7 +26,9 @@ namespace rerun {
         /// ```cpp,ignore
         /// #include <rerun.hpp>
         ///
+        /// #include <algorithm> // std::generate
         /// #include <random>
+        /// #include <vector>
         ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_tensor_simple");

--- a/rerun_cpp/src/rerun/archetypes/tensor_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor_ext.cpp
@@ -1,6 +1,11 @@
 #include "../error.hpp"
 #include "tensor.hpp"
 
+#include <algorithm> // std::min
+#include <string>    // std::to_string
+#include <utility>   // std::move
+#include <vector>
+
 // Uncomment for better auto-complete while editing the extension.
 // #define EDIT_EXTENSION
 

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -28,19 +28,15 @@ namespace rerun {
         /// ```cpp,ignore
         /// #include <rerun.hpp>
         ///
-        /// #include <cmath>
-        ///
-        /// namespace rrd = rerun::datatypes;
-        ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_text_document");
         ///     rec.spawn().throw_on_failure();
         ///
-        ///     rec.log("text_document", rerun::archetypes::TextDocument("Hello, TextDocument!"));
+        ///     rec.log("text_document", rerun::TextDocument("Hello, TextDocument!"));
         ///
         ///     rec.log(
         ///         "markdown",
-        ///         rerun::archetypes::TextDocument(R"#(# Hello Markdown!
+        ///         rerun::TextDocument(R"#(# Hello Markdown!
         /// [Click here to see the raw text](recording://markdown.Text).
         ///
         /// Basic formatting:
@@ -73,7 +69,7 @@ namespace rerun {
         ///
         /// ## Image
         /// ![A random image](https://picsum.photos/640/480))#")
-        ///             .with_media_type(rerun::components::MediaType::markdown())
+        ///             .with_media_type(rerun::MediaType::markdown())
         ///     );
         /// }
         /// ```

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -21,7 +21,6 @@ namespace rerun {
         ///
         /// ### Variety of 3D transforms
         /// ```cpp,ignore
-        /// #include <cmath>
         /// #include <rerun.hpp>
         ///
         /// constexpr float TAU = 6.28318530717958647692528676655900577f;

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -30,9 +30,6 @@ namespace rerun {
         /// ```cpp,ignore
         /// #include <rerun.hpp>
         ///
-        /// #include <cmath>
-        /// #include <numeric>
-        ///
         /// int main() {
         ///     auto rec = rerun::RecordingStream("rerun_example_view_coordinates");
         ///     rec.spawn().throw_on_failure();

--- a/rerun_cpp/src/rerun/demo_utils.hpp
+++ b/rerun_cpp/src/rerun/demo_utils.hpp
@@ -30,7 +30,7 @@ namespace rerun {
         inline std::vector<T> linspace(T start, T end, size_t num) {
             std::vector<T> linspaced(num);
             std::generate(linspaced.begin(), linspaced.end(), [&, i = 0]() mutable {
-                return static_cast<T>(start + i++ * (end - start) / static_cast<T>(num - 1));
+                return start + static_cast<T>(i++) * (end - start) / static_cast<T>(num - 1);
             });
             return linspaced;
         }

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -1,11 +1,12 @@
 #include "recording_stream.hpp"
+#include "c/rerun.h"
 #include "components/instance_key.hpp"
 #include "config.hpp"
 #include "string_utils.hpp"
 
-#include "c/rerun.h"
-
 #include <arrow/buffer.h>
+
+#include <string> // to_string
 #include <vector>
 
 namespace rerun {

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -1,21 +1,15 @@
-#include <catch2/catch_test_macros.hpp>
-#include <catch2/generators/catch_generators.hpp>
-
-#include <arrow/buffer.h>
-
-#include "error_check.hpp"
-
-#include <rerun/archetypes/points2d.hpp>
-#include <rerun/component_batch_adapter_builtins.hpp>
-#include <rerun/datatypes/vec2d.hpp>
-#include <rerun/recording_stream.hpp>
-
 #include <array>
 #include <filesystem>
 #include <vector>
 
+#include <arrow/buffer.h>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <rerun.hpp>
+
+#include "error_check.hpp"
+
 namespace fs = std::filesystem;
-namespace rrc = rerun::components;
 
 #define TEST_TAG "[recording_stream]"
 
@@ -152,15 +146,15 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                 // THEN("single components can be logged") {
                 //     stream.log(
                 //         "single-components",
-                //         rrc::Position2D{1.0, 2.0},
-                //         rrc::Color(0x00FF00FF)
+                //         rerun::Position2D{1.0, 2.0},
+                //         rerun::Color(0x00FF00FF)
                 //     );
                 // }
 
                 THEN("components as c-array can be logged") {
-                    rrc::Position2D c_style_array[2] = {
-                        rerun::datatypes::Vec2D{1.0, 2.0},
-                        rerun::datatypes::Vec2D{4.0, 5.0},
+                    rerun::Position2D c_style_array[2] = {
+                        rerun::Vec2D{1.0, 2.0},
+                        rerun::Vec2D{4.0, 5.0},
                     };
 
                     stream.log("as-carray", c_style_array);
@@ -177,66 +171,66 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                 THEN("components as std::array can be logged") {
                     stream.log(
                         "as-array",
-                        std::array<rrc::Position2D, 2>{
-                            rerun::datatypes::Vec2D{1.0, 2.0},
-                            rerun::datatypes::Vec2D{4.0, 5.0},
+                        std::array<rerun::Position2D, 2>{
+                            rerun::Vec2D{1.0, 2.0},
+                            rerun::Vec2D{4.0, 5.0},
                         }
                     );
                     stream.log_timeless(
                         "as-array",
-                        std::array<rrc::Position2D, 2>{
-                            rerun::datatypes::Vec2D{1.0, 2.0},
-                            rerun::datatypes::Vec2D{4.0, 5.0},
+                        std::array<rerun::Position2D, 2>{
+                            rerun::Vec2D{1.0, 2.0},
+                            rerun::Vec2D{4.0, 5.0},
                         }
                     );
                 }
                 THEN("components as std::vector can be logged") {
                     stream.log(
                         "as-vector",
-                        std::vector<rrc::Position2D>{
-                            rerun::datatypes::Vec2D{1.0, 2.0},
-                            rerun::datatypes::Vec2D{4.0, 5.0},
+                        std::vector<rerun::Position2D>{
+                            rerun::Vec2D{1.0, 2.0},
+                            rerun::Vec2D{4.0, 5.0},
                         }
                     );
                     stream.log_timeless(
                         "as-vector",
-                        std::vector<rrc::Position2D>{
-                            rerun::datatypes::Vec2D{1.0, 2.0},
-                            rerun::datatypes::Vec2D{4.0, 5.0},
+                        std::vector<rerun::Position2D>{
+                            rerun::Vec2D{1.0, 2.0},
+                            rerun::Vec2D{4.0, 5.0},
                         }
                     );
                 }
                 THEN("several components with a mix of vector, array and c-array can be logged") {
-                    rrc::Text c_style_array[3] = {
-                        rrc::Text("hello"),
-                        rrc::Text("friend"),
-                        rrc::Text("yo"),
+                    rerun::Text c_style_array[3] = {
+                        rerun::Text("hello"),
+                        rerun::Text("friend"),
+                        rerun::Text("yo"),
                     };
                     stream.log(
                         "as-mix",
                         std::vector{
-                            rrc::Position2D(rerun::datatypes::Vec2D{0.0, 0.0}),
-                            rrc::Position2D(rerun::datatypes::Vec2D{1.0, 3.0}),
-                            rrc::Position2D(rerun::datatypes::Vec2D{5.0, 5.0}),
+                            rerun::Position2D(rerun::Vec2D{0.0, 0.0}),
+                            rerun::Position2D(rerun::Vec2D{1.0, 3.0}),
+                            rerun::Position2D(rerun::Vec2D{5.0, 5.0}),
                         },
                         std::array{
-                            rrc::Color(0xFF0000FF),
-                            rrc::Color(0x00FF00FF),
-                            rrc::Color(0x0000FFFF),
+                            rerun::Color(0xFF0000FF),
+                            rerun::Color(0x00FF00FF),
+                            rerun::Color(0x0000FFFF),
                         },
                         c_style_array
                     );
                     stream.log_timeless(
                         "as-mix",
                         std::vector{
-                            rrc::Position2D(rerun::datatypes::Vec2D{0.0, 0.0}),
-                            rrc::Position2D(rerun::datatypes::Vec2D{1.0, 3.0}),
-                            rrc::Position2D(rerun::datatypes::Vec2D{5.0, 5.0}),
+                            rerun::Position2D(rerun::Vec2D{0.0, 0.0}),
+                            rerun::Position2D(rerun::Vec2D{1.0, 3.0}),
+                            rerun::Position2D(rerun::Vec2D{5.0, 5.0}),
                         },
                         std::array{
-                            rrc::Color(0xFF0000FF),
-                            rrc::Color(0x00FF00FF),
-                            rrc::Color(0x0000FFFF),
+                            rerun::Color(0xFF0000FF),
+                            rerun::Color(0x00FF00FF),
+                            rerun::Color(0x0000FFFF),
                         },
                         c_style_array
                     );
@@ -246,33 +240,31 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                     stream.log(
                         "log-splat",
                         std::vector{
-                            rrc::Position2D(rerun::datatypes::Vec2D{0.0, 0.0}),
-                            rrc::Position2D(rerun::datatypes::Vec2D{1.0, 3.0}),
+                            rerun::Position2D(rerun::Vec2D{0.0, 0.0}),
+                            rerun::Position2D(rerun::Vec2D{1.0, 3.0}),
                         },
-                        std::array{rrc::Color(0xFF0000FF)}
+                        std::array{rerun::Color(0xFF0000FF)}
                     );
                     stream.log_timeless(
                         "log-splat",
                         std::vector{
-                            rrc::Position2D(rerun::datatypes::Vec2D{0.0, 0.0}),
-                            rrc::Position2D(rerun::datatypes::Vec2D{1.0, 3.0}),
+                            rerun::Position2D(rerun::Vec2D{0.0, 0.0}),
+                            rerun::Position2D(rerun::Vec2D{1.0, 3.0}),
                         },
-                        std::array{rrc::Color(0xFF0000FF)}
+                        std::array{rerun::Color(0xFF0000FF)}
                     );
                 }
 
                 THEN("an archetype can be logged") {
                     stream.log(
                         "log_archetype-splat",
-                        rerun::archetypes::Points2D(
-                            {rerun::datatypes::Vec2D{1.0, 2.0}, rerun::datatypes::Vec2D{4.0, 5.0}}
-                        ).with_colors(rrc::Color(0xFF0000FF))
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
+                        ).with_colors(rerun::Color(0xFF0000FF))
                     );
                     stream.log_timeless(
                         "log_archetype-splat",
-                        rerun::archetypes::Points2D(
-                            {rerun::datatypes::Vec2D{1.0, 2.0}, rerun::datatypes::Vec2D{4.0, 5.0}}
-                        ).with_colors(rrc::Color(0xFF0000FF))
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
+                        ).with_colors(rerun::Color(0xFF0000FF))
                     );
                 }
 
@@ -332,9 +324,9 @@ SCENARIO("RecordingStream can log to file", TEST_TAG) {
                             check_logged_error([&] {
                                 stream1->log(
                                     "as-array",
-                                    std::array<rrc::Position2D, 2>{
-                                        rerun::datatypes::Vec2D{1.0, 2.0},
-                                        rerun::datatypes::Vec2D{4.0, 5.0},
+                                    std::array<rerun::Position2D, 2>{
+                                        rerun::Vec2D{1.0, 2.0},
+                                        rerun::Vec2D{4.0, 5.0},
                                     }
                                 );
                             });
@@ -349,9 +341,9 @@ SCENARIO("RecordingStream can log to file", TEST_TAG) {
                             check_logged_error([&] {
                                 stream1->log(
                                     "archetype",
-                                    rerun::archetypes::Points2D({
-                                        rerun::datatypes::Vec2D{1.0, 2.0},
-                                        rerun::datatypes::Vec2D{4.0, 5.0},
+                                    rerun::Points2D({
+                                        rerun::Vec2D{1.0, 2.0},
+                                        rerun::Vec2D{4.0, 5.0},
                                     })
                                 );
                             });
@@ -395,9 +387,9 @@ void test_logging_to_connection(const char* address, rerun::RecordingStream& str
                 check_logged_error([&] {
                     stream.log(
                         "as-array",
-                        std::array<rrc::Position2D, 2>{
-                            rerun::datatypes::Vec2D{1.0, 2.0},
-                            rerun::datatypes::Vec2D{4.0, 5.0},
+                        std::array<rerun::Position2D, 2>{
+                            rerun::Vec2D{1.0, 2.0},
+                            rerun::Vec2D{4.0, 5.0},
                         }
                     );
                 });
@@ -411,9 +403,9 @@ void test_logging_to_connection(const char* address, rerun::RecordingStream& str
                 check_logged_error([&] {
                     stream.log(
                         "archetype",
-                        rerun::archetypes::Points2D({
-                            rerun::datatypes::Vec2D{1.0, 2.0},
-                            rerun::datatypes::Vec2D{4.0, 5.0},
+                        rerun::Points2D({
+                            rerun::Vec2D{1.0, 2.0},
+                            rerun::Vec2D{4.0, 5.0},
                         })
                     );
                 });
@@ -461,27 +453,27 @@ SCENARIO("Recording stream handles invalid logging gracefully", TEST_TAG) {
         //         ),
         //     }));
         //     const auto [path, error] = variant;
-        //     auto v = rrc::Position2D{1.0, 2.0};
+        //     auto v = rerun::Position2D{1.0, 2.0};
 
         //     THEN("try_log_data_row returns the correct error") {
         //         CHECK(stream.try_log_data_row(path, 0, 0, nullptr, true).code == error);
         //     }
         //     THEN("try_log returns the correct error") {
-        //         CHECK(stream.try_log(path, rerun::archetypes::Points2D(v)).code == error);
+        //         CHECK(stream.try_log(path, rerun::Points2D(v)).code == error);
         //     }
         //     THEN("log logs the correct error") {
         //         check_logged_error(
-        //             [&] { stream.log(std::get<0>(variant), rerun::archetypes::Points2D(v)); },
+        //             [&] { stream.log(std::get<0>(variant), rerun::Points2D(v)); },
         //             error
         //         );
         //     }
         //     THEN("try_log_timeless returns the correct error") {
-        //         CHECK(stream.try_log_timeless(path, rerun::archetypes::Points2D(v)).code == error);
+        //         CHECK(stream.try_log_timeless(path, rerun::Points2D(v)).code == error);
         //     }
         //     THEN("log_timeless logs the correct error") {
         //         check_logged_error(
         //             [&] {
-        //                 stream.log_timeless(std::get<0>(variant), rerun::archetypes::Points2D(v));
+        //                 stream.log_timeless(std::get<0>(variant), rerun::Points2D(v));
         //             },
         //             error
         //         );


### PR DESCRIPTION
### What
Various cleanup to make them nicer!

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4043) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4043)
- [Docs preview](https://rerun.io/preview/e8e22a8966d557c22be31ee2b3e7830a52c08c79/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e8e22a8966d557c22be31ee2b3e7830a52c08c79/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)