### PR TITLE
Use built-in wgsl type aliases instead of our own, remove zero/one wgsl constants

### DIFF
--- a/crates/re_renderer/shader/colormap.wgsl
+++ b/crates/re_renderer/shader/colormap.wgsl
@@ -12,12 +12,12 @@ const COLORMAP_VIRIDIS:   u32 = 6u;
 /// Returns a gamma-space sRGB in 0-1 range.
 ///
 /// The input will be saturated to [0, 1] range.
-fn colormap_srgb(which: u32, t_unsaturated: f32) -> Vec3 {
+fn colormap_srgb(which: u32, t_unsaturated: f32) -> vec3f {
     let t = saturate(t_unsaturated);
     if which == COLORMAP_GRAYSCALE {
         // A linear gray gradient in sRGB gamma space is supposed to be perceptually even as-is!
         // Easy to get confused: A linear gradient in sRGB linear space is *not* perceptually even.
-        return Vec3(t);
+        return vec3f(t);
     } else if which == COLORMAP_INFERNO {
         return colormap_inferno_srgb(t);
     } else if which == COLORMAP_MAGMA {
@@ -36,7 +36,7 @@ fn colormap_srgb(which: u32, t_unsaturated: f32) -> Vec3 {
 /// Returns a linear-space sRGB in 0-1 range.
 ///
 /// The input will be saturated to [0, 1] range.
-fn colormap_linear(which: u32, t: f32) -> Vec3 {
+fn colormap_linear(which: u32, t: f32) -> vec3f {
     return linear_from_srgb(colormap_srgb(which, t));
 }
 
@@ -56,18 +56,18 @@ fn colormap_linear(which: u32, t: f32) -> Vec3 {
 /// Returns a gamma-space sRGB in 0-1 range.
 /// This is a polynomial approximation from Turbo color map, assuming `t` is
 /// normalized (it will be saturated no matter what).
-fn colormap_turbo_srgb(t: f32) -> Vec3 {
-    let r4 = Vec4(0.13572138, 4.61539260, -42.66032258, 132.13108234);
-    let g4 = Vec4(0.09140261, 2.19418839, 4.84296658, -14.18503333);
-    let b4 = Vec4(0.10667330, 12.64194608, -60.58204836, 110.36276771);
-    let r2 = Vec2(-152.94239396, 59.28637943);
-    let g2 = Vec2(4.27729857, 2.82956604);
-    let b2 = Vec2(-89.90310912, 27.34824973);
+fn colormap_turbo_srgb(t: f32) -> vec3f {
+    let r4 = vec4f(0.13572138, 4.61539260, -42.66032258, 132.13108234);
+    let g4 = vec4f(0.09140261, 2.19418839, 4.84296658, -14.18503333);
+    let b4 = vec4f(0.10667330, 12.64194608, -60.58204836, 110.36276771);
+    let r2 = vec2f(-152.94239396, 59.28637943);
+    let g2 = vec2f(4.27729857, 2.82956604);
+    let b2 = vec2f(-89.90310912, 27.34824973);
 
-    let v4 = vec4(1.0, t, t * t, t * t * t);
+    let v4 = vec4f(1.0, t, t * t, t * t * t);
     let v2 = v4.zw * v4.z;
 
-    return vec3(
+    return vec3f(
         dot(v4, r4) + dot(v2, r2),
         dot(v4, g4) + dot(v2, g2),
         dot(v4, b4) + dot(v2, b2)
@@ -91,55 +91,55 @@ fn colormap_turbo_srgb(t: f32) -> Vec3 {
 /// Returns a gamma-space sRGB in 0-1 range.
 /// This is a polynomial approximation from Viridis color map, assuming `t` is
 /// normalized (it will be saturated no matter what).
-fn colormap_viridis_srgb(t: f32) -> Vec3 {
-    let c0 = Vec3(0.2777273272234177, 0.005407344544966578, 0.3340998053353061);
-    let c1 = Vec3(0.1050930431085774, 1.404613529898575, 1.384590162594685);
-    let c2 = Vec3(-0.3308618287255563, 0.214847559468213, 0.09509516302823659);
-    let c3 = Vec3(-4.634230498983486, -5.799100973351585, -19.33244095627987);
-    let c4 = Vec3(6.228269936347081, 14.17993336680509, 56.69055260068105);
-    let c5 = Vec3(4.776384997670288, -13.74514537774601, -65.35303263337234);
-    let c6 = Vec3(-5.435455855934631, 4.645852612178535, 26.3124352495832);
+fn colormap_viridis_srgb(t: f32) -> vec3f {
+    let c0 = vec3f(0.2777273272234177, 0.005407344544966578, 0.3340998053353061);
+    let c1 = vec3f(0.1050930431085774, 1.404613529898575, 1.384590162594685);
+    let c2 = vec3f(-0.3308618287255563, 0.214847559468213, 0.09509516302823659);
+    let c3 = vec3f(-4.634230498983486, -5.799100973351585, -19.33244095627987);
+    let c4 = vec3f(6.228269936347081, 14.17993336680509, 56.69055260068105);
+    let c5 = vec3f(4.776384997670288, -13.74514537774601, -65.35303263337234);
+    let c6 = vec3f(-5.435455855934631, 4.645852612178535, 26.3124352495832);
     return c0 + t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * (c5 + t * c6)))));
 }
 
 /// Returns a gamma-space sRGB in 0-1 range.
 /// This is a polynomial approximation from Plasma color map, assuming `t` is
 /// normalized (it will be saturated no matter what).
-fn colormap_plasma_srgb(t: f32) -> Vec3 {
-    let c0 = Vec3(0.05873234392399702, 0.02333670892565664, 0.5433401826748754);
-    let c1 = Vec3(2.176514634195958, 0.2383834171260182, 0.7539604599784036);
-    let c2 = Vec3(-2.689460476458034, -7.455851135738909, 3.110799939717086);
-    let c3 = Vec3(6.130348345893603, 42.3461881477227, -28.51885465332158);
-    let c4 = Vec3(-11.10743619062271, -82.66631109428045, 60.13984767418263);
-    let c5 = Vec3(10.02306557647065, 71.41361770095349, -54.07218655560067);
-    let c6 = Vec3(-3.658713842777788, -22.93153465461149, 18.19190778539828);
+fn colormap_plasma_srgb(t: f32) -> vec3f {
+    let c0 = vec3f(0.05873234392399702, 0.02333670892565664, 0.5433401826748754);
+    let c1 = vec3f(2.176514634195958, 0.2383834171260182, 0.7539604599784036);
+    let c2 = vec3f(-2.689460476458034, -7.455851135738909, 3.110799939717086);
+    let c3 = vec3f(6.130348345893603, 42.3461881477227, -28.51885465332158);
+    let c4 = vec3f(-11.10743619062271, -82.66631109428045, 60.13984767418263);
+    let c5 = vec3f(10.02306557647065, 71.41361770095349, -54.07218655560067);
+    let c6 = vec3f(-3.658713842777788, -22.93153465461149, 18.19190778539828);
     return c0 + t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * (c5 + t * c6)))));
 }
 
 /// Returns a gamma-space sRGB in 0-1 range.
 /// This is a polynomial approximation from Magma color map, assuming `t` is
 /// normalized (it will be saturated no matter what).
-fn colormap_magma_srgb(t: f32) -> Vec3 {
-    let c0 = Vec3(-0.002136485053939582, -0.000749655052795221, -0.005386127855323933);
-    let c1 = Vec3(0.2516605407371642, 0.6775232436837668, 2.494026599312351);
-    let c2 = Vec3(8.353717279216625, -3.577719514958484, 0.3144679030132573);
-    let c3 = Vec3(-27.66873308576866, 14.26473078096533, -13.64921318813922);
-    let c4 = Vec3(52.17613981234068, -27.94360607168351, 12.94416944238394);
-    let c5 = Vec3(-50.76852536473588, 29.04658282127291, 4.23415299384598);
-    let c6 = Vec3(18.65570506591883, -11.48977351997711, -5.601961508734096);
+fn colormap_magma_srgb(t: f32) -> vec3f {
+    let c0 = vec3f(-0.002136485053939582, -0.000749655052795221, -0.005386127855323933);
+    let c1 = vec3f(0.2516605407371642, 0.6775232436837668, 2.494026599312351);
+    let c2 = vec3f(8.353717279216625, -3.577719514958484, 0.3144679030132573);
+    let c3 = vec3f(-27.66873308576866, 14.26473078096533, -13.64921318813922);
+    let c4 = vec3f(52.17613981234068, -27.94360607168351, 12.94416944238394);
+    let c5 = vec3f(-50.76852536473588, 29.04658282127291, 4.23415299384598);
+    let c6 = vec3f(18.65570506591883, -11.48977351997711, -5.601961508734096);
     return c0 + t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * (c5 + t * c6)))));
 }
 
 /// Returns a gamma-space sRGB in 0-1 range.
 /// This is a polynomial approximation from Inferno color map, assuming `t` is
 /// normalized (it will be saturated no matter what).
-fn colormap_inferno_srgb(t: f32) -> Vec3 {
-    let c0 = Vec3(0.0002189403691192265, 0.001651004631001012, -0.01948089843709184);
-    let c1 = Vec3(0.1065134194856116, 0.5639564367884091, 3.932712388889277);
-    let c2 = Vec3(11.60249308247187, -3.972853965665698, -15.9423941062914);
-    let c3 = Vec3(-41.70399613139459, 17.43639888205313, 44.35414519872813);
-    let c4 = Vec3(77.162935699427, -33.40235894210092, -81.80730925738993);
-    let c5 = Vec3(-71.31942824499214, 32.62606426397723, 73.20951985803202);
-    let c6 = Vec3(25.13112622477341, -12.24266895238567, -23.07032500287172);
+fn colormap_inferno_srgb(t: f32) -> vec3f {
+    let c0 = vec3f(0.0002189403691192265, 0.001651004631001012, -0.01948089843709184);
+    let c1 = vec3f(0.1065134194856116, 0.5639564367884091, 3.932712388889277);
+    let c2 = vec3f(11.60249308247187, -3.972853965665698, -15.9423941062914);
+    let c3 = vec3f(-41.70399613139459, 17.43639888205313, 44.35414519872813);
+    let c4 = vec3f(77.162935699427, -33.40235894210092, -81.80730925738993);
+    let c5 = vec3f(-71.31942824499214, 32.62606426397723, 73.20951985803202);
+    let c6 = vec3f(25.13112622477341, -12.24266895238567, -23.07032500287172);
     return c0 + t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * (c5 + t * c6)))));
 }

--- a/crates/re_renderer/shader/composite.wgsl
+++ b/crates/re_renderer/shader/composite.wgsl
@@ -4,8 +4,8 @@
 #import <./screen_triangle_vertex.wgsl>
 
 struct CompositeUniformBuffer {
-    outline_color_layer_a: Vec4,
-    outline_color_layer_b: Vec4,
+    outline_color_layer_a: vec4f,
+    outline_color_layer_b: vec4f,
     outline_radius_pixel: f32,
 };
 @group(1) @binding(0)
@@ -18,8 +18,8 @@ var color_texture: texture_2d<f32>;
 var outline_voronoi_texture: texture_2d<f32>;
 
 @fragment
-fn main(in: FragmentInput) -> @location(0) Vec4 {
-    let resolution = Vec2(textureDimensions(color_texture).xy);
+fn main(in: FragmentInput) -> @location(0) vec4f {
+    let resolution = vec2f(textureDimensions(color_texture).xy);
     let pixel_coordinates = floor(resolution * in.texcoord);
 
     // Note that we can't use a simple textureLoad using @builtin(position) here despite the lack of filtering.
@@ -51,9 +51,9 @@ fn main(in: FragmentInput) -> @location(0) Vec4 {
         //color = outline_color_a.rgb;
 
         // Show the raw voronoi texture. Useful for debugging.
-        //color = Vec3(closest_positions.xy / resolution, 0.0);
+        //color = vec3f(closest_positions.xy / resolution, 0.0);
     }
 
     // Apply srgb gamma curve - this is necessary since the final eframe output does *not* have an srgb format.
-    return Vec4(srgb_from_linear(color), 1.0);
+    return vec4f(srgb_from_linear(color), 1.0);
 }

--- a/crates/re_renderer/shader/composite.wgsl
+++ b/crates/re_renderer/shader/composite.wgsl
@@ -27,7 +27,7 @@ fn main(in: FragmentInput) -> @location(0) vec4f {
     // but are about the location of the texel in the target texture.
     var color = textureSample(color_texture, nearest_sampler, in.texcoord).rgb;
     // TODO(andreas): Do something meaningful with values above 1
-    color = clamp(color, vec3f(), vec3f(1.0));
+    color = clamp(color, vec3f(0.0), vec3f(1.0));
 
     // Outlines
     {

--- a/crates/re_renderer/shader/composite.wgsl
+++ b/crates/re_renderer/shader/composite.wgsl
@@ -27,7 +27,7 @@ fn main(in: FragmentInput) -> @location(0) vec4f {
     // but are about the location of the texel in the target texture.
     var color = textureSample(color_texture, nearest_sampler, in.texcoord).rgb;
     // TODO(andreas): Do something meaningful with values above 1
-    color = clamp(color, ZERO.xyz, ONE.xyz);
+    color = clamp(color, vec3f(), vec3f(1.0));
 
     // Outlines
     {

--- a/crates/re_renderer/shader/copy_texture.wgsl
+++ b/crates/re_renderer/shader/copy_texture.wgsl
@@ -10,6 +10,6 @@
 var tex: texture_2d<f32>;
 
 @fragment
-fn main(in: FragmentInput) -> @location(0) Vec4 {
+fn main(in: FragmentInput) -> @location(0) vec4f {
     return textureSample(tex, nearest_sampler, in.texcoord);
 }

--- a/crates/re_renderer/shader/debug_overlay.wgsl
+++ b/crates/re_renderer/shader/debug_overlay.wgsl
@@ -11,9 +11,9 @@
 #import <./global_bindings.wgsl>
 
 struct UniformBuffer {
-    screen_resolution: Vec2,
-    position_in_pixel: Vec2,
-    extent_in_pixel: Vec2,
+    screen_resolution: vec2f,
+    position_in_pixel: vec2f,
+    extent_in_pixel: vec2f,
     mode: u32,
     _padding: u32,
 };
@@ -30,39 +30,39 @@ const ShowFloatTexture: u32 = 0u;
 const ShowUintTexture: u32 = 1u;
 
 struct VertexOutput {
-    @builtin(position) position: Vec4,
-    @location(0) texcoord: Vec2,
+    @builtin(position) position: vec4f,
+    @location(0) texcoord: vec2f,
 };
 
 @vertex
 fn main_vs(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
-    let texcoord = Vec2(f32(vertex_index / 2u), f32(vertex_index % 2u));
+    let texcoord = vec2f(f32(vertex_index / 2u), f32(vertex_index % 2u));
 
     // This calculation could be simplified by pre-computing things on the CPU.
     // But this is not the point here - we want to debug this and other things rapidly by editing the shader.
     let screen_fraction = texcoord * (uniforms.extent_in_pixel / uniforms.screen_resolution) +
                         uniforms.position_in_pixel / uniforms.screen_resolution;
-    let screen_ndc = Vec2(screen_fraction.x * 2.0 - 1.0, 1.0 - screen_fraction.y * 2.0);
+    let screen_ndc = vec2f(screen_fraction.x * 2.0 - 1.0, 1.0 - screen_fraction.y * 2.0);
 
     var out: VertexOutput;
-    out.position = Vec4(screen_ndc, 0.0, 1.0);
+    out.position = vec4f(screen_ndc, 0.0, 1.0);
     out.texcoord = texcoord;
     return out;
 }
 
 @fragment
-fn main_fs(in: VertexOutput) -> @location(0) Vec4 {
+fn main_fs(in: VertexOutput) -> @location(0) vec4f {
     if uniforms.mode == ShowFloatTexture {
-        return Vec4(textureSample(debug_texture_float, nearest_sampler, in.texcoord).rgb, 1.0);
+        return vec4f(textureSample(debug_texture_float, nearest_sampler, in.texcoord).rgb, 1.0);
     } else if uniforms.mode == ShowUintTexture {
-        let coords = IVec2(in.texcoord * Vec2(textureDimensions(debug_texture_uint).xy));
+        let coords = vec2i(in.texcoord * vec2f(textureDimensions(debug_texture_uint).xy));
         let raw_values = textureLoad(debug_texture_uint, coords, 0);
 
         let num_color_levels = 20u;
-        let mapped_values = Vec4(raw_values % num_color_levels) / f32(num_color_levels - 1u);
+        let mapped_values = vec4f(raw_values % num_color_levels) / f32(num_color_levels - 1u);
 
-        return Vec4(mapped_values.rgb, 1.0);
+        return vec4f(mapped_values.rgb, 1.0);
     } else {
-        return Vec4(1.0, 0.0, 1.0, 1.0);
+        return vec4f(1.0, 0.0, 1.0, 1.0);
     }
 }

--- a/crates/re_renderer/shader/decodings.wgsl
+++ b/crates/re_renderer/shader/decodings.wgsl
@@ -2,15 +2,15 @@
 
 
 /// Loads an RGBA texel from a texture holding an NV12 encoded image at the given screen space coordinates.
-fn decode_nv12(texture: texture_2d<u32>, coords: IVec2) -> Vec4 {
-    let texture_dim = Vec2(textureDimensions(texture).xy);
+fn decode_nv12(texture: texture_2d<u32>, coords: vec2i) -> vec4f {
+    let texture_dim = vec2f(textureDimensions(texture).xy);
     let uv_offset = u32(floor(texture_dim.y / 1.5));
     let uv_row = u32(coords.y / 2);
     var uv_col = u32(coords.x / 2) * 2u;
 
-    let y = max(0.0, (f32(textureLoad(texture, UVec2(coords), 0).r) - 16.0)) / 219.0;
-    let u = (f32(textureLoad(texture, UVec2(u32(uv_col), uv_offset + uv_row), 0).r) - 128.0) / 224.0;
-    let v = (f32(textureLoad(texture, UVec2((u32(uv_col) + 1u), uv_offset + uv_row), 0).r) - 128.0) / 224.0;
+    let y = max(0.0, (f32(textureLoad(texture, vec2u(coords), 0).r) - 16.0)) / 219.0;
+    let u = (f32(textureLoad(texture, vec2u(u32(uv_col), uv_offset + uv_row), 0).r) - 128.0) / 224.0;
+    let v = (f32(textureLoad(texture, vec2u((u32(uv_col) + 1u), uv_offset + uv_row), 0).r) - 128.0) / 224.0;
 
     // Specifying the color standard should be exposed in the future (https://github.com/rerun-io/rerun/pull/3541)
     // BT.601 (aka. SDTV, aka. Rec.601). wiki: https://en.wikipedia.org/wiki/YCbCr#ITU-R_BT.601_conversion
@@ -21,5 +21,5 @@ fn decode_nv12(texture: texture_2d<u32>, coords: IVec2) -> Vec4 {
     // let r = clamp(y + 1.5748 * v, 0.0, 1.0);
     // let g = clamp(y + u * -0.1873 + v * -0.4681, 0.0, 1.0);
     // let b = clamp(y + u * 1.8556, 0.0 , 1.0);
-    return Vec4(r, g, b, 1.0);
+    return vec4f(r, g, b, 1.0);
 }

--- a/crates/re_renderer/shader/depth_cloud.wgsl
+++ b/crates/re_renderer/shader/depth_cloud.wgsl
@@ -23,18 +23,18 @@ const SAMPLE_TYPE_UINT  = 3u;
 /// Same for all draw-phases.
 struct DepthCloudInfo {
     /// The extrinsincs of the camera used for the projection.
-    world_from_rdf: Mat4,
+    world_from_rdf: mat4x4f,
 
     /// The intrinsics of the camera used for the projection.
     ///
     /// Only supports pinhole cameras at the moment.
-    depth_camera_intrinsics: Mat3,
+    depth_camera_intrinsics: mat3x3f,
 
     /// Outline mask id for the outline mask pass.
-    outline_mask_id: UVec2,
+    outline_mask_id: vec2u,
 
     /// Picking object id that applies for the entire depth cloud.
-    picking_layer_object_id: UVec2,
+    picking_layer_object_id: vec2u,
 
     /// Multiplier to get world-space depth from whatever is in the texture.
     world_depth_from_texture_value: f32,
@@ -69,16 +69,16 @@ var texture_uint: texture_2d<u32>;
 
 struct VertexOut {
     @builtin(position)
-    pos_in_clip: Vec4,
+    pos_in_clip: vec4f,
 
     @location(0) @interpolate(perspective)
-    pos_in_world: Vec3,
+    pos_in_world: vec3f,
 
     @location(1) @interpolate(flat)
-    point_pos_in_world: Vec3,
+    point_pos_in_world: vec3f,
 
     @location(2) @interpolate(flat)
-    point_color: Vec4,
+    point_color: vec4f,
 
     @location(3) @interpolate(flat)
     point_radius: f32,
@@ -90,26 +90,26 @@ struct VertexOut {
 // ---
 
 struct PointData {
-    pos_in_world: Vec3,
+    pos_in_world: vec3f,
     unresolved_radius: f32,
-    color: Vec4,
+    color: vec4f,
 }
 
 // Backprojects the depth texture using the intrinsics passed in the uniform buffer.
 fn compute_point_data(quad_idx: u32) -> PointData {
-    var texcoords: UVec2;
+    var texcoords: vec2u;
     var texture_value = 0.0;
     if depth_cloud_info.sample_type == SAMPLE_TYPE_FLOAT {
         let wh = textureDimensions(texture_float);
-        texcoords = UVec2(quad_idx % wh.x, quad_idx / wh.x);
+        texcoords = vec2u(quad_idx % wh.x, quad_idx / wh.x);
         texture_value = textureLoad(texture_float, texcoords, 0).x;
     } else if depth_cloud_info.sample_type == SAMPLE_TYPE_SINT {
         let wh = textureDimensions(texture_sint);
-        texcoords = UVec2(quad_idx % wh.x, quad_idx / wh.x);
+        texcoords = vec2u(quad_idx % wh.x, quad_idx / wh.x);
         texture_value = f32(textureLoad(texture_sint, texcoords, 0).x);
     } else {
         let wh = textureDimensions(texture_uint);
-        texcoords = UVec2(quad_idx % wh.x, quad_idx / wh.x);
+        texcoords = vec2u(quad_idx % wh.x, quad_idx / wh.x);
         texture_value = f32(textureLoad(texture_uint, texcoords, 0).x);
     }
 
@@ -120,29 +120,29 @@ fn compute_point_data(quad_idx: u32) -> PointData {
 
     if 0.0 < world_space_depth && world_space_depth < f32max {
         // TODO(cmc): albedo textures
-        let color = Vec4(colormap_linear(depth_cloud_info.colormap, world_space_depth / depth_cloud_info.max_depth_in_world), 1.0);
+        let color = vec4f(colormap_linear(depth_cloud_info.colormap, world_space_depth / depth_cloud_info.max_depth_in_world), 1.0);
 
         // TODO(cmc): This assumes a pinhole camera; need to support other kinds at some point.
         let intrinsics = depth_cloud_info.depth_camera_intrinsics;
-        let focal_length = Vec2(intrinsics[0][0], intrinsics[1][1]);
-        let offset = Vec2(intrinsics[2][0], intrinsics[2][1]);
+        let focal_length = vec2f(intrinsics[0][0], intrinsics[1][1]);
+        let offset = vec2f(intrinsics[2][0], intrinsics[2][1]);
 
         // RDF: X=Right, Y=Down, Z=Forward
-        let pos_in_rdf = Vec3(
-            (Vec2(texcoords) - offset) * world_space_depth / focal_length,
+        let pos_in_rdf = vec3f(
+            (vec2f(texcoords) - offset) * world_space_depth / focal_length,
             world_space_depth, // RDF, Z=forward, so positive depth
         );
 
-        let pos_in_world = depth_cloud_info.world_from_rdf * Vec4(pos_in_rdf, 1.0);
+        let pos_in_world = depth_cloud_info.world_from_rdf * vec4f(pos_in_rdf, 1.0);
 
         data.pos_in_world = pos_in_world.xyz;
         data.unresolved_radius = depth_cloud_info.point_radius_from_world_depth * world_space_depth;
         data.color = color;
     } else {
         // Degenerate case
-        data.pos_in_world = Vec3(0.0);
+        data.pos_in_world = vec3f(0.0);
         data.unresolved_radius = 0.0;
-        data.color = Vec4(0.0);
+        data.color = vec4f(0.0);
     }
     return data;
 }
@@ -163,13 +163,13 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
         // Span quad
         let quad = sphere_or_circle_quad_span(vertex_idx, point_data.pos_in_world, point_data.unresolved_radius,
                                                 depth_cloud_info.radius_boost_in_ui_points, false);
-        out.pos_in_clip = frame.projection_from_world * Vec4(quad.pos_in_world, 1.0);
+        out.pos_in_clip = frame.projection_from_world * vec4f(quad.pos_in_world, 1.0);
         out.pos_in_world = quad.pos_in_world;
         out.point_radius = quad.point_resolved_radius;
     } else {
         // Degenerate case - early-out!
-        out.pos_in_clip = Vec4(0.0);
-        out.pos_in_world = Vec3(0.0);
+        out.pos_in_clip = vec4f(0.0);
+        out.pos_in_world = vec3f(0.0);
         out.point_radius = 0.0;
     }
 
@@ -177,25 +177,25 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
 }
 
 @fragment
-fn fs_main(in: VertexOut) -> @location(0) Vec4 {
+fn fs_main(in: VertexOut) -> @location(0) vec4f {
     let coverage = sphere_quad_coverage(in.pos_in_world, in.point_radius, in.point_pos_in_world);
     if coverage < 0.001 {
         discard;
     }
-    return vec4(in.point_color.rgb, coverage);
+    return vec4f(in.point_color.rgb, coverage);
 }
 
 @fragment
-fn fs_main_picking_layer(in: VertexOut) -> @location(0) UVec4 {
+fn fs_main_picking_layer(in: VertexOut) -> @location(0) vec4u {
     let coverage = sphere_quad_coverage(in.pos_in_world, in.point_radius, in.point_pos_in_world);
     if coverage <= 0.5 {
         discard;
     }
-    return UVec4(depth_cloud_info.picking_layer_object_id, in.quad_idx, 0u);
+    return vec4u(depth_cloud_info.picking_layer_object_id, in.quad_idx, 0u);
 }
 
 @fragment
-fn fs_main_outline_mask(in: VertexOut) -> @location(0) UVec2 {
+fn fs_main_outline_mask(in: VertexOut) -> @location(0) vec2u {
     // Output is an integer target, can't use coverage therefore.
     // But we still want to discard fragments where coverage is low.
     // Since the outline extends a bit, a very low cut off tends to look better.

--- a/crates/re_renderer/shader/generic_skybox.wgsl
+++ b/crates/re_renderer/shader/generic_skybox.wgsl
@@ -4,21 +4,21 @@
 #import <./utils/camera.wgsl>
 #import <./screen_triangle_vertex.wgsl>
 
-fn skybox_dark_srgb(dir: Vec3) -> Vec3 {
-    let rgb = dir * 0.5 + Vec3(0.5);
-    return Vec3(0.05) + 0.20 * rgb;
+fn skybox_dark_srgb(dir: vec3f) -> vec3f {
+    let rgb = dir * 0.5 + vec3f(0.5);
+    return vec3f(0.05) + 0.20 * rgb;
 }
 
-fn skybox_light_srgb(dir: Vec3) -> Vec3 {
-    let rgb = dir * 0.5 + Vec3(0.5);
-    return Vec3(0.85) + 0.15 * rgb;
+fn skybox_light_srgb(dir: vec3f) -> vec3f {
+    let rgb = dir * 0.5 + vec3f(0.5);
+    return vec3f(0.85) + 0.15 * rgb;
 }
 
 @fragment
-fn main(in: FragmentInput) -> @location(0) Vec4 {
+fn main(in: FragmentInput) -> @location(0) vec4f {
     let camera_dir = camera_ray_direction_from_screenuv(in.texcoord);
     // Messing with direction a bit so it looks like in our old three-d based renderer (for easier comparison)
     let rgb = skybox_dark_srgb(camera_dir); // TODO(andreas): Allow switching to skybox_light
-    return Vec4(linear_from_srgb(rgb), 1.0);
-    //return Vec4(camera_dir, 1.0);
+    return vec4f(linear_from_srgb(rgb), 1.0);
+    //return vec4f(camera_dir, 1.0);
 }

--- a/crates/re_renderer/shader/global_bindings.wgsl
+++ b/crates/re_renderer/shader/global_bindings.wgsl
@@ -1,18 +1,18 @@
 struct FrameUniformBuffer {
-    view_from_world: Mat4x3,
-    projection_from_view: Mat4,
-    projection_from_world: Mat4,
+    view_from_world: mat4x3f,
+    projection_from_view: mat4x4f,
+    projection_from_world: mat4x4f,
 
     /// Camera position in world space.
-    camera_position: Vec3,
+    camera_position: vec3f,
 
     /// For perspective: Multiply this with a camera distance to get a measure of how wide a pixel is in world units.
     /// For orthographic: This is the world size value, independent of distance.
     pixel_world_size_from_camera_distance: f32,
 
     /// Camera direction in world space.
-    /// Same as -Vec3(view_from_world[0].z, view_from_world[1].z, view_from_world[2].z)
-    camera_forward: Vec3,
+    /// Same as -vec3f(view_from_world[0].z, view_from_world[1].z, view_from_world[2].z)
+    camera_forward: vec3f,
 
     /// How many pixels there are per point.
     /// I.e. the UI zoom factor.
@@ -20,7 +20,7 @@ struct FrameUniformBuffer {
 
     /// (tan(fov_y / 2) * aspect_ratio, tan(fov_y /2)), i.e. half ratio of screen dimension to screen distance in x & y.
     /// Both values are set to f32max for orthographic projection
-    tan_half_fov: Vec2,
+    tan_half_fov: vec2f,
 
     // Size used for all point radii given with Size::AUTO.
     auto_size_points: f32,

--- a/crates/re_renderer/shader/instanced_mesh.wgsl
+++ b/crates/re_renderer/shader/instanced_mesh.wgsl
@@ -8,7 +8,7 @@ var albedo_texture: texture_2d<f32>;
 
 // Keep in sync with gpu_data::MaterialUniformBuffer in mesh.rs
 struct MaterialUniformBuffer {
-    albedo_factor: Vec4,
+    albedo_factor: vec4f,
 };
 
 @group(1) @binding(1)
@@ -16,42 +16,42 @@ var<uniform> material: MaterialUniformBuffer;
 
 struct VertexOut {
     @builtin(position)
-    position: Vec4,
+    position: vec4f,
 
     @location(0)
-    color: Vec4, // 0-1 linear space with unmultiplied/separate alpha
+    color: vec4f, // 0-1 linear space with unmultiplied/separate alpha
 
     @location(1)
-    texcoord: Vec2,
+    texcoord: vec2f,
 
     @location(2)
-    normal_world_space: Vec3,
+    normal_world_space: vec3f,
 
     @location(3) @interpolate(flat)
-    additive_tint_rgb: Vec3, // 0-1 linear space
+    additive_tint_rgb: vec3f, // 0-1 linear space
 
     @location(4) @interpolate(flat)
-    outline_mask_ids: UVec2,
+    outline_mask_ids: vec2u,
 
     @location(5) @interpolate(flat)
-    picking_layer_id: UVec4,
+    picking_layer_id: vec4u,
 };
 
 @vertex
 fn vs_main(in_vertex: VertexIn, in_instance: InstanceIn) -> VertexOut {
-    let world_position = Vec3(
+    let world_position = vec3f(
         dot(in_instance.world_from_mesh_row_0.xyz, in_vertex.position) + in_instance.world_from_mesh_row_0.w,
         dot(in_instance.world_from_mesh_row_1.xyz, in_vertex.position) + in_instance.world_from_mesh_row_1.w,
         dot(in_instance.world_from_mesh_row_2.xyz, in_vertex.position) + in_instance.world_from_mesh_row_2.w,
     );
-    let world_normal = Vec3(
+    let world_normal = vec3f(
         dot(in_instance.world_from_mesh_normal_row_0.xyz, in_vertex.normal),
         dot(in_instance.world_from_mesh_normal_row_1.xyz, in_vertex.normal),
         dot(in_instance.world_from_mesh_normal_row_2.xyz, in_vertex.normal),
     );
 
     var out: VertexOut;
-    out.position = frame.projection_from_world * Vec4(world_position, 1.0);
+    out.position = frame.projection_from_world * vec4f(world_position, 1.0);
     out.color = linear_from_srgba(in_vertex.color);
     out.texcoord = in_vertex.texcoord;
     out.normal_world_space = world_normal;
@@ -63,33 +63,33 @@ fn vs_main(in_vertex: VertexIn, in_instance: InstanceIn) -> VertexOut {
 }
 
 @fragment
-fn fs_main_shaded(in: VertexOut) -> @location(0) Vec4 {
+fn fs_main_shaded(in: VertexOut) -> @location(0) vec4f {
     let albedo = textureSample(albedo_texture, trilinear_sampler, in.texcoord).rgb
                  * in.color.rgb
                  * material.albedo_factor.rgb
                  + in.additive_tint_rgb;
 
-    if all(in.normal_world_space == Vec3(0.0, 0.0, 0.0)) {
+    if all(in.normal_world_space == vec3f(0.0, 0.0, 0.0)) {
         // no normal, no shading
-        return Vec4(albedo, 1.0);
+        return vec4f(albedo, 1.0);
     } else {
         // Hardcoded lambert lighting. TODO(andreas): Some microfacet model.
-        let light_dir = normalize(vec3(1.0, 2.0, 0.0)); // TODO(andreas): proper lighting
+        let light_dir = normalize(vec3f(1.0, 2.0, 0.0)); // TODO(andreas): proper lighting
         let normal = normalize(in.normal_world_space);
         let shading = clamp(dot(normal, light_dir), 0.0, 1.0) + 0.2;
 
         let radiance = albedo * shading;
 
-        return Vec4(radiance, 1.0);
+        return vec4f(radiance, 1.0);
     }
 }
 
 @fragment
-fn fs_main_picking_layer(in: VertexOut) -> @location(0) UVec4 {
+fn fs_main_picking_layer(in: VertexOut) -> @location(0) vec4u {
     return in.picking_layer_id;
 }
 
 @fragment
-fn fs_main_outline_mask(in: VertexOut) -> @location(0) UVec2 {
+fn fs_main_outline_mask(in: VertexOut) -> @location(0) vec2u {
     return in.outline_mask_ids;
 }

--- a/crates/re_renderer/shader/mesh_vertex.wgsl
+++ b/crates/re_renderer/shader/mesh_vertex.wgsl
@@ -1,22 +1,22 @@
 // See mesh.rs#MeshVertex
 struct VertexIn {
-    @location(0) position: Vec3,
-    @location(1) color: Vec4, // gamma-space 0-1, unmultiplied
-    @location(2) normal: Vec3,
-    @location(3) texcoord: Vec2,
+    @location(0) position: vec3f,
+    @location(1) color: vec4f, // gamma-space 0-1, unmultiplied
+    @location(2) normal: vec3f,
+    @location(3) texcoord: vec2f,
 };
 
 // See mesh_renderer.rs
 struct InstanceIn {
     // We could alternatively store projection_from_mesh, but world position might be useful
-    // in the future and this saves us a Vec4 and simplifies dataflow on the cpu side.
-    @location(4) world_from_mesh_row_0: Vec4,
-    @location(5) world_from_mesh_row_1: Vec4,
-    @location(6) world_from_mesh_row_2: Vec4,
-    @location(7) world_from_mesh_normal_row_0: Vec3,
-    @location(8) world_from_mesh_normal_row_1: Vec3,
-    @location(9) world_from_mesh_normal_row_2: Vec3,
-    @location(10) additive_tint_srgb: Vec4,
-    @location(11) picking_layer_id: UVec4,
-    @location(12) outline_mask_ids: UVec2,
+    // in the future and this saves us a vec4f and simplifies dataflow on the cpu side.
+    @location(4) world_from_mesh_row_0: vec4f,
+    @location(5) world_from_mesh_row_1: vec4f,
+    @location(6) world_from_mesh_row_2: vec4f,
+    @location(7) world_from_mesh_normal_row_0: vec3f,
+    @location(8) world_from_mesh_normal_row_1: vec3f,
+    @location(9) world_from_mesh_normal_row_2: vec3f,
+    @location(10) additive_tint_srgb: vec4f,
+    @location(11) picking_layer_id: vec4u,
+    @location(12) outline_mask_ids: vec2u,
 };

--- a/crates/re_renderer/shader/outlines/jumpflooding_init.wgsl
+++ b/crates/re_renderer/shader/outlines/jumpflooding_init.wgsl
@@ -3,75 +3,75 @@
 @group(0) @binding(0)
 var mask_texture: texture_2d<u32>;
 
-fn has_edge(closest_center_sample: UVec2, sample_coord: IVec2) -> Vec2 {
+fn has_edge(closest_center_sample: vec2u, sample_coord: vec2i) -> vec2f {
     let mask_neighbor = textureLoad(mask_texture, sample_coord, 0).xy;
-    return Vec2(closest_center_sample != mask_neighbor);
+    return vec2f(closest_center_sample != mask_neighbor);
 }
 
 // Determine *where* in texture coordinates the closest edge to the center is.
 // For a more accurate version refer to `jumpflooding_init_msaa.wgsl`.
 // This is a simplified version that works on WebGL.
 @fragment
-fn main(in: FragmentInput) -> @location(0) Vec4 {
+fn main(in: FragmentInput) -> @location(0) vec4f {
     let resolution = textureDimensions(mask_texture).xy;
-    let center_coord = IVec2(Vec2(resolution) * in.texcoord);
+    let center_coord = vec2i(vec2f(resolution) * in.texcoord);
 
     let mask_center = textureLoad(mask_texture, center_coord, 0).xy;
 
-    var edge_pos_a_and_b = Vec4(0.0);
-    var num_edges_a_and_b = Vec2(0.0);
+    var edge_pos_a_and_b = vec4f(0.0);
+    var num_edges_a_and_b = vec2f(0.0);
 
     // A lot of this code is repetitive, but wgsl/naga doesn't know yet how to do static indexing from unrolled loops.
 
     // Sample closest neighbors top/bottom/left/right
     { // right
-        let edge = has_edge(mask_center, center_coord + IVec2(1, 0));
-        let edge_pos = Vec2(1.0, 0.5);
-        edge_pos_a_and_b += Vec4(edge_pos, edge_pos) * edge.xxyy;
+        let edge = has_edge(mask_center, center_coord + vec2i(1, 0));
+        let edge_pos = vec2f(1.0, 0.5);
+        edge_pos_a_and_b += vec4f(edge_pos, edge_pos) * edge.xxyy;
         num_edges_a_and_b += edge;
     }
     { // bottom
-        let edge = has_edge(mask_center, center_coord + IVec2(0, 1));
-        let edge_pos = Vec2(0.5, 1.0);
-        edge_pos_a_and_b += Vec4(edge_pos, edge_pos) * edge.xxyy;
+        let edge = has_edge(mask_center, center_coord + vec2i(0, 1));
+        let edge_pos = vec2f(0.5, 1.0);
+        edge_pos_a_and_b += vec4f(edge_pos, edge_pos) * edge.xxyy;
         num_edges_a_and_b += edge;
     }
     { // left
-        let edge = has_edge(mask_center, center_coord + IVec2(-1, 0));
-        let edge_pos = Vec2(0.0, 0.5);
-        edge_pos_a_and_b += Vec4(edge_pos, edge_pos) * edge.xxyy;
+        let edge = has_edge(mask_center, center_coord + vec2i(-1, 0));
+        let edge_pos = vec2f(0.0, 0.5);
+        edge_pos_a_and_b += vec4f(edge_pos, edge_pos) * edge.xxyy;
         num_edges_a_and_b += edge;
     }
     { // top
-        let edge = has_edge(mask_center, center_coord + IVec2(0, -1));
-        let edge_pos = Vec2(0.5, 0.0);
-        edge_pos_a_and_b += Vec4(edge_pos, edge_pos) * edge.xxyy;
+        let edge = has_edge(mask_center, center_coord + vec2i(0, -1));
+        let edge_pos = vec2f(0.5, 0.0);
+        edge_pos_a_and_b += vec4f(edge_pos, edge_pos) * edge.xxyy;
         num_edges_a_and_b += edge;
     }
 
     // Sample closest neighbors diagonally.
     { // top-right
-        let edge = has_edge(mask_center, center_coord + IVec2(1, -1));
-        let edge_pos = Vec2(1.0, 0.0);
-        edge_pos_a_and_b += Vec4(edge_pos, edge_pos) * edge.xxyy;
+        let edge = has_edge(mask_center, center_coord + vec2i(1, -1));
+        let edge_pos = vec2f(1.0, 0.0);
+        edge_pos_a_and_b += vec4f(edge_pos, edge_pos) * edge.xxyy;
         num_edges_a_and_b += edge;
     }
     { // bottom-right
-        let edge = has_edge(mask_center, center_coord + IVec2(1, 1));
-        let edge_pos = Vec2(1.0, 1.0);
-        edge_pos_a_and_b += Vec4(edge_pos, edge_pos) * edge.xxyy;
+        let edge = has_edge(mask_center, center_coord + vec2i(1, 1));
+        let edge_pos = vec2f(1.0, 1.0);
+        edge_pos_a_and_b += vec4f(edge_pos, edge_pos) * edge.xxyy;
         num_edges_a_and_b += edge;
     }
     { // bottom-left
-        let edge = has_edge(mask_center, center_coord + IVec2(-1, 1));
-        let edge_pos = Vec2(0.0, 1.0);
-        edge_pos_a_and_b += Vec4(edge_pos, edge_pos) * edge.xxyy;
+        let edge = has_edge(mask_center, center_coord + vec2i(-1, 1));
+        let edge_pos = vec2f(0.0, 1.0);
+        edge_pos_a_and_b += vec4f(edge_pos, edge_pos) * edge.xxyy;
         num_edges_a_and_b += edge;
     }
     { // top-left
-        let edge = has_edge(mask_center, center_coord + IVec2(-1, -1));
-        let edge_pos = Vec2(0.0, 0.0);
-        //edge_pos_a_and_b += Vec4(edge_pos, edge_pos) * edge.xxyy; // multiplied by zero, optimize out
+        let edge = has_edge(mask_center, center_coord + vec2i(-1, -1));
+        let edge_pos = vec2f(0.0, 0.0);
+        //edge_pos_a_and_b += vec4f(edge_pos, edge_pos) * edge.xxyy; // multiplied by zero, optimize out
         num_edges_a_and_b += edge;
     }
 

--- a/crates/re_renderer/shader/outlines/jumpflooding_init_shared.wgsl
+++ b/crates/re_renderer/shader/outlines/jumpflooding_init_shared.wgsl
@@ -1,26 +1,26 @@
 #import <../types.wgsl>
 #import <../screen_triangle_vertex.wgsl>
 
-fn compute_pixel_coords(center_coord: IVec2, unnormalized_edge_pos_a_and_b: Vec4, num_edges_a_and_b: Vec2) -> Vec4 {
+fn compute_pixel_coords(center_coord: vec2i, unnormalized_edge_pos_a_and_b: vec4f, num_edges_a_and_b: vec2f) -> vec4f {
     // Normalize edges ans get range from [0, 1] to [-0.5, 0.5].
-    let edge_pos_a_and_b = unnormalized_edge_pos_a_and_b / num_edges_a_and_b.xxyy - Vec4(0.5);
+    let edge_pos_a_and_b = unnormalized_edge_pos_a_and_b / num_edges_a_and_b.xxyy - vec4f(0.5);
 
     // We're outputting pixel coordinates (0-res) instead of texture coordinates (0-1).
     // This way we don't need to correct for aspect ratio when comparing distances in the jumpflooding steps.
     // When computing the actual outlines themselves we're also interested in pixel distances, not texcoord distances.
 
-    var pixel_coord_a: Vec2;
+    var pixel_coord_a: vec2f;
     if num_edges_a_and_b.x == 0.0 {
-        pixel_coord_a = Vec2(f32max);
+        pixel_coord_a = vec2f(f32max);
     } else {
-        pixel_coord_a = Vec2(center_coord) + edge_pos_a_and_b.xy;
+        pixel_coord_a = vec2f(center_coord) + edge_pos_a_and_b.xy;
     }
-    var pixel_coord_b: Vec2;
+    var pixel_coord_b: vec2f;
     if num_edges_a_and_b.y == 0.0 {
-        pixel_coord_b = Vec2(f32max);
+        pixel_coord_b = vec2f(f32max);
     } else {
-        pixel_coord_b = Vec2(center_coord) + edge_pos_a_and_b.zw;
+        pixel_coord_b = vec2f(center_coord) + edge_pos_a_and_b.zw;
     }
 
-    return Vec4(pixel_coord_a, pixel_coord_b);
+    return vec4f(pixel_coord_a, pixel_coord_b);
 }

--- a/crates/re_renderer/shader/outlines/jumpflooding_step.wgsl
+++ b/crates/re_renderer/shader/outlines/jumpflooding_step.wgsl
@@ -10,26 +10,26 @@ struct FrameUniformBuffer {
     step_width: i32,
     // There is actually more padding here. We're only putting this to satisfy lack of
     // wgt::DownlevelFlags::BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED
-    padding: IVec3,
+    padding: vec3i,
 };
 @group(0) @binding(2)
 var<uniform> uniforms: FrameUniformBuffer;
 
 
 @fragment
-fn main(in: FragmentInput) -> @location(0) Vec4 {
-    let resolution = Vec2(textureDimensions(voronoi_texture).xy);
-    let pixel_step = Vec2(f32(uniforms.step_width), f32(uniforms.step_width)) / resolution;
+fn main(in: FragmentInput) -> @location(0) vec4f {
+    let resolution = vec2f(textureDimensions(voronoi_texture).xy);
+    let pixel_step = vec2f(f32(uniforms.step_width), f32(uniforms.step_width)) / resolution;
     let pixel_coordinates = floor(resolution * in.texcoord);
 
-    var closest_positions_a = Vec2(f32min);
+    var closest_positions_a = vec2f(f32min);
     var closest_distance_sq_a = f32max;
-    var closest_positions_b = Vec2(f32min);
+    var closest_positions_b = vec2f(f32min);
     var closest_distance_sq_b = f32max;
 
     for (var y: i32 = -1; y <= 1; y += 1) {
         for (var x: i32 = -1; x <= 1; x += 1) {
-            let texcoord = in.texcoord + Vec2(f32(x), f32(y)) * pixel_step;
+            let texcoord = in.texcoord + vec2f(f32(x), f32(y)) * pixel_step;
             let positions_a_and_b = textureSampleLevel(voronoi_texture, voronoi_sampler, texcoord, 0.0);
             let to_positions_a_and_b = positions_a_and_b - pixel_coordinates.xyxy;
 
@@ -47,5 +47,5 @@ fn main(in: FragmentInput) -> @location(0) Vec4 {
         }
     }
 
-    return Vec4(closest_positions_a, closest_positions_b);
+    return vec4f(closest_positions_a, closest_positions_b);
 }

--- a/crates/re_renderer/shader/rectangle.wgsl
+++ b/crates/re_renderer/shader/rectangle.wgsl
@@ -19,30 +19,30 @@ const FILTER_BILINEAR = 2u;
 
 struct UniformBuffer {
     /// Top left corner position in world space.
-    top_left_corner_position: Vec3,
+    top_left_corner_position: vec3f,
 
     /// Which colormap to use, if any
     colormap_function: u32,
 
     /// Vector that spans up the rectangle from its top left corner along the u axis of the texture.
-    extent_u: Vec3,
+    extent_u: vec3f,
 
     /// Which texture sample to use
     sample_type: u32,
 
     /// Vector that spans up the rectangle from its top left corner along the v axis of the texture.
-    extent_v: Vec3,
+    extent_v: vec3f,
 
     depth_offset: f32,
 
     /// Tint multiplied with the texture color.
-    multiplicative_tint: Vec4,
+    multiplicative_tint: vec4f,
 
-    outline_mask: UVec2,
+    outline_mask: vec2u,
 
     /// Range of the texture values.
     /// Will be mapped to the [0, 1] range before we colormap.
-    range_min_max: Vec2,
+    range_min_max: vec2f,
 
     color_mapper: u32,
 
@@ -79,8 +79,8 @@ var colormap_texture: texture_2d<f32>;
 var texture_float_filterable: texture_2d<f32>;
 
 struct VertexOut {
-    @builtin(position) position: Vec4,
-    @location(0) texcoord: Vec2,
+    @builtin(position) position: vec4f,
+    @location(0) texcoord: vec2f,
 };
 
 // The fragment and vertex shaders are in two separate files in order

--- a/crates/re_renderer/shader/rectangle_vs.wgsl
+++ b/crates/re_renderer/shader/rectangle_vs.wgsl
@@ -3,12 +3,12 @@
 
 @vertex
 fn vs_main(@builtin(vertex_index) v_idx: u32) -> VertexOut {
-    let texcoord = Vec2(f32(v_idx / 2u), f32(v_idx % 2u));
+    let texcoord = vec2f(f32(v_idx / 2u), f32(v_idx % 2u));
     let pos = texcoord.x * rect_info.extent_u + texcoord.y * rect_info.extent_v +
                 rect_info.top_left_corner_position;
 
     var out: VertexOut;
-    out.position = apply_depth_offset(frame.projection_from_world * Vec4(pos, 1.0), rect_info.depth_offset);
+    out.position = apply_depth_offset(frame.projection_from_world * vec4f(pos, 1.0), rect_info.depth_offset);
     out.texcoord = texcoord;
     if rect_info.sample_type == SAMPLE_TYPE_NV12 {
         out.texcoord.y /= 1.5;

--- a/crates/re_renderer/shader/screen_triangle.wgsl
+++ b/crates/re_renderer/shader/screen_triangle.wgsl
@@ -1,16 +1,16 @@
 #import <./types.wgsl>
 #import <./screen_triangle_vertex.wgsl>
 
-var<private> positions: array<Vec2, 3> = array<Vec2, 3>(
-    Vec2(-1.0, -3.0),
-    Vec2(-1.0, 1.0),
-    Vec2(3.0, 1.0)
+var<private> positions: array<vec2f, 3> = array<vec2f, 3>(
+    vec2f(-1.0, -3.0),
+    vec2f(-1.0, 1.0),
+    vec2f(3.0, 1.0)
 );
 
 @vertex
 fn main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     var out: VertexOutput;
-    out.position = Vec4(positions[vertex_index], 0.0, 1.0);
+    out.position = vec4f(positions[vertex_index], 0.0, 1.0);
     out.texcoord = out.position.xy * 0.5 + 0.5;
     out.texcoord.y = 1.0 - out.texcoord.y;
     return out;

--- a/crates/re_renderer/shader/screen_triangle_vertex.wgsl
+++ b/crates/re_renderer/shader/screen_triangle_vertex.wgsl
@@ -5,14 +5,14 @@ struct VertexOutput {
     // Without @invariant, different usages in different render pipelines might optimize differently,
     // causing slightly different results.
     @invariant @builtin(position)
-    position: Vec4,
+    position: vec4f,
     @location(0)
-    texcoord: Vec2,
+    texcoord: vec2f,
 };
 
 // Workaround for https://github.com/gfx-rs/naga/issues/2252
 // Naga emits invariant flag on fragment input, but some implementations don't allow this.
 // Therefore we drop position here (we could still pass it in if needed if we drop the invariant flag)
 struct FragmentInput {
-    @location(0) texcoord: Vec2,
+    @location(0) texcoord: vec2f,
 };

--- a/crates/re_renderer/shader/test_triangle.wgsl
+++ b/crates/re_renderer/shader/test_triangle.wgsl
@@ -2,33 +2,33 @@
 #import <./global_bindings.wgsl>
 
 struct VertexOut {
-    @location(0) color: Vec4,
-    @builtin(position) position: Vec4,
+    @location(0) color: vec4f,
+    @builtin(position) position: vec4f,
 };
 
-var<private> v_positions: array<Vec2, 3> = array<Vec2, 3>(
-    Vec2(0.0, 1.0),
-    Vec2(1.0, -1.0),
-    Vec2(-1.0, -1.0),
+var<private> v_positions: array<vec2f, 3> = array<vec2f, 3>(
+    vec2f(0.0, 1.0),
+    vec2f(1.0, -1.0),
+    vec2f(-1.0, -1.0),
 );
 
-var<private> v_colors: array<Vec4, 3> = array<Vec4, 3>(
-    Vec4(1.0, 0.0, 0.0, 1.0),
-    Vec4(0.0, 1.0, 0.0, 1.0),
-    Vec4(0.0, 0.0, 1.0, 1.0),
+var<private> v_colors: array<vec4f, 3> = array<vec4f, 3>(
+    vec4f(1.0, 0.0, 0.0, 1.0),
+    vec4f(0.0, 1.0, 0.0, 1.0),
+    vec4f(0.0, 0.0, 1.0, 1.0),
 );
 
 @vertex
 fn vs_main(@builtin(vertex_index) v_idx: u32) -> VertexOut {
     var out: VertexOut;
 
-    out.position = frame.projection_from_world * Vec4(v_positions[v_idx] * 5.0, 0.0, 1.0);
+    out.position = frame.projection_from_world * vec4f(v_positions[v_idx] * 5.0, 0.0, 1.0);
     out.color = v_colors[v_idx];
 
     return out;
 }
 
 @fragment
-fn fs_main(in: VertexOut) -> @location(0) Vec4 {
+fn fs_main(in: VertexOut) -> @location(0) vec4f {
     return in.color;
 }

--- a/crates/re_renderer/shader/types.wgsl
+++ b/crates/re_renderer/shader/types.wgsl
@@ -1,17 +1,3 @@
-// Names chosen to match [`glam`](https://docs.rs/glam/latest/glam/)
-alias Vec2 = vec2<f32>;
-alias Vec3 = vec3<f32>;
-alias Vec4 = vec4<f32>;
-alias UVec2 = vec2<u32>;
-alias UVec3 = vec3<u32>;
-alias UVec4 = vec4<u32>;
-alias IVec2 = vec2<i32>;
-alias IVec3 = vec3<i32>;
-alias IVec4 = vec4<i32>;
-alias Mat3 = mat3x3<f32>;
-alias Mat4x3 = mat4x3<f32>;
-alias Mat4 = mat4x4<f32>;
-
 // Extreme values as documented by the spec:
 // https://www.w3.org/TR/WGSL/#floating-point-types
 //const f32max = 0x1.fffffep+127f;  // Largest positive float value.
@@ -31,12 +17,12 @@ const u32max = 0xffffffffu;
 // Difference between `1.0` and the next larger representable number.
 const f32eps = 0.00000011920928955078125;
 
-const X = Vec3(1.0, 0.0, 0.0);
-const Y = Vec3(0.0, 1.0, 0.0);
-const Z = Vec3(0.0, 0.0, 1.0);
+const X = vec3f(1.0, 0.0, 0.0);
+const Y = vec3f(0.0, 1.0, 0.0);
+const Z = vec3f(0.0, 0.0, 1.0);
 
-const ZERO = Vec4(0.0, 0.0, 0.0, 0.0);
-const ONE  = Vec4(1.0, 1.0, 1.0, 1.0);
+const ZERO = vec4f(0.0, 0.0, 0.0, 0.0);
+const ONE  = vec4f(1.0, 1.0, 1.0, 1.0);
 
 
 // Do NOT use inf() or nan() in your WGSL shaders. Ever.
@@ -52,4 +38,4 @@ const ONE  = Vec4(1.0, 1.0, 1.0, 1.0);
 
 
 /// The color to use when we encounter an error.
-const ERROR_RGBA = Vec4(1.0, 0.0, 1.0, 1.0);
+const ERROR_RGBA = vec4f(1.0, 0.0, 1.0, 1.0);

--- a/crates/re_renderer/shader/types.wgsl
+++ b/crates/re_renderer/shader/types.wgsl
@@ -21,9 +21,6 @@ const X = vec3f(1.0, 0.0, 0.0);
 const Y = vec3f(0.0, 1.0, 0.0);
 const Z = vec3f(0.0, 0.0, 1.0);
 
-const ZERO = vec4f(0.0, 0.0, 0.0, 0.0);
-const ONE  = vec4f(1.0, 1.0, 1.0, 1.0);
-
 
 // Do NOT use inf() or nan() in your WGSL shaders. Ever.
 // The WGSL spec allows implementations to assume that neither Inf or NaN are ever occurring:

--- a/crates/re_renderer/shader/utils/camera.wgsl
+++ b/crates/re_renderer/shader/utils/camera.wgsl
@@ -11,12 +11,12 @@ fn is_camera_perspective() -> bool {
 }
 
 struct Ray {
-    origin: Vec3,
-    direction: Vec3,
+    origin: vec3f,
+    direction: vec3f,
 }
 
 // Returns the ray from the camera to a given world position, assuming the camera is perspective
-fn camera_ray_to_world_pos_perspective(world_pos: Vec3) -> Ray {
+fn camera_ray_to_world_pos_perspective(world_pos: vec3f) -> Ray {
     var ray: Ray;
     ray.origin = frame.camera_position;
     ray.direction = normalize(world_pos - frame.camera_position);
@@ -24,7 +24,7 @@ fn camera_ray_to_world_pos_perspective(world_pos: Vec3) -> Ray {
 }
 
 // Returns the ray from the camera to a given world position, assuming the camera is orthographic
-fn camera_ray_to_world_pos_orthographic(world_pos: Vec3) -> Ray {
+fn camera_ray_to_world_pos_orthographic(world_pos: vec3f) -> Ray {
     var ray: Ray;
     // The ray originates on the camera plane, not from the camera position
     let to_pos = world_pos - frame.camera_position;
@@ -35,7 +35,7 @@ fn camera_ray_to_world_pos_orthographic(world_pos: Vec3) -> Ray {
 }
 
 // Returns the ray from the camera to a given world position.
-fn camera_ray_to_world_pos(world_pos: Vec3) -> Ray {
+fn camera_ray_to_world_pos(world_pos: vec3f) -> Ray {
     if is_camera_perspective() {
         return camera_ray_to_world_pos_perspective(world_pos);
     } else {
@@ -44,16 +44,16 @@ fn camera_ray_to_world_pos(world_pos: Vec3) -> Ray {
 }
 
 // Returns the camera ray direction through a given screen uv coordinates (ranging from 0 to 1, i.e. NOT ndc coordinates)
-fn camera_ray_direction_from_screenuv(texcoord: Vec2) -> Vec3 {
+fn camera_ray_direction_from_screenuv(texcoord: vec2f) -> vec3f {
     if is_camera_orthographic() {
         return frame.camera_forward;
     }
 
     // convert [0, 1] to [-1, +1 (Normalized Device Coordinates)
-    let ndc = Vec2(texcoord.x - 0.5, 0.5 - texcoord.y) * 2.0;
+    let ndc = vec2f(texcoord.x - 0.5, 0.5 - texcoord.y) * 2.0;
 
     // Negative z since z dir is towards viewer (by current RUB convention).
-    let view_space_dir = Vec3(ndc * frame.tan_half_fov, -1.0);
+    let view_space_dir = vec3f(ndc * frame.tan_half_fov, -1.0);
 
     // Note that since view_from_world is an orthonormal matrix, multiplying it from the right
     // means multiplying it with the transpose, meaning multiplying with the inverse!
@@ -65,14 +65,14 @@ fn camera_ray_direction_from_screenuv(texcoord: Vec2) -> Vec3 {
 
 // Returns distance to sphere surface (x) and distance to closest ray hit (y)
 // Via https://iquilezles.org/articles/spherefunctions/ but with more verbose names.
-fn ray_sphere_distance(ray: Ray, sphere_origin: Vec3, sphere_radius: f32) -> Vec2 {
+fn ray_sphere_distance(ray: Ray, sphere_origin: vec3f, sphere_radius: f32) -> vec2f {
     let sphere_radius_sq = sphere_radius * sphere_radius;
     let sphere_to_origin = ray.origin - sphere_origin;
     let b = dot(sphere_to_origin, ray.direction);
     let c = dot(sphere_to_origin, sphere_to_origin) - sphere_radius_sq;
     let h = b * b - c;
     let d = sqrt(max(0.0, sphere_radius_sq - h)) - sphere_radius;
-    return Vec2(d, -b - sqrt(max(h, 0.0)));
+    return vec2f(d, -b - sqrt(max(h, 0.0)));
 }
 
 // Returns the projected size of a pixel at a given distance from the camera.

--- a/crates/re_renderer/shader/utils/depth_offset.wgsl
+++ b/crates/re_renderer/shader/utils/depth_offset.wgsl
@@ -4,7 +4,7 @@
 /*
 We use reverse infinite depth, as promoted by https://developer.nvidia.com/content/depth-precision-visualized
 
-The projection matrix (from `glam::Mat4::perspective_infinite_reverse_rh`) looks like this:
+The projection matrix (from `glam::Mat::perspective_infinite_reverse_rh`) looks like this:
 
 f / aspect_ratio   0     0      0
 0                  f     0      0
@@ -70,7 +70,7 @@ The only reliable ways to mitigate this we found so far are:
 
 */
 
-fn apply_depth_offset(position: Vec4, offset: f32) -> Vec4 {
+fn apply_depth_offset(position: vec4f, offset: f32) -> vec4f {
     // On GLES/WebGL, the NDC clipspace range for depth is from -1 to 1 and y is flipped.
     // wgpu/Naga counteracts this by patching all vertex shaders with:
     // "gl_Position.yz = vec2(-gl_Position.y, gl_Position.z * 2.0 - gl_Position.w);",
@@ -91,7 +91,7 @@ fn apply_depth_offset(position: Vec4, offset: f32) -> Vec4 {
     }
     let w_scale = 1.0 - w_scale_bias;
 
-    return Vec4(
+    return vec4f(
         position.xyz,
         position.w * w_scale,
     );

--- a/crates/re_renderer/shader/utils/encoding.wgsl
+++ b/crates/re_renderer/shader/utils/encoding.wgsl
@@ -1,6 +1,6 @@
 // workaround for https://github.com/gfx-rs/naga/issues/2006
-fn unpack4x8unorm_workaround(v: u32) -> Vec4 {
-    let shifted = UVec4(v, v >> 8u, v >> 16u, v >> 24u);
-    let bytes = shifted & UVec4(0xFFu);
-    return Vec4(bytes) * (1.0 / 255.0);
+fn unpack4x8unorm_workaround(v: u32) -> vec4f {
+    let shifted = vec4u(v, v >> 8u, v >> 16u, v >> 24u);
+    let bytes = shifted & vec4u(0xFFu);
+    return vec4f(bytes) * (1.0 / 255.0);
 }

--- a/crates/re_renderer/shader/utils/quaternion.wgsl
+++ b/crates/re_renderer/shader/utils/quaternion.wgsl
@@ -1,4 +1,4 @@
-fn quat_rotate_vec3(q: Vec4, v: Vec3) -> Vec3 {
+fn quat_rotate_vec3f(q: vec4f, v: vec3f) -> vec3f {
     // via glam's quaternion.rs
     let b = q.xyz;
     return v * (q.w * q.w - dot(b, b)) +

--- a/crates/re_renderer/shader/utils/sphere_quad.wgsl
+++ b/crates/re_renderer/shader/utils/sphere_quad.wgsl
@@ -5,13 +5,13 @@
 /// Span a quad in a way that guarantees that we'll be able to draw a perspective correct sphere
 /// on it.
 fn sphere_quad(
-    point_pos: Vec3,
+    point_pos: vec3f,
     point_radius: f32,
     top_bottom: f32,
     left_right: f32,
-    to_camera: Vec3,
+    to_camera: vec3f,
     camera_distance: f32
-) -> Vec3 {
+) -> vec3f {
     let distance_to_camera_sq = camera_distance * camera_distance; // (passing on micro-optimization here for splitting this out of earlier length calculation)
     let distance_to_camera_inv = 1.0 / camera_distance;
     let quad_normal = to_camera * distance_to_camera_inv;
@@ -42,7 +42,7 @@ fn sphere_quad(
 
 /// Span a quad in a way that guarantees that we'll be able to draw an orthographic correct sphere
 /// on it.
-fn circle_quad(point_pos: Vec3, point_radius: f32, top_bottom: f32, left_right: f32) -> Vec3 {
+fn circle_quad(point_pos: vec3f, point_radius: f32, top_bottom: f32, left_right: f32) -> vec3f {
     let quad_normal = frame.camera_forward;
     let quad_right = normalize(cross(quad_normal, frame.view_from_world[1].xyz)); // It's spheres so any orthogonal vector would do.
     let quad_up = cross(quad_right, quad_normal);
@@ -62,14 +62,14 @@ fn sphere_quad_index(vertex_idx: u32) -> u32 {
 }
 
 struct SphereQuadData {
-    pos_in_world: Vec3,
+    pos_in_world: vec3f,
     point_resolved_radius: f32,
 }
 
 /// Span a quad onto which circles or perspective correct spheres can be drawn.
 ///
 /// Note that in orthographic mode, spheres are always circles.
-fn sphere_or_circle_quad_span(vertex_idx: u32, point_pos: Vec3, point_unresolved_radius: f32,
+fn sphere_or_circle_quad_span(vertex_idx: u32, point_pos: vec3f, point_unresolved_radius: f32,
                                 radius_boost_in_ui_points: f32, force_circle: bool) -> SphereQuadData {
     // Resolve radius to a world size. We need the camera distance for this, which is useful later on.
     let to_camera = frame.camera_position - point_pos;
@@ -83,7 +83,7 @@ fn sphere_or_circle_quad_span(vertex_idx: u32, point_pos: Vec3, point_unresolved
     let left_right = f32(vertex_idx % 2u) * 2.0 - 1.0; // 1 for a right vertex, -1 for a left vertex.
 
     // Span quad
-    var pos: Vec3;
+    var pos: vec3f;
     if is_camera_orthographic() || force_circle {
         pos = circle_quad(point_pos, radius, top_bottom, left_right);
     } else {
@@ -94,7 +94,7 @@ fn sphere_or_circle_quad_span(vertex_idx: u32, point_pos: Vec3, point_unresolved
 }
 
 /// Computes coverage of a 3D sphere placed at `sphere_center` in the fragment shader using the currently set camera.
-fn sphere_quad_coverage(world_position: Vec3, radius: f32, sphere_center: Vec3) -> f32 {
+fn sphere_quad_coverage(world_position: vec3f, radius: f32, sphere_center: vec3f) -> f32 {
     let ray = camera_ray_to_world_pos(world_position);
 
     // Sphere intersection with anti-aliasing as described by Iq here

--- a/crates/re_renderer/shader/utils/srgb.wgsl
+++ b/crates/re_renderer/shader/utils/srgb.wgsl
@@ -1,25 +1,25 @@
 // Converts a color from 0-1 sRGB to 0-1 linear
-fn linear_from_srgb(srgb: Vec3) -> Vec3 {
+fn linear_from_srgb(srgb: vec3f) -> vec3f {
     let cutoff = ceil(srgb - 0.04045);
     let under = srgb / 12.92;
-    let over = pow((srgb + 0.055) / 1.055,  Vec3(2.4));
+    let over = pow((srgb + 0.055) / 1.055,  vec3f(2.4));
     return mix(under, over, cutoff);
 }
 
 // Converts a color from 0-1 sRGB to 0-1 linear, leaves alpha untouched
-fn linear_from_srgba(srgb_a: Vec4) -> Vec4 {
-    return Vec4(linear_from_srgb(srgb_a.rgb), srgb_a.a);
+fn linear_from_srgba(srgb_a: vec4f) -> vec4f {
+    return vec4f(linear_from_srgb(srgb_a.rgb), srgb_a.a);
 }
 
 // Converts a color from 0-1 linear to 0-1 sRGB
-fn srgb_from_linear(color_linear: Vec3) -> Vec3 {
+fn srgb_from_linear(color_linear: vec3f) -> vec3f {
     let selector = ceil(color_linear - 0.0031308);
     let under = 12.92 * color_linear;
-    let over = 1.055 * pow(color_linear, Vec3(0.41666)) - 0.055;
+    let over = 1.055 * pow(color_linear, vec3f(0.41666)) - 0.055;
     return mix(under, over, selector);
 }
 
 // Converts a color from 0-1 sRGB to 0-1 linear, leaves alpha untouched
-fn srgba_from_linear(srgb_a: Vec4) -> Vec4 {
-    return Vec4(srgb_from_linear(srgb_a.rgb), srgb_a.a);
+fn srgba_from_linear(srgb_a: vec4f) -> vec4f {
+    return vec4f(srgb_from_linear(srgb_a.rgb), srgb_a.a);
 }


### PR DESCRIPTION
### What

Stumbled over the existence of those while working on another thing.
Zero/one constants seem to be pointless given how easily the values are initialized - default ctor for all types is defined to be zero :)

_commit by commit_

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4200) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4200)
- [Docs preview](https://rerun.io/preview/c329bdcdfc69278bbcc19a00113274087f24dabf/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c329bdcdfc69278bbcc19a00113274087f24dabf/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)