### PR TITLE
Do not use `RowId::ZERO` in query benchmarks (illegal RowId duplicates)

### DIFF
--- a/crates/re_query/benches/query_benchmark.rs
+++ b/crates/re_query/benches/query_benchmark.rs
@@ -195,7 +195,7 @@ fn build_points_rows(paths: &[EntityPath], num_points: usize) -> Vec<DataRow> {
         .flat_map(move |frame_idx| {
             paths.iter().map(move |path| {
                 let mut row = DataRow::from_cells2(
-                    RowId::ZERO,
+                    RowId::random(),
                     path.clone(),
                     [build_frame_nr((frame_idx as i64).into())],
                     num_points as _,
@@ -221,7 +221,7 @@ fn build_strings_rows(paths: &[EntityPath], num_strings: usize) -> Vec<DataRow> 
         .flat_map(move |frame_idx| {
             paths.iter().map(move |path| {
                 let mut row = DataRow::from_cells2(
-                    RowId::ZERO,
+                    RowId::random(),
                     path.clone(),
                     [build_frame_nr((frame_idx as i64).into())],
                     num_strings as _,


### PR DESCRIPTION
Benchmarks failed to run once I merge the `RowId` stuff, because they only run on `main` :( 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4187) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4187)
- [Docs preview](https://rerun.io/preview/0422a4568d1bd68212d5f6295178be62e8472d55/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0422a4568d1bd68212d5f6295178be62e8472d55/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)