### PR TITLE
Document that the C and C++ APIs are thread-safe

### DIFF
--- a/crates/rerun_c/src/rerun.h
+++ b/crates/rerun_c/src/rerun.h
@@ -4,6 +4,9 @@
 // This file is part of the rerun_c Rust crate.
 // EDITS TO COPIES OUTSIDE OF RERUN_C WILL BE OVERWRITTEN.
 // ----------------------------------------------------------------------------
+//
+// All Rerun functions and types are thread-safe,
+// which means you can share a `rr_recording_stream` across threads.
 
 #ifndef RERUN_H
 #define RERUN_H

--- a/docs/code-examples/annotation_context_connections.cpp
+++ b/docs/code-examples/annotation_context_connections.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
+    const auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
     rec.spawn().throw_on_failure();
 
     // Log an annotation context to assign a label and color to each class

--- a/docs/code-examples/annotation_context_rects.cpp
+++ b/docs/code-examples/annotation_context_rects.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_annotation_context_rects");
+    const auto rec = rerun::RecordingStream("rerun_example_annotation_context_rects");
     rec.spawn().throw_on_failure();
 
     // Log an annotation context to assign a label and color to each class

--- a/docs/code-examples/annotation_context_segmentation.cpp
+++ b/docs/code-examples/annotation_context_segmentation.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
+    const auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
     rec.spawn().throw_on_failure();
 
     // create an annotation context to describe the classes

--- a/docs/code-examples/arrow3d_simple.cpp
+++ b/docs/code-examples/arrow3d_simple.cpp
@@ -8,7 +8,7 @@
 constexpr float TAU = 6.28318530717958647692528676655900577f;
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_arrow3d");
+    const auto rec = rerun::RecordingStream("rerun_example_arrow3d");
     rec.spawn().throw_on_failure();
 
     std::vector<rerun::Position3D> origins;

--- a/docs/code-examples/asset3d_out_of_tree.cpp
+++ b/docs/code-examples/asset3d_out_of_tree.cpp
@@ -11,7 +11,7 @@ int main(int argc, char** argv) {
     }
     const auto path = argv[1];
 
-    auto rec = rerun::RecordingStream("rerun_example_asset3d_out_of_tree");
+    const auto rec = rerun::RecordingStream("rerun_example_asset3d_out_of_tree");
     rec.spawn().throw_on_failure();
 
     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis

--- a/docs/code-examples/asset3d_simple.cpp
+++ b/docs/code-examples/asset3d_simple.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* argv[]) {
 
     const auto path = argv[1];
 
-    auto rec = rerun::RecordingStream("rerun_example_asset3d_simple");
+    const auto rec = rerun::RecordingStream("rerun_example_asset3d_simple");
     rec.spawn().throw_on_failure();
 
     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis

--- a/docs/code-examples/bar_chart.cpp
+++ b/docs/code-examples/bar_chart.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_bar_chart");
+    const auto rec = rerun::RecordingStream("rerun_example_bar_chart");
     rec.spawn().throw_on_failure();
 
     rec.log("bar_chart", rerun::BarChart::i64({8, 4, 0, 9, 1, 4, 1, 6, 9, 0}));

--- a/docs/code-examples/box2d_simple.cpp
+++ b/docs/code-examples/box2d_simple.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_box2d");
+    const auto rec = rerun::RecordingStream("rerun_example_box2d");
     rec.spawn().throw_on_failure();
 
     rec.log("simple", rerun::Boxes2D::from_mins_and_sizes({{-1.f, -1.f}}, {{2.f, 2.f}}));

--- a/docs/code-examples/box3d_batch.cpp
+++ b/docs/code-examples/box3d_batch.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_box3d_batch");
+    const auto rec = rerun::RecordingStream("rerun_example_box3d_batch");
     rec.spawn().throw_on_failure();
 
     rec.log(

--- a/docs/code-examples/box3d_simple.cpp
+++ b/docs/code-examples/box3d_simple.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_box3d_simple");
+    const auto rec = rerun::RecordingStream("rerun_example_box3d_simple");
     rec.spawn().throw_on_failure();
 
     rec.log("simple", rerun::Boxes3D::from_half_sizes({{2.f, 2.f, 1.0f}}));

--- a/docs/code-examples/clear_recursive.cpp
+++ b/docs/code-examples/clear_recursive.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_clear_recursive");
+    const auto rec = rerun::RecordingStream("rerun_example_clear_recursive");
     rec.spawn().throw_on_failure();
 
     std::vector<rerun::Vector3D> vectors = {

--- a/docs/code-examples/clear_simple.cpp
+++ b/docs/code-examples/clear_simple.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_clear_simple");
+    const auto rec = rerun::RecordingStream("rerun_example_clear_simple");
     rec.spawn().throw_on_failure();
 
     std::vector<rerun::Vector3D> vectors = {

--- a/docs/code-examples/depth_image_3d.cpp
+++ b/docs/code-examples/depth_image_3d.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_depth_image");
+    const auto rec = rerun::RecordingStream("rerun_example_depth_image");
     rec.spawn().throw_on_failure();
 
     // Create a synthetic depth image.

--- a/docs/code-examples/depth_image_simple.cpp
+++ b/docs/code-examples/depth_image_simple.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_depth_image");
+    const auto rec = rerun::RecordingStream("rerun_example_depth_image");
     rec.spawn().throw_on_failure();
 
     // create a synthetic depth image.

--- a/docs/code-examples/disconnected_space.cpp
+++ b/docs/code-examples/disconnected_space.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_disconnected_space");
+    const auto rec = rerun::RecordingStream("rerun_example_disconnected_space");
     rec.spawn().throw_on_failure();
 
     // These two points can be projected into the same space..

--- a/docs/code-examples/image_simple.cpp
+++ b/docs/code-examples/image_simple.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_image_simple");
+    const auto rec = rerun::RecordingStream("rerun_example_image_simple");
     rec.spawn().throw_on_failure();
 
     // Create a synthetic image.

--- a/docs/code-examples/line_segments2d_simple.cpp
+++ b/docs/code-examples/line_segments2d_simple.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_line_segments2d");
+    const auto rec = rerun::RecordingStream("rerun_example_line_segments2d");
     rec.spawn().throw_on_failure();
 
     std::vector<std::vector<std::array<float, 2>>> points = {

--- a/docs/code-examples/line_segments3d_simple.cpp
+++ b/docs/code-examples/line_segments3d_simple.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_line_segments3d");
+    const auto rec = rerun::RecordingStream("rerun_example_line_segments3d");
     rec.spawn().throw_on_failure();
 
     std::vector<std::vector<std::array<float, 3>>> points = {

--- a/docs/code-examples/line_strip2d_batch.cpp
+++ b/docs/code-examples/line_strip2d_batch.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
+    const auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
     rec.spawn().throw_on_failure();
 
     std::vector<rerun::Vec2D> strip1 = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}};

--- a/docs/code-examples/line_strip2d_simple.cpp
+++ b/docs/code-examples/line_strip2d_simple.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
+    const auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
     rec.spawn().throw_on_failure();
 
     const auto strip = rerun::LineStrip2D({{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}});

--- a/docs/code-examples/line_strip3d_batch.cpp
+++ b/docs/code-examples/line_strip3d_batch.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
+    const auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
     rec.spawn().throw_on_failure();
 
     std::vector<rerun::Vec3D> strip1 = {

--- a/docs/code-examples/line_strip3d_simple.cpp
+++ b/docs/code-examples/line_strip3d_simple.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
+    const auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
     rec.spawn().throw_on_failure();
 
     rerun::LineStrip3D linestrip({

--- a/docs/code-examples/manual_indicator.cpp
+++ b/docs/code-examples/manual_indicator.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_manual_indicator");
+    const auto rec = rerun::RecordingStream("rerun_example_manual_indicator");
     rec.spawn().throw_on_failure();
 
     std::vector<rerun::Position3D> positions = {

--- a/docs/code-examples/mesh3d_indexed.cpp
+++ b/docs/code-examples/mesh3d_indexed.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_mesh3d_indexed");
+    const auto rec = rerun::RecordingStream("rerun_example_mesh3d_indexed");
     rec.spawn().throw_on_failure();
 
     const rerun::Position3D vertex_positions[3] = {

--- a/docs/code-examples/mesh3d_partial_updates.cpp
+++ b/docs/code-examples/mesh3d_partial_updates.cpp
@@ -10,7 +10,7 @@ rerun::Position3D mul_pos(float factor, rerun::Position3D vec) {
 }
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_mesh3d_partial_updates");
+    const auto rec = rerun::RecordingStream("rerun_example_mesh3d_partial_updates");
     rec.spawn().throw_on_failure();
 
     rerun::Position3D vertex_positions[3] = {

--- a/docs/code-examples/mesh3d_simple.cpp
+++ b/docs/code-examples/mesh3d_simple.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_mesh3d_simple");
+    const auto rec = rerun::RecordingStream("rerun_example_mesh3d_simple");
     rec.spawn().throw_on_failure();
 
     rerun::Position3D vertex_positions[3] = {

--- a/docs/code-examples/pinhole_simple.cpp
+++ b/docs/code-examples/pinhole_simple.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
+    const auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
     rec.spawn().throw_on_failure();
 
     rec.log("world/image", rerun::Pinhole::from_focal_length_and_resolution(3.0f, {3.0f, 3.0f}));

--- a/docs/code-examples/point2d_random.cpp
+++ b/docs/code-examples/point2d_random.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_points2d_simple");
+    const auto rec = rerun::RecordingStream("rerun_example_points2d_simple");
     rec.spawn().throw_on_failure();
 
     std::default_random_engine gen;

--- a/docs/code-examples/point2d_simple.cpp
+++ b/docs/code-examples/point2d_simple.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_points2d_simple");
+    const auto rec = rerun::RecordingStream("rerun_example_points2d_simple");
     rec.spawn().throw_on_failure();
 
     rec.log("points", rerun::Points2D({{0.0f, 0.0f}, {1.0f, 1.0f}}));

--- a/docs/code-examples/point3d_random.cpp
+++ b/docs/code-examples/point3d_random.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_points3d_random");
+    const auto rec = rerun::RecordingStream("rerun_example_points3d_random");
     rec.spawn().throw_on_failure();
 
     std::default_random_engine gen;

--- a/docs/code-examples/point3d_simple.cpp
+++ b/docs/code-examples/point3d_simple.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_points3d_simple");
+    const auto rec = rerun::RecordingStream("rerun_example_points3d_simple");
     rec.spawn().throw_on_failure();
 
     rec.log("points", rerun::Points3D({{0.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 1.0f}}));

--- a/docs/code-examples/quick_start_connect.cpp
+++ b/docs/code-examples/quick_start_connect.cpp
@@ -5,7 +5,7 @@ using namespace rerun::demo;
 
 int main() {
     // Create a new `RecordingStream` which sends data over TCP to the viewer process.
-    auto rec = rerun::RecordingStream("rerun_example_demo");
+    const auto rec = rerun::RecordingStream("rerun_example_demo");
     rec.spawn().throw_on_failure();
 
     // Create some data using the `grid` utility function.

--- a/docs/code-examples/scalar_multiple_plots.cpp
+++ b/docs/code-examples/scalar_multiple_plots.cpp
@@ -7,7 +7,7 @@
 constexpr float TAU = 6.28318530717958647692528676655900577f;
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_points3d_simple");
+    const auto rec = rerun::RecordingStream("rerun_example_points3d_simple");
     rec.spawn().throw_on_failure();
 
     int64_t lcg_state = 0;

--- a/docs/code-examples/scalar_simple.cpp
+++ b/docs/code-examples/scalar_simple.cpp
@@ -5,7 +5,7 @@
 #include <cmath>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_scalar");
+    const auto rec = rerun::RecordingStream("rerun_example_scalar");
     rec.spawn().throw_on_failure();
 
     for (int step = 0; step < 64; ++step) {

--- a/docs/code-examples/segmentation_image_simple.cpp
+++ b/docs/code-examples/segmentation_image_simple.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
+    const auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
     rec.spawn().throw_on_failure();
 
     // Create a segmentation image

--- a/docs/code-examples/tensor_simple.cpp
+++ b/docs/code-examples/tensor_simple.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_tensor_simple");
+    const auto rec = rerun::RecordingStream("rerun_example_tensor_simple");
     rec.spawn().throw_on_failure();
 
     std::default_random_engine gen;

--- a/docs/code-examples/text_document.cpp
+++ b/docs/code-examples/text_document.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_text_document");
+    const auto rec = rerun::RecordingStream("rerun_example_text_document");
     rec.spawn().throw_on_failure();
 
     rec.log("text_document", rerun::TextDocument("Hello, TextDocument!"));

--- a/docs/code-examples/text_log.cpp
+++ b/docs/code-examples/text_log.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_text_log");
+    const auto rec = rerun::RecordingStream("rerun_example_text_log");
     rec.spawn().throw_on_failure();
 
     rec.log("log", rerun::TextLog("Application started.").with_level(rerun::TextLogLevel::INFO));

--- a/docs/code-examples/transform3d_simple.cpp
+++ b/docs/code-examples/transform3d_simple.cpp
@@ -5,7 +5,7 @@
 constexpr float TAU = 6.28318530717958647692528676655900577f;
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_transform3d");
+    const auto rec = rerun::RecordingStream("rerun_example_transform3d");
     rec.spawn().throw_on_failure();
 
     auto arrow =

--- a/docs/code-examples/view_coordinates_simple.cpp
+++ b/docs/code-examples/view_coordinates_simple.cpp
@@ -3,7 +3,7 @@
 #include <rerun.hpp>
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_view_coordinates");
+    const auto rec = rerun::RecordingStream("rerun_example_view_coordinates");
     rec.spawn().throw_on_failure();
 
     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis

--- a/docs/content/getting-started/cpp.md
+++ b/docs/content/getting-started/cpp.md
@@ -80,7 +80,7 @@ using namespace rerun::demo;
 
 int main() {
     // Create a new `RecordingStream` which sends data over TCP to the viewer process.
-    auto rec = rerun::RecordingStream("rerun_example_cpp");
+    const auto rec = rerun::RecordingStream("rerun_example_cpp");
     // Try to spawn a new viewer instance.
     rec.spawn().throw_on_failure();
 

--- a/examples/cpp/clock/main.cpp
+++ b/examples/cpp/clock/main.cpp
@@ -7,8 +7,8 @@
 constexpr float TAU = 6.28318530717958647692528676655900577f;
 
 void log_hand(
-    rerun::RecordingStream& rec, const char* name, int step, float angle, float length, float width,
-    uint8_t blue
+    const rerun::RecordingStream& rec, const char* name, int step, float angle, float length,
+    float width, uint8_t blue
 ) {
     const auto tip = rerun::Vec3D{length * sinf(angle * TAU), length * cosf(angle * TAU), 0.0f};
     const auto c = static_cast<uint8_t>(angle * 255.0f);
@@ -40,7 +40,7 @@ int main() {
 
     const int num_steps = 10000;
 
-    auto rec = rerun::RecordingStream("rerun_example_clock");
+    const auto rec = rerun::RecordingStream("rerun_example_clock");
     rec.spawn().throw_on_failure();
 
     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Y_UP);

--- a/examples/cpp/custom_component_adapter/main.cpp
+++ b/examples/cpp/custom_component_adapter/main.cpp
@@ -46,7 +46,7 @@ struct rerun::ComponentBatchAdapter<rerun::Position3D, MyContainer<MyVec3>> {
 
 int main() {
     // Create a new `RecordingStream` which sends data over TCP to the viewer process.
-    auto rec = rerun::RecordingStream("rerun_example_custom_component_adapter");
+    const auto rec = rerun::RecordingStream("rerun_example_custom_component_adapter");
     rec.spawn().throw_on_failure();
 
     // Construct some data in a custom format.

--- a/examples/cpp/dna/main.cpp
+++ b/examples/cpp/dna/main.cpp
@@ -10,7 +10,7 @@ using namespace rerun::demo;
 static constexpr size_t NUM_POINTS = 100;
 
 int main() {
-    auto rec = rerun::RecordingStream("rerun_example_dna_abacus");
+    const auto rec = rerun::RecordingStream("rerun_example_dna_abacus");
     rec.spawn().throw_on_failure();
 
     std::vector<rerun::Position3D> points1, points2;

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -5,7 +5,7 @@ using rerun::demo::grid;
 
 int main() {
     // Create a new `RecordingStream` which sends data over TCP to the viewer process.
-    auto rec = rerun::RecordingStream("rerun_example_cpp");
+    const auto rec = rerun::RecordingStream("rerun_example_cpp");
     // Try to spawn a new viewer instance.
     rec.spawn().throw_on_failure();
 

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -33,7 +33,7 @@ namespace rerun {
         /// #include <vector>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     // create an annotation context to describe the classes

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -37,7 +37,7 @@ namespace rerun {
         /// constexpr float TAU = 6.28318530717958647692528676655900577f;
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_arrow3d");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_arrow3d");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     std::vector<rerun::Position3D> origins;

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -43,7 +43,7 @@ namespace rerun {
         ///
         ///     const auto path = argv[1];
         ///
-        ///     auto rec = rerun::RecordingStream("rerun_example_asset3d_simple");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_asset3d_simple");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -27,7 +27,7 @@ namespace rerun {
         /// #include <rerun.hpp>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_bar_chart");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_bar_chart");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     rec.log("bar_chart", rerun::BarChart::i64({8, 4, 0, 9, 1, 4, 1, 6, 9, 0}));

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -34,7 +34,7 @@ namespace rerun {
         /// #include <rerun.hpp>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_box2d");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_box2d");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     rec.log("simple", rerun::Boxes2D::from_mins_and_sizes({{-1.f, -1.f}}, {{2.f, 2.f}}));

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -34,7 +34,7 @@ namespace rerun {
         /// #include <rerun.hpp>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_box3d_batch");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_box3d_batch");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     rec.log(

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -29,7 +29,7 @@ namespace rerun {
         /// #include <vector>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_clear_simple");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_clear_simple");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     std::vector<rerun::Vector3D> vectors = {

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -35,7 +35,7 @@ namespace rerun {
         /// #include <vector>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_depth_image");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_depth_image");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     // Create a synthetic depth image.

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -29,7 +29,7 @@ namespace rerun {
         /// #include <rerun.hpp>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_disconnected_space");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_disconnected_space");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     // These two points can be projected into the same space..

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -38,7 +38,7 @@ namespace rerun {
         /// #include <vector>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_image_simple");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_image_simple");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     // Create a synthetic image.

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -34,7 +34,7 @@ namespace rerun {
         /// #include <vector>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     std::vector<rerun::Vec2D> strip1 = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}};

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -33,7 +33,7 @@ namespace rerun {
         /// #include <vector>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     std::vector<rerun::Vec3D> strip1 = {

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -34,7 +34,7 @@ namespace rerun {
         /// #include <vector>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_mesh3d_indexed");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_mesh3d_indexed");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     const rerun::Position3D vertex_positions[3] = {

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -32,7 +32,7 @@ namespace rerun {
         /// #include <vector>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     rec.log("world/image", rerun::Pinhole::from_focal_length_and_resolution(3.0f, {3.0f, 3.0f}));

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -37,7 +37,7 @@ namespace rerun {
         /// #include <vector>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_points2d_simple");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_points2d_simple");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     std::default_random_engine gen;

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -36,7 +36,7 @@ namespace rerun {
         /// #include <vector>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_points3d_random");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_points3d_random");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     std::default_random_engine gen;

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -37,7 +37,7 @@ namespace rerun {
         /// #include <vector>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     // Create a segmentation image

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -31,7 +31,7 @@ namespace rerun {
         /// #include <vector>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_tensor_simple");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_tensor_simple");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     std::default_random_engine gen;

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -29,7 +29,7 @@ namespace rerun {
         /// #include <rerun.hpp>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_text_document");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_text_document");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     rec.log("text_document", rerun::TextDocument("Hello, TextDocument!"));

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -35,7 +35,7 @@ namespace rerun {
         /// #include <cmath>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_scalar");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_scalar");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     for (int step = 0; step <64; ++step) {

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -26,7 +26,7 @@ namespace rerun {
         /// constexpr float TAU = 6.28318530717958647692528676655900577f;
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_transform3d");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_transform3d");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     auto arrow =

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -31,7 +31,7 @@ namespace rerun {
         /// #include <rerun.hpp>
         ///
         /// int main() {
-        ///     auto rec = rerun::RecordingStream("rerun_example_view_coordinates");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_view_coordinates");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -4,6 +4,9 @@
 // This file is part of the rerun_c Rust crate.
 // EDITS TO COPIES OUTSIDE OF RERUN_C WILL BE OVERWRITTEN.
 // ----------------------------------------------------------------------------
+//
+// All Rerun functions and types are thread-safe,
+// which means you can share a `rr_recording_stream` across threads.
 
 #ifndef RERUN_H
 #define RERUN_H

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -67,11 +67,11 @@ namespace rerun {
         }
     }
 
-    void RecordingStream::set_global() {
+    void RecordingStream::set_global() const {
         rr_recording_stream_set_global(_id, store_kind_to_c(_store_kind));
     }
 
-    void RecordingStream::set_thread_local() {
+    void RecordingStream::set_thread_local() const {
         rr_recording_stream_set_thread_local(_id, store_kind_to_c(_store_kind));
     }
 
@@ -95,7 +95,7 @@ namespace rerun {
         }
     }
 
-    Error RecordingStream::connect(std::string_view tcp_addr, float flush_timeout_sec) {
+    Error RecordingStream::connect(std::string_view tcp_addr, float flush_timeout_sec) const {
         rr_error status = {};
         rr_recording_stream_connect(
             _id,
@@ -109,7 +109,7 @@ namespace rerun {
     Error RecordingStream::spawn(
         uint16_t port, std::string_view memory_limit, std::string_view executable_name,
         std::optional<std::string_view> executable_path, float flush_timeout_sec
-    ) {
+    ) const {
         rr_spawn_options spawn_opts;
         spawn_opts.port = port;
         spawn_opts.memory_limit = detail::to_rr_string(memory_limit);
@@ -122,17 +122,18 @@ namespace rerun {
         return status;
     }
 
-    Error RecordingStream::save(std::string_view path) {
+    Error RecordingStream::save(std::string_view path) const {
         rr_error status = {};
         rr_recording_stream_save(_id, detail::to_rr_string(path), &status);
         return status;
     }
 
-    void RecordingStream::flush_blocking() {
+    void RecordingStream::flush_blocking() const {
         rr_recording_stream_flush_blocking(_id);
     }
 
-    void RecordingStream::set_time_sequence(std::string_view timeline_name, int64_t sequence_nr) {
+    void RecordingStream::set_time_sequence(std::string_view timeline_name, int64_t sequence_nr)
+        const {
         if (!is_enabled()) {
             return;
         }
@@ -146,7 +147,7 @@ namespace rerun {
         Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
     }
 
-    void RecordingStream::set_time_seconds(std::string_view timeline_name, double seconds) {
+    void RecordingStream::set_time_seconds(std::string_view timeline_name, double seconds) const {
         if (!is_enabled()) {
             return;
         }
@@ -160,7 +161,7 @@ namespace rerun {
         Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
     }
 
-    void RecordingStream::set_time_nanos(std::string_view timeline_name, int64_t nanos) {
+    void RecordingStream::set_time_nanos(std::string_view timeline_name, int64_t nanos) const {
         rr_error status = {};
         rr_recording_stream_set_time_nanos(
             _id,
@@ -171,20 +172,20 @@ namespace rerun {
         Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
     }
 
-    void RecordingStream::disable_timeline(std::string_view timeline_name) {
+    void RecordingStream::disable_timeline(std::string_view timeline_name) const {
         rr_error status = {};
         rr_recording_stream_disable_timeline(_id, detail::to_rr_string(timeline_name), &status);
         Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
     }
 
-    void RecordingStream::reset_time() {
+    void RecordingStream::reset_time() const {
         rr_recording_stream_reset_time(_id);
     }
 
     Error RecordingStream::try_log_serialized_batches(
         std::string_view entity_path, bool timeless,
         const std::vector<SerializedComponentBatch>& batches
-    ) {
+    ) const {
         if (!is_enabled()) {
             return Error::ok();
         }
@@ -227,7 +228,7 @@ namespace rerun {
     Error RecordingStream::try_log_data_row(
         std::string_view entity_path, size_t num_instances, size_t num_data_cells,
         const DataCell* data_cells, bool inject_time
-    ) {
+    ) const {
         if (!is_enabled()) {
             return Error::ok();
         }

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -361,7 +361,7 @@ SCENARIO("RecordingStream can log to file", TEST_TAG) {
     }
 }
 
-void test_logging_to_connection(const char* address, rerun::RecordingStream& stream) {
+void test_logging_to_connection(const char* address, const rerun::RecordingStream& stream) {
     // We changed to taking std::string_view instead of const char* and constructing such from nullptr crashes
     // at least on some C++ implementations.
     // If we'd want to support this in earnest we'd have to create out own string_view type.

--- a/tests/cpp/roundtrips/annotation_context/main.cpp
+++ b/tests/cpp/roundtrips/annotation_context/main.cpp
@@ -2,7 +2,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_annotation_context");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_annotation_context");
     rec.save(argv[1]).throw_on_failure();
 
     rec.log(

--- a/tests/cpp/roundtrips/arrows3d/main.cpp
+++ b/tests/cpp/roundtrips/arrows3d/main.cpp
@@ -2,7 +2,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_arrows3d");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_arrows3d");
     rec.save(argv[1]).throw_on_failure();
 
     rec.log(

--- a/tests/cpp/roundtrips/boxes2d/main.cpp
+++ b/tests/cpp/roundtrips/boxes2d/main.cpp
@@ -2,7 +2,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_box2d");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_box2d");
     rec.save(argv[1]).throw_on_failure();
 
     rec.log(

--- a/tests/cpp/roundtrips/boxes3d/main.cpp
+++ b/tests/cpp/roundtrips/boxes3d/main.cpp
@@ -3,7 +3,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_box3d");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_box3d");
     rec.save(argv[1]).throw_on_failure();
 
     rec.log(

--- a/tests/cpp/roundtrips/depth_image/main.cpp
+++ b/tests/cpp/roundtrips/depth_image/main.cpp
@@ -4,7 +4,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_depth_image");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_depth_image");
     rec.save(argv[1]).throw_on_failure();
 
     auto img = rerun::datatypes::TensorData({2, 3}, std::vector<uint8_t>{0, 1, 2, 3, 4, 5});

--- a/tests/cpp/roundtrips/disconnected_space/main.cpp
+++ b/tests/cpp/roundtrips/disconnected_space/main.cpp
@@ -2,7 +2,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_disconnected_space");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_disconnected_space");
     rec.save(argv[1]).throw_on_failure();
 
     rec.log("disconnected_space", rerun::archetypes::DisconnectedSpace(true));

--- a/tests/cpp/roundtrips/image/main.cpp
+++ b/tests/cpp/roundtrips/image/main.cpp
@@ -27,7 +27,7 @@ rerun::half half_from_float(const float x) {
 }
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_image");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_image");
     rec.save(argv[1]).throw_on_failure();
 
     // h=2 w=3 c=3 image. Red channel = x. Green channel = y. Blue channel = 128.

--- a/tests/cpp/roundtrips/line_strips2d/main.cpp
+++ b/tests/cpp/roundtrips/line_strips2d/main.cpp
@@ -3,7 +3,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_line_strip2d");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_line_strip2d");
     rec.save(argv[1]).throw_on_failure();
 
     rec.log(

--- a/tests/cpp/roundtrips/line_strips3d/main.cpp
+++ b/tests/cpp/roundtrips/line_strips3d/main.cpp
@@ -2,7 +2,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_line_strip3d");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_line_strip3d");
     rec.save(argv[1]).throw_on_failure();
 
     rec.log(

--- a/tests/cpp/roundtrips/pinhole/main.cpp
+++ b/tests/cpp/roundtrips/pinhole/main.cpp
@@ -2,7 +2,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_pinhole");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_pinhole");
     rec.save(argv[1]).throw_on_failure();
 
     rec.log(

--- a/tests/cpp/roundtrips/points2d/main.cpp
+++ b/tests/cpp/roundtrips/points2d/main.cpp
@@ -3,7 +3,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_points2d");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_points2d");
     rec.save(argv[1]).throw_on_failure();
 
     rec.log(

--- a/tests/cpp/roundtrips/points3d/main.cpp
+++ b/tests/cpp/roundtrips/points3d/main.cpp
@@ -2,7 +2,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_points3d");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_points3d");
     rec.save(argv[1]).throw_on_failure();
 
     rec.log(

--- a/tests/cpp/roundtrips/segmentation_image/main.cpp
+++ b/tests/cpp/roundtrips/segmentation_image/main.cpp
@@ -4,7 +4,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_segmentation_image");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_segmentation_image");
     rec.save(argv[1]).throw_on_failure();
 
     // 3x2 image. Each pixel is incremented down each row

--- a/tests/cpp/roundtrips/tensor/main.cpp
+++ b/tests/cpp/roundtrips/tensor/main.cpp
@@ -5,7 +5,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_tensor");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_tensor");
     rec.save(argv[1]).throw_on_failure();
 
     std::vector<rerun::datatypes::TensorDimension> dimensions{{3, 4, 5, 6}};

--- a/tests/cpp/roundtrips/text_document/main.cpp
+++ b/tests/cpp/roundtrips/text_document/main.cpp
@@ -1,7 +1,7 @@
 #include <rerun.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_text_document");
+    const auto rec = rerun::RecordingStream("rerun_example_text_document");
     rec.save(argv[1]).throw_on_failure();
     rec.log("text_document", rerun::archetypes::TextDocument("Hello, TextDocument!"));
     rec.log(

--- a/tests/cpp/roundtrips/text_log/main.cpp
+++ b/tests/cpp/roundtrips/text_log/main.cpp
@@ -1,7 +1,7 @@
 #include <rerun.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_text_log");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_text_log");
     rec.save(argv[1]).throw_on_failure();
     rec.log("log", rerun::archetypes::TextLog("No level"));
     rec.log(

--- a/tests/cpp/roundtrips/transform3d/main.cpp
+++ b/tests/cpp/roundtrips/transform3d/main.cpp
@@ -6,7 +6,7 @@
 constexpr float PI = 3.14159265358979323846264338327950288f;
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_transform3d");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_transform3d");
     rec.save(argv[1]).throw_on_failure();
 
     rec.log(

--- a/tests/cpp/roundtrips/view_coordinates/main.cpp
+++ b/tests/cpp/roundtrips/view_coordinates/main.cpp
@@ -1,7 +1,7 @@
 #include <rerun.hpp>
 
 int main(int, char** argv) {
-    auto rec = rerun::RecordingStream("rerun_example_roundtrip_view_coordinates");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_view_coordinates");
     rec.save(argv[1]).throw_on_failure();
     rec.log_timeless("/", rerun::archetypes::ViewCoordinates::RDF);
 }


### PR DESCRIPTION
…and mark all `RecordingStream` members as `const`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4067) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4067)
- [Docs preview](https://rerun.io/preview/2cb60265945e10a5151eb59246fe8100c00b2b50/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2cb60265945e10a5151eb59246fe8100c00b2b50/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)