### PR TITLE
`DataStore` changelog 2: introduce `StoreEvent`s

### DIFF
--- a/crates/re_arrow_store/Cargo.toml
+++ b/crates/re_arrow_store/Cargo.toml
@@ -71,6 +71,7 @@ polars-ops = { workspace = true, optional = true, features = [
 
 
 [dev-dependencies]
+re_log_types = { workspace = true, features = ["testing"] }
 re_types = { workspace = true, features = ["datagen"] }
 
 anyhow.workspace = true

--- a/crates/re_arrow_store/src/lib.rs
+++ b/crates/re_arrow_store/src/lib.rs
@@ -39,7 +39,7 @@ pub mod test_util;
 pub use self::arrow_util::ArrayExt;
 pub use self::store::{DataStore, DataStoreConfig, StoreGeneration};
 pub use self::store_event::{StoreDiff, StoreDiffKind, StoreEvent};
-pub use self::store_gc::{GarbageCollectionOptions, GarbageCollectionTarget};
+pub use self::store_gc::{Deleted, GarbageCollectionOptions, GarbageCollectionTarget};
 pub use self::store_helpers::VersionedComponent;
 pub use self::store_read::{LatestAtQuery, RangeQuery};
 pub use self::store_stats::{DataStoreRowStats, DataStoreStats, EntityStats};

--- a/crates/re_arrow_store/src/lib.rs
+++ b/crates/re_arrow_store/src/lib.rs
@@ -18,6 +18,7 @@ mod arrow_util;
 mod store;
 mod store_arrow;
 mod store_dump;
+mod store_event;
 mod store_format;
 mod store_gc;
 mod store_helpers;
@@ -37,7 +38,8 @@ pub mod test_util;
 
 pub use self::arrow_util::ArrayExt;
 pub use self::store::{DataStore, DataStoreConfig, StoreGeneration};
-pub use self::store_gc::{Deleted, GarbageCollectionOptions, GarbageCollectionTarget};
+pub use self::store_event::{StoreDiff, StoreDiffKind, StoreEvent};
+pub use self::store_gc::{GarbageCollectionOptions, GarbageCollectionTarget};
 pub use self::store_helpers::VersionedComponent;
 pub use self::store_read::{LatestAtQuery, RangeQuery};
 pub use self::store_stats::{DataStoreRowStats, DataStoreStats, EntityStats};

--- a/crates/re_arrow_store/src/store.rs
+++ b/crates/re_arrow_store/src/store.rs
@@ -5,13 +5,13 @@ use ahash::HashMap;
 use arrow2::datatypes::DataType;
 use nohash_hasher::IntMap;
 use parking_lot::RwLock;
-use re_types_core::{ComponentName, ComponentNameSet, SizeBytes};
 use smallvec::SmallVec;
 
 use re_log_types::{
     DataCell, DataCellColumn, EntityPath, EntityPathHash, ErasedTimeVec, NumInstancesVec, RowId,
     RowIdVec, StoreId, TimeInt, TimePoint, TimeRange, Timeline,
 };
+use re_types_core::{ComponentName, ComponentNameSet, SizeBytes};
 
 // --- Data store ---
 
@@ -229,6 +229,9 @@ pub struct DataStore {
 
     /// Monotonically increasing ID for GCs.
     pub(crate) gc_id: u64,
+
+    /// Monotonically increasing ID for store events.
+    pub(crate) event_id: AtomicU64,
 }
 
 impl Clone for DataStore {
@@ -245,6 +248,7 @@ impl Clone for DataStore {
             insert_id: Default::default(),
             query_id: Default::default(),
             gc_id: Default::default(),
+            event_id: Default::default(),
         }
     }
 }
@@ -264,6 +268,7 @@ impl DataStore {
             insert_id: 0,
             query_id: AtomicU64::new(0),
             gc_id: 0,
+            event_id: AtomicU64::new(0),
         }
     }
 

--- a/crates/re_arrow_store/src/store_event.rs
+++ b/crates/re_arrow_store/src/store_event.rs
@@ -223,3 +223,239 @@ impl StoreDiff {
         self.cells.len()
     }
 }
+
+#[cfg(tests)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use re_log_types::{
+        example_components::{MyColor, MyPoint, MyPoints},
+        DataRow, DataTable, RowId, TableId, Time, TimePoint, Timeline,
+    };
+    use re_types_core::{components::InstanceKey, Loggable as _};
+
+    use crate::{DataStore, GarbageCollectionOptions};
+
+    use super::*;
+
+    /// A simple store view for test purposes that keeps track of the quantity of data available
+    /// in the store a the lowest level of detail.
+    ///
+    /// The counts represent numbers of rows: e.g. how many unique rows contain this entity path?
+    #[derive(Default, Debug, PartialEq, Eq)]
+    struct GlobalCounts {
+        row_ids: BTreeMap<RowId, i64>,
+        timelines: BTreeMap<Timeline, i64>,
+        entity_paths: BTreeMap<EntityPath, i64>,
+        component_names: BTreeMap<ComponentName, i64>,
+        times: BTreeMap<TimeInt, i64>,
+        timeless: i64,
+    }
+
+    impl GlobalCounts {
+        fn new(
+            row_ids: impl IntoIterator<Item = (RowId, i64)>, //
+            timelines: impl IntoIterator<Item = (Timeline, i64)>, //
+            entity_paths: impl IntoIterator<Item = (EntityPath, i64)>, //
+            component_names: impl IntoIterator<Item = (ComponentName, i64)>, //
+            times: impl IntoIterator<Item = (TimeInt, i64)>, //
+            timeless: i64,
+        ) -> Self {
+            Self {
+                row_ids: row_ids.into_iter().collect(),
+                timelines: timelines.into_iter().collect(),
+                entity_paths: entity_paths.into_iter().collect(),
+                component_names: component_names.into_iter().collect(),
+                times: times.into_iter().collect(),
+                timeless,
+            }
+        }
+    }
+
+    impl GlobalCounts {
+        fn on_events(&mut self, events: &[StoreEvent]) {
+            for event in events {
+                let delta = event.delta();
+
+                *self.row_ids.entry(event.row_id).or_default() += delta;
+                *self
+                    .entity_paths
+                    .entry(event.entity_path.clone())
+                    .or_default() += delta;
+
+                for component_name in event.cells.keys() {
+                    *self.component_names.entry(*component_name).or_default() += delta;
+                }
+
+                if event.is_timeless() {
+                    self.timeless += delta;
+                } else {
+                    for (&timeline, &time) in &event.timepoint {
+                        *self.timelines.entry(timeline).or_default() += delta;
+                        *self.times.entry(time).or_default() += delta;
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn store_events() -> anyhow::Result<()> {
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            Default::default(),
+        );
+
+        let mut view = GlobalCounts::default();
+
+        let timeline_frame = Timeline::new_sequence("frame");
+        let timeline_other = Timeline::new_temporal("other");
+        let timeline_yet_another = Timeline::new_sequence("yet_another");
+
+        let row_id1 = RowId::random();
+        let timepoint1 = TimePoint::from_iter([
+            (timeline_frame, 42.into()),      //
+            (timeline_other, 666.into()),     //
+            (timeline_yet_another, 1.into()), //
+        ]);
+        let entity_path1: EntityPath = "entity_a".into();
+        let row1 = DataRow::from_component_batches(
+            row_id1,
+            timepoint1.clone(),
+            entity_path1.clone(),
+            [&InstanceKey::from_iter(0..10) as _],
+        )?;
+
+        view.on_events(&[store.insert_row(&row1)?]);
+
+        similar_asserts::assert_eq!(
+            GlobalCounts::new(
+                [
+                    (row_id1, 1), //
+                ],
+                [
+                    (timeline_frame, 1),
+                    (timeline_other, 1),
+                    (timeline_yet_another, 1),
+                ],
+                [
+                    (entity_path1.clone(), 1), //
+                ],
+                [
+                    (InstanceKey::name(), 1), //
+                ],
+                [
+                    (42.into(), 1), //
+                    (666.into(), 1),
+                    (1.into(), 1),
+                ],
+                0,
+            ),
+            view,
+        );
+
+        let row_id2 = RowId::random();
+        let timepoint2 = TimePoint::from_iter([
+            (timeline_frame, 42.into()),      //
+            (timeline_yet_another, 1.into()), //
+        ]);
+        let entity_path2: EntityPath = "entity_b".into();
+        let row2 = {
+            let num_instances = 3;
+            let points: Vec<_> = (0..num_instances)
+                .map(|i| MyPoint::new(0.0, i as f32))
+                .collect();
+            let colors = vec![MyColor::from(0xFF0000FF)];
+            DataRow::from_component_batches(
+                row_id2,
+                timepoint2.clone(),
+                entity_path2.clone(),
+                [&points as _, &colors as _],
+            )?
+        };
+
+        view.on_events(&[store.insert_row(&row2)?]);
+
+        similar_asserts::assert_eq!(
+            GlobalCounts::new(
+                [
+                    (row_id1, 1), //
+                    (row_id2, 1),
+                ],
+                [
+                    (timeline_frame, 2),
+                    (timeline_other, 1),
+                    (timeline_yet_another, 2),
+                ],
+                [
+                    (entity_path1.clone(), 1), //
+                    (entity_path2.clone(), 1), //
+                ],
+                [
+                    (InstanceKey::name(), 2), //
+                    (MyPoint::name(), 1),     //
+                    (MyColor::name(), 1),     //
+                ],
+                [
+                    (42.into(), 2), //
+                    (666.into(), 1),
+                    (1.into(), 2),
+                ],
+                0,
+            ),
+            view,
+        );
+
+        let row_id3 = RowId::random();
+        let timepoint3 = TimePoint::timeless();
+        let row3 = {
+            let num_instances = 6;
+            let colors = vec![MyColor::from(0x00DD00FF); num_instances];
+            DataRow::from_component_batches(
+                row_id3,
+                timepoint3.clone(),
+                entity_path2.clone(),
+                [
+                    &InstanceKey::from_iter(0..num_instances as _) as _,
+                    &colors as _,
+                ],
+            )?
+        };
+
+        view.on_events(&[store.insert_row(&row3)?]);
+
+        similar_asserts::assert_eq!(
+            GlobalCounts::new(
+                [
+                    (row_id1, 1), //
+                    (row_id2, 1),
+                    (row_id3, 1),
+                ],
+                [
+                    (timeline_frame, 2),
+                    (timeline_other, 1),
+                    (timeline_yet_another, 2),
+                ],
+                [
+                    (entity_path1.clone(), 1), //
+                    (entity_path2.clone(), 2), //
+                ],
+                [
+                    (InstanceKey::name(), 3), //
+                    (MyPoint::name(), 1),     //
+                    (MyColor::name(), 2),     //
+                ],
+                [
+                    (42.into(), 2), //
+                    (666.into(), 1),
+                    (1.into(), 2),
+                ],
+                1,
+            ),
+            view,
+        );
+
+        Ok(())
+    }
+}

--- a/crates/re_arrow_store/src/store_event.rs
+++ b/crates/re_arrow_store/src/store_event.rs
@@ -95,6 +95,11 @@ pub struct StoreDiff {
     ///
     /// A [`StoreDiff`] answers a logical question: "does there exist a query path which can return
     /// data from that row?".
+    ///
+    /// An event of kind deletion only tells you that, from this point on, no query can return data from that row.
+    /// That doesn't necessarily mean that the data is actually gone, i.e. don't make assumptions of e.g. the size
+    /// in bytes of the store based on these events.
+    /// They are in "query-model space" and are not an accurate representation of what happens in storage space.
     pub kind: StoreDiffKind,
 
     /// What's the row's [`RowId`]?
@@ -172,7 +177,7 @@ impl StoreDiff {
 
     /// Returns the union of two [`StoreDiff`]s.
     ///
-    /// They must share the same [`RowId`] and [`EntityPath`].
+    /// They must share the same [`RowId`], [`EntityPath`] and [`StoreDiffKind`].
     #[inline]
     pub fn union(&self, rhs: &Self) -> Option<Self> {
         let Self {

--- a/crates/re_arrow_store/src/store_event.rs
+++ b/crates/re_arrow_store/src/store_event.rs
@@ -1,0 +1,225 @@
+use nohash_hasher::IntMap;
+
+use re_log_types::{DataCell, EntityPath, RowId, StoreId, TimeInt, TimePoint, Timeline};
+use re_types_core::ComponentName;
+
+use crate::StoreGeneration;
+
+// Used all over in docstrings.
+#[allow(unused_imports)]
+use crate::DataStore;
+
+// ---
+
+/// The atomic unit of change in the Rerun [`DataStore`].
+///
+/// A [`StoreEvent`] describes the changes caused by the addition or deletion of a
+/// [`re_log_types::DataRow`] in the store.
+///
+/// Methods that mutate the [`DataStore`], such as [`DataStore::insert_row`] and [`DataStore::gc`],
+/// return [`StoreEvent`]s that describe the changes.
+///
+/// Refer to field-level documentation for more details and check out [`StoreDiff`] for a precise
+/// definition of what an event involves.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StoreEvent {
+    /// Which [`DataStore`] sent this event?
+    pub store_id: StoreId,
+
+    /// What was the store's generation when it sent that event?
+    pub store_generation: StoreGeneration,
+
+    /// Monotonically increasing ID of the event.
+    ///
+    /// This is on a per-store basis.
+    ///
+    /// When handling a [`StoreEvent`], if this is the first time you process this [`StoreId`] and
+    /// the associated `event_id` is not `1`, it means you registered late and missed some updates.
+    pub event_id: u64,
+
+    /// What actually changed?
+    ///
+    /// Refer to [`StoreDiff`] for more information.
+    pub diff: StoreDiff,
+}
+
+impl std::ops::Deref for StoreEvent {
+    type Target = StoreDiff;
+
+    fn deref(&self) -> &Self::Target {
+        &self.diff
+    }
+}
+
+/// Is it an addition or a deletion?
+///
+/// Reminder: ⚠ Do not confuse _a deletion_ and _a clear_ ⚠.
+///
+/// A deletion is the result of a row being completely removed from the store as part of the
+/// garbage collection process.
+///
+/// A clear, on the other hand, is the act of logging an empty [`re_types_core::ComponentBatch`],
+/// either directly using the logging APIs, or indirectly through the use of a
+/// [`re_types_core::archetypes::Clear`] archetype.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoreDiffKind {
+    Addition,
+    Deletion,
+}
+
+impl StoreDiffKind {
+    #[inline]
+    pub fn delta(&self) -> i64 {
+        match self {
+            StoreDiffKind::Addition => 1,
+            StoreDiffKind::Deletion => -1,
+        }
+    }
+}
+
+/// Describes an atomic change in the Rerun [`DataStore`]: a row has been added or deleted.
+///
+/// From a query model standpoint, the [`DataStore`] _always_ operates one row at a time:
+/// - The contents of a row (i.e. its columns) are immutable past insertion, by virtue of
+///   [`RowId`]s being unique and non-reusable.
+/// - Similarly, garbage collection always removes _all the data_ associated with a row in one go:
+///   there cannot be orphaned columns. When a row is gone, all data associated with it is gone too.
+///
+/// Refer to field-level documentation for more information.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StoreDiff {
+    /// Addition or deletion?
+    ///
+    /// The store's internals are opaque and don't necessarily reflect the query model (e.g. there
+    /// might be data in the store that cannot by reached by any query).
+    ///
+    /// A [`StoreDiff`] answers a logical question: "does there exist a query path which can return
+    /// data from that row?".
+    pub kind: StoreDiffKind,
+
+    /// What's the row's [`RowId`]?
+    ///
+    /// [`RowId`]s are guaranteed to be unique within a single [`DataStore`].
+    ///
+    /// Put another way, the same [`RowId`] can only appear twice in a [`StoreDiff`] event:
+    /// one addition and (optionally) one deletion (in that order!).
+    pub row_id: RowId,
+
+    /// The [`TimePoint`] associated with that row.
+    ///
+    /// Since insertions and deletions both work on a row-level basis, this is guaranteed to be the
+    /// same value for both the insertion and deletion events (if any).
+    pub timepoint: TimePoint,
+
+    /// The [`EntityPath`] associated with that row.
+    ///
+    /// Since insertions and deletions both work on a row-level basis, this is guaranteed to be the
+    /// same value for both the insertion and deletion events (if any).
+    pub entity_path: EntityPath,
+
+    /// All the [`DataCell`]s associated with that row.
+    ///
+    /// Since insertions and deletions both work on a row-level basis, this is guaranteed to be the
+    /// same set of values for both the insertion and deletion events (if any).
+    pub cells: IntMap<ComponentName, DataCell>,
+}
+
+impl StoreDiff {
+    #[inline]
+    pub fn addition(row_id: impl Into<RowId>, entity_path: impl Into<EntityPath>) -> Self {
+        Self {
+            kind: StoreDiffKind::Addition,
+            row_id: row_id.into(),
+            timepoint: TimePoint::timeless(),
+            entity_path: entity_path.into(),
+            cells: Default::default(),
+        }
+    }
+
+    #[inline]
+    pub fn deletion(row_id: impl Into<RowId>, entity_path: impl Into<EntityPath>) -> Self {
+        Self {
+            kind: StoreDiffKind::Deletion,
+            row_id: row_id.into(),
+            timepoint: TimePoint::timeless(),
+            entity_path: entity_path.into(),
+            cells: Default::default(),
+        }
+    }
+
+    #[inline]
+    pub fn at_timepoint(mut self, timepoint: impl Into<TimePoint>) -> StoreDiff {
+        self.timepoint = self.timepoint.union_max(&timepoint.into());
+        self
+    }
+
+    #[inline]
+    pub fn at_timestamp(
+        mut self,
+        timeline: impl Into<Timeline>,
+        time: impl Into<TimeInt>,
+    ) -> StoreDiff {
+        self.timepoint.insert(timeline.into(), time.into());
+        self
+    }
+
+    #[inline]
+    pub fn with_cells(mut self, cells: impl IntoIterator<Item = DataCell>) -> Self {
+        self.cells
+            .extend(cells.into_iter().map(|cell| (cell.component_name(), cell)));
+        self
+    }
+
+    /// Returns the union of two [`StoreDiff`]s.
+    ///
+    /// They must share the same [`RowId`] and [`EntityPath`].
+    #[inline]
+    pub fn union(&self, rhs: &Self) -> Option<Self> {
+        let Self {
+            kind: lhs_kind,
+            row_id: lhs_row_id,
+            timepoint: lhs_timepoint,
+            entity_path: lhs_entity_path,
+            cells: lhs_cells,
+        } = self;
+        let Self {
+            kind: rhs_kind,
+            row_id: rhs_row_id,
+            timepoint: rhs_timepoint,
+            entity_path: rhs_entity_path,
+            cells: rhs_cells,
+        } = rhs;
+
+        let same_kind = lhs_kind == rhs_kind;
+        let same_row_id = lhs_row_id == rhs_row_id;
+        let same_entity_path = lhs_entity_path == rhs_entity_path;
+
+        (same_kind && same_row_id && same_entity_path).then(|| Self {
+            kind: *lhs_kind,
+            row_id: *lhs_row_id,
+            timepoint: lhs_timepoint.clone().union_max(rhs_timepoint),
+            entity_path: lhs_entity_path.clone(),
+            cells: [lhs_cells.values(), rhs_cells.values()]
+                .into_iter()
+                .flatten()
+                .map(|cell| (cell.component_name(), cell.clone()))
+                .collect(),
+        })
+    }
+
+    #[inline]
+    pub fn is_timeless(&self) -> bool {
+        self.timepoint.is_timeless()
+    }
+
+    /// `-1` for deletions, `+1` for additions.
+    #[inline]
+    pub fn delta(&self) -> i64 {
+        self.kind.delta()
+    }
+
+    #[inline]
+    pub fn num_components(&self) -> usize {
+        self.cells.len()
+    }
+}

--- a/crates/re_arrow_store/src/store_event.rs
+++ b/crates/re_arrow_store/src/store_event.rs
@@ -456,6 +456,39 @@ mod tests {
             view,
         );
 
+        view.on_events(&store.gc(GarbageCollectionOptions::gc_everything()).0);
+
+        similar_asserts::assert_eq!(
+            GlobalCounts::new(
+                [
+                    (row_id1, 0), //
+                    (row_id2, 0),
+                    (row_id3, 0),
+                ],
+                [
+                    (timeline_frame, 0),
+                    (timeline_other, 0),
+                    (timeline_yet_another, 0),
+                ],
+                [
+                    (entity_path1.clone(), 0), //
+                    (entity_path2.clone(), 0), //
+                ],
+                [
+                    (InstanceKey::name(), 0), //
+                    (MyPoint::name(), 0),     //
+                    (MyColor::name(), 0),     //
+                ],
+                [
+                    (42.into(), 0), //
+                    (666.into(), 0),
+                    (1.into(), 0),
+                ],
+                0,
+            ),
+            view,
+        );
+
         Ok(())
     }
 }

--- a/crates/re_arrow_store/src/store_format.rs
+++ b/crates/re_arrow_store/src/store_format.rs
@@ -20,6 +20,7 @@ impl std::fmt::Display for DataStore {
             insert_id: _,
             query_id: _,
             gc_id: _,
+            event_id: _,
         } = self;
 
         f.write_str("DataStore {\n")?;

--- a/crates/re_arrow_store/src/store_write.rs
+++ b/crates/re_arrow_store/src/store_write.rs
@@ -164,10 +164,7 @@ impl DataStore {
             let index = self
                 .timeless_tables
                 .entry(ent_path_hash)
-                .or_insert_with(|| {
-                    // diffs.push(TimelessEntityPathDiff::new(*row_id, ent_path_hash).added());
-                    PersistentIndexedTable::new(self.cluster_key, ent_path.clone())
-                });
+                .or_insert_with(|| PersistentIndexedTable::new(self.cluster_key, ent_path.clone()));
 
             index.insert_row(insert_id, generated_cluster_cell.clone(), row);
         } else {
@@ -176,10 +173,7 @@ impl DataStore {
                 let index = self
                     .tables
                     .entry((*timeline, ent_path_hash))
-                    .or_insert_with(|| {
-                        // diffs.push(EntityPathDiff::new(*row_id, *timeline, ent_path_hash).added());
-                        IndexedTable::new(self.cluster_key, *timeline, ent_path)
-                    });
+                    .or_insert_with(|| IndexedTable::new(self.cluster_key, *timeline, ent_path));
 
                 index.insert_row(
                     &self.config,

--- a/crates/re_arrow_store/src/store_write.rs
+++ b/crates/re_arrow_store/src/store_write.rs
@@ -13,12 +13,9 @@ use re_types_core::{
 };
 
 use crate::{
-    store::MetadataRegistry, DataStore, DataStoreConfig, IndexedBucket, IndexedBucketInner,
-    IndexedTable, PersistentIndexedTable,
+    DataStore, DataStoreConfig, IndexedBucket, IndexedBucketInner, IndexedTable, MetadataRegistry,
+    PersistentIndexedTable, StoreDiff, StoreEvent,
 };
-
-// TODO(cmc): the store should insert column-per-column rather than row-per-row (purely a
-// performance matter).
 
 // --- Data store ---
 
@@ -38,6 +35,9 @@ pub enum WriteError {
             any duplicates, got {0:?}"
     )]
     InvalidClusteringComponent(DataCell),
+
+    #[error("The inserted data must contain at least one cell")]
+    Empty,
 
     #[error(
         "Component '{component}' failed to typecheck: expected {expected:#?} but got {got:#?}"
@@ -60,12 +60,12 @@ impl DataStore {
     /// If the bundle doesn't carry a payload for the cluster key, one will be auto-generated
     /// based on the length of the components in the payload, in the form of an array of
     /// monotonically increasing `u64`s going from `0` to `N-1`.
-    pub fn insert_row(&mut self, row: &DataRow) -> WriteResult<()> {
+    pub fn insert_row(&mut self, row: &DataRow) -> WriteResult<StoreEvent> {
         // TODO(cmc): kind & insert_id need to somehow propagate through the span system.
         self.insert_id += 1;
 
         if row.num_cells() == 0 {
-            return Ok(());
+            return Err(WriteError::Empty);
         }
 
         let DataRow {
@@ -81,6 +81,8 @@ impl DataStore {
         re_tracing::profile_function!();
 
         // Update type registry and do typechecking if enabled
+        // TODO(#1809): not only this should be replaced by a central arrow runtime registry, it should
+        // also be implemented as a changelog subscriber.
         if self.config.enable_typecheck {
             for cell in row.cells().iter() {
                 use std::collections::hash_map::Entry;
@@ -151,7 +153,9 @@ impl DataStore {
             // one… unless we've already generated one of this exact length in the past,
             // in which case we can simply re-use that cell.
 
-            Some(self.generate_cluster_cell(num_instances.into()))
+            let (cell, _) = self.generate_cluster_cell(num_instances.into());
+
+            Some(cell)
         };
 
         let insert_id = self.config.store_insert_ids.then_some(self.insert_id);
@@ -160,16 +164,22 @@ impl DataStore {
             let index = self
                 .timeless_tables
                 .entry(ent_path_hash)
-                .or_insert_with(|| PersistentIndexedTable::new(self.cluster_key, ent_path.clone()));
+                .or_insert_with(|| {
+                    // diffs.push(TimelessEntityPathDiff::new(*row_id, ent_path_hash).added());
+                    PersistentIndexedTable::new(self.cluster_key, ent_path.clone())
+                });
 
-            index.insert_row(insert_id, generated_cluster_cell, row);
+            index.insert_row(insert_id, generated_cluster_cell.clone(), row);
         } else {
             for (timeline, time) in timepoint.iter() {
                 let ent_path = ent_path.clone(); // shallow
                 let index = self
                     .tables
                     .entry((*timeline, ent_path_hash))
-                    .or_insert_with(|| IndexedTable::new(self.cluster_key, *timeline, ent_path));
+                    .or_insert_with(|| {
+                        // diffs.push(EntityPathDiff::new(*row_id, *timeline, ent_path_hash).added());
+                        IndexedTable::new(self.cluster_key, *timeline, ent_path)
+                    });
 
                 index.insert_row(
                     &self.config,
@@ -181,26 +191,38 @@ impl DataStore {
             }
         }
 
-        Ok(())
-    }
+        let mut diff = StoreDiff::addition(*row_id, ent_path.clone())
+            .at_timepoint(timepoint.clone())
+            .with_cells(cells.iter().cloned());
 
-    /// Wipes all timeless data.
-    ///
-    /// Mostly useful for testing/debugging purposes.
-    pub fn wipe_timeless_data(&mut self) {
-        self.timeless_tables = Default::default();
+        if let Some(cell) = generated_cluster_cell {
+            diff = diff.with_cells([cell]);
+        }
+
+        let event = StoreEvent {
+            store_id: self.id.clone(),
+            store_generation: self.generation(),
+            event_id: self
+                .event_id
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            diff,
+        };
+
+        Ok(event)
     }
 
     /// Auto-generates an appropriate cluster cell for the specified number of instances and
     /// transparently handles caching.
+    ///
+    /// Returns `true` if the cell was returned from cache.
     // TODO(#1777): shared slices for auto generated keys
-    fn generate_cluster_cell(&mut self, num_instances: u32) -> DataCell {
+    fn generate_cluster_cell(&mut self, num_instances: u32) -> (DataCell, bool) {
         re_tracing::profile_function!();
 
         if let Some(cell) = self.cluster_cell_cache.get(&num_instances) {
             // Cache hit!
 
-            cell.clone() // shallow
+            (cell.clone(), true)
         } else {
             // Cache miss! Craft a new instance keys from the ground up.
 
@@ -214,7 +236,7 @@ impl DataStore {
             self.cluster_cell_cache
                 .insert(num_instances, cell.clone() /* shallow */);
 
-            cell
+            (cell, false)
         }
     }
 }
@@ -378,8 +400,9 @@ impl IndexedTable {
             "inserted into indexed tables"
         );
 
-        self.buckets_size_bytes +=
+        let size_bytes =
             bucket.insert_row(insert_id, time, generated_cluster_cell, row, &components);
+        self.buckets_size_bytes += size_bytes;
         self.buckets_num_rows += 1;
 
         // Insert components last, only if bucket-insert succeeded.
@@ -445,7 +468,7 @@ impl IndexedBucket {
                 column
             });
             size_bytes_added += cluster_cell.total_size_bytes();
-            column.0.push(Some(cluster_cell));
+            column.0.push(Some(cluster_cell.clone()));
         }
 
         // append components to their respective columns (2-way merge)
@@ -806,7 +829,7 @@ impl PersistentIndexedTable {
             let column = columns
                 .entry(cluster_cell.component_name())
                 .or_insert_with(|| DataCellColumn::empty(num_rows));
-            column.0.push(Some(cluster_cell));
+            column.0.push(Some(cluster_cell.clone()));
         }
 
         // 2-way merge, step 1: left-to-right

--- a/crates/re_arrow_store/tests/data_store.rs
+++ b/crates/re_arrow_store/tests/data_store.rs
@@ -40,7 +40,7 @@ fn insert_table_with_retries(store: &mut DataStore, table: &DataTable) {
                 Err(WriteError::ReusedRowId(_)) => {
                     row.row_id = row.row_id.next();
                 }
-                err @ Err(_) => err.unwrap(),
+                err @ Err(_) => err.map(|_| ()).unwrap(),
             }
         }
     }
@@ -493,7 +493,6 @@ fn range_impl(store: &mut DataStore) {
             for table in store.to_data_tables(None) {
                 insert_table_with_retries(&mut store2, &table);
             }
-            store2.wipe_timeless_data();
             store2.gc(GarbageCollectionOptions::gc_everything());
             for table in store.to_data_tables(None) {
                 insert_table_with_retries(&mut store2, &table);

--- a/crates/re_arrow_store/tests/dump.rs
+++ b/crates/re_arrow_store/tests/dump.rs
@@ -25,7 +25,7 @@ fn insert_table_with_retries(store: &mut DataStore, table: &DataTable) {
                 Err(WriteError::ReusedRowId(_)) => {
                     row.row_id = row.row_id.next();
                 }
-                err @ Err(_) => err.unwrap(),
+                err @ Err(_) => err.map(|_| ()).unwrap(),
             }
         }
     }
@@ -60,11 +60,8 @@ fn data_store_dump() {
         data_store_dump_impl(&mut store1, &mut store2, &mut store3);
 
         // stress-test GC impl
-        store1.wipe_timeless_data();
         store1.gc(GarbageCollectionOptions::gc_everything());
-        store2.wipe_timeless_data();
         store2.gc(GarbageCollectionOptions::gc_everything());
-        store3.wipe_timeless_data();
         store3.gc(GarbageCollectionOptions::gc_everything());
 
         data_store_dump_impl(&mut store1, &mut store2, &mut store3);

--- a/crates/re_arrow_store/tests/internals.rs
+++ b/crates/re_arrow_store/tests/internals.rs
@@ -96,12 +96,13 @@ fn pathological_bucket_topology() {
             })
             .collect::<Vec<_>>();
 
-        rows.iter()
-            .for_each(|row| store_forward.insert_row(row).unwrap());
+        for row in &rows {
+            store_forward.insert_row(row).unwrap();
+        }
 
-        rows.iter()
-            .rev()
-            .for_each(|row| store_backward.insert_row(row).unwrap());
+        rows.iter().rev().for_each(|row| {
+            store_backward.insert_row(row).unwrap();
+        });
     }
 
     store_repeated_frame(1000, 10, &mut store_forward, &mut store_backward);


### PR DESCRIPTION
Introduces `StoreEvent`, an event that describes the atomic unit of change in the Rerun `DataStore`: a row has been added to or removed from the store.

`StoreEvent`s are fired on both the insertion and garbage collection paths, enabling listeners to build arbitrary, always up-to-date views & trigger systems.

```rust
/// The atomic unit of change in the Rerun [`DataStore`].
///
/// A [`StoreEvent`] describes the changes caused by the addition or deletion of a
/// [`re_log_types::DataRow`] in the store.
///
/// Methods that mutate the [`DataStore`], such as [`DataStore::insert_row`] and [`DataStore::gc`],
/// return [`StoreEvent`]s that describe the changes.
///
/// Refer to field-level documentation for more details and check out [`StoreDiff`] for a precise
/// definition of what an event involves.
#[derive(Debug, Clone, PartialEq)]
pub struct StoreEvent {
    /// Which [`DataStore`] sent this event?
    pub store_id: StoreId,

    /// What was the store's generation when it sent that event?
    pub store_generation: StoreGeneration,

    /// Monotonically increasing ID of the event.
    ///
    /// This is on a per-store basis.
    ///
    /// When handling a [`StoreEvent`], if this is the first time you process this [`StoreId`] and
    /// the associated `event_id` is not `1`, it means you registered late and missed some updates.
    pub event_id: u64,

    /// What actually changed?
    ///
    /// Refer to [`StoreDiff`] for more information.
    pub diff: StoreDiff,
}

/// Describes an atomic change in the Rerun [`DataStore`]: a row has been added or deleted.
///
/// From a query model standpoint, the [`DataStore`] _always_ operates one row at a time:
/// - The contents of a row (i.e. its columns) are immutable past insertion, by virtue of
///   [`RowId`]s being unique and non-reusable.
/// - Similarly, garbage collection always removes _all the data_ associated with a row in one go:
///   there cannot be orphaned columns. When a row is gone, all data associated with it is gone too.
///
/// Refer to field-level documentation for more information.
#[derive(Debug, Clone, PartialEq)]
pub struct StoreDiff {
    /// Addition or deletion?
    ///
    /// The store's internals are opaque and don't necessarily reflect the query model (e.g. there
    /// might be data in the store that cannot by reached by any query).
    ///
    /// A [`StoreDiff`] answers a logical question: "does there exist a query path which can return
    /// data from that row?".
    pub kind: StoreDiffKind,

    /// What's the row's [`RowId`]?
    ///
    /// [`RowId`]s are guaranteed to be unique within a single [`DataStore`].
    ///
    /// Put another way, the same [`RowId`] can only appear twice in a [`StoreDiff`] event:
    /// one addition and (optionally) one deletion (in that order!).
    pub row_id: RowId,

    /// The [`TimePoint`] associated with that row.
    ///
    /// Since insertions and deletions both work on a row-level basis, this is guaranteed to be the
    /// same value for both the insertion and deletion events (if any).
    pub timepoint: TimePoint,

    /// The [`EntityPath`] associated with that row.
    ///
    /// Since insertions and deletions both work on a row-level basis, this is guaranteed to be the
    /// same value for both the insertion and deletion events (if any).
    pub entity_path: EntityPath,

    /// All the [`DataCell`]s associated with that row.
    ///
    /// Since insertions and deletions both work on a row-level basis, this is guaranteed to be the
    /// same set of values for both the insertion and deletion events (if any).
    pub cells: IntMap<ComponentName, DataCell>,
}
```


---

`DataStore` changelog PR series:
- #4202
- #4203
- #4205
- #4206
- #4208
- #4209


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4202) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4202)
- [Docs preview](https://rerun.io/preview/e0e5d6dd795a38f17ffb543542d6cf09a990638a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e0e5d6dd795a38f17ffb543542d6cf09a990638a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)