### PR TITLE
Make on TextLogLevel PascalCase (instead of SCREAMING CASE) to avoid clashes with preprocessor defines

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -189,10 +189,17 @@ class Rect {
 }
 ```
 
+### Constants & Enums
+
+Constants & enum values have PascalCase names.
+
+When possible, use `constexpr` for (global & struct/class scoped) constants.
+
 ### String handling
 Whenever possible we use `std::string_view` to pass strings.
 
 To accommodate for this and other languages, strings on the C interface are almost never expected to be null-terminated and are always passed along with a byte length using `rr_string`.
+
 
 ### Misc
 We don't add `inline` before class/struct member functions if they are inlined in the class/struct definition.

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1530,7 +1530,7 @@ fn quote_fill_arrow_array_builder(
                             let error = format!("Failed to serialize {}::{}: {} in unions not yet implemented", obj.name, variant.name, arrow_builder_type);
                             quote! {
                                 (void)#variant_builder;
-                                return rerun::Error(ErrorCode::NotImplemented, #error)
+                                return rerun::Error(ErrorCode::NotImplemented, #error);
                             }
                         }
                     } else {

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1235,7 +1235,7 @@ fn new_arrow_array_builder_method(
         },
         definition_body: quote! {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
             #NEWLINE_TOKEN
             #NEWLINE_TOKEN
@@ -1264,7 +1264,7 @@ fn fill_arrow_array_builder_method(
         docs: "Fills an arrow array builder with an array of this type.".into(),
         declaration: MethodDeclaration {
             is_static: true,
-            return_type: quote! { Error },
+            return_type: quote! { rerun::Error },
             // TODO(andreas): Pass in validity map.
             name_and_parameters: quote! {
                 fill_arrow_array_builder(arrow::#arrow_builder_type* #builder, const #type_ident* elements, size_t num_elements)
@@ -1272,10 +1272,10 @@ fn fill_arrow_array_builder_method(
         },
         definition_body: quote! {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
             }
             if (elements == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Cannot serialize null pointer to arrow array.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Cannot serialize null pointer to arrow array.");
             }
             #NEWLINE_TOKEN
             #NEWLINE_TOKEN
@@ -1415,7 +1415,7 @@ fn quote_fill_arrow_array_builder(
                 quote! {
                     (void)num_elements;
                     if (true) { // Works around unreachability compiler warning.
-                        return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+                        return rerun::Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
                     }
                 }
             } else {
@@ -1470,7 +1470,7 @@ fn quote_fill_arrow_array_builder(
                             let error = format!("Failed to serialize {}::{}: nullable list types in unions not yet implemented", obj.name, variant.name);
                             quote! {
                                 (void)#variant_builder;
-                                return Error(ErrorCode::NotImplemented, #error);
+                                return rerun::Error(ErrorCode::NotImplemented, #error);
                             }
                         } else if arrow_builder_type == "ListBuilder" {
                             let field_name = format_ident!("{}", variant.snake_case_name());
@@ -1522,7 +1522,7 @@ fn quote_fill_arrow_array_builder(
                                     let error = format!("Failed to serialize {}::{}: objects ({:?}) in unions not yet implemented", obj.name, variant.name, element_type);
                                     quote! {
                                         (void)#variant_builder;
-                                        return Error(ErrorCode::NotImplemented, #error);
+                                        return rerun::Error(ErrorCode::NotImplemented, #error);
                                     }
                                 }
                             }
@@ -1530,7 +1530,7 @@ fn quote_fill_arrow_array_builder(
                             let error = format!("Failed to serialize {}::{}: {} in unions not yet implemented", obj.name, variant.name, arrow_builder_type);
                             quote! {
                                 (void)#variant_builder;
-                                return Error(ErrorCode::NotImplemented, #error);
+                                return rerun::Error(ErrorCode::NotImplemented, #error);
                             }
                         }
                     } else {

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -690,7 +690,7 @@ impl QuotedObject {
         // Putting non-POD types in a union requires C++11.
         //
         // enum class Rotation3DTag : uint8_t {
-        //     NONE = 0,
+        //     None = 0,
         //     Quaternion,
         //     AxisAngle,
         // };
@@ -722,7 +722,7 @@ impl QuotedObject {
             let comment = quote_doc_comment(
                 "Having a special empty state makes it possible to implement move-semantics. \
                 We need to be able to leave the object in a state which we can run the destructor on.");
-            let tag_name = format_ident!("NONE");
+            let tag_name = format_ident!("None");
             quote! {
                 #NEWLINE_TOKEN
                 #comment
@@ -854,7 +854,7 @@ impl QuotedObject {
             let destructor_match_arms = std::iter::once({
                 let comment = quote_comment("Nothing to destroy");
                 quote! {
-                    case detail::#tag_typename::NONE: {
+                    case detail::#tag_typename::None: {
                         #NEWLINE_TOKEN
                         #comment
                     } break;
@@ -948,7 +948,7 @@ impl QuotedObject {
                         switch (other._tag) {
                             #(#placement_new_arms)*
 
-                            case detail::#tag_typename::NONE: {
+                            case detail::#tag_typename::None: {
                                 // there is nothing to copy
                             } break;
                         }
@@ -967,7 +967,7 @@ impl QuotedObject {
                                 #trivial_memcpy
                             } break;
 
-                            case detail::#tag_typename::NONE: {
+                            case detail::#tag_typename::None: {
                                 // there is nothing to copy
                             } break;
                         }
@@ -1020,7 +1020,7 @@ impl QuotedObject {
                     struct #pascal_case_ident {
                         #(#constants_hpp;)*
 
-                        #pascal_case_ident() : _tag(detail::#tag_typename::NONE) {}
+                        #pascal_case_ident() : _tag(detail::#tag_typename::None) {}
 
                         #copy_constructor
 
@@ -1530,7 +1530,7 @@ fn quote_fill_arrow_array_builder(
                             let error = format!("Failed to serialize {}::{}: {} in unions not yet implemented", obj.name, variant.name, arrow_builder_type);
                             quote! {
                                 (void)#variant_builder;
-                                return rerun::Error(ErrorCode::NotImplemented, #error);
+                                return rerun::Error(ErrorCode::NotImplemented, #error)
                             }
                         }
                     } else {
@@ -1559,7 +1559,7 @@ fn quote_fill_arrow_array_builder(
                         #NEWLINE_TOKEN
                         #NEWLINE_TOKEN
                         switch (union_instance._tag) {
-                            case detail::#tag_name::NONE: {
+                            case detail::#tag_name::None: {
                                 ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                             } break;
                             #(#tag_cases)*

--- a/docs/code-examples/text_log.cpp
+++ b/docs/code-examples/text_log.cpp
@@ -6,8 +6,5 @@ int main() {
     const auto rec = rerun::RecordingStream("rerun_example_text_log");
     rec.spawn().exit_on_failure();
 
-    rec.log(
-        "log",
-        rerun::TextLog("Application started.").with_level(rerun::TextLogLevel::LEVEL_INFO)
-    );
+    rec.log("log", rerun::TextLog("Application started.").with_level(rerun::TextLogLevel::Info));
 }

--- a/docs/code-examples/text_log.cpp
+++ b/docs/code-examples/text_log.cpp
@@ -6,5 +6,8 @@ int main() {
     const auto rec = rerun::RecordingStream("rerun_example_text_log");
     rec.spawn().exit_on_failure();
 
-    rec.log("log", rerun::TextLog("Application started.").with_level(rerun::TextLogLevel::INFO));
+    rec.log(
+        "log",
+        rerun::TextLog("Application started.").with_level(rerun::TextLogLevel::LEVEL_INFO)
+    );
 }

--- a/docs/code-examples/text_log_integration.cpp
+++ b/docs/code-examples/text_log_integration.cpp
@@ -10,17 +10,17 @@ void loguru_to_rerun(void* user_data, const loguru::Message& message) {
 
     rerun::TextLogLevel level;
     if (message.verbosity == loguru::Verbosity_FATAL) {
-        level = rerun::TextLogLevel::LEVEL_CRITICAL;
+        level = rerun::TextLogLevel::Critical;
     } else if (message.verbosity == loguru::Verbosity_ERROR) {
-        level = rerun::TextLogLevel::LEVEL_ERROR;
+        level = rerun::TextLogLevel::Error;
     } else if (message.verbosity == loguru::Verbosity_WARNING) {
-        level = rerun::TextLogLevel::LEVEL_WARN;
+        level = rerun::TextLogLevel::Warning;
     } else if (message.verbosity == loguru::Verbosity_INFO) {
-        level = rerun::TextLogLevel::LEVEL_INFO;
+        level = rerun::TextLogLevel::Info;
     } else if (message.verbosity == loguru::Verbosity_1) {
-        level = rerun::TextLogLevel::LEVEL_DEBUG;
+        level = rerun::TextLogLevel::Debug;
     } else if (message.verbosity == loguru::Verbosity_2) {
-        level = rerun::TextLogLevel::LEVEL_TRACE;
+        level = rerun::TextLogLevel::Trace;
     } else {
         level = rerun::TextLogLevel(std::to_string(message.verbosity));
     }
@@ -38,7 +38,7 @@ int main() {
     // Log a text entry directly:
     rec.log(
         "logs",
-        rerun::TextLog("this entry has loglevel TRACE").with_level(rerun::TextLogLevel::LEVEL_TRACE)
+        rerun::TextLog("this entry has loglevel TRACE").with_level(rerun::TextLogLevel::Trace)
     );
 
     loguru::add_callback(

--- a/docs/code-examples/text_log_integration.cpp
+++ b/docs/code-examples/text_log_integration.cpp
@@ -10,17 +10,17 @@ void loguru_to_rerun(void* user_data, const loguru::Message& message) {
 
     rerun::TextLogLevel level;
     if (message.verbosity == loguru::Verbosity_FATAL) {
-        level = rerun::TextLogLevel::CRITICAL;
+        level = rerun::TextLogLevel::LEVEL_CRITICAL;
     } else if (message.verbosity == loguru::Verbosity_ERROR) {
-        level = rerun::TextLogLevel::ERROR;
+        level = rerun::TextLogLevel::LEVEL_ERROR;
     } else if (message.verbosity == loguru::Verbosity_WARNING) {
-        level = rerun::TextLogLevel::WARN;
+        level = rerun::TextLogLevel::LEVEL_WARN;
     } else if (message.verbosity == loguru::Verbosity_INFO) {
-        level = rerun::TextLogLevel::INFO;
+        level = rerun::TextLogLevel::LEVEL_INFO;
     } else if (message.verbosity == loguru::Verbosity_1) {
-        level = rerun::TextLogLevel::DEBUG;
+        level = rerun::TextLogLevel::LEVEL_DEBUG;
     } else if (message.verbosity == loguru::Verbosity_2) {
-        level = rerun::TextLogLevel::TRACE;
+        level = rerun::TextLogLevel::LEVEL_TRACE;
     } else {
         level = rerun::TextLogLevel(std::to_string(message.verbosity));
     }
@@ -38,7 +38,7 @@ int main() {
     // Log a text entry directly:
     rec.log(
         "logs",
-        rerun::TextLog("this entry has loglevel TRACE").with_level(rerun::TextLogLevel::TRACE)
+        rerun::TextLog("this entry has loglevel TRACE").with_level(rerun::TextLogLevel::LEVEL_TRACE)
     );
 
     loguru::add_callback(

--- a/pixi.toml
+++ b/pixi.toml
@@ -77,11 +77,15 @@ py-test = { cmd = "python -m pytest -vv rerun_py/tests/unit", depends_on = [
 cpp-clean = "rm -rf build CMakeCache.txt CMakeFiles"
 cpp-build-all = { depends_on = [
   "cpp-prepare",
-  "cpp-build-tests",
-  "cpp-build-examples",
   "cpp-build-doc-examples",
+  "cpp-build-examples",
+  "cpp-build-roundtrips",
+  "cpp-build-tests",
 ] }
 cpp-build-tests = { cmd = "cmake --build build --config Debug --target rerun_sdk_tests", depends_on = [
+  "cpp-prepare",
+] }
+cpp-build-roundtrips = { cmd = "cmake --build build --config Debug --target roundtrips", depends_on = [
   "cpp-prepare",
 ] }
 cpp-build-examples = { cmd = "cmake --build build --config Debug --target examples", depends_on = [

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -34,17 +34,17 @@ namespace rerun {
         ///
         ///     rerun::TextLogLevel level;
         ///     if (message.verbosity == loguru::Verbosity_FATAL) {
-        ///         level = rerun::TextLogLevel::LEVEL_CRITICAL;
+        ///         level = rerun::TextLogLevel::Critical;
         ///     } else if (message.verbosity == loguru::Verbosity_ERROR) {
-        ///         level = rerun::TextLogLevel::LEVEL_ERROR;
+        ///         level = rerun::TextLogLevel::Error;
         ///     } else if (message.verbosity == loguru::Verbosity_WARNING) {
-        ///         level = rerun::TextLogLevel::LEVEL_WARN;
+        ///         level = rerun::TextLogLevel::Warning;
         ///     } else if (message.verbosity == loguru::Verbosity_INFO) {
-        ///         level = rerun::TextLogLevel::LEVEL_INFO;
+        ///         level = rerun::TextLogLevel::Info;
         ///     } else if (message.verbosity == loguru::Verbosity_1) {
-        ///         level = rerun::TextLogLevel::LEVEL_DEBUG;
+        ///         level = rerun::TextLogLevel::Debug;
         ///     } else if (message.verbosity == loguru::Verbosity_2) {
-        ///         level = rerun::TextLogLevel::LEVEL_TRACE;
+        ///         level = rerun::TextLogLevel::Trace;
         ///     } else {
         ///         level = rerun::TextLogLevel(std::to_string(message.verbosity));
         ///     }
@@ -62,7 +62,7 @@ namespace rerun {
         ///     // Log a text entry directly:
         ///     rec.log(
         ///         "logs",
-        ///         rerun::TextLog("this entry has loglevel TRACE").with_level(rerun::TextLogLevel::LEVEL_TRACE)
+        ///         rerun::TextLog("this entry has loglevel TRACE").with_level(rerun::TextLogLevel::Trace)
         ///     );
         ///
         ///     loguru::add_callback(

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -34,17 +34,17 @@ namespace rerun {
         ///
         ///     rerun::TextLogLevel level;
         ///     if (message.verbosity == loguru::Verbosity_FATAL) {
-        ///         level = rerun::TextLogLevel::CRITICAL;
+        ///         level = rerun::TextLogLevel::LEVEL_CRITICAL;
         ///     } else if (message.verbosity == loguru::Verbosity_ERROR) {
-        ///         level = rerun::TextLogLevel::ERROR;
+        ///         level = rerun::TextLogLevel::LEVEL_ERROR;
         ///     } else if (message.verbosity == loguru::Verbosity_WARNING) {
-        ///         level = rerun::TextLogLevel::WARN;
+        ///         level = rerun::TextLogLevel::LEVEL_WARN;
         ///     } else if (message.verbosity == loguru::Verbosity_INFO) {
-        ///         level = rerun::TextLogLevel::INFO;
+        ///         level = rerun::TextLogLevel::LEVEL_INFO;
         ///     } else if (message.verbosity == loguru::Verbosity_1) {
-        ///         level = rerun::TextLogLevel::DEBUG;
+        ///         level = rerun::TextLogLevel::LEVEL_DEBUG;
         ///     } else if (message.verbosity == loguru::Verbosity_2) {
-        ///         level = rerun::TextLogLevel::TRACE;
+        ///         level = rerun::TextLogLevel::LEVEL_TRACE;
         ///     } else {
         ///         level = rerun::TextLogLevel(std::to_string(message.verbosity));
         ///     }
@@ -62,7 +62,7 @@ namespace rerun {
         ///     // Log a text entry directly:
         ///     rec.log(
         ///         "logs",
-        ///         rerun::TextLog("this entry has loglevel TRACE").with_level(rerun::TextLogLevel::TRACE)
+        ///         rerun::TextLog("this entry has loglevel TRACE").with_level(rerun::TextLogLevel::LEVEL_TRACE)
         ///     );
         ///
         ///     loguru::add_callback(

--- a/rerun_cpp/src/rerun/blueprint/auto_space_views.cpp
+++ b/rerun_cpp/src/rerun/blueprint/auto_space_views.cpp
@@ -17,20 +17,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::BooleanBuilder>(memory_pool));
         }
 
-        Error AutoSpaceViews::fill_arrow_array_builder(
+        rerun::Error AutoSpaceViews::fill_arrow_array_builder(
             arrow::BooleanBuilder* builder, const AutoSpaceViews* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/blueprint/auto_space_views.hpp
+++ b/rerun_cpp/src/rerun/blueprint/auto_space_views.hpp
@@ -41,7 +41,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::BooleanBuilder* builder, const AutoSpaceViews* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/blueprint/panel_view.cpp
+++ b/rerun_cpp/src/rerun/blueprint/panel_view.cpp
@@ -19,7 +19,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -31,14 +31,17 @@ namespace rerun {
             ));
         }
 
-        Error PanelView::fill_arrow_array_builder(
+        rerun::Error PanelView::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const PanelView* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/blueprint/panel_view.hpp
+++ b/rerun_cpp/src/rerun/blueprint/panel_view.hpp
@@ -41,7 +41,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const PanelView* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/blueprint/space_view_component.cpp
+++ b/rerun_cpp/src/rerun/blueprint/space_view_component.cpp
@@ -23,7 +23,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -38,14 +38,17 @@ namespace rerun {
             ));
         }
 
-        Error SpaceViewComponent::fill_arrow_array_builder(
+        rerun::Error SpaceViewComponent::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const SpaceViewComponent* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/blueprint/space_view_component.hpp
+++ b/rerun_cpp/src/rerun/blueprint/space_view_component.hpp
@@ -44,7 +44,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const SpaceViewComponent* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/blueprint/space_view_maximized.cpp
+++ b/rerun_cpp/src/rerun/blueprint/space_view_maximized.cpp
@@ -17,7 +17,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::ListBuilder>(
@@ -26,14 +26,17 @@ namespace rerun {
             ));
         }
 
-        Error SpaceViewMaximized::fill_arrow_array_builder(
+        rerun::Error SpaceViewMaximized::fill_arrow_array_builder(
             arrow::ListBuilder* builder, const SpaceViewMaximized* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/blueprint/space_view_maximized.hpp
+++ b/rerun_cpp/src/rerun/blueprint/space_view_maximized.hpp
@@ -44,7 +44,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const SpaceViewMaximized* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/blueprint/viewport_layout.cpp
+++ b/rerun_cpp/src/rerun/blueprint/viewport_layout.cpp
@@ -29,7 +29,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -49,14 +49,17 @@ namespace rerun {
             ));
         }
 
-        Error ViewportLayout::fill_arrow_array_builder(
+        rerun::Error ViewportLayout::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const ViewportLayout* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/blueprint/viewport_layout.hpp
+++ b/rerun_cpp/src/rerun/blueprint/viewport_layout.hpp
@@ -42,7 +42,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const ViewportLayout* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/components/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.cpp
@@ -25,7 +25,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::ListBuilder>(
@@ -35,14 +35,17 @@ namespace rerun {
             ));
         }
 
-        Error AnnotationContext::fill_arrow_array_builder(
+        rerun::Error AnnotationContext::fill_arrow_array_builder(
             arrow::ListBuilder* builder, const AnnotationContext* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.hpp
@@ -68,7 +68,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AnnotationContext* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/blob.cpp
+++ b/rerun_cpp/src/rerun/components/blob.cpp
@@ -19,7 +19,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::ListBuilder>(
@@ -28,14 +28,17 @@ namespace rerun {
             ));
         }
 
-        Error Blob::fill_arrow_array_builder(
+        rerun::Error Blob::fill_arrow_array_builder(
             arrow::ListBuilder* builder, const Blob* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/blob.hpp
+++ b/rerun_cpp/src/rerun/components/blob.hpp
@@ -45,7 +45,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const Blob* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/class_id.cpp
+++ b/rerun_cpp/src/rerun/components/class_id.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::ClassId::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error ClassId::fill_arrow_array_builder(
+        rerun::Error ClassId::fill_arrow_array_builder(
             arrow::UInt16Builder* builder, const ClassId* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/class_id.hpp
+++ b/rerun_cpp/src/rerun/components/class_id.hpp
@@ -60,7 +60,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::UInt16Builder* builder, const ClassId* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/clear_is_recursive.cpp
+++ b/rerun_cpp/src/rerun/components/clear_is_recursive.cpp
@@ -19,20 +19,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::BooleanBuilder>(memory_pool));
         }
 
-        Error ClearIsRecursive::fill_arrow_array_builder(
+        rerun::Error ClearIsRecursive::fill_arrow_array_builder(
             arrow::BooleanBuilder* builder, const ClearIsRecursive* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/clear_is_recursive.hpp
+++ b/rerun_cpp/src/rerun/components/clear_is_recursive.hpp
@@ -44,7 +44,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::BooleanBuilder* builder, const ClearIsRecursive* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/components/color.cpp
+++ b/rerun_cpp/src/rerun/components/color.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Rgba32::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error Color::fill_arrow_array_builder(
+        rerun::Error Color::fill_arrow_array_builder(
             arrow::UInt32Builder* builder, const Color* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/color.hpp
+++ b/rerun_cpp/src/rerun/components/color.hpp
@@ -85,7 +85,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::UInt32Builder* builder, const Color* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/depth_meter.cpp
+++ b/rerun_cpp/src/rerun/components/depth_meter.cpp
@@ -19,20 +19,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FloatBuilder>(memory_pool));
         }
 
-        Error DepthMeter::fill_arrow_array_builder(
+        rerun::Error DepthMeter::fill_arrow_array_builder(
             arrow::FloatBuilder* builder, const DepthMeter* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/depth_meter.hpp
+++ b/rerun_cpp/src/rerun/components/depth_meter.hpp
@@ -47,7 +47,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FloatBuilder* builder, const DepthMeter* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.cpp
@@ -19,20 +19,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::BooleanBuilder>(memory_pool));
         }
 
-        Error DisconnectedSpace::fill_arrow_array_builder(
+        rerun::Error DisconnectedSpace::fill_arrow_array_builder(
             arrow::BooleanBuilder* builder, const DisconnectedSpace* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.hpp
@@ -48,7 +48,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::BooleanBuilder* builder, const DisconnectedSpace* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/components/draw_order.cpp
+++ b/rerun_cpp/src/rerun/components/draw_order.cpp
@@ -19,20 +19,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FloatBuilder>(memory_pool));
         }
 
-        Error DrawOrder::fill_arrow_array_builder(
+        rerun::Error DrawOrder::fill_arrow_array_builder(
             arrow::FloatBuilder* builder, const DrawOrder* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/draw_order.hpp
+++ b/rerun_cpp/src/rerun/components/draw_order.hpp
@@ -53,7 +53,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FloatBuilder* builder, const DrawOrder* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/half_sizes2d.cpp
+++ b/rerun_cpp/src/rerun/components/half_sizes2d.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Vec2D::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error HalfSizes2D::fill_arrow_array_builder(
+        rerun::Error HalfSizes2D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const HalfSizes2D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/half_sizes2d.hpp
+++ b/rerun_cpp/src/rerun/components/half_sizes2d.hpp
@@ -74,7 +74,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const HalfSizes2D* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/components/half_sizes3d.cpp
+++ b/rerun_cpp/src/rerun/components/half_sizes3d.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error HalfSizes3D::fill_arrow_array_builder(
+        rerun::Error HalfSizes3D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const HalfSizes3D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/half_sizes3d.hpp
+++ b/rerun_cpp/src/rerun/components/half_sizes3d.hpp
@@ -78,7 +78,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const HalfSizes3D* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/components/instance_key.cpp
+++ b/rerun_cpp/src/rerun/components/instance_key.cpp
@@ -19,20 +19,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::UInt64Builder>(memory_pool));
         }
 
-        Error InstanceKey::fill_arrow_array_builder(
+        rerun::Error InstanceKey::fill_arrow_array_builder(
             arrow::UInt64Builder* builder, const InstanceKey* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/instance_key.hpp
+++ b/rerun_cpp/src/rerun/components/instance_key.hpp
@@ -47,7 +47,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::UInt64Builder* builder, const InstanceKey* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/keypoint_id.cpp
+++ b/rerun_cpp/src/rerun/components/keypoint_id.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::KeypointId::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error KeypointId::fill_arrow_array_builder(
+        rerun::Error KeypointId::fill_arrow_array_builder(
             arrow::UInt16Builder* builder, const KeypointId* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/keypoint_id.hpp
+++ b/rerun_cpp/src/rerun/components/keypoint_id.hpp
@@ -60,7 +60,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::UInt16Builder* builder, const KeypointId* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/line_strip2d.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d.cpp
@@ -22,7 +22,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::ListBuilder>(
@@ -31,14 +31,17 @@ namespace rerun {
             ));
         }
 
-        Error LineStrip2D::fill_arrow_array_builder(
+        rerun::Error LineStrip2D::fill_arrow_array_builder(
             arrow::ListBuilder* builder, const LineStrip2D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/line_strip2d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d.hpp
@@ -69,7 +69,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const LineStrip2D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/line_strip3d.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.cpp
@@ -22,7 +22,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::ListBuilder>(
@@ -31,14 +31,17 @@ namespace rerun {
             ));
         }
 
-        Error LineStrip3D::fill_arrow_array_builder(
+        rerun::Error LineStrip3D::fill_arrow_array_builder(
             arrow::ListBuilder* builder, const LineStrip3D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/line_strip3d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.hpp
@@ -69,7 +69,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const LineStrip3D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/material.cpp
+++ b/rerun_cpp/src/rerun/components/material.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Material::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error Material::fill_arrow_array_builder(
+        rerun::Error Material::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const Material* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/material.hpp
+++ b/rerun_cpp/src/rerun/components/material.hpp
@@ -66,7 +66,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const Material* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/media_type.cpp
+++ b/rerun_cpp/src/rerun/components/media_type.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Utf8::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error MediaType::fill_arrow_array_builder(
+        rerun::Error MediaType::fill_arrow_array_builder(
             arrow::StringBuilder* builder, const MediaType* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/media_type.hpp
+++ b/rerun_cpp/src/rerun/components/media_type.hpp
@@ -103,7 +103,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const MediaType* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/mesh_properties.cpp
+++ b/rerun_cpp/src/rerun/components/mesh_properties.cpp
@@ -21,7 +21,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(
@@ -29,14 +29,17 @@ namespace rerun {
             );
         }
 
-        Error MeshProperties::fill_arrow_array_builder(
+        rerun::Error MeshProperties::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const MeshProperties* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/mesh_properties.hpp
+++ b/rerun_cpp/src/rerun/components/mesh_properties.hpp
@@ -67,7 +67,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const MeshProperties* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/out_of_tree_transform3d.cpp
+++ b/rerun_cpp/src/rerun/components/out_of_tree_transform3d.cpp
@@ -20,22 +20,25 @@ namespace rerun {
         Result<std::shared_ptr<arrow::DenseUnionBuilder>>
             OutOfTreeTransform3D::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Transform3D::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        Error OutOfTreeTransform3D::fill_arrow_array_builder(
+        rerun::Error OutOfTreeTransform3D::fill_arrow_array_builder(
             arrow::DenseUnionBuilder* builder, const OutOfTreeTransform3D* elements,
             size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/out_of_tree_transform3d.hpp
+++ b/rerun_cpp/src/rerun/components/out_of_tree_transform3d.hpp
@@ -52,7 +52,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const OutOfTreeTransform3D* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/components/pinhole_projection.cpp
+++ b/rerun_cpp/src/rerun/components/pinhole_projection.cpp
@@ -20,21 +20,24 @@ namespace rerun {
         Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
             PinholeProjection::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Mat3x3::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error PinholeProjection::fill_arrow_array_builder(
+        rerun::Error PinholeProjection::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const PinholeProjection* elements,
             size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/pinhole_projection.hpp
+++ b/rerun_cpp/src/rerun/components/pinhole_projection.hpp
@@ -77,7 +77,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const PinholeProjection* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/components/position2d.cpp
+++ b/rerun_cpp/src/rerun/components/position2d.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Vec2D::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error Position2D::fill_arrow_array_builder(
+        rerun::Error Position2D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const Position2D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/position2d.hpp
+++ b/rerun_cpp/src/rerun/components/position2d.hpp
@@ -71,7 +71,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Position2D* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/components/position3d.cpp
+++ b/rerun_cpp/src/rerun/components/position3d.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error Position3D::fill_arrow_array_builder(
+        rerun::Error Position3D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const Position3D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/position3d.hpp
+++ b/rerun_cpp/src/rerun/components/position3d.hpp
@@ -75,7 +75,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Position3D* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/components/radius.cpp
+++ b/rerun_cpp/src/rerun/components/radius.cpp
@@ -19,20 +19,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FloatBuilder>(memory_pool));
         }
 
-        Error Radius::fill_arrow_array_builder(
+        rerun::Error Radius::fill_arrow_array_builder(
             arrow::FloatBuilder* builder, const Radius* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/radius.hpp
+++ b/rerun_cpp/src/rerun/components/radius.hpp
@@ -47,7 +47,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FloatBuilder* builder, const Radius* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/resolution.cpp
+++ b/rerun_cpp/src/rerun/components/resolution.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Vec2D::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error Resolution::fill_arrow_array_builder(
+        rerun::Error Resolution::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const Resolution* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/resolution.hpp
+++ b/rerun_cpp/src/rerun/components/resolution.hpp
@@ -71,7 +71,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Resolution* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/components/rotation3d.cpp
+++ b/rerun_cpp/src/rerun/components/rotation3d.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Rotation3D::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error Rotation3D::fill_arrow_array_builder(
+        rerun::Error Rotation3D::fill_arrow_array_builder(
             arrow::DenseUnionBuilder* builder, const Rotation3D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/rotation3d.hpp
+++ b/rerun_cpp/src/rerun/components/rotation3d.hpp
@@ -61,7 +61,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const Rotation3D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/scalar.cpp
+++ b/rerun_cpp/src/rerun/components/scalar.cpp
@@ -19,20 +19,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::DoubleBuilder>(memory_pool));
         }
 
-        Error Scalar::fill_arrow_array_builder(
+        rerun::Error Scalar::fill_arrow_array_builder(
             arrow::DoubleBuilder* builder, const Scalar* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/scalar.hpp
+++ b/rerun_cpp/src/rerun/components/scalar.hpp
@@ -49,7 +49,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::DoubleBuilder* builder, const Scalar* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/scalar_scattering.cpp
+++ b/rerun_cpp/src/rerun/components/scalar_scattering.cpp
@@ -19,20 +19,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::BooleanBuilder>(memory_pool));
         }
 
-        Error ScalarScattering::fill_arrow_array_builder(
+        rerun::Error ScalarScattering::fill_arrow_array_builder(
             arrow::BooleanBuilder* builder, const ScalarScattering* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/scalar_scattering.hpp
+++ b/rerun_cpp/src/rerun/components/scalar_scattering.hpp
@@ -43,7 +43,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::BooleanBuilder* builder, const ScalarScattering* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/components/tensor_data.cpp
+++ b/rerun_cpp/src/rerun/components/tensor_data.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::TensorData::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error TensorData::fill_arrow_array_builder(
+        rerun::Error TensorData::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const TensorData* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/tensor_data.hpp
+++ b/rerun_cpp/src/rerun/components/tensor_data.hpp
@@ -60,7 +60,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const TensorData* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/text.cpp
+++ b/rerun_cpp/src/rerun/components/text.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Utf8::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error Text::fill_arrow_array_builder(
+        rerun::Error Text::fill_arrow_array_builder(
             arrow::StringBuilder* builder, const Text* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/text.hpp
+++ b/rerun_cpp/src/rerun/components/text.hpp
@@ -68,7 +68,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const Text* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/text_log_level.cpp
+++ b/rerun_cpp/src/rerun/components/text_log_level.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Utf8::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error TextLogLevel::fill_arrow_array_builder(
+        rerun::Error TextLogLevel::fill_arrow_array_builder(
             arrow::StringBuilder* builder, const TextLogLevel* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/text_log_level.hpp
+++ b/rerun_cpp/src/rerun/components/text_log_level.hpp
@@ -39,22 +39,22 @@ namespace rerun {
             // Extensions to generated type defined in 'text_log_level_ext.cpp'
 
             /// Designates catastrophic failures.
-            static const TextLogLevel CRITICAL;
+            static const TextLogLevel LEVEL_CRITICAL;
 
             /// Designates very serious errors.
-            static const TextLogLevel ERROR;
+            static const TextLogLevel LEVEL_ERROR;
 
             /// Designates hazardous situations.
-            static const TextLogLevel WARN;
+            static const TextLogLevel LEVEL_WARN;
 
             /// Designates useful information.
-            static const TextLogLevel INFO;
+            static const TextLogLevel LEVEL_INFO;
 
             /// Designates lower priority information.
-            static const TextLogLevel DEBUG;
+            static const TextLogLevel LEVEL_DEBUG;
 
             /// Designates very low priority, often extremely verbose, information.
-            static const TextLogLevel TRACE;
+            static const TextLogLevel LEVEL_TRACE;
 
             /// Construct `TextLogLevel` from a null-terminated UTF8 string.
             TextLogLevel(const char* str) : value(str) {}

--- a/rerun_cpp/src/rerun/components/text_log_level.hpp
+++ b/rerun_cpp/src/rerun/components/text_log_level.hpp
@@ -39,22 +39,22 @@ namespace rerun {
             // Extensions to generated type defined in 'text_log_level_ext.cpp'
 
             /// Designates catastrophic failures.
-            static const TextLogLevel LEVEL_CRITICAL;
+            static const TextLogLevel Critical;
 
             /// Designates very serious errors.
-            static const TextLogLevel LEVEL_ERROR;
+            static const TextLogLevel Error;
 
             /// Designates hazardous situations.
-            static const TextLogLevel LEVEL_WARN;
+            static const TextLogLevel Warning;
 
             /// Designates useful information.
-            static const TextLogLevel LEVEL_INFO;
+            static const TextLogLevel Info;
 
             /// Designates lower priority information.
-            static const TextLogLevel LEVEL_DEBUG;
+            static const TextLogLevel Debug;
 
             /// Designates very low priority, often extremely verbose, information.
-            static const TextLogLevel LEVEL_TRACE;
+            static const TextLogLevel Trace;
 
             /// Construct `TextLogLevel` from a null-terminated UTF8 string.
             TextLogLevel(const char* str) : value(str) {}
@@ -94,7 +94,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const TextLogLevel* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/text_log_level_ext.cpp
+++ b/rerun_cpp/src/rerun/components/text_log_level_ext.cpp
@@ -16,22 +16,22 @@ namespace rerun {
             // [CODEGEN COPY TO HEADER START]
 
             /// Designates catastrophic failures.
-            static const TextLogLevel LEVEL_CRITICAL;
+            static const TextLogLevel Critical;
 
             /// Designates very serious errors.
-            static const TextLogLevel LEVEL_ERROR;
+            static const TextLogLevel Error;
 
             /// Designates hazardous situations.
-            static const TextLogLevel LEVEL_WARN;
+            static const TextLogLevel Warning;
 
             /// Designates useful information.
-            static const TextLogLevel LEVEL_INFO;
+            static const TextLogLevel Info;
 
             /// Designates lower priority information.
-            static const TextLogLevel LEVEL_DEBUG;
+            static const TextLogLevel Debug;
 
             /// Designates very low priority, often extremely verbose, information.
-            static const TextLogLevel LEVEL_TRACE;
+            static const TextLogLevel Trace;
 
             /// Construct `TextLogLevel` from a null-terminated UTF8 string.
             TextLogLevel(const char* str) : value(str) {}
@@ -48,11 +48,11 @@ namespace rerun {
 #define TextLogLevelExt TextLogLevel
 #endif
 
-        const TextLogLevel TextLogLevel::LEVEL_CRITICAL = "CRITICAL";
-        const TextLogLevel TextLogLevel::LEVEL_ERROR = "ERROR";
-        const TextLogLevel TextLogLevel::LEVEL_WARN = "WARN";
-        const TextLogLevel TextLogLevel::LEVEL_INFO = "INFO";
-        const TextLogLevel TextLogLevel::LEVEL_DEBUG = "DEBUG";
-        const TextLogLevel TextLogLevel::LEVEL_TRACE = "TRACE";
+        const TextLogLevel TextLogLevel::Critical = "CRITICAL";
+        const TextLogLevel TextLogLevel::Error = "ERROR";
+        const TextLogLevel TextLogLevel::Warning = "WARN";
+        const TextLogLevel TextLogLevel::Info = "INFO";
+        const TextLogLevel TextLogLevel::Debug = "DEBUG";
+        const TextLogLevel TextLogLevel::Trace = "TRACE";
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/text_log_level_ext.cpp
+++ b/rerun_cpp/src/rerun/components/text_log_level_ext.cpp
@@ -16,22 +16,22 @@ namespace rerun {
             // [CODEGEN COPY TO HEADER START]
 
             /// Designates catastrophic failures.
-            static const TextLogLevel CRITICAL;
+            static const TextLogLevel LEVEL_CRITICAL;
 
             /// Designates very serious errors.
-            static const TextLogLevel ERROR;
+            static const TextLogLevel LEVEL_ERROR;
 
             /// Designates hazardous situations.
-            static const TextLogLevel WARN;
+            static const TextLogLevel LEVEL_WARN;
 
             /// Designates useful information.
-            static const TextLogLevel INFO;
+            static const TextLogLevel LEVEL_INFO;
 
             /// Designates lower priority information.
-            static const TextLogLevel DEBUG;
+            static const TextLogLevel LEVEL_DEBUG;
 
             /// Designates very low priority, often extremely verbose, information.
-            static const TextLogLevel TRACE;
+            static const TextLogLevel LEVEL_TRACE;
 
             /// Construct `TextLogLevel` from a null-terminated UTF8 string.
             TextLogLevel(const char* str) : value(str) {}
@@ -48,11 +48,11 @@ namespace rerun {
 #define TextLogLevelExt TextLogLevel
 #endif
 
-        const TextLogLevel TextLogLevel::CRITICAL = "CRITICAL";
-        const TextLogLevel TextLogLevel::ERROR = "ERROR";
-        const TextLogLevel TextLogLevel::WARN = "WARN";
-        const TextLogLevel TextLogLevel::INFO = "INFO";
-        const TextLogLevel TextLogLevel::DEBUG = "DEBUG";
-        const TextLogLevel TextLogLevel::TRACE = "TRACE";
+        const TextLogLevel TextLogLevel::LEVEL_CRITICAL = "CRITICAL";
+        const TextLogLevel TextLogLevel::LEVEL_ERROR = "ERROR";
+        const TextLogLevel TextLogLevel::LEVEL_WARN = "WARN";
+        const TextLogLevel TextLogLevel::LEVEL_INFO = "INFO";
+        const TextLogLevel TextLogLevel::LEVEL_DEBUG = "DEBUG";
+        const TextLogLevel TextLogLevel::LEVEL_TRACE = "TRACE";
     } // namespace components
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/transform3d.cpp
+++ b/rerun_cpp/src/rerun/components/transform3d.cpp
@@ -21,21 +21,24 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Transform3D::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        Error Transform3D::fill_arrow_array_builder(
+        rerun::Error Transform3D::fill_arrow_array_builder(
             arrow::DenseUnionBuilder* builder, const Transform3D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/transform3d.hpp
+++ b/rerun_cpp/src/rerun/components/transform3d.hpp
@@ -50,7 +50,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const Transform3D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/vector3d.cpp
+++ b/rerun_cpp/src/rerun/components/vector3d.cpp
@@ -21,20 +21,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::Vec3D::new_arrow_array_builder(memory_pool).value);
         }
 
-        Error Vector3D::fill_arrow_array_builder(
+        rerun::Error Vector3D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const Vector3D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/vector3d.hpp
+++ b/rerun_cpp/src/rerun/components/vector3d.hpp
@@ -78,7 +78,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Vector3D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/components/view_coordinates.cpp
+++ b/rerun_cpp/src/rerun/components/view_coordinates.cpp
@@ -19,7 +19,7 @@ namespace rerun {
         Result<std::shared_ptr<arrow::FixedSizeListBuilder>>
             ViewCoordinates::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FixedSizeListBuilder>(
@@ -29,15 +29,18 @@ namespace rerun {
             ));
         }
 
-        Error ViewCoordinates::fill_arrow_array_builder(
+        rerun::Error ViewCoordinates::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const ViewCoordinates* elements,
             size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/components/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/components/view_coordinates.hpp
@@ -144,7 +144,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const ViewCoordinates* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/datatypes/angle.cpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.cpp
@@ -61,7 +61,7 @@ namespace rerun {
                 auto variant_builder_untyped = builder->child_builder(variant_index).get();
 
                 switch (union_instance._tag) {
-                    case detail::AngleTag::NONE: {
+                    case detail::AngleTag::None: {
                         ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                     } break;
                     case detail::AngleTag::Radians: {

--- a/rerun_cpp/src/rerun/datatypes/angle.cpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.cpp
@@ -21,7 +21,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::DenseUnionBuilder>(
@@ -36,14 +36,17 @@ namespace rerun {
             ));
         }
 
-        Error Angle::fill_arrow_array_builder(
+        rerun::Error Angle::fill_arrow_array_builder(
             arrow::DenseUnionBuilder* builder, const Angle* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.hpp
@@ -22,7 +22,7 @@ namespace rerun {
         namespace detail {
             enum class AngleTag : uint8_t {
                 /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
-                NONE = 0,
+                None = 0,
                 Radians,
                 Degrees,
             };
@@ -52,7 +52,7 @@ namespace rerun {
 
         /// **Datatype**: Angle in either radians or degrees.
         struct Angle {
-            Angle() : _tag(detail::AngleTag::NONE) {}
+            Angle() : _tag(detail::AngleTag::None) {}
 
             /// Copy constructor
             Angle(const Angle& other) : _tag(other._tag) {

--- a/rerun_cpp/src/rerun/datatypes/angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.hpp
@@ -122,7 +122,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const Angle* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/datatypes/annotation_info.cpp
+++ b/rerun_cpp/src/rerun/datatypes/annotation_info.cpp
@@ -24,7 +24,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -38,14 +38,17 @@ namespace rerun {
             ));
         }
 
-        Error AnnotationInfo::fill_arrow_array_builder(
+        rerun::Error AnnotationInfo::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AnnotationInfo* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/annotation_info.hpp
+++ b/rerun_cpp/src/rerun/datatypes/annotation_info.hpp
@@ -58,7 +58,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AnnotationInfo* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/class_description.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.cpp
@@ -40,7 +40,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -60,14 +60,17 @@ namespace rerun {
             ));
         }
 
-        Error ClassDescription::fill_arrow_array_builder(
+        rerun::Error ClassDescription::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const ClassDescription* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/class_description.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.hpp
@@ -66,7 +66,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const ClassDescription* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/class_description_map_elem.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description_map_elem.cpp
@@ -26,7 +26,7 @@ namespace rerun {
         Result<std::shared_ptr<arrow::StructBuilder>>
             ClassDescriptionMapElem::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -39,15 +39,18 @@ namespace rerun {
             ));
         }
 
-        Error ClassDescriptionMapElem::fill_arrow_array_builder(
+        rerun::Error ClassDescriptionMapElem::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const ClassDescriptionMapElem* elements,
             size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/class_description_map_elem.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description_map_elem.hpp
@@ -48,7 +48,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const ClassDescriptionMapElem* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/datatypes/class_id.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_id.cpp
@@ -17,20 +17,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::UInt16Builder>(memory_pool));
         }
 
-        Error ClassId::fill_arrow_array_builder(
+        rerun::Error ClassId::fill_arrow_array_builder(
             arrow::UInt16Builder* builder, const ClassId* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/class_id.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_id.hpp
@@ -43,7 +43,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::UInt16Builder* builder, const ClassId* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/float32.cpp
+++ b/rerun_cpp/src/rerun/datatypes/float32.cpp
@@ -17,20 +17,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FloatBuilder>(memory_pool));
         }
 
-        Error Float32::fill_arrow_array_builder(
+        rerun::Error Float32::fill_arrow_array_builder(
             arrow::FloatBuilder* builder, const Float32* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/float32.hpp
+++ b/rerun_cpp/src/rerun/datatypes/float32.hpp
@@ -43,7 +43,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FloatBuilder* builder, const Float32* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/keypoint_id.cpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_id.cpp
@@ -17,20 +17,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::UInt16Builder>(memory_pool));
         }
 
-        Error KeypointId::fill_arrow_array_builder(
+        rerun::Error KeypointId::fill_arrow_array_builder(
             arrow::UInt16Builder* builder, const KeypointId* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/keypoint_id.hpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_id.hpp
@@ -43,7 +43,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::UInt16Builder* builder, const KeypointId* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/keypoint_pair.cpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_pair.cpp
@@ -22,7 +22,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -35,14 +35,17 @@ namespace rerun {
             ));
         }
 
-        Error KeypointPair::fill_arrow_array_builder(
+        rerun::Error KeypointPair::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const KeypointPair* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
@@ -47,7 +47,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const KeypointPair* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.cpp
@@ -18,7 +18,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FixedSizeListBuilder>(
@@ -28,14 +28,17 @@ namespace rerun {
             ));
         }
 
-        Error Mat3x3::fill_arrow_array_builder(
+        rerun::Error Mat3x3::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const Mat3x3* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
@@ -84,7 +84,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Mat3x3* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.cpp
@@ -18,7 +18,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FixedSizeListBuilder>(
@@ -28,14 +28,17 @@ namespace rerun {
             ));
         }
 
-        Error Mat4x4::fill_arrow_array_builder(
+        rerun::Error Mat4x4::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const Mat4x4* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
@@ -99,7 +99,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Mat4x4* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/material.cpp
+++ b/rerun_cpp/src/rerun/datatypes/material.cpp
@@ -21,7 +21,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -33,14 +33,17 @@ namespace rerun {
             ));
         }
 
-        Error Material::fill_arrow_array_builder(
+        rerun::Error Material::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const Material* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/material.hpp
+++ b/rerun_cpp/src/rerun/datatypes/material.hpp
@@ -50,7 +50,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const Material* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/mesh_properties.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mesh_properties.cpp
@@ -23,7 +23,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -38,14 +38,17 @@ namespace rerun {
             ));
         }
 
-        Error MeshProperties::fill_arrow_array_builder(
+        rerun::Error MeshProperties::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const MeshProperties* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/mesh_properties.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mesh_properties.hpp
@@ -46,7 +46,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const MeshProperties* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/quaternion.cpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion.cpp
@@ -18,7 +18,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FixedSizeListBuilder>(
@@ -28,14 +28,17 @@ namespace rerun {
             ));
         }
 
-        Error Quaternion::fill_arrow_array_builder(
+        rerun::Error Quaternion::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const Quaternion* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/quaternion.hpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion.hpp
@@ -89,7 +89,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Quaternion* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/datatypes/rgba32.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rgba32.cpp
@@ -17,20 +17,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::UInt32Builder>(memory_pool));
         }
 
-        Error Rgba32::fill_arrow_array_builder(
+        rerun::Error Rgba32::fill_arrow_array_builder(
             arrow::UInt32Builder* builder, const Rgba32* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/rgba32.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rgba32.hpp
@@ -75,7 +75,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::UInt32Builder* builder, const Rgba32* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.cpp
@@ -68,7 +68,7 @@ namespace rerun {
                 auto variant_builder_untyped = builder->child_builder(variant_index).get();
 
                 switch (union_instance._tag) {
-                    case detail::Rotation3DTag::NONE: {
+                    case detail::Rotation3DTag::None: {
                         ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                     } break;
                     case detail::Rotation3DTag::Quaternion: {

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.cpp
@@ -28,7 +28,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::DenseUnionBuilder>(
@@ -43,14 +43,17 @@ namespace rerun {
             ));
         }
 
-        Error Rotation3D::fill_arrow_array_builder(
+        rerun::Error Rotation3D::fill_arrow_array_builder(
             arrow::DenseUnionBuilder* builder, const Rotation3D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
@@ -144,7 +144,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const Rotation3D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
@@ -24,7 +24,7 @@ namespace rerun {
         namespace detail {
             enum class Rotation3DTag : uint8_t {
                 /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
-                NONE = 0,
+                None = 0,
                 Quaternion,
                 AxisAngle,
             };
@@ -56,7 +56,7 @@ namespace rerun {
 
         /// **Datatype**: A 3D rotation.
         struct Rotation3D {
-            Rotation3D() : _tag(detail::Rotation3DTag::NONE) {}
+            Rotation3D() : _tag(detail::Rotation3DTag::None) {}
 
             /// Copy constructor
             Rotation3D(const Rotation3D& other) : _tag(other._tag) {

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.cpp
@@ -23,7 +23,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -36,14 +36,17 @@ namespace rerun {
             ));
         }
 
-        Error RotationAxisAngle::fill_arrow_array_builder(
+        rerun::Error RotationAxisAngle::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const RotationAxisAngle* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
@@ -48,7 +48,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const RotationAxisAngle* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/datatypes/scale3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.cpp
@@ -23,7 +23,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::DenseUnionBuilder>(
@@ -38,14 +38,17 @@ namespace rerun {
             ));
         }
 
-        Error Scale3D::fill_arrow_array_builder(
+        rerun::Error Scale3D::fill_arrow_array_builder(
             arrow::DenseUnionBuilder* builder, const Scale3D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/scale3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.cpp
@@ -63,7 +63,7 @@ namespace rerun {
                 auto variant_builder_untyped = builder->child_builder(variant_index).get();
 
                 switch (union_instance._tag) {
-                    case detail::Scale3DTag::NONE: {
+                    case detail::Scale3DTag::None: {
                         ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                     } break;
                     case detail::Scale3DTag::ThreeD: {

--- a/rerun_cpp/src/rerun/datatypes/scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.hpp
@@ -23,7 +23,7 @@ namespace rerun {
         namespace detail {
             enum class Scale3DTag : uint8_t {
                 /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
-                NONE = 0,
+                None = 0,
                 ThreeD,
                 Uniform,
             };
@@ -55,7 +55,7 @@ namespace rerun {
 
         /// **Datatype**: 3D scaling factor, part of a transform representation.
         struct Scale3D {
-            Scale3D() : _tag(detail::Scale3DTag::NONE) {}
+            Scale3D() : _tag(detail::Scale3DTag::None) {}
 
             /// Copy constructor
             Scale3D(const Scale3D& other) : _tag(other._tag) {

--- a/rerun_cpp/src/rerun/datatypes/scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.hpp
@@ -137,7 +137,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const Scale3D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer.cpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer.cpp
@@ -76,7 +76,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::DenseUnionBuilder>(
@@ -141,14 +141,17 @@ namespace rerun {
             ));
         }
 
-        Error TensorBuffer::fill_arrow_array_builder(
+        rerun::Error TensorBuffer::fill_arrow_array_builder(
             arrow::DenseUnionBuilder* builder, const TensorBuffer* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer.cpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer.cpp
@@ -166,7 +166,7 @@ namespace rerun {
                 auto variant_builder_untyped = builder->child_builder(variant_index).get();
 
                 switch (union_instance._tag) {
-                    case detail::TensorBufferTag::NONE: {
+                    case detail::TensorBufferTag::None: {
                         ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                     } break;
                     case detail::TensorBufferTag::U8: {

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
@@ -25,7 +25,7 @@ namespace rerun {
         namespace detail {
             enum class TensorBufferTag : uint8_t {
                 /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
-                NONE = 0,
+                None = 0,
                 U8,
                 U16,
                 U32,
@@ -90,7 +90,7 @@ namespace rerun {
         ///
         /// Tensor elements are stored in a contiguous buffer of a single type.
         struct TensorBuffer {
-            TensorBuffer() : _tag(detail::TensorBufferTag::NONE) {}
+            TensorBuffer() : _tag(detail::TensorBufferTag::None) {}
 
             /// Copy constructor
             TensorBuffer(const TensorBuffer& other) : _tag(other._tag) {
@@ -147,7 +147,7 @@ namespace rerun {
                         using TypeAlias = std::vector<uint8_t>;
                         new (&_data.nv12) TypeAlias(other._data.nv12);
                     } break;
-                    case detail::TensorBufferTag::NONE: {
+                    case detail::TensorBufferTag::None: {
                     } break;
                 }
             }
@@ -169,7 +169,7 @@ namespace rerun {
 
             ~TensorBuffer() {
                 switch (this->_tag) {
-                    case detail::TensorBufferTag::NONE: {
+                    case detail::TensorBufferTag::None: {
                         // Nothing to destroy
                     } break;
                     case detail::TensorBufferTag::U8: {

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
@@ -501,7 +501,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const TensorBuffer* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer_ext.cpp
@@ -75,7 +75,7 @@ namespace rerun {
         /// Number of elements in the buffer.
         size_t TensorBufferExt::num_elems() const {
             switch (this->_tag) {
-                case detail::TensorBufferTag::NONE: {
+                case detail::TensorBufferTag::None: {
                     return 0;
                 }
                 case detail::TensorBufferTag::U8: {

--- a/rerun_cpp/src/rerun/datatypes/tensor_data.cpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_data.cpp
@@ -31,7 +31,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -48,14 +48,17 @@ namespace rerun {
             ));
         }
 
-        Error TensorData::fill_arrow_array_builder(
+        rerun::Error TensorData::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const TensorData* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/tensor_data.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_data.hpp
@@ -54,7 +54,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const TensorData* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/tensor_dimension.cpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_dimension.cpp
@@ -20,7 +20,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -33,14 +33,17 @@ namespace rerun {
             ));
         }
 
-        Error TensorDimension::fill_arrow_array_builder(
+        rerun::Error TensorDimension::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const TensorDimension* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/tensor_dimension.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_dimension.hpp
@@ -49,7 +49,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const TensorDimension* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.cpp
@@ -32,7 +32,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::DenseUnionBuilder>(
@@ -51,14 +51,17 @@ namespace rerun {
             ));
         }
 
-        Error Transform3D::fill_arrow_array_builder(
+        rerun::Error Transform3D::fill_arrow_array_builder(
             arrow::DenseUnionBuilder* builder, const Transform3D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.cpp
@@ -76,7 +76,7 @@ namespace rerun {
                 auto variant_builder_untyped = builder->child_builder(variant_index).get();
 
                 switch (union_instance._tag) {
-                    case detail::Transform3DTag::NONE: {
+                    case detail::Transform3DTag::None: {
                         ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                     } break;
                     case detail::Transform3DTag::TranslationAndMat3x3: {

--- a/rerun_cpp/src/rerun/datatypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.hpp
@@ -143,7 +143,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const Transform3D* elements, size_t num_elements
             );
 

--- a/rerun_cpp/src/rerun/datatypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.hpp
@@ -24,7 +24,7 @@ namespace rerun {
         namespace detail {
             enum class Transform3DTag : uint8_t {
                 /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
-                NONE = 0,
+                None = 0,
                 TranslationAndMat3x3,
                 TranslationRotationScale,
             };
@@ -54,7 +54,7 @@ namespace rerun {
 
         /// **Datatype**: Representation of a 3D affine transform.
         struct Transform3D {
-            Transform3D() : _tag(detail::Transform3DTag::NONE) {}
+            Transform3D() : _tag(detail::Transform3DTag::None) {}
 
             /// Copy constructor
             Transform3D(const Transform3D& other) : _tag(other._tag) {

--- a/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.cpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.cpp
@@ -24,7 +24,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -38,14 +38,17 @@ namespace rerun {
             ));
         }
 
-        Error TranslationAndMat3x3::fill_arrow_array_builder(
+        rerun::Error TranslationAndMat3x3::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const TranslationAndMat3x3* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.hpp
@@ -79,7 +79,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const TranslationAndMat3x3* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.cpp
@@ -25,7 +25,7 @@ namespace rerun {
         Result<std::shared_ptr<arrow::StructBuilder>>
             TranslationRotationScale3D::new_arrow_array_builder(arrow::MemoryPool* memory_pool) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -40,15 +40,18 @@ namespace rerun {
             ));
         }
 
-        Error TranslationRotationScale3D::fill_arrow_array_builder(
+        rerun::Error TranslationRotationScale3D::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const TranslationRotationScale3D* elements,
             size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
@@ -204,7 +204,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const TranslationRotationScale3D* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/src/rerun/datatypes/uint32.cpp
+++ b/rerun_cpp/src/rerun/datatypes/uint32.cpp
@@ -17,20 +17,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::UInt32Builder>(memory_pool));
         }
 
-        Error UInt32::fill_arrow_array_builder(
+        rerun::Error UInt32::fill_arrow_array_builder(
             arrow::UInt32Builder* builder, const UInt32* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/uint32.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uint32.hpp
@@ -43,7 +43,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::UInt32Builder* builder, const UInt32* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/utf8.cpp
+++ b/rerun_cpp/src/rerun/datatypes/utf8.cpp
@@ -17,20 +17,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StringBuilder>(memory_pool));
         }
 
-        Error Utf8::fill_arrow_array_builder(
+        rerun::Error Utf8::fill_arrow_array_builder(
             arrow::StringBuilder* builder, const Utf8* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/utf8.hpp
+++ b/rerun_cpp/src/rerun/datatypes/utf8.hpp
@@ -51,7 +51,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const Utf8* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/uvec2d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec2d.cpp
@@ -18,7 +18,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FixedSizeListBuilder>(
@@ -28,14 +28,17 @@ namespace rerun {
             ));
         }
 
-        Error UVec2D::fill_arrow_array_builder(
+        rerun::Error UVec2D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const UVec2D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/uvec2d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec2d.hpp
@@ -40,7 +40,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const UVec2D* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/uvec3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec3d.cpp
@@ -18,7 +18,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FixedSizeListBuilder>(
@@ -28,14 +28,17 @@ namespace rerun {
             ));
         }
 
-        Error UVec3D::fill_arrow_array_builder(
+        rerun::Error UVec3D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const UVec3D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/uvec3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec3d.hpp
@@ -40,7 +40,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const UVec3D* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/uvec4d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec4d.cpp
@@ -18,7 +18,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FixedSizeListBuilder>(
@@ -28,14 +28,17 @@ namespace rerun {
             ));
         }
 
-        Error UVec4D::fill_arrow_array_builder(
+        rerun::Error UVec4D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const UVec4D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/uvec4d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec4d.hpp
@@ -40,7 +40,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const UVec4D* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/vec2d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d.cpp
@@ -18,7 +18,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FixedSizeListBuilder>(
@@ -28,14 +28,17 @@ namespace rerun {
             ));
         }
 
-        Error Vec2D::fill_arrow_array_builder(
+        rerun::Error Vec2D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const Vec2D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/vec2d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d.hpp
@@ -57,7 +57,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Vec2D* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/vec3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d.cpp
@@ -18,7 +18,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FixedSizeListBuilder>(
@@ -28,14 +28,17 @@ namespace rerun {
             ));
         }
 
-        Error Vec3D::fill_arrow_array_builder(
+        rerun::Error Vec3D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const Vec3D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/vec3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d.hpp
@@ -61,7 +61,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Vec3D* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/src/rerun/datatypes/vec4d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d.cpp
@@ -18,7 +18,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FixedSizeListBuilder>(
@@ -28,14 +28,17 @@ namespace rerun {
             ));
         }
 
-        Error Vec4D::fill_arrow_array_builder(
+        rerun::Error Vec4D::fill_arrow_array_builder(
             arrow::FixedSizeListBuilder* builder, const Vec4D* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/src/rerun/datatypes/vec4d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d.hpp
@@ -65,7 +65,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FixedSizeListBuilder* builder, const Vec4D* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/tests/generated/components/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer1.cpp
@@ -21,21 +21,24 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        Error AffixFuzzer1::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer1::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer1* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer1.hpp
@@ -50,7 +50,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer1* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer10.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer10.cpp
@@ -19,20 +19,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StringBuilder>(memory_pool));
         }
 
-        Error AffixFuzzer10::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer10::fill_arrow_array_builder(
             arrow::StringBuilder* builder, const AffixFuzzer10* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer10.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer10.hpp
@@ -45,7 +45,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const AffixFuzzer10* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer11.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer11.cpp
@@ -19,7 +19,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::ListBuilder>(
@@ -28,14 +28,17 @@ namespace rerun {
             ));
         }
 
-        Error AffixFuzzer11::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer11::fill_arrow_array_builder(
             arrow::ListBuilder* builder, const AffixFuzzer11* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer11.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer11.hpp
@@ -45,7 +45,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer11* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer12.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer12.cpp
@@ -19,7 +19,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::ListBuilder>(
@@ -28,14 +28,17 @@ namespace rerun {
             ));
         }
 
-        Error AffixFuzzer12::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer12::fill_arrow_array_builder(
             arrow::ListBuilder* builder, const AffixFuzzer12* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer12.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer12.hpp
@@ -45,7 +45,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer12* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer13.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer13.cpp
@@ -19,7 +19,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::ListBuilder>(
@@ -28,14 +28,17 @@ namespace rerun {
             ));
         }
 
-        Error AffixFuzzer13::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer13::fill_arrow_array_builder(
             arrow::ListBuilder* builder, const AffixFuzzer13* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer13.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer13.hpp
@@ -47,7 +47,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer13* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer14.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer14.cpp
@@ -21,21 +21,24 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        Error AffixFuzzer14::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer14::fill_arrow_array_builder(
             arrow::DenseUnionBuilder* builder, const AffixFuzzer14* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer14.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer14.hpp
@@ -50,7 +50,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const AffixFuzzer14* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer15.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer15.cpp
@@ -21,21 +21,24 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::AffixFuzzer3::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        Error AffixFuzzer15::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer15::fill_arrow_array_builder(
             arrow::DenseUnionBuilder* builder, const AffixFuzzer15* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );
@@ -43,7 +46,10 @@ namespace rerun {
 
             (void)num_elements;
             if (true) {
-                return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+                return rerun::Error(
+                    ErrorCode::NotImplemented,
+                    "TODO(andreas) Handle nullable extensions"
+                );
             }
 
             return Error::ok();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer15.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer15.hpp
@@ -53,7 +53,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const AffixFuzzer15* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer16.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer16.cpp
@@ -23,7 +23,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::ListBuilder>(
@@ -32,14 +32,17 @@ namespace rerun {
             ));
         }
 
-        Error AffixFuzzer16::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer16::fill_arrow_array_builder(
             arrow::ListBuilder* builder, const AffixFuzzer16* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer16.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer16.hpp
@@ -48,7 +48,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer16* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer17.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer17.cpp
@@ -23,7 +23,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::ListBuilder>(
@@ -32,14 +32,17 @@ namespace rerun {
             ));
         }
 
-        Error AffixFuzzer17::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer17::fill_arrow_array_builder(
             arrow::ListBuilder* builder, const AffixFuzzer17* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer17.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer17.hpp
@@ -51,7 +51,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer17* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer18.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer18.cpp
@@ -23,7 +23,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::ListBuilder>(
@@ -32,14 +32,17 @@ namespace rerun {
             ));
         }
 
-        Error AffixFuzzer18::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer18::fill_arrow_array_builder(
             arrow::ListBuilder* builder, const AffixFuzzer18* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer18.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer18.hpp
@@ -51,7 +51,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer18* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer19.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer19.cpp
@@ -21,21 +21,24 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::AffixFuzzer5::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        Error AffixFuzzer19::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer19::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer19* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer19.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer19.hpp
@@ -62,7 +62,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer19* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer2.cpp
@@ -21,21 +21,24 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        Error AffixFuzzer2::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer2::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer2* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer2.hpp
@@ -50,7 +50,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer2* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer20.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer20.cpp
@@ -21,7 +21,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(
@@ -29,14 +29,17 @@ namespace rerun {
             );
         }
 
-        Error AffixFuzzer20::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer20::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer20* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer20.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer20.hpp
@@ -50,7 +50,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer20* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer21.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer21.cpp
@@ -21,7 +21,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(
@@ -29,14 +29,17 @@ namespace rerun {
             );
         }
 
-        Error AffixFuzzer21::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer21::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer21* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer21.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer21.hpp
@@ -50,7 +50,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer21* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer3.cpp
@@ -21,21 +21,24 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        Error AffixFuzzer3::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer3::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer3* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer3.hpp
@@ -50,7 +50,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer3* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer4.cpp
@@ -21,21 +21,24 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        Error AffixFuzzer4::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer4::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer4* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );
@@ -43,7 +46,10 @@ namespace rerun {
 
             (void)num_elements;
             if (true) {
-                return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+                return rerun::Error(
+                    ErrorCode::NotImplemented,
+                    "TODO(andreas) Handle nullable extensions"
+                );
             }
 
             return Error::ok();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer4.hpp
@@ -52,7 +52,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer4* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer5.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer5.cpp
@@ -21,21 +21,24 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        Error AffixFuzzer5::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer5::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer5* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );
@@ -43,7 +46,10 @@ namespace rerun {
 
             (void)num_elements;
             if (true) {
-                return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+                return rerun::Error(
+                    ErrorCode::NotImplemented,
+                    "TODO(andreas) Handle nullable extensions"
+                );
             }
 
             return Error::ok();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer5.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer5.hpp
@@ -52,7 +52,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer5* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer6.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer6.cpp
@@ -21,21 +21,24 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(rerun::datatypes::AffixFuzzer1::new_arrow_array_builder(memory_pool).value
             );
         }
 
-        Error AffixFuzzer6::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer6::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer6* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );
@@ -43,7 +46,10 @@ namespace rerun {
 
             (void)num_elements;
             if (true) {
-                return Error(ErrorCode::NotImplemented, "TODO(andreas) Handle nullable extensions");
+                return rerun::Error(
+                    ErrorCode::NotImplemented,
+                    "TODO(andreas) Handle nullable extensions"
+                );
             }
 
             return Error::ok();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer6.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer6.hpp
@@ -52,7 +52,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer6* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer7.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer7.cpp
@@ -23,7 +23,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::ListBuilder>(
@@ -32,14 +32,17 @@ namespace rerun {
             ));
         }
 
-        Error AffixFuzzer7::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer7::fill_arrow_array_builder(
             arrow::ListBuilder* builder, const AffixFuzzer7* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer7.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer7.hpp
@@ -49,7 +49,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::ListBuilder* builder, const AffixFuzzer7* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer8.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer8.cpp
@@ -19,20 +19,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FloatBuilder>(memory_pool));
         }
 
-        Error AffixFuzzer8::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer8::fill_arrow_array_builder(
             arrow::FloatBuilder* builder, const AffixFuzzer8* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer8.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer8.hpp
@@ -47,7 +47,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FloatBuilder* builder, const AffixFuzzer8* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/components/affix_fuzzer9.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer9.cpp
@@ -19,20 +19,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StringBuilder>(memory_pool));
         }
 
-        Error AffixFuzzer9::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer9::fill_arrow_array_builder(
             arrow::StringBuilder* builder, const AffixFuzzer9* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/components/affix_fuzzer9.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer9.hpp
@@ -44,7 +44,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const AffixFuzzer9* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.cpp
@@ -45,7 +45,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -74,14 +74,17 @@ namespace rerun {
             ));
         }
 
-        Error AffixFuzzer1::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer1::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer1* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.hpp
@@ -51,7 +51,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer1* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.cpp
@@ -17,20 +17,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::FloatBuilder>(memory_pool));
         }
 
-        Error AffixFuzzer2::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer2::fill_arrow_array_builder(
             arrow::FloatBuilder* builder, const AffixFuzzer2* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.hpp
@@ -43,7 +43,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::FloatBuilder* builder, const AffixFuzzer2* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.cpp
@@ -23,7 +23,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -37,14 +37,17 @@ namespace rerun {
             ));
         }
 
-        Error AffixFuzzer20::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer20::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer20* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.hpp
@@ -35,7 +35,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer20* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer21.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer21.cpp
@@ -24,7 +24,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -40,14 +40,17 @@ namespace rerun {
             ));
         }
 
-        Error AffixFuzzer21::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer21::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer21* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer21.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer21.hpp
@@ -34,7 +34,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer21* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
@@ -86,7 +86,7 @@ namespace rerun {
                 auto variant_builder_untyped = builder->child_builder(variant_index).get();
 
                 switch (union_instance._tag) {
-                    case detail::AffixFuzzer3Tag::NONE: {
+                    case detail::AffixFuzzer3Tag::None: {
                         ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                     } break;
                     case detail::AffixFuzzer3Tag::degrees: {
@@ -120,7 +120,7 @@ namespace rerun {
                         return rerun::Error(
                             ErrorCode::NotImplemented,
                             "Failed to serialize AffixFuzzer3::fixed_size_shenanigans: FixedSizeListBuilder in unions not yet implemented"
-                        );
+                        )
                     } break;
                 }
             }

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
@@ -37,7 +37,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::DenseUnionBuilder>(
@@ -61,14 +61,17 @@ namespace rerun {
             ));
         }
 
-        Error AffixFuzzer3::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer3::fill_arrow_array_builder(
             arrow::DenseUnionBuilder* builder, const AffixFuzzer3* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );
@@ -105,7 +108,7 @@ namespace rerun {
                         auto variant_builder =
                             static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                         (void)variant_builder;
-                        return Error(
+                        return rerun::Error(
                             ErrorCode::NotImplemented,
                             "Failed to serialize AffixFuzzer3::craziness: objects (Object(\"rerun.testing.datatypes.AffixFuzzer1\")) in unions not yet implemented"
                         );
@@ -114,7 +117,7 @@ namespace rerun {
                         auto variant_builder =
                             static_cast<arrow::FixedSizeListBuilder*>(variant_builder_untyped);
                         (void)variant_builder;
-                        return Error(
+                        return rerun::Error(
                             ErrorCode::NotImplemented,
                             "Failed to serialize AffixFuzzer3::fixed_size_shenanigans: FixedSizeListBuilder in unions not yet implemented"
                         );

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
@@ -120,7 +120,7 @@ namespace rerun {
                         return rerun::Error(
                             ErrorCode::NotImplemented,
                             "Failed to serialize AffixFuzzer3::fixed_size_shenanigans: FixedSizeListBuilder in unions not yet implemented"
-                        )
+                        );
                     } break;
                 }
             }

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
@@ -26,7 +26,7 @@ namespace rerun {
         namespace detail {
             enum class AffixFuzzer3Tag : uint8_t {
                 /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
-                NONE = 0,
+                None = 0,
                 degrees,
                 radians,
                 craziness,
@@ -61,7 +61,7 @@ namespace rerun {
         } // namespace detail
 
         struct AffixFuzzer3 {
-            AffixFuzzer3() : _tag(detail::AffixFuzzer3Tag::NONE) {}
+            AffixFuzzer3() : _tag(detail::AffixFuzzer3Tag::None) {}
 
             /// Copy constructor
             AffixFuzzer3(const AffixFuzzer3& other) : _tag(other._tag) {
@@ -77,7 +77,7 @@ namespace rerun {
                         void* thisbytes = reinterpret_cast<void*>(&this->_data);
                         std::memcpy(thisbytes, otherbytes, sizeof(detail::AffixFuzzer3Data));
                     } break;
-                    case detail::AffixFuzzer3Tag::NONE: {
+                    case detail::AffixFuzzer3Tag::None: {
                     } break;
                 }
             }
@@ -99,7 +99,7 @@ namespace rerun {
 
             ~AffixFuzzer3() {
                 switch (this->_tag) {
-                    case detail::AffixFuzzer3Tag::NONE: {
+                    case detail::AffixFuzzer3Tag::None: {
                         // Nothing to destroy
                     } break;
                     case detail::AffixFuzzer3Tag::degrees: {

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
@@ -199,7 +199,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const AffixFuzzer3* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
@@ -91,7 +91,7 @@ namespace rerun {
                 auto variant_builder_untyped = builder->child_builder(variant_index).get();
 
                 switch (union_instance._tag) {
-                    case detail::AffixFuzzer4Tag::NONE: {
+                    case detail::AffixFuzzer4Tag::None: {
                         ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                     } break;
                     case detail::AffixFuzzer4Tag::single_required: {

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
@@ -44,7 +44,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::DenseUnionBuilder>(
@@ -66,14 +66,17 @@ namespace rerun {
             ));
         }
 
-        Error AffixFuzzer4::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer4::fill_arrow_array_builder(
             arrow::DenseUnionBuilder* builder, const AffixFuzzer4* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );
@@ -104,7 +107,7 @@ namespace rerun {
                         auto variant_builder =
                             static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                         (void)variant_builder;
-                        return Error(
+                        return rerun::Error(
                             ErrorCode::NotImplemented,
                             "Failed to serialize AffixFuzzer4::many_required: objects (Object(\"rerun.testing.datatypes.AffixFuzzer3\")) in unions not yet implemented"
                         );
@@ -113,7 +116,7 @@ namespace rerun {
                         auto variant_builder =
                             static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                         (void)variant_builder;
-                        return Error(
+                        return rerun::Error(
                             ErrorCode::NotImplemented,
                             "Failed to serialize AffixFuzzer4::many_optional: nullable list types in unions not yet implemented"
                         );

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
@@ -187,7 +187,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::DenseUnionBuilder* builder, const AffixFuzzer4* elements, size_t num_elements
             );
 

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
@@ -25,7 +25,7 @@ namespace rerun {
         namespace detail {
             enum class AffixFuzzer4Tag : uint8_t {
                 /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
-                NONE = 0,
+                None = 0,
                 single_required,
                 many_required,
                 many_optional,
@@ -57,7 +57,7 @@ namespace rerun {
         } // namespace detail
 
         struct AffixFuzzer4 {
-            AffixFuzzer4() : _tag(detail::AffixFuzzer4Tag::NONE) {}
+            AffixFuzzer4() : _tag(detail::AffixFuzzer4Tag::None) {}
 
             /// Copy constructor
             AffixFuzzer4(const AffixFuzzer4& other) : _tag(other._tag) {
@@ -75,7 +75,7 @@ namespace rerun {
                             std::optional<std::vector<rerun::datatypes::AffixFuzzer3>>;
                         new (&_data.many_optional) TypeAlias(other._data.many_optional);
                     } break;
-                    case detail::AffixFuzzer4Tag::NONE: {
+                    case detail::AffixFuzzer4Tag::None: {
                     } break;
                 }
             }
@@ -97,7 +97,7 @@ namespace rerun {
 
             ~AffixFuzzer4() {
                 switch (this->_tag) {
-                    case detail::AffixFuzzer4Tag::NONE: {
+                    case detail::AffixFuzzer4Tag::None: {
                         // Nothing to destroy
                     } break;
                     case detail::AffixFuzzer4Tag::single_required: {

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.cpp
@@ -25,7 +25,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -37,14 +37,17 @@ namespace rerun {
             ));
         }
 
-        Error AffixFuzzer5::fill_arrow_array_builder(
+        rerun::Error AffixFuzzer5::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const AffixFuzzer5* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.hpp
@@ -44,7 +44,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const AffixFuzzer5* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/tests/generated/datatypes/flattened_scalar.cpp
+++ b/rerun_cpp/tests/generated/datatypes/flattened_scalar.cpp
@@ -19,7 +19,7 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StructBuilder>(
@@ -31,14 +31,17 @@ namespace rerun {
             ));
         }
 
-        Error FlattenedScalar::fill_arrow_array_builder(
+        rerun::Error FlattenedScalar::fill_arrow_array_builder(
             arrow::StructBuilder* builder, const FlattenedScalar* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/datatypes/flattened_scalar.hpp
+++ b/rerun_cpp/tests/generated/datatypes/flattened_scalar.hpp
@@ -37,7 +37,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StructBuilder* builder, const FlattenedScalar* elements, size_t num_elements
             );
         };

--- a/rerun_cpp/tests/generated/datatypes/primitive_component.cpp
+++ b/rerun_cpp/tests/generated/datatypes/primitive_component.cpp
@@ -17,20 +17,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::UInt32Builder>(memory_pool));
         }
 
-        Error PrimitiveComponent::fill_arrow_array_builder(
+        rerun::Error PrimitiveComponent::fill_arrow_array_builder(
             arrow::UInt32Builder* builder, const PrimitiveComponent* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/datatypes/primitive_component.hpp
+++ b/rerun_cpp/tests/generated/datatypes/primitive_component.hpp
@@ -41,7 +41,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::UInt32Builder* builder, const PrimitiveComponent* elements,
                 size_t num_elements
             );

--- a/rerun_cpp/tests/generated/datatypes/string_component.cpp
+++ b/rerun_cpp/tests/generated/datatypes/string_component.cpp
@@ -17,20 +17,23 @@ namespace rerun {
             arrow::MemoryPool* memory_pool
         ) {
             if (memory_pool == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
+                return rerun::Error(ErrorCode::UnexpectedNullArgument, "Memory pool is null.");
             }
 
             return Result(std::make_shared<arrow::StringBuilder>(memory_pool));
         }
 
-        Error StringComponent::fill_arrow_array_builder(
+        rerun::Error StringComponent::fill_arrow_array_builder(
             arrow::StringBuilder* builder, const StringComponent* elements, size_t num_elements
         ) {
             if (builder == nullptr) {
-                return Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array builder is null."
+                );
             }
             if (elements == nullptr) {
-                return Error(
+                return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Cannot serialize null pointer to arrow array."
                 );

--- a/rerun_cpp/tests/generated/datatypes/string_component.hpp
+++ b/rerun_cpp/tests/generated/datatypes/string_component.hpp
@@ -39,7 +39,7 @@ namespace rerun {
             );
 
             /// Fills an arrow array builder with an array of this type.
-            static Error fill_arrow_array_builder(
+            static rerun::Error fill_arrow_array_builder(
                 arrow::StringBuilder* builder, const StringComponent* elements, size_t num_elements
             );
         };

--- a/tests/cpp/roundtrips/CMakeLists.txt
+++ b/tests/cpp/roundtrips/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.16...3.27)
 
 file(GLOB sources_list LIST_DIRECTORIES true ${CMAKE_CURRENT_SOURCE_DIR}/*)
 
+add_custom_target(roundtrips)
+
 foreach(DIR ${sources_list})
     IF(IS_DIRECTORY ${DIR})
         get_filename_component(ARCHETYPE ${DIR} NAME)
@@ -15,6 +17,7 @@ foreach(DIR ${sources_list})
         add_executable(${ROUNDTRIP_TARGET} ${DIR}/main.cpp)
         rerun_strict_warning_settings(${ROUNDTRIP_TARGET})
         target_link_libraries(${ROUNDTRIP_TARGET} PRIVATE rerun_sdk)
+        add_dependencies(roundtrips ${ROUNDTRIP_TARGET})
     ELSE()
         CONTINUE()
     ENDIF()

--- a/tests/cpp/roundtrips/text_log/main.cpp
+++ b/tests/cpp/roundtrips/text_log/main.cpp
@@ -6,7 +6,7 @@ int main(int, char** argv) {
     rec.log("log", rerun::archetypes::TextLog("No level"));
     rec.log(
         "log",
-        rerun::archetypes::TextLog("INFO level").with_level(rerun::components::TextLogLevel::INFO)
+        rerun::archetypes::TextLog("INFO level").with_level(rerun::components::TextLogLevel::Info)
     );
     rec.log("log", rerun::archetypes::TextLog("WILD level").with_level("WILD"));
 }


### PR DESCRIPTION
### What

Considered also just using lower case on these (nobody would do `#define debug`, ... RIGHT?). But they are _enum - like_ constants so all-caps felt appropriate.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4152) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4152)
- [Docs preview](https://rerun.io/preview/ff8b29947f85102e649b7cb2ed651228888d3bf1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ff8b29947f85102e649b7cb2ed651228888d3bf1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)