### PR TITLE
Fix markdown heading size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3423cc4ae1cb068e3aff8c6b33eb9bab2a79c5563e8e3979dac3d56c92f00a2f"
+checksum = "a1665b7659f041aa99d3f97ec11d5f1f7062cd757e2ebd12e13532b96a348a6b"
 dependencies = [
  "egui",
  "egui_extras",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ egui = { version = "0.23.0", features = [
   "log",
   "puffin",
 ] }
-egui_commonmark = { version = "0.9", default-features = false }
+egui_commonmark = { version = "0.9.2", default-features = false }
 egui_extras = { version = "0.23.0", features = ["http", "image", "puffin"] }
 egui_plot = "0.23.0"
 egui_tiles = "0.3.1"

--- a/crates/re_space_view_text_document/src/space_view_class.rs
+++ b/crates/re_space_view_text_document/src/space_view_class.rs
@@ -130,7 +130,7 @@ impl SpaceViewClass for TextDocumentSpaceView {
                                         .text_styles
                                         .entry(egui::TextStyle::Heading)
                                         .or_insert(egui::FontId::proportional(32.0))
-                                        .size = 24.0;
+                                        .size = 32.0;
 
                                     egui_commonmark::CommonMarkViewer::new("markdown_viewer")
                                         .max_image_width(Some(ui.available_width().floor() as _))

--- a/crates/re_space_view_text_document/src/space_view_class.rs
+++ b/crates/re_space_view_text_document/src/space_view_class.rs
@@ -130,7 +130,7 @@ impl SpaceViewClass for TextDocumentSpaceView {
                                         .text_styles
                                         .entry(egui::TextStyle::Heading)
                                         .or_insert(egui::FontId::proportional(32.0))
-                                        .size = 32.0;
+                                        .size = 24.0;
 
                                     egui_commonmark::CommonMarkViewer::new("markdown_viewer")
                                         .max_image_width(Some(ui.available_width().floor() as _))

--- a/crates/re_viewer/data/quick_start_guides/cpp_connect.md
+++ b/crates/re_viewer/data/quick_start_guides/cpp_connect.md
@@ -1,8 +1,8 @@
-## C++ Quick Start
+# C++ Quick Start
 
 ${SAFARI_WARNING}
 
-#### Installing the Rerun viewer
+## Installing the Rerun viewer
 The Rerun C++ SDK works by connecting to an awaiting Rerun Viewer over TCP.
 
 If you need to install the viewer, follow the [installation guide](https://www.rerun.io/docs/getting-started/installing-viewer). Two of the more common ways to install the Rerun are:
@@ -11,7 +11,7 @@ If you need to install the viewer, follow the [installation guide](https://www.r
 
 After you have installed it, you should be able to type `rerun` in your terminal to start the viewer.
 
-#### Using the Rerun C++ SDK with CMake
+## Using the Rerun C++ SDK with CMake
 ```cmake
 include(FetchContent)
 FetchContent_Declare(rerun_sdk URL
@@ -29,7 +29,7 @@ Make sure you link with `rerun_sdk`:
 target_link_libraries(your_executable PRIVATE rerun_sdk)
 ```
 
-##### Logging your own data
+### Logging your own data
 
 Put the following code to your `main.cpp`:
 

--- a/crates/re_viewer/data/quick_start_guides/how_does_it_work.md
+++ b/crates/re_viewer/data/quick_start_guides/how_does_it_work.md
@@ -1,4 +1,4 @@
-### How does it work?
+## How does it work?
 
 Rerun's goal is to make handling and visualizing multimodal data streams easy and performant.
 

--- a/crates/re_viewer/data/quick_start_guides/python_connect.md
+++ b/crates/re_viewer/data/quick_start_guides/python_connect.md
@@ -1,8 +1,8 @@
-## Python Quick Start
+# Python Quick Start
 
 ${SAFARI_WARNING}
 
-### Installing the Rerun SDK
+## Installing the Rerun SDK
 
 The Rerun SDK is available on [PyPI](https://pypi.org/) under the
 [`rerun-sdk`](https://pypi.org/project/rerun-sdk/) name. It can be installed like any other
@@ -12,7 +12,7 @@ Python package:
 pip install rerun-sdk
 ```
 
-### Logging your own data
+## Logging your own data
 
 Copy and paste the following snippet in a new Python file and execute it to create a new recording in this viewer:
 

--- a/crates/re_viewer/data/quick_start_guides/python_spawn.md
+++ b/crates/re_viewer/data/quick_start_guides/python_spawn.md
@@ -1,8 +1,8 @@
-## Python Quick Start
+# Python Quick Start
 
 ${SAFARI_WARNING}
 
-### Installing the Rerun SDK
+## Installing the Rerun SDK
 
 The Rerun SDK is available on [PyPI](https://pypi.org/) under the
 [`rerun-sdk`](https://pypi.org/project/rerun-sdk/) name. It can be installed like any other
@@ -12,7 +12,7 @@ Python package:
 pip install rerun-sdk
 ```
 
-### Logging your own data
+## Logging your own data
 
 Copy and paste the following snippet in a new Python file and execute it to create a recording in a new viewer:
 

--- a/crates/re_viewer/data/quick_start_guides/rust_connect.md
+++ b/crates/re_viewer/data/quick_start_guides/rust_connect.md
@@ -1,8 +1,8 @@
-## Rust Quick Start
+# Rust Quick Start
 
 ${SAFARI_WARNING}
 
-### Installing Rerun
+## Installing Rerun
 
 To use the Rerun SDK in your project, you need the [rerun crate](https://crates.io/crates/rerun) which you can add with `cargo add rerun`.
 
@@ -14,7 +14,7 @@ cargo init cube && cd cube && cargo add rerun --features native_viewer
 
 Note that the Rerun SDK requires a working installation of Rust 1.72+.
 
-### Logging your own data
+## Logging your own data
 
 Add the following code to your `main.rs` file:
 

--- a/crates/re_viewer/data/quick_start_guides/rust_spawn.md
+++ b/crates/re_viewer/data/quick_start_guides/rust_spawn.md
@@ -1,8 +1,8 @@
-## Rust Quick Start
+# Rust Quick Start
 
 ${SAFARI_WARNING}
 
-### Installing Rerun
+## Installing Rerun
 
 After you have [installed the viewer](https://www.rerun.io/docs/getting-started/installing-viewer) you can simply add [the rerun crate](https://crates.io/crates/rerun) to your project with `cargo add rerun`.
 
@@ -14,7 +14,7 @@ cargo init cube && cd cube && cargo add rerun
 
 Note that the Rerun SDK requires a working installation of Rust 1.72+.
 
-### Logging your own data
+## Logging your own data
 
 Add the following code to your `main.rs` file:
 


### PR DESCRIPTION
### What

- Take advantage of https://github.com/lampsitter/egui_commonmark/pull/20 to use "correct" headings in in-app quick start guides.
- Bump egui_commonmark to 0.9.2 which includes the PR above
- Fixes #3612

<img width="1305" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/a4befe22-2675-4a8f-a5ca-38cec3141b13">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4178) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4178)
- [Docs preview](https://rerun.io/preview/85986f760b9d674ecb58917f1b77693f43d3c3bf/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/85986f760b9d674ecb58917f1b77693f43d3c3bf/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)