### PR TITLE
New debug option to show the blueprint in the streams view

### DIFF
--- a/crates/re_data_ui/src/component_path.rs
+++ b/crates/re_data_ui/src/component_path.rs
@@ -16,7 +16,17 @@ impl DataUi for ComponentPath {
             component_name,
         } = self;
 
-        let store = ctx.store_db.store();
+        let store = if ctx.app_options.show_blueprint_in_timeline
+            && ctx
+                .store_context
+                .blueprint
+                .entity_db()
+                .is_logged_entity(entity_path)
+        {
+            ctx.store_context.blueprint.store()
+        } else {
+            ctx.store_db.store()
+        };
 
         if let Some(archetype_name) = component_name.indicator_component_archetype() {
             ui.label(format!(

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -19,7 +19,17 @@ impl DataUi for InstancePath {
             instance_key,
         } = self;
 
-        let store = ctx.store_db.store();
+        let store = if ctx.app_options.show_blueprint_in_timeline
+            && ctx
+                .store_context
+                .blueprint
+                .entity_db()
+                .is_logged_entity(entity_path)
+        {
+            ctx.store_context.blueprint.store()
+        } else {
+            ctx.store_db.store()
+        };
 
         let Some(components) = store.all_components(&query.timeline, entity_path) else {
             if ctx.store_db.entity_db().is_known_entity(entity_path) {

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -392,6 +392,7 @@ impl TimePanel {
                         None,
                         &ctx.store_db.entity_db().tree,
                         ui,
+                        "/",
                     );
                 } else {
                     self.show_children(
@@ -401,6 +402,18 @@ impl TimePanel {
                         tree_max_y,
                         &ctx.store_db.entity_db().tree,
                         ui,
+                    );
+                }
+                if ctx.app_options.show_blueprint_in_timeline {
+                    self.show_tree(
+                        ctx,
+                        time_area_response,
+                        time_area_painter,
+                        tree_max_y,
+                        None,
+                        &ctx.store_context.blueprint.entity_db().tree,
+                        ui,
+                        "/ (blueprint)",
                     );
                 }
             });
@@ -416,6 +429,7 @@ impl TimePanel {
         last_path_part: Option<&EntityPathPart>,
         tree: &EntityTree,
         ui: &mut egui::Ui,
+        show_root_as: &str,
     ) {
         let tree_has_data_in_current_timeline = ctx.tree_has_data_in_current_timeline(tree);
 
@@ -427,7 +441,7 @@ impl TimePanel {
                 format!("{last_path_part}/") // show we have children with a /
             }
         } else {
-            "/".to_owned()
+            show_root_as.to_owned()
         };
 
         let collapsing_header_id = ui.make_persistent_id(&tree.path);
@@ -531,6 +545,7 @@ impl TimePanel {
                 Some(last_component),
                 child,
                 ui,
+                "/",
             );
         }
 

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -338,6 +338,12 @@ impl App {
         )
             .on_hover_text("Show a debug overlay that renders the picking layer information using the `debug_overlay.wgsl` shader.");
 
+        self.re_ui.checkbox(ui,
+                       &mut self.state.app_options.show_blueprint_in_timeline,
+                       "Show the blueprint in the timeline",
+        )
+            .on_hover_text("Show the blueprint data in the timeline tree view. This is useful for debugging the blueprint.");
+
         ui.menu_button("Crash", |ui| {
             #[allow(clippy::manual_assert)]
             if ui.button("panic!").clicked() {

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -340,9 +340,9 @@ impl App {
 
         self.re_ui.checkbox(ui,
                        &mut self.state.app_options.show_blueprint_in_timeline,
-                       "Show the blueprint in the timeline",
+                       "Show Blueprint in the Time Panel",
         )
-            .on_hover_text("Show the blueprint data in the timeline tree view. This is useful for debugging the blueprint.");
+            .on_hover_text("Show the Blueprint data in the Time Panel tree view. This is useful for debugging the internal blueprint state.");
 
         ui.menu_button("Crash", |ui| {
             #[allow(clippy::manual_assert)]

--- a/crates/re_viewer_context/src/app_options.rs
+++ b/crates/re_viewer_context/src/app_options.rs
@@ -26,6 +26,9 @@ pub struct AppOptions {
     /// Displays an overlay for debugging picking.
     pub show_picking_debug_overlay: bool,
 
+    /// Includes the blueprint in the timeline view.
+    pub show_blueprint_in_timeline: bool,
+
     /// What time zone to display timestamps in.
     pub time_zone_for_timestamps: TimeZone,
 }
@@ -45,6 +48,8 @@ impl Default for AppOptions {
             experimental_space_view_screenshots: false,
 
             show_picking_debug_overlay: false,
+
+            show_blueprint_in_timeline: false,
 
             time_zone_for_timestamps: TimeZone::Utc,
         }


### PR DESCRIPTION
### What
It's much easier to debug the blueprint if we can see what's going on. Since the blueprint is just another store, we already have decent inspection tools for this.

This just adds a toggle to show the blueprint in the time panel and a bit of extra handling to resolve blueprint entity paths in the selection-panel.

This doesn't handle entity-path-collisions gracefully, but as a debug-only tool that seems like an acceptable trade-off. Eventually we are going to need to track the originating store as part of the selection anyways so this constraint should get resolved at that point.

This will become even more valuable as we migrate from serde-style to arrow-style blueprint components as the data UI will become much more useful.

![image](https://github.com/rerun-io/rerun/assets/3312232/eb24fe2b-607e-4bff-b101-54cb5d0fd83f)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4189) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4189)
- [Docs preview](https://rerun.io/preview/9489a45868312d757373e8de23f933b74b331bcb/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/9489a45868312d757373e8de23f933b74b331bcb/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)