### PR TITLE
`warn_once` on stream incompatibility

### DIFF
--- a/crates/re_log_encoding/src/decoder.rs
+++ b/crates/re_log_encoding/src/decoder.rs
@@ -44,7 +44,7 @@ fn warn_on_version_mismatch(
     } else {
         match version_policy {
             VersionPolicy::Warn => {
-                re_log::warn!(
+                re_log::warn_once!(
                     "Found log stream with Rerun version {encoded_version}, \
                      which is incompatible with the local Rerun version {LOCAL_VERSION}. \
                      Loading will try to continue, but might fail in subtle ways."


### PR DESCRIPTION
%!&#$ :@ 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4135) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4135)
- [Docs preview](https://rerun.io/preview/30164bf242f8404428a5d49b16bb4790e6f046c7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/30164bf242f8404428a5d49b16bb4790e6f046c7/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)