### PR TITLE
Use `macos-latest-large` runners when building wheels and rerun-cli

### DIFF
--- a/.github/workflows/reusable_build_and_test_wheels.yml
+++ b/.github/workflows/reusable_build_and_test_wheels.yml
@@ -83,13 +83,13 @@ jobs:
               container="null"
               ;;
             macos-arm)
-              runner="macos-latest"
+              runner="macos-latest-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="aarch64-apple-darwin"
               run_tests="false"
               container="null"
               ;;
             macos-intel)
-              runner="macos-latest"
+              runner="macos-latest-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="x86_64-apple-darwin"
               run_tests="false"
               container="null"

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -82,13 +82,13 @@ jobs:
               lib_name="rerun_c.lib"
               ;;
             macos-arm)
-              runner="macos-latest"
+              runner="macos-latest" # Small runners, because building rerun_c is fast
               target="aarch64-apple-darwin"
               container="null"
               lib_name="librerun_c.a"
               ;;
             macos-intel)
-              runner="macos-latest"
+              runner="macos-latest" # Small runners, because building rerun_c is fast
               target="x86_64-apple-darwin"
               container="null"
               lib_name="librerun_c.a"

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -83,13 +83,13 @@ jobs:
               bin_name="rerun.exe"
               ;;
             macos-arm)
-              runner="macos-latest"
+              runner="macos-latest-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="aarch64-apple-darwin"
               container="null"
               bin_name="rerun"
               ;;
             macos-intel)
-              runner="macos-latest"
+              runner="macos-latest-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="x86_64-apple-darwin"
               container="null"
               bin_name="rerun"


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/3693

In our latest release, building rerun-cli for mac took 35min on arm and 32min on x64. Windows took 14 min and ubunut 8min.

Building the wheels for mac took 25min on arm and 22min on x64. Windows took 13 min, and ubuntu 7min.

`macos-latest-large` is a 12-core x64 machine.
There is also `macos-latest-xlarge` we can try, which is ARM based.

That's at least if I understand this blog post correctly: https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/

That is the only docs I can find about this, at all.

Note that this currently only affects release builds and `main` builds.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4099) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4099)
- [Docs preview](https://rerun.io/preview/7d385e8d148727934ac4804f014f2799198fc5ae/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7d385e8d148727934ac4804f014f2799198fc5ae/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)