### PR TITLE
Add prefix to the manual-publish-cli for concurrency

### DIFF
--- a/.github/workflows/manual_publish_cli.yml
+++ b/.github/workflows/manual_publish_cli.yml
@@ -1,4 +1,4 @@
-name: Publish the CLI from a specific commit
+name: Manually publish the CLI from a specific commit
 
 on:
   workflow_dispatch:
@@ -23,5 +23,5 @@ jobs:
     with:
       release-version: ${{ inputs.RELEASE_VERSION }}
       release-commit: ${{ inputs.RELEASE_COMMIT }}
-      concurrency: ${{ github.ref_name }}
+      concurrency: manual-publish-cli-${{ github.ref_name }}
     secrets: inherit


### PR DESCRIPTION
### What
Job was being cancelled commit to main.

New job: https://github.com/rerun-io/rerun/actions/runs/6697460335

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4092) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4092)
- [Docs preview](https://rerun.io/preview/deecec8b9a69c25e1a11c2949965f24d856708bb/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/deecec8b9a69c25e1a11c2949965f24d856708bb/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)