### PR TITLE
Support std::chrono types for `set_time` on `rerun::RecordingStream`

### DIFF
--- a/docs/code-examples/timelines_example.cpp
+++ b/docs/code-examples/timelines_example.cpp
@@ -1,6 +1,6 @@
 for (auto frame : read_sensor_frames()) {
     rec.set_time_sequence("frame_idx", frame.idx);
-    rec.set_time_seconds("sensor_time", frame.timestamp);
+    rec.set_time("sensor_time", frame.timestamp);
 
     rec.log("sensor/points", rerun::Points3D(&frame.points));
 }

--- a/docs/content/getting-started/logging-cpp.md
+++ b/docs/content/getting-started/logging-cpp.md
@@ -77,6 +77,7 @@ Starting our `main.cpp`:
 #include <vector>
 
 using namespace rerun::demo;
+using namespace std::chrono_literals;
 
 static constexpr size_t NUM_POINTS = 100;
 ```
@@ -278,12 +279,12 @@ Let's add our custom timeline.
 Replace the section that logs the beads with a loop that logs the beads at different timestamps:
 ```cpp
 for (int t = 0; t < 400; t++) {
-    float time = static_cast<float>(t) * 0.01f;
+    auto time = std::chrono::duration<float>(t) * 0.01f;
 
-    rec.set_time_seconds("stable_time", time);
+    rec.set_time("stable_time");
 
     for (size_t i = 0; i < lines.size(); ++i) {
-        float time_offset = time + offsets[i];
+        float time_offset = time.count() + offsets[i];
         auto c = static_cast<uint8_t>(bounce_lerp(80.0f, 230.0f, time_offset * 2.0f));
 
         beads_positions[i] = rerun::Position3D(
@@ -357,7 +358,7 @@ for (int t = 0; t < 400; t++) {
         "dna/structure",
         rerun::archetypes::Transform3D(rerun::RotationAxisAngle(
             {0.0f, 0.0f, 1.0f},
-            rerun::Angle::radians(time / 4.0f * TAU)
+            rerun::Angle::radians(time.count() / 4.0f * TAU)
         ))
     );
 }

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -49,6 +49,7 @@
     "camino",
     "Carreira",
     "Chao",
+    "chrono",
     "Clément",
     "clippy",
     "codegen",

--- a/examples/cpp/clock/main.cpp
+++ b/examples/cpp/clock/main.cpp
@@ -4,10 +4,12 @@
 #include <cmath>
 #include <string>
 
+using namespace std::chrono;
+
 constexpr float TAU = 6.28318530717958647692528676655900577f;
 
 void log_hand(
-    const rerun::RecordingStream& rec, const char* name, int step, float angle, float length,
+    const rerun::RecordingStream& rec, const char* name, seconds step, float angle, float length,
     float width, uint8_t blue
 ) {
     const auto tip = rerun::Vec3D{length * sinf(angle * TAU), length * cosf(angle * TAU), 0.0f};
@@ -15,7 +17,7 @@ void log_hand(
     const auto color =
         rerun::Color{static_cast<uint8_t>(255 - c), c, blue, std::max<uint8_t>(128, blue)};
 
-    rec.set_time_seconds("sim_time", step);
+    rec.set_time("sim_time", step);
 
     rec.log(
         std::string("world/") + name + "_pt",
@@ -47,8 +49,8 @@ int main() {
     rec.log_timeless("world/frame", rerun::Boxes3D::from_half_sizes({{LENGTH_S, LENGTH_S, 1.0f}}));
 
     for (int step = 0; step < num_steps; step++) {
-        log_hand(rec, "seconds", step, (step % 60) / 60.0f, LENGTH_S, WIDTH_S, 0);
-        log_hand(rec, "minutes", step, (step % 3600) / 3600.0f, LENGTH_M, WIDTH_M, 128);
-        log_hand(rec, "hours", step, (step % 43200) / 43200.0f, LENGTH_H, WIDTH_H, 255);
+        log_hand(rec, "seconds", seconds(step), (step % 60) / 60.0f, LENGTH_S, WIDTH_S, 0);
+        log_hand(rec, "minutes", seconds(step), (step % 3600) / 3600.0f, LENGTH_M, WIDTH_M, 128);
+        log_hand(rec, "hours", seconds(step), (step % 43200) / 43200.0f, LENGTH_H, WIDTH_H, 255);
     }
 }

--- a/examples/cpp/dna/main.cpp
+++ b/examples/cpp/dna/main.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 using namespace rerun::demo;
+using namespace std::chrono_literals;
 
 static constexpr size_t NUM_POINTS = 100;
 
@@ -18,7 +19,7 @@ int main() {
     color_spiral(NUM_POINTS, 2.0f, 0.02f, 0.0f, 0.1f, points1, colors1);
     color_spiral(NUM_POINTS, 2.0f, 0.02f, TAU * 0.5f, 0.1f, points2, colors2);
 
-    rec.set_time_seconds("stable_time", 0.0f);
+    rec.set_time("stable_time", 0s);
 
     rec.log(
         "dna/structure/left",
@@ -48,12 +49,12 @@ int main() {
     std::vector<rerun::Color> beads_colors(lines.size());
 
     for (int t = 0; t < 400; t++) {
-        float time = static_cast<float>(t) * 0.01f;
+        auto time = std::chrono::duration<float>(t) * 0.01f;
 
-        rec.set_time_seconds("stable_time", time);
+        rec.set_time("stable_time", time);
 
         for (size_t i = 0; i < lines.size(); ++i) {
-            float time_offset = time + offsets[i];
+            float time_offset = time.count() + offsets[i];
             auto c = static_cast<uint8_t>(bounce_lerp(80.0f, 230.0f, time_offset * 2.0f));
 
             beads_positions[i] = rerun::Position3D(
@@ -73,7 +74,7 @@ int main() {
             "dna/structure",
             rerun::archetypes::Transform3D(rerun::RotationAxisAngle(
                 {0.0f, 0.0f, 1.0f},
-                rerun::Angle::radians(time / 4.0f * TAU)
+                rerun::Angle::radians(time.count() / 4.0f * TAU)
             ))
         );
     }

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -601,6 +601,16 @@ SCENARIO("RecordingStream can set time without errors", TEST_TAG) {
     SECTION("Setting time nanos does not log errors") {
         check_logged_error([&] { stream.set_time_nanos("my sequence", 1); });
     }
+    SECTION("Setting time via chrono duration does not log errors") {
+        using namespace std::chrono_literals;
+        check_logged_error([&] { stream.set_time("my sequence", 1.0s); });
+        check_logged_error([&] { stream.set_time("my sequence", 1000ms); });
+    }
+    SECTION("Setting time via chrono duration does not log errors") {
+        using namespace std::chrono_literals;
+        check_logged_error([&] { stream.set_time("my sequence", std::chrono::system_clock::now()); }
+        );
+    }
     SECTION("Resetting time does not log errors") {
         check_logged_error([&] { stream.reset_time(); });
     }

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -603,13 +603,11 @@ SCENARIO("RecordingStream can set time without errors", TEST_TAG) {
     }
     SECTION("Setting time via chrono duration does not log errors") {
         using namespace std::chrono_literals;
-        check_logged_error([&] { stream.set_time("my sequence", 1.0s); });
-        check_logged_error([&] { stream.set_time("my sequence", 1000ms); });
+        check_logged_error([&] { stream.set_time("duration", 1.0s); });
+        check_logged_error([&] { stream.set_time("duration", 1000ms); });
     }
     SECTION("Setting time via chrono duration does not log errors") {
-        using namespace std::chrono_literals;
-        check_logged_error([&] { stream.set_time("my sequence", std::chrono::system_clock::now()); }
-        );
+        check_logged_error([&] { stream.set_time("timepoint", std::chrono::system_clock::now()); });
     }
     SECTION("Resetting time does not log errors") {
         check_logged_error([&] { stream.reset_time(); });


### PR DESCRIPTION
### What

You can now use both chrono timepoints and chrono durations to set the time!

```cpp
using namespace std::chrono_literals;
rec.set_time("duration", 1.0ms)
rec.set_time("duration", 1000ms)
rec.set_time("clock", std::chrono::system_clock::now());
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4134) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4134)
- [Docs preview](https://rerun.io/preview/802408d616f9dd9f976905b27df6ecc13df1b57a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/802408d616f9dd9f976905b27df6ecc13df1b57a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)