### PR TITLE
Properly scale radii for 2D parts shown in 3D space view's pinhole image plane

### DIFF
--- a/crates/re_space_view_spatial/src/contexts/mod.rs
+++ b/crates/re_space_view_spatial/src/contexts/mod.rs
@@ -23,7 +23,7 @@ use re_viewer_context::{
 /// Context objects for a single entity in a spatial scene.
 pub struct SpatialSceneEntityContext<'a> {
     pub world_from_entity: glam::Affine3A,
-    pub pinhole_scale: Option<glam::Vec2>,
+    pub radii_scale_factor: Option<f32>,
     pub depth_offset: DepthOffset,
     pub annotations: std::sync::Arc<Annotations>,
     pub shared_render_builders: &'a SharedRenderBuilders,

--- a/crates/re_space_view_spatial/src/contexts/mod.rs
+++ b/crates/re_space_view_spatial/src/contexts/mod.rs
@@ -23,6 +23,7 @@ use re_viewer_context::{
 /// Context objects for a single entity in a spatial scene.
 pub struct SpatialSceneEntityContext<'a> {
     pub world_from_entity: glam::Affine3A,
+    pub pinhole_scale: Option<glam::Vec2>,
     pub depth_offset: DepthOffset,
     pub annotations: std::sync::Arc<Annotations>,
     pub shared_render_builders: &'a SharedRenderBuilders,

--- a/crates/re_space_view_spatial/src/contexts/mod.rs
+++ b/crates/re_space_view_spatial/src/contexts/mod.rs
@@ -23,6 +23,12 @@ use re_viewer_context::{
 /// Context objects for a single entity in a spatial scene.
 pub struct SpatialSceneEntityContext<'a> {
     pub world_from_entity: glam::Affine3A,
+
+    /// Scale factor to be applied on radii for 2D object drawn on a 3D space view's pinhole camera.
+    ///
+    /// `Some` when a parent pinhole transform exists for the entity (that isn't the space origin).
+    /// In this case the factor converts from the "pixel" unit of pinhole to the 3D pinhole widget
+    /// actual pixel size (taking into account the image plane distance).
     pub radii_scale_factor: Option<f32>,
     pub depth_offset: DepthOffset,
     pub annotations: std::sync::Arc<Annotations>,

--- a/crates/re_space_view_spatial/src/parts/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/parts/arrows3d.rs
@@ -88,7 +88,7 @@ impl Arrows3DPart {
             process_annotations::<Vector3D, Arrows3D>(query, arch_view, &ent_context.annotations)?;
 
         let colors = process_colors(arch_view, ent_path, &annotation_infos)?;
-        let radii = process_radii(arch_view, ent_path)?;
+        let radii = process_radii(arch_view, ent_context.pinhole_scale, ent_path)?;
 
         if arch_view.num_instances() <= self.max_labels {
             // Max labels is small enough that we can afford iterating on the colors again.

--- a/crates/re_space_view_spatial/src/parts/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/parts/arrows3d.rs
@@ -88,7 +88,7 @@ impl Arrows3DPart {
             process_annotations::<Vector3D, Arrows3D>(query, arch_view, &ent_context.annotations)?;
 
         let colors = process_colors(arch_view, ent_path, &annotation_infos)?;
-        let radii = process_radii(arch_view, ent_context.pinhole_scale, ent_path)?;
+        let radii = process_radii(arch_view, None, ent_path)?;
 
         if arch_view.num_instances() <= self.max_labels {
             // Max labels is small enough that we can afford iterating on the colors again.

--- a/crates/re_space_view_spatial/src/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes2d.rs
@@ -90,7 +90,7 @@ impl Boxes2DPart {
         let positions = arch_view
             .iter_optional_component::<Position2D>()?
             .map(|position| position.unwrap_or(Position2D::ZERO));
-        let radii = process_radii(arch_view, ent_context.pinhole_scale, ent_path)?;
+        let radii = process_radii(arch_view, ent_context.radii_scale_factor, ent_path)?;
         let colors = process_colors(arch_view, ent_path, &annotation_infos)?;
 
         if arch_view.num_instances() <= self.max_labels {

--- a/crates/re_space_view_spatial/src/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes2d.rs
@@ -90,7 +90,7 @@ impl Boxes2DPart {
         let positions = arch_view
             .iter_optional_component::<Position2D>()?
             .map(|position| position.unwrap_or(Position2D::ZERO));
-        let radii = process_radii(arch_view, ent_path)?;
+        let radii = process_radii(arch_view, ent_context.pinhole_scale, ent_path)?;
         let colors = process_colors(arch_view, ent_path, &annotation_infos)?;
 
         if arch_view.num_instances() <= self.max_labels {

--- a/crates/re_space_view_spatial/src/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes3d.rs
@@ -51,7 +51,7 @@ impl Boxes3DPart {
         let rotation = arch_view
             .iter_optional_component::<Rotation3D>()?
             .map(|position| position.unwrap_or(Rotation3D::IDENTITY));
-        let radii = process_radii(arch_view, ent_context.pinhole_scale, ent_path)?;
+        let radii = process_radii(arch_view, None, ent_path)?;
         let colors = process_colors(arch_view, ent_path, &annotation_infos)?;
         let labels = process_labels(arch_view, &annotation_infos)?;
 

--- a/crates/re_space_view_spatial/src/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes3d.rs
@@ -51,7 +51,7 @@ impl Boxes3DPart {
         let rotation = arch_view
             .iter_optional_component::<Rotation3D>()?
             .map(|position| position.unwrap_or(Rotation3D::IDENTITY));
-        let radii = process_radii(arch_view, ent_path)?;
+        let radii = process_radii(arch_view, ent_context.pinhole_scale, ent_path)?;
         let colors = process_colors(arch_view, ent_path, &annotation_infos)?;
         let labels = process_labels(arch_view, &annotation_infos)?;
 

--- a/crates/re_space_view_spatial/src/parts/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/parts/entity_iterator.rs
@@ -63,7 +63,7 @@ where
                 .per_entity
                 .get(&ent_path.hash())
                 .unwrap_or(&default_depth_offset),
-            radii_scale_factor: get_radii_scale_factor(ctx, query, transforms, ent_path),
+            radii_scale_factor: radii_scale_factor(ctx, query, transforms, ent_path),
             annotations: annotations.0.find(ent_path),
             shared_render_builders,
             highlight: query.highlights.entity_outline_mask(ent_path.hash()),
@@ -98,7 +98,7 @@ where
     Ok(())
 }
 
-fn get_radii_scale_factor(
+fn radii_scale_factor(
     ctx: &mut ViewerContext<'_>,
     query: &ViewQuery<'_>,
     transforms: &TransformContext,

--- a/crates/re_space_view_spatial/src/parts/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/parts/entity_iterator.rs
@@ -63,7 +63,7 @@ where
                 .per_entity
                 .get(&ent_path.hash())
                 .unwrap_or(&default_depth_offset),
-            pinhole_scale: get_pinhole_scale(ctx, query, transforms, ent_path),
+            radii_scale_factor: get_radii_scale_factor(ctx, query, transforms, ent_path),
             annotations: annotations.0.find(ent_path),
             shared_render_builders,
             highlight: query.highlights.entity_outline_mask(ent_path.hash()),
@@ -98,12 +98,12 @@ where
     Ok(())
 }
 
-fn get_pinhole_scale(
+fn get_radii_scale_factor(
     ctx: &mut ViewerContext<'_>,
     query: &ViewQuery<'_>,
     transforms: &TransformContext,
     ent_path: &EntityPath,
-) -> Option<glam::Vec2> {
+) -> Option<f32> {
     let pinhole_ent_path = transforms.parent_pinhole(ent_path)?;
 
     let pinhole = crate::query_pinhole(
@@ -120,6 +120,7 @@ fn get_pinhole_scale(
 
     let focal_length = pinhole.focal_length_in_pixels();
     let focal_length = glam::vec2(focal_length.x(), focal_length.y());
+    let scale = distance / focal_length;
 
-    Some(distance / focal_length)
+    Some(2.0 / (1.0 / scale.x + 1.0 / scale.y))
 }

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -91,7 +91,7 @@ impl Lines2DPart {
         )?;
 
         let colors = process_colors(arch_view, ent_path, &annotation_infos)?;
-        let radii = process_radii(arch_view, ent_path)?;
+        let radii = process_radii(arch_view, ent_context.pinhole_scale, ent_path)?;
 
         if arch_view.num_instances() <= self.max_labels {
             // Max labels is small enough that we can afford iterating on the colors again.

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -91,7 +91,7 @@ impl Lines2DPart {
         )?;
 
         let colors = process_colors(arch_view, ent_path, &annotation_infos)?;
-        let radii = process_radii(arch_view, ent_context.pinhole_scale, ent_path)?;
+        let radii = process_radii(arch_view, ent_context.radii_scale_factor, ent_path)?;
 
         if arch_view.num_instances() <= self.max_labels {
             // Max labels is small enough that we can afford iterating on the colors again.

--- a/crates/re_space_view_spatial/src/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines3d.rs
@@ -97,7 +97,7 @@ impl Lines3DPart {
         )?;
 
         let colors = process_colors(arch_view, ent_path, &annotation_infos)?;
-        let radii = process_radii(arch_view, ent_path)?;
+        let radii = process_radii(arch_view, ent_context.pinhole_scale, ent_path)?;
 
         if arch_view.num_instances() <= self.max_labels {
             // Max labels is small enough that we can afford iterating on the colors again.

--- a/crates/re_space_view_spatial/src/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines3d.rs
@@ -97,7 +97,7 @@ impl Lines3DPart {
         )?;
 
         let colors = process_colors(arch_view, ent_path, &annotation_infos)?;
-        let radii = process_radii(arch_view, ent_context.pinhole_scale, ent_path)?;
+        let radii = process_radii(arch_view, None, ent_path)?;
 
         if arch_view.num_instances() <= self.max_labels {
             // Max labels is small enough that we can afford iterating on the colors again.

--- a/crates/re_space_view_spatial/src/parts/mod.rs
+++ b/crates/re_space_view_spatial/src/parts/mod.rs
@@ -162,7 +162,7 @@ pub fn process_labels<'a, A: Archetype>(
 /// where no radius is specified.
 pub fn process_radii<'a, A: Archetype>(
     arch_view: &'a re_query::ArchetypeView<A>,
-    pinhole_scale: Option<glam::Vec2>,
+    radii_scale_factor: Option<f32>,
     ent_path: &EntityPath,
 ) -> Result<impl Iterator<Item = re_renderer::Size> + 'a, re_query::QueryError> {
     re_tracing::profile_function!();
@@ -173,13 +173,7 @@ pub fn process_radii<'a, A: Archetype>(
         .map(move |radius| {
             radius.map_or(re_renderer::Size::AUTO, |r| {
                 if 0.0 <= r.0 && r.0.is_finite() {
-                    let factor = if let Some(scale) = pinhole_scale {
-                        2.0 / (1.0 / scale.x + 1.0 / scale.y)
-                    } else {
-                        1.
-                    };
-
-                    re_renderer::Size::new_scene(r.0 * factor)
+                    re_renderer::Size::new_scene(r.0 * radii_scale_factor.unwrap_or(1.0))
                 } else {
                     if r.0 < 0.0 {
                         re_log::warn_once!("Found negative radius in entity {ent_path}");

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -86,7 +86,7 @@ impl Points2DPart {
             )?;
 
         let colors = process_colors(arch_view, ent_path, &annotation_infos)?;
-        let radii = process_radii(arch_view, ent_context.pinhole_scale, ent_path)?;
+        let radii = process_radii(arch_view, ent_context.radii_scale_factor, ent_path)?;
 
         let positions = arch_view
             .iter_required_component::<Position2D>()?

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -86,7 +86,7 @@ impl Points2DPart {
             )?;
 
         let colors = process_colors(arch_view, ent_path, &annotation_infos)?;
-        let radii = process_radii(arch_view, ent_path)?;
+        let radii = process_radii(arch_view, ent_context.pinhole_scale, ent_path)?;
 
         let positions = arch_view
             .iter_required_component::<Position2D>()?

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -267,10 +267,11 @@ impl LoadedPoints {
     #[inline]
     pub fn load_radii(
         arch_view: &ArchetypeView<Points3D>,
+
         ent_path: &EntityPath,
     ) -> Result<Vec<re_renderer::Size>, QueryError> {
         re_tracing::profile_function!();
-        process_radii(arch_view, ent_path).map(|radii| {
+        process_radii(arch_view, None, ent_path).map(|radii| {
             re_tracing::profile_scope!("collect");
             radii.collect()
         })

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -267,7 +267,6 @@ impl LoadedPoints {
     #[inline]
     pub fn load_radii(
         arch_view: &ArchetypeView<Points3D>,
-
         ent_path: &EntityPath,
     ) -> Result<Vec<re_renderer::Size>, QueryError> {
         re_tracing::profile_function!();


### PR DESCRIPTION
### What

* Fixes #2494 

https://github.com/rerun-io/rerun/assets/49431240/f22bb891-257e-4c15-90fb-f82bd1f5b999


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4196) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4196)
- [Docs preview](https://rerun.io/preview/0e4b60c6facb9c08753738e8e7852125efe2e96f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0e4b60c6facb9c08753738e8e7852125efe2e96f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)