### PR TITLE
Plumb through the release commit to the publish_cli jobs

### DIFF
--- a/.github/workflows/manual_publish_cli.yml
+++ b/.github/workflows/manual_publish_cli.yml
@@ -1,0 +1,27 @@
+name: Publish the CLI from a specific commit
+
+on:
+  workflow_dispatch:
+    inputs:
+      RELEASE_VERSION:
+        description: "Release Version Number (Must match Cargo.toml)"
+        type: string
+        required: true
+      RELEASE_COMMIT:
+        description: "Commit to release"
+        type: string
+        required: false
+
+permissions:
+  contents: write
+  id-token: "write"
+
+jobs:
+  publish-rerun-cli:
+    name: "Publish rerun-cli"
+    uses: ./.github/workflows/reusable_publish_rerun_cli.yml
+    with:
+      release-version: ${{ inputs.RELEASE_VERSION }}
+      release-commit: ${{ inputs.RELEASE_COMMIT }}
+      concurrency: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/reusable_publish_rerun_cli.yml
+++ b/.github/workflows/reusable_publish_rerun_cli.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       CONCURRENCY: push-linux-${{ github.ref_name }}
       PLATFORM: linux
+      RELEASE_COMMIT: ${{ inputs.release-commit }}
     secrets: inherit
 
   macos-intel:
@@ -30,6 +31,7 @@ jobs:
     with:
       CONCURRENCY: push-macos-intel-${{ github.ref_name }}
       PLATFORM: macos-intel
+      RELEASE_COMMIT: ${{ inputs.release-commit }}
     secrets: inherit
 
   macos-arm:
@@ -38,6 +40,7 @@ jobs:
     with:
       CONCURRENCY: push-macos-arm-${{ github.ref_name }}
       PLATFORM: macos-arm
+      RELEASE_COMMIT: ${{ inputs.release-commit }}
     secrets: inherit
 
   windows:
@@ -46,5 +49,6 @@ jobs:
     with:
       CONCURRENCY: push-windows-${{ github.ref_name }}
       PLATFORM: windows
+      RELEASE_COMMIT: ${{ inputs.release-commit }}
     secrets: inherit
 


### PR DESCRIPTION
### What

The publish_cli jobs ran off the wrong commit on the 0.10.0 release. This should fix it and also gives us a manual job for doing a 1-off.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
