### PR TITLE
Add command to copy direct link to fully qualified URL

### DIFF
--- a/crates/re_build_info/src/build_info.rs
+++ b/crates/re_build_info/src/build_info.rs
@@ -55,6 +55,18 @@ impl BuildInfo {
             self.git_hash.to_owned()
         }
     }
+
+    pub fn short_git_hash(&self) -> &str {
+        if self.git_hash.is_empty() {
+            ""
+        } else {
+            &self.git_hash[..7]
+        }
+    }
+
+    pub fn is_final(&self) -> bool {
+        self.version.meta.is_none()
+    }
 }
 
 /// For use with e.g. `--version`

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -61,6 +61,9 @@ pub enum UICommand {
     ScreenshotWholeApp,
     #[cfg(not(target_arch = "wasm32"))]
     PrintDatastore,
+
+    #[cfg(target_arch = "wasm32")]
+    CopyDirectLink,
 }
 
 impl UICommand {
@@ -161,6 +164,12 @@ impl UICommand {
                 "Print datastore",
                 "Prints the entire data store to the console. WARNING: this may be A LOT of text.",
             ),
+
+            #[cfg(target_arch = "wasm32")]
+            UICommand::CopyDirectLink => (
+                "Copy direct link",
+                "Copy a link to the viewer with the URL parameter set to the current .rrd data source."
+            )
         }
     }
 
@@ -231,6 +240,9 @@ impl UICommand {
             UICommand::ScreenshotWholeApp => None,
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::PrintDatastore => None,
+
+            #[cfg(target_arch = "wasm32")]
+            UICommand::CopyDirectLink => None,
         }
     }
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -524,6 +524,27 @@ impl App {
                     }
                 }
             }
+            #[cfg(target_arch = "wasm32")]
+            UICommand::CopyDirectLink => {
+                let Some(SmartChannelSource::RrdHttpStream { url }) = store_context
+                    .and_then(|ctx| ctx.recording)
+                    .and_then(|rec| rec.data_source.as_ref())
+                else {
+                    return;
+                };
+                let direct_link = match &self.startup_options.location {
+                    Some(eframe::Location { origin, .. }) => format!("{origin}/?url={url}"),
+                    None => format!("https://app.rerun.io/?url={url}"),
+                };
+                self.re_ui
+                    .egui_ctx
+                    .output_mut(|o| o.copied_text = direct_link.clone());
+                self.toasts.add(toasts::Toast {
+                    kind: toasts::ToastKind::Success,
+                    text: format!("Copied {direct_link} to clipboard"),
+                    options: toasts::ToastOptions::with_ttl_in_seconds(4.0),
+                });
+            }
         }
     }
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -568,20 +568,13 @@ impl App {
 
     #[cfg(target_arch = "wasm32")]
     fn run_copy_direct_link_command(&mut self, store_context: Option<&StoreContext<'_>>) {
-        let Some(SmartChannelSource::RrdHttpStream { url }) = store_context
+        let origin = eframe::web::web_location().origin;
+        let direct_link = match store_context
             .and_then(|ctx| ctx.recording)
             .and_then(|rec| rec.data_source.as_ref())
-        else {
-            self.toasts.add(toasts::Toast {
-                kind: toasts::ToastKind::Warning,
-                text: format!("Could not copy direct link, no recording is open"),
-                options: toasts::ToastOptions::with_ttl_in_seconds(4.0),
-            });
-            return;
-        };
-        let direct_link = match &self.startup_options.location {
-            Some(eframe::Location { origin, .. }) => format!("{origin}/?url={url}"),
-            None => format!("https://app.rerun.io/?url={url}"),
+        {
+            Some(SmartChannelSource::RrdHttpStream { url }) => format!("{origin}/?url={url}"),
+            _ => origin,
         };
         self.re_ui
             .egui_ctx

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -568,7 +568,17 @@ impl App {
 
     #[cfg(target_arch = "wasm32")]
     fn run_copy_direct_link_command(&mut self, store_context: Option<&StoreContext<'_>>) {
-        let origin = eframe::web::web_location().origin;
+        let location = eframe::web::web_location();
+        let mut origin = location.origin;
+        if location.host == "app.rerun.io" {
+            let path = match &self.build_info.version.meta {
+                // not a final release, use commit hash
+                Some(..) => format!("commit/{}", &self.build_info.git_hash[..7]),
+                // final release, use version tag
+                None => format!("version/{}", self.build_info.version),
+            };
+            origin = format!("{origin}/{path}/index.html");
+        }
         let direct_link = match store_context
             .and_then(|ctx| ctx.recording)
             .and_then(|rec| rec.data_source.as_ref())

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -571,6 +571,7 @@ impl App {
         let location = eframe::web::web_location();
         let mut origin = location.origin;
         if location.host == "app.rerun.io" {
+            // links to `app.rerun.io` can be made into permanent links:
             let path = match &self.build_info.version.meta {
                 // not a final release, use commit hash
                 Some(..) => format!("commit/{}", &self.build_info.git_hash[..7]),


### PR DESCRIPTION
### What

When on web, the command pallete now lists a command to copy a direct link to the "fully qualified" URL, which is `location.origin` + `query["url"]`.

Fixes https://github.com/rerun-io/rerun/issues/4122

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4165) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4165)
- [Docs preview](https://rerun.io/preview/511ef39edb815811050aa3d325ff517314cc082e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/511ef39edb815811050aa3d325ff517314cc082e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)