### PR TITLE
Implement recording/last-modified-at aware garbage collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4144,6 +4144,7 @@ dependencies = [
  "serde",
  "similar-asserts",
  "thiserror",
+ "web-time",
 ]
 
 [[package]]

--- a/crates/re_data_store/Cargo.toml
+++ b/crates/re_data_store/Cargo.toml
@@ -40,6 +40,7 @@ itertools.workspace = true
 nohash-hasher.workspace = true
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 thiserror.workspace = true
+web-time.workspace = true
 
 [dev-dependencies]
 re_log_encoding = { workspace = true, features = ["decoder", "encoder"] }

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -318,6 +318,9 @@ pub struct StoreDb {
 
     /// Where we store the entities.
     entity_db: EntityDb,
+
+    /// Keeps track of the last time data was inserted into this store (viewer wall-clock).
+    last_modified_at: web_time::Instant,
 }
 
 impl StoreDb {
@@ -327,6 +330,7 @@ impl StoreDb {
             data_source: None,
             set_store_info: None,
             entity_db: Default::default(),
+            last_modified_at: web_time::Instant::now(),
         }
     }
 
@@ -437,6 +441,8 @@ impl StoreDb {
             self.add_data_row(row?)?;
         }
 
+        self.last_modified_at = web_time::Instant::now();
+
         Ok(())
     }
 
@@ -489,6 +495,7 @@ impl StoreDb {
             data_source: _,
             set_store_info: _,
             entity_db,
+            last_modified_at: _,
         } = self;
 
         entity_db.purge(&deleted);

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -412,6 +412,10 @@ impl StoreDb {
         self.entity_db.data_store.generation()
     }
 
+    pub fn last_modified_at(&self) -> web_time::Instant {
+        self.last_modified_at
+    }
+
     pub fn is_empty(&self) -> bool {
         self.set_store_info.is_none() && self.num_rows() == 0
     }

--- a/tests/python/gc_stress/many_large_many_rows_recordings.py
+++ b/tests/python/gc_stress/many_large_many_rows_recordings.py
@@ -1,0 +1,26 @@
+"""
+Stress test for cross-recording garbage collection.
+
+Logs many large recordings that contain a lot of large rows.
+
+Usage:
+- Start a Rerun Viewer in release mode with 2GiB of memory limit:
+  `cargo r -p rerun-cli --release --no-default-features --features native_viewer -- --memory-limit 2GiB`
+- Open the memory panel to see what's going on.
+- Run this script.
+- You should see recordings coming in and going out in a ringbuffer-like rolling fashion.
+"""
+from __future__ import annotations
+
+import rerun as rr
+from numpy.random import default_rng
+
+rng = default_rng(12345)
+
+for i in range(0, 20000000):
+    rr.init("rerun_example_recording_gc", recording_id=f"image-rec-{i}", spawn=True)
+    for j in range(0, 10000):
+        positions = rng.uniform(-5, 5, size=[10000000, 3])
+        colors = rng.uniform(0, 255, size=[10000000, 3])
+        radii = rng.uniform(0, 1, size=[10000000])
+        rr.log("points", rr.Points3D(positions, colors=colors, radii=radii))

--- a/tests/python/gc_stress/many_large_single_row_recordings.py
+++ b/tests/python/gc_stress/many_large_single_row_recordings.py
@@ -1,0 +1,32 @@
+"""
+Stress test for cross-recording garbage collection.
+
+Logs many large recordings that contain a single large row.
+
+Usage:
+- Start a Rerun Viewer in release mode with 2GiB of memory limit:
+  `cargo r -p rerun-cli --release --no-default-features --features native_viewer -- --memory-limit 2GiB`
+- Open the memory panel to see what's going on.
+- Run this script.
+- You should see recordings coming in and going out in a ringbuffer-like rolling fashion.
+"""
+from __future__ import annotations
+
+import time
+
+import rerun as rr
+from numpy.random import default_rng
+
+rng = default_rng(12345)
+
+for i in range(0, 20000000):
+    rr.init("rerun_example_recording_gc", recording_id=f"recording-gc-rec-{i}", spawn=True)
+
+    positions = rng.uniform(-5, 5, size=[10000000, 3])
+    colors = rng.uniform(0, 255, size=[10000000, 3])
+    radii = rng.uniform(0, 1, size=[10000000])
+    rr.log("points", rr.Points3D(positions, colors=colors, radii=radii))
+
+    # Sleep because large rows will absolutely destroy the viewer.
+    # TODO(#4183): Investigate this.
+    time.sleep(1)

--- a/tests/python/gc_stress/many_medium_sized_many_rows_recordings.py
+++ b/tests/python/gc_stress/many_medium_sized_many_rows_recordings.py
@@ -1,0 +1,27 @@
+"""
+Stress test for cross-recording garbage collection.
+
+Logs many medium-sized recordings that contain a lot of small-ish rows.
+
+Usage:
+- Start a Rerun Viewer in release mode with 500MiB of memory limit:
+  `cargo r -p rerun-cli --release --no-default-features --features native_viewer -- --memory-limit 500MiB`
+- Open the memory panel to see what's going on.
+- Run this script.
+- You should see recordings coming in and going out in a ringbuffer-like rolling fashion.
+"""
+from __future__ import annotations
+
+import rerun as rr
+from numpy.random import default_rng
+
+rng = default_rng(12345)
+
+for i in range(0, 20000000):
+    rr.init("rerun_example_recording_gc", recording_id=f"image-rec-{i}", spawn=True)
+    for j in range(0, 10000):
+        rr.set_time_sequence("frame", j)
+        positions = rng.uniform(-5, 5, size=[1000, 3])
+        colors = rng.uniform(0, 255, size=[1000, 3])
+        radii = rng.uniform(0, 1, size=[1000])
+        rr.log("points", rr.Points3D(positions, colors=colors, radii=radii))

--- a/tests/python/gc_stress/many_medium_sized_single_row_recordings.py
+++ b/tests/python/gc_stress/many_medium_sized_single_row_recordings.py
@@ -1,0 +1,32 @@
+"""
+Stress test for cross-recording garbage collection.
+
+Logs many medium-sized recordings that contain a single medium-sized row.
+
+Usage:
+- Start a Rerun Viewer in release mode with 200MiB of memory limit:
+  `cargo r -p rerun-cli --release --no-default-features --features native_viewer -- --memory-limit 200MiB`
+- Open the memory panel to see what's going on.
+- Run this script.
+- You should see recordings coming in and going out in a ringbuffer-like rolling fashion.
+"""
+from __future__ import annotations
+
+import time
+
+import rerun as rr
+from numpy.random import default_rng
+
+rng = default_rng(12345)
+
+for i in range(0, 20000000):
+    rr.init("rerun_example_recording_gc", recording_id=f"recording-gc-rec-{i}", spawn=True)
+
+    positions = rng.uniform(-5, 5, size=[10000, 3])
+    colors = rng.uniform(0, 255, size=[10000, 3])
+    radii = rng.uniform(0, 1, size=[10000])
+    rr.log("points", rr.Points3D(positions, colors=colors, radii=radii))
+
+    # Sleep so we don't run out of TCP sockets.
+    # Timings might need to be adjusted depending on your hardware.
+    time.sleep(0.05)


### PR DESCRIPTION
**Commit by commit, there's renaming involved!**

GC will now focus on the oldest-modified recording first.
Tried a lot of fancy things, but a lot of stress testing has shown that nothing worked as well as doing this the dumb way.

Speaking of stress testing, the scripts I've used are now committed in the repository. Make sure to try them out when modifying the GC code :grimacing:.

In general, the GC supports stress much better than I thought/hoped:
- `many_medium_sized_single_row_recordings.py`, `many_medium_sized_many_rows_recordings.py` & `many_large_many_rows_recordings.py` all behave pretty nicely, something like this:

https://github.com/rerun-io/rerun/assets/2910679/26f67d69-de0e-4002-8936-2ac32c451cc3


- `many_large_single_row_recordings.py` on the other hand is _still_ a disaster (watch til the end, this slowly devolves into a blackhole):

https://github.com/rerun-io/rerun/assets/2910679/673ee10c-2eca-4e3e-b285-77714e5c3d61



This is not a new problem (not to me at least :grimacing:), large recordings with very few rows have always been a nightmare on the GC (not specifically the DataStore GC, the GC as a whole through the entire app).
I've never had time to investigate why, but now we have an issue for it at least:
- #4185 

---

- Fixes #1904 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4183) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4183)
- [Docs preview](https://rerun.io/preview/8e6b8853b3751037989e80c26704fbf3d0438a64/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8e6b8853b3751037989e80c26704fbf3d0438a64/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)