### PR TITLE
Remove duplicate words that span a newline

### DIFF
--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -42,7 +42,7 @@ trait PythonObjectExt {
     /// Returns `true` if the object is a delegating component.
     ///
     /// Components can either use a native type, or a custom datatype. In the latter case, the
-    /// the component delegates its implementation to the datatype.
+    /// component delegates its implementation to the datatype.
     fn is_delegating_component(&self) -> bool;
 
     /// Returns `true` if the object is a non-delegating component.

--- a/rerun_cpp/src/rerun/config.hpp
+++ b/rerun_cpp/src/rerun/config.hpp
@@ -23,7 +23,7 @@ namespace rerun {
     /// Change whether `RecordingStream`s are enabled by default.
     ///
     /// This governs the creation of new `RecordingStream`s. If `default_enabled` is
-    /// is `false`, `RecordingStreams` will be created in the disabled state. Changing
+    /// `false`, `RecordingStreams` will be created in the disabled state. Changing
     /// the value of `default_enabled` will not affect existing `RecordingStream`s.
     ///
     /// Note that regardless of usage of this API, the value of default_enabled will

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -848,7 +848,7 @@ fn log_arrow_msg(
 
     // It's important that we don't hold the session lock while building our arrow component.
     // the API we call to back through pyarrow temporarily releases the GIL, which can cause
-    // cause a deadlock.
+    // a deadlock.
     let row = crate::arrow::build_data_row_from_components(
         &entity_path,
         components,


### PR DESCRIPTION
### What
Just did this manually with a few regex's, since it would require more significant refactoring
refactoring of `lint.py`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4113) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4113)
- [Docs preview](https://rerun.io/preview/bc1e248bafed762595f51f2c3814d64010c3edec/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bc1e248bafed762595f51f2c3814d64010c3edec/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)