### PR TITLE
Replace the many parameters of  `rerun::spawn` / `rerun::RecordingStream::spawn` with a `struct`

### DIFF
--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -106,19 +106,11 @@ namespace rerun {
         return status;
     }
 
-    Error RecordingStream::spawn(
-        uint16_t port, std::string_view memory_limit, std::string_view executable_name,
-        std::optional<std::string_view> executable_path, float flush_timeout_sec
-    ) const {
-        rr_spawn_options spawn_opts;
-        spawn_opts.port = port;
-        spawn_opts.memory_limit = detail::to_rr_string(memory_limit);
-        spawn_opts.executable_name = detail::to_rr_string(executable_name);
-        spawn_opts.executable_path = detail::to_rr_string(executable_path);
-
+    Error RecordingStream::spawn(const SpawnOptions& options, float flush_timeout_sec) const {
+        rr_spawn_options rerun_c_options = {};
+        options.fill_rerun_c_struct(rerun_c_options);
         rr_error status = {};
-        rr_recording_stream_spawn(_id, &spawn_opts, flush_timeout_sec, &status);
-
+        rr_recording_stream_spawn(_id, &rerun_c_options, flush_timeout_sec, &status);
         return status;
     }
 

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -136,6 +136,18 @@ namespace rerun {
         /// timeout, and can cause a call to `flush` to block indefinitely.
         Error spawn(const SpawnOptions& options = {}, float flush_timeout_sec = 2.0) const;
 
+        /// See RecordingStream::spawn
+        template <typename TRep, typename TPeriod>
+        Error spawn(
+            const SpawnOptions& options = {},
+            std::chrono::duration<TRep, TPeriod> flush_timeout = std::chrono::seconds(2)
+        ) const {
+            return spawn(
+                options,
+                std::chrono::duration_cast<std::chrono::duration<float>>(flush_timeout).count()
+            );
+        }
+
         /// Stream all log-data to a given file.
         ///
         /// This function returns immediately.

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -129,6 +129,8 @@ namespace rerun {
         /// that viewer instead of starting a new one.
         ///
         /// ## Parameters
+        /// options:
+        /// See `rerun::SpawnOptions` for more information.
         ///
         /// flush_timeout_sec:
         /// The minimum time the SDK will wait during a flush before potentially
@@ -136,7 +138,7 @@ namespace rerun {
         /// timeout, and can cause a call to `flush` to block indefinitely.
         Error spawn(const SpawnOptions& options = {}, float flush_timeout_sec = 2.0) const;
 
-        /// See RecordingStream::spawn
+        /// @see RecordingStream::spawn
         template <typename TRep, typename TPeriod>
         Error spawn(
             const SpawnOptions& options = {},

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -144,10 +144,8 @@ namespace rerun {
             const SpawnOptions& options = {},
             std::chrono::duration<TRep, TPeriod> flush_timeout = std::chrono::seconds(2)
         ) const {
-            return spawn(
-                options,
-                std::chrono::duration_cast<std::chrono::duration<float>>(flush_timeout).count()
-            );
+            using seconds_float = std::chrono::duration<float>; // Default ratio is 1:1 == seconds.
+            return spawn(options, std::chrono::duration_cast<seconds_float>(flush_timeout).count());
         }
 
         /// Stream all log-data to a given file.
@@ -201,9 +199,11 @@ namespace rerun {
         void set_time(std::string_view timeline_name, std::chrono::duration<TRep, TPeriod> time)
             const {
             if constexpr (std::is_floating_point<TRep>::value) {
+                using seconds_double =
+                    std::chrono::duration<double>; // Default ratio is 1:1 == seconds.
                 set_time_seconds(
                     timeline_name,
-                    std::chrono::duration_cast<std::chrono::duration<double>>(time).count()
+                    std::chrono::duration_cast<seconds_double>(time).count()
                 );
             } else {
                 set_time_nanos(

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -9,6 +9,7 @@
 #include "as_components.hpp"
 #include "component_batch.hpp"
 #include "error.hpp"
+#include "spawn_options.hpp"
 
 namespace rerun {
     struct DataCell;
@@ -129,33 +130,11 @@ namespace rerun {
         ///
         /// ## Parameters
         ///
-        /// port:
-        /// The port to listen on.
-        ///
-        /// memory_limit:
-        /// An upper limit on how much memory the Rerun Viewer should use.
-        /// When this limit is reached, Rerun will drop the oldest data.
-        /// Example: `16GB` or `50%` (of system total).
-        ///
-        /// executable_name:
-        /// Specifies the name of the Rerun executable.
-        /// You can omit the `.exe` suffix on Windows.
-        ///
-        /// executable_path:
-        /// Enforce a specific executable to use instead of searching though PATH
-        /// for [`Self::executable_name`].
-        ///
         /// flush_timeout_sec:
         /// The minimum time the SDK will wait during a flush before potentially
         /// dropping data if progress is not being made. Passing a negative value indicates no
         /// timeout, and can cause a call to `flush` to block indefinitely.
-        Error spawn(
-            uint16_t port = 9876,                                           //
-            std::string_view memory_limit = "75%",                          //
-            std::string_view executable_name = "rerun",                     //
-            std::optional<std::string_view> executable_path = std::nullopt, //
-            float flush_timeout_sec = 2.0
-        ) const;
+        Error spawn(const SpawnOptions& options = {}, float flush_timeout_sec = 2.0) const;
 
         /// Stream all log-data to a given file.
         ///

--- a/rerun_cpp/src/rerun/spawn.cpp
+++ b/rerun_cpp/src/rerun/spawn.cpp
@@ -1,21 +1,12 @@
 #include "spawn.hpp"
 #include "c/rerun.h"
-#include "string_utils.hpp"
 
 namespace rerun {
-    Error spawn(
-        uint16_t port, std::string_view memory_limit, std::string_view executable_name,
-        std::optional<std::string_view> executable_path
-    ) {
-        rr_spawn_options spawn_opts;
-        spawn_opts.port = port;
-        spawn_opts.memory_limit = detail::to_rr_string(memory_limit);
-        spawn_opts.executable_name = detail::to_rr_string(executable_name);
-        spawn_opts.executable_path = detail::to_rr_string(executable_path);
+    Error spawn(const SpawnOptions& options) {
+        rr_spawn_options rerun_c_options = {};
+        options.fill_rerun_c_struct(rerun_c_options);
         rr_error error = {};
-
-        rr_spawn(&spawn_opts, &error);
-
+        rr_spawn(&rerun_c_options, &error);
         return Error(error);
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/spawn.hpp
+++ b/rerun_cpp/src/rerun/spawn.hpp
@@ -14,5 +14,8 @@ namespace rerun {
     ///
     /// If a Rerun Viewer is already listening on this TCP port, the stream will be redirected to
     /// that viewer instead of starting a new one.
+    ///
+    /// options:
+    /// See `rerun::SpawnOptions` for more information.
     Error spawn(const SpawnOptions& options = {});
 } // namespace rerun

--- a/rerun_cpp/src/rerun/spawn.hpp
+++ b/rerun_cpp/src/rerun/spawn.hpp
@@ -6,6 +6,7 @@
 #include <string_view>
 
 #include "error.hpp"
+#include "spawn_options.hpp"
 
 namespace rerun {
     /// Spawns a new Rerun Viewer process from an executable available in PATH, ready to
@@ -13,28 +14,5 @@ namespace rerun {
     ///
     /// If a Rerun Viewer is already listening on this TCP port, the stream will be redirected to
     /// that viewer instead of starting a new one.
-    ///
-    /// ## Parameters
-    ///
-    /// port:
-    /// The port to listen on.
-    ///
-    /// memory_limit:
-    /// An upper limit on how much memory the Rerun Viewer should use.
-    /// When this limit is reached, Rerun will drop the oldest data.
-    /// Example: `16GB` or `50%` (of system total).
-    ///
-    /// executable_name:
-    /// Specifies the name of the Rerun executable.
-    /// You can omit the `.exe` suffix on Windows.
-    ///
-    /// executable_path:
-    /// Enforce a specific executable to use instead of searching though PATH
-    /// for [`Self::executable_name`].
-    Error spawn(
-        uint16_t port = 9876,                                                //
-        const std::string_view memory_limit = "75%",                         //
-        const std::string_view executable_name = "rerun",                    //
-        const std::optional<std::string_view> executable_path = std::nullopt //
-    );
+    Error spawn(const SpawnOptions& options = {});
 } // namespace rerun

--- a/rerun_cpp/src/rerun/spawn_options.cpp
+++ b/rerun_cpp/src/rerun/spawn_options.cpp
@@ -1,0 +1,12 @@
+#include "spawn_options.hpp"
+#include "c/rerun.h"
+#include "string_utils.hpp"
+
+namespace rerun {
+    void SpawnOptions::fill_rerun_c_struct(rr_spawn_options& spawn_opts) const {
+        spawn_opts.port = port;
+        spawn_opts.memory_limit = detail::to_rr_string(memory_limit);
+        spawn_opts.executable_name = detail::to_rr_string(executable_name);
+        spawn_opts.executable_path = detail::to_rr_string(executable_path);
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/spawn_options.hpp
+++ b/rerun_cpp/src/rerun/spawn_options.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+extern "C" struct rr_spawn_options;
+
+namespace rerun {
+
+    /// Options to control the behavior of `spawn`.
+    ///
+    /// Refer to the field-level documentation for more information about each individual options.
+    ///
+    /// The defaults are ok for most use cases.
+    ///
+    /// Keep this in sync with rerun.h's `rr_spawn_options`.
+    struct SpawnOptions {
+        /// The port to listen on.
+        uint16_t port = 9876;
+
+        /// An upper limit on how much memory the Rerun Viewer should use.
+        /// When this limit is reached, Rerun will drop the oldest data.
+        /// Example: `16GB` or `50%` (of system total).
+        ///
+        /// Defaults to `75%` if null.
+        std::string_view memory_limit = "75%";
+
+        /// Specifies the name of the Rerun executable.
+        ///
+        /// You can omit the `.exe` suffix on Windows.
+        std::string_view executable_name = "rerun";
+
+        /// Enforce a specific executable to use instead of searching though PATH
+        /// for [`Self::executable_name`].
+        std::string_view executable_path = "";
+
+        /// Convert to the corresponding rerun_c struct.
+        ///
+        /// Implementation note:
+        /// By not returning it we avoid including the C header in this header.
+        void fill_rerun_c_struct(rr_spawn_options& spawn_opts) const;
+    };
+} // namespace rerun


### PR DESCRIPTION
### What

* Fixes  #4142

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4149) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4149)
- [Docs preview](https://rerun.io/preview/3ff39f98e3391a563a02494cdb91a8eb8cfdcfcb/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3ff39f98e3391a563a02494cdb91a8eb8cfdcfcb/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)