### PR TITLE
Use sccache 0.5.2

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -67,6 +67,7 @@ runs:
     - name: Set up sccache
       uses: rerun-io/sccache-action@v0.7.0
       with:
+        version: "v0.5.2"
         use_gcs: true
         gcs_bucket: rerun-sccache
         gcs_read_only: false


### PR DESCRIPTION
### What
This should fix the red CI

`sccache` 0.6 was released 30 minutes ago, but its binaries aren't published yet, so all our jobs are fialing.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4045) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4045)
- [Docs preview](https://rerun.io/preview/e9882fdbb4fa9ba3f23abd6bfaa86555b408f5ae/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e9882fdbb4fa9ba3f23abd6bfaa86555b408f5ae/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)