### PR TITLE
New `disable_timeline` APIs in all supported languages

### DIFF
--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1440,7 +1440,6 @@ impl RecordingStream {
     /// - [`Self::set_time_seconds`]
     /// - [`Self::set_time_nanos`]
     /// - [`Self::disable_timeline`]
-    /// - [`Self::disable_timeline_specific`]
     /// - [`Self::reset_time`]
     pub fn set_timepoint(&self, timepoint: impl Into<TimePoint>) {
         let Some(this) = &*self.inner else {
@@ -1470,7 +1469,6 @@ impl RecordingStream {
     /// - [`Self::set_time_seconds`]
     /// - [`Self::set_time_nanos`]
     /// - [`Self::disable_timeline`]
-    /// - [`Self::disable_timeline_specific`]
     /// - [`Self::reset_time`]
     pub fn set_time_sequence(&self, timeline: impl Into<TimelineName>, sequence: impl Into<i64>) {
         let Some(this) = &*self.inner else {
@@ -1500,7 +1498,6 @@ impl RecordingStream {
     /// - [`Self::set_time_sequence`]
     /// - [`Self::set_time_nanos`]
     /// - [`Self::disable_timeline`]
-    /// - [`Self::disable_timeline_specific`]
     /// - [`Self::reset_time`]
     pub fn set_time_seconds(&self, timeline: impl Into<TimelineName>, seconds: impl Into<f64>) {
         let Some(this) = &*self.inner else {
@@ -1530,7 +1527,6 @@ impl RecordingStream {
     /// - [`Self::set_time_sequence`]
     /// - [`Self::set_time_seconds`]
     /// - [`Self::disable_timeline`]
-    /// - [`Self::disable_timeline_specific`]
     /// - [`Self::reset_time`]
     pub fn set_time_nanos(&self, timeline: impl Into<TimelineName>, ns: impl Into<i64>) {
         let Some(this) = &*self.inner else {
@@ -1548,9 +1544,6 @@ impl RecordingStream {
     /// Clears out the current time of the recording for the specified timeline, for the
     /// current calling thread.
     ///
-    /// This will clear out _both sequential and temporal_ timelines of the specified name.
-    /// Refer to [`Self::disable_timeline_specific`] if you need more fine-grained control.
-    ///
     /// For example: `rec.disable_timeline("frame")`, `rec.disable_timeline("sim_time")`.
     ///
     /// See also:
@@ -1558,11 +1551,10 @@ impl RecordingStream {
     /// - [`Self::set_time_sequence`]
     /// - [`Self::set_time_seconds`]
     /// - [`Self::set_time_nanos`]
-    /// - [`Self::disable_timeline_specific`]
     /// - [`Self::reset_time`]
     pub fn disable_timeline(&self, timeline: impl Into<TimelineName>) {
         let Some(this) = &*self.inner else {
-            re_log::warn_once!("Recording disabled - call to reset_time() ignored");
+            re_log::warn_once!("Recording disabled - call to disable_timeline() ignored");
             return;
         };
 
@@ -1583,9 +1575,10 @@ impl RecordingStream {
     /// - [`Self::set_time_nanos`]
     /// - [`Self::disable_timeline`]
     /// - [`Self::reset_time`]
+    #[doc(hidden)]
     pub fn disable_timeline_specific(&self, timeline: impl Into<Timeline>) {
         let Some(this) = &*self.inner else {
-            re_log::warn_once!("Recording disabled - call to reset_time() ignored");
+            re_log::warn_once!("Recording disabled - call to disable_timeline_specific() ignored");
             return;
         };
 
@@ -1605,7 +1598,6 @@ impl RecordingStream {
     /// - [`Self::set_time_seconds`]
     /// - [`Self::set_time_nanos`]
     /// - [`Self::disable_timeline`]
-    /// - [`Self::disable_timeline_specific`]
     pub fn reset_time(&self) {
         let Some(this) = &*self.inner else {
             re_log::warn_once!("Recording disabled - call to reset_time() ignored");

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1563,28 +1563,6 @@ impl RecordingStream {
         ThreadInfo::unset_thread_time(&this.info.store_id, Timeline::new_temporal(timeline));
     }
 
-    /// Clears out the current time of the recording for the specified timeline of a specific
-    /// kind (see [`TimeType`]), for the current calling thread.
-    ///
-    /// For example: `rec.disable_timeline(Timeline::new_sequence("frame"))`.
-    ///
-    /// See also:
-    /// - [`Self::set_timepoint`]
-    /// - [`Self::set_time_sequence`]
-    /// - [`Self::set_time_seconds`]
-    /// - [`Self::set_time_nanos`]
-    /// - [`Self::disable_timeline`]
-    /// - [`Self::reset_time`]
-    #[doc(hidden)]
-    pub fn disable_timeline_specific(&self, timeline: impl Into<Timeline>) {
-        let Some(this) = &*self.inner else {
-            re_log::warn_once!("Recording disabled - call to disable_timeline_specific() ignored");
-            return;
-        };
-
-        ThreadInfo::unset_thread_time(&this.info.store_id, timeline.into());
-    }
-
     /// Clears out the current time of the recording, for the current calling thread.
     ///
     /// Used for all subsequent logging performed from this same thread, until the next call

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -461,7 +461,7 @@ fn rr_recording_stream_set_time_sequence_impl(
     sequence: i64,
 ) -> Result<(), CError> {
     let timeline = timeline_name.as_str("timeline_name")?;
-    recording_stream(stream)?.set_time_sequence(timeline, Some(sequence));
+    recording_stream(stream)?.set_time_sequence(timeline, sequence);
     Ok(())
 }
 
@@ -485,7 +485,7 @@ fn rr_recording_stream_set_time_seconds_impl(
     seconds: f64,
 ) -> Result<(), CError> {
     let timeline = timeline_name.as_str("timeline_name")?;
-    recording_stream(stream)?.set_time_seconds(timeline, Some(seconds));
+    recording_stream(stream)?.set_time_seconds(timeline, seconds);
     Ok(())
 }
 
@@ -509,7 +509,7 @@ fn rr_recording_stream_set_time_nanos_impl(
     nanos: i64,
 ) -> Result<(), CError> {
     let timeline = timeline_name.as_str("timeline_name")?;
-    recording_stream(stream)?.set_time_nanos(timeline, Some(nanos));
+    recording_stream(stream)?.set_time_nanos(timeline, nanos);
     Ok(())
 }
 
@@ -533,7 +533,7 @@ fn rr_recording_stream_disable_timeline_impl(
     timeline_name: CStringView,
 ) -> Result<(), CError> {
     let timeline = timeline_name.as_str("timeline_name")?;
-    recording_stream(stream)?.set_time_sequence(timeline, None);
+    recording_stream(stream)?.disable_timeline(timeline);
     Ok(())
 }
 
@@ -545,6 +545,52 @@ pub extern "C" fn rr_recording_stream_disable_timeline(
     error: *mut CError,
 ) {
     if let Err(err) = rr_recording_stream_disable_timeline_impl(stream, timeline_name) {
+        err.write_error(error);
+    }
+}
+
+#[allow(unsafe_code)]
+#[allow(clippy::result_large_err)]
+fn rr_recording_stream_disable_timeline_sequential_impl(
+    stream: CRecordingStream,
+    timeline_name: CStringView,
+) -> Result<(), CError> {
+    let timeline = timeline_name.as_str("timeline_name")?;
+    recording_stream(stream)?.disable_timeline_specific(re_sdk::Timeline::new_sequence(timeline));
+    Ok(())
+}
+
+#[allow(unsafe_code)]
+#[no_mangle]
+pub extern "C" fn rr_recording_stream_disable_timeline_sequential(
+    stream: CRecordingStream,
+    timeline_name: CStringView,
+    error: *mut CError,
+) {
+    if let Err(err) = rr_recording_stream_disable_timeline_sequential_impl(stream, timeline_name) {
+        err.write_error(error);
+    }
+}
+
+#[allow(unsafe_code)]
+#[allow(clippy::result_large_err)]
+fn rr_recording_stream_disable_timeline_temporal_impl(
+    stream: CRecordingStream,
+    timeline_name: CStringView,
+) -> Result<(), CError> {
+    let timeline = timeline_name.as_str("timeline_name")?;
+    recording_stream(stream)?.disable_timeline_specific(re_sdk::Timeline::new_temporal(timeline));
+    Ok(())
+}
+
+#[allow(unsafe_code)]
+#[no_mangle]
+pub extern "C" fn rr_recording_stream_disable_timeline_temporal(
+    stream: CRecordingStream,
+    timeline_name: CStringView,
+    error: *mut CError,
+) {
+    if let Err(err) = rr_recording_stream_disable_timeline_temporal_impl(stream, timeline_name) {
         err.write_error(error);
     }
 }

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -550,52 +550,6 @@ pub extern "C" fn rr_recording_stream_disable_timeline(
 }
 
 #[allow(unsafe_code)]
-#[allow(clippy::result_large_err)]
-fn rr_recording_stream_disable_timeline_sequential_impl(
-    stream: CRecordingStream,
-    timeline_name: CStringView,
-) -> Result<(), CError> {
-    let timeline = timeline_name.as_str("timeline_name")?;
-    recording_stream(stream)?.disable_timeline_specific(re_sdk::Timeline::new_sequence(timeline));
-    Ok(())
-}
-
-#[allow(unsafe_code)]
-#[no_mangle]
-pub extern "C" fn rr_recording_stream_disable_timeline_sequential(
-    stream: CRecordingStream,
-    timeline_name: CStringView,
-    error: *mut CError,
-) {
-    if let Err(err) = rr_recording_stream_disable_timeline_sequential_impl(stream, timeline_name) {
-        err.write_error(error);
-    }
-}
-
-#[allow(unsafe_code)]
-#[allow(clippy::result_large_err)]
-fn rr_recording_stream_disable_timeline_temporal_impl(
-    stream: CRecordingStream,
-    timeline_name: CStringView,
-) -> Result<(), CError> {
-    let timeline = timeline_name.as_str("timeline_name")?;
-    recording_stream(stream)?.disable_timeline_specific(re_sdk::Timeline::new_temporal(timeline));
-    Ok(())
-}
-
-#[allow(unsafe_code)]
-#[no_mangle]
-pub extern "C" fn rr_recording_stream_disable_timeline_temporal(
-    stream: CRecordingStream,
-    timeline_name: CStringView,
-    error: *mut CError,
-) {
-    if let Err(err) = rr_recording_stream_disable_timeline_temporal_impl(stream, timeline_name) {
-        err.write_error(error);
-    }
-}
-
-#[allow(unsafe_code)]
 #[no_mangle]
 pub extern "C" fn rr_recording_stream_reset_time(stream: CRecordingStream) {
     if let Some(stream) = RECORDING_STREAMS.lock().remove(stream) {

--- a/crates/rerun_c/src/rerun.h
+++ b/crates/rerun_c/src/rerun.h
@@ -345,32 +345,10 @@ extern void rr_recording_stream_set_time_nanos(
 
 /// Stops logging to the specified timeline for subsequent log calls.
 ///
-/// Clears out _both sequential and temporal_ timelines of the specified name.
-/// Refer to `disable_timeline_sequential`/`disable_timeline_temporal` if you need
-/// more fine-grained control.
+/// The timeline is still there, but will not be updated with any new data.
 ///
-/// The timelines are still there, but will not be updated with any new data.
-///
-/// No-op if the timelines don't exist.
+/// No-op if the timeline doesn't exist.
 void rr_recording_stream_disable_timeline(
-    rr_recording_stream stream, rr_string timeline_name, rr_error* error
-);
-
-/// Stops logging to the specified sequential timeline for subsequent log calls.
-///
-/// The timeline is still there, but will not be updated with any new data.
-///
-/// No-op if the timeline doesn't exist.
-void rr_recording_stream_disable_timeline_sequential(
-    rr_recording_stream stream, rr_string timeline_name, rr_error* error
-);
-
-/// Stops logging to the specified temporal timeline for subsequent log calls.
-///
-/// The timeline is still there, but will not be updated with any new data.
-///
-/// No-op if the timeline doesn't exist.
-void rr_recording_stream_disable_timeline_temporal(
     rr_recording_stream stream, rr_string timeline_name, rr_error* error
 );
 

--- a/crates/rerun_c/src/rerun.h
+++ b/crates/rerun_c/src/rerun.h
@@ -345,10 +345,32 @@ extern void rr_recording_stream_set_time_nanos(
 
 /// Stops logging to the specified timeline for subsequent log calls.
 ///
-/// The timeline is still there, but it will not be updated with any new data.
+/// Clears out _both sequential and temporal_ timelines of the specified name.
+/// Refer to `disable_timeline_sequential`/`disable_timeline_temporal` if you need
+/// more fine-grained control.
+///
+/// The timelines are still there, but will not be updated with any new data.
+///
+/// No-op if the timelines don't exist.
+void rr_recording_stream_disable_timeline(
+    rr_recording_stream stream, rr_string timeline_name, rr_error* error
+);
+
+/// Stops logging to the specified sequential timeline for subsequent log calls.
+///
+/// The timeline is still there, but will not be updated with any new data.
 ///
 /// No-op if the timeline doesn't exist.
-void rr_recording_stream_disable_timeline(
+void rr_recording_stream_disable_timeline_sequential(
+    rr_recording_stream stream, rr_string timeline_name, rr_error* error
+);
+
+/// Stops logging to the specified temporal timeline for subsequent log calls.
+///
+/// The timeline is still there, but will not be updated with any new data.
+///
+/// No-op if the timeline doesn't exist.
+void rr_recording_stream_disable_timeline_temporal(
     rr_recording_stream stream, rr_string timeline_name, rr_error* error
 );
 

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -345,32 +345,10 @@ extern void rr_recording_stream_set_time_nanos(
 
 /// Stops logging to the specified timeline for subsequent log calls.
 ///
-/// Clears out _both sequential and temporal_ timelines of the specified name.
-/// Refer to `disable_timeline_sequential`/`disable_timeline_temporal` if you need
-/// more fine-grained control.
+/// The timeline is still there, but will not be updated with any new data.
 ///
-/// The timelines are still there, but will not be updated with any new data.
-///
-/// No-op if the timelines don't exist.
+/// No-op if the timeline doesn't exist.
 void rr_recording_stream_disable_timeline(
-    rr_recording_stream stream, rr_string timeline_name, rr_error* error
-);
-
-/// Stops logging to the specified sequential timeline for subsequent log calls.
-///
-/// The timeline is still there, but will not be updated with any new data.
-///
-/// No-op if the timeline doesn't exist.
-void rr_recording_stream_disable_timeline_sequential(
-    rr_recording_stream stream, rr_string timeline_name, rr_error* error
-);
-
-/// Stops logging to the specified temporal timeline for subsequent log calls.
-///
-/// The timeline is still there, but will not be updated with any new data.
-///
-/// No-op if the timeline doesn't exist.
-void rr_recording_stream_disable_timeline_temporal(
     rr_recording_stream stream, rr_string timeline_name, rr_error* error
 );
 

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -345,10 +345,32 @@ extern void rr_recording_stream_set_time_nanos(
 
 /// Stops logging to the specified timeline for subsequent log calls.
 ///
-/// The timeline is still there, but it will not be updated with any new data.
+/// Clears out _both sequential and temporal_ timelines of the specified name.
+/// Refer to `disable_timeline_sequential`/`disable_timeline_temporal` if you need
+/// more fine-grained control.
+///
+/// The timelines are still there, but will not be updated with any new data.
+///
+/// No-op if the timelines don't exist.
+void rr_recording_stream_disable_timeline(
+    rr_recording_stream stream, rr_string timeline_name, rr_error* error
+);
+
+/// Stops logging to the specified sequential timeline for subsequent log calls.
+///
+/// The timeline is still there, but will not be updated with any new data.
 ///
 /// No-op if the timeline doesn't exist.
-void rr_recording_stream_disable_timeline(
+void rr_recording_stream_disable_timeline_sequential(
+    rr_recording_stream stream, rr_string timeline_name, rr_error* error
+);
+
+/// Stops logging to the specified temporal timeline for subsequent log calls.
+///
+/// The timeline is still there, but will not be updated with any new data.
+///
+/// No-op if the timeline doesn't exist.
+void rr_recording_stream_disable_timeline_temporal(
     rr_recording_stream stream, rr_string timeline_name, rr_error* error
 );
 

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -178,6 +178,18 @@ namespace rerun {
         Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
     }
 
+    void RecordingStream::disable_timeline_sequential(std::string_view timeline_name) const {
+        rr_error status = {};
+        rr_recording_stream_disable_timeline(_id, detail::to_rr_string(timeline_name), &status);
+        Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
+    }
+
+    void RecordingStream::disable_timeline_temporal(std::string_view timeline_name) const {
+        rr_error status = {};
+        rr_recording_stream_disable_timeline(_id, detail::to_rr_string(timeline_name), &status);
+        Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
+    }
+
     void RecordingStream::reset_time() const {
         rr_recording_stream_reset_time(_id);
     }

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -178,18 +178,6 @@ namespace rerun {
         Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
     }
 
-    void RecordingStream::disable_timeline_sequential(std::string_view timeline_name) const {
-        rr_error status = {};
-        rr_recording_stream_disable_timeline(_id, detail::to_rr_string(timeline_name), &status);
-        Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
-    }
-
-    void RecordingStream::disable_timeline_temporal(std::string_view timeline_name) const {
-        rr_error status = {};
-        rr_recording_stream_disable_timeline(_id, detail::to_rr_string(timeline_name), &status);
-        Error(status).handle(); // Too unlikely to fail to make it worth forwarding.
-    }
-
     void RecordingStream::reset_time() const {
         rr_recording_stream_reset_time(_id);
     }

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -176,8 +176,8 @@ namespace rerun {
         ///
         /// For example: `rec.set_time_sequence("frame_nr", frame_nr)`.
         ///
-        /// You can remove a timeline from subsequent log calls again using `rec.remove_timeline`.
-        /// @see set_timepoint, set_time_seconds, set_time_nanos, reset_time, remove_timeline
+        /// You can remove a timeline from subsequent log calls again using `rec.disable_timeline`.
+        /// @see set_timepoint, set_time_seconds, set_time_nanos, reset_time, disable_timeline
         void set_time_sequence(std::string_view timeline_name, int64_t sequence_nr) const;
 
         /// Set the current time of the recording, for the current calling thread.
@@ -187,8 +187,8 @@ namespace rerun {
         ///
         /// For example: `rec.set_time_seconds("sim_time", sim_time_secs)`.
         ///
-        /// You can remove a timeline from subsequent log calls again using `rec.remove_timeline`.
-        /// @see set_timepoint, set_time_sequence, set_time_nanos, reset_time, remove_timeline
+        /// You can remove a timeline from subsequent log calls again using `rec.disable_timeline`.
+        /// @see set_timepoint, set_time_sequence, set_time_nanos, reset_time, disable_timeline
         void set_time_seconds(std::string_view timeline_name, double seconds) const;
 
         /// Set the current time of the recording, for the current calling thread.
@@ -198,18 +198,43 @@ namespace rerun {
         ///
         /// For example: `rec.set_time_nanos("sim_time", sim_time_nanos)`.
         ///
-        /// You can remove a timeline from subsequent log calls again using `rec.remove_timeline`.
-        /// @see set_timepoint, set_time_sequence, set_time_seconds, reset_time, remove_timeline
+        /// You can remove a timeline from subsequent log calls again using `rec.disable_timeline`.
+        /// @see set_timepoint, set_time_sequence, set_time_seconds, reset_time, disable_timeline
         void set_time_nanos(std::string_view timeline_name, int64_t nanos) const;
 
         /// Stops logging to the specified timeline for subsequent log calls.
         ///
-        /// The timeline is still there, but it will not be updated with any new data.
+        /// Clears out _both sequential and temporal_ timelines of the specified name.
+        /// Refer to `disable_timeline_sequential`/`disable_timeline_temporal` if you need
+        /// more fine-grained control.
+        ///
+        /// The timelines are still there, but will not be updated with any new data.
+        ///
+        /// No-op if the timelines don't exist.
+        ///
+        /// @see set_timepoint, set_time_sequence, set_time_seconds, reset_time, disable_timeline_sequential,
+        /// disable_timeline_temporal
+        void disable_timeline(std::string_view timeline_name) const;
+
+        /// Stops logging to the specified sequential timeline for subsequent log calls.
+        ///
+        /// The timeline is still there, but will not be updated with any new data.
         ///
         /// No-op if the timeline doesn't exist.
         ///
-        /// @see set_timepoint, set_time_sequence, set_time_seconds, reset_time, remove_timeline
-        void disable_timeline(std::string_view timeline_name) const;
+        /// @see set_timepoint, set_time_sequence, set_time_seconds, reset_time, disable_timeline,
+        /// disable_timeline_temporal
+        void disable_timeline_sequential(std::string_view timeline_name) const;
+
+        /// Stops logging to the specified temporal timeline for subsequent log calls.
+        ///
+        /// The timeline is still there, but will not be updated with any new data.
+        ///
+        /// No-op if the timeline doesn't exist.
+        ///
+        /// @see set_timepoint, set_time_sequence, set_time_seconds, reset_time, disable_timeline,
+        /// disable_timeline_temporal
+        void disable_timeline_temporal(std::string_view timeline_name) const;
 
         /// Clears out the current time of the recording, for the current calling thread.
         ///
@@ -217,7 +242,7 @@ namespace rerun {
         /// to one of the time setting methods.
         ///
         /// For example: `rec.reset_time()`.
-        /// @see set_timepoint, set_time_sequence, set_time_seconds, set_time_nanos, remove_timeline
+        /// @see set_timepoint, set_time_sequence, set_time_seconds, set_time_nanos, disable_timeline
         void reset_time() const;
 
         // -----------------------------------------------------------------------------------------

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -204,37 +204,13 @@ namespace rerun {
 
         /// Stops logging to the specified timeline for subsequent log calls.
         ///
-        /// Clears out _both sequential and temporal_ timelines of the specified name.
-        /// Refer to `disable_timeline_sequential`/`disable_timeline_temporal` if you need
-        /// more fine-grained control.
+        /// The timeline is still there, but will not be updated with any new data.
         ///
-        /// The timelines are still there, but will not be updated with any new data.
-        ///
-        /// No-op if the timelines don't exist.
+        /// No-op if the timeline doesn't exist.
         ///
         /// @see set_timepoint, set_time_sequence, set_time_seconds, reset_time, disable_timeline_sequential,
         /// disable_timeline_temporal
         void disable_timeline(std::string_view timeline_name) const;
-
-        /// Stops logging to the specified sequential timeline for subsequent log calls.
-        ///
-        /// The timeline is still there, but will not be updated with any new data.
-        ///
-        /// No-op if the timeline doesn't exist.
-        ///
-        /// @see set_timepoint, set_time_sequence, set_time_seconds, reset_time, disable_timeline,
-        /// disable_timeline_temporal
-        void disable_timeline_sequential(std::string_view timeline_name) const;
-
-        /// Stops logging to the specified temporal timeline for subsequent log calls.
-        ///
-        /// The timeline is still there, but will not be updated with any new data.
-        ///
-        /// No-op if the timeline doesn't exist.
-        ///
-        /// @see set_timepoint, set_time_sequence, set_time_seconds, reset_time, disable_timeline,
-        /// disable_timeline_temporal
-        void disable_timeline_temporal(std::string_view timeline_name) const;
 
         /// Clears out the current time of the recording, for the current calling thread.
         ///

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -208,8 +208,7 @@ namespace rerun {
         ///
         /// No-op if the timeline doesn't exist.
         ///
-        /// @see set_timepoint, set_time_sequence, set_time_seconds, reset_time, disable_timeline_sequential,
-        /// disable_timeline_temporal
+        /// @see set_timepoint, set_time_sequence, set_time_seconds, reset_time
         void disable_timeline(std::string_view timeline_name) const;
 
         /// Clears out the current time of the recording, for the current calling thread.

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -68,6 +68,9 @@ __all__ = [
     "components",
     "connect",
     "datatypes",
+    "disable_timeline",
+    "disable_timeline_sequential",
+    "disable_timeline_temporal",
     "disconnect",
     "experimental",
     "get_application_id",
@@ -207,7 +210,15 @@ from .recording_stream import (
 )
 from .script_helpers import script_add_args, script_setup, script_teardown
 from .sinks import connect, disconnect, memory_recording, save, serve, spawn
-from .time import reset_time, set_time_nanos, set_time_seconds, set_time_sequence
+from .time import (
+    disable_timeline,
+    disable_timeline_sequential,
+    disable_timeline_temporal,
+    reset_time,
+    set_time_nanos,
+    set_time_seconds,
+    set_time_sequence,
+)
 
 # Import experimental last
 from . import experimental  # isort: skip
@@ -217,15 +228,15 @@ from . import experimental  # isort: skip
 # UTILITIES
 
 __all__ += [
+    "cleanup_if_forked_child",
     "init",
     "new_recording",
-    "version",
     "rerun_shutdown",
-    "unregister_shutdown",
-    "cleanup_if_forked_child",
-    "shutdown_at_exit",
     "set_strict_mode",
+    "shutdown_at_exit",
     "start_web_viewer_server",
+    "unregister_shutdown",
+    "version",
 ]
 
 
@@ -240,7 +251,15 @@ def _init_recording_stream() -> None:
 
     recording_stream_patch(
         [connect, save, disconnect, memory_recording, serve, spawn]
-        + [set_time_sequence, set_time_seconds, set_time_nanos, reset_time]
+        + [
+            set_time_sequence,
+            set_time_seconds,
+            set_time_nanos,
+            disable_timeline,
+            disable_timeline_temporal,
+            disable_timeline_sequential,
+            reset_time,
+        ]
         + [fn for name, fn in getmembers(sys.modules[__name__], isfunction) if name.startswith("log_")]
     )
 

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -69,8 +69,6 @@ __all__ = [
     "connect",
     "datatypes",
     "disable_timeline",
-    "disable_timeline_sequential",
-    "disable_timeline_temporal",
     "disconnect",
     "experimental",
     "get_application_id",
@@ -212,8 +210,6 @@ from .script_helpers import script_add_args, script_setup, script_teardown
 from .sinks import connect, disconnect, memory_recording, save, serve, spawn
 from .time import (
     disable_timeline,
-    disable_timeline_sequential,
-    disable_timeline_temporal,
     reset_time,
     set_time_nanos,
     set_time_seconds,
@@ -256,8 +252,6 @@ def _init_recording_stream() -> None:
             set_time_seconds,
             set_time_nanos,
             disable_timeline,
-            disable_timeline_temporal,
-            disable_timeline_sequential,
             reset_time,
         ]
         + [fn for name, fn in getmembers(sys.modules[__name__], isfunction) if name.startswith("log_")]

--- a/rerun_py/rerun_sdk/rerun/time.py
+++ b/rerun_py/rerun_sdk/rerun/time.py
@@ -7,7 +7,7 @@ from rerun.recording_stream import RecordingStream
 # --- Time ---
 
 
-def set_time_sequence(timeline: str, sequence: int | None, recording: RecordingStream | None = None) -> None:
+def set_time_sequence(timeline: str, sequence: int, recording: RecordingStream | None = None) -> None:
     """
     Set the current time for this thread as an integer sequence.
 
@@ -16,7 +16,7 @@ def set_time_sequence(timeline: str, sequence: int | None, recording: RecordingS
 
     For example: `set_time_sequence("frame_nr", frame_nr)`.
 
-    You can remove a timeline again using `set_time_sequence("frame_nr", None)`.
+    You can remove a timeline again using `disable_timeline("frame_nr")`.
 
     There is no requirement of monotonicity. You can move the time backwards if you like.
 
@@ -36,7 +36,7 @@ def set_time_sequence(timeline: str, sequence: int | None, recording: RecordingS
     bindings.set_time_sequence(timeline, sequence, recording=recording)
 
 
-def set_time_seconds(timeline: str, seconds: float | None, recording: RecordingStream | None = None) -> None:
+def set_time_seconds(timeline: str, seconds: float, recording: RecordingStream | None = None) -> None:
     """
     Set the current time for this thread in seconds.
 
@@ -45,7 +45,7 @@ def set_time_seconds(timeline: str, seconds: float | None, recording: RecordingS
 
     For example: `set_time_seconds("capture_time", seconds_since_unix_epoch)`.
 
-    You can remove a timeline again using `set_time_seconds("capture_time", None)`.
+    You can remove a timeline again using `disable_timeline("capture_time")`.
 
     Very large values will automatically be interpreted as seconds since unix epoch (1970-01-01).
     Small values (less than a few years) will be interpreted as relative
@@ -73,7 +73,7 @@ def set_time_seconds(timeline: str, seconds: float | None, recording: RecordingS
     bindings.set_time_seconds(timeline, seconds, recording=recording)
 
 
-def set_time_nanos(timeline: str, nanos: int | None, recording: RecordingStream | None = None) -> None:
+def set_time_nanos(timeline: str, nanos: int, recording: RecordingStream | None = None) -> None:
     """
     Set the current time for this thread.
 
@@ -82,7 +82,7 @@ def set_time_nanos(timeline: str, nanos: int | None, recording: RecordingStream 
 
     For example: `set_time_nanos("capture_time", nanos_since_unix_epoch)`.
 
-    You can remove a timeline again using `set_time_nanos("capture_time", None)`.
+    You can remove a timeline again using `disable_timeline("capture_time")`.
 
     Very large values will automatically be interpreted as nanoseconds since unix epoch (1970-01-01).
     Small values (less than a few years) will be interpreted as relative
@@ -111,11 +111,75 @@ def set_time_nanos(timeline: str, nanos: int | None, recording: RecordingStream 
     bindings.set_time_nanos(timeline, nanos, recording=recording)
 
 
+def disable_timeline(timeline: str, recording: RecordingStream | None = None) -> None:
+    """
+    Clear time information for the specified timeline on this thread.
+
+    This will clear out _both sequential and temporal_ timelines of the specified name.
+    Refer to [`disable_timeline_sequential`][]/[`disable_timeline_temporal`][] if you need
+    more fine-grained control.
+
+    Parameters
+    ----------
+    timeline : str
+        The name of the timeline to clear the time for.
+    recording:
+        Specifies the [`rerun.RecordingStream`][] to use.
+        If left unspecified, defaults to the current active data recording, if there is one.
+        See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
+
+    """
+
+    recording = RecordingStream.to_native(recording)
+
+    bindings.disable_timeline(timeline, recording=recording)
+
+
+def disable_timeline_sequential(timeline: str, recording: RecordingStream | None = None) -> None:
+    """
+    Clear time information for the specified sequential timeline on this thread.
+
+    Parameters
+    ----------
+    timeline : str
+        The name of the timeline to clear the time for.
+    recording:
+        Specifies the [`rerun.RecordingStream`][] to use.
+        If left unspecified, defaults to the current active data recording, if there is one.
+        See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
+
+    """
+
+    recording = RecordingStream.to_native(recording)
+
+    bindings.disable_timeline_sequential(timeline, recording=recording)
+
+
+def disable_timeline_temporal(timeline: str, recording: RecordingStream | None = None) -> None:
+    """
+    Clear time information for the specified temporal timeline on this thread.
+
+    Parameters
+    ----------
+    timeline : str
+        The name of the timeline to clear the time for.
+    recording:
+        Specifies the [`rerun.RecordingStream`][] to use.
+        If left unspecified, defaults to the current active data recording, if there is one.
+        See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
+
+    """
+
+    recording = RecordingStream.to_native(recording)
+
+    bindings.disable_timeline_temporal(timeline, recording=recording)
+
+
 def reset_time(recording: RecordingStream | None = None) -> None:
     """
     Clear all timeline information on this thread.
 
-    This is the same as calling `set_time_*` with `None` for all of the active timelines.
+    This is the same as calling `disable_timeline` for all of the active timelines.
 
     Used for all subsequent logging on the same thread,
     until the next call to [`rerun.set_time_nanos`][] or [`rerun.set_time_seconds`][].

--- a/rerun_py/rerun_sdk/rerun/time.py
+++ b/rerun_py/rerun_sdk/rerun/time.py
@@ -115,10 +115,6 @@ def disable_timeline(timeline: str, recording: RecordingStream | None = None) ->
     """
     Clear time information for the specified timeline on this thread.
 
-    This will clear out _both sequential and temporal_ timelines of the specified name.
-    Refer to [`disable_timeline_sequential`][]/[`disable_timeline_temporal`][] if you need
-    more fine-grained control.
-
     Parameters
     ----------
     timeline : str
@@ -133,46 +129,6 @@ def disable_timeline(timeline: str, recording: RecordingStream | None = None) ->
     recording = RecordingStream.to_native(recording)
 
     bindings.disable_timeline(timeline, recording=recording)
-
-
-def disable_timeline_sequential(timeline: str, recording: RecordingStream | None = None) -> None:
-    """
-    Clear time information for the specified sequential timeline on this thread.
-
-    Parameters
-    ----------
-    timeline : str
-        The name of the timeline to clear the time for.
-    recording:
-        Specifies the [`rerun.RecordingStream`][] to use.
-        If left unspecified, defaults to the current active data recording, if there is one.
-        See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
-
-    """
-
-    recording = RecordingStream.to_native(recording)
-
-    bindings.disable_timeline_sequential(timeline, recording=recording)
-
-
-def disable_timeline_temporal(timeline: str, recording: RecordingStream | None = None) -> None:
-    """
-    Clear time information for the specified temporal timeline on this thread.
-
-    Parameters
-    ----------
-    timeline : str
-        The name of the timeline to clear the time for.
-    recording:
-        Specifies the [`rerun.RecordingStream`][] to use.
-        If left unspecified, defaults to the current active data recording, if there is one.
-        See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
-
-    """
-
-    recording = RecordingStream.to_native(recording)
-
-    bindings.disable_timeline_temporal(timeline, recording=recording)
 
 
 def reset_time(recording: RecordingStream | None = None) -> None:

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -140,6 +140,9 @@ fn rerun_bindings(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(set_time_sequence, m)?)?;
     m.add_function(wrap_pyfunction!(set_time_seconds, m)?)?;
     m.add_function(wrap_pyfunction!(set_time_nanos, m)?)?;
+    m.add_function(wrap_pyfunction!(disable_timeline, m)?)?;
+    m.add_function(wrap_pyfunction!(disable_timeline_sequential, m)?)?;
+    m.add_function(wrap_pyfunction!(disable_timeline_temporal, m)?)?;
     m.add_function(wrap_pyfunction!(reset_time, m)?)?;
 
     // log any
@@ -669,7 +672,7 @@ fn flush(py: Python<'_>, blocking: bool, recording: Option<&PyRecordingStream>) 
 // --- Time ---
 
 #[pyfunction]
-fn set_time_sequence(timeline: &str, sequence: Option<i64>, recording: Option<&PyRecordingStream>) {
+fn set_time_sequence(timeline: &str, sequence: i64, recording: Option<&PyRecordingStream>) {
     let Some(recording) = get_data_recording(recording) else {
         return;
     };
@@ -677,7 +680,7 @@ fn set_time_sequence(timeline: &str, sequence: Option<i64>, recording: Option<&P
 }
 
 #[pyfunction]
-fn set_time_seconds(timeline: &str, seconds: Option<f64>, recording: Option<&PyRecordingStream>) {
+fn set_time_seconds(timeline: &str, seconds: f64, recording: Option<&PyRecordingStream>) {
     let Some(recording) = get_data_recording(recording) else {
         return;
     };
@@ -685,11 +688,33 @@ fn set_time_seconds(timeline: &str, seconds: Option<f64>, recording: Option<&PyR
 }
 
 #[pyfunction]
-fn set_time_nanos(timeline: &str, nanos: Option<i64>, recording: Option<&PyRecordingStream>) {
+fn set_time_nanos(timeline: &str, nanos: i64, recording: Option<&PyRecordingStream>) {
     let Some(recording) = get_data_recording(recording) else {
         return;
     };
     recording.set_time_nanos(timeline, nanos);
+}
+
+#[pyfunction]
+fn disable_timeline(timeline: &str, recording: Option<&PyRecordingStream>) {
+    disable_timeline_temporal(timeline, recording);
+    disable_timeline_sequential(timeline, recording);
+}
+
+#[pyfunction]
+fn disable_timeline_sequential(timeline: &str, recording: Option<&PyRecordingStream>) {
+    let Some(recording) = get_data_recording(recording) else {
+        return;
+    };
+    recording.disable_timeline_specific(re_log_types::Timeline::new_sequence(timeline));
+}
+
+#[pyfunction]
+fn disable_timeline_temporal(timeline: &str, recording: Option<&PyRecordingStream>) {
+    let Some(recording) = get_data_recording(recording) else {
+        return;
+    };
+    recording.disable_timeline_specific(re_log_types::Timeline::new_temporal(timeline));
 }
 
 #[pyfunction]

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -698,8 +698,7 @@ fn disable_timeline(timeline: &str, recording: Option<&PyRecordingStream>) {
     let Some(recording) = get_data_recording(recording) else {
         return;
     };
-    recording.disable_timeline_specific(re_log_types::Timeline::new_sequence(timeline));
-    recording.disable_timeline_specific(re_log_types::Timeline::new_temporal(timeline));
+    recording.disable_timeline(timeline);
 }
 
 #[pyfunction]

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -141,8 +141,6 @@ fn rerun_bindings(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(set_time_seconds, m)?)?;
     m.add_function(wrap_pyfunction!(set_time_nanos, m)?)?;
     m.add_function(wrap_pyfunction!(disable_timeline, m)?)?;
-    m.add_function(wrap_pyfunction!(disable_timeline_sequential, m)?)?;
-    m.add_function(wrap_pyfunction!(disable_timeline_temporal, m)?)?;
     m.add_function(wrap_pyfunction!(reset_time, m)?)?;
 
     // log any
@@ -697,23 +695,10 @@ fn set_time_nanos(timeline: &str, nanos: i64, recording: Option<&PyRecordingStre
 
 #[pyfunction]
 fn disable_timeline(timeline: &str, recording: Option<&PyRecordingStream>) {
-    disable_timeline_temporal(timeline, recording);
-    disable_timeline_sequential(timeline, recording);
-}
-
-#[pyfunction]
-fn disable_timeline_sequential(timeline: &str, recording: Option<&PyRecordingStream>) {
     let Some(recording) = get_data_recording(recording) else {
         return;
     };
     recording.disable_timeline_specific(re_log_types::Timeline::new_sequence(timeline));
-}
-
-#[pyfunction]
-fn disable_timeline_temporal(timeline: &str, recording: Option<&PyRecordingStream>) {
-    let Some(recording) = get_data_recording(recording) else {
-        return;
-    };
     recording.disable_timeline_specific(re_log_types::Timeline::new_temporal(timeline));
 }
 

--- a/tests/rust/test_api/src/main.rs
+++ b/tests/rust/test_api/src/main.rs
@@ -495,7 +495,7 @@ fn test_transforms_3d(rec: &RecordingStream) -> anyhow::Result<()> {
     for i in 0..6 * 120 {
         let time = i as f32 / 120.0;
 
-        rec.set_time_seconds("sim_time", Some(time as f64));
+        rec.set_time_seconds("sim_time", time as f64);
 
         rec.log(
             "transforms3d/sun/planet",


### PR DESCRIPTION
Also fix a bug in the C/C++ SDKs where only sequential timelines would be disabled.

- Fixes https://github.com/rerun-io/rerun/issues/3845

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4068) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4068)
- [Docs preview](https://rerun.io/preview/2d34b1ce0d5c9ae9169350903fb65f490f5c68c7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2d34b1ce0d5c9ae9169350903fb65f490f5c68c7/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)