### PR TITLE
Add example of integrating C++ with Loguru

### DIFF
--- a/docs/code-examples/CMakeLists.txt
+++ b/docs/code-examples/CMakeLists.txt
@@ -24,3 +24,6 @@ foreach(SOURCE_PATH ${sources_list})
 
     add_dependencies(doc_examples ${EXAMPLE_TARGET})
 endforeach()
+
+# `text_log_integration` uses `loguru` as the example text logging library.
+target_link_libraries(text_log_integration PRIVATE rerun_sdk loguru::loguru)

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -26,7 +26,6 @@ opt_out_run = {
     "image_advanced": ["cpp", "rust"], # Missing examples
     "log_line": ["cpp", "rust", "py"], # Not a complete example -- just a single log line
     "quick_start_spawn": ["cpp"], # TODO(#3870): Not yet implemented in C++
-    "text_log_integration": ["cpp"], # TODO(#2919): Not yet implemented in C++
     "timelines_example": ["py", "cpp", "rust"], # TODO(ab): incomplete code, need hideable stubs, see https://github.com/rerun-io/landing/issues/515
 
     # This is this script, it's not an example.

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -311,7 +311,7 @@ def cmake_build(target: str, release: bool) -> None:
 
 
 def run_comparison(rrd0_path: str, rrd1_path: str, full_dump: bool) -> None:
-    cmd = ["just", "rerun", "compare"]
+    cmd = ["rerun", "compare"]
     if full_dump:
         cmd += ["--full-dump"]
     cmd += [rrd0_path, rrd1_path]

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -311,7 +311,7 @@ def cmake_build(target: str, release: bool) -> None:
 
 
 def run_comparison(rrd0_path: str, rrd1_path: str, full_dump: bool) -> None:
-    cmd = ["rerun", "compare"]
+    cmd = ["just", "rerun", "compare"]
     if full_dump:
         cmd += ["--full-dump"]
     cmd += [rrd0_path, rrd1_path]

--- a/docs/code-examples/text_log_integration.cpp
+++ b/docs/code-examples/text_log_integration.cpp
@@ -1,0 +1,54 @@
+/// Shows integration of Rerun's `TextLog` with the C++ Loguru logging library
+/// (https://github.com/emilk/loguru).
+
+#include <loguru.hpp>
+#include <rerun.hpp>
+
+void loguru_to_rerun(void* user_data, const loguru::Message& message) {
+    // NOTE: `rerun::RecordingStream` is thread-safe.
+    const rerun::RecordingStream* rec = reinterpret_cast<const rerun::RecordingStream*>(user_data);
+
+    rerun::TextLogLevel level;
+    if (message.verbosity == loguru::Verbosity_FATAL) {
+        level = rerun::TextLogLevel::CRITICAL;
+    } else if (message.verbosity == loguru::Verbosity_ERROR) {
+        level = rerun::TextLogLevel::ERROR;
+    } else if (message.verbosity == loguru::Verbosity_WARNING) {
+        level = rerun::TextLogLevel::WARN;
+    } else if (message.verbosity == loguru::Verbosity_INFO) {
+        level = rerun::TextLogLevel::INFO;
+    } else if (message.verbosity == loguru::Verbosity_1) {
+        level = rerun::TextLogLevel::DEBUG;
+    } else if (message.verbosity == loguru::Verbosity_2) {
+        level = rerun::TextLogLevel::TRACE;
+    } else {
+        level = rerun::TextLogLevel(std::to_string(message.verbosity));
+    }
+
+    rec->log(
+        "logs/handler/text_log_integration",
+        rerun::TextLog(message.message).with_level(level)
+    );
+}
+
+int main() {
+    const auto rec = rerun::RecordingStream("rerun_example_text_log_integration");
+    rec.spawn().throw_on_failure();
+
+    // Log a text entry directly:
+    rec.log(
+        "logs",
+        rerun::TextLog("this entry has loglevel TRACE").with_level(rerun::TextLogLevel::TRACE)
+    );
+
+    loguru::add_callback(
+        "rerun",
+        loguru_to_rerun,
+        const_cast<void*>(reinterpret_cast<const void*>(&rec)),
+        loguru::Verbosity_INFO
+    );
+
+    LOG_F(INFO, "This INFO log got added through the standard logging interface");
+
+    loguru::remove_callback("rerun"); // we need to do this before `rec` goes out of scope
+}

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -20,6 +20,43 @@
 namespace rerun {
     namespace archetypes {
         /// **Archetype**: A log entry in a text log, comprised of a text body and its log level.
+        ///
+        /// ## Example
+        ///
+        /// ### `text_log_integration`:
+        /// ```cpp,ignore
+        /// #include <loguru.hpp>
+        /// #include <rerun.hpp>
+        ///
+        /// void loguru_to_rerun(void* user_data, const loguru::Message& message) {
+        ///     // NOTE: `rerun::RecordingStream` is thread-safe.
+        ///     const rerun::RecordingStream* rec = reinterpret_cast<const rerun::RecordingStream*>(user_data);
+        ///
+        ///     rec->log("loguru", rerun::TextLog(message.message));
+        /// }
+        ///
+        /// int main() {
+        ///     const auto rec = rerun::RecordingStream("rerun_example_text_log");
+        ///     rec.spawn().throw_on_failure();
+        ///
+        ///     // Log a text entry directly:
+        ///     rec.log(
+        ///         "log",
+        ///         rerun::TextLog("this entry has loglevel TRACE").with_level(rerun::TextLogLevel::TRACE)
+        ///     );
+        ///
+        ///     loguru::add_callback(
+        ///         "rerun",
+        ///         loguru_to_rerun,
+        ///         const_cast<void*>(reinterpret_cast<const void*>(&rec)),
+        ///         loguru::Verbosity_INFO
+        ///     );
+        ///
+        ///     LOG_F(INFO, "This INFO log got added through the standard logging interface");
+        ///
+        ///     loguru::remove_callback("rerun"); // we need to do this before `rec` goes out of scope
+        /// }
+        /// ```
         struct TextLog {
             /// The body of the message.
             rerun::components::Text text;

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -32,16 +32,36 @@ namespace rerun {
         ///     // NOTE: `rerun::RecordingStream` is thread-safe.
         ///     const rerun::RecordingStream* rec = reinterpret_cast<const rerun::RecordingStream*>(user_data);
         ///
-        ///     rec->log("loguru", rerun::TextLog(message.message));
+        ///     rerun::TextLogLevel level;
+        ///     if (message.verbosity == loguru::Verbosity_FATAL) {
+        ///         level = rerun::TextLogLevel::CRITICAL;
+        ///     } else if (message.verbosity == loguru::Verbosity_ERROR) {
+        ///         level = rerun::TextLogLevel::ERROR;
+        ///     } else if (message.verbosity == loguru::Verbosity_WARNING) {
+        ///         level = rerun::TextLogLevel::WARN;
+        ///     } else if (message.verbosity == loguru::Verbosity_INFO) {
+        ///         level = rerun::TextLogLevel::INFO;
+        ///     } else if (message.verbosity == loguru::Verbosity_1) {
+        ///         level = rerun::TextLogLevel::DEBUG;
+        ///     } else if (message.verbosity == loguru::Verbosity_2) {
+        ///         level = rerun::TextLogLevel::TRACE;
+        ///     } else {
+        ///         level = rerun::TextLogLevel(std::to_string(message.verbosity));
+        ///     }
+        ///
+        ///     rec->log(
+        ///         "logs/handler/text_log_integration",
+        ///         rerun::TextLog(message.message).with_level(level)
+        ///     );
         /// }
         ///
         /// int main() {
-        ///     const auto rec = rerun::RecordingStream("rerun_example_text_log");
+        ///     const auto rec = rerun::RecordingStream("rerun_example_text_log_integration");
         ///     rec.spawn().throw_on_failure();
         ///
         ///     // Log a text entry directly:
         ///     rec.log(
-        ///         "log",
+        ///         "logs",
         ///         rerun::TextLog("this entry has loglevel TRACE").with_level(rerun::TextLogLevel::TRACE)
         ///     );
         ///

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -252,7 +252,7 @@ def cmake_build(target: str, release: bool) -> None:
 
 
 def run_comparison(rrd0_path: str, rrd1_path: str, full_dump: bool) -> None:
-    cmd = ["just", "rerun", "compare"]
+    cmd = ["rerun", "compare"]
     if full_dump:
         cmd += ["--full-dump"]
     cmd += [rrd0_path, rrd1_path]

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -252,7 +252,7 @@ def cmake_build(target: str, release: bool) -> None:
 
 
 def run_comparison(rrd0_path: str, rrd1_path: str, full_dump: bool) -> None:
-    cmd = ["rerun", "compare"]
+    cmd = ["just", "rerun", "compare"]
     if full_dump:
         cmd += ["--full-dump"]
     cmd += [rrd0_path, rrd1_path]


### PR DESCRIPTION
### What
This adds a C++ example of integrating Rerun with a randomly chosen (😉 ) C++ logging library

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4070) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4070)
- [Docs preview](https://rerun.io/preview/d148024d77d54efe1d8b45c05e3724bd9d8e3dcb/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d148024d77d54efe1d8b45c05e3724bd9d8e3dcb/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)