### PR TITLE
`DataStore` changelog 1: let `DataStore`s know about their `StoreId`

### DIFF
--- a/crates/re_arrow_store/benches/data_store.rs
+++ b/crates/re_arrow_store/benches/data_store.rs
@@ -357,7 +357,11 @@ fn insert_table(
     cluster_key: ComponentName,
     table: &DataTable,
 ) -> DataStore {
-    let mut store = DataStore::new(cluster_key, config);
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        cluster_key,
+        config,
+    );
     for row in table.to_rows() {
         store.insert_row(&row.unwrap()).unwrap();
     }

--- a/crates/re_arrow_store/examples/dump_dataframe.rs
+++ b/crates/re_arrow_store/examples/dump_dataframe.rs
@@ -13,7 +13,11 @@ use re_types_core::Loggable as _;
 // ---
 
 fn main() {
-    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
 
     let ent_paths = [
         EntityPath::from("this/that"),

--- a/crates/re_arrow_store/examples/latest_component.rs
+++ b/crates/re_arrow_store/examples/latest_component.rs
@@ -15,7 +15,11 @@ use re_types::{
 use re_types_core::Loggable as _;
 
 fn main() {
-    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
 
     let ent_path = EntityPath::from("my/entity");
 

--- a/crates/re_arrow_store/examples/latest_components.rs
+++ b/crates/re_arrow_store/examples/latest_components.rs
@@ -17,7 +17,11 @@ use re_types::{
 use re_types_core::Loggable as _;
 
 fn main() {
-    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
 
     let ent_path = EntityPath::from("my/entity");
 

--- a/crates/re_arrow_store/examples/range_components.rs
+++ b/crates/re_arrow_store/examples/range_components.rs
@@ -15,7 +15,11 @@ use re_types::{
 use re_types_core::Loggable as _;
 
 fn main() {
-    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
 
     let ent_path = EntityPath::from("this/that");
 

--- a/crates/re_arrow_store/src/store.rs
+++ b/crates/re_arrow_store/src/store.rs
@@ -156,9 +156,12 @@ impl std::ops::DerefMut for ClusterCellCache {
 
 // ---
 
-/// Incremented on each edit
+/// Incremented on each edit.
 #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct StoreGeneration(u64);
+pub struct StoreGeneration {
+    insert_id: u64,
+    gc_id: u64,
+}
 
 /// A complete data store: covers all timelines, all entities, everything.
 ///
@@ -275,7 +278,10 @@ impl DataStore {
     /// Return the current `StoreGeneration`. This can be used to determine whether the
     /// database has been modified since the last time it was queried.
     pub fn generation(&self) -> StoreGeneration {
-        StoreGeneration(self.insert_id)
+        StoreGeneration {
+            insert_id: self.insert_id,
+            gc_id: self.gc_id,
+        }
     }
 
     /// See [`Self::cluster_key`] for more information about the cluster key.

--- a/crates/re_arrow_store/src/store_format.rs
+++ b/crates/re_arrow_store/src/store_format.rs
@@ -9,11 +9,12 @@ impl std::fmt::Display for DataStore {
     #[allow(clippy::string_add)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
+            id,
             cluster_key,
             config,
             cluster_cell_cache: _,
-            metadata_registry: _,
             type_registry: _,
+            metadata_registry: _,
             tables,
             timeless_tables,
             insert_id: _,
@@ -23,6 +24,7 @@ impl std::fmt::Display for DataStore {
 
         f.write_str("DataStore {\n")?;
 
+        f.write_str(&indent::indent_all_by(4, format!("id: {id}\n")))?;
         f.write_str(&indent::indent_all_by(
             4,
             format!("cluster_key: {cluster_key:?}\n"),

--- a/crates/re_arrow_store/tests/correctness.rs
+++ b/crates/re_arrow_store/tests/correctness.rs
@@ -36,7 +36,11 @@ fn row_id_ordering_semantics() -> anyhow::Result<()> {
     // * Query at frame #11 and make sure we get `point2` because random `RowId`s are monotonically
     //   increasing.
     {
-        let mut store = DataStore::new(InstanceKey::name(), Default::default());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            Default::default(),
+        );
 
         let row_id = RowId::random();
         let row = DataRow::from_component_batches(
@@ -73,7 +77,11 @@ fn row_id_ordering_semantics() -> anyhow::Result<()> {
     // * Insert `point1` at frame #10 with a random `RowId`.
     // * Fail to insert `point2` at frame #10 using `point1`s `RowId` because it is illegal.
     {
-        let mut store = DataStore::new(InstanceKey::name(), Default::default());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            Default::default(),
+        );
 
         let row_id = RowId::random();
 
@@ -100,7 +108,11 @@ fn row_id_ordering_semantics() -> anyhow::Result<()> {
     // * Insert `point2` at frame #10 using `point1`'s `RowId`, decremented by one.
     // * Query at frame #11 and make sure we get `point1` because of intra-timestamp tie-breaks.
     {
-        let mut store = DataStore::new(InstanceKey::name(), Default::default());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            Default::default(),
+        );
 
         let row_id1 = RowId::random();
         let row_id2 = row_id1.next();
@@ -151,7 +163,11 @@ fn write_errors() {
             DataCell::from_component_sparse::<InstanceKey>([Some(1), None, Some(3)])
         }
 
-        let mut store = DataStore::new(InstanceKey::name(), Default::default());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            Default::default(),
+        );
         let row = test_row!(ent_path @
             [build_frame_nr(32.into()), build_log_time(Time::now())] => 3; [
                 build_sparse_instances(), build_some_positions2d(3)
@@ -171,7 +187,11 @@ fn write_errors() {
             DataCell::from_component::<InstanceKey>([1, 2, 2])
         }
 
-        let mut store = DataStore::new(InstanceKey::name(), Default::default());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            Default::default(),
+        );
         {
             let row = test_row!(ent_path @
                 [build_frame_nr(32.into()), build_log_time(Time::now())] => 3; [
@@ -195,7 +215,11 @@ fn write_errors() {
     }
 
     {
-        let mut store = DataStore::new(InstanceKey::name(), Default::default());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            Default::default(),
+        );
 
         let mut row = test_row!(ent_path @ [
             build_frame_nr(1.into()),
@@ -228,7 +252,11 @@ fn latest_at_emptiness_edge_cases() {
     init_logs();
 
     for config in re_arrow_store::test_util::all_configs() {
-        let mut store = DataStore::new(InstanceKey::name(), config.clone());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            config.clone(),
+        );
         latest_at_emptiness_edge_cases_impl(&mut store);
     }
 }
@@ -354,7 +382,11 @@ fn range_join_across_single_row() {
     init_logs();
 
     for config in re_arrow_store::test_util::all_configs() {
-        let mut store = DataStore::new(InstanceKey::name(), config.clone());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            config.clone(),
+        );
         range_join_across_single_row_impl(&mut store);
     }
 }
@@ -422,7 +454,11 @@ fn range_join_across_single_row_impl(store: &mut DataStore) {
 fn gc_correct() {
     init_logs();
 
-    let mut store = DataStore::new(InstanceKey::name(), DataStoreConfig::default());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        DataStoreConfig::default(),
+    );
 
     let stats_empty = DataStoreStats::from_store(&store);
 

--- a/crates/re_arrow_store/tests/correctness.rs
+++ b/crates/re_arrow_store/tests/correctness.rs
@@ -537,7 +537,11 @@ fn entity_min_time_correct() -> anyhow::Result<()> {
     init_logs();
 
     for config in re_arrow_store::test_util::all_configs() {
-        let mut store = DataStore::new(InstanceKey::name(), config.clone());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            config.clone(),
+        );
         entity_min_time_correct_impl(&mut store)?;
     }
 

--- a/crates/re_arrow_store/tests/data_store.rs
+++ b/crates/re_arrow_store/tests/data_store.rs
@@ -63,7 +63,11 @@ fn all_components() {
     let assert_latest_components_at =
         |store: &mut DataStore, ent_path: &EntityPath, expected: Option<&[ComponentName]>| {
             // Stress test save-to-disk & load-from-disk
-            let mut store2 = DataStore::new(store.cluster_key(), store.config().clone());
+            let mut store2 = DataStore::new(
+                re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+                store.cluster_key(),
+                store.config().clone(),
+            );
             for table in store.to_data_tables(None) {
                 insert_table_with_retries(&mut store2, &table);
             }
@@ -100,6 +104,7 @@ fn all_components() {
     // One big bucket, demonstrating the easier-to-reason-about cases.
     {
         let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
             InstanceKey::name(),
             DataStoreConfig {
                 indexed_bucket_num_rows: u64::MAX,
@@ -143,6 +148,7 @@ fn all_components() {
     // Tiny buckets, demonstrating the harder-to-reason-about cases.
     {
         let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
             InstanceKey::name(),
             DataStoreConfig {
                 indexed_bucket_num_rows: 0,
@@ -203,6 +209,7 @@ fn all_components() {
     // reason about, it is technically incorrect.
     {
         let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
             InstanceKey::name(),
             DataStoreConfig {
                 indexed_bucket_num_rows: 0,
@@ -276,7 +283,11 @@ fn latest_at() {
     init_logs();
 
     for config in re_arrow_store::test_util::all_configs() {
-        let mut store = DataStore::new(InstanceKey::name(), config.clone());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            config.clone(),
+        );
         latest_at_impl(&mut store);
     }
 }
@@ -324,7 +335,11 @@ fn latest_at_impl(store: &mut DataStore) {
     );
 
     // Stress test save-to-disk & load-from-disk
-    let mut store2 = DataStore::new(store.cluster_key(), store.config().clone());
+    let mut store2 = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        store.cluster_key(),
+        store.config().clone(),
+    );
     for table in store.to_data_tables(None) {
         insert_table(&mut store2, &table);
     }
@@ -390,7 +405,11 @@ fn range() {
     init_logs();
 
     for config in re_arrow_store::test_util::all_configs() {
-        let mut store = DataStore::new(InstanceKey::name(), config.clone());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            config.clone(),
+        );
         range_impl(&mut store);
     }
 }
@@ -466,7 +485,11 @@ fn range_impl(store: &mut DataStore) {
          components: [ComponentName; 2],
          rows_at_times: &[(Option<TimeInt>, &[(ComponentName, &DataRow)])]| {
             // Stress test save-to-disk & load-from-disk
-            let mut store2 = DataStore::new(store.cluster_key(), store.config().clone());
+            let mut store2 = DataStore::new(
+                re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+                store.cluster_key(),
+                store.config().clone(),
+            );
             for table in store.to_data_tables(None) {
                 insert_table_with_retries(&mut store2, &table);
             }
@@ -869,7 +892,11 @@ fn gc() {
     init_logs();
 
     for config in re_arrow_store::test_util::all_configs() {
-        let mut store = DataStore::new(InstanceKey::name(), config.clone());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            config.clone(),
+        );
         gc_impl(&mut store);
     }
 }
@@ -933,7 +960,11 @@ fn protected_gc() {
     init_logs();
 
     for config in re_arrow_store::test_util::all_configs() {
-        let mut store = DataStore::new(InstanceKey::name(), config.clone());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            config.clone(),
+        );
         protected_gc_impl(&mut store);
     }
 }
@@ -1029,7 +1060,11 @@ fn protected_gc_clear() {
     init_logs();
 
     for config in re_arrow_store::test_util::all_configs() {
-        let mut store = DataStore::new(InstanceKey::name(), config.clone());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            config.clone(),
+        );
         protected_gc_clear_impl(&mut store);
     }
 }

--- a/crates/re_arrow_store/tests/dump.rs
+++ b/crates/re_arrow_store/tests/dump.rs
@@ -41,9 +41,21 @@ fn data_store_dump() {
         // NOTE: insert IDs aren't serialized and can be different across runs.
         config.store_insert_ids = false;
 
-        let mut store1 = DataStore::new(InstanceKey::name(), config.clone());
-        let mut store2 = DataStore::new(InstanceKey::name(), config.clone());
-        let mut store3 = DataStore::new(InstanceKey::name(), config.clone());
+        let mut store1 = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            config.clone(),
+        );
+        let mut store2 = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            config.clone(),
+        );
+        let mut store3 = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            config.clone(),
+        );
 
         data_store_dump_impl(&mut store1, &mut store2, &mut store3);
 
@@ -137,8 +149,16 @@ fn data_store_dump_filtered() {
         // NOTE: insert IDs aren't serialized and can be different across runs.
         config.store_insert_ids = false;
 
-        let mut store1 = DataStore::new(InstanceKey::name(), config.clone());
-        let mut store2 = DataStore::new(InstanceKey::name(), config.clone());
+        let mut store1 = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            config.clone(),
+        );
+        let mut store2 = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            config.clone(),
+        );
 
         data_store_dump_filtered_impl(&mut store1, &mut store2);
 
@@ -271,7 +291,11 @@ fn data_store_dump_empty_column() {
     };
     config.store_insert_ids = false;
 
-    let mut store = DataStore::new(InstanceKey::name(), config);
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        config,
+    );
 
     data_store_dump_empty_column_impl(&mut store);
 }

--- a/crates/re_arrow_store/tests/internals.rs
+++ b/crates/re_arrow_store/tests/internals.rs
@@ -25,6 +25,7 @@ fn pathological_bucket_topology() {
     init_logs();
 
     let mut store_forward = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
         InstanceKey::name(),
         DataStoreConfig {
             indexed_bucket_num_rows: 10,
@@ -32,6 +33,7 @@ fn pathological_bucket_topology() {
         },
     );
     let mut store_backward = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
         InstanceKey::name(),
         DataStoreConfig {
             indexed_bucket_num_rows: 10,

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -35,13 +35,17 @@ pub struct EntityDb {
     pub data_store: DataStore,
 }
 
-impl Default for EntityDb {
-    fn default() -> Self {
+impl EntityDb {
+    pub fn new(store_id: StoreId) -> Self {
         Self {
             entity_path_from_hash: Default::default(),
             times_per_timeline: Default::default(),
             tree: crate::EntityTree::root(),
-            data_store: DataStore::new(InstanceKey::name(), DataStoreConfig::default()),
+            data_store: re_arrow_store::DataStore::new(
+                store_id,
+                InstanceKey::name(),
+                DataStoreConfig::default(),
+            ),
         }
     }
 }
@@ -331,10 +335,10 @@ pub struct StoreDb {
 impl StoreDb {
     pub fn new(store_id: StoreId) -> Self {
         Self {
-            store_id,
+            store_id: store_id.clone(),
             data_source: None,
             set_store_info: None,
-            entity_db: Default::default(),
+            entity_db: EntityDb::new(store_id),
             last_modified_at: web_time::Instant::now(),
         }
     }

--- a/crates/re_query/benches/query_benchmark.rs
+++ b/crates/re_query/benches/query_benchmark.rs
@@ -248,8 +248,14 @@ fn build_strings_rows(paths: &[EntityPath], num_strings: usize) -> Vec<DataRow> 
 }
 
 fn insert_rows<'a>(msgs: impl Iterator<Item = &'a DataRow>) -> DataStore {
-    let mut store = DataStore::new(InstanceKey::name(), Default::default());
-    msgs.for_each(|row| store.insert_row(row).unwrap());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+    msgs.for_each(|row| {
+        store.insert_row(row).unwrap();
+    });
     store
 }
 

--- a/crates/re_query/src/query.rs
+++ b/crates/re_query/src/query.rs
@@ -169,7 +169,11 @@ pub fn __populate_example_store() -> DataStore {
     use re_log_types::example_components::{MyColor, MyPoint};
     use re_log_types::{build_frame_nr, DataRow};
 
-    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
 
     let ent_path = "point";
     let timepoint = [build_frame_nr(123.into())];

--- a/crates/re_query/tests/archetype_query_tests.rs
+++ b/crates/re_query/tests/archetype_query_tests.rs
@@ -11,7 +11,11 @@ use re_types_core::Loggable as _;
 
 #[test]
 fn simple_query() {
-    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
 
     let ent_path = "point";
     let timepoint = [build_frame_nr(123.into())];
@@ -78,7 +82,11 @@ fn simple_query() {
 
 #[test]
 fn timeless_query() {
-    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
 
     let ent_path = "point";
     let timepoint = [build_frame_nr(123.into())];
@@ -140,7 +148,11 @@ fn timeless_query() {
 
 #[test]
 fn no_instance_join_query() {
-    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
 
     let ent_path = "point";
     let timepoint = [build_frame_nr(123.into())];
@@ -202,7 +214,11 @@ fn no_instance_join_query() {
 
 #[test]
 fn missing_column_join_query() {
-    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
 
     let ent_path = "point";
     let timepoint = [build_frame_nr(123.into())];
@@ -255,7 +271,11 @@ fn missing_column_join_query() {
 
 #[test]
 fn splatted_query() {
-    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
 
     let ent_path = "point";
     let timepoint = [build_frame_nr(123.into())];

--- a/crates/re_query/tests/archetype_range_tests.rs
+++ b/crates/re_query/tests/archetype_range_tests.rs
@@ -11,7 +11,11 @@ use re_types_core::Loggable as _;
 
 #[test]
 fn simple_range() {
-    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
 
     let ent_path: EntityPath = "point".into();
 
@@ -235,7 +239,11 @@ fn simple_range() {
 
 #[test]
 fn timeless_range() {
-    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
 
     let ent_path: EntityPath = "point".into();
 
@@ -684,7 +692,11 @@ fn timeless_range() {
 
 #[test]
 fn simple_splatted_range() {
-    let mut store = DataStore::new(InstanceKey::name(), Default::default());
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
 
     let ent_path: EntityPath = "point".into();
 

--- a/crates/re_space_view_spatial/benches/bench_points.rs
+++ b/crates/re_space_view_spatial/benches/bench_points.rs
@@ -33,7 +33,11 @@ fn bench_points(c: &mut criterion::Criterion) {
     let ent_path = EntityPath::from("points");
 
     let store = {
-        let mut store = DataStore::new(InstanceKey::name(), Default::default());
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            Default::default(),
+        );
 
         let positions = vec![Position3D::new(0.1, 0.2, 0.3); NUM_POINTS];
         let colors = vec![Color::from(0xffffffff); NUM_POINTS];


### PR DESCRIPTION
The upcoming `StoreView` works in global scope: by registering a view you subscribe to changes to _all_ `DataStore`s, including those that are yet to be created.
This is very powerful as it allows views & triggers implementers to build cross-recording indices as well as be notified as soon as new recordings come in and go out.

But it means that `StoreEvent`s must indicate which `DataStore` they originate from, which isn't possible today since the stores themselves don't know who they are to begin with.
This trivial PR plumbs the `StoreId` all the way through so `DataStore`s know about their own ID.

Also made `StoreGeneration` account for the GC counter while I was at it.

---

Requires:
- #4215 

`DataStore` changelog PR series:
- #4202
- #4203
- #4205
- #4206
- #4208
- #4209


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4202) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4202)
- [Docs preview](https://rerun.io/preview/b00c552c937e22a02a3e95b8fb6d3491cb761b60/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b00c552c937e22a02a3e95b8fb6d3491cb761b60/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)