### PR TITLE
Actually unique `RowId`s 3: Rework `StoreDb` to support unique `RowId`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4125,6 +4125,7 @@ dependencies = [
  "anyhow",
  "criterion",
  "document-features",
+ "getrandom",
  "itertools 0.11.0",
  "mimalloc",
  "nohash-hasher",

--- a/crates/re_data_store/Cargo.toml
+++ b/crates/re_data_store/Cargo.toml
@@ -35,6 +35,7 @@ re_tracing.workspace = true
 re_types_core.workspace = true
 
 document-features.workspace = true
+getrandom.workspace = true
 itertools.workspace = true
 nohash-hasher.workspace = true
 serde = { workspace = true, features = ["derive", "rc"], optional = true }

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use nohash_hasher::IntMap;
 
 use re_arrow_store::{DataStore, DataStoreConfig, GarbageCollectionOptions};
-use re_log::warn_once;
 use re_log_types::{
     ApplicationId, ComponentPath, DataCell, DataRow, DataTable, EntityPath, EntityPathHash, LogMsg,
     PathOp, RowId, SetStoreInfo, StoreId, StoreInfo, StoreKind, TimePoint, Timeline,
@@ -123,7 +122,7 @@ impl EntityDb {
     fn add_data_row(&mut self, row: DataRow) -> Result<DataRow, Error> {
         // ## RowId duplication
         //
-        // We shouldn't be attempting to retry in this intance: a duplicated RowId at this stage
+        // We shouldn't be attempting to retry in this instance: a duplicated RowId at this stage
         // is likely a user error.
         //
         // We only do so because, the way our 'save' feature is currently implemented in the

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 
 use nohash_hasher::IntMap;
 
-use re_arrow_store::{DataStoreConfig, GarbageCollectionOptions};
+use re_arrow_store::{DataStore, DataStoreConfig, GarbageCollectionOptions};
+use re_log::warn_once;
 use re_log_types::{
     ApplicationId, ComponentPath, DataCell, DataRow, DataTable, EntityPath, EntityPathHash, LogMsg,
     PathOp, RowId, SetStoreInfo, StoreId, StoreInfo, StoreKind, TimePoint, Timeline,
@@ -27,7 +28,7 @@ pub struct EntityDb {
     pub tree: crate::EntityTree,
 
     /// Stores all components for all entities for all timelines.
-    pub data_store: re_arrow_store::DataStore,
+    pub data_store: DataStore,
 }
 
 impl Default for EntityDb {
@@ -36,12 +37,51 @@ impl Default for EntityDb {
             entity_path_from_hash: Default::default(),
             times_per_timeline: Default::default(),
             tree: crate::EntityTree::root(),
-            data_store: re_arrow_store::DataStore::new(
-                InstanceKey::name(),
-                DataStoreConfig::default(),
-            ),
+            data_store: DataStore::new(InstanceKey::name(), DataStoreConfig::default()),
         }
     }
+}
+
+/// See [`insert_row_with_retries`].
+const MAX_INSERT_ROW_ATTEMPTS: usize = 1_000;
+
+/// See [`insert_row_with_retries`].
+const DEFAULT_INSERT_ROW_STEP_SIZE: u64 = 100;
+
+/// Inserts a [`DataRow`] into the [`DataStore`], retrying in case of duplicated `RowId`s.
+///
+/// Retries a maximum of `num_attempts` times if the row couldn't be inserted because of a
+/// duplicated [`RowId`], bumping the [`RowId`]'s internal counter by `step_size` between attempts.
+///
+/// Returns the actual [`DataRow`] that was successfully inserted, if any.
+///
+/// The default value of `num_attempts` (see [`MAX_INSERT_ROW_ATTEMPTS`]) should be (way) more than
+/// enough for all valid use cases.
+///
+/// When using this function, please add a comment explaining the rationale.
+fn insert_row_with_retries(
+    store: &mut DataStore,
+    mut row: DataRow,
+    num_attempts: usize,
+    step_size: u64,
+) -> re_arrow_store::WriteResult<DataRow> {
+    fn random_u64() -> u64 {
+        let mut bytes = [0_u8; 8];
+        getrandom::getrandom(&mut bytes).map_or(0, |_| u64::from_le_bytes(bytes))
+    }
+
+    for _ in 0..num_attempts {
+        match store.insert_row(&row) {
+            Ok(_) => return Ok(row),
+            Err(re_arrow_store::WriteError::ReusedRowId(_)) => {
+                re_log::warn!(row_id = %row.row_id(), "Found duplicated RowId, retrying…");
+                row.row_id = row.row_id.increment(random_u64() % step_size + 1);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    Err(re_arrow_store::WriteError::ReusedRowId(row.row_id()))
 }
 
 impl EntityDb {
@@ -75,10 +115,30 @@ impl EntityDb {
             .or_insert_with(|| entity_path.clone());
     }
 
-    // TODO(cmc): Updates of secondary datastructures should be the result of subscribing to the
+    /// Returns the [`DataRow`] that was inserted. It might have been modified!
+    //
+    // TODO(#374): Updates of secondary datastructures should be the result of subscribing to the
     // datastore's changelog and reacting to these changes appropriately. We shouldn't be creating
     // many sources of truth.
-    fn add_data_row(&mut self, row: &DataRow) -> Result<(), Error> {
+    fn add_data_row(&mut self, row: DataRow) -> Result<DataRow, Error> {
+        // ## RowId duplication
+        //
+        // We shouldn't be attempting to retry in this intance: a duplicated RowId at this stage
+        // is likely a user error.
+        //
+        // We only do so because, the way our 'save' feature is currently implemented in the
+        // viewer can result in a single row's worth of data to be split across several insertions
+        // when loading that data back (because we dump per-bucket, and RowIds get duplicated
+        // across buckets).
+        //
+        // TODO(#1894): Remove this once the save/load process becomes RowId-driven.
+        let row = insert_row_with_retries(
+            &mut self.data_store,
+            row,
+            MAX_INSERT_ROW_ATTEMPTS,
+            DEFAULT_INSERT_ROW_STEP_SIZE,
+        )?;
+
         self.register_entity_path(&row.entity_path);
 
         for (&timeline, &time_int) in row.timepoint().iter() {
@@ -96,23 +156,37 @@ impl EntityDb {
                 let cell =
                     DataCell::from_arrow_empty(cell.component_name(), cell.datatype().clone());
 
-                // NOTE(cmc): The fact that this inserts data to multiple entity paths using a
-                // single `RowId` is… interesting. Keep it in mind.
                 let row = DataRow::from_cells1(
-                    row_id,
+                    row_id.next(), // see comment below
                     row.entity_path.clone(),
                     time_point.clone(),
                     cell.num_instances(),
                     cell,
                 )?;
-                self.data_store.insert_row(&row).ok();
+
+                // ## RowId duplication
+                //
+                // We are inserting new data (empty cells) with an old RowId (specifically, the RowId
+                // of the original insertion that was used to register the pending clear in the first
+                // place).
+                // By definition, this is illegal: RowIds are unique.
+                //
+                // On the other hand, the GC process is driven by RowId order, which means we must make
+                // sure that the empty cell we're inserting uses a RowId with a similar timestamp as the
+                // one used in the original Clear component cell, so they roughly get GC'd at the same time.
+                if let Err(err) = insert_row_with_retries(
+                    &mut self.data_store,
+                    row,
+                    MAX_INSERT_ROW_ATTEMPTS,
+                    DEFAULT_INSERT_ROW_STEP_SIZE,
+                ) {
+                    re_log::error!(%err, "Failed to insert pending clear cell");
+                }
 
                 // Also update the tree with the clear-event
                 self.tree.add_data_msg(&time_point, &component_path);
             }
         }
-
-        self.data_store.insert_row(row)?;
 
         // Look for a `ClearIsRecursive` component, and if it's there, go through the clear path
         // instead.
@@ -125,14 +199,13 @@ impl EntityDb {
             } else {
                 PathOp::ClearComponents(row.entity_path.clone())
             };
-            // NOTE: We've just added the row itself, so make sure to bump the row ID already!
-            self.add_path_op(row.row_id().next(), row.timepoint(), &path_op);
+            self.add_path_op(row.row_id(), row.timepoint(), &path_op);
         }
 
-        Ok(())
+        Ok(row)
     }
 
-    fn add_path_op(&mut self, row_id: RowId, time_point: &TimePoint, path_op: &PathOp) {
+    fn add_path_op(&mut self, mut row_id: RowId, time_point: &TimePoint, path_op: &PathOp) {
         let cleared_paths = self.tree.add_path_op(row_id, time_point, path_op);
 
         // NOTE: Btree! We need a stable ordering here!
@@ -156,25 +229,46 @@ impl EntityDb {
             }
         }
 
+        row_id = row_id.next(); // see comment below
+
         // Create and insert empty components into the arrow store.
-        let mut row_id = row_id;
         for (ent_path, cells) in cells {
             // NOTE: It is important we insert all those empty components using a single row (id)!
             // 1. It'll be much more efficient when querying that data back.
             // 2. Otherwise we will end up with a flaky row ordering, as we have no way to tie-break
             //    these rows! This flaky ordering will in turn leak through the public
             //    API (e.g. range queries)!!
-            match DataRow::from_cells(row_id, time_point.clone(), ent_path, 0, cells) {
+            row_id = match DataRow::from_cells(row_id, time_point.clone(), ent_path, 0, cells) {
                 Ok(row) => {
-                    self.data_store.insert_row(&row).ok();
+                    // ## RowId duplication
+                    //
+                    // We are inserting new data (empty cells) with an already used RowId (specifically,
+                    // the RowId of the row containing the clear cell itself).
+                    // By definition, this is illegal: RowIds are unique.
+                    //
+                    // On the other hand, the GC process is driven by RowId order, which means we must make
+                    // sure that the empty cell we're inserting uses a RowId with a similar timestamp as the
+                    // one used in the original Clear component cell, so they roughly get GC'd at the same time.
+                    match insert_row_with_retries(
+                        &mut self.data_store,
+                        row,
+                        MAX_INSERT_ROW_ATTEMPTS,
+                        DEFAULT_INSERT_ROW_STEP_SIZE,
+                    ) {
+                        Ok(row) => row.row_id(),
+                        Err(err) => {
+                            re_log::error!(%err, ?path_op, "Failed to insert PathOp");
+                            row_id
+                        }
+                    }
                 }
                 Err(err) => {
-                    re_log::error_once!("Failed to insert PathOp {path_op:?}: {err}");
+                    re_log::error!(%err, ?path_op, "Failed to insert PathOp");
+                    row_id
                 }
-            }
+            };
 
-            // Don't reuse the same row ID for the next entity!
-            row_id = row_id.next();
+            row_id = row_id.next(); // see comment above
         }
     }
 
@@ -252,7 +346,7 @@ impl StoreDb {
             info: store_info,
         });
         for row in rows {
-            store_db.add_data_row(&row)?;
+            store_db.add_data_row(row)?;
         }
 
         Ok(store_db)
@@ -276,7 +370,7 @@ impl StoreDb {
     }
 
     #[inline]
-    pub fn store(&self) -> &re_arrow_store::DataStore {
+    pub fn store(&self) -> &DataStore {
         &self.entity_db.data_store
     }
 
@@ -340,17 +434,15 @@ impl StoreDb {
         // TODO(#1760): Compute the size of the datacells in the batching threads on the clients.
         table.compute_all_size_bytes();
 
-        // TODO(cmc): batch all of this
         for row in table.to_rows() {
-            let row = row?;
-            self.add_data_row(&row)?;
+            self.add_data_row(row?)?;
         }
 
         Ok(())
     }
 
-    pub fn add_data_row(&mut self, row: &DataRow) -> Result<(), Error> {
-        self.entity_db.add_data_row(row)
+    pub fn add_data_row(&mut self, row: DataRow) -> Result<(), Error> {
+        self.entity_db.add_data_row(row).map(|_| ())
     }
 
     pub fn set_store_info(&mut self, store_info: SetStoreInfo) {

--- a/crates/re_data_store/tests/clear.rs
+++ b/crates/re_data_store/tests/clear.rs
@@ -18,13 +18,6 @@ fn clears() -> anyhow::Result<()> {
     let entity_path_child2: EntityPath = "parent/deep/deep/down/child2".into();
     let entity_path_grandchild: EntityPath = "parent/child1/grandchild".into();
 
-    // TODO(cmc): We have to temporarily disable this test suite, because the current pending clear
-    // implementation illegally re-uses RowIds and swallows store errors (`.ok()`)!
-    // Fixed in PR#3.
-    if true {
-        return Ok(());
-    }
-
     // * Insert a 2D point & color for 'parent' at frame #10.
     // * Query 'parent' at frame #11 and make sure we find everything back.
     {
@@ -39,7 +32,7 @@ fn clears() -> anyhow::Result<()> {
             [&[point] as _, &[color] as _],
         )?;
 
-        db.add_data_row(&row)?;
+        db.add_data_row(row)?;
 
         {
             let query = LatestAtQuery {
@@ -76,7 +69,7 @@ fn clears() -> anyhow::Result<()> {
             [&[point] as _],
         )?;
 
-        db.add_data_row(&row)?;
+        db.add_data_row(row)?;
 
         {
             let query = LatestAtQuery {
@@ -107,7 +100,7 @@ fn clears() -> anyhow::Result<()> {
             [&[color] as _],
         )?;
 
-        db.add_data_row(&row)?;
+        db.add_data_row(row)?;
 
         {
             let query = LatestAtQuery {
@@ -140,7 +133,7 @@ fn clears() -> anyhow::Result<()> {
             clear.as_component_batches().iter().map(|b| b.as_ref()),
         )?;
 
-        db.add_data_row(&row)?;
+        db.add_data_row(row)?;
 
         {
             let query = LatestAtQuery {
@@ -187,7 +180,7 @@ fn clears() -> anyhow::Result<()> {
             clear.as_component_batches().iter().map(|b| b.as_ref()),
         )?;
 
-        db.add_data_row(&row)?;
+        db.add_data_row(row)?;
 
         {
             let query = LatestAtQuery {
@@ -233,7 +226,7 @@ fn clears() -> anyhow::Result<()> {
             [&[instance_key] as _],
         )?;
 
-        db.add_data_row(&row)?;
+        db.add_data_row(row)?;
 
         {
             let query = LatestAtQuery {
@@ -278,7 +271,7 @@ fn clears() -> anyhow::Result<()> {
             [&[point] as _, &[color] as _],
         )?;
 
-        db.add_data_row(&row)?;
+        db.add_data_row(row)?;
 
         {
             let query = LatestAtQuery {
@@ -334,7 +327,7 @@ fn clears() -> anyhow::Result<()> {
             [&[color] as _, &[point] as _],
         )?;
 
-        db.add_data_row(&row)?;
+        db.add_data_row(row)?;
 
         {
             let query = LatestAtQuery {
@@ -388,7 +381,7 @@ fn clears() -> anyhow::Result<()> {
             [&[color] as _],
         )?;
 
-        db.add_data_row(&row)?;
+        db.add_data_row(row)?;
 
         {
             let query = LatestAtQuery {

--- a/crates/re_log_types/src/data_row.rs
+++ b/crates/re_log_types/src/data_row.rs
@@ -133,6 +133,18 @@ impl RowId {
     pub fn next(&self) -> Self {
         Self(self.0.next())
     }
+
+    /// Returns the `n`-next logical [`RowId`].
+    ///
+    /// This is equivalent to calling [`RowId::next`] `n` times.
+    /// Wraps the monotonically increasing back to zero on overflow.
+    ///
+    /// Beware: wrong usage can easily lead to conflicts.
+    /// Prefer [`RowId::random`] when unsure.
+    #[inline]
+    pub fn increment(&self, n: u64) -> Self {
+        Self(self.0.increment(n))
+    }
 }
 
 impl SizeBytes for RowId {

--- a/crates/re_log_types/src/data_table.rs
+++ b/crates/re_log_types/src/data_table.rs
@@ -161,6 +161,18 @@ impl TableId {
     pub fn next(&self) -> Self {
         Self(self.0.next())
     }
+
+    /// Returns the `n`-next logical [`TableId`].
+    ///
+    /// This is equivalent to calling [`TableId::next`] `n` times.
+    /// Wraps the monotonically increasing back to zero on overflow.
+    ///
+    /// Beware: wrong usage can easily lead to conflicts.
+    /// Prefer [`TableId::random`] when unsure.
+    #[inline]
+    pub fn increment(&self, n: u64) -> Self {
+        Self(self.0.increment(n))
+    }
 }
 
 impl SizeBytes for TableId {

--- a/crates/re_tuid/Cargo.toml
+++ b/crates/re_tuid/Cargo.toml
@@ -28,7 +28,7 @@ serde = ["dep:serde", "re_types_core?/serde"]
 
 [dependencies]
 document-features.workspace = true
-getrandom = "0.2"
+getrandom.workspace = true
 once_cell.workspace = true
 web-time.workspace = true
 

--- a/crates/re_tuid/src/lib.rs
+++ b/crates/re_tuid/src/lib.rs
@@ -84,7 +84,7 @@ impl Tuid {
         ((self.time_ns as u128) << 64) | (self.inc as u128)
     }
 
-    /// Returns the next logical `Tuid`.
+    /// Returns the next logical [`Tuid`].
     ///
     /// Wraps the monotonically increasing back to zero on overflow.
     ///
@@ -97,6 +97,22 @@ impl Tuid {
         Self {
             time_ns,
             inc: inc.wrapping_add(1),
+        }
+    }
+
+    /// Returns the `n`-next logical [`Tuid`].
+    ///
+    /// This is equivalent to calling [`Tuid::next`] `n` times.
+    /// Wraps the monotonically increasing back to zero on overflow.
+    ///
+    /// Beware: wrong usage can easily lead to conflicts.
+    /// Prefer [`Tuid::random`] when unsure.
+    #[inline]
+    pub fn increment(&self, n: u64) -> Self {
+        let Self { time_ns, inc } = *self;
+        Self {
+            time_ns,
+            inc: inc.wrapping_add(n),
         }
     }
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -359,7 +359,7 @@ impl App {
             SystemCommand::UpdateBlueprint(blueprint_id, updates) => {
                 let blueprint_db = store_hub.store_db_mut(&blueprint_id);
                 for row in updates {
-                    match blueprint_db.add_data_row(&row) {
+                    match blueprint_db.add_data_row(row) {
                         Ok(()) => {}
                         Err(err) => {
                             re_log::warn_once!("Failed to store blueprint delta: {err}");

--- a/crates/re_viewer/src/app_blueprint.rs
+++ b/crates/re_viewer/src/app_blueprint.rs
@@ -94,7 +94,7 @@ pub fn setup_welcome_screen_blueprint(welcome_screen_blueprint: &mut StoreDb) {
             DataRow::from_cells1_sized(RowId::random(), entity_path, timepoint, 1, [component])
                 .unwrap(); // Can only fail if we have the wrong number of instances for the component, and we don't
 
-        welcome_screen_blueprint.add_data_row(&row).unwrap(); // Can only fail if we have the wrong number of instances for the component, and we don't
+        welcome_screen_blueprint.add_data_row(row).unwrap(); // Can only fail if we have the wrong number of instances for the component, and we don't
     }
 }
 


### PR DESCRIPTION
This PR introduces insertion retries in order to make `StoreDb` compatible with a world of unique `RowId`s.
A lot of care has to be taken around clears & pending clears specifically (which do not swallow errors anymore!!).

---

_Part of a small PR series whose goal is to make `RowId`s truly unique: i.e. a `RowId` corresponds to one insertion in the store, using the store's atomic unit of insertion -- the `DataRow` (which itself might still carry arbitrarily many timestamps(!)).
This creates an invariant that downstream subscribers of store events can trust and build on: a RowId is introduced once and GC'd once, that's it._


- #4174 
- #4175 
- #4176
- #4180

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4176) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4176)
- [Docs preview](https://rerun.io/preview/3b26f5ca621cee383dcc54ce6583a5a08f1da8f6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3b26f5ca621cee383dcc54ce6583a5a08f1da8f6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)