### PR TITLE
Spelling: "adaptor" -> "adapter"

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -16,6 +16,10 @@ ND = "ND"       # np.NDArray
 somes = "somes" # many `Some`
 teh = "teh"     # part of @teh-cmc
 
+# Use the more common spelling
+adaptor = "adapter"
+adaptors = "adapters"
+
 # For consistency we prefer American English:
 aeroplane = "airplane"
 analogue = "analog"

--- a/rerun_cpp/src/rerun/component_batch_adapter.hpp
+++ b/rerun_cpp/src/rerun/component_batch_adapter.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 namespace rerun {
-    /// The ComponentBatchAdaptor trait is responsible for mapping an input argument to a
+    /// The `ComponentBatchAdapter` trait is responsible for mapping an input argument to a
     /// ComponentBatch.
     ///
     /// There are default implementations for standard containers of components, as well as single

--- a/rerun_cpp/src/rerun/component_batch_adapter_builtins.hpp
+++ b/rerun_cpp/src/rerun/component_batch_adapter_builtins.hpp
@@ -64,7 +64,7 @@ namespace rerun {
         }
     };
 
-    /// Adaptor from a C-Array reference.
+    /// Adapter from a C-Array reference.
     ///
     /// *Attention*: Does *not* take ownership of the data,
     /// you need to ensure that the data outlives the component batch.

--- a/rerun_cpp/tests/component_batch.cpp
+++ b/rerun_cpp/tests/component_batch.cpp
@@ -11,7 +11,7 @@
 
 using namespace rerun::components;
 
-SCENARIO("ComponentBatch creation via common adaptors", TEST_TAG) {
+SCENARIO("ComponentBatch creation via common adapters", TEST_TAG) {
     GIVEN("a vector of components") {
         std::vector<Position2D> components = {
             Position2D(0.0f, 1.0f),


### PR DESCRIPTION
Based on comments on https://github.com/rerun-io/landing/pull/506

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4072) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4072)
- [Docs preview](https://rerun.io/preview/96dee835635ef343566429694032d96674984967/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/96dee835635ef343566429694032d96674984967/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)