### PR TITLE
Automatically sync assets on release

### DIFF
--- a/.github/workflows/on_gh_release.yml
+++ b/.github/workflows/on_gh_release.yml
@@ -1,0 +1,22 @@
+name: "GitHub Release"
+
+on:
+  release:
+    types: [released]
+
+concurrency:
+  group: "release-${{ github.event.release.tag_name }}"
+  cancel-in-progress: true
+
+permissions:
+  # required for updating the release
+  contents: write
+
+jobs:
+  sync-release-assets:
+    name: "Sync Release Assets"
+    uses: ./.github/workflows/reusable_sync_release_assets.yml
+    with:
+      CONCURRENCY: "${{ github.event.release.tag_name }}"
+      RELEASE_VERSION: "${{ github.event.release.tag_name }}"
+    secrets: inherit

--- a/scripts/ci/sync_release_assets.py
+++ b/scripts/ci/sync_release_assets.py
@@ -178,7 +178,7 @@ def main() -> None:
     parser.add_argument(
         "--github-release",
         required=True,
-        help="ID of the Github (pre)release (e.g. `prerelease` or `0.9.0`)",
+        help="Github (pre)release tag (e.g. `prerelease` or `0.9.0`)",
     )
     parser.add_argument("--github-timeout", default=120, help="Timeout for Github related operations")
     parser.add_argument("--wait", default=0, help="Sleep a bit before doing anything")


### PR DESCRIPTION
### What

The release assets are now synced automatically on the `release` event with type `released`

https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=released#release

> A release was published, or a pre-release was changed to a release.

Fixes https://github.com/rerun-io/rerun/issues/4133 (no longer needed)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4163) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4163)
- [Docs preview](https://rerun.io/preview/517970c00aec905c9ee2de6dcc977e456d289802/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/517970c00aec905c9ee2de6dcc977e456d289802/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)