### PR TITLE
C++ Windows CI

### DIFF
--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -370,8 +370,8 @@ jobs:
           # Only check c/cpp/h/hpp (default checks also .proto and others)
           include-regex: ^.*\.(c|cpp|h|hpp)$
 
-  cpp-tests:
-    name: C++ tests
+  cpp-tests-linux:
+    name: C++ tests Linux
     runs-on: ubuntu-latest
     container:
       image: rerunio/ci_docker:0.10.0
@@ -412,3 +412,34 @@ jobs:
           pixi run cpp-clean
           RERUN_WERROR=ON RERUN_USE_ASAN=ON CXX=g++ pixi run cpp-build-all
           RERUN_WERROR=ON RERUN_USE_ASAN=ON CXX=g++ pixi run cpp-test
+
+  cpp-tests-windows:
+    name: C++ tests Windows
+    runs-on: windows-latest-8-cores
+    env:
+      RUSTC_WRAPPER: "sccache"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+
+      - uses: prefix-dev/setup-pixi@v0.3.0
+        with:
+          pixi-version: v0.6.0
+          cache: true
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache_key: "build-windows"
+          # Cache will be produced by `reusable_checks/rs-lints`
+          save_cache: false
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+
+      - name: Build and run C++ tests with MSVC
+        shell: bash
+        run: |
+          pixi run cpp-clean
+          RERUN_WERROR=ON pixi run cpp-build-all
+          RERUN_WERROR=ON pixi run cpp-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,14 @@ endif()
 
 function(set_default_warning_settings target)
     if(MSVC)
+        # TODO(andreas): Try to enable /Wall
         target_compile_options(${target} PRIVATE /W4)
+
+        # CMAKE_COMPILE_WARNING_AS_ERROR is only directly supported starting in CMake `3.24`
+        # https://cmake.org/cmake/help/latest/prop_tgt/COMPILE_WARNING_AS_ERROR.html
+        if(CMAKE_COMPILE_WARNING_AS_ERROR)
+            target_compile_options(${target} PRIVATE /WX)
+        endif()
     else()
         # Enabled warnings.
         target_compile_options(${target} PRIVATE

--- a/docs/code-examples/pinhole_simple.cpp
+++ b/docs/code-examples/pinhole_simple.cpp
@@ -13,7 +13,6 @@ int main() {
     rec.log("world/image", rerun::Pinhole::from_focal_length_and_resolution(3.0f, {3.0f, 3.0f}));
 
     std::vector<uint8_t> random_data(3 * 3 * 3);
-    std::generate(random_data.begin(), random_data.end(), std::rand);
     std::generate(random_data.begin(), random_data.end(), [] {
         return static_cast<uint8_t>(std::rand());
     });

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -38,7 +38,6 @@ namespace rerun {
         ///     rec.log("world/image", rerun::Pinhole::from_focal_length_and_resolution(3.0f, {3.0f, 3.0f}));
         ///
         ///     std::vector<uint8_t> random_data(3 * 3 * 3);
-        ///     std::generate(random_data.begin(), random_data.end(), std::rand);
         ///     std::generate(random_data.begin(), random_data.end(), [] {
         ///         return static_cast<uint8_t>(std::rand());
         ///     });


### PR DESCRIPTION
### What

* Fixes #3756
* Run VS2022 C++ tests as part of pull request CI.
    * decided to go pull request for now because it's very easy to break C++ things on one compiler while you're on any of the other compilers 
    * This is a 12min windows job currently which *also* has to build rerun_c for windows first
    * in the future we'd ideally just skip most C++ jobs if no cpp/hpp/h file has changed!
* Enable warnings as errors for msvc

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4110) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4110)
- [Docs preview](https://rerun.io/preview/f5d9cc2f5b6ea8907e82a2bcd7ade265457beb49/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f5d9cc2f5b6ea8907e82a2bcd7ade265457beb49/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)