### PR TITLE
Lint app ids

### DIFF
--- a/examples/python/nv12/main.py
+++ b/examples/python/nv12/main.py
@@ -39,7 +39,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    rr.script_setup(args, "NV12 image example")
+    rr.script_setup(args, "rerun_example_nv12")
 
     cap = cv2.VideoCapture(0)
     if not cap.isOpened():

--- a/rerun_py/tests/unit/test_exceptions.py
+++ b/rerun_py/tests/unit/test_exceptions.py
@@ -56,7 +56,7 @@ def expected_warnings(warnings: Any, mem: Any, starting_msgs: int, count: int, e
 def test_stack_tracking() -> None:
     # Force flushing so we can count the messages
     os.environ["RERUN_FLUSH_NUM_ROWS"] = "0"
-    rr.init("test_enable_strict_mode", spawn=False)
+    rr.init("rerun_example_strict_mode", spawn=False)
 
     mem = rr.memory_recording()
     with pytest.warns(RerunWarning) as warnings:

--- a/rerun_py/tests/unit/test_expected_warnings.py
+++ b/rerun_py/tests/unit/test_expected_warnings.py
@@ -4,7 +4,7 @@ import pytest
 import rerun as rr
 from rerun.error_utils import RerunWarning
 
-rr.init("exceptions", spawn=False)
+rr.init("rerun_example_exceptions", spawn=False)
 # Make sure strict mode isn't leaking in from another context
 mem = rr.memory_recording()
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -47,7 +47,7 @@ def is_valid_todo_part(part: str) -> bool:
     return False
 
 
-def lint_line(line: str, file_extension: str = "rs") -> str | None:
+def lint_line(line: str, file_extension: str = "rs", is_in_docstring: bool = False) -> str | None:
     if line == "":
         return None
 
@@ -129,6 +129,18 @@ def lint_line(line: str, file_extension: str = "rs") -> str | None:
     if "rec_stream" in line or "rr_stream" in line:
         return "Instantiated RecordingStreams should be named `rec`"
 
+    if not is_in_docstring:
+        if m := re.search(
+            r'(RecordingStreamBuilder::new|\.init|RecordingStream)\("(\w+)',
+            line,
+        ) or re.search(
+            r'(rr.script_setup)\(args, "(\w+)',
+            line,
+        ):
+            app_id = m.group(2)
+            if not app_id.startswith("rerun_example_"):
+                return f"All examples should have an app_id starting with 'rerun_example_'. Found '{app_id}'"
+
     return None
 
 
@@ -170,6 +182,8 @@ def test_lint_line() -> None:
         "anyhow::Result<()>",
         "The theme is great",
         "template <typename... Args>",
+        'protoc_prebuilt::init("22.0")',
+        'rr.init("rerun_example_app")',
     ]
 
     should_error = [
@@ -203,10 +217,16 @@ def test_lint_line() -> None:
         "Result<(), anyhow::Error>",
         "The the problem with double words",
         "More than meets the eye...",
+        'RecordingStreamBuilder::new("missing_prefix")',
+        'args.rerun.init("missing_prefix")',
+        'RecordingStream("missing_prefix")',
+        'rr.init("missing_prefix")',
+        'rr.script_setup(args, "missing_prefix")',
     ]
 
     for line in should_pass:
-        assert lint_line(line) is None, f'expected "{line}" to pass'
+        err = lint_line(line)
+        assert err is None, f'expected "{line}" to pass, but got error: "{err}"'
 
     for line in should_error:
         assert lint_line(line) is not None, f'expected "{line}" to fail'
@@ -590,12 +610,16 @@ def lint_file(filepath: str, args: Any) -> int:
 
     error: str | None
 
+    is_in_docstring = False
+
     for line_nr, line in enumerate(source.lines):
         if line == "" or line[-1] != "\n":
             error = "Missing newline at end of file"
         else:
             line = line[:-1]
-            error = lint_line(line, source.ext)
+            if line.strip() == '"""':
+                is_in_docstring = not is_in_docstring
+            error = lint_line(line, source.ext, is_in_docstring)
         if error is not None:
             num_errors += 1
             print(source.error(error, line_nr=line_nr))
@@ -655,14 +679,35 @@ def main() -> None:
         nargs="*",
         help="File paths. Empty = all files, recursively.",
     )
-    parser.add_argument("--fix", dest="fix", action="store_true", help="Automatically fix some problems.")
+    parser.add_argument(
+        "--fix",
+        dest="fix",
+        action="store_true",
+        help="Automatically fix some problems.",
+    )
 
     args = parser.parse_args()
 
     num_errors = 0
 
     # This list of file extensions matches the one in `.github/workflows/documentation.yaml`
-    extensions = ["c", "cpp", "fbs", "h", "hpp", "html", "js", "md", "py", "rs", "sh", "toml", "txt", "wgsl", "yml"]
+    extensions = [
+        "c",
+        "cpp",
+        "fbs",
+        "h",
+        "hpp",
+        "html",
+        "js",
+        "md",
+        "py",
+        "rs",
+        "sh",
+        "toml",
+        "txt",
+        "wgsl",
+        "yml",
+    ]
 
     exclude_paths = {
         "./.github/workflows/reusable_checks.yml",  # zombie TODO hunting job

--- a/scripts/screenshot_compare/build_screenshot_compare.py
+++ b/scripts/screenshot_compare/build_screenshot_compare.py
@@ -233,7 +233,7 @@ def serve_files() -> None:
 
         os.environ["RUST_LOG"] = "rerun=warn"
 
-        rr.init("Screenshot compare")
+        rr.init("rerun_example_screenshot_compare")
         rr.serve(open_browser=False)
 
     threading.Thread(target=serve, daemon=True).start()

--- a/tests/python/nv12image/main.py
+++ b/tests/python/nv12image/main.py
@@ -24,7 +24,7 @@ def main() -> None:
     rr.script_add_args(parser)
     args = parser.parse_args()
 
-    rr.script_setup(args, "rerun_test_nv12image")
+    rr.script_setup(args, "rerun_example_nv12image")
 
     # Make sure you use a colorful image!
     dir_path = os.path.dirname(os.path.realpath(__file__))

--- a/tests/rust/test_image_memory/src/main.rs
+++ b/tests/rust/test_image_memory/src/main.rs
@@ -15,7 +15,7 @@ static GLOBAL: AccountingAllocator<MiMalloc> = AccountingAllocator::new(MiMalloc
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     re_memory::accounting_allocator::turn_on_tracking_if_env_var("RERUN_TRACK_ALLOCATIONS");
 
-    let rec = rerun::RecordingStreamBuilder::new("test_image_memory").spawn()?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_memory").spawn()?;
     log_images(&rec).unwrap();
 
     Ok(())


### PR DESCRIPTION
### What
All our examples should use `rerun_example_` as the prefix for the app ids. We detect this specially in analytics.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4046) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4046)
- [Docs preview](https://rerun.io/preview/9b72a92d7d9acc6c77388bf7ab86dc3bab8bda94/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/9b72a92d7d9acc6c77388bf7ab86dc3bab8bda94/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)