### PR TITLE
Pin python docs build dependencies

### DIFF
--- a/rerun_py/requirements-doc.txt
+++ b/rerun_py/requirements-doc.txt
@@ -1,10 +1,10 @@
-mkdocs
-mkdocs-gen-files
-mkdocs-literate-nav
-mkdocs-material
-mkdocs-material-extensions
+mkdocs==1.5.3
+mkdocs-gen-files==0.5.0
+mkdocs-literate-nav==0.6.1
+mkdocs-material==9.4.7
+mkdocs-material-extensions==1.3
 git+https://github.com/rerun-io/mkdocs-redirects.git@v1.3.1 # forked mkdocs-redirects with https://github.com/rerun-io/mkdocs-redirects/commit/d367a0847928438b66f73508e49852be1190409b
-mkdocstrings
-mkdocstrings-python
-mike
-typing_extensions # uncaptured dep for mkdocstrings (https://github.com/mkdocstrings/mkdocstrings/issues/548)
+mkdocstrings==0.23.0
+mkdocstrings-python==1.7.3
+mike==1.1.2
+typing_extensions==4.8.0 # uncaptured dep for mkdocstrings (https://github.com/mkdocstrings/mkdocstrings/issues/548)


### PR DESCRIPTION
### What

Fixes the error from https://github.com/rerun-io/rerun/actions/runs/6744670076/job/18335351486

```
usage: mike [-h] [--version] [--debug] COMMAND ...
mike: error: unrecognized arguments: --rebase --prefix
Error: Process completed with exit code 2.
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4139) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4139)
- [Docs preview](https://rerun.io/preview/489e33fda6dd5829b8ca2f0d991dbb291484a5c2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/489e33fda6dd5829b8ca2f0d991dbb291484a5c2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)