### PR TITLE
Simple logging benchmarks for C++ & Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ crates/re_types_builder/source_hash.txt
 *.o
 **/arrow/
 **/build/
+**/build-msvc/
 **/CMakeFiles/
 **/CMakeCache.txt
 **/Makefile

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,6 +2799,7 @@ name = "log_benchmark"
 version = "0.11.0-alpha.1+dev"
 dependencies = [
  "anyhow",
+ "bytemuck",
  "clap",
  "glam",
  "re_tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,6 +2795,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "log_benchmark"
+version = "0.11.0-alpha.1+dev"
+dependencies = [
+ "anyhow",
+ "clap",
+ "glam",
+ "re_tracing",
+ "rerun",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,9 @@ members = [
   "docs/code-examples",
   "rerun_py",
   "run_wasm",
-  "tests/rust/test_*",
+  "tests/rust/log_benchmark",
   "tests/rust/roundtrips/*",
+  "tests/rust/test_*",
 ]
 
 [workspace.package]
@@ -80,6 +81,7 @@ async-executor = "1.0"
 backtrace = "0.3"
 bincode = "1.3"
 bitflags = "1.3"
+blackbox = "0.2.0"
 bytemuck = { version = "1.11", features = ["extern_crate_alloc"] }
 camino = "1.1"
 cargo-run-wasm = "0.3.2"

--- a/pixi.lock
+++ b/pixi.lock
@@ -18,17 +18,16 @@ metadata:
   inputs_metadata: null
   custom_metadata: null
 package:
-- name: _libgcc_mutex
+- platform: linux-64
+  name: _libgcc_mutex
   version: '0.1'
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   hash:
     md5: d7c89558ba9fa0495403155b64376d81
     sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
-  optional: false
-  category: main
   build: conda_forge
   arch: x86_64
   subdir: linux-64
@@ -36,19 +35,18 @@ package:
   license: None
   size: 2562
   timestamp: 1578324546067
-- name: _openmp_mutex
+- platform: linux-64
+  name: _openmp_mutex
   version: '4.5'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    _libgcc_mutex: ==0.1 conda_forge
-    libgomp: '>=7.5.0'
+  - _libgcc_mutex ==0.1 conda_forge
+  - libgomp >=7.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
   hash:
     md5: 73aaf86a425cc6e73fcf236a5a46396d
     sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
-  optional: false
-  category: main
   build: 2_gnu
   arch: x86_64
   subdir: linux-64
@@ -59,95 +57,17 @@ package:
   license_family: BSD
   size: 23621
   timestamp: 1650670423406
-- name: arrow-cpp
-  version: 10.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libarrow: ==10.0.1 hc3189b8_44_cpu
-  url: https://conda.anaconda.org/conda-forge/linux-64/arrow-cpp-10.0.1-ha770c72_44_cpu.conda
-  hash:
-    md5: 9085ef32fdacb90187d09a7def867fb5
-    sha256: fe1c16111692b769bfdaa80125cbb4d994e866fd9e83d85bf84a9dbd8d6ea906
-  optional: false
-  category: main
-  build: ha770c72_44_cpu
-  arch: x86_64
-  subdir: linux-64
-  build_number: 44
-  license: Apache-2.0
-  size: 34141
-  timestamp: 1696592689038
-- name: arrow-cpp
-  version: 10.0.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libarrow: ==10.0.1 h962698a_46_cpu
-  url: https://conda.anaconda.org/conda-forge/osx-64/arrow-cpp-10.0.1-h694c41f_46_cpu.conda
-  hash:
-    md5: 1e215a28c1c718ca3bb8c691a9f84243
-    sha256: f70fe32076cd4e5bd655d453f0efc4b5f4360699b98a218f2275c80c886a4898
-  optional: false
-  category: main
-  build: h694c41f_46_cpu
-  arch: x86_64
-  subdir: osx-64
-  build_number: 46
-  license: Apache-2.0
-  license_family: APACHE
-  size: 34336
-  timestamp: 1696861098496
-- name: arrow-cpp
-  version: 10.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libarrow: ==10.0.1 he713f65_44_cpu
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/arrow-cpp-10.0.1-hce30654_44_cpu.conda
-  hash:
-    md5: b1e2ad14fdbb4e093d8856f44f101dd4
-    sha256: f053812c247347af8c83e28ceec75d1303d77a1f82ff8c962fb9666be5f6cfd9
-  optional: false
-  category: main
-  build: hce30654_44_cpu
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 44
-  license: Apache-2.0
-  size: 34319
-  timestamp: 1696593771071
-- name: arrow-cpp
-  version: 10.0.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    libarrow: ==10.0.1 h58a770d_44_cpu
-  url: https://conda.anaconda.org/conda-forge/win-64/arrow-cpp-10.0.1-h57928b3_44_cpu.conda
-  hash:
-    md5: 069703cf87380c23476ea1874106c099
-    sha256: c7e64f54fda8f8bb179420c3bdeb71636a6db320ebd00b599f8f35213fb2f9dc
-  optional: false
-  category: main
-  build: h57928b3_44_cpu
-  arch: x86_64
-  subdir: win-64
-  build_number: 44
-  license: Apache-2.0
-  size: 34597
-  timestamp: 1696593807482
-- name: attrs
+- platform: linux-64
+  name: attrs
   version: 23.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
   hash:
     md5: 3edfead7cedd1ab4400a6c588f3e75f8
     sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
-  optional: false
-  category: main
   build: pyh71513ae_1
   arch: x86_64
   subdir: linux-64
@@ -157,18 +77,17 @@ package:
   noarch: python
   size: 55022
   timestamp: 1683424195402
-- name: attrs
+- platform: osx-64
+  name: attrs
   version: 23.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
   hash:
     md5: 3edfead7cedd1ab4400a6c588f3e75f8
     sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
-  optional: false
-  category: main
   build: pyh71513ae_1
   arch: x86_64
   subdir: osx-64
@@ -178,18 +97,17 @@ package:
   noarch: python
   size: 55022
   timestamp: 1683424195402
-- name: attrs
+- platform: osx-arm64
+  name: attrs
   version: 23.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
   hash:
     md5: 3edfead7cedd1ab4400a6c588f3e75f8
     sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
-  optional: false
-  category: main
   build: pyh71513ae_1
   arch: aarch64
   subdir: osx-arm64
@@ -199,18 +117,17 @@ package:
   noarch: python
   size: 55022
   timestamp: 1683424195402
-- name: attrs
+- platform: win-64
+  name: attrs
   version: 23.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
   hash:
     md5: 3edfead7cedd1ab4400a6c588f3e75f8
     sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
-  optional: false
-  category: main
   build: pyh71513ae_1
   arch: x86_64
   subdir: win-64
@@ -220,23 +137,22 @@ package:
   noarch: python
   size: 55022
   timestamp: 1683424195402
-- name: aws-c-auth
+- platform: linux-64
+  name: aws-c-auth
   version: 0.7.4
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-c-sdkutils: '>=0.1.12,<0.1.13.0a0'
-    libgcc-ng: '>=12'
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.4-hc8144f4_1.conda
   hash:
     md5: 81b00630260ff8c9388ee3913465b208
     sha256: a41d33da5f25bb6666805a8ac72ff7f03742ce6d311c4241de7beb94681c1289
-  optional: false
-  category: main
   build: hc8144f4_1
   arch: x86_64
   subdir: linux-64
@@ -245,22 +161,21 @@ package:
   license_family: Apache
   size: 101876
   timestamp: 1695806693576
-- name: aws-c-auth
+- platform: osx-64
+  name: aws-c-auth
   version: 0.7.4
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-c-sdkutils: '>=0.1.12,<0.1.13.0a0'
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.4-h7fea801_1.conda
   hash:
     md5: 6a391ec90c3efedcd4e29eecdc10198a
     sha256: 316b595cd5491b68b890cfd8ec9f5401a78274774667f9be7bbb9c1498c4bcd0
-  optional: false
-  category: main
   build: h7fea801_1
   arch: x86_64
   subdir: osx-64
@@ -269,22 +184,21 @@ package:
   license_family: Apache
   size: 89157
   timestamp: 1695806962937
-- name: aws-c-auth
+- platform: osx-arm64
+  name: aws-c-auth
   version: 0.7.4
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-c-sdkutils: '>=0.1.12,<0.1.13.0a0'
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.4-h2ed40ff_1.conda
   hash:
     md5: a897b4d99ffa78d5a24664620503ef07
     sha256: 7bd08be2a58285e82d51cb7c3562fb253cec1e6056fc808941fd25152625ffb4
-  optional: false
-  category: main
   build: h2ed40ff_1
   arch: aarch64
   subdir: osx-arm64
@@ -293,25 +207,24 @@ package:
   license_family: Apache
   size: 91803
   timestamp: 1695807139469
-- name: aws-c-auth
+- platform: win-64
+  name: aws-c-auth
   version: 0.7.4
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-c-sdkutils: '>=0.1.12,<0.1.13.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.4-hc10d58f_1.conda
   hash:
     md5: 7ed6baf38798ebb4152b821c6b04f061
     sha256: beea4633962b493cb6b19e54331b3a3cdfff006ee92fcd8bf80fe432ef1eb254
-  optional: false
-  category: main
   build: hc10d58f_1
   arch: x86_64
   subdir: win-64
@@ -320,20 +233,19 @@ package:
   license_family: Apache
   size: 98155
   timestamp: 1695807069215
-- name: aws-c-cal
+- platform: linux-64
+  name: aws-c-cal
   version: 0.6.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    libgcc-ng: '>=12'
-    openssl: '>=3.1.3,<4.0a0'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - libgcc-ng >=12
+  - openssl >=3.1.3,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.2-h09139f6_2.conda
   hash:
     md5: 29c3112841eee851f6f5451f6d705782
     sha256: f6f91c7d04be3888365499628f3369fc94dada451360bd82e5e3c61abeb7fc3e
-  optional: false
-  category: main
   build: h09139f6_2
   arch: x86_64
   subdir: linux-64
@@ -342,18 +254,17 @@ package:
   license_family: Apache
   size: 50982
   timestamp: 1695755343237
-- name: aws-c-cal
+- platform: osx-64
+  name: aws-c-cal
   version: 0.6.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.2-hfc10710_2.conda
   hash:
     md5: a340450b9351a8979cc1130fece3cc9f
     sha256: 8752777b77fdb1a8b60ec2903916fd4397ad0ddff8618ee8e5156a3cbfe4095a
-  optional: false
-  category: main
   build: hfc10710_2
   arch: x86_64
   subdir: osx-64
@@ -362,18 +273,17 @@ package:
   license_family: Apache
   size: 40963
   timestamp: 1695755654862
-- name: aws-c-cal
+- platform: osx-arm64
+  name: aws-c-cal
   version: 0.6.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.2-h12c43c8_2.conda
   hash:
     md5: 423341b3cb1db3a396657724de60f36c
     sha256: e7629ac17aef8c2a2701d5b5b781011c466d035f174ec103f3f65a81312d83b8
-  optional: false
-  category: main
   build: h12c43c8_2
   arch: aarch64
   subdir: osx-arm64
@@ -382,21 +292,20 @@ package:
   license_family: Apache
   size: 35967
   timestamp: 1695755681761
-- name: aws-c-cal
+- platform: win-64
+  name: aws-c-cal
   version: 0.6.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.2-hd5965a7_2.conda
   hash:
     md5: cbfd6b62693f67233f205e72e505109a
     sha256: bf8bc4eae5baacc4a12bef32c25a7f43129b79cf167d2e45c5c5b8672af50815
-  optional: false
-  category: main
   build: hd5965a7_2
   arch: x86_64
   subdir: win-64
@@ -405,18 +314,17 @@ package:
   license_family: Apache
   size: 51212
   timestamp: 1695756000021
-- name: aws-c-common
+- platform: linux-64
+  name: aws-c-common
   version: 0.9.3
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.3-hd590300_0.conda
   hash:
     md5: 434466e97a4174b0c4de114eb7100550
     sha256: 6f3a9c285199f828ac1917112495b4e5f4ca578d385442f33aae282bd95618ac
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -425,17 +333,16 @@ package:
   license_family: Apache
   size: 220352
   timestamp: 1695654440131
-- name: aws-c-common
+- platform: osx-64
+  name: aws-c-common
   version: 0.9.3
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.3-h0dc2134_0.conda
   hash:
     md5: 08315e4f10bb6df0b6457dd2c4aefe04
     sha256: cd186a847486ecc6f4c90f321552422a148b30bde40c1984cb3c2cdedb5b6842
-  optional: false
-  category: main
   build: h0dc2134_0
   arch: x86_64
   subdir: osx-64
@@ -444,17 +351,16 @@ package:
   license_family: Apache
   size: 203404
   timestamp: 1695654891068
-- name: aws-c-common
+- platform: osx-arm64
+  name: aws-c-common
   version: 0.9.3
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.3-hb547adb_0.conda
   hash:
     md5: aadc66cc167bd7e71c743954dfa8db45
     sha256: a81b6e28a1c0d5597efb84e2b56b31d2d318520a5e1db64532d54ede7d3405a6
-  optional: false
-  category: main
   build: hb547adb_0
   arch: aarch64
   subdir: osx-arm64
@@ -463,20 +369,19 @@ package:
   license_family: Apache
   size: 205552
   timestamp: 1695654812022
-- name: aws-c-common
+- platform: win-64
+  name: aws-c-common
   version: 0.9.3
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.3-hcfcfb64_0.conda
   hash:
     md5: ef7faef92f32551745303430e45d61d8
     sha256: 4a83811c573c965c55f3f67c149f232ce81c157391b651699a8c8ad22b743ead
-  optional: false
-  category: main
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
@@ -485,19 +390,18 @@ package:
   license_family: Apache
   size: 217632
   timestamp: 1695654879342
-- name: aws-c-compression
+- platform: linux-64
+  name: aws-c-compression
   version: 0.2.17
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    libgcc-ng: '>=12'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h184a658_3.conda
   hash:
     md5: c62775b5028b5a4eda25037f9af7f5b3
     sha256: 07f3431f097f64c1ee916c27ac7745bbf27a9b06768fa0449d9e0eaea1b6f4d2
-  optional: false
-  category: main
   build: h184a658_3
   arch: x86_64
   subdir: linux-64
@@ -506,18 +410,17 @@ package:
   license_family: Apache
   size: 19162
   timestamp: 1695755217636
-- name: aws-c-compression
+- platform: osx-64
+  name: aws-c-compression
   version: 0.2.17
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-hd41bdd4_3.conda
   hash:
     md5: 8477d925cf7a7972e85139c385ec6f45
     sha256: 922f2be31994d2ba277f2452c801a35c4695335938788bd280f73ab1cbd189df
-  optional: false
-  category: main
   build: hd41bdd4_3
   arch: x86_64
   subdir: osx-64
@@ -526,18 +429,17 @@ package:
   license_family: Apache
   size: 18078
   timestamp: 1695755408655
-- name: aws-c-compression
+- platform: osx-arm64
+  name: aws-c-compression
   version: 0.2.17
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-h12c43c8_3.conda
   hash:
     md5: c339bef71fc5d6350770c3248f720218
     sha256: b3ec15b2c1b323d15ada7ffe0b14281646cb0d5efe594c393258e0a96b0fe0a6
-  optional: false
-  category: main
   build: h12c43c8_3
   arch: aarch64
   subdir: osx-arm64
@@ -546,21 +448,20 @@ package:
   license_family: Apache
   size: 18362
   timestamp: 1695755460655
-- name: aws-c-compression
+- platform: win-64
+  name: aws-c-compression
   version: 0.2.17
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.17-hd5965a7_3.conda
   hash:
     md5: b0e3df9a002b961bf5fa2400235a8f74
     sha256: 5d63e840b6ba0f737503584e14ed94b94397e68e1768f1d76b263dee771a07dd
-  optional: false
-  category: main
   build: hd5965a7_3
   arch: x86_64
   subdir: win-64
@@ -569,22 +470,21 @@ package:
   license_family: Apache
   size: 22691
   timestamp: 1695755699057
-- name: aws-c-event-stream
+- platform: linux-64
+  name: aws-c-event-stream
   version: 0.3.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.2-hd6ebb48_1.conda
   hash:
     md5: ef9692e74f437004ef47a4363552bcb6
     sha256: 32385f297271fcbdfa97adeceea56c1317ffb96d94a681933805f97ef30bda12
-  optional: false
-  category: main
   build: hd6ebb48_1
   arch: x86_64
   subdir: linux-64
@@ -593,21 +493,20 @@ package:
   license_family: Apache
   size: 53665
   timestamp: 1695786768147
-- name: aws-c-event-stream
+- platform: osx-64
+  name: aws-c-event-stream
   version: 0.3.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    libcxx: '>=15.0.7'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.3.2-hab6341b_1.conda
   hash:
     md5: ea7090c6dce0f098e6f27531204ae9c3
     sha256: ed52fda59f2c42a50a53055f909189d48169fa875f9fdcf4aa280c326aac3123
-  optional: false
-  category: main
   build: hab6341b_1
   arch: x86_64
   subdir: osx-64
@@ -616,21 +515,20 @@ package:
   license_family: Apache
   size: 46908
   timestamp: 1695787042268
-- name: aws-c-event-stream
+- platform: osx-arm64
+  name: aws-c-event-stream
   version: 0.3.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    libcxx: '>=15.0.7'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.2-h88fe898_1.conda
   hash:
     md5: 3a85cb3bbafc0ec228374328322ca747
     sha256: 62121f5526428ee103e488224311dd75ba6938648ef0df5a18b67065d3d71c9b
-  optional: false
-  category: main
   build: h88fe898_1
   arch: aarch64
   subdir: osx-arm64
@@ -639,23 +537,22 @@ package:
   license_family: Apache
   size: 49509
   timestamp: 1695787081576
-- name: aws-c-event-stream
+- platform: win-64
+  name: aws-c-event-stream
   version: 0.3.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.3.2-hea44b67_1.conda
   hash:
     md5: 8714f7f7c40e43d9830f41b8f010b9d6
     sha256: 9aa0bb1e4417b17935094e8fadfba1bc9e00f7e20a9e36f04d790ea7ab4cf308
-  optional: false
-  category: main
   build: hea44b67_1
   arch: x86_64
   subdir: win-64
@@ -664,22 +561,21 @@ package:
   license_family: Apache
   size: 54351
   timestamp: 1695787146551
-- name: aws-c-http
+- platform: linux-64
+  name: aws-c-http
   version: 0.7.13
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-compression: '>=0.2.17,<0.2.18.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    libgcc-ng: '>=12'
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.13-hc690213_1.conda
   hash:
     md5: c912831e92c565598072243266073161
     sha256: 609016dcb4c3480362ba6307759b9dabc59fd02f936d6c09f299c46964c19a7c
-  optional: false
-  category: main
   build: hc690213_1
   arch: x86_64
   subdir: linux-64
@@ -688,21 +584,20 @@ package:
   license_family: Apache
   size: 193066
   timestamp: 1695786758113
-- name: aws-c-http
+- platform: osx-64
+  name: aws-c-http
   version: 0.7.13
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-compression: '>=0.2.17,<0.2.18.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.7.13-h868b204_1.conda
   hash:
     md5: f43a2a8cae0408db86d4461359a0dbe2
     sha256: f3db9629daee50f27f86676a2d4dec58c9aa2d6d4a6d0f32433928bac7d58dcd
-  optional: false
-  category: main
   build: h868b204_1
   arch: x86_64
   subdir: osx-64
@@ -711,21 +606,20 @@ package:
   license_family: Apache
   size: 164664
   timestamp: 1695786938189
-- name: aws-c-http
+- platform: osx-arm64
+  name: aws-c-http
   version: 0.7.13
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-compression: '>=0.2.17,<0.2.18.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.13-he062130_1.conda
   hash:
     md5: 5bbf0c00da06bdae9b745a4a7c61ef92
     sha256: 7f1587b31e5810c377e46a2332898aa5783cf7dbd12031c0531ab28226459c39
-  optional: false
-  category: main
   build: he062130_1
   arch: aarch64
   subdir: osx-arm64
@@ -734,24 +628,23 @@ package:
   license_family: Apache
   size: 158464
   timestamp: 1695787011797
-- name: aws-c-http
+- platform: win-64
+  name: aws-c-http
   version: 0.7.13
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-compression: '>=0.2.17,<0.2.18.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.7.13-h6dd44e3_1.conda
   hash:
     md5: cf2be4ecb54d59f946b6041859051b66
     sha256: 536f6e1153fd374ed75632bb568a7b9ab106e8634084235b56f128e9be65175e
-  optional: false
-  category: main
   build: h6dd44e3_1
   arch: x86_64
   subdir: win-64
@@ -760,21 +653,20 @@ package:
   license_family: Apache
   size: 179477
   timestamp: 1695787045722
-- name: aws-c-io
+- platform: linux-64
+  name: aws-c-io
   version: 0.13.32
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    libgcc-ng: '>=12'
-    s2n: '>=1.3.52,<1.3.53.0a0'
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - libgcc-ng >=12
+  - s2n >=1.3.52,<1.3.53.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.32-h63140e9_5.conda
   hash:
     md5: be4f0759b0134af4eefdf776527548ad
     sha256: 36868632387356b9aab1edf5316f75ed7942aab264687bc894270d93e0379e16
-  optional: false
-  category: main
   build: h63140e9_5
   arch: x86_64
   subdir: linux-64
@@ -783,19 +675,18 @@ package:
   license_family: Apache
   size: 154130
   timestamp: 1696458895506
-- name: aws-c-io
+- platform: osx-64
+  name: aws-c-io
   version: 0.13.32
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.13.32-h2566903_6.conda
   hash:
     md5: da6927252893084bf95269d745eedada
     sha256: 196f33bf7304c08c913b652d58463772a7db6c47d0d2a9c1be9d92b14094ff0a
-  optional: false
-  category: main
   build: h2566903_6
   arch: x86_64
   subdir: osx-64
@@ -804,19 +695,18 @@ package:
   license_family: Apache
   size: 135831
   timestamp: 1696719527
-- name: aws-c-io
+- platform: osx-arm64
+  name: aws-c-io
   version: 0.13.32
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.32-h13ba428_5.conda
   hash:
     md5: 8c647b0c4f55503ed18159203a8ff4b3
     sha256: 02a52a9808aecaaa1764fc040551e0cb9a105867c01280fd634b3327877ac48b
-  optional: false
-  category: main
   build: h13ba428_5
   arch: aarch64
   subdir: osx-arm64
@@ -825,22 +715,21 @@ package:
   license_family: Apache
   size: 140024
   timestamp: 1696459135953
-- name: aws-c-io
+- platform: win-64
+  name: aws-c-io
   version: 0.13.32
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.13.32-ha16e049_5.conda
   hash:
     md5: 489fe8c63b6abd67533c26a401b947be
     sha256: 785d9b884432aaaab66069ffaf3f0b13c51d89507153984cc40e5518b1c6f679
-  optional: false
-  category: main
   build: ha16e049_5
   arch: x86_64
   subdir: win-64
@@ -849,21 +738,20 @@ package:
   license_family: Apache
   size: 158577
   timestamp: 1696459312242
-- name: aws-c-mqtt
+- platform: linux-64
+  name: aws-c-mqtt
   version: 0.9.6
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    libgcc-ng: '>=12'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.9.6-h32970c0_2.conda
   hash:
     md5: 21dd1cb1e73b0ce2ea31e9f9f692e051
     sha256: ff961111d41afc107bcb263d1ce727a2900b4546adbb7bae03046e1473157e64
-  optional: false
-  category: main
   build: h32970c0_2
   arch: x86_64
   subdir: linux-64
@@ -872,20 +760,19 @@ package:
   license_family: Apache
   size: 162703
   timestamp: 1695917197677
-- name: aws-c-mqtt
+- platform: osx-64
+  name: aws-c-mqtt
   version: 0.9.6
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.9.6-he6da789_2.conda
   hash:
     md5: 4b30f7acb9cf20c7570b000213484f52
     sha256: 343781159bb6bc47dd8e69c41eaeaacfc4d146cfa18fd01bf2c75e8b7bd45ba6
-  optional: false
-  category: main
   build: he6da789_2
   arch: x86_64
   subdir: osx-64
@@ -894,20 +781,19 @@ package:
   license_family: Apache
   size: 139336
   timestamp: 1695917405265
-- name: aws-c-mqtt
+- platform: osx-arm64
+  name: aws-c-mqtt
   version: 0.9.6
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.6-h3ffe4bb_2.conda
   hash:
     md5: e5c6218bc68df45a7b7c0419f78fa5e0
     sha256: 04b50e4acddf6dbecfb3420270344d2807b9c0b2dc606d7fda2f2bd9dab43c92
-  optional: false
-  category: main
   build: h3ffe4bb_2
   arch: aarch64
   subdir: osx-arm64
@@ -916,23 +802,22 @@ package:
   license_family: Apache
   size: 123593
   timestamp: 1695917011884
-- name: aws-c-mqtt
+- platform: win-64
+  name: aws-c-mqtt
   version: 0.9.6
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.9.6-h5e85a83_2.conda
   hash:
     md5: 348bde350e6eee35c3dd310cef20775f
     sha256: 8f6e103b8a5c85275b541fe52d69b879aa96c9996f5edc81fd6a21d662bc7392
-  optional: false
-  category: main
   build: h5e85a83_2
   arch: x86_64
   subdir: win-64
@@ -941,25 +826,24 @@ package:
   license_family: Apache
   size: 157202
   timestamp: 1695917786835
-- name: aws-c-s3
+- platform: linux-64
+  name: aws-c-s3
   version: 0.3.17
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    aws-c-auth: '>=0.7.4,<0.7.5.0a0'
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    libgcc-ng: '>=12'
-    openssl: '>=3.1.3,<4.0a0'
+  - aws-c-auth >=0.7.4,<0.7.5.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libgcc-ng >=12
+  - openssl >=3.1.3,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.3.17-hb5e3142_3.conda
   hash:
     md5: f0eeadc3f7fc9a29b7ce416897056826
     sha256: e2735df82153f7bc29d9d118453349b8d1fdd565e43764188af502fbcd32635a
-  optional: false
-  category: main
   build: hb5e3142_3
   arch: x86_64
   subdir: linux-64
@@ -968,23 +852,22 @@ package:
   license_family: Apache
   size: 86367
   timestamp: 1695816475381
-- name: aws-c-s3
+- platform: osx-64
+  name: aws-c-s3
   version: 0.3.17
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    aws-c-auth: '>=0.7.4,<0.7.5.0a0'
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
+  - aws-c-auth >=0.7.4,<0.7.5.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.3.17-h5997705_3.conda
   hash:
     md5: e4e8a0ea0385a06a83944f603e56320e
     sha256: 4146f40b392860c1bb9c76e39d5a6aa95a8429da4d5a7e10b30318147faddfe8
-  optional: false
-  category: main
   build: h5997705_3
   arch: x86_64
   subdir: osx-64
@@ -993,23 +876,22 @@ package:
   license_family: Apache
   size: 74663
   timestamp: 1695816593583
-- name: aws-c-s3
+- platform: osx-arm64
+  name: aws-c-s3
   version: 0.3.17
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    aws-c-auth: '>=0.7.4,<0.7.5.0a0'
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
+  - aws-c-auth >=0.7.4,<0.7.5.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.3.17-hf064be9_3.conda
   hash:
     md5: 208b606834b0aba73dc867900bb610dc
     sha256: ea8cdaeee4249d01ec1b58137d0cb345d05a6335e5c44f3dd1b079c9ae1e97a5
-  optional: false
-  category: main
   build: hf064be9_3
   arch: aarch64
   subdir: osx-arm64
@@ -1018,26 +900,25 @@ package:
   license_family: Apache
   size: 77697
   timestamp: 1695816759059
-- name: aws-c-s3
+- platform: win-64
+  name: aws-c-s3
   version: 0.3.17
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    aws-c-auth: '>=0.7.4,<0.7.5.0a0'
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - aws-c-auth >=0.7.4,<0.7.5.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.3.17-ha8f72b6_3.conda
   hash:
     md5: e6e98f522c89d8b02766d09468d790f3
     sha256: ee731c295a74363afae65e3268d524e3a3d8d198aaaf0b0ab6af4c0cbfd56756
-  optional: false
-  category: main
   build: ha8f72b6_3
   arch: x86_64
   subdir: win-64
@@ -1046,19 +927,18 @@ package:
   license_family: Apache
   size: 83349
   timestamp: 1695817009484
-- name: aws-c-sdkutils
+- platform: linux-64
+  name: aws-c-sdkutils
   version: 0.1.12
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    libgcc-ng: '>=12'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.12-h184a658_2.conda
   hash:
     md5: ba06d81b81ec3eaf4ee83cd47f808134
     sha256: f8cea4495d2d6c622aa65257aa24958fde6e5f5d518772036ba1fe5dfd0666ad
-  optional: false
-  category: main
   build: h184a658_2
   arch: x86_64
   subdir: linux-64
@@ -1067,18 +947,17 @@ package:
   license_family: Apache
   size: 53021
   timestamp: 1695742870649
-- name: aws-c-sdkutils
+- platform: osx-64
+  name: aws-c-sdkutils
   version: 0.1.12
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.12-hd41bdd4_2.conda
   hash:
     md5: ca04a04205202fee021697f614bd59dd
     sha256: 763f1091d0abae8ec74ffe6077788e4a558e88e0a0c9aaba69c66b88f91f9b14
-  optional: false
-  category: main
   build: hd41bdd4_2
   arch: x86_64
   subdir: osx-64
@@ -1087,18 +966,17 @@ package:
   license_family: Apache
   size: 47319
   timestamp: 1695743229851
-- name: aws-c-sdkutils
+- platform: osx-arm64
+  name: aws-c-sdkutils
   version: 0.1.12
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.12-h12c43c8_2.conda
   hash:
     md5: 59aa1ab1702812aaa2473b758194c929
     sha256: b337915a72328498e454ceec99996692cd3fd0ce61d48dc9a4cb069dd12776aa
-  optional: false
-  category: main
   build: h12c43c8_2
   arch: aarch64
   subdir: osx-arm64
@@ -1107,21 +985,20 @@ package:
   license_family: Apache
   size: 49038
   timestamp: 1695743341991
-- name: aws-c-sdkutils
+- platform: win-64
+  name: aws-c-sdkutils
   version: 0.1.12
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.12-hd5965a7_2.conda
   hash:
     md5: 5ac1b07dec55938a5f410e04aba2e27a
     sha256: 029e039ff2bc526d5f31637a5525192787b3457b03cf33e479cd07641a9b5430
-  optional: false
-  category: main
   build: hd5965a7_2
   arch: x86_64
   subdir: win-64
@@ -1130,19 +1007,18 @@ package:
   license_family: Apache
   size: 51875
   timestamp: 1695743449932
-- name: aws-checksums
+- platform: linux-64
+  name: aws-checksums
   version: 0.1.17
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    libgcc-ng: '>=12'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h184a658_2.conda
   hash:
     md5: 10fcdbd02ba7fa0827fb8f7d94f8375b
     sha256: feeea13a9a15c4dd27a2244fedbe439ee7548192b21e5e6cf6c07142af5a92d1
-  optional: false
-  category: main
   build: h184a658_2
   arch: x86_64
   subdir: linux-64
@@ -1151,18 +1027,17 @@ package:
   license_family: Apache
   size: 50130
   timestamp: 1695743103287
-- name: aws-checksums
+- platform: osx-64
+  name: aws-checksums
   version: 0.1.17
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-hd41bdd4_2.conda
   hash:
     md5: e4d679bf261bafcf215804bcbcd63e6f
     sha256: d59f0b77d02fe275f0d758148c5705c72dfca85d97b55c9a227579eb284dd6a2
-  optional: false
-  category: main
   build: hd41bdd4_2
   arch: x86_64
   subdir: osx-64
@@ -1171,18 +1046,17 @@ package:
   license_family: Apache
   size: 48675
   timestamp: 1695743318668
-- name: aws-checksums
+- platform: osx-arm64
+  name: aws-checksums
   version: 0.1.17
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-h12c43c8_2.conda
   hash:
     md5: dbbfcdd6867ab169c8eacd56583d4754
     sha256: 36d6174ab27b0af46c00f6249f19875b7b5e9e1ebe05211b9537086afd81cfa4
-  optional: false
-  category: main
   build: h12c43c8_2
   arch: aarch64
   subdir: osx-arm64
@@ -1191,21 +1065,20 @@ package:
   license_family: Apache
   size: 49232
   timestamp: 1695743891251
-- name: aws-checksums
+- platform: win-64
+  name: aws-checksums
   version: 0.1.17
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.17-hd5965a7_2.conda
   hash:
     md5: 750eaf78f1354c70743cb15c1e2ad4ac
     sha256: 0c9e36f6b0729e8b0507b16fd10ab01b6bf59afd99d7d3b6fa93151485ac481f
-  optional: false
-  category: main
   build: hd5965a7_2
   arch: x86_64
   subdir: win-64
@@ -1214,28 +1087,27 @@ package:
   license_family: Apache
   size: 52214
   timestamp: 1695743755136
-- name: aws-crt-cpp
+- platform: linux-64
+  name: aws-crt-cpp
   version: 0.23.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    aws-c-auth: '>=0.7.4,<0.7.5.0a0'
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-event-stream: '>=0.3.2,<0.3.3.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-c-mqtt: '>=0.9.6,<0.9.7.0a0'
-    aws-c-s3: '>=0.3.17,<0.3.18.0a0'
-    aws-c-sdkutils: '>=0.1.12,<0.1.13.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - aws-c-auth >=0.7.4,<0.7.5.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-mqtt >=0.9.6,<0.9.7.0a0
+  - aws-c-s3 >=0.3.17,<0.3.18.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.23.1-h94c364a_5.conda
   hash:
     md5: 0d9257d4ebe9af80677c178f172d3c39
     sha256: 2c3af3148c4625a9f4bc8cd46b0d55f6e39f7381ee54095752c62f1c1598c24b
-  optional: false
-  category: main
   build: h94c364a_5
   arch: x86_64
   subdir: linux-64
@@ -1244,28 +1116,27 @@ package:
   license_family: Apache
   size: 323319
   timestamp: 1695993507703
-- name: aws-crt-cpp
+- platform: osx-64
+  name: aws-crt-cpp
   version: 0.24.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    aws-c-auth: '>=0.7.4,<0.7.5.0a0'
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-event-stream: '>=0.3.2,<0.3.3.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-c-mqtt: '>=0.9.6,<0.9.7.0a0'
-    aws-c-s3: '>=0.3.17,<0.3.18.0a0'
-    aws-c-sdkutils: '>=0.1.12,<0.1.13.0a0'
-    libcxx: '>=16.0.6'
+  - __osx >=10.9
+  - aws-c-auth >=0.7.4,<0.7.5.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-mqtt >=0.9.6,<0.9.7.0a0
+  - aws-c-s3 >=0.3.17,<0.3.18.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libcxx >=16.0.6
   url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.24.2-h6afeb1b_0.conda
   hash:
     md5: e354dc036dcdb47384615d26caf6459d
     sha256: e8e55f7d2300fdb979fbe0932e8c75d47e701476fdc40fd2d387229850eb7fab
-  optional: false
-  category: main
   build: h6afeb1b_0
   arch: x86_64
   subdir: osx-64
@@ -1274,27 +1145,26 @@ package:
   license_family: Apache
   size: 274674
   timestamp: 1696552701312
-- name: aws-crt-cpp
+- platform: osx-arm64
+  name: aws-crt-cpp
   version: 0.23.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    aws-c-auth: '>=0.7.4,<0.7.5.0a0'
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-event-stream: '>=0.3.2,<0.3.3.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-c-mqtt: '>=0.9.6,<0.9.7.0a0'
-    aws-c-s3: '>=0.3.17,<0.3.18.0a0'
-    aws-c-sdkutils: '>=0.1.12,<0.1.13.0a0'
-    libcxx: '>=15.0.7'
+  - aws-c-auth >=0.7.4,<0.7.5.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-mqtt >=0.9.6,<0.9.7.0a0
+  - aws-c-s3 >=0.3.17,<0.3.18.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.23.1-h96fc18d_5.conda
   hash:
     md5: ebc5b298b28d4853ff64a06c31df9170
     sha256: 46ce6e4a7cb204545c9c95f127f63d0ef96469bc1927035fc632fda95293a9be
-  optional: false
-  category: main
   build: h96fc18d_5
   arch: aarch64
   subdir: osx-arm64
@@ -1303,29 +1173,28 @@ package:
   license_family: Apache
   size: 224128
   timestamp: 1695993881572
-- name: aws-crt-cpp
+- platform: win-64
+  name: aws-crt-cpp
   version: 0.23.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    aws-c-auth: '>=0.7.4,<0.7.5.0a0'
-    aws-c-cal: '>=0.6.2,<0.6.3.0a0'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-event-stream: '>=0.3.2,<0.3.3.0a0'
-    aws-c-http: '>=0.7.13,<0.7.14.0a0'
-    aws-c-io: '>=0.13.32,<0.13.33.0a0'
-    aws-c-mqtt: '>=0.9.6,<0.9.7.0a0'
-    aws-c-s3: '>=0.3.17,<0.3.18.0a0'
-    aws-c-sdkutils: '>=0.1.12,<0.1.13.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - aws-c-auth >=0.7.4,<0.7.5.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-mqtt >=0.9.6,<0.9.7.0a0
+  - aws-c-s3 >=0.3.17,<0.3.18.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.23.1-h70f7a23_5.conda
   hash:
     md5: c0c9016cd7385ad14dcd575ef349c620
     sha256: 7b39b5bbd278838543655068f8779e538b6cd2b7931689762127082b544eea4e
-  optional: false
-  category: main
   build: h70f7a23_5
   arch: x86_64
   subdir: win-64
@@ -1334,26 +1203,25 @@ package:
   license_family: Apache
   size: 236477
   timestamp: 1695993950546
-- name: aws-sdk-cpp
+- platform: linux-64
+  name: aws-sdk-cpp
   version: 1.11.156
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-event-stream: '>=0.3.2,<0.3.3.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    aws-crt-cpp: '>=0.23.1,<0.23.2.0a0'
-    libcurl: '>=8.3.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.23.1,<0.23.2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.156-h6600424_3.conda
   hash:
     md5: 6caecdec46acbd4743807b4be6efce33
     sha256: ed42d559b18025f422d4b4ae81e0574eae200c3e321b9f97e3b269a6d064994a
-  optional: false
-  category: main
   build: h6600424_3
   arch: x86_64
   subdir: linux-64
@@ -1362,26 +1230,25 @@ package:
   license_family: Apache
   size: 3432093
   timestamp: 1696017730687
-- name: aws-sdk-cpp
+- platform: osx-64
+  name: aws-sdk-cpp
   version: 1.11.156
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-event-stream: '>=0.3.2,<0.3.3.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    aws-crt-cpp: '>=0.24.2,<0.24.3.0a0'
-    libcurl: '>=8.3.0,<9.0a0'
-    libcxx: '>=16.0.6'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
+  - __osx >=10.9
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.24.2,<0.24.3.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libcxx >=16.0.6
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.156-hf61f2bb_4.conda
   hash:
     md5: b2c502e01831e4c570b46d39a95cc110
     sha256: c08c45bcdf52981467bcf56024ee746fa86f225cbfe83b5f6b3984b1355a860d
-  optional: false
-  category: main
   build: hf61f2bb_4
   arch: x86_64
   subdir: osx-64
@@ -1390,25 +1257,24 @@ package:
   license_family: Apache
   size: 3147313
   timestamp: 1696711645679
-- name: aws-sdk-cpp
+- platform: osx-arm64
+  name: aws-sdk-cpp
   version: 1.11.156
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-event-stream: '>=0.3.2,<0.3.3.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    aws-crt-cpp: '>=0.23.1,<0.23.2.0a0'
-    libcurl: '>=8.3.0,<9.0a0'
-    libcxx: '>=15.0.7'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.23.1,<0.23.2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.156-he831950_3.conda
   hash:
     md5: 4276b9c8572bb539b41225a4b5d065ea
     sha256: 09d3a7557d8460c9d6abbbd915290f839af09024110dc873757785707fbcca5e
-  optional: false
-  category: main
   build: he831950_3
   arch: aarch64
   subdir: osx-arm64
@@ -1417,25 +1283,24 @@ package:
   license_family: Apache
   size: 3198982
   timestamp: 1696018516789
-- name: aws-sdk-cpp
+- platform: win-64
+  name: aws-sdk-cpp
   version: 1.11.156
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.3,<0.9.4.0a0'
-    aws-c-event-stream: '>=0.3.2,<0.3.3.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    aws-crt-cpp: '>=0.23.1,<0.23.2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.23.1,<0.23.2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.156-h02852bd_3.conda
   hash:
     md5: 1a232e6d0c8b7ce34b0f819e072fbf7c
     sha256: e183eda509e1079ef8e72927c68ed3108a3006b67d8a07a39edad49dc79636e3
-  optional: false
-  category: main
   build: h02852bd_3
   arch: x86_64
   subdir: win-64
@@ -1444,18 +1309,17 @@ package:
   license_family: Apache
   size: 3228453
   timestamp: 1696018718586
-- name: binutils
+- platform: linux-64
+  name: binutils
   version: '2.40'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    binutils_impl_linux-64: '>=2.40,<2.41.0a0'
+  - binutils_impl_linux-64 >=2.40,<2.41.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-hdd6e379_0.conda
   hash:
     md5: ccc940fddbc3fcd3d79cd4c654c4b5c4
     sha256: 35f3b042f295fd7387de11cf426ca8ee5257e5c98b88560c6c5ad4ef3c85d38c
-  optional: false
-  category: main
   build: hdd6e379_0
   arch: x86_64
   subdir: linux-64
@@ -1464,19 +1328,18 @@ package:
   license_family: GPL
   size: 30469
   timestamp: 1674833987166
-- name: binutils_impl_linux-64
+- platform: linux-64
+  name: binutils_impl_linux-64
   version: '2.40'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    ld_impl_linux-64: ==2.40 h41732ed_0
-    sysroot_linux-64: '*'
+  - ld_impl_linux-64 ==2.40 h41732ed_0
+  - sysroot_linux-64 *
   url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
   hash:
     md5: 33084421a8c0af6aef1b439707f7662a
     sha256: a7e0ea2b71a5b03d82e5a58fb6b612ab1c44d72ce161f9aa441f7ba467cd4c8d
-  optional: false
-  category: main
   build: hf600244_0
   arch: x86_64
   subdir: linux-64
@@ -1485,19 +1348,18 @@ package:
   license_family: GPL
   size: 5414922
   timestamp: 1674833958334
-- name: binutils_linux-64
+- platform: linux-64
+  name: binutils_linux-64
   version: '2.40'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    binutils_impl_linux-64: 2.40.*
-    sysroot_linux-64: '*'
+  - binutils_impl_linux-64 2.40.*
+  - sysroot_linux-64 *
   url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hbdbef99_2.conda
   hash:
     md5: adfebae9fdc63a598495dfe3b006973a
     sha256: 333f3339d94c93bcc02a723e3e460cb6ff6075e05f5247e15bef5dcdcec541a3
-  optional: false
-  category: main
   build: hbdbef99_2
   arch: x86_64
   subdir: linux-64
@@ -1506,24 +1368,23 @@ package:
   license_family: BSD
   size: 28178
   timestamp: 1694604071236
-- name: black
+- platform: linux-64
+  name: black
   version: 23.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    click: '>=8.0.0'
-    mypy_extensions: '>=0.4.3'
-    packaging: '>=22.0'
-    pathspec: '>=0.9'
-    platformdirs: '>=2'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
+  - click >=8.0.0
+  - mypy_extensions >=0.4.3
+  - packaging >=22.0
+  - pathspec >=0.9
+  - platformdirs >=2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/linux-64/black-23.3.0-py311h38be061_1.conda
   hash:
     md5: b0d621848bfba5aacbdfc43dfdeabfec
     sha256: c729ebbdca2ca7286305ad51cc3beea6b85e68cd02794fb9895f3d5e16540b86
-  optional: false
-  category: main
   build: py311h38be061_1
   arch: x86_64
   subdir: linux-64
@@ -1532,24 +1393,23 @@ package:
   license_family: MIT
   size: 354716
   timestamp: 1682492111062
-- name: black
+- platform: osx-64
+  name: black
   version: 23.3.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    click: '>=8.0.0'
-    mypy_extensions: '>=0.4.3'
-    packaging: '>=22.0'
-    pathspec: '>=0.9'
-    platformdirs: '>=2'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
+  - click >=8.0.0
+  - mypy_extensions >=0.4.3
+  - packaging >=22.0
+  - pathspec >=0.9
+  - platformdirs >=2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/osx-64/black-23.3.0-py311h6eed73b_1.conda
   hash:
     md5: 2783c68e84c0573fece0880488c7c001
     sha256: 78b007b394be2e0ddd42224970be1b212639a8941fee0e7d724986155e517e24
-  optional: false
-  category: main
   build: py311h6eed73b_1
   arch: x86_64
   subdir: osx-64
@@ -1558,24 +1418,23 @@ package:
   license_family: MIT
   size: 355441
   timestamp: 1682492328351
-- name: black
+- platform: osx-arm64
+  name: black
   version: 23.3.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    click: '>=8.0.0'
-    mypy_extensions: '>=0.4.3'
-    packaging: '>=22.0'
-    pathspec: '>=0.9'
-    platformdirs: '>=2'
-    python: '>=3.11,<3.12.0a0 *_cpython'
-    python_abi: 3.11.* *_cp311
+  - click >=8.0.0
+  - mypy_extensions >=0.4.3
+  - packaging >=22.0
+  - pathspec >=0.9
+  - platformdirs >=2
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/osx-arm64/black-23.3.0-py311h267d04e_1.conda
   hash:
     md5: 6df8788f081abb97d20ffa83de27d029
     sha256: 6968e8bcc232a32cd34934d14ada2a9a2549db7f8276ba9709eb16595e5545fd
-  optional: false
-  category: main
   build: py311h267d04e_1
   arch: aarch64
   subdir: osx-arm64
@@ -1584,24 +1443,23 @@ package:
   license_family: MIT
   size: 355456
   timestamp: 1682492376012
-- name: black
+- platform: win-64
+  name: black
   version: 23.3.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    click: '>=8.0.0'
-    mypy_extensions: '>=0.4.3'
-    packaging: '>=22.0'
-    pathspec: '>=0.9'
-    platformdirs: '>=2'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
+  - click >=8.0.0
+  - mypy_extensions >=0.4.3
+  - packaging >=22.0
+  - pathspec >=0.9
+  - platformdirs >=2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/win-64/black-23.3.0-py311h1ea47a8_1.conda
   hash:
     md5: cff72d53d4ea05005adc2f478447a0a1
     sha256: 12f319748c11697ee3ea154413c7c4895db2dfcc18b44b0bdb2019da1144abdb
-  optional: false
-  category: main
   build: py311h1ea47a8_1
   arch: x86_64
   subdir: win-64
@@ -1610,23 +1468,22 @@ package:
   license_family: MIT
   size: 369420
   timestamp: 1682492626505
-- name: blackdoc
+- platform: linux-64
+  name: blackdoc
   version: 0.3.8
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    black: '*'
-    importlib-metadata: '*'
-    more-itertools: '*'
-    python: '>=3.7'
-    rich: '*'
-    tomli: '*'
+  - black *
+  - importlib-metadata *
+  - more-itertools *
+  - python >=3.7
+  - rich *
+  - tomli *
   url: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: c03749cb0d5874fd5b9c1620a3d230c4
     sha256: ec7b75c0f88db3e8c8b506ec48fa4fa210b0c1d09b0969df726a68b5563d151d
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -1636,23 +1493,22 @@ package:
   noarch: python
   size: 30092
   timestamp: 1667565048643
-- name: blackdoc
+- platform: osx-64
+  name: blackdoc
   version: 0.3.8
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    black: '*'
-    importlib-metadata: '*'
-    more-itertools: '*'
-    python: '>=3.7'
-    rich: '*'
-    tomli: '*'
+  - black *
+  - importlib-metadata *
+  - more-itertools *
+  - python >=3.7
+  - rich *
+  - tomli *
   url: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: c03749cb0d5874fd5b9c1620a3d230c4
     sha256: ec7b75c0f88db3e8c8b506ec48fa4fa210b0c1d09b0969df726a68b5563d151d
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -1662,23 +1518,22 @@ package:
   noarch: python
   size: 30092
   timestamp: 1667565048643
-- name: blackdoc
+- platform: osx-arm64
+  name: blackdoc
   version: 0.3.8
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    black: '*'
-    importlib-metadata: '*'
-    more-itertools: '*'
-    python: '>=3.7'
-    rich: '*'
-    tomli: '*'
+  - black *
+  - importlib-metadata *
+  - more-itertools *
+  - python >=3.7
+  - rich *
+  - tomli *
   url: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: c03749cb0d5874fd5b9c1620a3d230c4
     sha256: ec7b75c0f88db3e8c8b506ec48fa4fa210b0c1d09b0969df726a68b5563d151d
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -1688,23 +1543,22 @@ package:
   noarch: python
   size: 30092
   timestamp: 1667565048643
-- name: blackdoc
+- platform: win-64
+  name: blackdoc
   version: 0.3.8
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    black: '*'
-    importlib-metadata: '*'
-    more-itertools: '*'
-    python: '>=3.7'
-    rich: '*'
-    tomli: '*'
+  - black *
+  - importlib-metadata *
+  - more-itertools *
+  - python >=3.7
+  - rich *
+  - tomli *
   url: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: c03749cb0d5874fd5b9c1620a3d230c4
     sha256: ec7b75c0f88db3e8c8b506ec48fa4fa210b0c1d09b0969df726a68b5563d151d
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -1714,18 +1568,17 @@ package:
   noarch: python
   size: 30092
   timestamp: 1667565048643
-- name: bzip2
+- platform: linux-64
+  name: bzip2
   version: 1.0.8
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
+  - libgcc-ng >=9.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
   hash:
     md5: a1fd65c7ccbf10880423d82bca54eb54
     sha256: cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa
-  optional: false
-  category: main
   build: h7f98852_4
   arch: x86_64
   subdir: linux-64
@@ -1734,17 +1587,16 @@ package:
   license_family: BSD
   size: 495686
   timestamp: 1606604745109
-- name: bzip2
+- platform: osx-64
+  name: bzip2
   version: 1.0.8
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
   hash:
     md5: 37edc4e6304ca87316e160f5ca0bd1b5
     sha256: 60ba4c64f5d0afca0d283c7addba577d3e2efc0db86002808dadb0498661b2f2
-  optional: false
-  category: main
   build: h0d85af4_4
   arch: x86_64
   subdir: osx-64
@@ -1753,17 +1605,16 @@ package:
   license_family: BSD
   size: 158829
   timestamp: 1618862580095
-- name: bzip2
+- platform: osx-arm64
+  name: bzip2
   version: 1.0.8
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
   hash:
     md5: fc76ace7b94fb1f694988ab1b14dd248
     sha256: a3efbd06ad1432edb0163c48225421f34c2660f5cc002283a8d27e791320b549
-  optional: false
-  category: main
   build: h3422bc3_4
   arch: aarch64
   subdir: osx-arm64
@@ -1772,19 +1623,18 @@ package:
   license_family: BSD
   size: 151850
   timestamp: 1618862645215
-- name: bzip2
+- platform: win-64
+  name: bzip2
   version: 1.0.8
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15.0a0'
-    vs2015_runtime: '>=14.16.27012'
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
   url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
   hash:
     md5: 7c03c66026944073040cb19a4f3ec3c9
     sha256: 5389dad4e73e4865bb485f460fc60b120bae74404003d457ecb1a62eb7abf0c1
-  optional: false
-  category: main
   build: h8ffe710_4
   arch: x86_64
   subdir: win-64
@@ -1793,18 +1643,17 @@ package:
   license_family: BSD
   size: 152247
   timestamp: 1606605223049
-- name: c-ares
+- platform: linux-64
+  name: c-ares
   version: 1.19.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.19.1-hd590300_0.conda
   hash:
     md5: e8c18d865be43e2fb3f7a145b6adf1f5
     sha256: c4276b1a0e8f18ab08018b1881666656742b325e0fcf2354f714e924d28683b6
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -1813,17 +1662,16 @@ package:
   license_family: MIT
   size: 113362
   timestamp: 1684782732180
-- name: c-ares
+- platform: osx-64
+  name: c-ares
   version: 1.20.1
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.20.1-h10d778d_0.conda
   hash:
     md5: cef472367265d424d83dca1e97f1d8f6
     sha256: a54b5406b7367e0f0431048725c33df7161d218d68fe4c7c3478d86fcf605e1b
-  optional: false
-  category: main
   build: h10d778d_0
   arch: x86_64
   subdir: osx-64
@@ -1832,17 +1680,16 @@ package:
   license_family: MIT
   size: 103052
   timestamp: 1696842904783
-- name: c-ares
+- platform: osx-arm64
+  name: c-ares
   version: 1.19.1
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.19.1-hb547adb_0.conda
   hash:
     md5: e7fc7430440d255e3a9c7e5a52f7b294
     sha256: fc9d0fcfb30c20c0032b294120b6ba9c01078ddb372c34dd491214c598aecc06
-  optional: false
-  category: main
   build: hb547adb_0
   arch: aarch64
   subdir: osx-arm64
@@ -1851,20 +1698,19 @@ package:
   license_family: MIT
   size: 101998
   timestamp: 1684783026131
-- name: c-ares
+- platform: win-64
+  name: c-ares
   version: 1.19.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.19.1-hcfcfb64_0.conda
   hash:
     md5: 8aa74d9a74ed3a31d9ed38a387a8ca50
     sha256: 4dc79f3b5784ea9bffcbd27f2c23a52f0507e877af59d002aa2202c07d0d4951
-  optional: false
-  category: main
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
@@ -1873,20 +1719,19 @@ package:
   license_family: MIT
   size: 112589
   timestamp: 1684783302054
-- name: c-compiler
+- platform: linux-64
+  name: c-compiler
   version: 1.6.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    binutils: '*'
-    gcc: '*'
-    gcc_linux-64: 12.*
+  - binutils *
+  - gcc *
+  - gcc_linux-64 12.*
   url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.6.0-hd590300_0.conda
   hash:
     md5: ea6c792f792bdd7ae6e7e2dee32f0a48
     sha256: d741ff93d5f71a83a9be0f592682f31ca2d468c37177f18a8d1a2469bb821c05
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -1894,21 +1739,20 @@ package:
   license: BSD
   size: 6184
   timestamp: 1689097480051
-- name: c-compiler
+- platform: osx-64
+  name: c-compiler
   version: 1.6.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    cctools: '>=949.0.1'
-    clang_osx-64: 15.*
-    ld64: '>=530'
-    llvm-openmp: '*'
+  - cctools >=949.0.1
+  - clang_osx-64 15.*
+  - ld64 >=530
+  - llvm-openmp *
   url: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.6.0-h63c33a9_0.conda
   hash:
     md5: d7f3b8d3a85b4e7eded31adb611bb665
     sha256: fe43bbe1b7c809b618808123a662333c20417bc98ffa5dc7d6da23c3c8ec236b
-  optional: false
-  category: main
   build: h63c33a9_0
   arch: x86_64
   subdir: osx-64
@@ -1916,21 +1760,20 @@ package:
   license: BSD
   size: 6250
   timestamp: 1689097835926
-- name: c-compiler
+- platform: osx-arm64
+  name: c-compiler
   version: 1.6.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    cctools: '>=949.0.1'
-    clang_osx-arm64: 15.*
-    ld64: '>=530'
-    llvm-openmp: '*'
+  - cctools >=949.0.1
+  - clang_osx-arm64 15.*
+  - ld64 >=530
+  - llvm-openmp *
   url: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.6.0-hd291e01_0.conda
   hash:
     md5: 7d58fb216ad601b545826449d8d4c34e
     sha256: f2e837668ff628ef8b5d54fffbfe9596cdd3820f7c5a3fc5ad48b259ff99a501
-  optional: false
-  category: main
   build: hd291e01_0
   arch: aarch64
   subdir: osx-arm64
@@ -1938,17 +1781,16 @@ package:
   license: BSD
   size: 6269
   timestamp: 1689097851052
-- name: ca-certificates
+- platform: linux-64
+  name: ca-certificates
   version: 2023.7.22
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
   hash:
     md5: a73ecd2988327ad4c8f2c331482917f2
     sha256: 525b7b6b5135b952ec1808de84e5eca57c7c7ff144e29ef3e96ae4040ff432c1
-  optional: false
-  category: main
   build: hbcca054_0
   arch: x86_64
   subdir: linux-64
@@ -1956,17 +1798,16 @@ package:
   license: ISC
   size: 149515
   timestamp: 1690026108541
-- name: ca-certificates
+- platform: osx-64
+  name: ca-certificates
   version: 2023.7.22
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
   hash:
     md5: bf2c54c18997bf3542af074c10191771
     sha256: 27de15e18a12117e83ac1eb8a8e52eb65731cc7f0b607a7922206a15e2460c7b
-  optional: false
-  category: main
   build: h8857fd0_0
   arch: x86_64
   subdir: osx-64
@@ -1974,17 +1815,16 @@ package:
   license: ISC
   size: 149911
   timestamp: 1690026363769
-- name: ca-certificates
+- platform: osx-arm64
+  name: ca-certificates
   version: 2023.7.22
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.7.22-hf0a4a13_0.conda
   hash:
     md5: e1b99ac4dbcee71a71682996f67f7965
     sha256: b220c001b0c1448a47cc49b42a622e06a540ec60b3f7a1e057fca1f37ce515e4
-  optional: false
-  category: main
   build: hf0a4a13_0
   arch: aarch64
   subdir: osx-arm64
@@ -1992,17 +1832,16 @@ package:
   license: ISC
   size: 149918
   timestamp: 1690026385821
-- name: ca-certificates
+- platform: win-64
+  name: ca-certificates
   version: 2023.7.22
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
   hash:
     md5: b1c2327b36f1a25d96f2039b0d3e3739
     sha256: b85a6f307f8e1c803cb570bdfb9e4d811a361417873ecd2ecf687587405a72e0
-  optional: false
-  category: main
   build: h56e8100_0
   arch: x86_64
   subdir: win-64
@@ -2010,20 +1849,19 @@ package:
   license: ISC
   size: 150013
   timestamp: 1690026269050
-- name: cctools
+- platform: osx-64
+  name: cctools
   version: 973.0.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    cctools_osx-64: ==973.0.1 habff3f6_15
-    ld64: ==609 ha91a046_15
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - cctools_osx-64 ==973.0.1 habff3f6_15
+  - ld64 ==609 ha91a046_15
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/cctools-973.0.1-hd9ad811_15.conda
   hash:
     md5: 00374d616829d1e4d2266e571147848a
     sha256: 6fc0e86e24687cde3476e04f001ac1edf5813c0caa15b72c913b660533428987
-  optional: false
-  category: main
   build: hd9ad811_15
   arch: x86_64
   subdir: osx-64
@@ -2032,20 +1870,19 @@ package:
   license_family: Other
   size: 21917
   timestamp: 1697075797642
-- name: cctools
+- platform: osx-arm64
+  name: cctools
   version: 973.0.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    cctools_osx-arm64: ==973.0.1 h2a25c60_14
-    ld64: ==609 h89fa09d_14
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - cctools_osx-arm64 ==973.0.1 h2a25c60_14
+  - ld64 ==609 h89fa09d_14
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-973.0.1-hd1ac623_14.conda
   hash:
     md5: 46c0f28ac1c5f417f46e028212f72f91
     sha256: d7520a360b9d9ea0690f20403d19a9bee5069f5844aa2f092c5bd24816f0a84d
-  optional: false
-  category: main
   build: hd1ac623_14
   arch: aarch64
   subdir: osx-arm64
@@ -2054,22 +1891,21 @@ package:
   license_family: Other
   size: 22053
   timestamp: 1690768497252
-- name: cctools_osx-64
+- platform: osx-64
+  name: cctools_osx-64
   version: 973.0.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    ld64_osx-64: '>=609,<610.0a0'
-    libcxx: '*'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    sigtool: '*'
+  - ld64_osx-64 >=609,<610.0a0
+  - libcxx *
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - sigtool *
   url: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-973.0.1-habff3f6_15.conda
   hash:
     md5: 015a19b3900b9fce20a48551e66f7699
     sha256: ca00afdafb22d6c363921f1c81b35fabd9b7eefee7e1ea2ad4f0fe920b63d035
-  optional: false
-  category: main
   build: habff3f6_15
   arch: x86_64
   subdir: osx-64
@@ -2082,22 +1918,21 @@ package:
   license_family: Other
   size: 1116869
   timestamp: 1697075736696
-- name: cctools_osx-arm64
+- platform: osx-arm64
+  name: cctools_osx-arm64
   version: 973.0.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    ld64_osx-arm64: '>=609,<610.0a0'
-    libcxx: '*'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    sigtool: '*'
+  - ld64_osx-arm64 >=609,<610.0a0
+  - libcxx *
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - sigtool *
   url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-973.0.1-h2a25c60_14.conda
   hash:
     md5: 09f973985e770a7fbbca9a299af51a8b
     sha256: 3c0b4237f5751617c2fa63180ae56ae8c39c349b1b30d78a651b0274758b65d1
-  optional: false
-  category: main
   build: h2a25c60_14
   arch: aarch64
   subdir: osx-arm64
@@ -2110,19 +1945,18 @@ package:
   license_family: Other
   size: 1122294
   timestamp: 1690768462517
-- name: clang
+- platform: linux-64
+  name: clang
   version: 15.0.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    clang-15: ==15.0.7 default_h7634d5b_3
-    gcc_impl_linux-64: '*'
+  - clang-15 ==15.0.7 default_h7634d5b_3
+  - gcc_impl_linux-64 *
   url: https://conda.anaconda.org/conda-forge/linux-64/clang-15.0.7-ha770c72_3.conda
   hash:
     md5: d6d3417df41b77a4ffdc3955a1bedb20
     sha256: 0119454827f79a3ee489482c7f439abf9107fb02286f928d5f6599f51e1dc220
-  optional: false
-  category: main
   build: ha770c72_3
   arch: x86_64
   subdir: linux-64
@@ -2136,18 +1970,17 @@ package:
   license_family: Apache
   size: 132855
   timestamp: 1690549739551
-- name: clang
+- platform: osx-64
+  name: clang
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    clang-15: ==15.0.7 default_hdb78580_3
+  - clang-15 ==15.0.7 default_hdb78580_3
   url: https://conda.anaconda.org/conda-forge/osx-64/clang-15.0.7-h694c41f_3.conda
   hash:
     md5: 8a48d466e519b8db7dda7c5d27cc1d31
     sha256: 3eab054ba786b0b80609bea17342385dcbdce69c6158e6ec7443f4f940c92883
-  optional: false
-  category: main
   build: h694c41f_3
   arch: x86_64
   subdir: osx-64
@@ -2161,18 +1994,17 @@ package:
   license_family: Apache
   size: 132843
   timestamp: 1690549855885
-- name: clang
+- platform: osx-arm64
+  name: clang
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    clang-15: ==15.0.7 default_h5dc8d65_3
+  - clang-15 ==15.0.7 default_h5dc8d65_3
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-15.0.7-hce30654_3.conda
   hash:
     md5: 0871ba77c4bec31504b371a4f2525a7b
     sha256: 7eceef0863863c7e6c8752ca8359dedebc87cc9fba108856533115e2d9a8d9ba
-  optional: false
-  category: main
   build: hce30654_3
   arch: aarch64
   subdir: osx-arm64
@@ -2186,22 +2018,21 @@ package:
   license_family: Apache
   size: 133018
   timestamp: 1690549798814
-- name: clang-15
+- platform: linux-64
+  name: clang-15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libclang-cpp15: ==15.0.7 default_h7634d5b_3
-    libgcc-ng: '>=12'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libclang-cpp15 ==15.0.7 default_h7634d5b_3
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/clang-15-15.0.7-default_h7634d5b_3.conda
   hash:
     md5: 7245ec4bd999e025455c80b6ea493143
     sha256: 0b40914ea7070af1113b2fd86af79b42a6180d0f39bcdae3ad8dbc68a9e9ab83
-  optional: false
-  category: main
   build: default_h7634d5b_3
   arch: x86_64
   subdir: linux-64
@@ -2215,20 +2046,19 @@ package:
   license_family: Apache
   size: 809528
   timestamp: 1690549681144
-- name: clang-15
+- platform: osx-64
+  name: clang-15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libclang-cpp15: ==15.0.7 default_hdb78580_3
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libclang-cpp15 ==15.0.7 default_hdb78580_3
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/clang-15-15.0.7-default_hdb78580_3.conda
   hash:
     md5: 688d6b9e178cb7786a07e3cfca2a8f09
     sha256: 686abd626e3fe42c040c77e38b5c07d4fe5cd6f1561feb4b92ffbbba6b36e262
-  optional: false
-  category: main
   build: default_hdb78580_3
   arch: x86_64
   subdir: osx-64
@@ -2242,20 +2072,19 @@ package:
   license_family: Apache
   size: 794748
   timestamp: 1690549737577
-- name: clang-15
+- platform: osx-arm64
+  name: clang-15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libclang-cpp15: ==15.0.7 default_h5dc8d65_3
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libclang-cpp15 ==15.0.7 default_h5dc8d65_3
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-15-15.0.7-default_h5dc8d65_3.conda
   hash:
     md5: 3b214c8a23030d3a04389cbcd4bb84e4
     sha256: 92d974b4675fa1f56f5ba1f396cc811a830ecbba0195ef1697235298535fad39
-  optional: false
-  category: main
   build: default_h5dc8d65_3
   arch: aarch64
   subdir: osx-arm64
@@ -2269,23 +2098,22 @@ package:
   license_family: Apache
   size: 795051
   timestamp: 1690549670667
-- name: clang-format
+- platform: linux-64
+  name: clang-format
   version: 15.0.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    clang-format-15: ==15.0.7 default_h7634d5b_3
-    libclang-cpp15: '>=15.0.7,<15.1.0a0'
-    libgcc-ng: '>=12'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - clang-format-15 ==15.0.7 default_h7634d5b_3
+  - libclang-cpp15 >=15.0.7,<15.1.0a0
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/clang-format-15.0.7-default_h7634d5b_3.conda
   hash:
     md5: 5ce1db65053ef3f8f4d093a724c277cc
     sha256: f976f20823b48a7d95f04dcbddcb33ae81a5900d8b00c31cac0268ce21e3fe07
-  optional: false
-  category: main
   build: default_h7634d5b_3
   arch: x86_64
   subdir: linux-64
@@ -2294,21 +2122,20 @@ package:
   license_family: Apache
   size: 133277
   timestamp: 1690549957754
-- name: clang-format
+- platform: osx-64
+  name: clang-format
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    clang-format-15: ==15.0.7 default_hdb78580_3
-    libclang-cpp15: '>=15.0.7,<15.1.0a0'
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - clang-format-15 ==15.0.7 default_hdb78580_3
+  - libclang-cpp15 >=15.0.7,<15.1.0a0
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/clang-format-15.0.7-default_hdb78580_3.conda
   hash:
     md5: 71b6895e2161905506c72b8d705072f7
     sha256: 06bc8e49cb56acaa0ba50493a6c6689f31ee8573b45eebb5df5ecce4736a1392
-  optional: false
-  category: main
   build: default_hdb78580_3
   arch: x86_64
   subdir: osx-64
@@ -2317,21 +2144,20 @@ package:
   license_family: Apache
   size: 133176
   timestamp: 1690550267740
-- name: clang-format
+- platform: osx-arm64
+  name: clang-format
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    clang-format-15: ==15.0.7 default_h5dc8d65_3
-    libclang-cpp15: '>=15.0.7,<15.1.0a0'
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - clang-format-15 ==15.0.7 default_h5dc8d65_3
+  - libclang-cpp15 >=15.0.7,<15.1.0a0
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-15.0.7-default_h5dc8d65_3.conda
   hash:
     md5: c5238e0f10ad14fd48a282bdda50e164
     sha256: 4e410c58ed91b79aeb9d62945f5981030d121f906c269df93f92c5e73500c185
-  optional: false
-  category: main
   build: default_h5dc8d65_3
   arch: aarch64
   subdir: osx-arm64
@@ -2340,21 +2166,20 @@ package:
   license_family: Apache
   size: 133475
   timestamp: 1690550223126
-- name: clang-format
+- platform: win-64
+  name: clang-format
   version: 15.0.7
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/clang-format-15.0.7-default_h66ee7f4_3.conda
   hash:
     md5: e602a61e64266e854ab2234b8e80957a
     sha256: 2788d948c2c7eeee1f02d7936d5b84f5547a94521abee10deb5287106c31d393
-  optional: false
-  category: main
   build: default_h66ee7f4_3
   arch: x86_64
   subdir: win-64
@@ -2363,22 +2188,21 @@ package:
   license_family: Apache
   size: 1223464
   timestamp: 1690553805296
-- name: clang-format-15
+- platform: linux-64
+  name: clang-format-15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libclang-cpp15: '>=15.0.7,<15.1.0a0'
-    libgcc-ng: '>=12'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libclang-cpp15 >=15.0.7,<15.1.0a0
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/clang-format-15-15.0.7-default_h7634d5b_3.conda
   hash:
     md5: 9c03ef6af3f5a320ce9780dcf705e4d2
     sha256: ab0eff716fa20c9de8133e2c1987a38abb37aa3d33d52fe8beccd979e3b652ad
-  optional: false
-  category: main
   build: default_h7634d5b_3
   arch: x86_64
   subdir: linux-64
@@ -2387,20 +2211,19 @@ package:
   license_family: Apache
   size: 259946
   timestamp: 1690549899367
-- name: clang-format-15
+- platform: osx-64
+  name: clang-format-15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libclang-cpp15: '>=15.0.7,<15.1.0a0'
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libclang-cpp15 >=15.0.7,<15.1.0a0
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/clang-format-15-15.0.7-default_hdb78580_3.conda
   hash:
     md5: 2bb52de137d26760268139c33a16c966
     sha256: bfcae5a04fb7ec8fb1b097eab18b5222e9380463dd63683f78a171ad58f1df37
-  optional: false
-  category: main
   build: default_hdb78580_3
   arch: x86_64
   subdir: osx-64
@@ -2409,20 +2232,19 @@ package:
   license_family: Apache
   size: 257644
   timestamp: 1690550167340
-- name: clang-format-15
+- platform: osx-arm64
+  name: clang-format-15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libclang-cpp15: '>=15.0.7,<15.1.0a0'
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libclang-cpp15 >=15.0.7,<15.1.0a0
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-15-15.0.7-default_h5dc8d65_3.conda
   hash:
     md5: 037fa18a2b6befdc1be50237a07b7827
     sha256: d3280499403ebe78beaab02d2f20588184f5a6d22863b7c2e67e7f93877eef74
-  optional: false
-  category: main
   build: default_h5dc8d65_3
   arch: aarch64
   subdir: osx-arm64
@@ -2431,24 +2253,23 @@ package:
   license_family: Apache
   size: 255409
   timestamp: 1690550130184
-- name: clang-tools
+- platform: linux-64
+  name: clang-tools
   version: 15.0.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    clang-format: ==15.0.7 default_h7634d5b_3
-    libclang: '>=15.0.7,<15.1.0a0'
-    libclang-cpp15: '>=15.0.7,<15.1.0a0'
-    libgcc-ng: '>=12'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - clang-format ==15.0.7 default_h7634d5b_3
+  - libclang >=15.0.7,<15.1.0a0
+  - libclang-cpp15 >=15.0.7,<15.1.0a0
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/clang-tools-15.0.7-default_h7634d5b_3.conda
   hash:
     md5: 0041e55028e791d403bdd0af5272a191
     sha256: e2863149d76c5cb01656f9f27584b9c4b9494ef7d8c37fbdbae83b4230c0dce0
-  optional: false
-  category: main
   build: default_h7634d5b_3
   arch: x86_64
   subdir: linux-64
@@ -2463,22 +2284,21 @@ package:
   license_family: Apache
   size: 25224796
   timestamp: 1690550008802
-- name: clang-tools
+- platform: osx-64
+  name: clang-tools
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    clang-format: ==15.0.7 default_hdb78580_3
-    libclang: '>=15.0.7,<15.1.0a0'
-    libclang-cpp15: '>=15.0.7,<15.1.0a0'
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - clang-format ==15.0.7 default_hdb78580_3
+  - libclang >=15.0.7,<15.1.0a0
+  - libclang-cpp15 >=15.0.7,<15.1.0a0
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/clang-tools-15.0.7-default_hdb78580_3.conda
   hash:
     md5: f3433671cb6c36f66f1d0f81254e0858
     sha256: f54bca9c18ee9486682f7a796921dad2534920b48a04788f974dfb66550f9f77
-  optional: false
-  category: main
   build: default_hdb78580_3
   arch: x86_64
   subdir: osx-64
@@ -2493,22 +2313,21 @@ package:
   license_family: Apache
   size: 17091066
   timestamp: 1690550394142
-- name: clang-tools
+- platform: osx-arm64
+  name: clang-tools
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    clang-format: ==15.0.7 default_h5dc8d65_3
-    libclang: '>=15.0.7,<15.1.0a0'
-    libclang-cpp15: '>=15.0.7,<15.1.0a0'
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - clang-format ==15.0.7 default_h5dc8d65_3
+  - libclang >=15.0.7,<15.1.0a0
+  - libclang-cpp15 >=15.0.7,<15.1.0a0
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-tools-15.0.7-default_h5dc8d65_3.conda
   hash:
     md5: ab94653a176bda40d45bb6406f0bcff1
     sha256: 19585e0a3ff5c0cfcf75c678f1471daa862013532cc9985e2662c1fb7d6a6707
-  optional: false
-  category: main
   build: default_h5dc8d65_3
   arch: aarch64
   subdir: osx-arm64
@@ -2523,22 +2342,21 @@ package:
   license_family: Apache
   size: 16055653
   timestamp: 1690550344308
-- name: clang-tools
+- platform: win-64
+  name: clang-tools
   version: 15.0.7
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    clang-format: ==15.0.7 default_h66ee7f4_3
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - clang-format ==15.0.7 default_h66ee7f4_3
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/clang-tools-15.0.7-default_h66ee7f4_3.conda
   hash:
     md5: 1fb8f6a1457d6ed1b9af746d5bc2d9a6
     sha256: da98cba02f253133a9f727348c1671c0a619c52eba8ab1a7030f223414aba59e
-  optional: false
-  category: main
   build: default_h66ee7f4_3
   arch: x86_64
   subdir: win-64
@@ -2553,22 +2371,21 @@ package:
   license_family: Apache
   size: 207487053
   timestamp: 1690554250567
-- name: clang_osx-64
+- platform: osx-64
+  name: clang_osx-64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    cctools_osx-64: '*'
-    clang: 15.0.7.*
-    compiler-rt: 15.0.7.*
-    ld64_osx-64: '*'
-    llvm-tools: 15.0.7.*
+  - cctools_osx-64 *
+  - clang 15.0.7.*
+  - compiler-rt 15.0.7.*
+  - ld64_osx-64 *
+  - llvm-tools 15.0.7.*
   url: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-15.0.7-h03d6864_3.conda
   hash:
     md5: 9dfd4e8cbc51c07a7b1ad59ad8415fad
     sha256: 1257bf432219240be7b3eddde72fcfad1e85c8eacea2871e6f9121d66eccd965
-  optional: false
-  category: main
   build: h03d6864_3
   arch: x86_64
   subdir: osx-64
@@ -2577,22 +2394,21 @@ package:
   license_family: BSD
   size: 20620
   timestamp: 1684463185776
-- name: clang_osx-arm64
+- platform: osx-arm64
+  name: clang_osx-arm64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    cctools_osx-arm64: '*'
-    clang: 15.0.7.*
-    compiler-rt: 15.0.7.*
-    ld64_osx-arm64: '*'
-    llvm-tools: 15.0.7.*
+  - cctools_osx-arm64 *
+  - clang 15.0.7.*
+  - compiler-rt 15.0.7.*
+  - ld64_osx-arm64 *
+  - llvm-tools 15.0.7.*
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-15.0.7-h77e971b_3.conda
   hash:
     md5: 4799cb60f8ff17edaf3574b28681d2a0
     sha256: 556ab57b9d190bf3ad2b9e7ba3c164157f8d163489a65235c0cfe52478521da0
-  optional: false
-  category: main
   build: h77e971b_3
   arch: aarch64
   subdir: osx-arm64
@@ -2601,18 +2417,17 @@ package:
   license_family: BSD
   size: 20618
   timestamp: 1684463162877
-- name: clangxx
+- platform: osx-64
+  name: clangxx
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    clang: ==15.0.7 h694c41f_3
+  - clang ==15.0.7 h694c41f_3
   url: https://conda.anaconda.org/conda-forge/osx-64/clangxx-15.0.7-default_hdb78580_3.conda
   hash:
     md5: 58df9ff86fefc7684670be729b41412f
     sha256: b68fbe1f7c401401622b61f9e65be6fffae4104727c2f39feacede5c393fa65e
-  optional: false
-  category: main
   build: default_hdb78580_3
   arch: x86_64
   subdir: osx-64
@@ -2621,18 +2436,17 @@ package:
   license_family: Apache
   size: 132973
   timestamp: 1690549872764
-- name: clangxx
+- platform: osx-arm64
+  name: clangxx
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    clang: ==15.0.7 hce30654_3
+  - clang ==15.0.7 hce30654_3
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-15.0.7-default_h610c423_3.conda
   hash:
     md5: 1919a441b26f5cd1181870be6b4ce31a
     sha256: 59e1545bac0207bb8b82c3718a16ec79dd9ac218eb00679f8cb5ed2cd115ffe3
-  optional: false
-  category: main
   build: default_h610c423_3
   arch: aarch64
   subdir: osx-arm64
@@ -2641,21 +2455,20 @@ package:
   license_family: Apache
   size: 133212
   timestamp: 1690549817560
-- name: clangxx_osx-64
+- platform: osx-64
+  name: clangxx_osx-64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    clang_osx-64: ==15.0.7 h03d6864_3
-    clangxx: 15.0.7.*
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - clang_osx-64 ==15.0.7 h03d6864_3
+  - clangxx 15.0.7.*
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-15.0.7-h2133e9c_3.conda
   hash:
     md5: 2ff16b86a981da4b1a2658423db664bb
     sha256: 04900d8758347c81d8f3904ba513fced2cb86af258d6ce70f8377e2515c9ec51
-  optional: false
-  category: main
   build: h2133e9c_3
   arch: x86_64
   subdir: osx-64
@@ -2664,21 +2477,20 @@ package:
   license_family: BSD
   size: 19427
   timestamp: 1684463207952
-- name: clangxx_osx-arm64
+- platform: osx-arm64
+  name: clangxx_osx-arm64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    clang_osx-arm64: ==15.0.7 h77e971b_3
-    clangxx: 15.0.7.*
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - clang_osx-arm64 ==15.0.7 h77e971b_3
+  - clangxx 15.0.7.*
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-15.0.7-h768a7fd_3.conda
   hash:
     md5: 16e11574eeb3cfa3da194692da449aeb
     sha256: 83c774c3dd206f4772a4a0abd10d21ad4aa9aa472fc9e2af16bf0b9a07476684
-  optional: false
-  category: main
   build: h768a7fd_3
   arch: aarch64
   subdir: osx-arm64
@@ -2687,19 +2499,18 @@ package:
   license_family: BSD
   size: 19504
   timestamp: 1684463181478
-- name: click
+- platform: linux-64
+  name: click
   version: 8.1.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    __unix: '*'
-    python: '>=3.8'
+  - __unix *
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
   hash:
     md5: f3ad426304898027fc619827ff428eca
     sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
-  optional: false
-  category: main
   build: unix_pyh707e725_0
   arch: x86_64
   subdir: linux-64
@@ -2709,19 +2520,18 @@ package:
   noarch: python
   size: 84437
   timestamp: 1692311973840
-- name: click
+- platform: osx-64
+  name: click
   version: 8.1.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __unix: '*'
-    python: '>=3.8'
+  - __unix *
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
   hash:
     md5: f3ad426304898027fc619827ff428eca
     sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
-  optional: false
-  category: main
   build: unix_pyh707e725_0
   arch: x86_64
   subdir: osx-64
@@ -2731,19 +2541,18 @@ package:
   noarch: python
   size: 84437
   timestamp: 1692311973840
-- name: click
+- platform: osx-arm64
+  name: click
   version: 8.1.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __unix: '*'
-    python: '>=3.8'
+  - __unix *
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
   hash:
     md5: f3ad426304898027fc619827ff428eca
     sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
-  optional: false
-  category: main
   build: unix_pyh707e725_0
   arch: aarch64
   subdir: osx-arm64
@@ -2753,20 +2562,19 @@ package:
   noarch: python
   size: 84437
   timestamp: 1692311973840
-- name: click
+- platform: win-64
+  name: click
   version: 8.1.7
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    __win: '*'
-    colorama: '*'
-    python: '>=3.8'
+  - __win *
+  - colorama *
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
   hash:
     md5: 3549ecbceb6cd77b91a105511b7d0786
     sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
-  optional: false
-  category: main
   build: win_pyh7428d3b_0
   arch: x86_64
   subdir: win-64
@@ -2776,28 +2584,27 @@ package:
   noarch: python
   size: 85051
   timestamp: 1692312207348
-- name: cmake
+- platform: linux-64
+  name: cmake
   version: 3.27.6
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.3.0,<9.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libuv: '>=1.46.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    rhash: '>=1.4.4,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libuv >=1.46.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.27.6-hcfe8598_0.conda
   hash:
     md5: 4c0101485c452ea86f846523c4fae698
     sha256: 64e08c246195d6956f7a04fa7d96a53de696b26b1dae8b08cfe716950f696e12
-  optional: false
-  category: main
   build: hcfe8598_0
   arch: x86_64
   subdir: linux-64
@@ -2806,27 +2613,26 @@ package:
   license_family: BSD
   size: 18494905
   timestamp: 1695269729661
-- name: cmake
+- platform: osx-64
+  name: cmake
   version: 3.27.6
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.3.0,<9.0a0'
-    libcxx: '>=15.0.7'
-    libexpat: '>=2.5.0,<3.0a0'
-    libuv: '>=1.46.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    rhash: '>=1.4.4,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libcxx >=15.0.7
+  - libexpat >=2.5.0,<3.0a0
+  - libuv >=1.46.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.27.6-hf40c264_0.conda
   hash:
     md5: 771da6a52aaf0f9d84114d0ed0d0299f
     sha256: 9216698f88b82e99db950f8c372038931c54ea3e0b0b05e2a3ce03ec4b405df7
-  optional: false
-  category: main
   build: hf40c264_0
   arch: x86_64
   subdir: osx-64
@@ -2835,27 +2641,26 @@ package:
   license_family: BSD
   size: 16525734
   timestamp: 1695270838345
-- name: cmake
+- platform: osx-arm64
+  name: cmake
   version: 3.27.6
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.3.0,<9.0a0'
-    libcxx: '>=15.0.7'
-    libexpat: '>=2.5.0,<3.0a0'
-    libuv: '>=1.46.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    rhash: '>=1.4.4,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libcxx >=15.0.7
+  - libexpat >=2.5.0,<3.0a0
+  - libuv >=1.46.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.27.6-h1c59155_0.conda
   hash:
     md5: 3c0dd04401438fec44cd113247ba2852
     sha256: 31be31e358e6f6f8818d8f9c9086da4404f8c6fc89d71d55887bed11ce6d463e
-  optional: false
-  category: main
   build: h1c59155_0
   arch: aarch64
   subdir: osx-arm64
@@ -2864,26 +2669,25 @@ package:
   license_family: BSD
   size: 16007289
   timestamp: 1695270816826
-- name: cmake
+- platform: win-64
+  name: cmake
   version: 3.27.6
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.3.0,<9.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libuv: '>=1.44.2,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc14_runtime: '>=14.29.30139'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libuv >=1.44.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/win-64/cmake-3.27.6-hf0feee3_0.conda
   hash:
     md5: 4dc81f3bf26f0949fedd4e31cecea1d1
     sha256: 12b94bce6d7c76ff408f8ea240c7d78987b0bc3cb4f632f381c4b0efd30ebfe0
-  optional: false
-  category: main
   build: hf0feee3_0
   arch: x86_64
   subdir: win-64
@@ -2892,18 +2696,17 @@ package:
   license_family: BSD
   size: 13777396
   timestamp: 1695270971791
-- name: colorama
+- platform: linux-64
+  name: colorama
   version: 0.4.6
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 3faab06a954c2a04039983f2c4a50d99
     sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -2913,18 +2716,17 @@ package:
   noarch: python
   size: 25170
   timestamp: 1666700778190
-- name: colorama
+- platform: osx-64
+  name: colorama
   version: 0.4.6
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 3faab06a954c2a04039983f2c4a50d99
     sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -2934,18 +2736,17 @@ package:
   noarch: python
   size: 25170
   timestamp: 1666700778190
-- name: colorama
+- platform: osx-arm64
+  name: colorama
   version: 0.4.6
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 3faab06a954c2a04039983f2c4a50d99
     sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -2955,18 +2756,17 @@ package:
   noarch: python
   size: 25170
   timestamp: 1666700778190
-- name: colorama
+- platform: win-64
+  name: colorama
   version: 0.4.6
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 3faab06a954c2a04039983f2c4a50d99
     sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -2976,20 +2776,19 @@ package:
   noarch: python
   size: 25170
   timestamp: 1666700778190
-- name: compiler-rt
+- platform: osx-64
+  name: compiler-rt
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    clang: 15.0.7.*
-    clangxx: 15.0.7.*
-    compiler-rt_osx-64: 15.0.7.*
+  - clang 15.0.7.*
+  - clangxx 15.0.7.*
+  - compiler-rt_osx-64 15.0.7.*
   url: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-15.0.7-he1888fc_1.conda
   hash:
     md5: 8ec296a4b097aeb2d85eafaf745c770a
     sha256: 90a2dd7a9baf8d6ddde9d11ad682dbd74f74c1f40ce0e4e9df7c356b0275ca31
-  optional: false
-  category: main
   build: he1888fc_1
   arch: x86_64
   subdir: osx-64
@@ -2998,20 +2797,19 @@ package:
   license_family: APACHE
   size: 92129
   timestamp: 1684403261646
-- name: compiler-rt
+- platform: osx-arm64
+  name: compiler-rt
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    clang: 15.0.7.*
-    clangxx: 15.0.7.*
-    compiler-rt_osx-arm64: 15.0.7.*
+  - clang 15.0.7.*
+  - clangxx 15.0.7.*
+  - compiler-rt_osx-arm64 15.0.7.*
   url: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-15.0.7-hf8d1dfb_1.conda
   hash:
     md5: 355703f3e33fd12037800d28680845cb
     sha256: d2ab8bc610038e40dafdb6b6172343553f1f3aba4e9a4c540e878474062b1b89
-  optional: false
-  category: main
   build: hf8d1dfb_1
   arch: aarch64
   subdir: osx-arm64
@@ -3020,19 +2818,18 @@ package:
   license_family: APACHE
   size: 92034
   timestamp: 1684403020973
-- name: compiler-rt_osx-64
+- platform: osx-64
+  name: compiler-rt_osx-64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    clang: 15.0.7.*
-    clangxx: 15.0.7.*
+  - clang 15.0.7.*
+  - clangxx 15.0.7.*
   url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-15.0.7-he1888fc_1.conda
   hash:
     md5: e1f93ea86259a549f2dcbfd245bf0422
     sha256: a2c19b4ec885e668266f5dd0e90193d9436c0be63c370c91ae1b840a19071159
-  optional: false
-  category: main
   build: he1888fc_1
   arch: x86_64
   subdir: osx-64
@@ -3044,19 +2841,18 @@ package:
   noarch: generic
   size: 11208907
   timestamp: 1684403213219
-- name: compiler-rt_osx-arm64
+- platform: osx-arm64
+  name: compiler-rt_osx-arm64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    clang: 15.0.7.*
-    clangxx: 15.0.7.*
+  - clang 15.0.7.*
+  - clangxx 15.0.7.*
   url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-15.0.7-hf8d1dfb_1.conda
   hash:
     md5: 0722cbdc69a52c82acc4e265913a21cd
     sha256: 5a801e344b2a18983199190cb34ad798e3ce5966a4a4031c74f7e395d8c38802
-  optional: false
-  category: main
   build: hf8d1dfb_1
   arch: aarch64
   subdir: osx-arm64
@@ -3068,20 +2864,19 @@ package:
   noarch: generic
   size: 11283089
   timestamp: 1684402974671
-- name: cxx-compiler
+- platform: linux-64
+  name: cxx-compiler
   version: 1.6.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    c-compiler: ==1.6.0 hd590300_0
-    gxx: '*'
-    gxx_linux-64: 12.*
+  - c-compiler ==1.6.0 hd590300_0
+  - gxx *
+  - gxx_linux-64 12.*
   url: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.6.0-h00ab1b0_0.conda
   hash:
     md5: 364c6ae36c4e36fcbd4d273cf4db78af
     sha256: 472b6b7f967df1db634c67d71c6b31cd186d18b5d0548196c2e426833ff17d99
-  optional: false
-  category: main
   build: h00ab1b0_0
   arch: x86_64
   subdir: linux-64
@@ -3089,19 +2884,18 @@ package:
   license: BSD
   size: 6179
   timestamp: 1689097484095
-- name: cxx-compiler
+- platform: osx-64
+  name: cxx-compiler
   version: 1.6.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    c-compiler: ==1.6.0 h63c33a9_0
-    clangxx_osx-64: 15.*
+  - c-compiler ==1.6.0 h63c33a9_0
+  - clangxx_osx-64 15.*
   url: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.6.0-h1c7c39f_0.conda
   hash:
     md5: 9adaf7c9d4e1e15e70a8dd46befbbab2
     sha256: dc0860c05ef3083192b8ff4ac8242403f05a550cc42c7709ec8c9f4eaa88e993
-  optional: false
-  category: main
   build: h1c7c39f_0
   arch: x86_64
   subdir: osx-64
@@ -3109,19 +2903,18 @@ package:
   license: BSD
   size: 6258
   timestamp: 1689097854160
-- name: cxx-compiler
+- platform: osx-arm64
+  name: cxx-compiler
   version: 1.6.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    c-compiler: ==1.6.0 hd291e01_0
-    clangxx_osx-arm64: 15.*
+  - c-compiler ==1.6.0 hd291e01_0
+  - clangxx_osx-arm64 15.*
   url: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.6.0-h1995070_0.conda
   hash:
     md5: 35c1be0a08578238276ca9417fc1615c
     sha256: f0a94c6312d0fd9e3d3c3546894bafa9f9b8b20a411bee0767ad4dac916f3eb5
-  optional: false
-  category: main
   build: h1995070_0
   arch: aarch64
   subdir: osx-arm64
@@ -3129,18 +2922,17 @@ package:
   license: BSD
   size: 6301
   timestamp: 1689097905706
-- name: exceptiongroup
+- platform: linux-64
+  name: exceptiongroup
   version: 1.1.3
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
   hash:
     md5: e6518222753f519e911e83136d2158d9
     sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -3150,18 +2942,17 @@ package:
   noarch: python
   size: 19262
   timestamp: 1692026296517
-- name: exceptiongroup
+- platform: osx-64
+  name: exceptiongroup
   version: 1.1.3
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
   hash:
     md5: e6518222753f519e911e83136d2158d9
     sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -3171,18 +2962,17 @@ package:
   noarch: python
   size: 19262
   timestamp: 1692026296517
-- name: exceptiongroup
+- platform: osx-arm64
+  name: exceptiongroup
   version: 1.1.3
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
   hash:
     md5: e6518222753f519e911e83136d2158d9
     sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -3192,18 +2982,17 @@ package:
   noarch: python
   size: 19262
   timestamp: 1692026296517
-- name: exceptiongroup
+- platform: win-64
+  name: exceptiongroup
   version: 1.1.3
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
   hash:
     md5: e6518222753f519e911e83136d2158d9
     sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -3213,19 +3002,18 @@ package:
   noarch: python
   size: 19262
   timestamp: 1692026296517
-- name: flatbuffers
+- platform: linux-64
+  name: flatbuffers
   version: 23.5.26
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-23.5.26-h59595ed_1.conda
   hash:
     md5: 913a1c6fd00b66f33392a129e835ceca
     sha256: 898446f402c14da0e74cd2062e78ebcfbc531e08a8207f4df36dd596d30ccb70
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
@@ -3234,18 +3022,17 @@ package:
   license_family: APACHE
   size: 1578461
   timestamp: 1685303689874
-- name: flatbuffers
+- platform: osx-64
+  name: flatbuffers
   version: 23.5.26
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-23.5.26-he965462_1.conda
   hash:
     md5: 76123c120b7b701941234d774e18c7c0
     sha256: 4b1c90079e7bb323dd22f13b9bc014da7f0105b29323efb9097b0610997c9e04
-  optional: false
-  category: main
   build: he965462_1
   arch: x86_64
   subdir: osx-64
@@ -3254,18 +3041,17 @@ package:
   license_family: APACHE
   size: 1303407
   timestamp: 1685304046679
-- name: flatbuffers
+- platform: osx-arm64
+  name: flatbuffers
   version: 23.5.26
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-23.5.26-h13dd4ca_1.conda
   hash:
     md5: 789ac6fe52a8b2ce8dade900eb30f482
     sha256: 83b28e6f3c1737f4aa250473ecc77fdcdf2802019b77515d95d95daa55111ad0
-  optional: false
-  category: main
   build: h13dd4ca_1
   arch: aarch64
   subdir: osx-arm64
@@ -3274,20 +3060,19 @@ package:
   license_family: APACHE
   size: 1279401
   timestamp: 1685304189845
-- name: flatbuffers
+- platform: win-64
+  name: flatbuffers
   version: 23.5.26
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-23.5.26-h63175ca_1.conda
   hash:
     md5: 45c48934e47a0b2e80536e395f722f3b
     sha256: 70de98e6e01129a518fad72e46a0b6b937d633b59d61b61abb8b84843fcc1c90
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
@@ -3296,18 +3081,17 @@ package:
   license_family: APACHE
   size: 1695306
   timestamp: 1685303935893
-- name: gcc
+- platform: linux-64
+  name: gcc
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    gcc_impl_linux-64: 12.3.0.*
+  - gcc_impl_linux-64 12.3.0.*
   url: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h8d2909c_2.conda
   hash:
     md5: e2f2f81f367e14ca1f77a870bda2fe59
     sha256: 1bbf077688822993c39518056fb43d83ff0920eb42fef11e8714d2a298cc0f27
-  optional: false
-  category: main
   build: h8d2909c_2
   arch: x86_64
   subdir: linux-64
@@ -3316,24 +3100,23 @@ package:
   license_family: BSD
   size: 27086
   timestamp: 1694604171830
-- name: gcc_impl_linux-64
+- platform: linux-64
+  name: gcc_impl_linux-64
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    binutils_impl_linux-64: '>=2.39'
-    libgcc-devel_linux-64: ==12.3.0 h8bca6fd_2
-    libgcc-ng: '>=12.3.0'
-    libgomp: '>=12.3.0'
-    libsanitizer: ==12.3.0 h0f45ef3_2
-    libstdcxx-ng: '>=12.3.0'
-    sysroot_linux-64: '*'
+  - binutils_impl_linux-64 >=2.39
+  - libgcc-devel_linux-64 ==12.3.0 h8bca6fd_2
+  - libgcc-ng >=12.3.0
+  - libgomp >=12.3.0
+  - libsanitizer ==12.3.0 h0f45ef3_2
+  - libstdcxx-ng >=12.3.0
+  - sysroot_linux-64 *
   url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_2.conda
   hash:
     md5: 2f4d8677dc7dd87f93e9abfb2ce86808
     sha256: 62a897343229e6dc4a3ace4f419a30e60a0a22ce7d0eac0b9bfb8f0308cf3de5
-  optional: false
-  category: main
   build: he2b93b0_2
   arch: x86_64
   subdir: linux-64
@@ -3342,20 +3125,19 @@ package:
   license_family: GPL
   size: 51573870
   timestamp: 1695218760476
-- name: gcc_linux-64
+- platform: linux-64
+  name: gcc_linux-64
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    binutils_linux-64: ==2.40 hbdbef99_2
-    gcc_impl_linux-64: 12.3.0.*
-    sysroot_linux-64: '*'
+  - binutils_linux-64 ==2.40 hbdbef99_2
+  - gcc_impl_linux-64 12.3.0.*
+  - sysroot_linux-64 *
   url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h76fc315_2.conda
   hash:
     md5: 11517e7b5c910c5b5d6985c0c7eb7f50
     sha256: 86f6db7399ec0362e4c4025939debbfebc8ad9ccef75e3c0e4069f85b149f24d
-  optional: false
-  category: main
   build: h76fc315_2
   arch: x86_64
   subdir: linux-64
@@ -3364,19 +3146,18 @@ package:
   license_family: BSD
   size: 30351
   timestamp: 1694604476800
-- name: gflags
+- platform: linux-64
+  name: gflags
   version: 2.2.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-    libstdcxx-ng: '>=7.5.0'
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
   hash:
     md5: cddaf2c63ea4a5901cf09524c490ecdc
     sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
-  optional: false
-  category: main
   build: he1b5a44_1004
   arch: x86_64
   subdir: linux-64
@@ -3385,18 +3166,17 @@ package:
   license_family: BSD
   size: 116549
   timestamp: 1594303828933
-- name: gflags
+- platform: osx-64
+  name: gflags
   version: 2.2.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=10.0.1'
+  - libcxx >=10.0.1
   url: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
   hash:
     md5: 3f59cc77a929537e42120faf104e0d16
     sha256: 39540f879057ae529cad131644af111a8c3c48b384ec6212de6a5381e0863948
-  optional: false
-  category: main
   build: hb1e8313_1004
   arch: x86_64
   subdir: osx-64
@@ -3405,18 +3185,17 @@ package:
   license_family: BSD
   size: 94612
   timestamp: 1599590973213
-- name: gflags
+- platform: osx-arm64
+  name: gflags
   version: 2.2.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=11.0.0.rc1'
+  - libcxx >=11.0.0.rc1
   url: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
   hash:
     md5: aab9ddfad863e9ef81229a1f8852211b
     sha256: 25d4a20af2e5ace95fdec88970f6d190e77e20074d2f6d3cef766198b76a4289
-  optional: false
-  category: main
   build: hc88da5d_1004
   arch: aarch64
   subdir: osx-arm64
@@ -3425,19 +3204,18 @@ package:
   license_family: BSD
   size: 86690
   timestamp: 1599590990520
-- name: gitdb
+- platform: linux-64
+  name: gitdb
   version: 4.0.11
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
-    smmap: '>=3.0.1,<6'
+  - python >=3.7
+  - smmap >=3.0.1,<6
   url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
   hash:
     md5: 623b19f616f2ca0c261441067e18ae40
     sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -3447,19 +3225,18 @@ package:
   noarch: python
   size: 52872
   timestamp: 1697791718749
-- name: gitdb
+- platform: osx-64
+  name: gitdb
   version: 4.0.11
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
-    smmap: '>=3.0.1,<6'
+  - python >=3.7
+  - smmap >=3.0.1,<6
   url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
   hash:
     md5: 623b19f616f2ca0c261441067e18ae40
     sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -3469,19 +3246,18 @@ package:
   noarch: python
   size: 52872
   timestamp: 1697791718749
-- name: gitdb
+- platform: osx-arm64
+  name: gitdb
   version: 4.0.11
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    smmap: '>=3.0.1,<6'
+  - python >=3.7
+  - smmap >=3.0.1,<6
   url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
   hash:
     md5: 623b19f616f2ca0c261441067e18ae40
     sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -3491,19 +3267,18 @@ package:
   noarch: python
   size: 52872
   timestamp: 1697791718749
-- name: gitdb
+- platform: win-64
+  name: gitdb
   version: 4.0.11
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
-    smmap: '>=3.0.1,<6'
+  - python >=3.7
+  - smmap >=3.0.1,<6
   url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
   hash:
     md5: 623b19f616f2ca0c261441067e18ae40
     sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -3513,18 +3288,17 @@ package:
   noarch: python
   size: 52872
   timestamp: 1697791718749
-- name: gitignore-parser
+- platform: linux-64
+  name: gitignore-parser
   version: 0.1.9
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
   hash:
     md5: d7a00f5bb919ecb71b3da47f33b23825
     sha256: c35e803e65892d2757a9d713fd03bac57b7f5a38cbbb19ccc067831f3df409b4
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -3534,18 +3308,17 @@ package:
   noarch: python
   size: 11371
   timestamp: 1696511979480
-- name: gitignore-parser
+- platform: osx-64
+  name: gitignore-parser
   version: 0.1.9
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
   hash:
     md5: d7a00f5bb919ecb71b3da47f33b23825
     sha256: c35e803e65892d2757a9d713fd03bac57b7f5a38cbbb19ccc067831f3df409b4
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -3555,18 +3328,17 @@ package:
   noarch: python
   size: 11371
   timestamp: 1696511979480
-- name: gitignore-parser
+- platform: osx-arm64
+  name: gitignore-parser
   version: 0.1.9
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
   hash:
     md5: d7a00f5bb919ecb71b3da47f33b23825
     sha256: c35e803e65892d2757a9d713fd03bac57b7f5a38cbbb19ccc067831f3df409b4
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -3576,18 +3348,17 @@ package:
   noarch: python
   size: 11371
   timestamp: 1696511979480
-- name: gitignore-parser
+- platform: win-64
+  name: gitignore-parser
   version: 0.1.9
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
   hash:
     md5: d7a00f5bb919ecb71b3da47f33b23825
     sha256: c35e803e65892d2757a9d713fd03bac57b7f5a38cbbb19ccc067831f3df409b4
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -3597,20 +3368,19 @@ package:
   noarch: python
   size: 11371
   timestamp: 1696511979480
-- name: gitpython
+- platform: linux-64
+  name: gitpython
   version: 3.1.40
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    gitdb: '>=4.0.1,<5'
-    python: '>=3.7'
-    typing_extensions: '>=3.7.4.3'
+  - gitdb >=4.0.1,<5
+  - python >=3.7
+  - typing_extensions >=3.7.4.3
   url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
   hash:
     md5: 6bf74c3b7c13079a91d4bd3da51cefcf
     sha256: 6b85809ffbfe5c1887b674bf0492cc4dd1ac8a25f4d9fa20ef404be92186259b
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -3620,20 +3390,19 @@ package:
   noarch: python
   size: 147305
   timestamp: 1697650463508
-- name: gitpython
+- platform: osx-64
+  name: gitpython
   version: 3.1.40
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    gitdb: '>=4.0.1,<5'
-    python: '>=3.7'
-    typing_extensions: '>=3.7.4.3'
+  - gitdb >=4.0.1,<5
+  - python >=3.7
+  - typing_extensions >=3.7.4.3
   url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
   hash:
     md5: 6bf74c3b7c13079a91d4bd3da51cefcf
     sha256: 6b85809ffbfe5c1887b674bf0492cc4dd1ac8a25f4d9fa20ef404be92186259b
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -3643,20 +3412,19 @@ package:
   noarch: python
   size: 147305
   timestamp: 1697650463508
-- name: gitpython
+- platform: osx-arm64
+  name: gitpython
   version: 3.1.40
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    gitdb: '>=4.0.1,<5'
-    python: '>=3.7'
-    typing_extensions: '>=3.7.4.3'
+  - gitdb >=4.0.1,<5
+  - python >=3.7
+  - typing_extensions >=3.7.4.3
   url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
   hash:
     md5: 6bf74c3b7c13079a91d4bd3da51cefcf
     sha256: 6b85809ffbfe5c1887b674bf0492cc4dd1ac8a25f4d9fa20ef404be92186259b
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -3666,20 +3434,19 @@ package:
   noarch: python
   size: 147305
   timestamp: 1697650463508
-- name: gitpython
+- platform: win-64
+  name: gitpython
   version: 3.1.40
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    gitdb: '>=4.0.1,<5'
-    python: '>=3.7'
-    typing_extensions: '>=3.7.4.3'
+  - gitdb >=4.0.1,<5
+  - python >=3.7
+  - typing_extensions >=3.7.4.3
   url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
   hash:
     md5: 6bf74c3b7c13079a91d4bd3da51cefcf
     sha256: 6b85809ffbfe5c1887b674bf0492cc4dd1ac8a25f4d9fa20ef404be92186259b
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -3689,20 +3456,19 @@ package:
   noarch: python
   size: 147305
   timestamp: 1697650463508
-- name: glog
+- platform: linux-64
+  name: glog
   version: 0.6.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    gflags: '>=2.2.2,<2.3.0a0'
-    libgcc-ng: '>=10.3.0'
-    libstdcxx-ng: '>=10.3.0'
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
   hash:
     md5: b31f3565cb84435407594e548a2fb7b2
     sha256: 888cbcfb67f6e3d88a4c4ab9d26c9a406f620c4101a35dc6d2dbadb95f2221d4
-  optional: false
-  category: main
   build: h6f12383_0
   arch: x86_64
   subdir: linux-64
@@ -3711,19 +3477,18 @@ package:
   license_family: BSD
   size: 114321
   timestamp: 1649143789233
-- name: glog
+- platform: osx-64
+  name: glog
   version: 0.6.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    gflags: '>=2.2.2,<2.3.0a0'
-    libcxx: '>=12.0.1'
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=12.0.1
   url: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
   hash:
     md5: 69eb97ca709a136c53fdca1f2fd33ddf
     sha256: fdb38560094fb4a952346dc72a79b3cb09e23e4d0cae9ba4f524e6e88203d3c8
-  optional: false
-  category: main
   build: h8ac2a54_0
   arch: x86_64
   subdir: osx-64
@@ -3732,19 +3497,18 @@ package:
   license_family: BSD
   size: 100624
   timestamp: 1649143914155
-- name: glog
+- platform: osx-arm64
+  name: glog
   version: 0.6.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    gflags: '>=2.2.2,<2.3.0a0'
-    libcxx: '>=12.0.1'
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=12.0.1
   url: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
   hash:
     md5: 5a570729c7709399cf8511aeeda6f989
     sha256: 4d772c42477f64be708594ac45870feba3e838977871118eb25e00deb0e9a73c
-  optional: false
-  category: main
   build: h6da1cb0_0
   arch: aarch64
   subdir: osx-arm64
@@ -3753,19 +3517,18 @@ package:
   license_family: BSD
   size: 97658
   timestamp: 1649144191039
-- name: gxx
+- platform: linux-64
+  name: gxx
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    gcc: 12.3.0.*
-    gxx_impl_linux-64: 12.3.0.*
+  - gcc 12.3.0.*
+  - gxx_impl_linux-64 12.3.0.*
   url: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h8d2909c_2.conda
   hash:
     md5: 673bac341be6b90ef9e8abae7e52ca46
     sha256: 5fd65768fb602fd21466831c96e7a2355a4df692507abbd481aa65a777151d85
-  optional: false
-  category: main
   build: h8d2909c_2
   arch: x86_64
   subdir: linux-64
@@ -3774,20 +3537,19 @@ package:
   license_family: BSD
   size: 26539
   timestamp: 1694604501713
-- name: gxx_impl_linux-64
+- platform: linux-64
+  name: gxx_impl_linux-64
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    gcc_impl_linux-64: ==12.3.0 he2b93b0_2
-    libstdcxx-devel_linux-64: ==12.3.0 h8bca6fd_2
-    sysroot_linux-64: '*'
+  - gcc_impl_linux-64 ==12.3.0 he2b93b0_2
+  - libstdcxx-devel_linux-64 ==12.3.0 h8bca6fd_2
+  - sysroot_linux-64 *
   url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_2.conda
   hash:
     md5: f89b9916afc36fc5562fbfc11330a8a2
     sha256: 1ca91c1a3892b61da7efe150f9a1830e18aac82f563b27bf707520cb3297cc7a
-  optional: false
-  category: main
   build: he2b93b0_2
   arch: x86_64
   subdir: linux-64
@@ -3796,21 +3558,20 @@ package:
   license_family: GPL
   size: 12667490
   timestamp: 1695218983245
-- name: gxx_linux-64
+- platform: linux-64
+  name: gxx_linux-64
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    binutils_linux-64: ==2.40 hbdbef99_2
-    gcc_linux-64: ==12.3.0 h76fc315_2
-    gxx_impl_linux-64: 12.3.0.*
-    sysroot_linux-64: '*'
+  - binutils_linux-64 ==2.40 hbdbef99_2
+  - gcc_linux-64 ==12.3.0 h76fc315_2
+  - gxx_impl_linux-64 12.3.0.*
+  - sysroot_linux-64 *
   url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h8a814eb_2.conda
   hash:
     md5: f517b1525e9783849bd56a5dc45a9960
     sha256: 9878771cf1316230150a795d213a2f1dd7dead07dc0bccafae20533d631d5e69
-  optional: false
-  category: main
   build: h8a814eb_2
   arch: x86_64
   subdir: linux-64
@@ -3819,19 +3580,18 @@ package:
   license_family: BSD
   size: 28640
   timestamp: 1694604524890
-- name: icu
+- platform: linux-64
+  name: icu
   version: '73.2'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
   hash:
     md5: cc47e1facc155f91abd89b11e48e72ff
     sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
-  optional: false
-  category: main
   build: h59595ed_0
   arch: x86_64
   subdir: linux-64
@@ -3840,17 +3600,16 @@ package:
   license_family: MIT
   size: 12089150
   timestamp: 1692900650789
-- name: icu
+- platform: osx-64
+  name: icu
   version: '73.2'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
   hash:
     md5: 5cc301d759ec03f28328428e28f65591
     sha256: f66362dc36178ac9b7c7a9b012948a9d2d050b3debec24bbd94aadbc44854185
-  optional: false
-  category: main
   build: hf5e326d_0
   arch: x86_64
   subdir: osx-64
@@ -3859,17 +3618,16 @@ package:
   license_family: MIT
   size: 11787527
   timestamp: 1692901622519
-- name: icu
+- platform: osx-arm64
+  name: icu
   version: '73.2'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
   hash:
     md5: 8521bd47c0e11c5902535bb1a17c565f
     sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
-  optional: false
-  category: main
   build: hc8870d7_0
   arch: aarch64
   subdir: osx-arm64
@@ -3878,19 +3636,18 @@ package:
   license_family: MIT
   size: 11997841
   timestamp: 1692902104771
-- name: importlib-metadata
+- platform: linux-64
+  name: importlib-metadata
   version: 6.8.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.8'
-    zipp: '>=0.5'
+  - python >=3.8
+  - zipp >=0.5
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
   hash:
     md5: 4e9f59a060c3be52bc4ddc46ee9b6946
     sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: x86_64
   subdir: linux-64
@@ -3900,19 +3657,18 @@ package:
   noarch: python
   size: 25910
   timestamp: 1688754651944
-- name: importlib-metadata
+- platform: osx-64
+  name: importlib-metadata
   version: 6.8.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.8'
-    zipp: '>=0.5'
+  - python >=3.8
+  - zipp >=0.5
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
   hash:
     md5: 4e9f59a060c3be52bc4ddc46ee9b6946
     sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: x86_64
   subdir: osx-64
@@ -3922,19 +3678,18 @@ package:
   noarch: python
   size: 25910
   timestamp: 1688754651944
-- name: importlib-metadata
+- platform: osx-arm64
+  name: importlib-metadata
   version: 6.8.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    zipp: '>=0.5'
+  - python >=3.8
+  - zipp >=0.5
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
   hash:
     md5: 4e9f59a060c3be52bc4ddc46ee9b6946
     sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: aarch64
   subdir: osx-arm64
@@ -3944,19 +3699,18 @@ package:
   noarch: python
   size: 25910
   timestamp: 1688754651944
-- name: importlib-metadata
+- platform: win-64
+  name: importlib-metadata
   version: 6.8.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.8'
-    zipp: '>=0.5'
+  - python >=3.8
+  - zipp >=0.5
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
   hash:
     md5: 4e9f59a060c3be52bc4ddc46ee9b6946
     sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: x86_64
   subdir: win-64
@@ -3966,18 +3720,17 @@ package:
   noarch: python
   size: 25910
   timestamp: 1688754651944
-- name: iniconfig
+- platform: linux-64
+  name: iniconfig
   version: 2.0.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: f800d2da156d08e289b14e87e43c1ae5
     sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -3987,18 +3740,17 @@ package:
   noarch: python
   size: 11101
   timestamp: 1673103208955
-- name: iniconfig
+- platform: osx-64
+  name: iniconfig
   version: 2.0.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: f800d2da156d08e289b14e87e43c1ae5
     sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -4008,18 +3760,17 @@ package:
   noarch: python
   size: 11101
   timestamp: 1673103208955
-- name: iniconfig
+- platform: osx-arm64
+  name: iniconfig
   version: 2.0.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: f800d2da156d08e289b14e87e43c1ae5
     sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -4029,18 +3780,17 @@ package:
   noarch: python
   size: 11101
   timestamp: 1673103208955
-- name: iniconfig
+- platform: win-64
+  name: iniconfig
   version: 2.0.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: f800d2da156d08e289b14e87e43c1ae5
     sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -4050,17 +3800,16 @@ package:
   noarch: python
   size: 11101
   timestamp: 1673103208955
-- name: intel-openmp
+- platform: win-64
+  name: intel-openmp
   version: 2023.2.0
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50496.conda
   hash:
     md5: 519f9c42672f1e8a334ec9471e93f4fe
     sha256: 38367c264bace64d6f939c1170cda3aba2eb0fb2300570c16a8c63aff9ca8031
-  optional: false
-  category: main
   build: h57928b3_50496
   arch: x86_64
   subdir: win-64
@@ -4069,18 +3818,17 @@ package:
   license_family: Proprietary
   size: 2520627
   timestamp: 1695994411378
-- name: just
+- platform: linux-64
+  name: just
   version: 1.15.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/just-1.15.0-he8a937b_0.conda
   hash:
     md5: 7e60e76dd956032a16543773f1488955
     sha256: 3df9d0c1674c41699533211dc43b6f85a5650a987746faad659eb3c222cd6168
-  optional: false
-  category: main
   build: he8a937b_0
   arch: x86_64
   subdir: linux-64
@@ -4088,17 +3836,16 @@ package:
   license: CC0-1.0
   size: 1119533
   timestamp: 1697287198405
-- name: just
+- platform: osx-64
+  name: just
   version: 1.15.0
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/just-1.15.0-h63b85fc_0.conda
   hash:
     md5: 9d17474a2fd0286a95e472369a27f4a0
     sha256: 32cfa40bed1c71342488e02c4c984c7e7c515645ac7286b2e866afbd017e2234
-  optional: false
-  category: main
   build: h63b85fc_0
   arch: x86_64
   subdir: osx-64
@@ -4106,17 +3853,16 @@ package:
   license: CC0-1.0
   size: 1045840
   timestamp: 1697287468425
-- name: just
+- platform: osx-arm64
+  name: just
   version: 1.15.0
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/just-1.15.0-h5ef7bb8_0.conda
   hash:
     md5: a283dd994c0181833cd289e1a0d374e5
     sha256: 457c259b027cd035aa9fa11d9eeedfbe2298e6cfcebe6c2e1f4cdfce47cc5fc9
-  optional: false
-  category: main
   build: h5ef7bb8_0
   arch: aarch64
   subdir: osx-arm64
@@ -4124,19 +3870,18 @@ package:
   license: CC0-1.0
   size: 967137
   timestamp: 1697287585467
-- name: just
+- platform: win-64
+  name: just
   version: 1.15.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    m2w64-gcc-libs: '*'
-    m2w64-gcc-libs-core: '*'
+  - m2w64-gcc-libs *
+  - m2w64-gcc-libs-core *
   url: https://conda.anaconda.org/conda-forge/win-64/just-1.15.0-h7f3b576_0.conda
   hash:
     md5: c99de86aee5b1280526e717881fb31f4
     sha256: c70bc660ef68da0a7128a133ac3d41b1aa4a6f8ace1894b11b691ae2464ad3ab
-  optional: false
-  category: main
   build: h7f3b576_0
   arch: x86_64
   subdir: win-64
@@ -4144,17 +3889,16 @@ package:
   license: CC0-1.0
   size: 1075396
   timestamp: 1697288439231
-- name: kernel-headers_linux-64
+- platform: linux-64
+  name: kernel-headers_linux-64
   version: 2.6.32
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_16.conda
   hash:
     md5: 7ca122655873935e02c91279c5b03c8c
     sha256: aaa8aa6dc776d734a6702032588ff3c496721da905366d91162e3654c082aef0
-  optional: false
-  category: main
   build: he073ed8_16
   arch: x86_64
   subdir: linux-64
@@ -4166,18 +3910,17 @@ package:
   noarch: generic
   size: 709007
   timestamp: 1689214970644
-- name: keyutils
+- platform: linux-64
+  name: keyutils
   version: 1.6.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=10.3.0'
+  - libgcc-ng >=10.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
   hash:
     md5: 30186d27e2c9fa62b45fb1476b7200e3
     sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
-  optional: false
-  category: main
   build: h166bdaf_0
   arch: x86_64
   subdir: linux-64
@@ -4185,22 +3928,21 @@ package:
   license: LGPL-2.1-or-later
   size: 117831
   timestamp: 1646151697040
-- name: krb5
+- platform: linux-64
+  name: krb5
   version: 1.21.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    keyutils: '>=1.6.1,<2.0a0'
-    libedit: '>=3.1.20191231,<4.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.1.2,<4.0a0'
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.1.2,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
   hash:
     md5: cd95826dbd331ed1be26bdf401432844
     sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
-  optional: false
-  category: main
   build: h659d440_0
   arch: x86_64
   subdir: linux-64
@@ -4209,20 +3951,19 @@ package:
   license_family: MIT
   size: 1371181
   timestamp: 1692097755782
-- name: krb5
+- platform: osx-64
+  name: krb5
   version: 1.21.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
-    libedit: '>=3.1.20191231,<4.0a0'
-    openssl: '>=3.1.2,<4.0a0'
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.1.2,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
   hash:
     md5: 80505a68783f01dc8d7308c075261b2f
     sha256: 081ae2008a21edf57c048f331a17c65d1ccb52d6ca2f87ee031a73eff4dc0fc6
-  optional: false
-  category: main
   build: hb884880_0
   arch: x86_64
   subdir: osx-64
@@ -4231,20 +3972,19 @@ package:
   license_family: MIT
   size: 1183568
   timestamp: 1692098004387
-- name: krb5
+- platform: osx-arm64
+  name: krb5
   version: 1.21.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
-    libedit: '>=3.1.20191231,<4.0a0'
-    openssl: '>=3.1.2,<4.0a0'
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.1.2,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
   hash:
     md5: 92f1cff174a538e0722bf2efb16fc0b2
     sha256: 70bdb9b4589ec7c7d440e485ae22b5a352335ffeb91a771d4c162996c3070875
-  optional: false
-  category: main
   build: h92f50d5_0
   arch: aarch64
   subdir: osx-arm64
@@ -4253,21 +3993,20 @@ package:
   license_family: MIT
   size: 1195575
   timestamp: 1692098070699
-- name: krb5
+- platform: win-64
+  name: krb5
   version: 1.21.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    openssl: '>=3.1.2,<4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
   hash:
     md5: 6e8b0f22b4eef3b3cb3849bb4c3d47f9
     sha256: 6002adff9e3dcfc9732b861730cb9e33d45fd76b2035b2cdb4e6daacb8262c0b
-  optional: false
-  category: main
   build: heb0366b_0
   arch: x86_64
   subdir: win-64
@@ -4276,19 +4015,18 @@ package:
   license_family: MIT
   size: 710894
   timestamp: 1692098129546
-- name: ld64
+- platform: osx-64
+  name: ld64
   version: '609'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    ld64_osx-64: ==609 h0fd476b_15
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - ld64_osx-64 ==609 h0fd476b_15
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/ld64-609-ha91a046_15.conda
   hash:
     md5: 3c27099076bcf8fdde53785efb46dbf1
     sha256: 5c13ce2916f592adb29301dfbbcfe773437744f2890881615210b041b6276fc2
-  optional: false
-  category: main
   build: ha91a046_15
   arch: x86_64
   subdir: osx-64
@@ -4300,19 +4038,18 @@ package:
   license_family: Other
   size: 19091
   timestamp: 1697075759131
-- name: ld64
+- platform: osx-arm64
+  name: ld64
   version: '609'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    ld64_osx-arm64: ==609 hc4dc95b_14
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - ld64_osx-arm64 ==609 hc4dc95b_14
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-609-h89fa09d_14.conda
   hash:
     md5: 5d2c82c220addd4630baaa7118a301d3
     sha256: 1bddb451bb0f2e95414239c43a528ec6039f8c84a9b84a212a3a0d851c74306b
-  optional: false
-  category: main
   build: h89fa09d_14
   arch: aarch64
   subdir: osx-arm64
@@ -4324,21 +4061,20 @@ package:
   license_family: Other
   size: 19226
   timestamp: 1690768480431
-- name: ld64_osx-64
+- platform: osx-64
+  name: ld64_osx-64
   version: '609'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '*'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    sigtool: '*'
-    tapi: '>=1100.0.11,<1101.0a0'
+  - libcxx *
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - sigtool *
+  - tapi >=1100.0.11,<1101.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-609-h0fd476b_15.conda
   hash:
     md5: f98d11f8e568521e1e3f88cbe5a4d53c
     sha256: 6d793058554a46ffd4a059bf3bd33741856bfcbdaeab8e11cc1dc2df1137f7f0
-  optional: false
-  category: main
   build: h0fd476b_15
   arch: x86_64
   subdir: osx-64
@@ -4352,21 +4088,20 @@ package:
   license_family: Other
   size: 1062203
   timestamp: 1697075547194
-- name: ld64_osx-arm64
+- platform: osx-arm64
+  name: ld64_osx-arm64
   version: '609'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '*'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    sigtool: '*'
-    tapi: '>=1100.0.11,<1101.0a0'
+  - libcxx *
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - sigtool *
+  - tapi >=1100.0.11,<1101.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-609-hc4dc95b_14.conda
   hash:
     md5: 1d41ae30b0c077ef3feab2f2e27bd593
     sha256: 138f187e16d6952cb4f54ae1abef014a368948f0eb568c472f0798aa76fd959d
-  optional: false
-  category: main
   build: hc4dc95b_14
   arch: aarch64
   subdir: osx-arm64
@@ -4380,17 +4115,16 @@ package:
   license_family: Other
   size: 1041974
   timestamp: 1690768191902
-- name: ld_impl_linux-64
+- platform: linux-64
+  name: ld_impl_linux-64
   version: '2.40'
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
   hash:
     md5: 7aca3059a1729aa76c597603f10b0dd3
     sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
-  optional: false
-  category: main
   build: h41732ed_0
   arch: x86_64
   subdir: linux-64
@@ -4401,19 +4135,18 @@ package:
   license_family: GPL
   size: 704696
   timestamp: 1674833944779
-- name: libabseil
+- platform: linux-64
+  name: libabseil
   version: '20230802.1'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
   hash:
     md5: 2785ddf4cb0e7e743477991d64353947
     sha256: 8729021a93e67bb93b4e73ef0a132499db516accfea11561b667635bcd0507e7
-  optional: false
-  category: main
   build: cxx17_h59595ed_0
   arch: x86_64
   subdir: linux-64
@@ -4425,18 +4158,17 @@ package:
   license_family: Apache
   size: 1263396
   timestamp: 1695063868515
-- name: libabseil
+- platform: osx-64
+  name: libabseil
   version: '20230802.1'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
   hash:
     md5: 6554f5fb47c025273268bcdb7bf3cd48
     sha256: 05431a6adb376a865e10d4ae673399d7890083c06f61cf18edb7c6629e75f39e
-  optional: false
-  category: main
   build: cxx17_h048a20a_0
   arch: x86_64
   subdir: osx-64
@@ -4449,18 +4181,17 @@ package:
   license_family: Apache
   size: 1148356
   timestamp: 1695064289396
-- name: libabseil
+- platform: osx-arm64
+  name: libabseil
   version: '20230802.1'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
   hash:
     md5: fb6dfadc1898666616dfda242d8aea10
     sha256: 459a58f36607246b4483d7a370c2d9a03e7f824e79da2c6e3e9d62abf80393e7
-  optional: false
-  category: main
   build: cxx17_h13dd4ca_0
   arch: aarch64
   subdir: osx-arm64
@@ -4472,20 +4203,19 @@ package:
   license_family: Apache
   size: 1173407
   timestamp: 1695064439482
-- name: libabseil
+- platform: win-64
+  name: libabseil
   version: '20230802.1'
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230802.1-cxx17_h63175ca_0.conda
   hash:
     md5: 02674c18394394ee4f76cdbd1012f526
     sha256: 8a016d49fad3d4216ce5ae4a60869b5384d31b2009e1ed9f445b6551ce7ef9e8
-  optional: false
-  category: main
   build: cxx17_h63175ca_0
   arch: x86_64
   subdir: win-64
@@ -4497,40 +4227,39 @@ package:
   license_family: Apache
   size: 1733638
   timestamp: 1695064265262
-- name: libarrow
+- platform: linux-64
+  name: libarrow
   version: 10.0.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    aws-crt-cpp: '>=0.23.1,<0.23.2.0a0'
-    aws-sdk-cpp: '>=1.11.156,<1.11.157.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    gflags: '>=2.2.2,<2.3.0a0'
-    glog: '>=0.6.0,<0.7.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libbrotlidec: '>=1.1.0,<1.2.0a0'
-    libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libgcc-ng: '>=12'
-    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
-    libgrpc: '>=1.57.0,<1.58.0a0'
-    libprotobuf: '>=4.23.4,<4.23.5.0a0'
-    libstdcxx-ng: '>=12'
-    libthrift: '>=0.19.0,<0.19.1.0a0'
-    libutf8proc: '>=2.8.0,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    orc: '>=1.9.0,<1.9.1.0a0'
-    re2: '>=2023.3.2,<2023.3.3.0a0'
-    snappy: '>=1.1.10,<2.0a0'
-    ucx: '>=1.15.0,<1.16.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - aws-crt-cpp >=0.23.1,<0.23.2.0a0
+  - aws-sdk-cpp >=1.11.156,<1.11.157.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - libabseil >=20230802.1,<20230803.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libgcc-ng >=12
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.57.0,<1.58.0a0
+  - libprotobuf >=4.23.4,<4.23.5.0a0
+  - libstdcxx-ng >=12
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.3,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2 >=2023.3.2,<2023.3.3.0a0
+  - snappy >=1.1.10,<2.0a0
+  - ucx >=1.15.0,<1.16.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-10.0.1-hc3189b8_44_cpu.conda
   hash:
     md5: 4eeabe3fad32d2a96082f7fc8706831a
     sha256: f205679ff8f18a9284e09f1862fdbc22269cc7c39d0949bac3fd5ebd9e9bc3df
-  optional: false
-  category: main
   build: hc3189b8_44_cpu
   arch: x86_64
   subdir: linux-64
@@ -4542,39 +4271,38 @@ package:
   license: Apache-2.0
   size: 27248742
   timestamp: 1696592607446
-- name: libarrow
+- platform: osx-64
+  name: libarrow
   version: 10.0.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    aws-crt-cpp: '>=0.24.2,<0.24.3.0a0'
-    aws-sdk-cpp: '>=1.11.156,<1.11.157.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    gflags: '>=2.2.2,<2.3.0a0'
-    glog: '>=0.6.0,<0.7.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libbrotlidec: '>=1.1.0,<1.2.0a0'
-    libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libcxx: '>=14.0.6'
-    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
-    libgrpc: '>=1.58.1,<1.59.0a0'
-    libprotobuf: '>=4.24.3,<4.24.4.0a0'
-    libthrift: '>=0.19.0,<0.19.1.0a0'
-    libutf8proc: '>=2.8.0,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    orc: '>=1.9.0,<1.9.1.0a0'
-    re2: '>=2023.3.2,<2023.3.3.0a0'
-    snappy: '>=1.1.10,<2.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - __osx >=10.13
+  - aws-crt-cpp >=0.24.2,<0.24.3.0a0
+  - aws-sdk-cpp >=1.11.156,<1.11.157.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - libabseil >=20230802.1,<20230803.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=14.0.6
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.3,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2 >=2023.3.2,<2023.3.3.0a0
+  - snappy >=1.1.10,<2.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-10.0.1-h962698a_46_cpu.conda
   hash:
     md5: 27a26ab8a95cb43c45158dd028a958c0
     sha256: 58d0c230a4cc15c66490e1785ad224b0f21ffd6ed134ffbb8de73945c2259d5a
-  optional: false
-  category: main
   build: h962698a_46_cpu
   arch: x86_64
   subdir: osx-64
@@ -4587,38 +4315,37 @@ package:
   license_family: APACHE
   size: 19450810
   timestamp: 1696861009499
-- name: libarrow
+- platform: osx-arm64
+  name: libarrow
   version: 10.0.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    aws-crt-cpp: '>=0.23.1,<0.23.2.0a0'
-    aws-sdk-cpp: '>=1.11.156,<1.11.157.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    gflags: '>=2.2.2,<2.3.0a0'
-    glog: '>=0.6.0,<0.7.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libbrotlidec: '>=1.1.0,<1.2.0a0'
-    libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libcxx: '>=14.0.6'
-    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
-    libgrpc: '>=1.57.0,<1.58.0a0'
-    libprotobuf: '>=4.23.4,<4.23.5.0a0'
-    libthrift: '>=0.19.0,<0.19.1.0a0'
-    libutf8proc: '>=2.8.0,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    orc: '>=1.9.0,<1.9.1.0a0'
-    re2: '>=2023.3.2,<2023.3.3.0a0'
-    snappy: '>=1.1.10,<2.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - aws-crt-cpp >=0.23.1,<0.23.2.0a0
+  - aws-sdk-cpp >=1.11.156,<1.11.157.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - libabseil >=20230802.1,<20230803.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=14.0.6
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.57.0,<1.58.0a0
+  - libprotobuf >=4.23.4,<4.23.5.0a0
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.3,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2 >=2023.3.2,<2023.3.3.0a0
+  - snappy >=1.1.10,<2.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-10.0.1-he713f65_44_cpu.conda
   hash:
     md5: 55c07aefe7dbfe592d94606dfc2ca55f
     sha256: 4373d43fc16b3ccca21b43e4d4a05f6ef2974c5810eb3bad0a79a6890faa7910
-  optional: false
-  category: main
   build: he713f65_44_cpu
   arch: aarch64
   subdir: osx-arm64
@@ -4630,39 +4357,38 @@ package:
   license: Apache-2.0
   size: 16909047
   timestamp: 1696593679184
-- name: libarrow
+- platform: win-64
+  name: libarrow
   version: 10.0.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    aws-sdk-cpp: '>=1.11.156,<1.11.157.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libbrotlidec: '>=1.1.0,<1.2.0a0'
-    libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: '>=8.3.0,<9.0a0'
-    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
-    libgrpc: '>=1.57.0,<1.58.0a0'
-    libprotobuf: '>=4.23.4,<4.23.5.0a0'
-    libthrift: '>=0.19.0,<0.19.1.0a0'
-    libutf8proc: '>=2.8.0,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    orc: '>=1.9.0,<1.9.1.0a0'
-    re2: '>=2023.3.2,<2023.3.3.0a0'
-    snappy: '>=1.1.10,<2.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - aws-sdk-cpp >=1.11.156,<1.11.157.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil >=20230802.1,<20230803.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.57.0,<1.58.0a0
+  - libprotobuf >=4.23.4,<4.23.5.0a0
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.3,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2 >=2023.3.2,<2023.3.3.0a0
+  - snappy >=1.1.10,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/win-64/libarrow-10.0.1-h58a770d_44_cpu.conda
   hash:
     md5: 8c4ccc5a4742b0a08ae751be4a5d8798
     sha256: 68ee5fc622e8e7c4bbc653354ab0abf4b8f276345a34a3825af26153fa019427
-  optional: false
-  category: main
   build: h58a770d_44_cpu
   arch: x86_64
   subdir: win-64
@@ -4674,18 +4400,17 @@ package:
   license: Apache-2.0
   size: 16020194
   timestamp: 1696593685137
-- name: libblas
+- platform: linux-64
+  name: libblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libopenblas: '>=0.3.24,<1.0a0'
+  - libopenblas >=0.3.24,<1.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-18_linux64_openblas.conda
   hash:
     md5: bcddbb497582ece559465b9cd11042e7
     sha256: 92142c12eb42172365c96c865be8f164a2653649b28b23bded0e658f8d5d0815
-  optional: false
-  category: main
   build: 18_linux64_openblas
   arch: x86_64
   subdir: linux-64
@@ -4699,18 +4424,17 @@ package:
   license_family: BSD
   size: 14545
   timestamp: 1693951361891
-- name: libblas
+- platform: osx-64
+  name: libblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libopenblas: '>=0.3.24,<1.0a0'
+  - libopenblas >=0.3.24,<1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-18_osx64_openblas.conda
   hash:
     md5: 6461cded280f7a46ebef0f1b687d4883
     sha256: 6df6e9c008a1a68493c8c394e6dcdd51cfeb7e51f91c0699a596f62f4d9d8995
-  optional: false
-  category: main
   build: 18_osx64_openblas
   arch: x86_64
   subdir: osx-64
@@ -4724,18 +4448,17 @@ package:
   license_family: BSD
   size: 14765
   timestamp: 1693951714123
-- name: libblas
+- platform: osx-arm64
+  name: libblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libopenblas: '>=0.3.24,<1.0a0'
+  - libopenblas >=0.3.24,<1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-18_osxarm64_openblas.conda
   hash:
     md5: 928d0c0b57e342a8629f5f5e001ee0d0
     sha256: efef2710d5309124e200dccb883cdd66531f3f4dcb4af2eb4b7b1e5cf1bac57d
-  optional: false
-  category: main
   build: 18_osxarm64_openblas
   arch: aarch64
   subdir: osx-arm64
@@ -4749,18 +4472,17 @@ package:
   license_family: BSD
   size: 14859
   timestamp: 1693951888126
-- name: libblas
+- platform: win-64
+  name: libblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    mkl: ==2022.1.0 h6a75c08_874
+  - mkl ==2022.1.0 h6a75c08_874
   url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-18_win64_mkl.conda
   hash:
     md5: b241da5b7a888f72bb3c3e82747334f4
     sha256: 5aef8d69197108f3c320a5d4ad4d19ab9c809cdbbf731c7ab988c227de42d6b5
-  optional: false
-  category: main
   build: 18_win64_mkl
   arch: x86_64
   subdir: win-64
@@ -4774,18 +4496,17 @@ package:
   license_family: BSD
   size: 3656012
   timestamp: 1693952074690
-- name: libbrotlicommon
+- platform: linux-64
+  name: libbrotlicommon
   version: 1.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
   hash:
     md5: aec6c91c7371c26392a06708a73c70e5
     sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
-  optional: false
-  category: main
   build: hd590300_1
   arch: x86_64
   subdir: linux-64
@@ -4794,17 +4515,16 @@ package:
   license_family: MIT
   size: 69403
   timestamp: 1695990007212
-- name: libbrotlicommon
+- platform: osx-64
+  name: libbrotlicommon
   version: 1.1.0
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
   hash:
     md5: 9e6c31441c9aa24e41ace40d6151aab6
     sha256: f57c57c442ef371982619f82af8735f93a4f50293022cfd1ffaf2ff89c2e0b2a
-  optional: false
-  category: main
   build: h0dc2134_1
   arch: x86_64
   subdir: osx-64
@@ -4813,17 +4533,16 @@ package:
   license_family: MIT
   size: 67476
   timestamp: 1695990207321
-- name: libbrotlicommon
+- platform: osx-arm64
+  name: libbrotlicommon
   version: 1.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
   hash:
     md5: cd68f024df0304be41d29a9088162b02
     sha256: 556f0fddf4bd4d35febab404d98cb6862ce3b7ca843e393da0451bfc4654cf07
-  optional: false
-  category: main
   build: hb547adb_1
   arch: aarch64
   subdir: osx-arm64
@@ -4832,20 +4551,19 @@ package:
   license_family: MIT
   size: 68579
   timestamp: 1695990426128
-- name: libbrotlicommon
+- platform: win-64
+  name: libbrotlicommon
   version: 1.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
   hash:
     md5: f77f319fb82980166569e1280d5b2864
     sha256: f75fed29b0cc503d1b149a4945eaa32df56e19da5e2933de29e8f03947203709
-  optional: false
-  category: main
   build: hcfcfb64_1
   arch: x86_64
   subdir: win-64
@@ -4854,19 +4572,18 @@ package:
   license_family: MIT
   size: 70598
   timestamp: 1695990405143
-- name: libbrotlidec
+- platform: linux-64
+  name: libbrotlidec
   version: 1.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libbrotlicommon: ==1.1.0 hd590300_1
-    libgcc-ng: '>=12'
+  - libbrotlicommon ==1.1.0 hd590300_1
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
   hash:
     md5: f07002e225d7a60a694d42a7bf5ff53f
     sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
-  optional: false
-  category: main
   build: hd590300_1
   arch: x86_64
   subdir: linux-64
@@ -4875,18 +4592,17 @@ package:
   license_family: MIT
   size: 32775
   timestamp: 1695990022788
-- name: libbrotlidec
+- platform: osx-64
+  name: libbrotlidec
   version: 1.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libbrotlicommon: ==1.1.0 h0dc2134_1
+  - libbrotlicommon ==1.1.0 h0dc2134_1
   url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
   hash:
     md5: 9ee0bab91b2ca579e10353738be36063
     sha256: b11939c4c93c29448660ab5f63273216969d1f2f315dd9be60f3c43c4e61a50c
-  optional: false
-  category: main
   build: h0dc2134_1
   arch: x86_64
   subdir: osx-64
@@ -4895,18 +4611,17 @@ package:
   license_family: MIT
   size: 30327
   timestamp: 1695990232422
-- name: libbrotlidec
+- platform: osx-arm64
+  name: libbrotlidec
   version: 1.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libbrotlicommon: ==1.1.0 hb547adb_1
+  - libbrotlicommon ==1.1.0 hb547adb_1
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
   hash:
     md5: ee1a519335cc10d0ec7e097602058c0a
     sha256: c1c85937828ad3bc434ac60b7bcbde376f4d2ea4ee42d15d369bf2a591775b4a
-  optional: false
-  category: main
   build: hb547adb_1
   arch: aarch64
   subdir: osx-arm64
@@ -4915,21 +4630,20 @@ package:
   license_family: MIT
   size: 28928
   timestamp: 1695990463780
-- name: libbrotlidec
+- platform: win-64
+  name: libbrotlidec
   version: 1.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libbrotlicommon: ==1.1.0 hcfcfb64_1
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libbrotlicommon ==1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
   hash:
     md5: 19ce3e1dacc7912b3d6ff40690ba9ae0
     sha256: 1b352ee05931ea24c11cd4a994d673890fd1cc690c21e023e736bdaac2632e93
-  optional: false
-  category: main
   build: hcfcfb64_1
   arch: x86_64
   subdir: win-64
@@ -4938,19 +4652,18 @@ package:
   license_family: MIT
   size: 32788
   timestamp: 1695990443165
-- name: libbrotlienc
+- platform: linux-64
+  name: libbrotlienc
   version: 1.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libbrotlicommon: ==1.1.0 hd590300_1
-    libgcc-ng: '>=12'
+  - libbrotlicommon ==1.1.0 hd590300_1
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
   hash:
     md5: 5fc11c6020d421960607d821310fcd4d
     sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
-  optional: false
-  category: main
   build: hd590300_1
   arch: x86_64
   subdir: linux-64
@@ -4959,18 +4672,17 @@ package:
   license_family: MIT
   size: 282523
   timestamp: 1695990038302
-- name: libbrotlienc
+- platform: osx-64
+  name: libbrotlienc
   version: 1.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libbrotlicommon: ==1.1.0 h0dc2134_1
+  - libbrotlicommon ==1.1.0 h0dc2134_1
   url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
   hash:
     md5: 8a421fe09c6187f0eb5e2338a8a8be6d
     sha256: bc964c23e1a60ca1afe7bac38a9c1f2af3db4a8072c9f2eac4e4de537a844ac7
-  optional: false
-  category: main
   build: h0dc2134_1
   arch: x86_64
   subdir: osx-64
@@ -4979,18 +4691,17 @@ package:
   license_family: MIT
   size: 299092
   timestamp: 1695990259225
-- name: libbrotlienc
+- platform: osx-arm64
+  name: libbrotlienc
   version: 1.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libbrotlicommon: ==1.1.0 hb547adb_1
+  - libbrotlicommon ==1.1.0 hb547adb_1
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
   hash:
     md5: d7e077f326a98b2cc60087eaff7c730b
     sha256: 690dfc98e891ee1871c54166d30f6e22edfc2d7d6b29e7988dde5f1ce271c81a
-  optional: false
-  category: main
   build: hb547adb_1
   arch: aarch64
   subdir: osx-arm64
@@ -4999,21 +4710,20 @@ package:
   license_family: MIT
   size: 280943
   timestamp: 1695990509392
-- name: libbrotlienc
+- platform: win-64
+  name: libbrotlienc
   version: 1.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libbrotlicommon: ==1.1.0 hcfcfb64_1
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libbrotlicommon ==1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
   hash:
     md5: 71e890a0b361fd58743a13f77e1506b7
     sha256: eae6b76154e594c6d211160c6d1aeed848672618152a562e0eabdfa641d34aca
-  optional: false
-  category: main
   build: hcfcfb64_1
   arch: x86_64
   subdir: win-64
@@ -5022,18 +4732,17 @@ package:
   license_family: MIT
   size: 246515
   timestamp: 1695990479484
-- name: libcblas
+- platform: linux-64
+  name: libcblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libblas: ==3.9.0 18_linux64_openblas
+  - libblas ==3.9.0 18_linux64_openblas
   url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-18_linux64_openblas.conda
   hash:
     md5: 93dd9ab275ad888ed8113953769af78c
     sha256: b5a3eac5a1e14ad7054a19249afeee6536ab8c9fb6d6ddc26e277f5c3b1acce4
-  optional: false
-  category: main
   build: 18_linux64_openblas
   arch: x86_64
   subdir: linux-64
@@ -5046,18 +4755,17 @@ package:
   license_family: BSD
   size: 14455
   timestamp: 1693951371996
-- name: libcblas
+- platform: osx-64
+  name: libcblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libblas: ==3.9.0 18_osx64_openblas
+  - libblas ==3.9.0 18_osx64_openblas
   url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-18_osx64_openblas.conda
   hash:
     md5: b359d4c7d91ff6bf5442604d06538985
     sha256: 7e8d8bc42c2c21d75b2121cfee0842bd0cf5500e6306c964bea4a9fafd3abba5
-  optional: false
-  category: main
   build: 18_osx64_openblas
   arch: x86_64
   subdir: osx-64
@@ -5070,18 +4778,17 @@ package:
   license_family: BSD
   size: 14699
   timestamp: 1693951732651
-- name: libcblas
+- platform: osx-arm64
+  name: libcblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libblas: ==3.9.0 18_osxarm64_openblas
+  - libblas ==3.9.0 18_osxarm64_openblas
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-18_osxarm64_openblas.conda
   hash:
     md5: ee0108105d7181f1c6f8c4269883ff3b
     sha256: d01e63f9b02b3b45283319341662b2fc5e5598019ba3bceb131b0f79c6962ca8
-  optional: false
-  category: main
   build: 18_osxarm64_openblas
   arch: aarch64
   subdir: osx-arm64
@@ -5094,18 +4801,17 @@ package:
   license_family: BSD
   size: 14733
   timestamp: 1693951904664
-- name: libcblas
+- platform: win-64
+  name: libcblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libblas: ==3.9.0 18_win64_mkl
+  - libblas ==3.9.0 18_win64_mkl
   url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-18_win64_mkl.conda
   hash:
     md5: fb0b514194c14342a97dfe31a41d60fc
     sha256: d5f60ed6508b3889a77caf5ff2b66203714e45ec4eea6e5cdb12fe6e8ef2bbdb
-  optional: false
-  category: main
   build: 18_win64_mkl
   arch: x86_64
   subdir: win-64
@@ -5118,22 +4824,21 @@ package:
   license_family: BSD
   size: 3655770
   timestamp: 1693952109193
-- name: libclang
+- platform: linux-64
+  name: libclang
   version: 15.0.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libclang13: ==15.0.7 default_h9986a30_3
-    libgcc-ng: '>=12'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libclang13 ==15.0.7 default_h9986a30_3
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_h7634d5b_3.conda
   hash:
     md5: 0922208521c0463e690bbaebba7eb551
     sha256: c2b0c8dd675e30d86bad410679f258820bc36723fbadffc13c2f60249be91815
-  optional: false
-  category: main
   build: default_h7634d5b_3
   arch: x86_64
   subdir: linux-64
@@ -5142,20 +4847,19 @@ package:
   license_family: Apache
   size: 133162
   timestamp: 1690549855318
-- name: libclang
+- platform: osx-64
+  name: libclang
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libclang13: ==15.0.7 default_h953c2e9_3
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libclang13 ==15.0.7 default_h953c2e9_3
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libclang-15.0.7-default_hdb78580_3.conda
   hash:
     md5: 23c66251664b188887eb702a02d22517
     sha256: 5f958cf2b82934b9a244fdb9bd2ccd782da1a1460c44957190eea64ea9f9588c
-  optional: false
-  category: main
   build: default_hdb78580_3
   arch: x86_64
   subdir: osx-64
@@ -5164,20 +4868,19 @@ package:
   license_family: Apache
   size: 133142
   timestamp: 1690550061681
-- name: libclang
+- platform: osx-arm64
+  name: libclang
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libclang13: ==15.0.7 default_hc7183e1_3
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libclang13 ==15.0.7 default_hc7183e1_3
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-15.0.7-default_h5dc8d65_3.conda
   hash:
     md5: c89d217a6315d89044ed531292678456
     sha256: 9aa880fbcd910b2ead0ad1c629fd13fae0fa39717192481345f64caf7fb5ed26
-  optional: false
-  category: main
   build: default_h5dc8d65_3
   arch: aarch64
   subdir: osx-arm64
@@ -5186,21 +4889,20 @@ package:
   license_family: Apache
   size: 133359
   timestamp: 1690550025084
-- name: libclang-cpp15
+- platform: linux-64
+  name: libclang-cpp15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp15-15.0.7-default_h7634d5b_3.conda
   hash:
     md5: 3dc837e8d805debd6c62a6dd89005811
     sha256: 4d112ee1ccb56054fb266d61a3e75077129a299bcdc83547b701e528ce2e7d17
-  optional: false
-  category: main
   build: default_h7634d5b_3
   arch: x86_64
   subdir: linux-64
@@ -5209,19 +4911,18 @@ package:
   license_family: Apache
   size: 17212684
   timestamp: 1690549595833
-- name: libclang-cpp15
+- platform: osx-64
+  name: libclang-cpp15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp15-15.0.7-default_hdb78580_3.conda
   hash:
     md5: 73639154fe4a7ca500d1361eef58fb65
     sha256: 413c923b922c6d440f5e10012b65a733ff53d00af01298935b31a1567af2cb12
-  optional: false
-  category: main
   build: default_hdb78580_3
   arch: x86_64
   subdir: osx-64
@@ -5230,19 +4931,18 @@ package:
   license_family: Apache
   size: 12426526
   timestamp: 1690549605370
-- name: libclang-cpp15
+- platform: osx-arm64
+  name: libclang-cpp15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp15-15.0.7-default_h5dc8d65_3.conda
   hash:
     md5: 99c37593de0f76769f089218e493f083
     sha256: 33375e4e41f06c90c3a50f5efe15e9ad488243585a1dc994d3d9a897313d1cc4
-  optional: false
-  category: main
   build: default_h5dc8d65_3
   arch: aarch64
   subdir: osx-arm64
@@ -5251,21 +4951,20 @@ package:
   license_family: Apache
   size: 11402301
   timestamp: 1690549536998
-- name: libclang13
+- platform: linux-64
+  name: libclang13
   version: 15.0.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_h9986a30_3.conda
   hash:
     md5: 1720df000b48e31842500323cb7be18c
     sha256: df1221a9a05b9bb3bd9b43c08a7e2fe57a0e15a0010ef26065f7ed7666083f45
-  optional: false
-  category: main
   build: default_h9986a30_3
   arch: x86_64
   subdir: linux-64
@@ -5274,19 +4973,18 @@ package:
   license_family: Apache
   size: 9557507
   timestamp: 1690549793486
-- name: libclang13
+- platform: osx-64
+  name: libclang13
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libclang13-15.0.7-default_h953c2e9_3.conda
   hash:
     md5: fb8bc95ebc36a4682d3f45a3a31304a8
     sha256: 87b42a1a905bdd77e8e000536c986edb91fbec6e8af2dec3db39c6ececfa872f
-  optional: false
-  category: main
   build: default_h953c2e9_3
   arch: x86_64
   subdir: osx-64
@@ -5295,19 +4993,18 @@ package:
   license_family: Apache
   size: 7000324
   timestamp: 1690549961410
-- name: libclang13
+- platform: osx-arm64
+  name: libclang13
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-15.0.7-default_hc7183e1_3.conda
   hash:
     md5: 3d011fbc2c7d55b4d6716a9b26da1185
     sha256: 10e2f651456fa5869b944394093ed153616cc0ddaca69966b57d33f51e4d0316
-  optional: false
-  category: main
   build: default_hc7183e1_3
   arch: aarch64
   subdir: osx-arm64
@@ -5316,19 +5013,18 @@ package:
   license_family: Apache
   size: 6453035
   timestamp: 1690549917828
-- name: libcrc32c
+- platform: linux-64
+  name: libcrc32c
   version: 1.1.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.4.0'
-    libstdcxx-ng: '>=9.4.0'
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
   hash:
     md5: c965a5aa0d5c1c37ffc62dff36e28400
     sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
-  optional: false
-  category: main
   build: h9c3ff4c_0
   arch: x86_64
   subdir: linux-64
@@ -5337,18 +5033,17 @@ package:
   license_family: BSD
   size: 20440
   timestamp: 1633683576494
-- name: libcrc32c
+- platform: osx-64
+  name: libcrc32c
   version: 1.1.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=11.1.0'
+  - libcxx >=11.1.0
   url: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
   hash:
     md5: 23d6d5a69918a438355d7cbc4c3d54c9
     sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
-  optional: false
-  category: main
   build: he49afe7_0
   arch: x86_64
   subdir: osx-64
@@ -5357,18 +5052,17 @@ package:
   license_family: BSD
   size: 20128
   timestamp: 1633683906221
-- name: libcrc32c
+- platform: osx-arm64
+  name: libcrc32c
   version: 1.1.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=11.1.0'
+  - libcxx >=11.1.0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
   hash:
     md5: 32bd82a6a625ea6ce090a81c3d34edeb
     sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
-  optional: false
-  category: main
   build: hbdafb3b_0
   arch: aarch64
   subdir: osx-arm64
@@ -5377,19 +5071,18 @@ package:
   license_family: BSD
   size: 18765
   timestamp: 1633683992603
-- name: libcrc32c
+- platform: win-64
+  name: libcrc32c
   version: 1.1.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15.0a0'
-    vs2015_runtime: '>=14.16.27012'
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
   url: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
   hash:
     md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
     sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
-  optional: false
-  category: main
   build: h0e60522_0
   arch: x86_64
   subdir: win-64
@@ -5398,24 +5091,23 @@ package:
   license_family: BSD
   size: 25694
   timestamp: 1633684287072
-- name: libcurl
+- platform: linux-64
+  name: libcurl
   version: 8.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libgcc-ng: '>=12'
-    libnghttp2: '>=1.52.0,<2.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.2,<4.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.2,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.3.0-hca28451_0.conda
   hash:
     md5: 4ab41bee09a2d2e08de5f09d6f1eef62
     sha256: 177b2d2cd552dcb88c0ce74b14512e1a8cd44146645120529e19755eb493232e
-  optional: false
-  category: main
   build: hca28451_0
   arch: x86_64
   subdir: linux-64
@@ -5424,23 +5116,22 @@ package:
   license_family: MIT
   size: 388309
   timestamp: 1694599609110
-- name: libcurl
+- platform: osx-64
+  name: libcurl
   version: 8.4.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libnghttp2: '>=1.52.0,<2.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - krb5 >=1.21.2,<1.22.0a0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.4.0-h726d00d_0.conda
   hash:
     md5: 2c17b4dedf0039736951471f493353bd
     sha256: cd3400ecb42fc420acb18e2d836535c44ebd501ebeb4e0bf3830776e9b4ca650
-  optional: false
-  category: main
   build: h726d00d_0
   arch: x86_64
   subdir: osx-64
@@ -5449,23 +5140,22 @@ package:
   license_family: MIT
   size: 366039
   timestamp: 1697009485409
-- name: libcurl
+- platform: osx-arm64
+  name: libcurl
   version: 8.3.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libnghttp2: '>=1.52.0,<2.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.2,<4.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - krb5 >=1.21.2,<1.22.0a0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.2,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.3.0-hc52a3a8_0.conda
   hash:
     md5: f7cd06ec16f40bf40c565977c363d1fd
     sha256: e4fb2f81a81449d6185129ade6c8c90cbde3259555a4080b742a566b29dbb535
-  optional: false
-  category: main
   build: hc52a3a8_0
   arch: aarch64
   subdir: osx-arm64
@@ -5474,23 +5164,22 @@ package:
   license_family: MIT
   size: 359883
   timestamp: 1694600164644
-- name: libcurl
+- platform: win-64
+  name: libcurl
   version: 8.3.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - krb5 >=1.21.2,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.3.0-hd5e4a3a_0.conda
   hash:
     md5: 4a493128ac1b1b6b2b283213a9e9abe6
     sha256: 66133dc58a4d797c4302835b8d67b0bfac1a0b1a67228ac9043a97e2eb5cbe96
-  optional: false
-  category: main
   build: hd5e4a3a_0
   arch: x86_64
   subdir: win-64
@@ -5499,17 +5188,16 @@ package:
   license_family: MIT
   size: 318789
   timestamp: 1694600121125
-- name: libcxx
+- platform: osx-64
+  name: libcxx
   version: 16.0.6
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
   hash:
     md5: 7d6972792161077908b62971802f289a
     sha256: 9063271847cf05f3a6cc6cae3e7f0ced032ab5f3a3c9d3f943f876f39c5c2549
-  optional: false
-  category: main
   build: hd57cbcb_0
   arch: x86_64
   subdir: osx-64
@@ -5518,17 +5206,16 @@ package:
   license_family: Apache
   size: 1142172
   timestamp: 1686896907750
-- name: libcxx
+- platform: osx-arm64
+  name: libcxx
   version: 16.0.6
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
   hash:
     md5: 9d7d724faf0413bf1dbc5a85935700c8
     sha256: 11d3fb51c14832d9e4f6d84080a375dec21ea8a3a381a1910e67ff9cedc20355
-  optional: false
-  category: main
   build: h4653b0c_0
   arch: aarch64
   subdir: osx-arm64
@@ -5537,19 +5224,18 @@ package:
   license_family: Apache
   size: 1160232
   timestamp: 1686896993785
-- name: libedit
+- platform: linux-64
+  name: libedit
   version: 3.1.20191231
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-    ncurses: '>=6.2,<7.0.0a0'
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
   hash:
     md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
     sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
-  optional: false
-  category: main
   build: he28a2e2_2
   arch: x86_64
   subdir: linux-64
@@ -5558,18 +5244,17 @@ package:
   license_family: BSD
   size: 123878
   timestamp: 1597616541093
-- name: libedit
+- platform: osx-64
+  name: libedit
   version: 3.1.20191231
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    ncurses: '>=6.2,<7.0.0a0'
+  - ncurses >=6.2,<7.0.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
   hash:
     md5: 6016a8a1d0e63cac3de2c352cd40208b
     sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
-  optional: false
-  category: main
   build: h0678c8f_2
   arch: x86_64
   subdir: osx-64
@@ -5578,18 +5263,17 @@ package:
   license_family: BSD
   size: 105382
   timestamp: 1597616576726
-- name: libedit
+- platform: osx-arm64
+  name: libedit
   version: 3.1.20191231
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    ncurses: '>=6.2,<7.0.0a0'
+  - ncurses >=6.2,<7.0.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
   hash:
     md5: 30e4362988a2623e9eb34337b83e01f9
     sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
-  optional: false
-  category: main
   build: hc8eb9b7_2
   arch: aarch64
   subdir: osx-arm64
@@ -5598,18 +5282,17 @@ package:
   license_family: BSD
   size: 96607
   timestamp: 1597616630749
-- name: libev
+- platform: linux-64
+  name: libev
   version: '4.33'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
+  - libgcc-ng >=7.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
   hash:
     md5: 6f8720dff19e17ce5d48cfe7f3d2f0a3
     sha256: 8c9635aa0ea28922877dc96358f9547f6a55fc7e2eb75a556b05f1725496baf9
-  optional: false
-  category: main
   build: h516909a_1
   arch: x86_64
   subdir: linux-64
@@ -5618,17 +5301,16 @@ package:
   license_family: BSD
   size: 106190
   timestamp: 1598867915
-- name: libev
+- platform: osx-64
+  name: libev
   version: '4.33'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
   hash:
     md5: 79dc2be110b2a3d1e97ec21f691c50ad
     sha256: c4154d424431898d84d6afb8b32e3ba749fe5d270d322bb0af74571a3cb09c6b
-  optional: false
-  category: main
   build: haf1e3a3_1
   arch: x86_64
   subdir: osx-64
@@ -5637,17 +5319,16 @@ package:
   license_family: BSD
   size: 101424
   timestamp: 1598868359024
-- name: libev
+- platform: osx-arm64
+  name: libev
   version: '4.33'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
   hash:
     md5: 566dbf70fe79eacdb3c3d3d195a27f55
     sha256: eb7325eb2e6bd4c291cb9682781b35b8c0f68cb72651c35a5b9dd22707ebd25c
-  optional: false
-  category: main
   build: h642e427_1
   arch: aarch64
   subdir: osx-arm64
@@ -5656,19 +5337,18 @@ package:
   license_family: BSD
   size: 100668
   timestamp: 1598868103393
-- name: libevent
+- platform: linux-64
+  name: libevent
   version: 2.1.12
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    openssl: '>=3.1.1,<4.0a0'
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
   hash:
     md5: a1cfcc585f0c42bf8d5546bb1dfb668d
     sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
-  optional: false
-  category: main
   build: hf998b51_1
   arch: x86_64
   subdir: linux-64
@@ -5677,18 +5357,17 @@ package:
   license_family: BSD
   size: 427426
   timestamp: 1685725977222
-- name: libevent
+- platform: osx-64
+  name: libevent
   version: 2.1.12
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    openssl: '>=3.1.1,<4.0a0'
+  - openssl >=3.1.1,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
   hash:
     md5: e38e467e577bd193a7d5de7c2c540b04
     sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
-  optional: false
-  category: main
   build: ha90c15b_1
   arch: x86_64
   subdir: osx-64
@@ -5697,18 +5376,17 @@ package:
   license_family: BSD
   size: 372661
   timestamp: 1685726378869
-- name: libevent
+- platform: osx-arm64
+  name: libevent
   version: 2.1.12
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    openssl: '>=3.1.1,<4.0a0'
+  - openssl >=3.1.1,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
   hash:
     md5: 1a109764bff3bdc7bdd84088347d71dc
     sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
-  optional: false
-  category: main
   build: h2757513_1
   arch: aarch64
   subdir: osx-arm64
@@ -5717,21 +5395,20 @@ package:
   license_family: BSD
   size: 368167
   timestamp: 1685726248899
-- name: libevent
+- platform: win-64
+  name: libevent
   version: 2.1.12
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    openssl: '>=3.1.1,<4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
   hash:
     md5: 25efbd786caceef438be46da78a7b5ef
     sha256: af03882afb7a7135288becf340c2f0cf8aa8221138a9a7b108aaeb308a486da1
-  optional: false
-  category: main
   build: h3671451_1
   arch: x86_64
   subdir: win-64
@@ -5740,18 +5417,17 @@ package:
   license_family: BSD
   size: 410555
   timestamp: 1685726568668
-- name: libexpat
+- platform: linux-64
+  name: libexpat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
   hash:
     md5: 6305a3dd2752c76335295da4e581f2fd
     sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
-  optional: false
-  category: main
   build: hcb278e6_1
   arch: x86_64
   subdir: linux-64
@@ -5762,17 +5438,16 @@ package:
   license_family: MIT
   size: 77980
   timestamp: 1680190528313
-- name: libexpat
+- platform: osx-64
+  name: libexpat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
   hash:
     md5: 6c81cb022780ee33435cca0127dd43c9
     sha256: 80024bd9f44d096c4cc07fb2bac76b5f1f7553390112dab3ad6acb16a05f0b96
-  optional: false
-  category: main
   build: hf0c8a7f_1
   arch: x86_64
   subdir: osx-64
@@ -5783,17 +5458,16 @@ package:
   license_family: MIT
   size: 69602
   timestamp: 1680191040160
-- name: libexpat
+- platform: osx-arm64
+  name: libexpat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
   hash:
     md5: 5a097ad3d17e42c148c9566280481317
     sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
-  optional: false
-  category: main
   build: hb7217d7_1
   arch: aarch64
   subdir: osx-arm64
@@ -5804,17 +5478,16 @@ package:
   license_family: MIT
   size: 63442
   timestamp: 1680190916539
-- name: libexpat
+- platform: win-64
+  name: libexpat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
   hash:
     md5: 636cc3cbbd2e28bcfd2f73b2044aac2c
     sha256: 794b2a9be72f176a2767c299574d330ffb76b2ed75d7fd20bee3bbadce5886cf
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
@@ -5825,18 +5498,17 @@ package:
   license_family: MIT
   size: 138689
   timestamp: 1680190844101
-- name: libffi
+- platform: linux-64
+  name: libffi
   version: 3.4.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.4.0'
+  - libgcc-ng >=9.4.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
   hash:
     md5: d645c6d2ac96843a2bfaccd2d62b3ac3
     sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
-  optional: false
-  category: main
   build: h7f98852_5
   arch: x86_64
   subdir: linux-64
@@ -5845,17 +5517,16 @@ package:
   license_family: MIT
   size: 58292
   timestamp: 1636488182923
-- name: libffi
+- platform: osx-64
+  name: libffi
   version: 3.4.2
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
   hash:
     md5: ccb34fb14960ad8b125962d3d79b31a9
     sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
-  optional: false
-  category: main
   build: h0d85af4_5
   arch: x86_64
   subdir: osx-64
@@ -5864,17 +5535,16 @@ package:
   license_family: MIT
   size: 51348
   timestamp: 1636488394370
-- name: libffi
+- platform: osx-arm64
+  name: libffi
   version: 3.4.2
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
   hash:
     md5: 086914b672be056eb70fd4285b6783b6
     sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
-  optional: false
-  category: main
   build: h3422bc3_5
   arch: aarch64
   subdir: osx-arm64
@@ -5883,19 +5553,18 @@ package:
   license_family: MIT
   size: 39020
   timestamp: 1636488587153
-- name: libffi
+- platform: win-64
+  name: libffi
   version: 3.4.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15.0a0'
-    vs2015_runtime: '>=14.16.27012'
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
   url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
   hash:
     md5: 2c96d1b6915b408893f9472569dee135
     sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
-  optional: false
-  category: main
   build: h8ffe710_5
   arch: x86_64
   subdir: win-64
@@ -5904,17 +5573,16 @@ package:
   license_family: MIT
   size: 42063
   timestamp: 1636489106777
-- name: libgcc-devel_linux-64
+- platform: linux-64
+  name: libgcc-devel_linux-64
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-12.3.0-h8bca6fd_2.conda
   hash:
     md5: ed613582de7b8569fdc53ca141be176a
     sha256: 7e12d0496389017ca526254913b24d9024e1728c849a0d6476a4b7fde9d03cba
-  optional: false
-  category: main
   build: h8bca6fd_2
   arch: x86_64
   subdir: linux-64
@@ -5923,19 +5591,18 @@ package:
   license_family: GPL
   size: 2405867
   timestamp: 1695218559716
-- name: libgcc-ng
+- platform: linux-64
+  name: libgcc-ng
   version: 13.2.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    _libgcc_mutex: ==0.1 conda_forge
-    _openmp_mutex: '>=4.5'
+  - _libgcc_mutex ==0.1 conda_forge
+  - _openmp_mutex >=4.5
   url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
   hash:
     md5: c28003b0be0494f9a7664389146716ff
     sha256: d361d3c87c376642b99c1fc25cddec4b9905d3d9b9203c1c545b8c8c1b04539a
-  optional: false
-  category: main
   build: h807b86a_2
   arch: x86_64
   subdir: linux-64
@@ -5946,18 +5613,17 @@ package:
   license_family: GPL
   size: 771133
   timestamp: 1695219384393
-- name: libgfortran
+- platform: osx-64
+  name: libgfortran
   version: 5.0.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libgfortran5: ==13.2.0 h2873a65_1
+  - libgfortran5 ==13.2.0 h2873a65_1
   url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
   hash:
     md5: b55fd11ab6318a6e67ac191309701d5a
     sha256: 5be1a59316e5063f4e6492ea86d692600a7b8e32caa25269f8a3b386a028e5f3
-  optional: false
-  category: main
   build: 13_2_0_h97931a8_1
   arch: x86_64
   subdir: osx-64
@@ -5966,18 +5632,17 @@ package:
   license_family: GPL
   size: 109855
   timestamp: 1694165674845
-- name: libgfortran
+- platform: osx-arm64
+  name: libgfortran
   version: 5.0.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libgfortran5: ==13.2.0 hf226fd6_1
+  - libgfortran5 ==13.2.0 hf226fd6_1
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
   hash:
     md5: 1ad37a5c60c250bb2b4a9f75563e181c
     sha256: bc8750e7893e693fa380bf2f342d4a5ce44995467cbdf72e56a00e5106b4892d
-  optional: false
-  category: main
   build: 13_2_0_hd922786_1
   arch: aarch64
   subdir: osx-arm64
@@ -5986,18 +5651,17 @@ package:
   license_family: GPL
   size: 110095
   timestamp: 1694172198016
-- name: libgfortran-ng
+- platform: linux-64
+  name: libgfortran-ng
   version: 13.2.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgfortran5: ==13.2.0 ha4646dd_2
+  - libgfortran5 ==13.2.0 ha4646dd_2
   url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
   hash:
     md5: e75a75a6eaf6f318dae2631158c46575
     sha256: 767d71999e5386210fe2acaf1b67073e7943c2af538efa85c101e3401e94ff62
-  optional: false
-  category: main
   build: h69a702a_2
   arch: x86_64
   subdir: linux-64
@@ -6006,18 +5670,17 @@ package:
   license_family: GPL
   size: 23722
   timestamp: 1695219642066
-- name: libgfortran5
+- platform: linux-64
+  name: libgfortran5
   version: 13.2.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=13.2.0'
+  - libgcc-ng >=13.2.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
   hash:
     md5: 78fdab09d9138851dde2b5fe2a11019e
     sha256: 55ecf5c46c05a98b4822a041d6e1cb196a7b0606126eb96b24131b7d2c8ca561
-  optional: false
-  category: main
   build: ha4646dd_2
   arch: x86_64
   subdir: linux-64
@@ -6028,18 +5691,17 @@ package:
   license_family: GPL
   size: 1441830
   timestamp: 1695219403435
-- name: libgfortran5
+- platform: osx-64
+  name: libgfortran5
   version: 13.2.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    llvm-openmp: '>=8.0.0'
+  - llvm-openmp >=8.0.0
   url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
   hash:
     md5: 3af564516b5163cd8cc08820413854bc
     sha256: 44de8930eef3b14d4d9fdfe419e6c909c13b7c859617d3616d5a5e964f3fcf63
-  optional: false
-  category: main
   build: h2873a65_1
   arch: x86_64
   subdir: osx-64
@@ -6050,18 +5712,17 @@ package:
   license_family: GPL
   size: 1571764
   timestamp: 1694165583047
-- name: libgfortran5
+- platform: osx-arm64
+  name: libgfortran5
   version: 13.2.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    llvm-openmp: '>=8.0.0'
+  - llvm-openmp >=8.0.0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
   hash:
     md5: 4480d71b98c87faafab132d33e23135e
     sha256: cb9cb11e49a6a8466ea7556a723080d3aeefd556df9b444b941afc5b54368b22
-  optional: false
-  category: main
   build: hf226fd6_1
   arch: aarch64
   subdir: osx-arm64
@@ -6072,18 +5733,17 @@ package:
   license_family: GPL
   size: 995733
   timestamp: 1694172076009
-- name: libgomp
+- platform: linux-64
+  name: libgomp
   version: 13.2.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    _libgcc_mutex: ==0.1 conda_forge
+  - _libgcc_mutex ==0.1 conda_forge
   url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
   hash:
     md5: e2042154faafe61969556f28bade94b9
     sha256: e1e82348f8296abfe344162b3b5f0ddc2f504759ebeb8b337ba99beaae583b15
-  optional: false
-  category: main
   build: h807b86a_2
   arch: x86_64
   subdir: linux-64
@@ -6092,25 +5752,24 @@ package:
   license_family: GPL
   size: 421133
   timestamp: 1695219303065
-- name: libgoogle-cloud
+- platform: linux-64
+  name: libgoogle-cloud
   version: 2.12.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libabseil: '>=20230802.0,<20230803.0a0'
-    libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: '>=8.2.1,<9.0a0'
-    libgcc-ng: '>=12'
-    libgrpc: '>=1.57.0,<1.58.0a0'
-    libprotobuf: '>=4.23.4,<4.23.5.0a0'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.1.2,<4.0a0'
+  - libabseil >=20230802.0,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libgcc-ng >=12
+  - libgrpc >=1.57.0,<1.58.0a0
+  - libprotobuf >=4.23.4,<4.23.5.0a0
+  - libstdcxx-ng >=12
+  - openssl >=3.1.2,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-h8d7e28b_2.conda
   hash:
     md5: ed3cd026aa12259ce96c0552873705c9
     sha256: b97ec8dc4a076b804cf84668e87ce1d3e7e6c2e6d6088be3cf7b19a708c1cdb6
-  optional: false
-  category: main
   build: h8d7e28b_2
   arch: x86_64
   subdir: linux-64
@@ -6121,25 +5780,24 @@ package:
   license_family: Apache
   size: 46181592
   timestamp: 1694371473062
-- name: libgoogle-cloud
+- platform: osx-64
+  name: libgoogle-cloud
   version: 2.12.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: '>=8.3.0,<9.0a0'
-    libcxx: '>=16.0.6'
-    libgrpc: '>=1.58.1,<1.59.0a0'
-    libprotobuf: '>=4.24.3,<4.24.4.0a0'
-    openssl: '>=3.1.3,<4.0a0'
+  - __osx >=10.9
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libcxx >=16.0.6
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - openssl >=3.1.3,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-h407922f_3.conda
   hash:
     md5: 9d9423eb233bbd6f82184eb9e2a95f2d
     sha256: ad0dbbd851ec86974b239de1c800c8ef52d665ea90c4fdc2ea855c3dcbb34983
-  optional: false
-  category: main
   build: h407922f_3
   arch: x86_64
   subdir: osx-64
@@ -6150,24 +5808,23 @@ package:
   license_family: Apache
   size: 30907199
   timestamp: 1696838955088
-- name: libgoogle-cloud
+- platform: osx-arm64
+  name: libgoogle-cloud
   version: 2.12.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libabseil: '>=20230802.0,<20230803.0a0'
-    libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: '>=8.2.1,<9.0a0'
-    libcxx: '>=15.0.7'
-    libgrpc: '>=1.57.0,<1.58.0a0'
-    libprotobuf: '>=4.23.4,<4.23.5.0a0'
-    openssl: '>=3.1.2,<4.0a0'
+  - libabseil >=20230802.0,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=15.0.7
+  - libgrpc >=1.57.0,<1.58.0a0
+  - libprotobuf >=4.23.4,<4.23.5.0a0
+  - openssl >=3.1.2,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-hde42cda_2.conda
   hash:
     md5: c00f510ad8d6c789df20ec69072c162d
     sha256: 3e8a980bf8c2d4fe4cb9ba2245f433029d5a04daeedc8960fcf2de5ee1111554
-  optional: false
-  category: main
   build: hde42cda_2
   arch: aarch64
   subdir: osx-arm64
@@ -6178,26 +5835,25 @@ package:
   license_family: Apache
   size: 36600587
   timestamp: 1694395733961
-- name: libgoogle-cloud
+- platform: win-64
+  name: libgoogle-cloud
   version: 2.12.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libabseil: '>=20230802.0,<20230803.0a0'
-    libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: '>=8.2.1,<9.0a0'
-    libgrpc: '>=1.57.0,<1.58.0a0'
-    libprotobuf: '>=4.23.4,<4.23.5.0a0'
-    openssl: '>=3.1.2,<4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libabseil >=20230802.0,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libgrpc >=1.57.0,<1.58.0a0
+  - libprotobuf >=4.23.4,<4.23.5.0a0
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-h0a0a397_2.conda
   hash:
     md5: 7118be3d559211085bf62e0f08070e5b
     sha256: 017b1a77c5edb91e54491014f66c0a96f2a230077e19033b390981d5b9996590
-  optional: false
-  category: main
   build: h0a0a397_2
   arch: x86_64
   subdir: win-64
@@ -6208,25 +5864,24 @@ package:
   license_family: Apache
   size: 13320
   timestamp: 1694367447260
-- name: libgrpc
+- platform: linux-64
+  name: libgrpc
   version: 1.57.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    c-ares: '>=1.19.1,<2.0a0'
-    libabseil: '>=20230802.0,<20230803.0a0'
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.23.4,<4.23.5.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.2,<4.0a0'
-    re2: '>=2023.3.2,<2023.3.3.0a0'
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil >=20230802.0,<20230803.0a0
+  - libgcc-ng >=12
+  - libprotobuf >=4.23.4,<4.23.5.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.2,<4.0a0
+  - re2 >=2023.3.2,<2023.3.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.57.0-ha4d0f93_1.conda
   hash:
     md5: 56ce4bcc0e1cd0b4c3d7149010410e9a
     sha256: f21f520fa98466e9a1ea367162348c7fa6438b19e83a200c97b612bdf576063c
-  optional: false
-  category: main
   build: ha4d0f93_1
   arch: x86_64
   subdir: linux-64
@@ -6237,25 +5892,24 @@ package:
   license_family: APACHE
   size: 5984664
   timestamp: 1691795612144
-- name: libgrpc
+- platform: osx-64
+  name: libgrpc
   version: 1.58.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    c-ares: '>=1.20.1,<2.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcxx: '>=16.0.6'
-    libprotobuf: '>=4.24.3,<4.24.4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    re2: '>=2023.3.2,<2023.3.3.0a0'
+  - __osx >=10.9
+  - c-ares >=1.20.1,<2.0a0
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=16.0.6
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - re2 >=2023.3.2,<2023.3.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.58.1-he2498c0_1.conda
   hash:
     md5: 831766c77966c927e4c1a49b56649117
     sha256: 874f808383d5379ee8d84868472796778175db76b93a484f86fb51742ceaba2d
-  optional: false
-  category: main
   build: he2498c0_1
   arch: x86_64
   subdir: osx-64
@@ -6266,24 +5920,23 @@ package:
   license_family: APACHE
   size: 4090853
   timestamp: 1697170268696
-- name: libgrpc
+- platform: osx-arm64
+  name: libgrpc
   version: 1.57.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    c-ares: '>=1.19.1,<2.0a0'
-    libabseil: '>=20230802.0,<20230803.0a0'
-    libcxx: '>=15.0.7'
-    libprotobuf: '>=4.23.4,<4.23.5.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.2,<4.0a0'
-    re2: '>=2023.3.2,<2023.3.3.0a0'
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil >=20230802.0,<20230803.0a0
+  - libcxx >=15.0.7
+  - libprotobuf >=4.23.4,<4.23.5.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.2,<4.0a0
+  - re2 >=2023.3.2,<2023.3.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.57.0-hdbe17d8_1.conda
   hash:
     md5: 79e53c0f32d2c636513cd3314ef81eb8
     sha256: 293ba4b612fb68f48fe442b2e32ddfa8c7a7911e431848dc6e26f3bfd798aee5
-  optional: false
-  category: main
   build: hdbe17d8_1
   arch: aarch64
   subdir: osx-arm64
@@ -6294,26 +5947,25 @@ package:
   license_family: APACHE
   size: 4048184
   timestamp: 1691796067953
-- name: libgrpc
+- platform: win-64
+  name: libgrpc
   version: 1.57.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    c-ares: '>=1.19.1,<2.0a0'
-    libabseil: '>=20230802.0,<20230803.0a0'
-    libprotobuf: '>=4.23.4,<4.23.5.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.2,<4.0a0'
-    re2: '>=2023.3.2,<2023.3.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil >=20230802.0,<20230803.0a0
+  - libprotobuf >=4.23.4,<4.23.5.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.2,<4.0a0
+  - re2 >=2023.3.2,<2023.3.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.57.0-h550f6bd_1.conda
   hash:
     md5: e0742a36421bb36128ab4b305a27a4ed
     sha256: bc90d0f9233f98257f4ebdb551fa2da8a49fb7193b7c7462b1afc19b062b89ff
-  optional: false
-  category: main
   build: h550f6bd_1
   arch: x86_64
   subdir: win-64
@@ -6324,22 +5976,21 @@ package:
   license_family: APACHE
   size: 12967454
   timestamp: 1691796762776
-- name: libhwloc
+- platform: win-64
+  name: libhwloc
   version: 2.9.3
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libxml2: '>=2.11.5,<2.12.0a0'
-    pthreads-win32: '*'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libxml2 >=2.11.5,<2.12.0a0
+  - pthreads-win32 *
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
   hash:
     md5: 87da045f6d26ce9fe20ad76a18f6a18a
     sha256: 2e8c4bb7173f281a8e13f333a23c9fb7a1c86d342d7dccdd74f2eb583ddde450
-  optional: false
-  category: main
   build: default_haede6df_1009
   arch: x86_64
   subdir: win-64
@@ -6348,18 +5999,17 @@ package:
   license_family: BSD
   size: 2578462
   timestamp: 1694533393675
-- name: libiconv
+- platform: linux-64
+  name: libiconv
   version: '1.17'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=10.3.0'
+  - libgcc-ng >=10.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
   hash:
     md5: b62b52da46c39ee2bc3c162ac7f1804d
     sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
-  optional: false
-  category: main
   build: h166bdaf_0
   arch: x86_64
   subdir: linux-64
@@ -6367,17 +6017,16 @@ package:
   license: GPL and LGPL
   size: 1450368
   timestamp: 1652700749886
-- name: libiconv
+- platform: osx-64
+  name: libiconv
   version: '1.17'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2
   hash:
     md5: 691d103d11180486154af49c037b7ed9
     sha256: 4a3294037d595754f7da7c11a41f3922f995aaa333f3cb66f02d8afa032a7bc2
-  optional: false
-  category: main
   build: hac89ed1_0
   arch: x86_64
   subdir: osx-64
@@ -6385,17 +6034,16 @@ package:
   license: GPL and LGPL
   size: 1378276
   timestamp: 1652702364402
-- name: libiconv
+- platform: osx-arm64
+  name: libiconv
   version: '1.17'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
   hash:
     md5: 686f9c755574aa221f29fbcf36a67265
     sha256: 2eb33065783b802f71d52bef6f15ce0fafea0adc8506f10ebd0d490244087bec
-  optional: false
-  category: main
   build: he4db4b2_0
   arch: aarch64
   subdir: osx-arm64
@@ -6403,19 +6051,18 @@ package:
   license: GPL and LGPL
   size: 1407036
   timestamp: 1652700956112
-- name: libiconv
+- platform: win-64
+  name: libiconv
   version: '1.17'
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15'
-    vs2015_runtime: '>=14.16.27033'
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
   url: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
   hash:
     md5: 050119977a86e4856f0416e2edcf81bb
     sha256: 657c2a992c896475021a25faebd9ccfaa149c5d70c7dc824d4069784b686cea1
-  optional: false
-  category: main
   build: h8ffe710_0
   arch: x86_64
   subdir: win-64
@@ -6423,18 +6070,17 @@ package:
   license: GPL and LGPL
   size: 714518
   timestamp: 1652702326553
-- name: liblapack
+- platform: linux-64
+  name: liblapack
   version: 3.9.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libblas: ==3.9.0 18_linux64_openblas
+  - libblas ==3.9.0 18_linux64_openblas
   url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-18_linux64_openblas.conda
   hash:
     md5: a1244707531e5b143c420c70573c8ec5
     sha256: 7b59c9bf8399b34818d36c7bbd30cd447649fe4ff2136d3102bb67da0af67a3a
-  optional: false
-  category: main
   build: 18_linux64_openblas
   arch: x86_64
   subdir: linux-64
@@ -6447,18 +6093,17 @@ package:
   license_family: BSD
   size: 14482
   timestamp: 1693951382004
-- name: liblapack
+- platform: osx-64
+  name: liblapack
   version: 3.9.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libblas: ==3.9.0 18_osx64_openblas
+  - libblas ==3.9.0 18_osx64_openblas
   url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-18_osx64_openblas.conda
   hash:
     md5: e3e4572494c68a638faea31e7b72ec56
     sha256: 2a297c50fdd566f8a1685ca3da2d3fc3e8b33806240b20ce9e1dc3a739cd48ff
-  optional: false
-  category: main
   build: 18_osx64_openblas
   arch: x86_64
   subdir: osx-64
@@ -6471,18 +6116,17 @@ package:
   license_family: BSD
   size: 14676
   timestamp: 1693951751596
-- name: liblapack
+- platform: osx-arm64
+  name: liblapack
   version: 3.9.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libblas: ==3.9.0 18_osxarm64_openblas
+  - libblas ==3.9.0 18_osxarm64_openblas
   url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-18_osxarm64_openblas.conda
   hash:
     md5: 92cd5c16ed732ac6c439145aa21ec7c5
     sha256: 8e19b14ba16d286d889e3d1c78aaa3344e4c6dff50a21b54ee00ee88a95bb2e9
-  optional: false
-  category: main
   build: 18_osxarm64_openblas
   arch: aarch64
   subdir: osx-arm64
@@ -6495,18 +6139,17 @@ package:
   license_family: BSD
   size: 14767
   timestamp: 1693951919599
-- name: liblapack
+- platform: win-64
+  name: liblapack
   version: 3.9.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libblas: ==3.9.0 18_win64_mkl
+  - libblas ==3.9.0 18_win64_mkl
   url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-18_win64_mkl.conda
   hash:
     md5: 82117ef735a916ace2df6f2de4df4824
     sha256: f90d96695938659fad4dd47d92dbeebff4a3824979bfb1aac33c8287a83e9d23
-  optional: false
-  category: main
   build: 18_win64_mkl
   arch: x86_64
   subdir: win-64
@@ -6519,22 +6162,21 @@ package:
   license_family: BSD
   size: 3655780
   timestamp: 1693952143445
-- name: libllvm15
+- platform: linux-64
+  name: libllvm15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.11.4,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.11.4,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-h5cf9203_3.conda
   hash:
     md5: 9efe82d44b76a7529a1d702e5a37752e
     sha256: bb94e7535a309c2a8d58585cb82bac954ed59f473eef2cac6ea677d6f576a3b6
-  optional: false
-  category: main
   build: h5cf9203_3
   arch: x86_64
   subdir: linux-64
@@ -6543,21 +6185,20 @@ package:
   license_family: Apache
   size: 33333655
   timestamp: 1690527825436
-- name: libllvm15
+- platform: osx-64
+  name: libllvm15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15'
-    libxml2: '>=2.11.4,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
+  - libcxx >=15
+  - libxml2 >=2.11.4,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-he4b1e75_3.conda
   hash:
     md5: ecc6df80c4b0445ac0de9cabae189db3
     sha256: 02c7f5fe1ae9cdf4b0152cc76fef0ccb26137075054bdd9336ebf956fd22d8c9
-  optional: false
-  category: main
   build: he4b1e75_3
   arch: x86_64
   subdir: osx-64
@@ -6566,20 +6207,19 @@ package:
   license_family: Apache
   size: 23877550
   timestamp: 1690533932497
-- name: libllvm15
+- platform: osx-arm64
+  name: libllvm15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15'
-    libxml2: '>=2.11.4,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libcxx >=15
+  - libxml2 >=2.11.4,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h504e6bf_3.conda
   hash:
     md5: cef4a00532f06f6797fbe2425d4db2a7
     sha256: 8fbe19f2133c501a43a45f4dab701adf5206ed61f4bd6317f287a8d87409fdee
-  optional: false
-  category: main
   build: h504e6bf_3
   arch: aarch64
   subdir: osx-arm64
@@ -6588,23 +6228,22 @@ package:
   license_family: Apache
   size: 21956912
   timestamp: 1690530007064
-- name: libnghttp2
+- platform: linux-64
+  name: libnghttp2
   version: 1.52.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    c-ares: '>=1.18.1,<2.0a0'
-    libev: '>=4.33,<4.34.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.0.8,<4.0a0'
+  - c-ares >=1.18.1,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.0.8,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.52.0-h61bc06f_0.conda
   hash:
     md5: 613955a50485812985c059e7b269f42e
     sha256: ecd6b08c2b5abe7d1586428c4dd257dcfa00ee53700d79cdc8bca098fdfbd79a
-  optional: false
-  category: main
   build: h61bc06f_0
   arch: x86_64
   subdir: linux-64
@@ -6613,22 +6252,21 @@ package:
   license_family: MIT
   size: 622366
   timestamp: 1677678076121
-- name: libnghttp2
+- platform: osx-64
+  name: libnghttp2
   version: 1.52.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    c-ares: '>=1.18.1,<2.0a0'
-    libcxx: '>=14.0.6'
-    libev: '>=4.33,<4.34.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.0.8,<4.0a0'
+  - c-ares >=1.18.1,<2.0a0
+  - libcxx >=14.0.6
+  - libev >=4.33,<4.34.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.0.8,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.52.0-he2ab024_0.conda
   hash:
     md5: 12ac7d100bf260263e30a019517f42a2
     sha256: 093e4f3f62b3b07befa403e84a1f550cffe3b3961e435d42a75284f44be5f68a
-  optional: false
-  category: main
   build: he2ab024_0
   arch: x86_64
   subdir: osx-64
@@ -6637,22 +6275,21 @@ package:
   license_family: MIT
   size: 613074
   timestamp: 1677678399575
-- name: libnghttp2
+- platform: osx-arm64
+  name: libnghttp2
   version: 1.52.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    c-ares: '>=1.18.1,<2.0a0'
-    libcxx: '>=14.0.6'
-    libev: '>=4.33,<4.34.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.0.8,<4.0a0'
+  - c-ares >=1.18.1,<2.0a0
+  - libcxx >=14.0.6
+  - libev >=4.33,<4.34.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.0.8,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.52.0-hae82a92_0.conda
   hash:
     md5: 1d319e95a0216f801293626a00337712
     sha256: 1a3944d6295dcbecdf6489ce8a05fe416ad401727c901ec390e9200a351bdb10
-  optional: false
-  category: main
   build: hae82a92_0
   arch: aarch64
   subdir: osx-arm64
@@ -6661,18 +6298,17 @@ package:
   license_family: MIT
   size: 564295
   timestamp: 1677678452375
-- name: libnsl
+- platform: linux-64
+  name: libnsl
   version: 2.0.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.0-hd590300_1.conda
   hash:
     md5: 854e3e1623b39777140f199c5f9ab952
     sha256: c0a0c0abc1c17983168c3239d79a62d53c424bc5dd1764dbcd0fa953d6fce5e0
-  optional: false
-  category: main
   build: hd590300_1
   arch: x86_64
   subdir: linux-64
@@ -6681,18 +6317,17 @@ package:
   license_family: GPL
   size: 33210
   timestamp: 1695799598317
-- name: libnuma
+- platform: linux-64
+  name: libnuma
   version: 2.0.16
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.16-h0b41bf4_1.conda
   hash:
     md5: 28bfe2cb11357ccc5be21101a6b7ce86
     sha256: 814a50cba215548ec3ebfb53033ffb9b3b070b2966570ff44910b8d9ba1c359d
-  optional: false
-  category: main
   build: h0b41bf4_1
   arch: x86_64
   subdir: linux-64
@@ -6700,20 +6335,19 @@ package:
   license: LGPL-2.1-only
   size: 41107
   timestamp: 1676004391774
-- name: libopenblas
+- platform: linux-64
+  name: libopenblas
   version: 0.3.24
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libgfortran-ng: '*'
-    libgfortran5: '>=12.3.0'
+  - libgcc-ng >=12
+  - libgfortran-ng *
+  - libgfortran5 >=12.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
   hash:
     md5: 6e4ef6ca28655124dcde9bd500e44c32
     sha256: c8e080ae4d57506238023e98869928ae93564e6407ef5b0c4d3a337e8c2b7662
-  optional: false
-  category: main
   build: pthreads_h413a1c8_0
   arch: x86_64
   subdir: linux-64
@@ -6724,20 +6358,19 @@ package:
   license_family: BSD
   size: 5492091
   timestamp: 1693785223074
-- name: libopenblas
+- platform: osx-64
+  name: libopenblas
   version: 0.3.24
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libgfortran: 5.*
-    libgfortran5: '>=12.3.0'
-    llvm-openmp: '>=15.0.7'
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
   hash:
     md5: 077718837dd06cf0c3089070108869f6
     sha256: ff2c14f7ed121f1df3ad06bea353288eade77c12fb891212a27af88a61483490
-  optional: false
-  category: main
   build: openmp_h48a4ad5_0
   arch: x86_64
   subdir: osx-64
@@ -6748,20 +6381,19 @@ package:
   license_family: BSD
   size: 6157393
   timestamp: 1693785988209
-- name: libopenblas
+- platform: osx-arm64
+  name: libopenblas
   version: 0.3.24
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libgfortran: 5.*
-    libgfortran5: '>=12.3.0'
-    llvm-openmp: '>=15.0.7'
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
   hash:
     md5: aacb05989f358affe1bafd4ea7294db4
     sha256: 21edfdf620ac5c93571aab452199b6b4622c445441dad88ab4d2eb326a7b91b3
-  optional: false
-  category: main
   build: openmp_hd76b1f2_0
   arch: aarch64
   subdir: osx-arm64
@@ -6772,21 +6404,20 @@ package:
   license_family: BSD
   size: 2849225
   timestamp: 1693784744674
-- name: libprotobuf
+- platform: linux-64
+  name: libprotobuf
   version: 4.23.4
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libabseil: '>=20230802.0,<20230803.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libabseil >=20230802.0,<20230803.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.23.4-hf27288f_6.conda
   hash:
     md5: f28b3651e20e63f7da58798880061089
     sha256: 33ce0a281abe4b3d59630f8e326fd73d38ca7a7030d1161aa4ca32792f35037e
-  optional: false
-  category: main
   build: hf27288f_6
   arch: x86_64
   subdir: linux-64
@@ -6795,21 +6426,20 @@ package:
   license_family: BSD
   size: 2558192
   timestamp: 1694476855040
-- name: libprotobuf
+- platform: osx-64
+  name: libprotobuf
   version: 4.24.3
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcxx: '>=15.0.7'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - __osx >=10.13
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.24.3-he0c2237_1.conda
   hash:
     md5: 45b790be289d0759d1eb91283c98e95d
     sha256: 42426fb0dba77e8f8cdf7732e9ee5d1dbed6724d1d94c84deeb98376f4cdcadd
-  optional: false
-  category: main
   build: he0c2237_1
   arch: x86_64
   subdir: osx-64
@@ -6818,20 +6448,19 @@ package:
   license_family: BSD
   size: 2157294
   timestamp: 1697158160443
-- name: libprotobuf
+- platform: osx-arm64
+  name: libprotobuf
   version: 4.23.4
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libabseil: '>=20230802.0,<20230803.0a0'
-    libcxx: '>=15.0.7'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libabseil >=20230802.0,<20230803.0a0
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.23.4-hf590ac1_6.conda
   hash:
     md5: 743cb961d7a0ccd8014ee7b3e4d731db
     sha256: ccf913d59991822203bcdf61cb4679c0a51327081600f97dba370adc16488e47
-  optional: false
-  category: main
   build: hf590ac1_6
   arch: aarch64
   subdir: osx-arm64
@@ -6840,22 +6469,21 @@ package:
   license_family: BSD
   size: 2062262
   timestamp: 1694477204434
-- name: libprotobuf
+- platform: win-64
+  name: libprotobuf
   version: 4.23.4
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libabseil: '>=20230802.0,<20230803.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libabseil >=20230802.0,<20230803.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.23.4-hb8276f3_6.conda
   hash:
     md5: 1b9498bb8e615cfc5cb443f216b6ec1c
     sha256: 505137db3057884783bf4a8e40622e29fa8c80e1425d93a94fa478f06dcf6750
-  optional: false
-  category: main
   build: hb8276f3_6
   arch: x86_64
   subdir: win-64
@@ -6864,18 +6492,17 @@ package:
   license_family: BSD
   size: 5205221
   timestamp: 1694477777276
-- name: libsanitizer
+- platform: linux-64
+  name: libsanitizer
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12.3.0'
+  - libgcc-ng >=12.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_2.conda
   hash:
     md5: 4655db64eca78a6fcc4fb654fc1f8d57
     sha256: a58add0b4477c59aee324b508d834267360b659f9c543f551ca4442196e656fe
-  optional: false
-  category: main
   build: h0f45ef3_2
   arch: x86_64
   subdir: linux-64
@@ -6884,19 +6511,18 @@ package:
   license_family: GPL
   size: 3910499
   timestamp: 1695218679356
-- name: libsqlite
+- platform: linux-64
+  name: libsqlite
   version: 3.43.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.43.0-h2797004_0.conda
   hash:
     md5: 903fa782a9067d5934210df6d79220f6
     sha256: e715fab7ec6b3f3df2a5962ef372ff0f871d215fe819482dcd80357999513652
-  optional: false
-  category: main
   build: h2797004_0
   arch: x86_64
   subdir: linux-64
@@ -6904,18 +6530,17 @@ package:
   license: Unlicense
   size: 840871
   timestamp: 1692911324643
-- name: libsqlite
+- platform: osx-64
+  name: libsqlite
   version: 3.43.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.43.2-h92b6c6a_0.conda
   hash:
     md5: 61b88c5f99f1537ed30b34758bd54d54
     sha256: e0ba6181738d5250213576167935a97dc3ee581032f716dd4e2acbc817c763dc
-  optional: false
-  category: main
   build: h92b6c6a_0
   arch: x86_64
   subdir: osx-64
@@ -6923,18 +6548,17 @@ package:
   license: Unlicense
   size: 885196
   timestamp: 1696959083399
-- name: libsqlite
+- platform: osx-arm64
+  name: libsqlite
   version: 3.43.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.43.0-hb31c410_0.conda
   hash:
     md5: 060a9948665e56a38060a1ed3ebc553a
     sha256: ddc90cc7a33563cd1f2b179a4964d144c221f9148634c006fd83ec9e1c667907
-  optional: false
-  category: main
   build: hb31c410_0
   arch: aarch64
   subdir: osx-arm64
@@ -6942,20 +6566,19 @@ package:
   license: Unlicense
   size: 834286
   timestamp: 1692911796861
-- name: libsqlite
+- platform: win-64
+  name: libsqlite
   version: 3.43.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.43.0-hcfcfb64_0.conda
   hash:
     md5: 16c6f482e70cb3da41d0bee5d49c6bf3
     sha256: d79128a279c8e8b4afeef5cfe9d4302a2fd65b1af3973732d92a7cc396d5332f
-  optional: false
-  category: main
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
@@ -6963,20 +6586,19 @@ package:
   license: Unlicense
   size: 846526
   timestamp: 1692911612959
-- name: libssh2
+- platform: linux-64
+  name: libssh2
   version: 1.11.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.1,<4.0a0'
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
   hash:
     md5: 1f5a58e686b13bcfde88b93f547d23fe
     sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
-  optional: false
-  category: main
   build: h0841786_0
   arch: x86_64
   subdir: linux-64
@@ -6985,19 +6607,18 @@ package:
   license_family: BSD
   size: 271133
   timestamp: 1685837707056
-- name: libssh2
+- platform: osx-64
+  name: libssh2
   version: 1.11.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.1,<4.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
   hash:
     md5: ca3a72efba692c59a90d4b9fc0dfe774
     sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
-  optional: false
-  category: main
   build: hd019ec5_0
   arch: x86_64
   subdir: osx-64
@@ -7006,19 +6627,18 @@ package:
   license_family: BSD
   size: 259556
   timestamp: 1685837820566
-- name: libssh2
+- platform: osx-arm64
+  name: libssh2
   version: 1.11.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.1,<4.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
   hash:
     md5: 029f7dc931a3b626b94823bc77830b01
     sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
-  optional: false
-  category: main
   build: h7a5bd25_0
   arch: aarch64
   subdir: osx-arm64
@@ -7027,22 +6647,21 @@ package:
   license_family: BSD
   size: 255610
   timestamp: 1685837894256
-- name: libssh2
+- platform: win-64
+  name: libssh2
   version: 1.11.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.1,<4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
   hash:
     md5: dc262d03aae04fe26825062879141a41
     sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
-  optional: false
-  category: main
   build: h7dfc565_0
   arch: x86_64
   subdir: win-64
@@ -7051,17 +6670,16 @@ package:
   license_family: BSD
   size: 266806
   timestamp: 1685838242099
-- name: libstdcxx-devel_linux-64
+- platform: linux-64
+  name: libstdcxx-devel_linux-64
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_2.conda
   hash:
     md5: 7268a17e56eb099d1b8869bbbf46de4c
     sha256: e8483069599561ef24b884c898442eadc510190f978fa388db3281b10c3c084e
-  optional: false
-  category: main
   build: h8bca6fd_2
   arch: x86_64
   subdir: linux-64
@@ -7070,17 +6688,16 @@ package:
   license_family: GPL
   size: 8542654
   timestamp: 1695218598349
-- name: libstdcxx-ng
+- platform: linux-64
+  name: libstdcxx-ng
   version: 13.2.0
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
   hash:
     md5: 9172c297304f2a20134fc56c97fbe229
     sha256: ab22ecdc974cdbe148874ea876d9c564294d5eafa760f403ed4fd495307b4243
-  optional: false
-  category: main
   build: h7e041cc_2
   arch: x86_64
   subdir: linux-64
@@ -7089,22 +6706,21 @@ package:
   license_family: GPL
   size: 3842773
   timestamp: 1695219454837
-- name: libthrift
+- platform: linux-64
+  name: libthrift
   version: 0.19.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
   hash:
     md5: 8cdb7d41faa0260875ba92414c487e2d
     sha256: 719add2cf20d144ef9962c57cd0f77178259bdb3aae1cded2e2b2b7c646092f5
-  optional: false
-  category: main
   build: hb90f79a_1
   arch: x86_64
   subdir: linux-64
@@ -7113,21 +6729,20 @@ package:
   license_family: APACHE
   size: 409409
   timestamp: 1695958011498
-- name: libthrift
+- platform: osx-64
+  name: libthrift
   version: 0.19.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
+  - libcxx >=15.0.7
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
   hash:
     md5: b152655bfad7c2374ff03be0596052b6
     sha256: 4346c25ef6e2ff3d0fc93074238508531188ecd0dbea6414f6cb93a7775072c4
-  optional: false
-  category: main
   build: h064b379_1
   arch: x86_64
   subdir: osx-64
@@ -7136,21 +6751,20 @@ package:
   license_family: APACHE
   size: 325415
   timestamp: 1695958330036
-- name: libthrift
+- platform: osx-arm64
+  name: libthrift
   version: 0.19.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
+  - libcxx >=15.0.7
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.19.0-h026a170_1.conda
   hash:
     md5: 4b8b21eb00d9019e9fa351141da2a6ac
     sha256: b2c1b30d36f0412c0c0313db76a0236d736f3a9b887b8ed16182f531e4b7cb80
-  optional: false
-  category: main
   build: h026a170_1
   arch: aarch64
   subdir: osx-arm64
@@ -7159,23 +6773,22 @@ package:
   license_family: APACHE
   size: 331154
   timestamp: 1695958512679
-- name: libthrift
+- platform: win-64
+  name: libthrift
   version: 0.19.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
   hash:
     md5: d3432b9d4950e91d2fdf3bed91248ee0
     sha256: 89bbc59898c827429a52315c9c0dd888ea73ab1157a8c86098aeae7d13454ac4
-  optional: false
-  category: main
   build: ha2b3283_1
   arch: x86_64
   subdir: win-64
@@ -7184,18 +6797,17 @@ package:
   license_family: APACHE
   size: 612342
   timestamp: 1695958519927
-- name: libutf8proc
+- platform: linux-64
+  name: libutf8proc
   version: 2.8.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
   hash:
     md5: ede4266dc02e875fe1ea77b25dd43747
     sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
-  optional: false
-  category: main
   build: h166bdaf_0
   arch: x86_64
   subdir: linux-64
@@ -7204,17 +6816,16 @@ package:
   license_family: MIT
   size: 101070
   timestamp: 1667316029302
-- name: libutf8proc
+- platform: osx-64
+  name: libutf8proc
   version: 2.8.0
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
   hash:
     md5: db98dc3e58cbc11583180609c429c17d
     sha256: 55a7f96b2802e94def207fdfe92bc52c24d705d139bb6cdb3d936cbe85e1c505
-  optional: false
-  category: main
   build: hb7f2c08_0
   arch: x86_64
   subdir: osx-64
@@ -7223,17 +6834,16 @@ package:
   license_family: MIT
   size: 98942
   timestamp: 1667316472080
-- name: libutf8proc
+- platform: osx-arm64
+  name: libutf8proc
   version: 2.8.0
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
   hash:
     md5: f8c9c41a122ab3abdf8943b13f4957ee
     sha256: a3faddac08efd930fa3a1cc254b5053b4ed9428c49a888d437bf084d403c931a
-  optional: false
-  category: main
   build: h1a8c8d9_0
   arch: aarch64
   subdir: osx-arm64
@@ -7242,20 +6852,19 @@ package:
   license_family: MIT
   size: 103492
   timestamp: 1667316405233
-- name: libutf8proc
+- platform: win-64
+  name: libutf8proc
   version: 2.8.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
   hash:
     md5: 076894846fe9f068f91c57d158c90cba
     sha256: 6efa83e3f2fb9acaf096a18d21d0f679d110934798348c5defc780d4b759a76c
-  optional: false
-  category: main
   build: h82a8f57_0
   arch: x86_64
   subdir: win-64
@@ -7264,18 +6873,17 @@ package:
   license_family: MIT
   size: 104389
   timestamp: 1667316359211
-- name: libuuid
+- platform: linux-64
+  name: libuuid
   version: 2.38.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
   hash:
     md5: 40b61aab5c7ba9ff276c41cfffe6b80b
     sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
-  optional: false
-  category: main
   build: h0b41bf4_0
   arch: x86_64
   subdir: linux-64
@@ -7284,18 +6892,17 @@ package:
   license_family: BSD
   size: 33601
   timestamp: 1680112270483
-- name: libuv
+- platform: linux-64
+  name: libuv
   version: 1.46.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.46.0-hd590300_0.conda
   hash:
     md5: d23c76f7e6dcd6243d1b6ef5e62d17d2
     sha256: 4bc4c946e9a532c066442714eeeeb1ffbd03cd89789c4047293f5e782b5fedd7
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -7304,17 +6911,16 @@ package:
   license_family: MIT
   size: 893348
   timestamp: 1693539405436
-- name: libuv
+- platform: osx-64
+  name: libuv
   version: 1.46.0
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.46.0-h0c2f820_0.conda
   hash:
     md5: 27664a5d39d9c32ae38880fec2b33b36
     sha256: e51667c756f15580d3ce131d6157f0238d931c05af118c89f019854f2a7c125e
-  optional: false
-  category: main
   build: h0c2f820_0
   arch: x86_64
   subdir: osx-64
@@ -7323,17 +6929,16 @@ package:
   license_family: MIT
   size: 396101
   timestamp: 1693539567563
-- name: libuv
+- platform: osx-arm64
+  name: libuv
   version: 1.46.0
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.46.0-hb547adb_0.conda
   hash:
     md5: 5f1d535f82e8210ac80d191610b92325
     sha256: f2fe8e22a99f91761c16dc7b00408bff0f5c30d4cccc6ea562db00a4041c5579
-  optional: false
-  category: main
   build: hb547adb_0
   arch: aarch64
   subdir: osx-arm64
@@ -7342,20 +6947,19 @@ package:
   license_family: MIT
   size: 402723
   timestamp: 1693539587068
-- name: libuv
+- platform: win-64
+  name: libuv
   version: 1.44.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libuv-1.44.2-hcfcfb64_1.conda
   hash:
     md5: db1816a489a1b69dd1fd93e523cf026a
     sha256: d602dc13e1b0a955aa5f14772a3b8dc5ee72a4f68a4d63adb82a1ee105ffe4b2
-  optional: false
-  category: main
   build: hcfcfb64_1
   arch: x86_64
   subdir: win-64
@@ -7364,22 +6968,21 @@ package:
   license_family: MIT
   size: 285183
   timestamp: 1690371821520
-- name: libxml2
+- platform: linux-64
+  name: libxml2
   version: 2.11.5
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    icu: '>=73.2,<74.0a0'
-    libgcc-ng: '>=12'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.5-h232c23b_1.conda
   hash:
     md5: f3858448893839820d4bcfb14ad3ecdf
     sha256: 1b3cb6864de1a558ea5fb144c780121d52507837d15df0600491d8ed92cff90c
-  optional: false
-  category: main
   build: h232c23b_1
   arch: x86_64
   subdir: linux-64
@@ -7388,21 +6991,20 @@ package:
   license_family: MIT
   size: 705542
   timestamp: 1692960341690
-- name: libxml2
+- platform: osx-64
+  name: libxml2
   version: 2.11.5
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    icu: '>=73.2,<74.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.5-h3346baf_1.conda
   hash:
     md5: 7584dee6af7de378aed0ae49aebedb8a
     sha256: d901fab32e57a43c44e630fb1c4d0a163d23b109eecd6c68b9ee371800760bca
-  optional: false
-  category: main
   build: h3346baf_1
   arch: x86_64
   subdir: osx-64
@@ -7411,21 +7013,20 @@ package:
   license_family: MIT
   size: 623399
   timestamp: 1692960844532
-- name: libxml2
+- platform: osx-arm64
+  name: libxml2
   version: 2.11.5
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    icu: '>=73.2,<74.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.5-h25269f3_1.conda
   hash:
     md5: 627b5d1377536b5b632ba53cd1455555
     sha256: 8291549b87aca48e9cd4aec124af01b5037acd16f8ad14083d7af23c8bb6bebe
-  optional: false
-  category: main
   build: h25269f3_1
   arch: aarch64
   subdir: osx-arm64
@@ -7434,22 +7035,21 @@ package:
   license_family: MIT
   size: 614831
   timestamp: 1692960705224
-- name: libxml2
+- platform: win-64
+  name: libxml2
   version: 2.11.5
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
   hash:
     md5: 27974f880a010b1441093d9f737a949f
     sha256: ad3b5a510be2c5f9fe90b2c20e10adb135717304bcb3a197f256feb48d713d99
-  optional: false
-  category: main
   build: hc3477c8_1
   arch: x86_64
   subdir: win-64
@@ -7458,18 +7058,17 @@ package:
   license_family: MIT
   size: 1600640
   timestamp: 1692960798126
-- name: libzlib
+- platform: linux-64
+  name: libzlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
   hash:
     md5: f36c115f1ee199da648e0597ec2047ad
     sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
-  optional: false
-  category: main
   build: hd590300_5
   arch: x86_64
   subdir: linux-64
@@ -7480,17 +7079,16 @@ package:
   license_family: Other
   size: 61588
   timestamp: 1686575217516
-- name: libzlib
+- platform: osx-64
+  name: libzlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
   hash:
     md5: 4a3ad23f6e16f99c04e166767193d700
     sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
-  optional: false
-  category: main
   build: h8a1eda9_5
   arch: x86_64
   subdir: osx-64
@@ -7501,17 +7099,16 @@ package:
   license_family: Other
   size: 59404
   timestamp: 1686575566695
-- name: libzlib
+- platform: osx-arm64
+  name: libzlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
   hash:
     md5: 1a47f5236db2e06a320ffa0392f81bd8
     sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
-  optional: false
-  category: main
   build: h53f4e23_5
   arch: aarch64
   subdir: osx-arm64
@@ -7522,20 +7119,19 @@ package:
   license_family: Other
   size: 48102
   timestamp: 1686575426584
-- name: libzlib
+- platform: win-64
+  name: libzlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
   hash:
     md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
     sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
-  optional: false
-  category: main
   build: hcfcfb64_5
   arch: x86_64
   subdir: win-64
@@ -7546,17 +7142,16 @@ package:
   license_family: Other
   size: 55800
   timestamp: 1686575452215
-- name: llvm-openmp
+- platform: osx-64
+  name: llvm-openmp
   version: 17.0.2
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.2-hff08bdf_0.conda
   hash:
     md5: fe9a7b6676832e214e7b135b611592bc
     sha256: c251012a7504b67907bd22efa1df13ac88a4f3bce2d83850665b465125b43e18
-  optional: false
-  category: main
   build: hff08bdf_0
   arch: x86_64
   subdir: osx-64
@@ -7567,17 +7162,16 @@ package:
   license_family: APACHE
   size: 304623
   timestamp: 1696555642332
-- name: llvm-openmp
+- platform: osx-arm64
+  name: llvm-openmp
   version: 17.0.2
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.2-h1c12783_0.conda
   hash:
     md5: cc2d5e802daf2135a1eaa5983ee47827
     sha256: 4bbe783de0fafa9e05b0af28c8afbfde5b9525acd65e8f387562c5e80f5ec4bd
-  optional: false
-  category: main
   build: h1c12783_0
   arch: aarch64
   subdir: osx-arm64
@@ -7588,21 +7182,20 @@ package:
   license_family: APACHE
   size: 275849
   timestamp: 1696555855843
-- name: llvm-tools
+- platform: osx-64
+  name: llvm-tools
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libllvm15: ==15.0.7 he4b1e75_3
-    libxml2: '>=2.11.4,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
+  - libllvm15 ==15.0.7 he4b1e75_3
+  - libxml2 >=2.11.4,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-15.0.7-he4b1e75_3.conda
   hash:
     md5: 7177e9334a86af1b1581f14607ced61c
     sha256: 93bf3db0bb0db82d91be7226374c239e88d885b850ab9791ec6755c63ffecc82
-  optional: false
-  category: main
   build: he4b1e75_3
   arch: x86_64
   subdir: osx-64
@@ -7616,20 +7209,19 @@ package:
   license_family: Apache
   size: 11380889
   timestamp: 1690534088911
-- name: llvm-tools
+- platform: osx-arm64
+  name: llvm-tools
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libllvm15: ==15.0.7 h504e6bf_3
-    libxml2: '>=2.11.4,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libllvm15 ==15.0.7 h504e6bf_3
+  - libxml2 >=2.11.4,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-15.0.7-h504e6bf_3.conda
   hash:
     md5: 56a351b4eba7ce574fa2702770e74252
     sha256: 102c7da379f508e55b60a24625a3174b85d7e716ead452c1d7c88f84174b7a99
-  optional: false
-  category: main
   build: h504e6bf_3
   arch: aarch64
   subdir: osx-arm64
@@ -7643,19 +7235,18 @@ package:
   license_family: Apache
   size: 10034129
   timestamp: 1690530165545
-- name: lz4-c
+- platform: linux-64
+  name: lz4-c
   version: 1.9.4
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
   hash:
     md5: 318b08df404f9c9be5712aaa5a6f0bb0
     sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
-  optional: false
-  category: main
   build: hcb278e6_0
   arch: x86_64
   subdir: linux-64
@@ -7664,18 +7255,17 @@ package:
   license_family: BSD
   size: 143402
   timestamp: 1674727076728
-- name: lz4-c
+- platform: osx-64
+  name: lz4-c
   version: 1.9.4
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=14.0.6'
+  - libcxx >=14.0.6
   url: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
   hash:
     md5: aa04f7143228308662696ac24023f991
     sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
-  optional: false
-  category: main
   build: hf0c8a7f_0
   arch: x86_64
   subdir: osx-64
@@ -7684,18 +7274,17 @@ package:
   license_family: BSD
   size: 156415
   timestamp: 1674727335352
-- name: lz4-c
+- platform: osx-arm64
+  name: lz4-c
   version: 1.9.4
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=14.0.6'
+  - libcxx >=14.0.6
   url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
   hash:
     md5: 45505bec548634f7d05e02fb25262cb9
     sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
-  optional: false
-  category: main
   build: hb7217d7_0
   arch: aarch64
   subdir: osx-arm64
@@ -7704,20 +7293,19 @@ package:
   license_family: BSD
   size: 141188
   timestamp: 1674727268278
-- name: lz4-c
+- platform: win-64
+  name: lz4-c
   version: 1.9.4
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
   hash:
     md5: e34720eb20a33fc3bfb8451dd837ab7a
     sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
-  optional: false
-  category: main
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
@@ -7726,19 +7314,18 @@ package:
   license_family: BSD
   size: 134235
   timestamp: 1674728465431
-- name: m2w64-gcc-libgfortran
+- platform: win-64
+  name: m2w64-gcc-libgfortran
   version: 5.3.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    m2w64-gcc-libs-core: '*'
-    msys2-conda-epoch: ==20160418
+  - m2w64-gcc-libs-core *
+  - msys2-conda-epoch ==20160418
   url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
   hash:
     md5: 066552ac6b907ec6d72c0ddab29050dc
     sha256: 9de95a7996d5366ae0808eef2acbc63f9b11b874aa42375f55379e6715845dc6
-  optional: false
-  category: main
   build: '6'
   arch: x86_64
   subdir: win-64
@@ -7746,22 +7333,21 @@ package:
   license: GPL, LGPL, FDL, custom
   size: 350687
   timestamp: 1608163451316
-- name: m2w64-gcc-libs
+- platform: win-64
+  name: m2w64-gcc-libs
   version: 5.3.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    m2w64-gcc-libgfortran: '*'
-    m2w64-gcc-libs-core: '*'
-    m2w64-gmp: '*'
-    m2w64-libwinpthread-git: '*'
-    msys2-conda-epoch: ==20160418
+  - m2w64-gcc-libgfortran *
+  - m2w64-gcc-libs-core *
+  - m2w64-gmp *
+  - m2w64-libwinpthread-git *
+  - msys2-conda-epoch ==20160418
   url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
   hash:
     md5: fe759119b8b3bfa720b8762c6fdc35de
     sha256: 3bd1ab02b7c89a5b153a17be03b36d833f1517ff2a6a77ead7c4a808b88196aa
-  optional: false
-  category: main
   build: '7'
   arch: x86_64
   subdir: win-64
@@ -7769,20 +7355,19 @@ package:
   license: GPL3+, partial:GCCRLE, partial:LGPL2+
   size: 532390
   timestamp: 1608163512830
-- name: m2w64-gcc-libs-core
+- platform: win-64
+  name: m2w64-gcc-libs-core
   version: 5.3.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    m2w64-gmp: '*'
-    m2w64-libwinpthread-git: '*'
-    msys2-conda-epoch: ==20160418
+  - m2w64-gmp *
+  - m2w64-libwinpthread-git *
+  - msys2-conda-epoch ==20160418
   url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
   hash:
     md5: 4289d80fb4d272f1f3b56cfe87ac90bd
     sha256: 58afdfe859ed2e9a9b1cc06bc408720cb2c3a6a132e59d4805b090d7574f4ee0
-  optional: false
-  category: main
   build: '7'
   arch: x86_64
   subdir: win-64
@@ -7790,18 +7375,17 @@ package:
   license: GPL3+, partial:GCCRLE, partial:LGPL2+
   size: 219240
   timestamp: 1608163481341
-- name: m2w64-gmp
+- platform: win-64
+  name: m2w64-gmp
   version: 6.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    msys2-conda-epoch: ==20160418
+  - msys2-conda-epoch ==20160418
   url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
   hash:
     md5: 53a1c73e1e3d185516d7e3af177596d9
     sha256: 7e3cd95f554660de45f8323fca359e904e8d203efaf07a4d311e46d611481ed1
-  optional: false
-  category: main
   build: '2'
   arch: x86_64
   subdir: win-64
@@ -7809,18 +7393,17 @@ package:
   license: LGPL3
   size: 743501
   timestamp: 1608163782057
-- name: m2w64-libwinpthread-git
+- platform: win-64
+  name: m2w64-libwinpthread-git
   version: 5.0.0.4634.697f757
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    msys2-conda-epoch: ==20160418
+  - msys2-conda-epoch ==20160418
   url: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
   hash:
     md5: 774130a326dee16f1ceb05cc687ee4f0
     sha256: f63a09b2cae7defae0480f1740015d6235f1861afa6fe2e2d3e10bd0d1314ee0
-  optional: false
-  category: main
   build: '2'
   arch: x86_64
   subdir: win-64
@@ -7828,19 +7411,18 @@ package:
   license: MIT, BSD
   size: 31928
   timestamp: 1608166099896
-- name: markdown-it-py
+- platform: linux-64
+  name: markdown-it-py
   version: 3.0.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    mdurl: '>=0.1,<1'
-    python: '>=3.8'
+  - mdurl >=0.1,<1
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: 93a8e71256479c62074356ef6ebf501b
     sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -7850,19 +7432,18 @@ package:
   noarch: python
   size: 64356
   timestamp: 1686175179621
-- name: markdown-it-py
+- platform: osx-64
+  name: markdown-it-py
   version: 3.0.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    mdurl: '>=0.1,<1'
-    python: '>=3.8'
+  - mdurl >=0.1,<1
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: 93a8e71256479c62074356ef6ebf501b
     sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -7872,19 +7453,18 @@ package:
   noarch: python
   size: 64356
   timestamp: 1686175179621
-- name: markdown-it-py
+- platform: osx-arm64
+  name: markdown-it-py
   version: 3.0.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    mdurl: '>=0.1,<1'
-    python: '>=3.8'
+  - mdurl >=0.1,<1
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: 93a8e71256479c62074356ef6ebf501b
     sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -7894,19 +7474,18 @@ package:
   noarch: python
   size: 64356
   timestamp: 1686175179621
-- name: markdown-it-py
+- platform: win-64
+  name: markdown-it-py
   version: 3.0.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    mdurl: '>=0.1,<1'
-    python: '>=3.8'
+  - mdurl >=0.1,<1
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: 93a8e71256479c62074356ef6ebf501b
     sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -7916,21 +7495,20 @@ package:
   noarch: python
   size: 64356
   timestamp: 1686175179621
-- name: maturin
+- platform: linux-64
+  name: maturin
   version: 0.14.17
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    tomli: '>=1.1.0'
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli >=1.1.0
   url: https://conda.anaconda.org/conda-forge/linux-64/maturin-0.14.17-py311h46250e7_1.conda
   hash:
     md5: bffeab02e3f3b01122bf48fbc463e2a6
     sha256: 9a408d448521ec66e413e2d07fa0455c7b84ee8c19a04092f0a0d1a5804ebe10
-  optional: false
-  category: main
   build: py311h46250e7_1
   arch: x86_64
   subdir: linux-64
@@ -7939,20 +7517,19 @@ package:
   license_family: MIT
   size: 7051949
   timestamp: 1695991411795
-- name: maturin
+- platform: osx-64
+  name: maturin
   version: 0.14.17
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    tomli: '>=1.1.0'
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli >=1.1.0
   url: https://conda.anaconda.org/conda-forge/osx-64/maturin-0.14.17-py311h5b17fdd_1.conda
   hash:
     md5: 951219fb757f9a441c778e3be0caa610
     sha256: befcdd1dd7d43f2e4076e0f88094377165152421496ec625a7187628f388b3ec
-  optional: false
-  category: main
   build: py311h5b17fdd_1
   arch: x86_64
   subdir: osx-64
@@ -7961,20 +7538,19 @@ package:
   license_family: MIT
   size: 5465974
   timestamp: 1695991988214
-- name: maturin
+- platform: osx-arm64
+  name: maturin
   version: 0.14.17
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.11,<3.12.0a0 *_cpython'
-    python_abi: 3.11.* *_cp311
-    tomli: '>=1.1.0'
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tomli >=1.1.0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-0.14.17-py311h0563b04_1.conda
   hash:
     md5: 7a107334132e3ae17a010ecc0fd47352
     sha256: f5cb528ece8bcdb7ae07327a4eafa6b2e877a4a5a45afd40308004e444a8d684
-  optional: false
-  category: main
   build: py311h0563b04_1
   arch: aarch64
   subdir: osx-arm64
@@ -7983,22 +7559,21 @@ package:
   license_family: MIT
   size: 5394957
   timestamp: 1695992435269
-- name: maturin
+- platform: win-64
+  name: maturin
   version: 0.14.17
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    m2w64-gcc-libs: '*'
-    m2w64-gcc-libs-core: '*'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    tomli: '>=1.1.0'
+  - m2w64-gcc-libs *
+  - m2w64-gcc-libs-core *
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli >=1.1.0
   url: https://conda.anaconda.org/conda-forge/win-64/maturin-0.14.17-py311h9a9e57f_1.conda
   hash:
     md5: 290aae658b0aa0894f8066403ba7997b
     sha256: db786d65b3f603c42a9a44311358016f7edadb9cc8af6e9842c75a4a0dcb83f1
-  optional: false
-  category: main
   build: py311h9a9e57f_1
   arch: x86_64
   subdir: win-64
@@ -8007,18 +7582,17 @@ package:
   license_family: MIT
   size: 5146488
   timestamp: 1695992858881
-- name: mdurl
+- platform: linux-64
+  name: mdurl
   version: 0.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.6'
+  - python >=3.6
   url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: f8dab71fdc13b1bf29a01248b156d268
     sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -8028,18 +7602,17 @@ package:
   noarch: python
   size: 13707
   timestamp: 1639515992326
-- name: mdurl
+- platform: osx-64
+  name: mdurl
   version: 0.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.6'
+  - python >=3.6
   url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: f8dab71fdc13b1bf29a01248b156d268
     sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -8049,18 +7622,17 @@ package:
   noarch: python
   size: 13707
   timestamp: 1639515992326
-- name: mdurl
+- platform: osx-arm64
+  name: mdurl
   version: 0.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.6'
+  - python >=3.6
   url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: f8dab71fdc13b1bf29a01248b156d268
     sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -8070,18 +7642,17 @@ package:
   noarch: python
   size: 13707
   timestamp: 1639515992326
-- name: mdurl
+- platform: win-64
+  name: mdurl
   version: 0.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.6'
+  - python >=3.6
   url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: f8dab71fdc13b1bf29a01248b156d268
     sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -8091,19 +7662,18 @@ package:
   noarch: python
   size: 13707
   timestamp: 1639515992326
-- name: mkl
+- platform: win-64
+  name: mkl
   version: 2022.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    intel-openmp: '*'
-    tbb: 2021.*
+  - intel-openmp *
+  - tbb 2021.*
   url: https://conda.anaconda.org/conda-forge/win-64/mkl-2022.1.0-h6a75c08_874.tar.bz2
   hash:
     md5: 2ff89a7337a9636029b4db9466e9f8e3
     sha256: b130d13dba6a798cbcce8f19c52e9765b75b8668d2f8f95ba8210c63b6fa84eb
-  optional: false
-  category: main
   build: h6a75c08_874
   arch: x86_64
   subdir: win-64
@@ -8112,18 +7682,17 @@ package:
   license_family: Proprietary
   size: 191569511
   timestamp: 1652946602922
-- name: more-itertools
+- platform: linux-64
+  name: more-itertools
   version: 10.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
     sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -8133,18 +7702,17 @@ package:
   noarch: python
   size: 53654
   timestamp: 1691087125209
-- name: more-itertools
+- platform: osx-64
+  name: more-itertools
   version: 10.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
     sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -8154,18 +7722,17 @@ package:
   noarch: python
   size: 53654
   timestamp: 1691087125209
-- name: more-itertools
+- platform: osx-arm64
+  name: more-itertools
   version: 10.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
     sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -8175,18 +7742,17 @@ package:
   noarch: python
   size: 53654
   timestamp: 1691087125209
-- name: more-itertools
+- platform: win-64
+  name: more-itertools
   version: 10.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
     sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -8196,41 +7762,39 @@ package:
   noarch: python
   size: 53654
   timestamp: 1691087125209
-- name: msys2-conda-epoch
+- platform: win-64
+  name: msys2-conda-epoch
   version: '20160418'
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
   hash:
     md5: b0309b72560df66f71a9d5e34a5efdfa
     sha256: 99358d58d778abee4dca82ad29fb58058571f19b0f86138363c260049d4ac7f1
-  optional: false
-  category: main
   build: '1'
   arch: x86_64
   subdir: win-64
   build_number: 1
   size: 3227
   timestamp: 1608166968312
-- name: mypy
+- platform: linux-64
+  name: mypy
   version: 1.4.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    mypy_extensions: '>=0.4.3'
-    psutil: '>=4.0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    tomli: '>=1.1.0'
-    typing_extensions: '>=3.10'
+  - libgcc-ng >=12
+  - mypy_extensions >=0.4.3
+  - psutil >=4.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli >=1.1.0
+  - typing_extensions >=3.10
   url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.4.1-py311h459d7ec_0.conda
   hash:
     md5: 70099a5eee9a60f4bd52e388b77b3378
     sha256: 235514c25d96fe726403893509c573aa1071fba49a57dcfa88ae37d87ba317c8
-  optional: false
-  category: main
   build: py311h459d7ec_0
   arch: x86_64
   subdir: linux-64
@@ -8239,23 +7803,22 @@ package:
   license_family: MIT
   size: 15268473
   timestamp: 1687821217638
-- name: mypy
+- platform: osx-64
+  name: mypy
   version: 1.4.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    mypy_extensions: '>=0.4.3'
-    psutil: '>=4.0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    tomli: '>=1.1.0'
-    typing_extensions: '>=3.10'
+  - mypy_extensions >=0.4.3
+  - psutil >=4.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli >=1.1.0
+  - typing_extensions >=3.10
   url: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.4.1-py311h2725bcf_0.conda
   hash:
     md5: a29b75d2d8ddd4a6208ba8e6548e661f
     sha256: cd4c55fa0ad4ae2cd2ace3f9f4c3b5680c640cef4eb837ab81967a9dc052dba6
-  optional: false
-  category: main
   build: py311h2725bcf_0
   arch: x86_64
   subdir: osx-64
@@ -8264,23 +7827,22 @@ package:
   license_family: MIT
   size: 9803193
   timestamp: 1687821896289
-- name: mypy
+- platform: osx-arm64
+  name: mypy
   version: 1.4.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    mypy_extensions: '>=0.4.3'
-    psutil: '>=4.0'
-    python: '>=3.11,<3.12.0a0 *_cpython'
-    python_abi: 3.11.* *_cp311
-    tomli: '>=1.1.0'
-    typing_extensions: '>=3.10'
+  - mypy_extensions >=0.4.3
+  - psutil >=4.0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tomli >=1.1.0
+  - typing_extensions >=3.10
   url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.4.1-py311heffc1b2_0.conda
   hash:
     md5: 388c8df4d57c047bec3f17bd274843e2
     sha256: 534eb1914c32392372c236740868bf72f769563315c3df54deef145a2924ebfa
-  optional: false
-  category: main
   build: py311heffc1b2_0
   arch: aarch64
   subdir: osx-arm64
@@ -8289,26 +7851,25 @@ package:
   license_family: MIT
   size: 9520844
   timestamp: 1687822156007
-- name: mypy
+- platform: win-64
+  name: mypy
   version: 1.4.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    mypy_extensions: '>=0.4.3'
-    psutil: '>=4.0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    tomli: '>=1.1.0'
-    typing_extensions: '>=3.10'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - mypy_extensions >=0.4.3
+  - psutil >=4.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli >=1.1.0
+  - typing_extensions >=3.10
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.4.1-py311ha68e1ae_0.conda
   hash:
     md5: 6d8c5eed03be56e4ceedee017d5edb83
     sha256: 821f051883edbee804c3f1be27fa3e0fe652d0e686dca5c98bc3d031f5a919ad
-  optional: false
-  category: main
   build: py311ha68e1ae_0
   arch: x86_64
   subdir: win-64
@@ -8317,18 +7878,17 @@ package:
   license_family: MIT
   size: 7927695
   timestamp: 1687821196175
-- name: mypy_extensions
+- platform: linux-64
+  name: mypy_extensions
   version: 1.0.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.5'
+  - python >=3.5
   url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
   hash:
     md5: 4eccaeba205f0aed9ac3a9ea58568ca3
     sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: x86_64
   subdir: linux-64
@@ -8338,18 +7898,17 @@ package:
   noarch: python
   size: 10492
   timestamp: 1675543414256
-- name: mypy_extensions
+- platform: osx-64
+  name: mypy_extensions
   version: 1.0.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.5'
+  - python >=3.5
   url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
   hash:
     md5: 4eccaeba205f0aed9ac3a9ea58568ca3
     sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: x86_64
   subdir: osx-64
@@ -8359,18 +7918,17 @@ package:
   noarch: python
   size: 10492
   timestamp: 1675543414256
-- name: mypy_extensions
+- platform: osx-arm64
+  name: mypy_extensions
   version: 1.0.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.5'
+  - python >=3.5
   url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
   hash:
     md5: 4eccaeba205f0aed9ac3a9ea58568ca3
     sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: aarch64
   subdir: osx-arm64
@@ -8380,18 +7938,17 @@ package:
   noarch: python
   size: 10492
   timestamp: 1675543414256
-- name: mypy_extensions
+- platform: win-64
+  name: mypy_extensions
   version: 1.0.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.5'
+  - python >=3.5
   url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
   hash:
     md5: 4eccaeba205f0aed9ac3a9ea58568ca3
     sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: x86_64
   subdir: win-64
@@ -8401,18 +7958,17 @@ package:
   noarch: python
   size: 10492
   timestamp: 1675543414256
-- name: ncurses
+- platform: linux-64
+  name: ncurses
   version: '6.4'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
   hash:
     md5: 681105bccc2a3f7f1a837d47d39c9179
     sha256: ccf61e61d58a8a7b2d66822d5568e2dc9387883dd9b2da61e1d787ece4c4979a
-  optional: false
-  category: main
   build: hcb278e6_0
   arch: x86_64
   subdir: linux-64
@@ -8420,17 +7976,16 @@ package:
   license: X11 AND BSD-3-Clause
   size: 880967
   timestamp: 1686076725450
-- name: ncurses
+- platform: osx-64
+  name: ncurses
   version: '6.4'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-hf0c8a7f_0.conda
   hash:
     md5: c3dbae2411164d9b02c69090a9a91857
     sha256: 7841b1fce1ffb0bfb038f9687b92f04d64acab1f7cb96431972386ea98c7b2fd
-  optional: false
-  category: main
   build: hf0c8a7f_0
   arch: x86_64
   subdir: osx-64
@@ -8438,17 +7993,16 @@ package:
   license: X11 AND BSD-3-Clause
   size: 828118
   timestamp: 1686077056765
-- name: ncurses
+- platform: osx-arm64
+  name: ncurses
   version: '6.4'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
   hash:
     md5: 318337fb9d0c53ba635efb7888242373
     sha256: 017e230a1f912e15005d4c4f3d387119190b53240f9ae0ba8a319dd958901780
-  optional: false
-  category: main
   build: h7ea286d_0
   arch: aarch64
   subdir: osx-arm64
@@ -8456,19 +8010,18 @@ package:
   license: X11 AND BSD-3-Clause
   size: 799196
   timestamp: 1686077139703
-- name: ninja
+- platform: linux-64
+  name: ninja
   version: 1.11.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.1-h924138e_0.conda
   hash:
     md5: 73a4953a2d9c115bdc10ff30a52f675f
     sha256: b555247ac8859b4ff311e3d708a0640f1bfe9fae7125c485b444072474a84c41
-  optional: false
-  category: main
   build: h924138e_0
   arch: x86_64
   subdir: linux-64
@@ -8477,18 +8030,17 @@ package:
   license_family: Apache
   size: 2251263
   timestamp: 1676837602636
-- name: ninja
+- platform: osx-64
+  name: ninja
   version: 1.11.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=14.0.6'
+  - libcxx >=14.0.6
   url: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.1-hb8565cd_0.conda
   hash:
     md5: 49ad513efe39447aa51affd47e3aa68f
     sha256: 6f738d9a26fa275317b95b2b96832daab9059ef64af9a338f904a3cb684ae426
-  optional: false
-  category: main
   build: hb8565cd_0
   arch: x86_64
   subdir: osx-64
@@ -8497,18 +8049,17 @@ package:
   license_family: Apache
   size: 121284
   timestamp: 1676837793132
-- name: ninja
+- platform: osx-arm64
+  name: ninja
   version: 1.11.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=14.0.6'
+  - libcxx >=14.0.6
   url: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.1-hffc8910_0.conda
   hash:
     md5: fdecec4002f41cf6ea1eea5b52947ee0
     sha256: a594e90b0ed8202c280fff4a008f6a355d0db54a62b17067dc4a950370ddffc0
-  optional: false
-  category: main
   build: hffc8910_0
   arch: aarch64
   subdir: osx-arm64
@@ -8517,24 +8068,44 @@ package:
   license_family: Apache
   size: 107047
   timestamp: 1676837935565
-- name: numpy
-  version: 1.26.0
+- platform: win-64
+  name: ninja
+  version: 1.11.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    liblapack: '>=3.9.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/ninja-1.11.1-h91493d7_0.conda
+  hash:
+    md5: 44a99ef26178ea98626ff8e027702795
+    sha256: 0ffb1912768af8354a930f482368ef170bf3d8217db328dfea1c8b09772c8c71
+  build: h91493d7_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 279200
+  timestamp: 1676838681615
+- platform: linux-64
+  name: numpy
+  version: 1.26.0
+  category: main
+  manager: conda
+  dependencies:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.0-py311h64a7726_0.conda
   hash:
     md5: bf16a9f625126e378302f08e7ed67517
     sha256: 0aab5cef67cc2a1cd584f6e9cc6f2065c7a28c142d7defcb8096e8f719d9b3bf
-  optional: false
-  category: main
   build: py311h64a7726_0
   arch: x86_64
   subdir: linux-64
@@ -8545,23 +8116,22 @@ package:
   license_family: BSD
   size: 8039946
   timestamp: 1694920380273
-- name: numpy
+- platform: osx-64
+  name: numpy
   version: 1.26.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libcxx: '>=15.0.7'
-    liblapack: '>=3.9.0,<4.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.0-py311hc44ba51_0.conda
   hash:
     md5: f95605c5b73f5f6a0f5f1b0aabfc2f39
     sha256: 517cb22d5594fdb934523dd1951929961f686b5d994c684201acbf282433ec9b
-  optional: false
-  category: main
   build: py311hc44ba51_0
   arch: x86_64
   subdir: osx-64
@@ -8572,23 +8142,22 @@ package:
   license_family: BSD
   size: 7616817
   timestamp: 1694920728660
-- name: numpy
+- platform: osx-arm64
+  name: numpy
   version: 1.26.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libcxx: '>=15.0.7'
-    liblapack: '>=3.9.0,<4.0a0'
-    python: '>=3.11,<3.12.0a0 *_cpython'
-    python_abi: 3.11.* *_cp311
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.0-py311hb8f3215_0.conda
   hash:
     md5: 97f8632bf2ad5c179ff68fc90c71c2ae
     sha256: fca5ee1363f22a160c97e92d6400d4636f4b05987b08085e4f79fb6efb75fd0a
-  optional: false
-  category: main
   build: py311hb8f3215_0
   arch: aarch64
   subdir: osx-arm64
@@ -8599,25 +8168,24 @@ package:
   license_family: BSD
   size: 6780798
   timestamp: 1694920700859
-- name: numpy
+- platform: win-64
+  name: numpy
   version: 1.26.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    liblapack: '>=3.9.0,<4.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.0-py311h0b4df5a_0.conda
   hash:
     md5: a65e57fff208fd1d0f632e0afa8985d4
     sha256: 3da6bcf524a4418d7d0dbc084c23c74e1f2fc4b19c34a5805f5e201e5d7fcd8f
-  optional: false
-  category: main
   build: py311h0b4df5a_0
   arch: x86_64
   subdir: win-64
@@ -8628,19 +8196,18 @@ package:
   license_family: BSD
   size: 7085715
   timestamp: 1694920741486
-- name: openssl
+- platform: linux-64
+  name: openssl
   version: 3.1.3
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    ca-certificates: '*'
-    libgcc-ng: '>=12'
+  - ca-certificates *
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.3-hd590300_0.conda
   hash:
     md5: 7bb88ce04c8deb9f7d763ae04a1da72f
     sha256: f4e35f506c7e8ab7dfdc47255b0d5aa8ce0c99028ae0affafd274333042c4f70
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -8651,18 +8218,17 @@ package:
   license_family: Apache
   size: 2642850
   timestamp: 1695158025027
-- name: openssl
+- platform: osx-64
+  name: openssl
   version: 3.1.3
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    ca-certificates: '*'
+  - ca-certificates *
   url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.1.3-h8a1eda9_0.conda
   hash:
     md5: 26f9b58f905547e658e9587f8e8cfe43
     sha256: 69731ce62d4b68e538af559747da53f837ae0bbca519b38f2eea28680eb9e8d1
-  optional: false
-  category: main
   build: h8a1eda9_0
   arch: x86_64
   subdir: osx-64
@@ -8673,18 +8239,17 @@ package:
   license_family: Apache
   size: 2329752
   timestamp: 1695158667922
-- name: openssl
+- platform: osx-arm64
+  name: openssl
   version: 3.1.3
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    ca-certificates: '*'
+  - ca-certificates *
   url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.1.3-h53f4e23_0.conda
   hash:
     md5: 40d01d3f39589f54b618ddd28a5a48cb
     sha256: d9af6208610d4985322b8eade79215f1ded6e2a2b41b0a885714b971a36a5bae
-  optional: false
-  category: main
   build: h53f4e23_0
   arch: aarch64
   subdir: osx-arm64
@@ -8695,21 +8260,20 @@ package:
   license_family: Apache
   size: 2225422
   timestamp: 1695158154709
-- name: openssl
+- platform: win-64
+  name: openssl
   version: 3.1.3
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ca-certificates: '*'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ca-certificates *
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.3-hcfcfb64_0.conda
   hash:
     md5: 16b2c80ad196f18acd31b588ef28cb9a
     sha256: 6a6b20aa2b9f32d94f8d2c352b7635b5e8b9fb7ffad823bf2ce88dc8ef61ffc8
-  optional: false
-  category: main
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
@@ -8720,24 +8284,23 @@ package:
   license_family: Apache
   size: 7427366
   timestamp: 1695218580613
-- name: orc
+- platform: linux-64
+  name: orc
   version: 1.9.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.23.4,<4.23.5.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.1.10,<2.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - libgcc-ng >=12
+  - libprotobuf >=4.23.4,<4.23.5.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.0-h52d3b3c_2.conda
   hash:
     md5: 6e1931d3d8512593f606aa08d9bd5192
     sha256: eedf0d27e6934f733496f70b636707a0c669b7349431d81b20eb9d93d6369fdb
-  optional: false
-  category: main
   build: h52d3b3c_2
   arch: x86_64
   subdir: linux-64
@@ -8746,24 +8309,23 @@ package:
   license_family: Apache
   size: 1023519
   timestamp: 1694341236679
-- name: orc
+- platform: osx-64
+  name: orc
   version: 1.9.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libprotobuf: '>=4.24.3,<4.24.4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.1.10,<2.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.0-hb037d9a_3.conda
   hash:
     md5: 6f7bea3c994dc0308d467ca3871ead7f
     sha256: b41971a64f3d12b5dd8024dc93382d30431c9fb9d42c47e96db65b528537e686
-  optional: false
-  category: main
   build: hb037d9a_3
   arch: x86_64
   subdir: osx-64
@@ -8772,23 +8334,22 @@ package:
   license_family: Apache
   size: 423379
   timestamp: 1696768921701
-- name: orc
+- platform: osx-arm64
+  name: orc
   version: 1.9.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
-    libprotobuf: '>=4.23.4,<4.23.5.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.1.10,<2.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - libcxx >=15.0.7
+  - libprotobuf >=4.23.4,<4.23.5.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.0-hbfdecac_2.conda
   hash:
     md5: 50090e3c6ce0570039cdf97650012307
     sha256: e7936497994b34f8e338917b22f8b5b0605341bf75cc53fdb64b52d6278c2b3e
-  optional: false
-  category: main
   build: hbfdecac_2
   arch: aarch64
   subdir: osx-arm64
@@ -8797,25 +8358,24 @@ package:
   license_family: Apache
   size: 441321
   timestamp: 1694341495980
-- name: orc
+- platform: win-64
+  name: orc
   version: 1.9.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libprotobuf: '>=4.23.4,<4.23.5.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.1.10,<2.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - libprotobuf >=4.23.4,<4.23.5.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.0-h8dbeef6_2.conda
   hash:
     md5: 1a77b6711c85b6d04eac70c028cc905a
     sha256: 682bc9ec7265ac3ebbb47cb2e31ef1f0014ea938a7559ae687071ae1a29aefcc
-  optional: false
-  category: main
   build: h8dbeef6_2
   arch: x86_64
   subdir: win-64
@@ -8824,18 +8384,17 @@ package:
   license_family: Apache
   size: 887526
   timestamp: 1694341479135
-- name: packaging
+- platform: linux-64
+  name: packaging
   version: '23.2'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
   hash:
     md5: 79002079284aa895f883c6b7f3f88fd6
     sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -8845,18 +8404,17 @@ package:
   noarch: python
   size: 49452
   timestamp: 1696202521121
-- name: packaging
+- platform: osx-64
+  name: packaging
   version: '23.2'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
   hash:
     md5: 79002079284aa895f883c6b7f3f88fd6
     sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -8866,18 +8424,17 @@ package:
   noarch: python
   size: 49452
   timestamp: 1696202521121
-- name: packaging
+- platform: osx-arm64
+  name: packaging
   version: '23.2'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
   hash:
     md5: 79002079284aa895f883c6b7f3f88fd6
     sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -8887,18 +8444,17 @@ package:
   noarch: python
   size: 49452
   timestamp: 1696202521121
-- name: packaging
+- platform: win-64
+  name: packaging
   version: '23.2'
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
   hash:
     md5: 79002079284aa895f883c6b7f3f88fd6
     sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -8908,19 +8464,18 @@ package:
   noarch: python
   size: 49452
   timestamp: 1696202521121
-- name: patchelf
+- platform: linux-64
+  name: patchelf
   version: 0.17.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-    libstdcxx-ng: '>=7.5.0'
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
   hash:
     md5: ba76a6a448819560b5f8b08a9c74f415
     sha256: eb355ac225be2f698e19dba4dcab7cb0748225677a9799e9cc8e4cadc3cb738f
-  optional: false
-  category: main
   build: h58526e2_0
   arch: x86_64
   subdir: linux-64
@@ -8929,18 +8484,17 @@ package:
   license_family: GPL
   size: 94048
   timestamp: 1673473024463
-- name: pathspec
+- platform: linux-64
+  name: pathspec
   version: 0.11.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
   hash:
     md5: e41debb259e68490e3ab81e46b639ab6
     sha256: 7bcfa6d86359d45572ba9ccaeaedc04b0452e2654fe44b6fe378d0d37b8745e1
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -8950,18 +8504,17 @@ package:
   noarch: python
   size: 38649
   timestamp: 1690598108100
-- name: pathspec
+- platform: osx-64
+  name: pathspec
   version: 0.11.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
   hash:
     md5: e41debb259e68490e3ab81e46b639ab6
     sha256: 7bcfa6d86359d45572ba9ccaeaedc04b0452e2654fe44b6fe378d0d37b8745e1
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -8971,18 +8524,17 @@ package:
   noarch: python
   size: 38649
   timestamp: 1690598108100
-- name: pathspec
+- platform: osx-arm64
+  name: pathspec
   version: 0.11.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
   hash:
     md5: e41debb259e68490e3ab81e46b639ab6
     sha256: 7bcfa6d86359d45572ba9ccaeaedc04b0452e2654fe44b6fe378d0d37b8745e1
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -8992,18 +8544,17 @@ package:
   noarch: python
   size: 38649
   timestamp: 1690598108100
-- name: pathspec
+- platform: win-64
+  name: pathspec
   version: 0.11.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
   hash:
     md5: e41debb259e68490e3ab81e46b639ab6
     sha256: 7bcfa6d86359d45572ba9ccaeaedc04b0452e2654fe44b6fe378d0d37b8745e1
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -9013,20 +8564,19 @@ package:
   noarch: python
   size: 38649
   timestamp: 1690598108100
-- name: pip
+- platform: linux-64
+  name: pip
   version: 23.2.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
-    setuptools: '*'
-    wheel: '*'
+  - python >=3.7
+  - setuptools *
+  - wheel *
   url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
   hash:
     md5: e2783aa3f9235225eec92f9081c5b801
     sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -9036,20 +8586,19 @@ package:
   noarch: python
   size: 1386212
   timestamp: 1690024763393
-- name: pip
+- platform: osx-64
+  name: pip
   version: 23.2.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
-    setuptools: '*'
-    wheel: '*'
+  - python >=3.7
+  - setuptools *
+  - wheel *
   url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
   hash:
     md5: e2783aa3f9235225eec92f9081c5b801
     sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -9059,20 +8608,19 @@ package:
   noarch: python
   size: 1386212
   timestamp: 1690024763393
-- name: pip
+- platform: osx-arm64
+  name: pip
   version: 23.2.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    setuptools: '*'
-    wheel: '*'
+  - python >=3.7
+  - setuptools *
+  - wheel *
   url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
   hash:
     md5: e2783aa3f9235225eec92f9081c5b801
     sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -9082,20 +8630,19 @@ package:
   noarch: python
   size: 1386212
   timestamp: 1690024763393
-- name: pip
+- platform: win-64
+  name: pip
   version: 23.2.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
-    setuptools: '*'
-    wheel: '*'
+  - python >=3.7
+  - setuptools *
+  - wheel *
   url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
   hash:
     md5: e2783aa3f9235225eec92f9081c5b801
     sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -9105,19 +8652,18 @@ package:
   noarch: python
   size: 1386212
   timestamp: 1690024763393
-- name: platformdirs
+- platform: linux-64
+  name: platformdirs
   version: 3.11.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.3'
+  - python >=3.7
+  - typing-extensions >=4.6.3
   url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
   hash:
     md5: 8f567c0a74aa44cf732f15773b4083b0
     sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -9127,19 +8673,18 @@ package:
   noarch: python
   size: 19985
   timestamp: 1696272419779
-- name: platformdirs
+- platform: osx-64
+  name: platformdirs
   version: 3.11.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.3'
+  - python >=3.7
+  - typing-extensions >=4.6.3
   url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
   hash:
     md5: 8f567c0a74aa44cf732f15773b4083b0
     sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -9149,19 +8694,18 @@ package:
   noarch: python
   size: 19985
   timestamp: 1696272419779
-- name: platformdirs
+- platform: osx-arm64
+  name: platformdirs
   version: 3.11.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.3'
+  - python >=3.7
+  - typing-extensions >=4.6.3
   url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
   hash:
     md5: 8f567c0a74aa44cf732f15773b4083b0
     sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -9171,19 +8715,18 @@ package:
   noarch: python
   size: 19985
   timestamp: 1696272419779
-- name: platformdirs
+- platform: win-64
+  name: platformdirs
   version: 3.11.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.3'
+  - python >=3.7
+  - typing-extensions >=4.6.3
   url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
   hash:
     md5: 8f567c0a74aa44cf732f15773b4083b0
     sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -9193,18 +8736,17 @@ package:
   noarch: python
   size: 19985
   timestamp: 1696272419779
-- name: pluggy
+- platform: linux-64
+  name: pluggy
   version: 1.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
   hash:
     md5: 2390bd10bed1f3fdc7a537fb5a447d8d
     sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -9214,18 +8756,17 @@ package:
   noarch: python
   size: 22548
   timestamp: 1693086745921
-- name: pluggy
+- platform: osx-64
+  name: pluggy
   version: 1.3.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
   hash:
     md5: 2390bd10bed1f3fdc7a537fb5a447d8d
     sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -9235,18 +8776,17 @@ package:
   noarch: python
   size: 22548
   timestamp: 1693086745921
-- name: pluggy
+- platform: osx-arm64
+  name: pluggy
   version: 1.3.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
   hash:
     md5: 2390bd10bed1f3fdc7a537fb5a447d8d
     sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -9256,18 +8796,17 @@ package:
   noarch: python
   size: 22548
   timestamp: 1693086745921
-- name: pluggy
+- platform: win-64
+  name: pluggy
   version: 1.3.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
   hash:
     md5: 2390bd10bed1f3fdc7a537fb5a447d8d
     sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -9277,20 +8816,19 @@ package:
   noarch: python
   size: 22548
   timestamp: 1693086745921
-- name: psutil
+- platform: linux-64
+  name: psutil
   version: 5.9.5
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py311h459d7ec_1.conda
   hash:
     md5: 490d7fa8675afd1aa6f1b2332d156a45
     sha256: e92d2120fc4b98fe838b3d52d4907fae97808bdd504fb84aa33aea8c4be7bc61
-  optional: false
-  category: main
   build: py311h459d7ec_1
   arch: x86_64
   subdir: linux-64
@@ -9299,19 +8837,18 @@ package:
   license_family: BSD
   size: 498698
   timestamp: 1695367306421
-- name: psutil
+- platform: osx-64
+  name: psutil
   version: 5.9.5
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py311h2725bcf_1.conda
   hash:
     md5: 16221cd0488a32152a6b3f1a301ccf19
     sha256: 2eee900e0e5a103cff0159cdd81d401b67ccfb919be6cd868fc34c22dab981f1
-  optional: false
-  category: main
   build: py311h2725bcf_1
   arch: x86_64
   subdir: osx-64
@@ -9320,19 +8857,18 @@ package:
   license_family: BSD
   size: 506611
   timestamp: 1695367402674
-- name: psutil
+- platform: osx-arm64
+  name: psutil
   version: 5.9.5
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.11,<3.12.0a0 *_cpython'
-    python_abi: 3.11.* *_cp311
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py311heffc1b2_1.conda
   hash:
     md5: a40123b40642b8b08b3830a3f6bc7fd9
     sha256: a12a525d3bcaed04e0885b2bd00f4f626c80c19d7c0ae8bb7cf7121aefb39e52
-  optional: false
-  category: main
   build: py311heffc1b2_1
   arch: aarch64
   subdir: osx-arm64
@@ -9341,22 +8877,21 @@ package:
   license_family: BSD
   size: 506971
   timestamp: 1695367619126
-- name: psutil
+- platform: win-64
+  name: psutil
   version: 5.9.5
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py311ha68e1ae_1.conda
   hash:
     md5: f64b2d9577e753fea9662dae11339ac2
     sha256: e5c09eee9902e0c56d89f88210009b34d819d241ac5b7dde38266324a85fde51
-  optional: false
-  category: main
   build: py311ha68e1ae_1
   arch: x86_64
   subdir: win-64
@@ -9365,18 +8900,17 @@ package:
   license_family: BSD
   size: 516106
   timestamp: 1695367685028
-- name: pthreads-win32
+- platform: win-64
+  name: pthreads-win32
   version: 2.9.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: 14.*
+  - vc 14.*
   url: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
   hash:
     md5: e2da8758d7d51ff6aa78a14dfb9dbed4
     sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
-  optional: false
-  category: main
   build: hfa6e2cd_3
   arch: x86_64
   subdir: win-64
@@ -9384,24 +8918,23 @@ package:
   license: LGPL 2
   size: 144301
   timestamp: 1537755684331
-- name: pyarrow
+- platform: linux-64
+  name: pyarrow
   version: 10.0.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    gflags: '>=2.2.2,<2.3.0a0'
-    libarrow: ==10.0.1 hc3189b8_44_cpu
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.23.5,<2.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
+  - gflags >=2.2.2,<2.3.0a0
+  - libarrow ==10.0.1 hc3189b8_44_cpu
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-10.0.1-py311hdf9aeb4_44_cpu.conda
   hash:
     md5: 1771fbe64fecac19035246d4791525a3
     sha256: a7b4f55e57da79bf0e90f421f2078737a85c524a9f9b01c399da90eb3363ffef
-  optional: false
-  category: main
   build: py311hdf9aeb4_44_cpu
   arch: x86_64
   subdir: linux-64
@@ -9411,23 +8944,22 @@ package:
   license: Apache-2.0
   size: 3893289
   timestamp: 1696593004335
-- name: pyarrow
+- platform: osx-64
+  name: pyarrow
   version: 10.0.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    gflags: '>=2.2.2,<2.3.0a0'
-    libarrow: ==10.0.1 h962698a_46_cpu
-    libcxx: '>=14.0.6'
-    numpy: '>=1.23.5,<2.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
+  - gflags >=2.2.2,<2.3.0a0
+  - libarrow ==10.0.1 h962698a_46_cpu
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-10.0.1-py311h0d82e2d_46_cpu.conda
   hash:
     md5: 5fa12482a3f13be864867c902b1f7b35
     sha256: 6ade4e83f87813b1c9febf6813cc748e703cb9b6c1ad34f852978930b6e6fd09
-  optional: false
-  category: main
   build: py311h0d82e2d_46_cpu
   arch: x86_64
   subdir: osx-64
@@ -9438,23 +8970,22 @@ package:
   license_family: APACHE
   size: 3397752
   timestamp: 1696862420259
-- name: pyarrow
+- platform: osx-arm64
+  name: pyarrow
   version: 10.0.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    gflags: '>=2.2.2,<2.3.0a0'
-    libarrow: ==10.0.1 he713f65_44_cpu
-    libcxx: '>=14.0.6'
-    numpy: '>=1.23.5,<2.0a0'
-    python: '>=3.11,<3.12.0a0 *_cpython'
-    python_abi: 3.11.* *_cp311
+  - gflags >=2.2.2,<2.3.0a0
+  - libarrow ==10.0.1 he713f65_44_cpu
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-10.0.1-py311h1e679ab_44_cpu.conda
   hash:
     md5: 855ccb2ff15732410c8520c98d953560
     sha256: 2c27ff03385f7135010a87cd2bc71cbf56263b17f85d4675db96de4a6da548c4
-  optional: false
-  category: main
   build: py311h1e679ab_44_cpu
   arch: aarch64
   subdir: osx-arm64
@@ -9464,24 +8995,23 @@ package:
   license: Apache-2.0
   size: 3315686
   timestamp: 1696595673154
-- name: pyarrow
+- platform: win-64
+  name: pyarrow
   version: 10.0.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libarrow: ==10.0.1 h58a770d_44_cpu
-    numpy: '>=1.23.5,<2.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libarrow ==10.0.1 h58a770d_44_cpu
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-10.0.1-py311h6a6099b_44_cpu.conda
   hash:
     md5: 85b840d5bdcde185ab775d6d3f3933f5
     sha256: cd004b57449c8c255463754b665cdcd0def668fb001bceb046f44222b3b2718b
-  optional: false
-  category: main
   build: py311h6a6099b_44_cpu
   arch: x86_64
   subdir: win-64
@@ -9491,18 +9021,17 @@ package:
   license: Apache-2.0
   size: 2892382
   timestamp: 1696595180252
-- name: pygments
+- platform: linux-64
+  name: pygments
   version: 2.16.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
   hash:
     md5: 40e5cb18165466773619e5c963f00a7b
     sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -9512,18 +9041,17 @@ package:
   noarch: python
   size: 853439
   timestamp: 1691408777841
-- name: pygments
+- platform: osx-64
+  name: pygments
   version: 2.16.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
   hash:
     md5: 40e5cb18165466773619e5c963f00a7b
     sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -9533,18 +9061,17 @@ package:
   noarch: python
   size: 853439
   timestamp: 1691408777841
-- name: pygments
+- platform: osx-arm64
+  name: pygments
   version: 2.16.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
   hash:
     md5: 40e5cb18165466773619e5c963f00a7b
     sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -9554,18 +9081,17 @@ package:
   noarch: python
   size: 853439
   timestamp: 1691408777841
-- name: pygments
+- platform: win-64
+  name: pygments
   version: 2.16.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
   hash:
     md5: 40e5cb18165466773619e5c963f00a7b
     sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -9575,24 +9101,23 @@ package:
   noarch: python
   size: 853439
   timestamp: 1691408777841
-- name: pytest
+- platform: linux-64
+  name: pytest
   version: 7.4.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    colorama: '*'
-    exceptiongroup: '>=1.0.0rc8'
-    iniconfig: '*'
-    packaging: '*'
-    pluggy: '>=0.12,<2.0'
-    python: '>=3.7'
-    tomli: '>=1.0.0'
+  - colorama *
+  - exceptiongroup >=1.0.0rc8
+  - iniconfig *
+  - packaging *
+  - pluggy >=0.12,<2.0
+  - python >=3.7
+  - tomli >=1.0.0
   url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
   hash:
     md5: 6dd662ff5ac9a783e5c940ce9f3fe649
     sha256: 150bfb2a86dffd4ce1e91c2d61dde5779fb3ee338675e210fec4ef508ffff28c
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -9604,24 +9129,23 @@ package:
   noarch: python
   size: 244691
   timestamp: 1694128618921
-- name: pytest
+- platform: osx-64
+  name: pytest
   version: 7.4.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    colorama: '*'
-    exceptiongroup: '>=1.0.0rc8'
-    iniconfig: '*'
-    packaging: '*'
-    pluggy: '>=0.12,<2.0'
-    python: '>=3.7'
-    tomli: '>=1.0.0'
+  - colorama *
+  - exceptiongroup >=1.0.0rc8
+  - iniconfig *
+  - packaging *
+  - pluggy >=0.12,<2.0
+  - python >=3.7
+  - tomli >=1.0.0
   url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
   hash:
     md5: 6dd662ff5ac9a783e5c940ce9f3fe649
     sha256: 150bfb2a86dffd4ce1e91c2d61dde5779fb3ee338675e210fec4ef508ffff28c
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -9633,24 +9157,23 @@ package:
   noarch: python
   size: 244691
   timestamp: 1694128618921
-- name: pytest
+- platform: osx-arm64
+  name: pytest
   version: 7.4.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    colorama: '*'
-    exceptiongroup: '>=1.0.0rc8'
-    iniconfig: '*'
-    packaging: '*'
-    pluggy: '>=0.12,<2.0'
-    python: '>=3.7'
-    tomli: '>=1.0.0'
+  - colorama *
+  - exceptiongroup >=1.0.0rc8
+  - iniconfig *
+  - packaging *
+  - pluggy >=0.12,<2.0
+  - python >=3.7
+  - tomli >=1.0.0
   url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
   hash:
     md5: 6dd662ff5ac9a783e5c940ce9f3fe649
     sha256: 150bfb2a86dffd4ce1e91c2d61dde5779fb3ee338675e210fec4ef508ffff28c
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -9662,24 +9185,23 @@ package:
   noarch: python
   size: 244691
   timestamp: 1694128618921
-- name: pytest
+- platform: win-64
+  name: pytest
   version: 7.4.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    colorama: '*'
-    exceptiongroup: '>=1.0.0rc8'
-    iniconfig: '*'
-    packaging: '*'
-    pluggy: '>=0.12,<2.0'
-    python: '>=3.7'
-    tomli: '>=1.0.0'
+  - colorama *
+  - exceptiongroup >=1.0.0rc8
+  - iniconfig *
+  - packaging *
+  - pluggy >=0.12,<2.0
+  - python >=3.7
+  - tomli >=1.0.0
   url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
   hash:
     md5: 6dd662ff5ac9a783e5c940ce9f3fe649
     sha256: 150bfb2a86dffd4ce1e91c2d61dde5779fb3ee338675e210fec4ef508ffff28c
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -9691,32 +9213,31 @@ package:
   noarch: python
   size: 244691
   timestamp: 1694128618921
-- name: python
+- platform: linux-64
+  name: python
   version: 3.11.6
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    ld_impl_linux-64: '>=2.36.1'
-    libexpat: '>=2.5.0,<3.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libgcc-ng: '>=12'
-    libnsl: '>=2.0.0,<2.1.0a0'
-    libsqlite: '>=3.43.0,<4.0a0'
-    libuuid: '>=2.38.1,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: '*'
-    xz: '>=5.2.6,<6.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.0,<2.1.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata *
+  - xz >=5.2.6,<6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.6-hab00c5b_0_cpython.conda
   hash:
     md5: b0dfbe2fcbfdb097d321bfd50ecddab1
     sha256: 84f13bd70cff5dcdaee19263b2d4291d5793856a718efc1b63a9cfa9eb6e2ca1
-  optional: false
-  category: main
   build: hab00c5b_0_cpython
   arch: x86_64
   subdir: linux-64
@@ -9726,28 +9247,27 @@ package:
   license: Python-2.0
   size: 30720625
   timestamp: 1696331287478
-- name: python
+- platform: osx-64
+  name: python
   version: 3.11.6
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.43.0,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: '*'
-    xz: '>=5.2.6,<6.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata *
+  - xz >=5.2.6,<6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.6-h30d4d87_0_cpython.conda
   hash:
     md5: 4d66c5fc01e9be526afe5d828d4de24d
     sha256: e3ed331204fbeb03a9a2c2fa834e74997ad4f732ba2124b36f327d38b0cded93
-  optional: false
-  category: main
   build: h30d4d87_0_cpython
   arch: x86_64
   subdir: osx-64
@@ -9757,28 +9277,27 @@ package:
   license: Python-2.0
   size: 15393521
   timestamp: 1696330855485
-- name: python
+- platform: osx-arm64
+  name: python
   version: 3.11.6
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.43.0,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: '*'
-    xz: '>=5.2.6,<6.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata *
+  - xz >=5.2.6,<6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.6-h47c9636_0_cpython.conda
   hash:
     md5: 2271df1db9534f5cac7c2d0820c3359d
     sha256: 77054fa9a8fc30f71a18f599ee2897905a3c515202b614fa0f793add7a04a155
-  optional: false
-  category: main
   build: h47c9636_0_cpython
   arch: aarch64
   subdir: osx-arm64
@@ -9788,29 +9307,28 @@ package:
   license: Python-2.0
   size: 14626958
   timestamp: 1696329727433
-- name: python
+- platform: win-64
+  name: python
   version: 3.11.6
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.43.0,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: '*'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    xz: '>=5.2.6,<6.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata *
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
   url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.6-h2628c8c_0_cpython.conda
   hash:
     md5: 80b761856b20383615a3fe8b1b13eef8
     sha256: 7fb38fda8296b2651ef727bb57603f0952c07fc533b172044395744a2641a00a
-  optional: false
-  category: main
   build: h2628c8c_0_cpython
   arch: x86_64
   subdir: win-64
@@ -9820,19 +9338,18 @@ package:
   license: Python-2.0
   size: 18121128
   timestamp: 1696329396864
-- name: python-frontmatter
+- platform: linux-64
+  name: python-frontmatter
   version: 1.0.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.6'
-    pyyaml: '*'
+  - python >=3.6
+  - pyyaml *
   url: https://conda.anaconda.org/conda-forge/noarch/python-frontmatter-1.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: 33d38b9f3f1aaa47317d684930a33748
     sha256: 208112ae96bcf4de400cab706df53f2e7b150e8eded4808c5b17bd83c4df4253
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -9842,19 +9359,18 @@ package:
   noarch: python
   size: 13634
   timestamp: 1670619667945
-- name: python-frontmatter
+- platform: osx-64
+  name: python-frontmatter
   version: 1.0.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.6'
-    pyyaml: '*'
+  - python >=3.6
+  - pyyaml *
   url: https://conda.anaconda.org/conda-forge/noarch/python-frontmatter-1.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: 33d38b9f3f1aaa47317d684930a33748
     sha256: 208112ae96bcf4de400cab706df53f2e7b150e8eded4808c5b17bd83c4df4253
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -9864,19 +9380,18 @@ package:
   noarch: python
   size: 13634
   timestamp: 1670619667945
-- name: python-frontmatter
+- platform: osx-arm64
+  name: python-frontmatter
   version: 1.0.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-    pyyaml: '*'
+  - python >=3.6
+  - pyyaml *
   url: https://conda.anaconda.org/conda-forge/noarch/python-frontmatter-1.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: 33d38b9f3f1aaa47317d684930a33748
     sha256: 208112ae96bcf4de400cab706df53f2e7b150e8eded4808c5b17bd83c4df4253
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -9886,19 +9401,18 @@ package:
   noarch: python
   size: 13634
   timestamp: 1670619667945
-- name: python-frontmatter
+- platform: win-64
+  name: python-frontmatter
   version: 1.0.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.6'
-    pyyaml: '*'
+  - python >=3.6
+  - pyyaml *
   url: https://conda.anaconda.org/conda-forge/noarch/python-frontmatter-1.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: 33d38b9f3f1aaa47317d684930a33748
     sha256: 208112ae96bcf4de400cab706df53f2e7b150e8eded4808c5b17bd83c4df4253
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -9908,17 +9422,16 @@ package:
   noarch: python
   size: 13634
   timestamp: 1670619667945
-- name: python_abi
+- platform: linux-64
+  name: python_abi
   version: '3.11'
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
   hash:
     md5: d786502c97404c94d7d58d258a445a65
     sha256: 0be3ac1bf852d64f553220c7e6457e9c047dfb7412da9d22fbaa67e60858b3cf
-  optional: false
-  category: main
   build: 4_cp311
   arch: x86_64
   subdir: linux-64
@@ -9929,17 +9442,16 @@ package:
   license_family: BSD
   size: 6385
   timestamp: 1695147338551
-- name: python_abi
+- platform: osx-64
+  name: python_abi
   version: '3.11'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
   hash:
     md5: fef7a52f0eca6bae9e8e2e255bc86394
     sha256: f56dfe2a57b3b27bad3f9527f943548e8b2526e949d9d6fc0a383020d9359afe
-  optional: false
-  category: main
   build: 4_cp311
   arch: x86_64
   subdir: osx-64
@@ -9950,17 +9462,16 @@ package:
   license_family: BSD
   size: 6478
   timestamp: 1695147518012
-- name: python_abi
+- platform: osx-arm64
+  name: python_abi
   version: '3.11'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
   hash:
     md5: 8d3751bc73d3bbb66f216fa2331d5649
     sha256: 4837089c477b9b84fa38a17f453e6634e68237267211b27a8a2f5ccd847f4e55
-  optional: false
-  category: main
   build: 4_cp311
   arch: aarch64
   subdir: osx-arm64
@@ -9971,17 +9482,16 @@ package:
   license_family: BSD
   size: 6492
   timestamp: 1695147509940
-- name: python_abi
+- platform: win-64
+  name: python_abi
   version: '3.11'
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
   hash:
     md5: 70513332c71b56eace4ee6441e66c012
     sha256: 67c2aade3e2160642eec0742384e766b20c766055e3d99335681e3e05d88ed7b
-  optional: false
-  category: main
   build: 4_cp311
   arch: x86_64
   subdir: win-64
@@ -9992,21 +9502,20 @@ package:
   license_family: BSD
   size: 6755
   timestamp: 1695147711935
-- name: pyyaml
+- platform: linux-64
+  name: pyyaml
   version: 6.0.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    yaml: '>=0.2.5,<0.3.0a0'
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py311h459d7ec_1.conda
   hash:
     md5: 52719a74ad130de8fb5d047dc91f247a
     sha256: 28729ef1ffa7f6f9dfd54345a47c7faac5d34296d66a2b9891fb147f4efe1348
-  optional: false
-  category: main
   build: py311h459d7ec_1
   arch: x86_64
   subdir: linux-64
@@ -10015,20 +9524,19 @@ package:
   license_family: MIT
   size: 200626
   timestamp: 1695373818537
-- name: pyyaml
+- platform: osx-64
+  name: pyyaml
   version: 6.0.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    yaml: '>=0.2.5,<0.3.0a0'
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py311h2725bcf_1.conda
   hash:
     md5: 9283f991b5e5856a99f8aabba9927df5
     sha256: 8ce2ba443414170a2570514d0ce6d03625a847e91af9763d48dc58c338e6f7f3
-  optional: false
-  category: main
   build: py311h2725bcf_1
   arch: x86_64
   subdir: osx-64
@@ -10037,20 +9545,19 @@ package:
   license_family: MIT
   size: 188606
   timestamp: 1695373840022
-- name: pyyaml
+- platform: osx-arm64
+  name: pyyaml
   version: 6.0.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.11,<3.12.0a0 *_cpython'
-    python_abi: 3.11.* *_cp311
-    yaml: '>=0.2.5,<0.3.0a0'
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py311heffc1b2_1.conda
   hash:
     md5: d310bfbb8230b9175c0cbc10189ad804
     sha256: b155f5c27f0e2951256774628c4b91fdeee3267018eef29897a74e3d1316c8b0
-  optional: false
-  category: main
   build: py311heffc1b2_1
   arch: aarch64
   subdir: osx-arm64
@@ -10059,23 +9566,22 @@ package:
   license_family: MIT
   size: 187795
   timestamp: 1695373829282
-- name: pyyaml
+- platform: win-64
+  name: pyyaml
   version: 6.0.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    yaml: '>=0.2.5,<0.3.0a0'
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
   url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py311ha68e1ae_1.conda
   hash:
     md5: 2b4128962cd665153e946f2a88667a3b
     sha256: 4fb0770fc70381a8ab3ced33413ad9dc5e82d4c535b593edd580113ce8760298
-  optional: false
-  category: main
   build: py311ha68e1ae_1
   arch: x86_64
   subdir: win-64
@@ -10084,20 +9590,19 @@ package:
   license_family: MIT
   size: 175469
   timestamp: 1695374086205
-- name: rdma-core
+- platform: linux-64
+  name: rdma-core
   version: '28.9'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-28.9-h59595ed_1.conda
   hash:
     md5: aeffb7c06b5f65e55e6c637408dc4100
     sha256: 832f9393ab3144ce6468c6f150db9d398fad4451e96a8879afb3059f0c9902f6
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
@@ -10106,19 +9611,18 @@ package:
   license_family: BSD
   size: 3735644
   timestamp: 1684785130341
-- name: re2
+- platform: linux-64
+  name: re2
   version: 2023.03.02
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.03.02-h8c504da_0.conda
   hash:
     md5: 206f8fa808748f6e90599c3368a1114e
     sha256: 1727f893a352ca735fb96b09f9edf6fe18c409d65550fd37e8a192919e8c827b
-  optional: false
-  category: main
   build: h8c504da_0
   arch: x86_64
   subdir: linux-64
@@ -10127,18 +9631,17 @@ package:
   license_family: BSD
   size: 201211
   timestamp: 1677698930545
-- name: re2
+- platform: osx-64
+  name: re2
   version: 2023.03.02
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=14.0.6'
+  - libcxx >=14.0.6
   url: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.03.02-h096449b_0.conda
   hash:
     md5: 68580e997396899915eef7771ef3a646
     sha256: 6faebc3e5cb65bdf1ca5f1333d83118ec4b92c0d6fc27044cc998dab7e501a11
-  optional: false
-  category: main
   build: h096449b_0
   arch: x86_64
   subdir: osx-64
@@ -10147,18 +9650,17 @@ package:
   license_family: BSD
   size: 185478
   timestamp: 1677699240835
-- name: re2
+- platform: osx-arm64
+  name: re2
   version: 2023.03.02
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=14.0.6'
+  - libcxx >=14.0.6
   url: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.03.02-hc5e2d97_0.conda
   hash:
     md5: 7a851c0ab05247e3246eca2c3b243b9a
     sha256: 39bc32dcef3b699e6f748cc51d5e6b05ab788334d5787c64f069f0122e74c0c5
-  optional: false
-  category: main
   build: hc5e2d97_0
   arch: aarch64
   subdir: osx-arm64
@@ -10167,20 +9669,19 @@ package:
   license_family: BSD
   size: 169959
   timestamp: 1677699275465
-- name: re2
+- platform: win-64
+  name: re2
   version: 2023.03.02
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/re2-2023.03.02-hd4eee63_0.conda
   hash:
     md5: a59c371d7364446cf1d0b8299e05c1ea
     sha256: 8e1bccfe360351251b6a7140bebe66e9f678d940926bb7a92b1b2b06325fdd34
-  optional: false
-  category: main
   build: hd4eee63_0
   arch: x86_64
   subdir: win-64
@@ -10189,19 +9690,18 @@ package:
   license_family: BSD
   size: 378635
   timestamp: 1677699429007
-- name: readline
+- platform: linux-64
+  name: readline
   version: '8.2'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    ncurses: '>=6.3,<7.0a0'
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
   hash:
     md5: 47d31b792659ce70f470b5c82fdfb7a4
     sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
-  optional: false
-  category: main
   build: h8228510_1
   arch: x86_64
   subdir: linux-64
@@ -10210,18 +9710,17 @@ package:
   license_family: GPL
   size: 281456
   timestamp: 1679532220005
-- name: readline
+- platform: osx-64
+  name: readline
   version: '8.2'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    ncurses: '>=6.3,<7.0a0'
+  - ncurses >=6.3,<7.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
   hash:
     md5: f17f77f2acf4d344734bda76829ce14e
     sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
-  optional: false
-  category: main
   build: h9e318b2_1
   arch: x86_64
   subdir: osx-64
@@ -10230,18 +9729,17 @@ package:
   license_family: GPL
   size: 255870
   timestamp: 1679532707590
-- name: readline
+- platform: osx-arm64
+  name: readline
   version: '8.2'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    ncurses: '>=6.3,<7.0a0'
+  - ncurses >=6.3,<7.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
   hash:
     md5: 8cbb776a2f641b943d413b3e19df71f4
     sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
-  optional: false
-  category: main
   build: h92ec313_1
   arch: aarch64
   subdir: osx-arm64
@@ -10250,18 +9748,17 @@ package:
   license_family: GPL
   size: 250351
   timestamp: 1679532511311
-- name: rhash
+- platform: linux-64
+  name: rhash
   version: 1.4.4
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.4-hd590300_0.conda
   hash:
     md5: ec972a9a2925ac8d7a19eb9606561fff
     sha256: 12711d2d4a808a503c2e49b25d26ecb351435521e814c154e682dd2be71c2611
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -10270,17 +9767,16 @@ package:
   license_family: MIT
   size: 185144
   timestamp: 1693455923632
-- name: rhash
+- platform: osx-64
+  name: rhash
   version: 1.4.4
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.4-h0dc2134_0.conda
   hash:
     md5: 55a2ada70c8a208c01f77978f2783121
     sha256: f1ae47e8c4e46f856faf5d8ee1e5291f55627aa93401b61a877f18ade5780c87
-  optional: false
-  category: main
   build: h0dc2134_0
   arch: x86_64
   subdir: osx-64
@@ -10289,17 +9785,16 @@ package:
   license_family: MIT
   size: 177229
   timestamp: 1693456080514
-- name: rhash
+- platform: osx-arm64
+  name: rhash
   version: 1.4.4
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.4-hb547adb_0.conda
   hash:
     md5: 710c4b1abf65b697c1d9716eba16dbb0
     sha256: 3ab595e2280ed2118b6b1e8ce7e5949da2047846c81b6af1bbf5ac859d062edd
-  optional: false
-  category: main
   build: hb547adb_0
   arch: aarch64
   subdir: osx-arm64
@@ -10308,21 +9803,20 @@ package:
   license_family: MIT
   size: 177491
   timestamp: 1693456037505
-- name: rich
+- platform: linux-64
+  name: rich
   version: 13.6.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    markdown-it-py: '>=2.2.0'
-    pygments: '>=2.13.0,<3.0.0'
-    python: '>=3.7.0'
-    typing_extensions: '>=4.0.0,<5.0.0'
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.7.0
+  - typing_extensions >=4.0.0,<5.0.0
   url: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
   hash:
     md5: 3ca4829f40710f581ca1d76bc907e99f
     sha256: a2f8838a75ab8c2c1da0a813c7569d4f6efba0d2b5dc3a7659e2cb6d96bd8e19
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -10332,21 +9826,20 @@ package:
   noarch: python
   size: 183200
   timestamp: 1696096819794
-- name: rich
+- platform: osx-64
+  name: rich
   version: 13.6.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    markdown-it-py: '>=2.2.0'
-    pygments: '>=2.13.0,<3.0.0'
-    python: '>=3.7.0'
-    typing_extensions: '>=4.0.0,<5.0.0'
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.7.0
+  - typing_extensions >=4.0.0,<5.0.0
   url: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
   hash:
     md5: 3ca4829f40710f581ca1d76bc907e99f
     sha256: a2f8838a75ab8c2c1da0a813c7569d4f6efba0d2b5dc3a7659e2cb6d96bd8e19
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -10356,21 +9849,20 @@ package:
   noarch: python
   size: 183200
   timestamp: 1696096819794
-- name: rich
+- platform: osx-arm64
+  name: rich
   version: 13.6.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    markdown-it-py: '>=2.2.0'
-    pygments: '>=2.13.0,<3.0.0'
-    python: '>=3.7.0'
-    typing_extensions: '>=4.0.0,<5.0.0'
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.7.0
+  - typing_extensions >=4.0.0,<5.0.0
   url: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
   hash:
     md5: 3ca4829f40710f581ca1d76bc907e99f
     sha256: a2f8838a75ab8c2c1da0a813c7569d4f6efba0d2b5dc3a7659e2cb6d96bd8e19
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -10380,21 +9872,20 @@ package:
   noarch: python
   size: 183200
   timestamp: 1696096819794
-- name: rich
+- platform: win-64
+  name: rich
   version: 13.6.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    markdown-it-py: '>=2.2.0'
-    pygments: '>=2.13.0,<3.0.0'
-    python: '>=3.7.0'
-    typing_extensions: '>=4.0.0,<5.0.0'
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.7.0
+  - typing_extensions >=4.0.0,<5.0.0
   url: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
   hash:
     md5: 3ca4829f40710f581ca1d76bc907e99f
     sha256: a2f8838a75ab8c2c1da0a813c7569d4f6efba0d2b5dc3a7659e2cb6d96bd8e19
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -10404,21 +9895,20 @@ package:
   noarch: python
   size: 183200
   timestamp: 1696096819794
-- name: ruff
+- platform: linux-64
+  name: ruff
   version: 0.1.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.1.2-py311h7145743_0.conda
   hash:
     md5: 4c457c2b25f5b58e75e052ada556314d
     sha256: fb600b02d9d20266a7f9ee9eed4b63a8a5829d7f1c0ed7c290720560bb7dac39
-  optional: false
-  category: main
   build: py311h7145743_0
   arch: x86_64
   subdir: linux-64
@@ -10427,21 +9917,20 @@ package:
   license_family: MIT
   size: 4784587
   timestamp: 1698171225351
-- name: ruff
+- platform: osx-64
+  name: ruff
   version: 0.1.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.1.2-py311hec6fdf1_0.conda
   hash:
     md5: aa5b695132c2c78232b93d80f1e5e04c
     sha256: cf0b66945d13d1fa4840421ca169c4cfd68e791931f6316f528ddae6b74f9845
-  optional: false
-  category: main
   build: py311hec6fdf1_0
   arch: x86_64
   subdir: osx-64
@@ -10450,21 +9939,20 @@ package:
   license_family: MIT
   size: 4544170
   timestamp: 1698171913911
-- name: ruff
+- platform: osx-arm64
+  name: ruff
   version: 0.1.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    python: '>=3.11,<3.12.0a0 *_cpython'
-    python_abi: 3.11.* *_cp311
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.1.2-py311h6fc163c_0.conda
   hash:
     md5: 4eae3a2a9b8ae663b4c0c599221d088d
     sha256: 4eaab7aaa52989e02e5ed672c16a0da3237e3c24a412f25246ef66e08d7abbf9
-  optional: false
-  category: main
   build: py311h6fc163c_0
   arch: aarch64
   subdir: osx-arm64
@@ -10473,22 +9961,21 @@ package:
   license_family: MIT
   size: 4310473
   timestamp: 1698171765257
-- name: ruff
+- platform: win-64
+  name: ruff
   version: 0.1.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.1.2-py311hc14472d_0.conda
   hash:
     md5: aeb1cc6180bf34af39f4c6c567bb7b4d
     sha256: 0456eb29fb927927371df97edba3391eccb6f93a6a554f2bc8221b9913aa9875
-  optional: false
-  category: main
   build: py311hc14472d_0
   arch: x86_64
   subdir: win-64
@@ -10497,19 +9984,18 @@ package:
   license_family: MIT
   size: 4698356
   timestamp: 1698172312917
-- name: s2n
+- platform: linux-64
+  name: s2n
   version: 1.3.52
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    openssl: '>=3.1.3,<4.0a0'
+  - libgcc-ng >=12
+  - openssl >=3.1.3,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.3.52-h06160fa_0.conda
   hash:
     md5: 1451ff9968f582d759825058c664b901
     sha256: 454c5dc15964579829905b9a28bae51cac215360f427bb977f92a724773620a6
-  optional: false
-  category: main
   build: h06160fa_0
   arch: x86_64
   subdir: linux-64
@@ -10518,18 +10004,17 @@ package:
   license_family: Apache
   size: 384111
   timestamp: 1696287992665
-- name: semver
+- platform: linux-64
+  name: semver
   version: 2.13.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '*'
+  - python *
   url: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
   hash:
     md5: 2cab9f3a9683cb40a2176ccaf76e66c6
     sha256: 673ef5ef04cef60c3584b1d9b81024646b9d9a4c50749356c7ba5cede755e61d
-  optional: false
-  category: main
   build: pyh9f0ad1d_0
   arch: x86_64
   subdir: linux-64
@@ -10539,18 +10024,17 @@ package:
   noarch: python
   size: 15712
   timestamp: 1603697876069
-- name: semver
+- platform: osx-64
+  name: semver
   version: 2.13.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '*'
+  - python *
   url: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
   hash:
     md5: 2cab9f3a9683cb40a2176ccaf76e66c6
     sha256: 673ef5ef04cef60c3584b1d9b81024646b9d9a4c50749356c7ba5cede755e61d
-  optional: false
-  category: main
   build: pyh9f0ad1d_0
   arch: x86_64
   subdir: osx-64
@@ -10560,18 +10044,17 @@ package:
   noarch: python
   size: 15712
   timestamp: 1603697876069
-- name: semver
+- platform: osx-arm64
+  name: semver
   version: 2.13.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '*'
+  - python *
   url: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
   hash:
     md5: 2cab9f3a9683cb40a2176ccaf76e66c6
     sha256: 673ef5ef04cef60c3584b1d9b81024646b9d9a4c50749356c7ba5cede755e61d
-  optional: false
-  category: main
   build: pyh9f0ad1d_0
   arch: aarch64
   subdir: osx-arm64
@@ -10581,18 +10064,17 @@ package:
   noarch: python
   size: 15712
   timestamp: 1603697876069
-- name: semver
+- platform: win-64
+  name: semver
   version: 2.13.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '*'
+  - python *
   url: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
   hash:
     md5: 2cab9f3a9683cb40a2176ccaf76e66c6
     sha256: 673ef5ef04cef60c3584b1d9b81024646b9d9a4c50749356c7ba5cede755e61d
-  optional: false
-  category: main
   build: pyh9f0ad1d_0
   arch: x86_64
   subdir: win-64
@@ -10602,18 +10084,17 @@ package:
   noarch: python
   size: 15712
   timestamp: 1603697876069
-- name: setuptools
+- platform: linux-64
+  name: setuptools
   version: 68.2.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
   hash:
     md5: fc2166155db840c634a1291a5c35a709
     sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -10623,18 +10104,17 @@ package:
   noarch: python
   size: 464399
   timestamp: 1694548452441
-- name: setuptools
+- platform: osx-64
+  name: setuptools
   version: 68.2.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
   hash:
     md5: fc2166155db840c634a1291a5c35a709
     sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -10644,18 +10124,17 @@ package:
   noarch: python
   size: 464399
   timestamp: 1694548452441
-- name: setuptools
+- platform: osx-arm64
+  name: setuptools
   version: 68.2.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
   hash:
     md5: fc2166155db840c634a1291a5c35a709
     sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -10665,18 +10144,17 @@ package:
   noarch: python
   size: 464399
   timestamp: 1694548452441
-- name: setuptools
+- platform: win-64
+  name: setuptools
   version: 68.2.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
   hash:
     md5: fc2166155db840c634a1291a5c35a709
     sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -10686,18 +10164,17 @@ package:
   noarch: python
   size: 464399
   timestamp: 1694548452441
-- name: sigtool
+- platform: osx-64
+  name: sigtool
   version: 0.1.3
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    openssl: '>=3.0.0,<4.0a0'
+  - openssl >=3.0.0,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
   hash:
     md5: fbfb84b9de9a6939cb165c02c69b1865
     sha256: 46fdeadf8f8d725819c4306838cdfd1099cd8fe3e17bd78862a5dfdcd6de61cf
-  optional: false
-  category: main
   build: h88f4db0_0
   arch: x86_64
   subdir: osx-64
@@ -10706,18 +10183,17 @@ package:
   license_family: MIT
   size: 213817
   timestamp: 1643442169866
-- name: sigtool
+- platform: osx-arm64
+  name: sigtool
   version: 0.1.3
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    openssl: '>=3.0.0,<4.0a0'
+  - openssl >=3.0.0,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
   hash:
     md5: 4a2cac04f86a4540b8c9b8d8f597848f
     sha256: 70791ae00a3756830cb50451db55f63e2a42a2fa2a8f1bab1ebd36bbb7d55bff
-  optional: false
-  category: main
   build: h44b9a77_0
   arch: aarch64
   subdir: osx-arm64
@@ -10726,18 +10202,17 @@ package:
   license_family: MIT
   size: 210264
   timestamp: 1643442231687
-- name: smmap
+- platform: linux-64
+  name: smmap
   version: 5.0.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.5'
+  - python >=3.5
   url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 62f26a3d1387acee31322208f0cfa3e0
     sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -10747,18 +10222,17 @@ package:
   noarch: python
   size: 22483
   timestamp: 1634310465482
-- name: smmap
+- platform: osx-64
+  name: smmap
   version: 5.0.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.5'
+  - python >=3.5
   url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 62f26a3d1387acee31322208f0cfa3e0
     sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -10768,18 +10242,17 @@ package:
   noarch: python
   size: 22483
   timestamp: 1634310465482
-- name: smmap
+- platform: osx-arm64
+  name: smmap
   version: 5.0.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.5'
+  - python >=3.5
   url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 62f26a3d1387acee31322208f0cfa3e0
     sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -10789,18 +10262,17 @@ package:
   noarch: python
   size: 22483
   timestamp: 1634310465482
-- name: smmap
+- platform: win-64
+  name: smmap
   version: 5.0.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.5'
+  - python >=3.5
   url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 62f26a3d1387acee31322208f0cfa3e0
     sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -10810,19 +10282,18 @@ package:
   noarch: python
   size: 22483
   timestamp: 1634310465482
-- name: snappy
+- platform: linux-64
+  name: snappy
   version: 1.1.10
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
   hash:
     md5: e6d228cd0bb74a51dd18f5bfce0b4115
     sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
-  optional: false
-  category: main
   build: h9fff704_0
   arch: x86_64
   subdir: linux-64
@@ -10831,18 +10302,17 @@ package:
   license_family: BSD
   size: 38865
   timestamp: 1678534590321
-- name: snappy
+- platform: osx-64
+  name: snappy
   version: 1.1.10
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=14.0.6'
+  - libcxx >=14.0.6
   url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
   hash:
     md5: 4320a8781f14cd959689b86e349f3b73
     sha256: 575915dc13152e446a84e2f88de70a14f8b6af1a870e708f9370bd4be105583b
-  optional: false
-  category: main
   build: h225ccf5_0
   arch: x86_64
   subdir: osx-64
@@ -10851,18 +10321,17 @@ package:
   license_family: BSD
   size: 34657
   timestamp: 1678534768395
-- name: snappy
+- platform: osx-arm64
+  name: snappy
   version: 1.1.10
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=14.0.6'
+  - libcxx >=14.0.6
   url: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
   hash:
     md5: ac82a611d1a67a598096ebaa857198e3
     sha256: dfae03cd2339587871e53b42833657faa4c9e42e3e2c56ee9e32bc60797c7f62
-  optional: false
-  category: main
   build: h17c5cce_0
   arch: aarch64
   subdir: osx-arm64
@@ -10871,20 +10340,19 @@ package:
   license_family: BSD
   size: 33879
   timestamp: 1678534968831
-- name: snappy
+- platform: win-64
+  name: snappy
   version: 1.1.10
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
   hash:
     md5: cff1df79c9cff719460eb2dd172568de
     sha256: 2a195b38cb63f03ad9f73a82db52434ebefe216fb70f7ea3defe4ddf263d408a
-  optional: false
-  category: main
   build: hfb803bf_0
   arch: x86_64
   subdir: win-64
@@ -10893,18 +10361,17 @@ package:
   license_family: BSD
   size: 57065
   timestamp: 1678534804734
-- name: sysroot_linux-64
+- platform: linux-64
+  name: sysroot_linux-64
   version: '2.12'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    kernel-headers_linux-64: ==2.6.32 he073ed8_16
+  - kernel-headers_linux-64 ==2.6.32 he073ed8_16
   url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_16.conda
   hash:
     md5: 071ea8dceff4d30ac511f4a2f8437cd1
     sha256: 4c024b2eee24c6da7d3e08723111ec02665c578844c5b3e9e6b38f89000bec41
-  optional: false
-  category: main
   build: he073ed8_16
   arch: x86_64
   subdir: linux-64
@@ -10914,18 +10381,17 @@ package:
   noarch: generic
   size: 15277813
   timestamp: 1689214980563
-- name: tapi
+- platform: osx-64
+  name: tapi
   version: 1100.0.11
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=10.0.0.a0'
+  - libcxx >=10.0.0.a0
   url: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
   hash:
     md5: f9ff42ccf809a21ba6f8607f8de36108
     sha256: 34b18ce8d1518b67e333ca1d3af733c3976ecbdf3a36b727f9b4dedddcc588fa
-  optional: false
-  category: main
   build: h9ce4665_0
   arch: x86_64
   subdir: osx-64
@@ -10934,18 +10400,17 @@ package:
   license_family: MIT
   size: 201044
   timestamp: 1602664232074
-- name: tapi
+- platform: osx-arm64
+  name: tapi
   version: 1100.0.11
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=11.0.0.a0'
+  - libcxx >=11.0.0.a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
   hash:
     md5: d83362e7d0513f35f454bc50b0ca591d
     sha256: 1709265fbee693a9e8b4126b0a3e68a6c4718b05821c659279c1af051f2d40f3
-  optional: false
-  category: main
   build: he4954df_0
   arch: aarch64
   subdir: osx-arm64
@@ -10954,18 +10419,17 @@ package:
   license_family: MIT
   size: 191416
   timestamp: 1602687595316
-- name: taplo
+- platform: linux-64
+  name: taplo
   version: 0.8.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.8.1-he8a937b_0.conda
   hash:
     md5: 3d83fa9962fc353485bab815c9df9fe4
     sha256: 901e0ba452bd249db45cbea25e7d865e43eb5322078e4724f43d83641b73335b
-  optional: false
-  category: main
   build: he8a937b_0
   arch: x86_64
   subdir: linux-64
@@ -10974,17 +10438,16 @@ package:
   license_family: MIT
   size: 3586993
   timestamp: 1689047789269
-- name: taplo
+- platform: osx-64
+  name: taplo
   version: 0.8.1
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.8.1-h7205ca4_0.conda
   hash:
     md5: 8e99d4b2850401094fe7c83273d3c4e8
     sha256: 493b5f8db450f37e8bb50fdfd02c06499c18391c806d2220e65ac801f6b7c2f0
-  optional: false
-  category: main
   build: h7205ca4_0
   arch: x86_64
   subdir: osx-64
@@ -10993,17 +10456,16 @@ package:
   license_family: MIT
   size: 3446470
   timestamp: 1689048461323
-- name: taplo
+- platform: osx-arm64
+  name: taplo
   version: 0.8.1
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.8.1-h69fbcac_0.conda
   hash:
     md5: 268425eeb6db286378bb05f69331feea
     sha256: 5a46bbdac42c2aa1d59f3f7f61aa92eaed5f6936b01de4f3519f5ad40374973f
-  optional: false
-  category: main
   build: h69fbcac_0
   arch: aarch64
   subdir: osx-arm64
@@ -11012,19 +10474,18 @@ package:
   license_family: MIT
   size: 3339855
   timestamp: 1689048706766
-- name: taplo
+- platform: win-64
+  name: taplo
   version: 0.8.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    m2w64-gcc-libs: '*'
-    m2w64-gcc-libs-core: '*'
+  - m2w64-gcc-libs *
+  - m2w64-gcc-libs-core *
   url: https://conda.anaconda.org/conda-forge/win-64/taplo-0.8.1-h7f3b576_0.conda
   hash:
     md5: 2041cd474504dd82b83aa58ccec82a78
     sha256: 4f0ddb3c2942ff9b2d627de9093075df30f28f64bf71520710c031cb7fff8d9d
-  optional: false
-  category: main
   build: h7f3b576_0
   arch: x86_64
   subdir: win-64
@@ -11033,21 +10494,20 @@ package:
   license_family: MIT
   size: 3652740
   timestamp: 1689048946860
-- name: tbb
+- platform: win-64
+  name: tbb
   version: 2021.10.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libhwloc: '>=2.9.3,<2.9.4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libhwloc >=2.9.3,<2.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_1.conda
   hash:
     md5: 57ea1be8408c5a9a737648b5f919e725
     sha256: 492c57a480ad283e467c0bdfc8ea55eaf20c4c7e73340a0c1b200a077c9ba2d9
-  optional: false
-  category: main
   build: h91493d7_1
   arch: x86_64
   subdir: win-64
@@ -11056,19 +10516,18 @@ package:
   license_family: APACHE
   size: 156524
   timestamp: 1695626239415
-- name: tk
+- platform: linux-64
+  name: tk
   version: 8.6.13
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
   hash:
     md5: 513336054f884f95d9fd925748f41ef3
     sha256: 679e944eb93fde45d0963a22598fafacbb429bb9e7ee26009ba81c4e0c435055
-  optional: false
-  category: main
   build: h2797004_0
   arch: x86_64
   subdir: linux-64
@@ -11077,18 +10536,17 @@ package:
   license_family: BSD
   size: 3290187
   timestamp: 1695506262576
-- name: tk
+- platform: osx-64
+  name: tk
   version: 8.6.13
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
   hash:
     md5: 0c25eedcc888b6d765948ab62a18c03e
     sha256: 573e5d7dde0a63b06ceef2c574295cbc2ec8668ec08e35d2f2c6220f4aa7fb98
-  optional: false
-  category: main
   build: hef22860_0
   arch: x86_64
   subdir: osx-64
@@ -11097,18 +10555,17 @@ package:
   license_family: BSD
   size: 3273909
   timestamp: 1695506576288
-- name: tk
+- platform: osx-arm64
+  name: tk
   version: 8.6.13
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
   hash:
     md5: aa913a828b65f30ee3aba9c59bb0b514
     sha256: 6df6ff49dba487eb891ddc0099642a36af2fe3929ed8023f76b745f0485c54a6
-  optional: false
-  category: main
   build: hb31c410_0
   arch: aarch64
   subdir: osx-arm64
@@ -11117,20 +10574,19 @@ package:
   license_family: BSD
   size: 3223549
   timestamp: 1695506653047
-- name: tk
+- platform: win-64
+  name: tk
   version: 8.6.13
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
   hash:
     md5: 74405f2ccbb40af409fee1a71ce70dc6
     sha256: 7e42db6b5f1c5ef8d4660e6ce41b52802b6c2fdc270d5e1eccc0048d0a3f03a8
-  optional: false
-  category: main
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
@@ -11139,18 +10595,17 @@ package:
   license_family: BSD
   size: 3478482
   timestamp: 1695506766462
-- name: tomli
+- platform: linux-64
+  name: tomli
   version: 2.0.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 5844808ffab9ebdb694585b50ba02a96
     sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -11160,18 +10615,17 @@ package:
   noarch: python
   size: 15940
   timestamp: 1644342331069
-- name: tomli
+- platform: osx-64
+  name: tomli
   version: 2.0.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 5844808ffab9ebdb694585b50ba02a96
     sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -11181,18 +10635,17 @@ package:
   noarch: python
   size: 15940
   timestamp: 1644342331069
-- name: tomli
+- platform: osx-arm64
+  name: tomli
   version: 2.0.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 5844808ffab9ebdb694585b50ba02a96
     sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -11202,18 +10655,17 @@ package:
   noarch: python
   size: 15940
   timestamp: 1644342331069
-- name: tomli
+- platform: win-64
+  name: tomli
   version: 2.0.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 5844808ffab9ebdb694585b50ba02a96
     sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -11223,18 +10675,17 @@ package:
   noarch: python
   size: 15940
   timestamp: 1644342331069
-- name: typing-extensions
+- platform: linux-64
+  name: typing-extensions
   version: 4.8.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    typing_extensions: ==4.8.0 pyha770c72_0
+  - typing_extensions ==4.8.0 pyha770c72_0
   url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
   hash:
     md5: 384462e63262a527bda564fa2d9126c0
     sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
-  optional: false
-  category: main
   build: hd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -11244,18 +10695,17 @@ package:
   noarch: python
   size: 10104
   timestamp: 1695040958008
-- name: typing-extensions
+- platform: osx-64
+  name: typing-extensions
   version: 4.8.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    typing_extensions: ==4.8.0 pyha770c72_0
+  - typing_extensions ==4.8.0 pyha770c72_0
   url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
   hash:
     md5: 384462e63262a527bda564fa2d9126c0
     sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
-  optional: false
-  category: main
   build: hd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -11265,18 +10715,17 @@ package:
   noarch: python
   size: 10104
   timestamp: 1695040958008
-- name: typing-extensions
+- platform: osx-arm64
+  name: typing-extensions
   version: 4.8.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    typing_extensions: ==4.8.0 pyha770c72_0
+  - typing_extensions ==4.8.0 pyha770c72_0
   url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
   hash:
     md5: 384462e63262a527bda564fa2d9126c0
     sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
-  optional: false
-  category: main
   build: hd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -11286,18 +10735,17 @@ package:
   noarch: python
   size: 10104
   timestamp: 1695040958008
-- name: typing-extensions
+- platform: win-64
+  name: typing-extensions
   version: 4.8.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    typing_extensions: ==4.8.0 pyha770c72_0
+  - typing_extensions ==4.8.0 pyha770c72_0
   url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
   hash:
     md5: 384462e63262a527bda564fa2d9126c0
     sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
-  optional: false
-  category: main
   build: hd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -11307,18 +10755,17 @@ package:
   noarch: python
   size: 10104
   timestamp: 1695040958008
-- name: typing_extensions
+- platform: linux-64
+  name: typing_extensions
   version: 4.8.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
   hash:
     md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
     sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: x86_64
   subdir: linux-64
@@ -11328,18 +10775,17 @@ package:
   noarch: python
   size: 35108
   timestamp: 1695040948828
-- name: typing_extensions
+- platform: osx-64
+  name: typing_extensions
   version: 4.8.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
   hash:
     md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
     sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: x86_64
   subdir: osx-64
@@ -11349,18 +10795,17 @@ package:
   noarch: python
   size: 35108
   timestamp: 1695040948828
-- name: typing_extensions
+- platform: osx-arm64
+  name: typing_extensions
   version: 4.8.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
   hash:
     md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
     sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: aarch64
   subdir: osx-arm64
@@ -11370,18 +10815,17 @@ package:
   noarch: python
   size: 35108
   timestamp: 1695040948828
-- name: typing_extensions
+- platform: win-64
+  name: typing_extensions
   version: 4.8.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
   hash:
     md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
     sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: x86_64
   subdir: win-64
@@ -11391,18 +10835,17 @@ package:
   noarch: python
   size: 35108
   timestamp: 1695040948828
-- name: typos
+- platform: linux-64
+  name: typos
   version: 1.16.20
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/typos-1.16.20-he8a937b_0.conda
   hash:
     md5: 947fb92bd27a9b50f3595110b383cda1
     sha256: 7d62a430a0b2265405db223bccfc5cf72f28953bc64617a2cb2ea5ba5e78fbd2
-  optional: false
-  category: main
   build: he8a937b_0
   arch: x86_64
   subdir: linux-64
@@ -11411,17 +10854,16 @@ package:
   license_family: MIT
   size: 3604039
   timestamp: 1697488922704
-- name: typos
+- platform: osx-64
+  name: typos
   version: 1.16.20
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/typos-1.16.20-h63b85fc_0.conda
   hash:
     md5: 0a1d328583703fd1b2b24d840ede73c2
     sha256: 25db319c9a9ab2f15a25195f29f2606769974a6ade7acf0e5b546ff010a51188
-  optional: false
-  category: main
   build: h63b85fc_0
   arch: x86_64
   subdir: osx-64
@@ -11430,17 +10872,16 @@ package:
   license_family: MIT
   size: 3329339
   timestamp: 1697489265161
-- name: typos
+- platform: osx-arm64
+  name: typos
   version: 1.16.20
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.16.20-h5ef7bb8_0.conda
   hash:
     md5: 1556f9ec74d6d4324d0914eb87bacb2f
     sha256: 97a5ea5c6594eb18ff0fba16f833c971d08c524e1b14d68235a874f4b4233bd7
-  optional: false
-  category: main
   build: h5ef7bb8_0
   arch: aarch64
   subdir: osx-arm64
@@ -11449,19 +10890,18 @@ package:
   license_family: MIT
   size: 3313786
   timestamp: 1697489550453
-- name: typos
+- platform: win-64
+  name: typos
   version: 1.16.20
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    m2w64-gcc-libs: '*'
-    m2w64-gcc-libs-core: '*'
+  - m2w64-gcc-libs *
+  - m2w64-gcc-libs-core *
   url: https://conda.anaconda.org/conda-forge/win-64/typos-1.16.20-h7f3b576_0.conda
   hash:
     md5: f651424355b19e3af998a185d52d14ca
     sha256: c0adea11c394812d068a1ab14bb2d58ae01dd9b2f2d1be1c934367908eb520d0
-  optional: false
-  category: main
   build: h7f3b576_0
   arch: x86_64
   subdir: win-64
@@ -11470,17 +10910,16 @@ package:
   license_family: MIT
   size: 2575765
   timestamp: 1697490297038
-- name: tzdata
+- platform: linux-64
+  name: tzdata
   version: 2023c
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
   hash:
     md5: 939e3e74d8be4dac89ce83b20de2492a
     sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  optional: false
-  category: main
   build: h71feb2d_0
   arch: x86_64
   subdir: linux-64
@@ -11489,17 +10928,16 @@ package:
   noarch: generic
   size: 117580
   timestamp: 1680041306008
-- name: tzdata
+- platform: osx-64
+  name: tzdata
   version: 2023c
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
   hash:
     md5: 939e3e74d8be4dac89ce83b20de2492a
     sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  optional: false
-  category: main
   build: h71feb2d_0
   arch: x86_64
   subdir: osx-64
@@ -11508,17 +10946,16 @@ package:
   noarch: generic
   size: 117580
   timestamp: 1680041306008
-- name: tzdata
+- platform: osx-arm64
+  name: tzdata
   version: 2023c
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
   hash:
     md5: 939e3e74d8be4dac89ce83b20de2492a
     sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  optional: false
-  category: main
   build: h71feb2d_0
   arch: aarch64
   subdir: osx-arm64
@@ -11527,17 +10964,16 @@ package:
   noarch: generic
   size: 117580
   timestamp: 1680041306008
-- name: tzdata
+- platform: win-64
+  name: tzdata
   version: 2023c
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
   hash:
     md5: 939e3e74d8be4dac89ce83b20de2492a
     sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  optional: false
-  category: main
   build: h71feb2d_0
   arch: x86_64
   subdir: win-64
@@ -11546,17 +10982,16 @@ package:
   noarch: generic
   size: 117580
   timestamp: 1680041306008
-- name: ucrt
+- platform: win-64
+  name: ucrt
   version: 10.0.22621.0
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
   hash:
     md5: 72608f6cd3e5898229c3ea16deb1ac43
     sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
-  optional: false
-  category: main
   build: h57928b3_0
   arch: x86_64
   subdir: win-64
@@ -11567,21 +11002,20 @@ package:
   license_family: PROPRIETARY
   size: 1283972
   timestamp: 1666630199266
-- name: ucx
+- platform: linux-64
+  name: ucx
   version: 1.15.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libnuma: '>=2.0.16,<3.0a0'
-    libstdcxx-ng: '>=12'
-    rdma-core: '>=28.9,<29.0a0'
+  - libgcc-ng >=12
+  - libnuma >=2.0.16,<3.0a0
+  - libstdcxx-ng >=12
+  - rdma-core >=28.9,<29.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-h64cca9d_0.conda
   hash:
     md5: b35b1f1a9fdbf93266c91f297dc9060e
     sha256: 8a4dce10304fee0df715addec3d078421aa7aa0824422a6630d621d15bd98e5f
-  optional: false
-  category: main
   build: h64cca9d_0
   arch: x86_64
   subdir: linux-64
@@ -11592,40 +11026,37 @@ package:
   license_family: BSD
   size: 15425900
   timestamp: 1696028080367
-- name: vc
+- platform: win-64
+  name: vc
   version: '14.3'
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc14_runtime: '>=14.36.32532'
+  - vc14_runtime >=14.36.32532
   url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
   hash:
     md5: 67ff6791f235bb606659bf2a5c169191
     sha256: 86ae94bf680980776aa761c2b0909a0ddbe1f817e7eeb8b16a1730f10f8891b6
-  optional: false
-  category: main
   build: h64f974e_17
   arch: x86_64
   subdir: win-64
   build_number: 17
-  track_features:
-  - vc14
+  track_features: vc14
   license: BSD-3-Clause
   license_family: BSD
   size: 17176
   timestamp: 1688020629925
-- name: vc14_runtime
+- platform: win-64
+  name: vc14_runtime
   version: 14.36.32532
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
+  - ucrt >=10.0.20348.0
   url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
   hash:
     md5: d0de20f2f3fc806a81b44fcdd941aaf7
     sha256: b317d49af32d5c031828e62c08d56f01d9a64cd3f40d4cccb052bc38c7a9e62e
-  optional: false
-  category: main
   build: hdcecf7f_17
   arch: x86_64
   subdir: win-64
@@ -11636,18 +11067,17 @@ package:
   license_family: Proprietary
   size: 739437
   timestamp: 1694292382336
-- name: vs2015_runtime
+- platform: win-64
+  name: vs2015_runtime
   version: 14.36.32532
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc14_runtime: '>=14.36.32532'
+  - vc14_runtime >=14.36.32532
   url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
   hash:
     md5: 4618046c39f7c81861e53ded842e738a
     sha256: 5ecbd731dc7f13762d67be0eadc47eb7f14713005e430d9b5fc680e965ac0f81
-  optional: false
-  category: main
   build: h05e6639_17
   arch: x86_64
   subdir: win-64
@@ -11656,39 +11086,36 @@ package:
   license_family: BSD
   size: 17207
   timestamp: 1688020635322
-- name: vs2022_win-64
+- platform: win-64
+  name: vs2022_win-64
   version: 19.37.32822
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vswhere: '*'
+  - vswhere *
   url: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.37.32822-h0123c8e_17.conda
   hash:
     md5: 8b02594cf497f7516a3ed20a164de75e
     sha256: 259b5d4ac07b131bf15bf1a2d101eb9eb039e32cfef57de79061cb4c8f1889fe
-  optional: false
-  category: main
   build: h0123c8e_17
   arch: x86_64
   subdir: win-64
   build_number: 17
-  track_features:
-  - vc14
+  track_features: vc14
   license: BSD-3-Clause
   license_family: BSD
   size: 19405
   timestamp: 1694292390059
-- name: vswhere
+- platform: win-64
+  name: vswhere
   version: 3.1.4
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
   hash:
     md5: b1d1d6a1f874d8c93a57b5efece52f03
     sha256: 553c41fc1a883415a39444313f8d99236685529776fdd04e8d97288b73496002
-  optional: false
-  category: main
   build: h57928b3_0
   arch: x86_64
   subdir: win-64
@@ -11697,18 +11124,17 @@ package:
   license_family: MIT
   size: 218421
   timestamp: 1682376911339
-- name: wheel
+- platform: linux-64
+  name: wheel
   version: 0.38.4
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: c829cfb8cb826acb9de0ac1a2df0a940
     sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -11718,18 +11144,17 @@ package:
   noarch: python
   size: 32521
   timestamp: 1668051714265
-- name: wheel
+- platform: osx-64
+  name: wheel
   version: 0.38.4
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: c829cfb8cb826acb9de0ac1a2df0a940
     sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -11739,18 +11164,17 @@ package:
   noarch: python
   size: 32521
   timestamp: 1668051714265
-- name: wheel
+- platform: osx-arm64
+  name: wheel
   version: 0.38.4
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: c829cfb8cb826acb9de0ac1a2df0a940
     sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -11760,18 +11184,17 @@ package:
   noarch: python
   size: 32521
   timestamp: 1668051714265
-- name: wheel
+- platform: win-64
+  name: wheel
   version: 0.38.4
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: c829cfb8cb826acb9de0ac1a2df0a940
     sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -11781,18 +11204,17 @@ package:
   noarch: python
   size: 32521
   timestamp: 1668051714265
-- name: xz
+- platform: linux-64
+  name: xz
   version: 5.2.6
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
   hash:
     md5: 2161070d867d1b1204ea749c8eec4ef0
     sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
-  optional: false
-  category: main
   build: h166bdaf_0
   arch: x86_64
   subdir: linux-64
@@ -11800,17 +11222,16 @@ package:
   license: LGPL-2.1 and GPL-2.0
   size: 418368
   timestamp: 1660346797927
-- name: xz
+- platform: osx-64
+  name: xz
   version: 5.2.6
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
   hash:
     md5: a72f9d4ea13d55d745ff1ed594747f10
     sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
-  optional: false
-  category: main
   build: h775f41a_0
   arch: x86_64
   subdir: osx-64
@@ -11818,17 +11239,16 @@ package:
   license: LGPL-2.1 and GPL-2.0
   size: 238119
   timestamp: 1660346964847
-- name: xz
+- platform: osx-arm64
+  name: xz
   version: 5.2.6
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
   hash:
     md5: 39c6b54e94014701dd157f4f576ed211
     sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
-  optional: false
-  category: main
   build: h57fd34a_0
   arch: aarch64
   subdir: osx-arm64
@@ -11836,19 +11256,18 @@ package:
   license: LGPL-2.1 and GPL-2.0
   size: 235693
   timestamp: 1660346961024
-- name: xz
+- platform: win-64
+  name: xz
   version: 5.2.6
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15'
-    vs2015_runtime: '>=14.16.27033'
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
   url: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
   hash:
     md5: 515d77642eaa3639413c6b1bc3f94219
     sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
-  optional: false
-  category: main
   build: h8d14728_0
   arch: x86_64
   subdir: win-64
@@ -11856,18 +11275,17 @@ package:
   license: LGPL-2.1 and GPL-2.0
   size: 217804
   timestamp: 1660346976440
-- name: yaml
+- platform: linux-64
+  name: yaml
   version: 0.2.5
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.4.0'
+  - libgcc-ng >=9.4.0
   url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
   hash:
     md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
     sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
-  optional: false
-  category: main
   build: h7f98852_2
   arch: x86_64
   subdir: linux-64
@@ -11876,17 +11294,16 @@ package:
   license_family: MIT
   size: 89141
   timestamp: 1641346969816
-- name: yaml
+- platform: osx-64
+  name: yaml
   version: 0.2.5
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
   hash:
     md5: d7e08fcf8259d742156188e8762b4d20
     sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
-  optional: false
-  category: main
   build: h0d85af4_2
   arch: x86_64
   subdir: osx-64
@@ -11895,17 +11312,16 @@ package:
   license_family: MIT
   size: 84237
   timestamp: 1641347062780
-- name: yaml
+- platform: osx-arm64
+  name: yaml
   version: 0.2.5
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
   hash:
     md5: 4bb3f014845110883a3c5ee811fd84b4
     sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
-  optional: false
-  category: main
   build: h3422bc3_2
   arch: aarch64
   subdir: osx-arm64
@@ -11914,19 +11330,18 @@ package:
   license_family: MIT
   size: 88016
   timestamp: 1641347076660
-- name: yaml
+- platform: win-64
+  name: yaml
   version: 0.2.5
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15.0a0'
-    vs2015_runtime: '>=14.16.27012'
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
   url: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
   hash:
     md5: adbfb9f45d1004a26763652246a33764
     sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
-  optional: false
-  category: main
   build: h8ffe710_2
   arch: x86_64
   subdir: win-64
@@ -11935,18 +11350,17 @@ package:
   license_family: MIT
   size: 63274
   timestamp: 1641347623319
-- name: zipp
+- platform: linux-64
+  name: zipp
   version: 3.17.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
   hash:
     md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
     sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -11956,18 +11370,17 @@ package:
   noarch: python
   size: 18954
   timestamp: 1695255262261
-- name: zipp
+- platform: osx-64
+  name: zipp
   version: 3.17.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
   hash:
     md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
     sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -11977,18 +11390,17 @@ package:
   noarch: python
   size: 18954
   timestamp: 1695255262261
-- name: zipp
+- platform: osx-arm64
+  name: zipp
   version: 3.17.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
   hash:
     md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
     sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -11998,18 +11410,17 @@ package:
   noarch: python
   size: 18954
   timestamp: 1695255262261
-- name: zipp
+- platform: win-64
+  name: zipp
   version: 3.17.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.8'
+  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
   hash:
     md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
     sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -12019,20 +11430,19 @@ package:
   noarch: python
   size: 18954
   timestamp: 1695255262261
-- name: zstd
+- platform: linux-64
+  name: zstd
   version: 1.5.5
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
   hash:
     md5: 04b88013080254850d6c01ed54810589
     sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
-  optional: false
-  category: main
   build: hfc55251_0
   arch: x86_64
   subdir: linux-64
@@ -12041,18 +11451,17 @@ package:
   license_family: BSD
   size: 545199
   timestamp: 1693151163452
-- name: zstd
+- platform: osx-64
+  name: zstd
   version: 1.5.5
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
   hash:
     md5: 80abc41d0c48b82fe0f04e7f42f5cb7e
     sha256: d54e31d3d8de5e254c0804abd984807b8ae5cd3708d758a8bf1adff1f5df166c
-  optional: false
-  category: main
   build: h829000d_0
   arch: x86_64
   subdir: osx-64
@@ -12061,18 +11470,17 @@ package:
   license_family: BSD
   size: 499383
   timestamp: 1693151312586
-- name: zstd
+- platform: osx-arm64
+  name: zstd
   version: 1.5.5
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
   hash:
     md5: 5b212cfb7f9d71d603ad891879dc7933
     sha256: 7e1fe6057628bbb56849a6741455bbb88705bae6d6646257e57904ac5ee5a481
-  optional: false
-  category: main
   build: h4f39d0f_0
   arch: aarch64
   subdir: osx-arm64
@@ -12081,21 +11489,20 @@ package:
   license_family: BSD
   size: 400508
   timestamp: 1693151393180
-- name: zstd
+- platform: win-64
+  name: zstd
   version: 1.5.5
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
   hash:
     md5: 792bb5da68bf0a6cac6a6072ecb8dbeb
     sha256: d540dd56c5ec772b60e4ce7d45f67f01c6614942225885911964ea1e70bb99e3
-  optional: false
-  category: main
   build: h12be248_0
   arch: x86_64
   subdir: win-64

--- a/pixi.toml
+++ b/pixi.toml
@@ -26,6 +26,9 @@ version = "0.1.0"                                                              #
 [target.win-64.tasks]
 cpp-prepare = "cmake -G 'Visual Studio 17 2022' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
 cpp-prepare-release = "cmake -G 'Visual Studio 17 2022' -B build -S . -DCMAKE_BUILD_TYPE=Release"
+cpp-build-all = { cmd = "cmake --build build --config Debug --target ALL_BUILD", depends_on = [
+  "cpp-prepare",
+] }
 cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/Debug/rerun_sdk_tests.exe", depends_on = [
   "cpp-build-tests",
 ] }
@@ -33,6 +36,9 @@ cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/Debug/rerun
 [target.linux-64.tasks]
 cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
 cpp-prepare-release = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Release"
+cpp-build-all = { cmd = "cmake --build build --config Debug --target all", depends_on = [
+  "cpp-prepare",
+] }
 cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
   "cpp-build-tests",
 ] }
@@ -40,6 +46,9 @@ cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_t
 [target.osx-64.tasks]
 cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
 cpp-prepare-release = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Release"
+cpp-build-all = { cmd = "cmake --build build --config Debug --target all", depends_on = [
+  "cpp-prepare",
+] }
 cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
   "cpp-build-tests",
 ] }
@@ -47,6 +56,9 @@ cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_t
 [target.osx-arm64.tasks]
 cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
 cpp-prepare-release = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Release"
+cpp-build-all = { cmd = "cmake --build build --config Debug --target all", depends_on = [
+  "cpp-prepare",
+] }
 cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
   "cpp-build-tests",
 ] }
@@ -79,9 +91,6 @@ py-test = { cmd = "python -m pytest -vv rerun_py/tests/unit", depends_on = [
 
 # All the cpp-* tasks can be configured with environment variables, e.g.:  RERUN_WERROR=ON  CXX=clang++
 cpp-clean = "rm -rf build CMakeCache.txt CMakeFiles"
-cpp-build-all = { cmd = "cmake --build build --config Debug --target all", depends_on = [
-  "cpp-prepare",
-] }
 cpp-build-tests = { cmd = "cmake --build build --config Debug --target rerun_sdk_tests", depends_on = [
   "cpp-prepare",
 ] }

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,48 +21,6 @@ readme = "README.md"
 repository = "https://github.com/rerun-io/rerun"
 version = "0.1.0"                                                              # TODO(emilk): sync version with `Cargo.toml` with help from `crates.py`
 
-# We could use Ninja on Windows as well, but this makes the compiler setup needlessly complicated.
-# Also, it's more likely that users are also going to use Visual Studio/MSBuild directly.
-[target.win-64.tasks]
-cpp-prepare = "cmake -G 'Visual Studio 17 2022' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
-cpp-prepare-release = "cmake -G 'Visual Studio 17 2022' -B build -S . -DCMAKE_BUILD_TYPE=Release"
-cpp-build-all = { cmd = "cmake --build build --config Debug --target ALL_BUILD", depends_on = [
-  "cpp-prepare",
-] }
-cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/Debug/rerun_sdk_tests.exe", depends_on = [
-  "cpp-build-tests",
-] }
-
-[target.linux-64.tasks]
-cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
-cpp-prepare-release = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Release"
-cpp-build-all = { cmd = "cmake --build build --config Debug --target all", depends_on = [
-  "cpp-prepare",
-] }
-cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
-  "cpp-build-tests",
-] }
-
-[target.osx-64.tasks]
-cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
-cpp-prepare-release = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Release"
-cpp-build-all = { cmd = "cmake --build build --config Debug --target all", depends_on = [
-  "cpp-prepare",
-] }
-cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
-  "cpp-build-tests",
-] }
-
-[target.osx-arm64.tasks]
-cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
-cpp-prepare-release = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Release"
-cpp-build-all = { cmd = "cmake --build build --config Debug --target all", depends_on = [
-  "cpp-prepare",
-] }
-cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
-  "cpp-build-tests",
-] }
-
 [tasks]
 # Note: extra CLI argument after `pixi run TASK` are passed to the task cmd.
 
@@ -90,6 +48,11 @@ py-test = { cmd = "python -m pytest -vv rerun_py/tests/unit", depends_on = [
 ] }
 
 # All the cpp-* tasks can be configured with environment variables, e.g.:  RERUN_WERROR=ON  CXX=clang++
+cpp-prepare-release = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Release"
+cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
+cpp-build-all = { cmd = "cmake --build build --config Debug --target all", depends_on = [
+  "cpp-prepare",
+] }
 cpp-clean = "rm -rf build CMakeCache.txt CMakeFiles"
 cpp-build-tests = { cmd = "cmake --build build --config Debug --target rerun_sdk_tests", depends_on = [
   "cpp-prepare",
@@ -112,8 +75,10 @@ cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_t
 cpp-log-benchmark = { cmd = "export RERUN_STRICT=1 && ./build/tests/cpp/log_benchmark/log_benchmark", depends_on = [
   "cpp-build-log-benchmark",
 ] }
-
 cpp-build-and-test-all = { depends_on = ["cpp-build-all", "cpp-test"] }
+
+[target.win-64.tasks]
+cpp-prepare-msvc = "cmake -G 'Visual Studio 17 2022' -B build-msvc -S ."
 
 [dependencies]
 attrs = ">=23.1.0"
@@ -137,6 +102,7 @@ taplo = ">=0.8.1"
 typing_extensions = ">4.5"
 typos = ">=1.16.20"
 wheel = ">=0.38,<0.39"
+ninja = "1.11.1"
 
 [target.linux-64.dependencies]
 patchelf = ">=0.17"

--- a/pixi.toml
+++ b/pixi.toml
@@ -25,24 +25,28 @@ version = "0.1.0"                                                              #
 # Also, it's more likely that users are also going to use Visual Studio/MSBuild directly.
 [target.win-64.tasks]
 cpp-prepare = "cmake -G 'Visual Studio 17 2022' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
+cpp-prepare-release = "cmake -G 'Visual Studio 17 2022' -B build -S . -DCMAKE_BUILD_TYPE=Release"
 cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/Debug/rerun_sdk_tests.exe", depends_on = [
   "cpp-build-tests",
 ] }
 
 [target.linux-64.tasks]
 cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
+cpp-prepare-release = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Release"
 cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
   "cpp-build-tests",
 ] }
 
 [target.osx-64.tasks]
 cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
+cpp-prepare-release = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Release"
 cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
   "cpp-build-tests",
 ] }
 
 [target.osx-arm64.tasks]
 cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
+cpp-prepare-release = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Release"
 cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
   "cpp-build-tests",
 ] }
@@ -94,9 +98,16 @@ cpp-build-examples = { cmd = "cmake --build build --config Debug --target exampl
 cpp-build-doc-examples = { cmd = "cmake --build build --config Debug --target doc_examples", depends_on = [
   "cpp-prepare",
 ] }
+cpp-build-log-benchmark = { cmd = "cmake --build build --config Release --target log_benchmark", depends_on = [
+  "cpp-prepare-release",
+] }
 cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
   "cpp-build-tests",
 ] }
+cpp-log-benchmark = { cmd = "export RERUN_STRICT=1 && ./build/tests/cpp/log_benchmark/log_benchmark", depends_on = [
+  "cpp-build-log-benchmark",
+] }
+
 cpp-build-and-test-all = { depends_on = ["cpp-build-all", "cpp-test"] }
 
 [dependencies]

--- a/pixi.toml
+++ b/pixi.toml
@@ -79,12 +79,8 @@ py-test = { cmd = "python -m pytest -vv rerun_py/tests/unit", depends_on = [
 
 # All the cpp-* tasks can be configured with environment variables, e.g.:  RERUN_WERROR=ON  CXX=clang++
 cpp-clean = "rm -rf build CMakeCache.txt CMakeFiles"
-cpp-build-all = { depends_on = [
+cpp-build-all = { cmd = "cmake --build build --config Debug --target all", depends_on = [
   "cpp-prepare",
-  "cpp-build-doc-examples",
-  "cpp-build-examples",
-  "cpp-build-roundtrips",
-  "cpp-build-tests",
 ] }
 cpp-build-tests = { cmd = "cmake --build build --config Debug --target rerun_sdk_tests", depends_on = [
   "cpp-prepare",

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -1,3 +1,4 @@
 cmake_minimum_required(VERSION 3.16...3.27)
 
 add_subdirectory(roundtrips)
+add_subdirectory(log_benchmark)

--- a/tests/cpp/log_benchmark/CMakeLists.txt
+++ b/tests/cpp/log_benchmark/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.16...3.27)
+
+file(GLOB LOG_BENCHMARK_SOURCES LIST_DIRECTORIES true ${CMAKE_CURRENT_SOURCE_DIR}/*)
+
+add_executable(log_benchmark ${LOG_BENCHMARK_SOURCES})
+rerun_strict_warning_settings(log_benchmark)
+target_link_libraries(log_benchmark PRIVATE rerun_sdk)

--- a/tests/cpp/log_benchmark/benchmarks.hpp
+++ b/tests/cpp/log_benchmark/benchmarks.hpp
@@ -18,4 +18,7 @@ void run_image();
 // ---
 
 /// Very simple linear congruency "random" number generator to spread out values a bit.
-int64_t lcg(int64_t& lcg_state);
+inline int64_t lcg(int64_t& lcg_state) {
+    lcg_state = 1140671485 * lcg_state + 128201163 % 16777216;
+    return lcg_state;
+}

--- a/tests/cpp/log_benchmark/benchmarks.hpp
+++ b/tests/cpp/log_benchmark/benchmarks.hpp
@@ -2,10 +2,6 @@
 
 #include <cstdint>
 
-static const char* ArgPoints3DLargeBatch = "points3d_large_batch";
-static const char* ArgPoints3DManyIndividual = "points3d_many_individual";
-static const char* ArgImage = "image";
-
 /// Log a single large batch of points with positions, colors, radii and a splatted string.
 void run_points3d_large_batch();
 

--- a/tests/cpp/log_benchmark/benchmarks.hpp
+++ b/tests/cpp/log_benchmark/benchmarks.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+
+static const char* ArgPoints3DLargeBatch = "points3d_large_batch";
+static const char* ArgPoints3DManyIndividual = "points3d_many_individual";
+static const char* ArgImage = "image";
+
+/// Log a single large batch of points with positions, colors, radii and a splatted string.
+void run_points3d_large_batch();
+
+/// Log many individual points (position, color, radius), each with a different timestamp.
+void run_points3d_many_individual();
+
+/// Log a few large images.
+void run_image();
+
+// ---
+
+/// Very simple linear congruency "random" number generator to spread out values a bit.
+int64_t lcg(int64_t& lcg_state);

--- a/tests/cpp/log_benchmark/image.cpp
+++ b/tests/cpp/log_benchmark/image.cpp
@@ -1,0 +1,11 @@
+#include "benchmarks.hpp"
+#include "profile_scope.hpp"
+
+static void prepare() {
+    PROFILE_FUNCTION();
+}
+
+void run_image() {
+    PROFILE_FUNCTION();
+    prepare();
+}

--- a/tests/cpp/log_benchmark/image.cpp
+++ b/tests/cpp/log_benchmark/image.cpp
@@ -1,11 +1,52 @@
+#include <vector>
+
 #include "benchmarks.hpp"
 #include "profile_scope.hpp"
 
-static void prepare() {
+#include <rerun.hpp>
+
+// About 1gb of image data.
+constexpr size_t IMAGE_DIMENSION = 16384;
+constexpr size_t IMAGE_CHANNELS = 4;
+
+// How many times we log the image.
+// Each time with a single pixel changed.
+constexpr size_t NUM_LOG_CALLS = 4;
+
+static std::vector<uint8_t> prepare() {
     PROFILE_FUNCTION();
+
+    std::vector<uint8_t> image(
+        IMAGE_DIMENSION * IMAGE_DIMENSION * IMAGE_CHANNELS,
+        static_cast<uint8_t>(0)
+    );
+
+    return image;
+}
+
+static void execute(std::vector<uint8_t> raw_image_data) {
+    PROFILE_FUNCTION();
+
+    rerun::RecordingStream rec("rerun_example_benchmark_image");
+
+    for (size_t i = 0; i < NUM_LOG_CALLS; ++i) {
+        raw_image_data[i] += 1;
+        rec.log(
+            "test_image",
+            rerun::Image(
+                {
+                    IMAGE_DIMENSION,
+                    IMAGE_DIMENSION,
+                    IMAGE_CHANNELS,
+                },
+                raw_image_data
+            )
+        );
+    }
 }
 
 void run_image() {
     PROFILE_FUNCTION();
-    prepare();
+    auto input = prepare();
+    execute(std::move(input));
 }

--- a/tests/cpp/log_benchmark/main.cpp
+++ b/tests/cpp/log_benchmark/main.cpp
@@ -9,7 +9,7 @@
 //
 // The data we generate for benchmarking should be:
 // * minimal overhead to generate
-// * not homogenous (arrow, ourselves, or even the compiler might exploit this)
+// * not homogeneous (arrow, ourselves, or even the compiler might exploit this)
 // * not trivially optimized out
 // * not random between runs
 //

--- a/tests/cpp/log_benchmark/main.cpp
+++ b/tests/cpp/log_benchmark/main.cpp
@@ -1,0 +1,58 @@
+// Simple benchmark suite for logging data.
+// The goal is to get an estimate for the entire process of logging data,
+// including serialization and processing by the recording stream.
+//
+// Timings are printed out while running, it's recommended to measure process run time to ensure
+// we account for all startup overheads and have all background threads finish.
+//
+// If not specified otherwise, memory recordings are used.
+//
+// The data we generate for benchmarking should be:
+// * minimal overhead to generate
+// * not homogenous (arrow, ourselves, or even the compiler might exploit this)
+// * not trivially optimized out
+// * not random between runs
+//
+// Run all benchmarks using:
+// ```
+// pixi run cpp-log-benchmark
+// ```
+// Or, run a single benchmark using:
+// ```
+// pixi run cpp-log-benchmark points3d_large_batch
+// ```
+//
+
+#include <cstdio>
+#include <vector>
+
+#include "benchmarks.hpp"
+
+int64_t lcg(int64_t& lcg_state) {
+    lcg_state = 1140671485 * lcg_state + 128201163 % 16777216;
+    return lcg_state;
+}
+
+int main(int argc, char** argv) {
+    std::vector<const char*> benchmarks(argv + 1, argv + argc);
+    if (argc == 1) {
+        benchmarks.push_back(ArgPoints3DLargeBatch);
+        benchmarks.push_back(ArgPoints3DManyIndividual);
+        benchmarks.push_back(ArgImage);
+    }
+
+    for (const auto& benchmark : benchmarks) {
+        if (strcmp(benchmark, ArgPoints3DLargeBatch) == 0) {
+            run_points3d_large_batch();
+        } else if (benchmark == ArgPoints3DManyIndividual) {
+            run_points3d_many_individual();
+        } else if (benchmark == ArgImage) {
+            run_image();
+        } else {
+            printf("Unknown benchmark: %s\n", benchmark);
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/tests/cpp/log_benchmark/main.cpp
+++ b/tests/cpp/log_benchmark/main.cpp
@@ -34,6 +34,10 @@
 
 #include "benchmarks.hpp"
 
+static const char* ArgPoints3DLargeBatch = "points3d_large_batch";
+static const char* ArgPoints3DManyIndividual = "points3d_many_individual";
+static const char* ArgImage = "image";
+
 int main(int argc, char** argv) {
 #ifndef NDEBUG
     printf("WARNING: Debug build, timings will be inaccurate!\n");

--- a/tests/cpp/log_benchmark/main.cpp
+++ b/tests/cpp/log_benchmark/main.cpp
@@ -22,18 +22,23 @@
 // pixi run cpp-log-benchmark points3d_large_batch
 // ```
 //
+// For better whole-executable timing capture you can also first build the executable and then run:
+// ```
+// pixi run cpp-build-log-benchmark
+// ./build/tests/cpp/log_benchmark/log_benchmark
+// ```
+//
 
 #include <cstdio>
 #include <vector>
 
 #include "benchmarks.hpp"
 
-int64_t lcg(int64_t& lcg_state) {
-    lcg_state = 1140671485 * lcg_state + 128201163 % 16777216;
-    return lcg_state;
-}
-
 int main(int argc, char** argv) {
+#ifndef NDEBUG
+    printf("WARNING: Debug build, timings will be inaccurate!\n");
+#endif
+
     std::vector<const char*> benchmarks(argv + 1, argv + argc);
     if (argc == 1) {
         benchmarks.push_back(ArgPoints3DLargeBatch);
@@ -44,9 +49,9 @@ int main(int argc, char** argv) {
     for (const auto& benchmark : benchmarks) {
         if (strcmp(benchmark, ArgPoints3DLargeBatch) == 0) {
             run_points3d_large_batch();
-        } else if (benchmark == ArgPoints3DManyIndividual) {
+        } else if (strcmp(benchmark, ArgPoints3DManyIndividual) == 0) {
             run_points3d_many_individual();
-        } else if (benchmark == ArgImage) {
+        } else if (strcmp(benchmark, ArgImage) == 0) {
             run_image();
         } else {
             printf("Unknown benchmark: %s\n", benchmark);

--- a/tests/cpp/log_benchmark/main.cpp
+++ b/tests/cpp/log_benchmark/main.cpp
@@ -30,6 +30,7 @@
 //
 
 #include <cstdio>
+#include <cstring>
 #include <vector>
 
 #include "benchmarks.hpp"

--- a/tests/cpp/log_benchmark/points3d_large_batch.cpp
+++ b/tests/cpp/log_benchmark/points3d_large_batch.cpp
@@ -1,0 +1,11 @@
+#include "benchmarks.hpp"
+#include "profile_scope.hpp"
+
+static void prepare() {
+    PROFILE_FUNCTION();
+}
+
+void run_points3d_large_batch() {
+    PROFILE_FUNCTION();
+    prepare();
+}

--- a/tests/cpp/log_benchmark/points3d_large_batch.cpp
+++ b/tests/cpp/log_benchmark/points3d_large_batch.cpp
@@ -1,11 +1,29 @@
+#include <utility>
+
 #include "benchmarks.hpp"
+#include "points3d_shared.hpp"
 #include "profile_scope.hpp"
 
-static void prepare() {
+#include <rerun.hpp>
+
+constexpr int64_t NUM_POINTS = 50000000;
+
+static void execute(Point3DInput input) {
     PROFILE_FUNCTION();
+
+    rerun::RecordingStream rec("rerun_example_benchmark_points3d_large_batch");
+
+    rec.log(
+        "large_batch",
+        rerun::Points3D(input.positions)
+            .with_colors(input.colors)
+            .with_radii(input.radii)
+            .with_labels({input.label})
+    );
 }
 
 void run_points3d_large_batch() {
     PROFILE_FUNCTION();
-    prepare();
+    auto input = prepare_points3d(42, NUM_POINTS);
+    execute(std::move(input));
 }

--- a/tests/cpp/log_benchmark/points3d_many_individual.cpp
+++ b/tests/cpp/log_benchmark/points3d_many_individual.cpp
@@ -17,7 +17,7 @@ static void execute(Point3DInput input) {
         rec.set_time_sequence("my_timeline", static_cast<int64_t>(i));
         rec.log(
             "large_batch",
-            rerun::Points3D({input.positions[i]})
+            rerun::Points3D(input.positions[i])
                 .with_colors({input.colors[i]})
                 .with_radii({input.radii[i]})
         );

--- a/tests/cpp/log_benchmark/points3d_many_individual.cpp
+++ b/tests/cpp/log_benchmark/points3d_many_individual.cpp
@@ -1,12 +1,31 @@
+#include <utility>
+
 #include "benchmarks.hpp"
+#include "points3d_shared.hpp"
 #include "profile_scope.hpp"
 
-static void prepare() {
+#include <rerun.hpp>
+
+constexpr int64_t NUM_POINTS = 1000000;
+
+static void execute(Point3DInput input) {
     PROFILE_FUNCTION();
+
+    rerun::RecordingStream rec("rerun_example_benchmark_points3d_many_individual");
+
+    for (size_t i = 0; i < NUM_POINTS; ++i) {
+        rec.set_time_sequence("my_timeline", static_cast<int64_t>(i));
+        rec.log(
+            "large_batch",
+            rerun::Points3D({input.positions[i]})
+                .with_colors({input.colors[i]})
+                .with_radii({input.radii[i]})
+        );
+    }
 }
 
 void run_points3d_many_individual() {
     PROFILE_FUNCTION();
-
-    prepare();
+    auto input = prepare_points3d(1337, NUM_POINTS);
+    execute(std::move(input));
 }

--- a/tests/cpp/log_benchmark/points3d_many_individual.cpp
+++ b/tests/cpp/log_benchmark/points3d_many_individual.cpp
@@ -1,0 +1,12 @@
+#include "benchmarks.hpp"
+#include "profile_scope.hpp"
+
+static void prepare() {
+    PROFILE_FUNCTION();
+}
+
+void run_points3d_many_individual() {
+    PROFILE_FUNCTION();
+
+    prepare();
+}

--- a/tests/cpp/log_benchmark/points3d_shared.hpp
+++ b/tests/cpp/log_benchmark/points3d_shared.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "benchmarks.hpp"
+#include "profile_scope.hpp"
+
+#include <rerun.hpp>
+
+struct MyPoint3D {
+    float x, y, z;
+};
+
+struct Point3DInput {
+    std::vector<MyPoint3D> positions;
+    std::vector<uint32_t> colors;
+    std::vector<float> radii;
+    std::string label;
+
+    Point3DInput() = default;
+    Point3DInput(Point3DInput&&) = default;
+};
+
+inline Point3DInput prepare_points3d(int64_t lcg_state, size_t num_points) {
+    PROFILE_FUNCTION();
+
+    Point3DInput input;
+    input.positions.resize(num_points);
+    for (auto& pos : input.positions) {
+        pos.x = static_cast<float>(lcg(lcg_state));
+        pos.y = static_cast<float>(lcg(lcg_state));
+        pos.z = static_cast<float>(lcg(lcg_state));
+    }
+    input.colors.resize(num_points);
+    for (auto& color : input.colors) {
+        color = static_cast<uint32_t>(lcg(lcg_state));
+    }
+    input.radii.resize(num_points);
+    for (auto& radius : input.radii) {
+        radius = static_cast<float>(lcg(lcg_state));
+    }
+    input.label = "some label";
+
+    return input;
+}
+
+// TODO(andreas): We want this adapter in rerun, ideally in a generated manner.
+//                Can we do something like a `binary compatible` attribute on fbs that will generate this as well as ctors?
+template <>
+struct rerun::ComponentBatchAdapter<rerun::Color, std::vector<uint32_t>> {
+    ComponentBatch<Color> operator()(const std::vector<uint32_t>& container) {
+        return ComponentBatch<Color>::borrow(container.data(), container.size());
+    }
+
+    ComponentBatch<Color> operator()(std::vector<uint32_t>&&) {
+        throw std::runtime_error("Not implemented for temporaries");
+    }
+};
+
+template <>
+struct rerun::ComponentBatchAdapter<rerun::Position3D, std::vector<MyPoint3D>> {
+    ComponentBatch<rerun::Position3D> operator()(const std::vector<MyPoint3D>& container) {
+        return ComponentBatch<rerun::Position3D>::borrow(container.data(), container.size());
+    }
+
+    ComponentBatch<rerun::Position3D> operator()(std::vector<MyPoint3D>&&) {
+        throw std::runtime_error("Not implemented for temporaries");
+    }
+};
+
+template <>
+struct rerun::ComponentBatchAdapter<rerun::Position3D, MyPoint3D> {
+    ComponentBatch<rerun::Position3D> operator()(const MyPoint3D& single) {
+        return ComponentBatch<rerun::Position3D>::borrow(&single, 1);
+    }
+
+    ComponentBatch<rerun::Position3D> operator()(MyPoint3D&&) {
+        throw std::runtime_error("Not implemented for temporaries");
+    }
+};

--- a/tests/cpp/log_benchmark/profile_scope.cpp
+++ b/tests/cpp/log_benchmark/profile_scope.cpp
@@ -1,0 +1,3 @@
+#include "profile_scope.hpp"
+
+int ProfileScope::_indentation = 0;

--- a/tests/cpp/log_benchmark/profile_scope.hpp
+++ b/tests/cpp/log_benchmark/profile_scope.hpp
@@ -1,0 +1,44 @@
+#include <chrono>
+#include <cstdio>
+
+/// Simplistic RAII scope for additional profiling.
+///
+/// All inlined on purpose.
+/// Not threadsafe due to indentation!
+class ProfileScope {
+  public:
+    // std::source_location would be nice here, but it's not widely enough supported
+    // ProfileScope(const std::source_location& location = std::source_location::current())
+
+    ProfileScope(const char* location)
+        : _start(std::chrono::high_resolution_clock::now()), _location(location) {
+        print_indent();
+        printf("%s start …\n", _location);
+        ++_indentation;
+    }
+
+    ~ProfileScope() {
+        const auto end = std::chrono::high_resolution_clock::now();
+        const auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - _start);
+        --_indentation;
+        print_indent();
+        printf("%s end: %fms\n", _location, duration.count() / 1000.0f);
+    }
+
+    static void print_indent() {
+        for (int i = 0; i < _indentation; ++i) {
+            printf("--");
+        }
+        if (_indentation > 0) {
+            printf(" ");
+        }
+    }
+
+  private:
+    std::chrono::high_resolution_clock::time_point _start;
+    const char* _location;
+    static int _indentation;
+};
+
+// Quick and dirty macro to profile a function.
+#define PROFILE_FUNCTION() ProfileScope _function_profile_scope(__FUNCTION__)

--- a/tests/cpp/log_benchmark/profile_scope.hpp
+++ b/tests/cpp/log_benchmark/profile_scope.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <chrono>
 #include <cstdio>
 

--- a/tests/cpp/log_benchmark/profile_scope.hpp
+++ b/tests/cpp/log_benchmark/profile_scope.hpp
@@ -19,12 +19,14 @@ class ProfileScope {
 
     ~ProfileScope() {
         const auto end = std::chrono::high_resolution_clock::now();
-        const auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - _start);
+        const auto duration =
+            std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(end - _start);
         --_indentation;
         print_indent();
-        printf("%s end: %fms\n", _location, duration.count() / 1000.0f);
+        printf("%s end: %.2fms\n", _location, duration.count());
     }
 
+  private:
     static void print_indent() {
         for (int i = 0; i < _indentation; ++i) {
             printf("--");
@@ -34,7 +36,6 @@ class ProfileScope {
         }
     }
 
-  private:
     std::chrono::high_resolution_clock::time_point _start;
     const char* _location;
     static int _indentation;

--- a/tests/rust/log_benchmark/Cargo.toml
+++ b/tests/rust/log_benchmark/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "log_benchmark"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+rerun = { path = "../../../crates/rerun" }
+re_tracing = { path = "../../../crates/re_tracing", features = ["server"] }
+
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+glam.workspace = true

--- a/tests/rust/log_benchmark/Cargo.toml
+++ b/tests/rust/log_benchmark/Cargo.toml
@@ -11,5 +11,6 @@ rerun = { path = "../../../crates/rerun" }
 re_tracing = { path = "../../../crates/re_tracing", features = ["server"] }
 
 anyhow.workspace = true
+bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 clap = { workspace = true, features = ["derive"] }
 glam.workspace = true

--- a/tests/rust/log_benchmark/src/image.rs
+++ b/tests/rust/log_benchmark/src/image.rs
@@ -1,0 +1,3 @@
+pub fn run() -> anyhow::Result<()> {
+    Ok(())
+}

--- a/tests/rust/log_benchmark/src/image.rs
+++ b/tests/rust/log_benchmark/src/image.rs
@@ -12,13 +12,6 @@ const IMAGE_CHANNELS: u64 = 4;
 // Each time with a single pixel changed.
 const NUM_LOG_CALLS: usize = 4;
 
-/// Log a single large image.
-pub fn run() -> anyhow::Result<()> {
-    re_tracing::profile_function!();
-    let input = std::hint::black_box(prepare());
-    execute(input)
-}
-
 fn prepare() -> Vec<u8> {
     re_tracing::profile_function!();
 
@@ -44,7 +37,7 @@ fn execute(mut raw_image_data: Vec<u8>) -> anyhow::Result<()> {
     re_tracing::profile_function!();
 
     let (rec, _storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").memory()?;
+        rerun::RecordingStreamBuilder::new("rerun_example_benchmark_").memory()?;
 
     for i in 0..NUM_LOG_CALLS {
         raw_image_data[i] += 1;
@@ -68,4 +61,11 @@ fn execute(mut raw_image_data: Vec<u8>) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Log a single large image.
+pub fn run() -> anyhow::Result<()> {
+    re_tracing::profile_function!();
+    let input = std::hint::black_box(prepare());
+    execute(input)
 }

--- a/tests/rust/log_benchmark/src/image.rs
+++ b/tests/rust/log_benchmark/src/image.rs
@@ -1,3 +1,71 @@
+use rerun::{
+    datatypes::TensorBuffer,
+    datatypes::{TensorData, TensorDimension},
+    external::re_types_core::ArrowBuffer,
+};
+
+// About 1gb of image data.
+const IMAGE_DIMENSION: u64 = 16_384;
+const IMAGE_CHANNELS: u64 = 4;
+
+// How many times we log the image.
+// Each time with a single pixel changed.
+const NUM_LOG_CALLS: usize = 4;
+
+/// Log a single large image.
 pub fn run() -> anyhow::Result<()> {
+    re_tracing::profile_function!();
+    let input = std::hint::black_box(prepare());
+    execute(input)
+}
+
+fn prepare() -> Vec<u8> {
+    re_tracing::profile_function!();
+
+    let mut image = Vec::new();
+    image.resize(
+        (IMAGE_DIMENSION * IMAGE_DIMENSION * IMAGE_CHANNELS) as usize,
+        0,
+    );
+
+    // Skip filling with non-zero values, this adds a bit too much extra overhead.
+    // image.resize_with(
+    //     (IMAGE_DIMENSION * IMAGE_DIMENSION * IMAGE_CHANNELS) as usize,
+    //     || {
+    //         i += 1;
+    //         i as u8
+    //     },
+    // );
+
+    image
+}
+
+fn execute(mut raw_image_data: Vec<u8>) -> anyhow::Result<()> {
+    re_tracing::profile_function!();
+
+    let (rec, _storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").memory()?;
+
+    for i in 0..NUM_LOG_CALLS {
+        raw_image_data[i] += 1;
+
+        rec.log(
+            "test_image",
+            // TODO(andreas): We should have a more ergonomic way to create images from raw bytes!
+            &rerun::Image::new(TensorData::new(
+                vec![
+                    TensorDimension::width(IMAGE_DIMENSION),
+                    TensorDimension::height(IMAGE_DIMENSION),
+                    TensorDimension::depth(IMAGE_CHANNELS),
+                ],
+                // TODO(andreas): We have to copy the image every time since the tensor buffer wants to
+                // take ownership of it.
+                // Note that even though our example here is *very* contrived, it's likely that a user
+                // will want to keep their image, so this copy is definitely part of our API overhead!
+                TensorBuffer::U8(ArrowBuffer::from(raw_image_data.clone())),
+            )),
+        )?;
+    }
+
     Ok(())
 }

--- a/tests/rust/log_benchmark/src/main.rs
+++ b/tests/rust/log_benchmark/src/main.rs
@@ -23,6 +23,12 @@
 //! cargo run -p log_benchmark --release -- --benchmarks points3d_large_batch
 //! ```
 //!
+//! For better whole-executable timing capture you can also first build the executable and then run:
+//! ```
+//! cargo build -p log_benchmark --release
+//! ./target/release/log_benchmark
+//! ```
+//!
 
 use clap::{Parser as _, ValueEnum as _};
 
@@ -68,6 +74,9 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
+    #[cfg(debug_assertions)]
+    println!("WARNING: Debug build, timings will be inaccurate!");
+
     let args = Args::parse();
 
     let mut profiler = re_tracing::Profiler::default();

--- a/tests/rust/log_benchmark/src/main.rs
+++ b/tests/rust/log_benchmark/src/main.rs
@@ -1,0 +1,93 @@
+//! Simple benchmark suite for logging data.
+//! The goal is to get an estimate for the entire process of logging data,
+//! including serialization and processing by the recording stream.
+//!
+//! Timings are printed out while running, it's recommended to measure process run time to ensure
+//! we account for all startup overheads and have all background threads finish.
+//!
+//! If not specified otherwise, memory recordings are used.
+//!
+//! The data we generate for benchmarking should be:
+//! * minimal overhead to generate
+//! * not homogenous (arrow, ourselves, or even the compiler might exploit this)
+//! * not trivially optimized out
+//! * not random between runs
+//!
+//! Run all benchmarks:
+//! ```
+//! cargo run -p log_benchmark --release
+//! ```
+//!
+//! Run specific benchmark:
+//! ```
+//! cargo run -p log_benchmark --release -- --benchmarks points3d_large_batch
+//! ```
+//!
+
+use clap::{Parser as _, ValueEnum as _};
+
+mod image;
+mod points3d_large_batch;
+mod points3d_many_individual;
+
+// ---
+
+/// Very simple linear congruency "random" number generator to spread out values a bit.
+pub fn lcg(lcg_state: &mut i64) -> i64 {
+    *lcg_state = (1140671485_i64
+        .wrapping_mul(*lcg_state)
+        .wrapping_add(128201163))
+        % 16777216;
+    *lcg_state
+}
+// ---
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, clap::ValueEnum)]
+enum Benchmark {
+    #[value(name("points3d_large_batch"))]
+    Points3DLargeBatch,
+
+    #[value(name("points3d_many_individual"))]
+    Points3DManyIndividual,
+
+    #[value(name("image"))]
+    Image,
+}
+
+#[derive(Debug, clap::Parser)]
+#[clap(author, version, about)]
+struct Args {
+    /// Which test should we run? All of them by default.
+    #[clap(long, value_enum)]
+    benchmarks: Option<Vec<Benchmark>>,
+
+    /// If enabled, brings up the puffin profiler on startup.
+    #[clap(long, default_value = "false")]
+    profile: bool,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    let mut profiler = re_tracing::Profiler::default();
+    if args.profile {
+        profiler.start();
+    }
+
+    let benchmarks: Vec<Benchmark> = args.benchmarks.as_ref().map_or_else(
+        || Benchmark::value_variants().to_vec(),
+        |benchmarks| benchmarks.clone(),
+    );
+
+    for benchmark in benchmarks {
+        println!("Running benchmark: {benchmark:?}");
+
+        match benchmark {
+            Benchmark::Points3DLargeBatch => points3d_large_batch::run()?,
+            Benchmark::Points3DManyIndividual => points3d_many_individual::run()?,
+            Benchmark::Image => image::run()?,
+        }
+    }
+
+    Ok(())
+}

--- a/tests/rust/log_benchmark/src/main.rs
+++ b/tests/rust/log_benchmark/src/main.rs
@@ -29,6 +29,7 @@ use clap::{Parser as _, ValueEnum as _};
 mod image;
 mod points3d_large_batch;
 mod points3d_many_individual;
+mod points3d_shared;
 
 // ---
 

--- a/tests/rust/log_benchmark/src/main.rs
+++ b/tests/rust/log_benchmark/src/main.rs
@@ -9,7 +9,7 @@
 //!
 //! The data we generate for benchmarking should be:
 //! * minimal overhead to generate
-//! * not homogenous (arrow, ourselves, or even the compiler might exploit this)
+//! * not homogeneous (arrow, ourselves, or even the compiler might exploit this)
 //! * not trivially optimized out
 //! * not random between runs
 //!

--- a/tests/rust/log_benchmark/src/points3d_large_batch.rs
+++ b/tests/rust/log_benchmark/src/points3d_large_batch.rs
@@ -2,13 +2,6 @@ use crate::points3d_shared::{prepare_points3d, Point3DInput};
 
 const NUM_POINTS: usize = 50_000_000;
 
-/// Log a single large batch of points with positions, colors, radii and a splatted string.
-pub fn run() -> anyhow::Result<()> {
-    re_tracing::profile_function!();
-    let input = std::hint::black_box(prepare_points3d(42, NUM_POINTS));
-    execute(input)
-}
-
 fn execute(input: Point3DInput) -> anyhow::Result<()> {
     re_tracing::profile_function!();
 
@@ -20,7 +13,8 @@ fn execute(input: Point3DInput) -> anyhow::Result<()> {
     } = input;
 
     let (rec, _storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_benchmark_points3d_large_batch").memory()?;
+        rerun::RecordingStreamBuilder::new("rerun_example_benchmark_points3d_large_batch")
+            .memory()?;
     rec.log(
         "large_batch",
         &rerun::Points3D::new(positions)
@@ -29,4 +23,11 @@ fn execute(input: Point3DInput) -> anyhow::Result<()> {
             .with_labels([label]),
     )?;
     Ok(())
+}
+
+/// Log a single large batch of points with positions, colors, radii and a splatted string.
+pub fn run() -> anyhow::Result<()> {
+    re_tracing::profile_function!();
+    let input = std::hint::black_box(prepare_points3d(42, NUM_POINTS));
+    execute(input)
 }

--- a/tests/rust/log_benchmark/src/points3d_large_batch.rs
+++ b/tests/rust/log_benchmark/src/points3d_large_batch.rs
@@ -20,7 +20,7 @@ fn execute(input: Point3DInput) -> anyhow::Result<()> {
     } = input;
 
     let (rec, _storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").memory()?;
+        rerun::RecordingStreamBuilder::new("rerun_example_benchmark_points3d_large_batch").memory()?;
     rec.log(
         "large_batch",
         &rerun::Points3D::new(positions)

--- a/tests/rust/log_benchmark/src/points3d_large_batch.rs
+++ b/tests/rust/log_benchmark/src/points3d_large_batch.rs
@@ -1,51 +1,18 @@
-use crate::lcg;
+use crate::points3d_shared::{prepare_points3d, Point3DInput};
 
 const NUM_POINTS: usize = 50_000_000;
 
 /// Log a single large batch of points with positions, colors, radii and a splatted string.
 pub fn run() -> anyhow::Result<()> {
     re_tracing::profile_function!();
-    let input = std::hint::black_box(prepare());
+    let input = std::hint::black_box(prepare_points3d(42, NUM_POINTS));
     execute(input)
 }
 
-/// Batch that should be logged.
-/// Intentionally not using `rerun::Points3D` here already.
-struct PointBatchInput {
-    positions: Vec<glam::Vec3>,
-    colors: Vec<u32>,
-    radii: Vec<f32>,
-    label: String,
-}
-
-fn prepare() -> PointBatchInput {
-    re_tracing::profile_function!();
-    let mut lcg_state = 42_i64;
-
-    PointBatchInput {
-        positions: (0..NUM_POINTS)
-            .map(|_| {
-                glam::vec3(
-                    lcg(&mut lcg_state) as f32,
-                    lcg(&mut lcg_state) as f32,
-                    lcg(&mut lcg_state) as f32,
-                )
-            })
-            .collect(),
-        colors: (0..NUM_POINTS)
-            .map(|_| lcg(&mut lcg_state) as u32)
-            .collect(),
-        radii: (0..NUM_POINTS)
-            .map(|_| lcg(&mut lcg_state) as f32)
-            .collect(),
-        label: "large_batch".to_owned(),
-    }
-}
-
-fn execute(input: PointBatchInput) -> anyhow::Result<()> {
+fn execute(input: Point3DInput) -> anyhow::Result<()> {
     re_tracing::profile_function!();
 
-    let PointBatchInput {
+    let Point3DInput {
         positions,
         colors,
         radii,

--- a/tests/rust/log_benchmark/src/points3d_large_batch.rs
+++ b/tests/rust/log_benchmark/src/points3d_large_batch.rs
@@ -1,0 +1,65 @@
+use crate::lcg;
+
+const NUM_POINTS: usize = 50_000_000;
+
+/// Log a single large batch of points with positions, colors, radii and a splatted string.
+pub fn run() -> anyhow::Result<()> {
+    re_tracing::profile_function!();
+    let input = std::hint::black_box(prepare());
+    execute(input)
+}
+
+/// Batch that should be logged.
+/// Intentionally not using `rerun::Points3D` here already.
+struct PointBatchInput {
+    positions: Vec<glam::Vec3>,
+    colors: Vec<u32>,
+    radii: Vec<f32>,
+    label: String,
+}
+
+fn prepare() -> PointBatchInput {
+    re_tracing::profile_function!();
+    let mut lcg_state = 42_i64;
+
+    PointBatchInput {
+        positions: (0..NUM_POINTS)
+            .map(|_| {
+                glam::vec3(
+                    lcg(&mut lcg_state) as f32,
+                    lcg(&mut lcg_state) as f32,
+                    lcg(&mut lcg_state) as f32,
+                )
+            })
+            .collect(),
+        colors: (0..NUM_POINTS)
+            .map(|_| lcg(&mut lcg_state) as u32)
+            .collect(),
+        radii: (0..NUM_POINTS)
+            .map(|_| lcg(&mut lcg_state) as f32)
+            .collect(),
+        label: "large_batch".to_owned(),
+    }
+}
+
+fn execute(input: PointBatchInput) -> anyhow::Result<()> {
+    re_tracing::profile_function!();
+
+    let PointBatchInput {
+        positions,
+        colors,
+        radii,
+        label,
+    } = input;
+
+    let (rec, _storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").memory()?;
+    rec.log(
+        "large_batch",
+        &rerun::Points3D::new(positions)
+            .with_colors(colors)
+            .with_radii(radii)
+            .with_labels([label]),
+    )?;
+    Ok(())
+}

--- a/tests/rust/log_benchmark/src/points3d_many_individual.rs
+++ b/tests/rust/log_benchmark/src/points3d_many_individual.rs
@@ -1,0 +1,3 @@
+pub fn run() -> anyhow::Result<()> {
+    Ok(())
+}

--- a/tests/rust/log_benchmark/src/points3d_many_individual.rs
+++ b/tests/rust/log_benchmark/src/points3d_many_individual.rs
@@ -1,3 +1,35 @@
+use crate::points3d_shared::{prepare_points3d, Point3DInput};
+
+const NUM_POINTS: usize = 1_000_000;
+
+/// Log many individual points (position, color, radius), each with a different timestamp.
 pub fn run() -> anyhow::Result<()> {
+    re_tracing::profile_function!();
+    let input = std::hint::black_box(prepare_points3d(1337, NUM_POINTS));
+    execute(input)
+}
+
+fn execute(input: Point3DInput) -> anyhow::Result<()> {
+    re_tracing::profile_function!();
+
+    let Point3DInput {
+        positions,
+        colors,
+        radii,
+        label: _,
+    } = input;
+
+    let (rec, _storage) =
+        rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").memory()?;
+
+    for i in 0..NUM_POINTS {
+        rec.set_time_sequence("my_timeline", i as i64);
+        rec.log(
+            "large_batch",
+            &rerun::Points3D::new([positions[i]])
+                .with_colors([colors[i]])
+                .with_radii([radii[i]]),
+        )?;
+    }
     Ok(())
 }

--- a/tests/rust/log_benchmark/src/points3d_many_individual.rs
+++ b/tests/rust/log_benchmark/src/points3d_many_individual.rs
@@ -20,12 +20,13 @@ fn execute(input: Point3DInput) -> anyhow::Result<()> {
     } = input;
 
     let (rec, _storage) =
-        rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").memory()?;
+        rerun::RecordingStreamBuilder::new("rerun_example_benchmark_points3d_many_individual")
+            .memory()?;
 
     for i in 0..NUM_POINTS {
         rec.set_time_sequence("my_timeline", i as i64);
         rec.log(
-            "large_batch",
+            "single_point",
             &rerun::Points3D::new([positions[i]])
                 .with_colors([colors[i]])
                 .with_radii([radii[i]]),

--- a/tests/rust/log_benchmark/src/points3d_many_individual.rs
+++ b/tests/rust/log_benchmark/src/points3d_many_individual.rs
@@ -2,13 +2,6 @@ use crate::points3d_shared::{prepare_points3d, Point3DInput};
 
 const NUM_POINTS: usize = 1_000_000;
 
-/// Log many individual points (position, color, radius), each with a different timestamp.
-pub fn run() -> anyhow::Result<()> {
-    re_tracing::profile_function!();
-    let input = std::hint::black_box(prepare_points3d(1337, NUM_POINTS));
-    execute(input)
-}
-
 fn execute(input: Point3DInput) -> anyhow::Result<()> {
     re_tracing::profile_function!();
 
@@ -33,4 +26,11 @@ fn execute(input: Point3DInput) -> anyhow::Result<()> {
         )?;
     }
     Ok(())
+}
+
+/// Log many individual points (position, color, radius), each with a different timestamp.
+pub fn run() -> anyhow::Result<()> {
+    re_tracing::profile_function!();
+    let input = std::hint::black_box(prepare_points3d(1337, NUM_POINTS));
+    execute(input)
 }

--- a/tests/rust/log_benchmark/src/points3d_shared.rs
+++ b/tests/rust/log_benchmark/src/points3d_shared.rs
@@ -1,0 +1,33 @@
+use crate::lcg;
+
+/// Batch that should be logged.
+/// Intentionally not using `rerun::Points3D` here already.
+pub struct Point3DInput {
+    pub positions: Vec<glam::Vec3>,
+    pub colors: Vec<u32>,
+    pub radii: Vec<f32>,
+    pub label: String,
+}
+
+pub fn prepare_points3d(mut lcg_state: i64, num_points: usize) -> Point3DInput {
+    re_tracing::profile_function!();
+
+    Point3DInput {
+        positions: (0..num_points)
+            .map(|_| {
+                glam::vec3(
+                    lcg(&mut lcg_state) as f32,
+                    lcg(&mut lcg_state) as f32,
+                    lcg(&mut lcg_state) as f32,
+                )
+            })
+            .collect(),
+        colors: (0..num_points)
+            .map(|_| lcg(&mut lcg_state) as u32)
+            .collect(),
+        radii: (0..num_points)
+            .map(|_| lcg(&mut lcg_state) as f32)
+            .collect(),
+        label: "large_batch".to_owned(),
+    }
+}

--- a/tests/rust/log_benchmark/src/points3d_shared.rs
+++ b/tests/rust/log_benchmark/src/points3d_shared.rs
@@ -28,6 +28,6 @@ pub fn prepare_points3d(mut lcg_state: i64, num_points: usize) -> Point3DInput {
         radii: (0..num_points)
             .map(|_| lcg(&mut lcg_state) as f32)
             .collect(),
-        label: "large_batch".to_owned(),
+        label: "some label".to_owned(),
     }
 }


### PR DESCRIPTION
### What

* Part of #4100

Implements SDK sided logging benchmark for C++ & Rust.
Kept as simple as possible, meant for whole-process profiling so we capture all sideeffects. This makes tthe data generation ('prepare') inside the benchmark apps ofc quite tricky as it has to be as fast as possible.
Additionally, both Rust & Cpp app expose a way to get more fine grained logging. Cpp does this via a simple profiler scope, Rust via Puffin/re_tracing.

Logging always happens to a memory recording.
Data is currently never passed in in the Rerun format

Contains the tree initial benchmarks we wanted to have:
* points3d_large_batch
   * Single batch of 50mio points (color, position, radius, single label)
* points3d_many_individual
   * 1mio individual points with different time stamp each (color, position, radius) 
* image
   * log 4 different 16k x 16k RGBA8 images (4GiB of memory!)

Running instructions in `main.rs` & `main.cpp`!


Timings on my M1 Max in seconds
(tests are not perfectly comparable, they do not do the exact same thing. Prepare times are also slightly different and most significant in the _large_batch test)

* points3d_large_batch
   * C++:  0.94s
   * Rust: 1.34s
* points3d_many_individual
   * C++: 16.86s (⚠️ there's almost certainly some involuntary allocation going on there)
   * Rust: 2.75s
* image
   * C++: 3.11s
   * Rust: 1.10s


Missing
* Python version
* utility script for building, running and publishing data


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4181) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4181)
- [Docs preview](https://rerun.io/preview/73a3736ac3c0be33fa8d6e6b40a2af243c4aa2d9/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/73a3736ac3c0be33fa8d6e6b40a2af243c4aa2d9/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)