### PR TITLE
Remove `pip` slowness warning when `spawn`ing

### DIFF
--- a/crates/re_sdk/src/spawn.rs
+++ b/crates/re_sdk/src/spawn.rs
@@ -137,7 +137,7 @@ pub fn spawn(opts: &SpawnOptions) -> Result<(), SpawnError> {
     You can install binary releases of the Rerun Viewer:
     * Using `cargo`: `cargo binstall rerun-cli` (see https://github.com/cargo-bins/cargo-binstall)
     * Via direct download from our release assets: https://github.com/rerun-io/rerun/releases/latest/
-    * Using `pip`: `pip3 install rerun-sdk` (warning: pip version has slower start times!)
+    * Using `pip`: `pip3 install rerun-sdk`
 
     For more information, refer to our complete install documentation over at:
     https://rerun.io/docs/getting-started/installing-viewer
@@ -148,7 +148,7 @@ pub fn spawn(opts: &SpawnOptions) -> Result<(), SpawnError> {
     You can install an appropriate version of the Rerun Viewer via binary releases:
     * Using `cargo`: `cargo binstall --force rerun-cli@__VIEWER_VERSION__` (see https://github.com/cargo-bins/cargo-binstall)
     * Via direct download from our release assets: https://github.com/rerun-io/rerun/releases/__VIEWER_VERSION__/
-    * Using `pip`: `pip3 install rerun-sdk==__VIEWER_VERSION__` (warning: pip version has slower start times!)
+    * Using `pip`: `pip3 install rerun-sdk==__VIEWER_VERSION__`
 
     For more information, refer to our complete install documentation over at:
     https://rerun.io/docs/getting-started/installing-viewer


### PR DESCRIPTION
- Slowness was fixed by https://github.com/rerun-io/rerun/pull/4053

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4073) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4073)
- [Docs preview](https://rerun.io/preview/7199492ed9a4765beddd326569584f48c385e1ae/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7199492ed9a4765beddd326569584f48c385e1ae/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)