### PR TITLE
Reduce amount of cmake log from building & downloading libArrow

### DIFF
--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -109,13 +109,14 @@ target_link_libraries(rerun_sdk PRIVATE rerun_c)
 
 # -----------------------------------------------------------------------------
 # Arrow:
-if (WIN32)
+if(WIN32)
     # This makes the setup a lot easier on Windows where we otherwise need to put Arrow.dll either in path or copy it with the executable.
     set(RERUN_ARROW_LINK_SHARED_DEFAULT OFF)
 else()
     # On non-windows platforms ld search path settings alleviate this concern and this makes linking faster!
     set(RERUN_ARROW_LINK_SHARED_DEFAULT ON)
 endif()
+
 option(RERUN_ARROW_LINK_SHARED "Link to the Arrow shared library" ${RERUN_ARROW_LINK_SHARED_DEFAULT})
 option(RERUN_DOWNLOAD_AND_BUILD_ARROW "If enabled, arrow will be added as an external project and built with the minimal set required by the Rerun C++ SDK" ON)
 
@@ -165,12 +166,10 @@ if(RERUN_DOWNLOAD_AND_BUILD_ARROW)
         GIT_REPOSITORY https://github.com/apache/arrow.git
         GIT_TAG apache-arrow-10.0.1
         GIT_SHALLOW ON
+        GIT_PROGRESS OFF # Git progress sounds like a nice idea but is in practive very spammy.
 
-        # Git progress sounds like a nice idea but is in practive very spammy.
-        # GIT_PROGRESS ON
-
-        # LOG_X ON means that the output of the command will *not* be printed to the console,
-        # but instead be directed to a file (it logs where the file goes).
+        # LOG_X ON means that the output of the command will
+        # be logged to a file _instead_ of printed to the console.
         LOG_CONFIGURE ON
         LOG_BUILD ON
         LOG_INSTALL ON

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -164,8 +164,17 @@ if(RERUN_DOWNLOAD_AND_BUILD_ARROW)
         PREFIX ${ARROW_DOWNLOAD_PATH}
         GIT_REPOSITORY https://github.com/apache/arrow.git
         GIT_TAG apache-arrow-10.0.1
-        GIT_SHALLOW true
-        GIT_PROGRESS true
+        GIT_SHALLOW ON
+
+        # Git progress sounds like a nice idea but is in practive very spammy.
+        # GIT_PROGRESS ON
+
+        # LOG_X ON means that the output of the command will *not* be printed to the console,
+        # but instead be directed to a file (it logs where the file goes).
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON
+
         CMAKE_ARGS
         --preset ninja-debug-minimal
         -DARROW_IPC=ON
@@ -180,6 +189,7 @@ if(RERUN_DOWNLOAD_AND_BUILD_ARROW)
         -DBOOST_SOURCE=BUNDLED
         -DARROW_BOOST_USE_SHARED=OFF
         -DARROW_CXXFLAGS=${DARROW_CXXFLAGS}
+
         SOURCE_SUBDIR cpp
         BUILD_BYPRODUCTS ${ARROW_LIBRARY_FILE}
     )


### PR DESCRIPTION
### What

Before: _unspeakable amount of log_
Now: (windows):

```
  1>Creating directories for 'arrow_cpp'
  Performing download step (git clone) for 'arrow_cpp'
  Cloning into 'arrow_cpp'...
  HEAD is now at a6eabc2b MINOR: [Release] Update versions for 10.0.1
  Submodule 'cpp/submodules/parquet-testing' (https://github.com/apache/parquet-testing.git) registered for path 'cpp/submodules/parquet-testing'
  Submodule 'testing' (https://github.com/apache/arrow-testing) registered for path 'testing'
  Cloning into 'C:/dev/rerun-io/rerun/build/arrow/src/arrow_cpp/cpp/submodules/parquet-testing'...
  Cloning into 'C:/dev/rerun-io/rerun/build/arrow/src/arrow_cpp/testing'...
  Submodule path 'cpp/submodules/parquet-testing': checked out 'e13af117de7c4f0a4d9908ae3827b3ab119868f3'
  Submodule path 'testing': checked out '00c483283433b4c02cb811f260dbe35414c806a4'
  Building Custom Rule C:/dev/rerun-io/rerun/rerun_cpp/CMakeLists.txt
  Performing update step for 'arrow_cpp'
  No patch step for 'arrow_cpp'
  Performing configure step for 'arrow_cpp'
  -- arrow_cpp configure command succeeded.  See also C:/dev/rerun-io/rerun/build/arrow/src/arrow_cpp-stamp/arrow_cpp-configure-*.log
  Performing build step for 'arrow_cpp'
  -- arrow_cpp build command succeeded.  See also C:/dev/rerun-io/rerun/build/arrow/src/arrow_cpp-stamp/arrow_cpp-build-*.log
  Performing install step for 'arrow_cpp'
  -- arrow_cpp install command succeeded.  See also C:/dev/rerun-io/rerun/build/arrow/src/arrow_cpp-stamp/arrow_cpp-install-*.log
  Completed 'arrow_cpp'
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4103) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4103)
- [Docs preview](https://rerun.io/preview/bbba3dd8c2966ac6c76a9b5806a8cc0649e52871/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bbba3dd8c2966ac6c76a9b5806a8cc0649e52871/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)