### PR TITLE
Introduce `exit_on_error` and use this instead of `throw_on_error` everywhere

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -34,7 +34,8 @@ jobs:
           paths: "**/*.c, **/*.cpp, **/*.fbs, **/*.h, **/*.hpp, **/*.js, **/*.md, **/*.py, **/*.rs, **/*.sh, **/*.toml, **/*.txt, **/*.wgsl, **/*.yml"
 
           # Avoid crates.io rate-limiting, skip changelog PR links (so many), and skip speculative links
-          linksToSkip: "https://crates.io/crates/.*, https://github.com/rerun-io/rerun/pull/.*, .*?speculative-link, https://www.rerun.io/docs/getting-started/installing-viewer, https://www.rerun.io/docs/howto/arrow-cpp-install"
+          # https://rerun-io.github.io/rerun/dev/bench/ often 404:s for unknown reasons
+          linksToSkip: "https://crates.io/crates/.*, https://github.com/rerun-io/rerun/pull/.*, .*?speculative-link, https://www.rerun.io/docs/getting-started/installing-viewer, https://www.rerun.io/docs/howto/arrow-cpp-install, https://rerun-io.github.io/rerun/dev/bench/"
           retry: true
           retryErrors: true
           retryErrorsCount: 5

--- a/docs/code-examples/annotation_context_connections.cpp
+++ b/docs/code-examples/annotation_context_connections.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     // Log an annotation context to assign a label and color to each class
     // Create a class description with labels and color for each keypoint ID as well as some

--- a/docs/code-examples/annotation_context_rects.cpp
+++ b/docs/code-examples/annotation_context_rects.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_annotation_context_rects");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     // Log an annotation context to assign a label and color to each class
     rec.log_timeless(

--- a/docs/code-examples/annotation_context_segmentation.cpp
+++ b/docs/code-examples/annotation_context_segmentation.cpp
@@ -7,7 +7,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     // create an annotation context to describe the classes
     rec.log_timeless(

--- a/docs/code-examples/arrow3d_simple.cpp
+++ b/docs/code-examples/arrow3d_simple.cpp
@@ -9,7 +9,7 @@ constexpr float TAU = 6.28318530717958647692528676655900577f;
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_arrow3d");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     std::vector<rerun::Position3D> origins;
     std::vector<rerun::Vector3D> vectors;

--- a/docs/code-examples/asset3d_out_of_tree.cpp
+++ b/docs/code-examples/asset3d_out_of_tree.cpp
@@ -12,7 +12,7 @@ int main(int argc, char** argv) {
     const auto path = argv[1];
 
     const auto rec = rerun::RecordingStream("rerun_example_asset3d_out_of_tree");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
 

--- a/docs/code-examples/asset3d_simple.cpp
+++ b/docs/code-examples/asset3d_simple.cpp
@@ -15,7 +15,7 @@ int main(int argc, char* argv[]) {
     const auto path = argv[1];
 
     const auto rec = rerun::RecordingStream("rerun_example_asset3d_simple");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
     rec.log("world/asset", rerun::Asset3D::from_file(path).value_or_throw());

--- a/docs/code-examples/bar_chart.cpp
+++ b/docs/code-examples/bar_chart.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_bar_chart");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rec.log("bar_chart", rerun::BarChart::i64({8, 4, 0, 9, 1, 4, 1, 6, 9, 0}));
 }

--- a/docs/code-examples/box2d_simple.cpp
+++ b/docs/code-examples/box2d_simple.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_box2d");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rec.log("simple", rerun::Boxes2D::from_mins_and_sizes({{-1.f, -1.f}}, {{2.f, 2.f}}));
 

--- a/docs/code-examples/box3d_batch.cpp
+++ b/docs/code-examples/box3d_batch.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_box3d_batch");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rec.log(
         "batch",

--- a/docs/code-examples/box3d_simple.cpp
+++ b/docs/code-examples/box3d_simple.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_box3d_simple");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rec.log("simple", rerun::Boxes3D::from_half_sizes({{2.f, 2.f, 1.0f}}));
 }

--- a/docs/code-examples/clear_recursive.cpp
+++ b/docs/code-examples/clear_recursive.cpp
@@ -9,7 +9,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_clear_recursive");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     std::vector<rerun::Vector3D> vectors = {
         {1.0, 0.0, 0.0},

--- a/docs/code-examples/clear_simple.cpp
+++ b/docs/code-examples/clear_simple.cpp
@@ -9,7 +9,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_clear_simple");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     std::vector<rerun::Vector3D> vectors = {
         {1.0, 0.0, 0.0},

--- a/docs/code-examples/depth_image_3d.cpp
+++ b/docs/code-examples/depth_image_3d.cpp
@@ -7,7 +7,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_depth_image");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     // Create a synthetic depth image.
     const int HEIGHT = 200;

--- a/docs/code-examples/depth_image_simple.cpp
+++ b/docs/code-examples/depth_image_simple.cpp
@@ -7,7 +7,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_depth_image");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     // create a synthetic depth image.
     const int HEIGHT = 200;

--- a/docs/code-examples/disconnected_space.cpp
+++ b/docs/code-examples/disconnected_space.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_disconnected_space");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     // These two points can be projected into the same space..
     rec.log("world/room1/point", rerun::Points3D({{0.0f, 0.0f, 0.0f}}));

--- a/docs/code-examples/image_simple.cpp
+++ b/docs/code-examples/image_simple.cpp
@@ -6,7 +6,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_image_simple");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     // Create a synthetic image.
     const int HEIGHT = 200;

--- a/docs/code-examples/line_segments2d_simple.cpp
+++ b/docs/code-examples/line_segments2d_simple.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_line_segments2d");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     std::vector<std::vector<std::array<float, 2>>> points = {
         {{0.f, 0.f}, {2.f, 1.f}},

--- a/docs/code-examples/line_segments3d_simple.cpp
+++ b/docs/code-examples/line_segments3d_simple.cpp
@@ -7,7 +7,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_line_segments3d");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     std::vector<std::vector<std::array<float, 3>>> points = {
         {{0.f, 0.f, 0.f}, {0.f, 0.f, 1.f}},

--- a/docs/code-examples/line_strip2d_batch.cpp
+++ b/docs/code-examples/line_strip2d_batch.cpp
@@ -6,7 +6,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     std::vector<rerun::Vec2D> strip1 = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}};
     std::vector<rerun::Vec2D> strip2 =

--- a/docs/code-examples/line_strip2d_simple.cpp
+++ b/docs/code-examples/line_strip2d_simple.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     const auto strip = rerun::LineStrip2D({{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}});
     rec.log("strip", rerun::LineStrips2D(strip));

--- a/docs/code-examples/line_strip3d_batch.cpp
+++ b/docs/code-examples/line_strip3d_batch.cpp
@@ -6,7 +6,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     std::vector<rerun::Vec3D> strip1 = {
         {0.f, 0.f, 2.f},

--- a/docs/code-examples/line_strip3d_simple.cpp
+++ b/docs/code-examples/line_strip3d_simple.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rerun::LineStrip3D linestrip({
         {0.f, 0.f, 0.f},

--- a/docs/code-examples/manual_indicator.cpp
+++ b/docs/code-examples/manual_indicator.cpp
@@ -6,7 +6,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_manual_indicator");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     std::vector<rerun::Position3D> positions = {
         {0.0, 0.0, 0.0},

--- a/docs/code-examples/mesh3d_indexed.cpp
+++ b/docs/code-examples/mesh3d_indexed.cpp
@@ -6,7 +6,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_mesh3d_indexed");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     const rerun::Position3D vertex_positions[3] = {
         {0.0f, 1.0f, 0.0f},

--- a/docs/code-examples/mesh3d_partial_updates.cpp
+++ b/docs/code-examples/mesh3d_partial_updates.cpp
@@ -11,7 +11,7 @@ rerun::Position3D mul_pos(float factor, rerun::Position3D vec) {
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_mesh3d_partial_updates");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rerun::Position3D vertex_positions[3] = {
         {0.0f, 0.0f, 0.0f},

--- a/docs/code-examples/mesh3d_simple.cpp
+++ b/docs/code-examples/mesh3d_simple.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_mesh3d_simple");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rerun::Position3D vertex_positions[3] = {
         {0.0f, 0.0f, 0.0f},

--- a/docs/code-examples/pinhole_simple.cpp
+++ b/docs/code-examples/pinhole_simple.cpp
@@ -8,7 +8,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rec.log("world/image", rerun::Pinhole::from_focal_length_and_resolution(3.0f, {3.0f, 3.0f}));
 

--- a/docs/code-examples/point2d_random.cpp
+++ b/docs/code-examples/point2d_random.cpp
@@ -8,7 +8,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_points2d_simple");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     std::default_random_engine gen;
     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);

--- a/docs/code-examples/point2d_simple.cpp
+++ b/docs/code-examples/point2d_simple.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_points2d_simple");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rec.log("points", rerun::Points2D({{0.0f, 0.0f}, {1.0f, 1.0f}}));
 

--- a/docs/code-examples/point3d_random.cpp
+++ b/docs/code-examples/point3d_random.cpp
@@ -8,7 +8,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_points3d_random");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     std::default_random_engine gen;
     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);

--- a/docs/code-examples/point3d_simple.cpp
+++ b/docs/code-examples/point3d_simple.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_points3d_simple");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rec.log("points", rerun::Points3D({{0.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 1.0f}}));
 }

--- a/docs/code-examples/quick_start_connect.cpp
+++ b/docs/code-examples/quick_start_connect.cpp
@@ -6,7 +6,7 @@ using namespace rerun::demo;
 int main() {
     // Create a new `RecordingStream` which sends data over TCP to the viewer process.
     const auto rec = rerun::RecordingStream("rerun_example_demo");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     // Create some data using the `grid` utility function.
     auto points = grid<rerun::Position3D, float>({-10.f, -10.f, -10.f}, {10.f, 10.f, 10.f}, 10);

--- a/docs/code-examples/scalar_multiple_plots.cpp
+++ b/docs/code-examples/scalar_multiple_plots.cpp
@@ -8,7 +8,7 @@ constexpr float TAU = 6.28318530717958647692528676655900577f;
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_points3d_simple");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     int64_t lcg_state = 0;
 

--- a/docs/code-examples/scalar_simple.cpp
+++ b/docs/code-examples/scalar_simple.cpp
@@ -6,7 +6,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_scalar");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     for (int step = 0; step < 64; ++step) {
         rec.set_time_sequence("step", step);

--- a/docs/code-examples/segmentation_image_simple.cpp
+++ b/docs/code-examples/segmentation_image_simple.cpp
@@ -7,7 +7,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     // Create a segmentation image
     const int HEIGHT = 8;

--- a/docs/code-examples/tensor_simple.cpp
+++ b/docs/code-examples/tensor_simple.cpp
@@ -8,7 +8,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_tensor_simple");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     std::default_random_engine gen;
     // On MSVC uint8_t distributions are not supported.

--- a/docs/code-examples/text_document.cpp
+++ b/docs/code-examples/text_document.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_text_document");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rec.log("text_document", rerun::TextDocument("Hello, TextDocument!"));
 

--- a/docs/code-examples/text_log.cpp
+++ b/docs/code-examples/text_log.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_text_log");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rec.log("log", rerun::TextLog("Application started.").with_level(rerun::TextLogLevel::INFO));
 }

--- a/docs/code-examples/text_log_integration.cpp
+++ b/docs/code-examples/text_log_integration.cpp
@@ -33,7 +33,7 @@ void loguru_to_rerun(void* user_data, const loguru::Message& message) {
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_text_log_integration");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     // Log a text entry directly:
     rec.log(

--- a/docs/code-examples/transform3d_simple.cpp
+++ b/docs/code-examples/transform3d_simple.cpp
@@ -6,7 +6,7 @@ constexpr float TAU = 6.28318530717958647692528676655900577f;
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_transform3d");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     auto arrow =
         rerun::Arrows3D::from_vectors({{0.0f, 1.0f, 0.0f}}).with_origins({{0.0f, 0.0f, 0.0f}});

--- a/docs/code-examples/view_coordinates_simple.cpp
+++ b/docs/code-examples/view_coordinates_simple.cpp
@@ -4,7 +4,7 @@
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_view_coordinates");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
     rec.log(

--- a/docs/content/getting-started/cpp.md
+++ b/docs/content/getting-started/cpp.md
@@ -75,7 +75,7 @@ int main() {
     // Create a new `RecordingStream` which sends data over TCP to the viewer process.
     const auto rec = rerun::RecordingStream("rerun_example_cpp");
     // Try to spawn a new viewer instance.
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     // Create some data using the `grid` utility function.
     auto points = grid<rerun::Position3D, float>({-10.f, -10.f, -10.f}, {10.f, 10.f, 10.f}, 10);

--- a/docs/content/getting-started/logging-cpp.md
+++ b/docs/content/getting-started/logging-cpp.md
@@ -14,14 +14,23 @@ This guide aims to go wide instead of deep.
 There are links to other doc pages where you can learn more about specific topics.
 
 At any time, you can checkout the complete code listing for this tutorial [here](https://github.com/rerun-io/rerun/tree/latest/examples/cpp/dna/main.cpp?speculative-link) to better keep track of the overall picture.
-To run the example from the repository, run:
+To build the example from the repository, run:
 
 ```bash
-cd main/examples/cpp/dna
+cd examples/cpp/dna
 cmake -B build
 cmake --build build -j
+```
+
+And then to run it on Linux/Mac:
+```
 ./build/example_dna
 ```
+and windows respectively:
+```
+build\Debug\example_dna.exe
+```
+
 
 ## Prerequisites
 

--- a/docs/content/getting-started/logging-cpp.md
+++ b/docs/content/getting-started/logging-cpp.md
@@ -83,7 +83,7 @@ Add our initial `main` to `main.cpp`:
 ```cpp
 int main() {
     auto rec = rerun::RecordingStream("rerun_example_dna_abacus");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 }
 ```
 

--- a/examples/cpp/clock/main.cpp
+++ b/examples/cpp/clock/main.cpp
@@ -41,7 +41,7 @@ int main() {
     const int num_steps = 10000;
 
     const auto rec = rerun::RecordingStream("rerun_example_clock");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Y_UP);
     rec.log_timeless("world/frame", rerun::Boxes3D::from_half_sizes({{LENGTH_S, LENGTH_S, 1.0f}}));

--- a/examples/cpp/custom_component_adapter/main.cpp
+++ b/examples/cpp/custom_component_adapter/main.cpp
@@ -47,7 +47,7 @@ struct rerun::ComponentBatchAdapter<rerun::Position3D, MyContainer<MyVec3>> {
 int main() {
     // Create a new `RecordingStream` which sends data over TCP to the viewer process.
     const auto rec = rerun::RecordingStream("rerun_example_custom_component_adapter");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     // Construct some data in a custom format.
     MyContainer<MyVec3> points(3);

--- a/examples/cpp/dna/main.cpp
+++ b/examples/cpp/dna/main.cpp
@@ -11,7 +11,7 @@ static constexpr size_t NUM_POINTS = 100;
 
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_dna_abacus");
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     std::vector<rerun::Position3D> points1, points2;
     std::vector<rerun::Color> colors1, colors2;

--- a/examples/cpp/minimal/main.cpp
+++ b/examples/cpp/minimal/main.cpp
@@ -7,7 +7,7 @@ int main() {
     // Create a new `RecordingStream` which sends data over TCP to the viewer process.
     const auto rec = rerun::RecordingStream("rerun_example_cpp");
     // Try to spawn a new viewer instance.
-    rec.spawn().throw_on_failure();
+    rec.spawn().exit_on_failure();
 
     // Create some data using the `grid` utility function.
     auto points = grid<rerun::Position3D, float>({-10.f, -10.f, -10.f}, {10.f, 10.f, 10.f}, 10);

--- a/examples/cpp/spawn_viewer/main.cpp
+++ b/examples/cpp/spawn_viewer/main.cpp
@@ -1,5 +1,5 @@
 #include <rerun.hpp>
 
 int main() {
-    rerun::spawn().throw_on_failure();
+    rerun::spawn().exit_on_failure();
 }

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -34,7 +34,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     // create an annotation context to describe the classes
         ///     rec.log_timeless(

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -38,7 +38,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_arrow3d");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     std::vector<rerun::Position3D> origins;
         ///     std::vector<rerun::Vector3D> vectors;

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -44,7 +44,7 @@ namespace rerun {
         ///     const auto path = argv[1];
         ///
         ///     const auto rec = rerun::RecordingStream("rerun_example_asset3d_simple");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure()
         ///
         ///     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
         ///     rec.log("world/asset", rerun::Asset3D::from_file(path).value_or_throw());

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -44,7 +44,7 @@ namespace rerun {
         ///     const auto path = argv[1];
         ///
         ///     const auto rec = rerun::RecordingStream("rerun_example_asset3d_simple");
-        ///     rec.spawn().exit_on_failure()
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
         ///     rec.log("world/asset", rerun::Asset3D::from_file(path).value_or_throw());

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -28,7 +28,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_bar_chart");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure()
         ///
         ///     rec.log("bar_chart", rerun::BarChart::i64({8, 4, 0, 9, 1, 4, 1, 6, 9, 0}));
         /// }

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -28,7 +28,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_bar_chart");
-        ///     rec.spawn().exit_on_failure()
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     rec.log("bar_chart", rerun::BarChart::i64({8, 4, 0, 9, 1, 4, 1, 6, 9, 0}));
         /// }

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -35,7 +35,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_box2d");
-        ///     rec.spawn().exit_on_failure()
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     rec.log("simple", rerun::Boxes2D::from_mins_and_sizes({{-1.f, -1.f}}, {{2.f, 2.f}}));
         ///

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -35,7 +35,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_box2d");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure()
         ///
         ///     rec.log("simple", rerun::Boxes2D::from_mins_and_sizes({{-1.f, -1.f}}, {{2.f, 2.f}}));
         ///

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -35,7 +35,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_box3d_batch");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     rec.log(
         ///         "batch",

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -30,7 +30,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_clear_simple");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     std::vector<rerun::Vector3D> vectors = {
         ///         {1.0, 0.0, 0.0},

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -36,7 +36,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_depth_image");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     // Create a synthetic depth image.
         ///     const int HEIGHT = 200;

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -30,7 +30,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_disconnected_space");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     // These two points can be projected into the same space..
         ///     rec.log("world/room1/point", rerun::Points3D({{0.0f, 0.0f, 0.0f}}));

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -39,7 +39,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_image_simple");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure()
         ///
         ///     // Create a synthetic image.
         ///     const int HEIGHT = 200;

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -39,7 +39,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_image_simple");
-        ///     rec.spawn().exit_on_failure()
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     // Create a synthetic image.
         ///     const int HEIGHT = 200;

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -35,7 +35,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
-        ///     rec.spawn().exit_on_failure()
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     std::vector<rerun::Vec2D> strip1 = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}};
         ///     std::vector<rerun::Vec2D> strip2 =

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -35,7 +35,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_line_strip2d");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure()
         ///
         ///     std::vector<rerun::Vec2D> strip1 = {{0.f, 0.f}, {2.f, 1.f}, {4.f, -1.f}, {6.f, 0.f}};
         ///     std::vector<rerun::Vec2D> strip2 =

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -34,7 +34,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     std::vector<rerun::Vec3D> strip1 = {
         ///         {0.f, 0.f, 2.f},

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -35,7 +35,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_mesh3d_indexed");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure()
         ///
         ///     const rerun::Position3D vertex_positions[3] = {
         ///         {0.0f, 1.0f, 0.0f},

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -35,7 +35,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_mesh3d_indexed");
-        ///     rec.spawn().exit_on_failure()
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     const rerun::Position3D vertex_positions[3] = {
         ///         {0.0f, 1.0f, 0.0f},

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -33,7 +33,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
-        ///     rec.spawn().exit_on_failure()
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     rec.log("world/image", rerun::Pinhole::from_focal_length_and_resolution(3.0f, {3.0f, 3.0f}));
         ///

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -33,7 +33,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_line_strip3d");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure()
         ///
         ///     rec.log("world/image", rerun::Pinhole::from_focal_length_and_resolution(3.0f, {3.0f, 3.0f}));
         ///

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -38,7 +38,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_points2d_simple");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure()
         ///
         ///     std::default_random_engine gen;
         ///     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -38,7 +38,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_points2d_simple");
-        ///     rec.spawn().exit_on_failure()
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     std::default_random_engine gen;
         ///     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -37,7 +37,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_points3d_random");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     std::default_random_engine gen;
         ///     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -38,7 +38,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure()
         ///
         ///     // Create a segmentation image
         ///     const int HEIGHT = 8;

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -38,7 +38,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_annotation_context_connections");
-        ///     rec.spawn().exit_on_failure()
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     // Create a segmentation image
         ///     const int HEIGHT = 8;

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -32,7 +32,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_tensor_simple");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure()
         ///
         ///     std::default_random_engine gen;
         ///     // On MSVC uint8_t distributions are not supported.

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -32,7 +32,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_tensor_simple");
-        ///     rec.spawn().exit_on_failure()
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     std::default_random_engine gen;
         ///     // On MSVC uint8_t distributions are not supported.

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -30,7 +30,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_text_document");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure()
         ///
         ///     rec.log("text_document", rerun::TextDocument("Hello, TextDocument!"));
         ///

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -30,7 +30,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_text_document");
-        ///     rec.spawn().exit_on_failure()
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     rec.log("text_document", rerun::TextDocument("Hello, TextDocument!"));
         ///

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -57,7 +57,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_text_log_integration");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     // Log a text entry directly:
         ///     rec.log(

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -36,7 +36,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_scalar");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     for (int step = 0; step <64; ++step) {
         ///         rec.set_time_sequence("step", step);

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -27,7 +27,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_transform3d");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     auto arrow =
         ///         rerun::Arrows3D::from_vectors({{0.0f, 1.0f, 0.0f}}).with_origins({{0.0f, 0.0f, 0.0f}});

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -32,7 +32,7 @@ namespace rerun {
         ///
         /// int main() {
         ///     const auto rec = rerun::RecordingStream("rerun_example_view_coordinates");
-        ///     rec.spawn().throw_on_failure();
+        ///     rec.spawn().exit_on_failure();
         ///
         ///     rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
         ///     rec.log(

--- a/rerun_cpp/src/rerun/error.cpp
+++ b/rerun_cpp/src/rerun/error.cpp
@@ -29,12 +29,12 @@ namespace rerun {
 
         if (v == "1" || v == "true" || v == "yes" || v == "on") {
             return true;
-        } else if (v == "0" || v == "false" || v == "no" || v == "off") {
+        } else if (v == "0" || v == "false" || v == "no" || v == "off" || v == "") {
             return false;
         } else {
             fprintf(
                 stderr,
-                "Expected env-var RERUN_STRICT to be 0/1 true/false yes/no on/off, found '%s'",
+                "Expected env-var RERUN_STRICT to be 0/1 true/false yes/no on/off, found '%s'\n",
                 env
             );
             return false;

--- a/rerun_cpp/src/rerun/error.cpp
+++ b/rerun_cpp/src/rerun/error.cpp
@@ -4,7 +4,7 @@
 #include <arrow/status.h>
 
 #include <algorithm> // For std::transform
-#include <cstdlib>   // For getenv
+#include <cstdlib>   // For getenv & std::exit
 #include <string>
 
 namespace rerun {
@@ -110,6 +110,13 @@ namespace rerun {
     void Error::set_log_handler(StatusLogHandler handler, void* userdata) {
         global_log_handler = handler;
         global_log_handler_user_data = userdata;
+    }
+
+    void Error::exit_on_failure() const {
+        if (is_err()) {
+            handle();
+            std::exit(1);
+        }
     }
 
     void Error::handle() const {

--- a/rerun_cpp/src/rerun/error.hpp
+++ b/rerun_cpp/src/rerun/error.hpp
@@ -144,6 +144,9 @@ namespace rerun {
         /// the error will be logged to stderr.
         void handle() const;
 
+        /// Calls the `handle` method and then exits the application with code 1 if the error is not `Ok`.
+        void exit_on_failure() const;
+
 #ifdef __cpp_exceptions
         /// Throws a `std::runtime_error` if the status is not `Ok`.
         void throw_on_failure() const {

--- a/rerun_cpp/tests/archetypes/transform3d.cpp
+++ b/rerun_cpp/tests/archetypes/transform3d.cpp
@@ -18,9 +18,11 @@ SCENARIO(
 
     SECTION("TranslationAndMat3x3") {
 // Do NOT write this as rrd::Mat3x3 as this actually caught an overload resolution  bug.
-#define MATRIX_ILIST                                                 \
-    {                                                                \
-        {1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}, { 7.0f, 8.0f, 9.0f } \
+#define MATRIX_ILIST                              \
+    {                                             \
+        {1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}, { \
+            7.0f, 8.0f, 9.0f                      \
+        }                                         \
     }
 
         rrd::Vec3D columns[3] = MATRIX_ILIST;

--- a/rerun_cpp/tests/archetypes/transform3d.cpp
+++ b/rerun_cpp/tests/archetypes/transform3d.cpp
@@ -18,11 +18,9 @@ SCENARIO(
 
     SECTION("TranslationAndMat3x3") {
 // Do NOT write this as rrd::Mat3x3 as this actually caught an overload resolution  bug.
-#define MATRIX_ILIST                              \
-    {                                             \
-        {1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}, { \
-            7.0f, 8.0f, 9.0f                      \
-        }                                         \
+#define MATRIX_ILIST                                                 \
+    {                                                                \
+        {1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}, { 7.0f, 8.0f, 9.0f } \
     }
 
         rrd::Vec3D columns[3] = MATRIX_ILIST;

--- a/tests/cpp/roundtrips/annotation_context/main.cpp
+++ b/tests/cpp/roundtrips/annotation_context/main.cpp
@@ -3,7 +3,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_annotation_context");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
 
     rec.log(
         "annotation_context",

--- a/tests/cpp/roundtrips/arrows3d/main.cpp
+++ b/tests/cpp/roundtrips/arrows3d/main.cpp
@@ -3,7 +3,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_arrows3d");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
 
     rec.log(
         "arrows3d",

--- a/tests/cpp/roundtrips/boxes2d/main.cpp
+++ b/tests/cpp/roundtrips/boxes2d/main.cpp
@@ -3,7 +3,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_box2d");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
 
     rec.log(
         "boxes2d",

--- a/tests/cpp/roundtrips/boxes3d/main.cpp
+++ b/tests/cpp/roundtrips/boxes3d/main.cpp
@@ -4,7 +4,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_box3d");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
 
     rec.log(
         "boxes3d",

--- a/tests/cpp/roundtrips/depth_image/main.cpp
+++ b/tests/cpp/roundtrips/depth_image/main.cpp
@@ -5,7 +5,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_depth_image");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
 
     auto img = rerun::datatypes::TensorData({2, 3}, std::vector<uint8_t>{0, 1, 2, 3, 4, 5});
 

--- a/tests/cpp/roundtrips/disconnected_space/main.cpp
+++ b/tests/cpp/roundtrips/disconnected_space/main.cpp
@@ -3,7 +3,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_disconnected_space");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
 
     rec.log("disconnected_space", rerun::archetypes::DisconnectedSpace(true));
 }

--- a/tests/cpp/roundtrips/image/main.cpp
+++ b/tests/cpp/roundtrips/image/main.cpp
@@ -28,7 +28,7 @@ rerun::half half_from_float(const float x) {
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_image");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
 
     // h=2 w=3 c=3 image. Red channel = x. Green channel = y. Blue channel = 128.
     {

--- a/tests/cpp/roundtrips/line_strips2d/main.cpp
+++ b/tests/cpp/roundtrips/line_strips2d/main.cpp
@@ -4,7 +4,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_line_strip2d");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
 
     rec.log(
         "line_strips2d",

--- a/tests/cpp/roundtrips/line_strips3d/main.cpp
+++ b/tests/cpp/roundtrips/line_strips3d/main.cpp
@@ -3,7 +3,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_line_strip3d");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
 
     rec.log(
         "line_strips3d",

--- a/tests/cpp/roundtrips/pinhole/main.cpp
+++ b/tests/cpp/roundtrips/pinhole/main.cpp
@@ -3,7 +3,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_pinhole");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
 
     rec.log(
         "pinhole",

--- a/tests/cpp/roundtrips/points2d/main.cpp
+++ b/tests/cpp/roundtrips/points2d/main.cpp
@@ -4,7 +4,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_points2d");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
 
     rec.log(
         "points2d",

--- a/tests/cpp/roundtrips/points3d/main.cpp
+++ b/tests/cpp/roundtrips/points3d/main.cpp
@@ -3,7 +3,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_points3d");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
 
     rec.log(
         "points3d",

--- a/tests/cpp/roundtrips/segmentation_image/main.cpp
+++ b/tests/cpp/roundtrips/segmentation_image/main.cpp
@@ -7,8 +7,8 @@ int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_segmentation_image");
     rec.save(argv[1]).exit_on_failure()
 
-        // 3x2 image. Each pixel is incremented down each row
-        auto img = rerun::datatypes::TensorData({2, 3}, std::vector<uint8_t>{0, 1, 2, 3, 4, 5});
+    // 3x2 image. Each pixel is incremented down each row
+    auto img = rerun::datatypes::TensorData({2, 3}, std::vector<uint8_t>{0, 1, 2, 3, 4, 5});
 
     rec.log("segmentation_image", rerun::archetypes::SegmentationImage(img));
 }

--- a/tests/cpp/roundtrips/segmentation_image/main.cpp
+++ b/tests/cpp/roundtrips/segmentation_image/main.cpp
@@ -5,7 +5,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_segmentation_image");
-    rec.save(argv[1]).exit_on_failure()
+    rec.save(argv[1]).exit_on_failure();
 
     // 3x2 image. Each pixel is incremented down each row
     auto img = rerun::datatypes::TensorData({2, 3}, std::vector<uint8_t>{0, 1, 2, 3, 4, 5});

--- a/tests/cpp/roundtrips/segmentation_image/main.cpp
+++ b/tests/cpp/roundtrips/segmentation_image/main.cpp
@@ -5,10 +5,10 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_segmentation_image");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure()
 
-    // 3x2 image. Each pixel is incremented down each row
-    auto img = rerun::datatypes::TensorData({2, 3}, std::vector<uint8_t>{0, 1, 2, 3, 4, 5});
+        // 3x2 image. Each pixel is incremented down each row
+        auto img = rerun::datatypes::TensorData({2, 3}, std::vector<uint8_t>{0, 1, 2, 3, 4, 5});
 
     rec.log("segmentation_image", rerun::archetypes::SegmentationImage(img));
 }

--- a/tests/cpp/roundtrips/tensor/main.cpp
+++ b/tests/cpp/roundtrips/tensor/main.cpp
@@ -6,7 +6,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_tensor");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
 
     std::vector<rerun::datatypes::TensorDimension> dimensions{{3, 4, 5, 6}};
 

--- a/tests/cpp/roundtrips/text_document/main.cpp
+++ b/tests/cpp/roundtrips/text_document/main.cpp
@@ -2,7 +2,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_text_document");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
     rec.log("text_document", rerun::archetypes::TextDocument("Hello, TextDocument!"));
     rec.log(
         "markdown",

--- a/tests/cpp/roundtrips/text_log/main.cpp
+++ b/tests/cpp/roundtrips/text_log/main.cpp
@@ -2,8 +2,7 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_text_log");
-    rec.save(argv[1]).throw_on_failure();
-    rec.log("log", rerun::archetypes::TextLog("No level"));
+    rec.save(argv[1]).exit_on_failure() rec.log("log", rerun::archetypes::TextLog("No level"));
     rec.log(
         "log",
         rerun::archetypes::TextLog("INFO level").with_level(rerun::components::TextLogLevel::INFO)

--- a/tests/cpp/roundtrips/text_log/main.cpp
+++ b/tests/cpp/roundtrips/text_log/main.cpp
@@ -2,7 +2,8 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_text_log");
-    rec.save(argv[1]).exit_on_failure() rec.log("log", rerun::archetypes::TextLog("No level"));
+    rec.save(argv[1]).exit_on_failure();
+    rec.log("log", rerun::archetypes::TextLog("No level"));
     rec.log(
         "log",
         rerun::archetypes::TextLog("INFO level").with_level(rerun::components::TextLogLevel::INFO)

--- a/tests/cpp/roundtrips/transform3d/main.cpp
+++ b/tests/cpp/roundtrips/transform3d/main.cpp
@@ -7,7 +7,7 @@ constexpr float PI = 3.14159265358979323846264338327950288f;
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_transform3d");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
 
     rec.log(
         "translation_and_mat3x3/identity",

--- a/tests/cpp/roundtrips/view_coordinates/main.cpp
+++ b/tests/cpp/roundtrips/view_coordinates/main.cpp
@@ -2,6 +2,6 @@
 
 int main(int, char** argv) {
     const auto rec = rerun::RecordingStream("rerun_example_roundtrip_view_coordinates");
-    rec.save(argv[1]).throw_on_failure();
+    rec.save(argv[1]).exit_on_failure();
     rec.log_timeless("/", rerun::archetypes::ViewCoordinates::RDF);
 }


### PR DESCRIPTION
### What

Throwing doesn't look great especially on windows debug builds:
![image](https://github.com/rerun-io/rerun/assets/1220815/ec44224e-cc17-4b2b-8054-42a038da5d3a)

Thew new method gives a nice error when you start from command line:
```
 build\Debug\example_dna.exe
Expected env-var RERUN_STRICT to be 0/1 true/false yes/no on/off, found ''Rerun ERROR: Failed to find Rerun Viewer executable in PATH.

    You can install binary releases of the Rerun Viewer:
    * Using `cargo`: `cargo binstall rerun-cli` (see https://github.com/cargo-bins/cargo-binstall)
    * Via direct download from our release assets: https://github.com/rerun-io/rerun/releases/latest/
    * Using `pip`: `pip3 install rerun-sdk` (warning: pip version has slower start times!)

    For more information, refer to our complete install documentation over at:
    https://rerun.io/docs/getting-started/installing-viewer
```



Also fixed typo in the C++ tutorial and added windows specific instructions


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4081) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4081)
- [Docs preview](https://rerun.io/preview/7dcf776f91aae882c88e87fa1d0108bf63704728/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7dcf776f91aae882c88e87fa1d0108bf63704728/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)