### PR TITLE
Changed `spawn()` and the `rerun` script to call into `rerun_bindings` (12x startup time improvement)

### DIFF
--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -40,7 +40,7 @@ homepage = "https://www.rerun.io"
 repository = "https://github.com/rerun-io/rerun"
 
 [project.scripts]
-rerun = "rerun.__main__:main"
+rerun = "rerun_bindings:main"
 
 [tool.ruff]
 # https://beta.ruff.rs/docs/configuration/

--- a/rerun_py/rerun_sdk/rerun/__main__.py
+++ b/rerun_py/rerun_sdk/rerun/__main__.py
@@ -7,10 +7,12 @@ from rerun import unregister_shutdown
 
 
 def main() -> None:
-    # We don't need to call shutdown in this case. Rust should be handling everything
-    # TODO(ab): we only do that because __init__.py was loaded and register_shutdown() was called.
-    # Ideally, nothing should be loaded at all but `rerun_bindings` when we run `python3 -m rerun`.
+    # When running `python -m rerun` (i.e. executing this file), the `rerun` package and its `__init__.py` are still
+    # loaded. This has the side effect of executing `register_shutdown()` (schedule `bindings.shutdown()` to be called
+    # at exit. We don't need this here, so we unregister that call.
+    # TODO(ab): figure out a way to skip loading `__init__.py` entirely (to avoid doing this and save on loading time)
     unregister_shutdown()
+
     exit(bindings.main())
 
 

--- a/rerun_py/rerun_sdk/rerun/__main__.py
+++ b/rerun_py/rerun_sdk/rerun/__main__.py
@@ -1,15 +1,17 @@
 """See `python3 -m rerun --help`."""
 from __future__ import annotations
 
-import sys
+import rerun_bindings as bindings
 
-from rerun import bindings, unregister_shutdown
+from rerun import unregister_shutdown
 
 
 def main() -> None:
     # We don't need to call shutdown in this case. Rust should be handling everything
+    # TODO(ab): we only do that because __init__.py was loaded and register_shutdown() was called.
+    # Ideally, nothing should be loaded at all but `rerun_bindings` when we run `python3 -m rerun`.
     unregister_shutdown()
-    exit(bindings.main(sys.argv))
+    exit(bindings.main())
 
 
 if __name__ == "__main__":

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -224,8 +224,8 @@ def spawn(
         subprocess.Popen(
             [
                 python_executable,
-                "-m",
-                "rerun",
+                "-c",
+                "import rerun_bindings; rerun_bindings.main()",
                 f"--port={port}",
                 f"--memory-limit={memory_limit}",
                 "--skip-welcome-screen",

--- a/rerun_py/rerun_sdk/rerun_demo/__main__.py
+++ b/rerun_py/rerun_sdk/rerun_demo/__main__.py
@@ -50,7 +50,8 @@ def run_structure_from_motion(args):
         print(f"No demo file found at {rrd_file}. Package was built without demo support", file=sys.stderr)
         exit(1)
     else:
-        exit(bindings.main([sys.argv[0], str(rrd_file)] + serve_opts))
+        sys.argv = [sys.argv[0], str(rrd_file)] + serve_opts
+        exit(bindings.main())
 
 
 def main() -> None:

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -59,7 +59,10 @@ fn global_web_viewer_server(
 }
 
 #[pyfunction]
-fn main(py: Python<'_>, argv: Vec<String>) -> PyResult<u8> {
+fn main(py: Python<'_>) -> PyResult<u8> {
+    let sys = py.import("sys")?;
+    let argv: Vec<String> = sys.getattr("argv")?.extract()?;
+
     let build_info = re_build_info::build_info!();
     let call_src = rerun::CallSource::Python(python_version(py));
     tokio::runtime::Builder::new_multi_thread()

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -60,6 +60,8 @@ fn global_web_viewer_server(
 
 #[pyfunction]
 fn main(py: Python<'_>) -> PyResult<u8> {
+    // We access argv ourselves instead of accepting as parameter, so that `main`'s signature is
+    // compatible with `[project.scripts]` in `pyproject.toml`.
     let sys = py.import("sys")?;
     let argv: Vec<String> = sys.getattr("argv")?.extract()?;
 
@@ -70,7 +72,7 @@ fn main(py: Python<'_>) -> PyResult<u8> {
         .build()
         .unwrap()
         .block_on(async {
-            // Python catches SIGINT and waits for us to release the GIL before shtting down.
+            // Python catches SIGINT and waits for us to release the GIL before shutting down.
             // That's no good, so we need to catch SIGINT ourselves and shut down:
             tokio::spawn(async move {
                 tokio::signal::ctrl_c().await.unwrap();


### PR DESCRIPTION
### What

Python package can include so-called "scripts" definitiosn, which are recognised by pip, pipx, etc. When they exist, a stub script is created upon package installation which calls into the defined python function. We use this to map `rerun` to launch the viewer from the binary embedded in our wheels.

So far, this was done as follows (from `pyproject.toml`):

```toml
[project.scripts]
rerun = "rerun.__main__:main"
```

The drawback of this is that the *entire* `rerun` SDK package was loaded (including numpy, Pillow, etc.), incurring a ~300+ms startup time.

This PR changes it to:

```toml
[project.scripts]
rerun = "rerun_bindings:main"
```

This drastically reduces the loading time, as the `rerun` python package is no longer loaded. The signature of our binding's `main` function needed to be changed: it now internally reads from `sys.argv` instead of accepting an argument.

This PR also changes `spawn()` to call directly into the bindings, with the same loading time benefit.

**Note**: This PR improves startup time when running `rerun` in a venv (with the SDK installed), or when installed via pipx. The startup time of `python -m rerun` is *not* improved, as this still involves loading the `rerun` python package.

#### Benchmark

```shell
❯ cat `which rerun`
   1   │ #!/Users/hhip/src/rerun/venv/bin/python
   2   │ # -*- coding: utf-8 -*-
   3   │ import re
   4   │ import sys
   5   │ from rerun_bindings import main
   6   │ if __name__ == '__main__':
   7   │     sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
   8   │     sys.exit(main())

❯ cat `which rerun_0.9.1`
   1   │ #!/Users/hhip/.local/pipx/venvs/rerun-sdk-0-9-1/bin/python
   2   │ # -*- coding: utf-8 -*-
   3   │ import re
   4   │ import sys
   5   │ from rerun.__main__ import main
   6   │ if __name__ == '__main__':
   7   │     sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
   8   │     sys.exit(main())

❯ hyperfine --warmup 5  "rerun --version" "rerun_0.9.1 --version"
Benchmark 1: rerun --version
  Time (mean ± σ):      34.8 ms ±   1.7 ms    [User: 21.8 ms, System: 11.1 ms]
  Range (min … max):    32.5 ms …  41.5 ms    82 runs
 
Benchmark 2: rerun_0.9.1 --version
  Time (mean ± σ):     422.1 ms ±  52.2 ms    [User: 716.1 ms, System: 1971.6 ms]
  Range (min … max):   333.0 ms … 494.0 ms    10 runs
 
Summary
  rerun --version ran
   12.14 ± 1.62 times faster than rerun_0.9.1 --version
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4053) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4053)
- [Docs preview](https://rerun.io/preview/b6e6514607a0ef8b3fdc71f53d79345cd6c49235/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b6e6514607a0ef8b3fdc71f53d79345cd6c49235/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)