### PR TITLE
Scope the defaultFormatter override to python

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,19 @@
             "*.unsafe:rust": "#eb5046"
         }
     },
+    "files.autoGuessEncoding": true,
+    "files.exclude": {
+        "venv": true,
+        ".pixi": true,
+        "build": true,
+        "compare_screenshot": true,
+        "target": true,
+        "target_ra": true,
+        "target_wasm": true,
+        "web_demo": true
+    },
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
-    "files.autoGuessEncoding": true,
     "cSpell.ignorePaths": [
         ".vscode",
         "pixi.lock"
@@ -77,11 +87,13 @@
     "cmake.buildDirectory": "${workspaceRoot}/build/",
     "cmake.generator": "Ninja", // Use Ninja, just like we do in our just/pixi command.
     "rust-analyzer.showUnlinkedFileNotification": false,
-    "editor.defaultFormatter": "charliermarsh.ruff",
     "ruff.format.args": [
         "--config=rerun_py/pyproject.toml"
     ],
     "ruff.lint.args": [
         "--config=rerun_py/pyproject.toml"
-    ]
+    ],
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff",
+    },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,16 +6,6 @@
         }
     },
     "files.autoGuessEncoding": true,
-    "files.exclude": {
-        "venv": true,
-        ".pixi": true,
-        "build": true,
-        "compare_screenshot": true,
-        "target": true,
-        "target_ra": true,
-        "target_wasm": true,
-        "web_demo": true
-    },
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
     "cSpell.ignorePaths": [


### PR DESCRIPTION
### What
Without this, vs code stopped running rust-analyzer on my project.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4177) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4177)
- [Docs preview](https://rerun.io/preview/bda06c132a491981b33dc4a08c3776916e5b8a11/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bda06c132a491981b33dc4a08c3776916e5b8a11/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)