### PR TITLE
`DataStore` changelog 4: add standalone "Custom StoreView" example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom_store_view"
+version = "0.11.0-alpha.1+dev"
+dependencies = [
+ "re_build_tools",
+ "rerun",
+]
+
+[[package]]
 name = "d3d12"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/re_data_store/src/lib.rs
+++ b/crates/re_data_store/src/lib.rs
@@ -4,28 +4,30 @@
 #![doc = document_features::document_features!()]
 //!
 
-#[cfg(feature = "serde")]
-mod blueprint;
-#[cfg(feature = "serde")]
-mod editable_auto_value;
 pub mod entity_properties;
 pub mod entity_tree;
 mod instance_path;
 pub mod store_db;
 mod versioned_instance_path;
 
+#[cfg(feature = "serde")]
+mod editable_auto_value;
+
 pub use self::entity_properties::*;
-pub use self::entity_tree::*;
+pub use self::entity_tree::{ComponentStats, EntityTree, TimeHistogram, TimesPerTimeline};
 pub use self::instance_path::{InstancePath, InstancePathHash};
 pub use self::store_db::StoreDb;
 pub use self::versioned_instance_path::{VersionedInstancePath, VersionedInstancePathHash};
 
-#[cfg(feature = "serde")]
-pub use blueprint::EntityPropertiesComponent;
-#[cfg(feature = "serde")]
-pub use editable_auto_value::EditableAutoValue;
 use re_log_types::DataTableError;
 pub use re_log_types::{EntityPath, EntityPathPart, Index, TimeInt, Timeline};
+
+#[cfg(feature = "serde")]
+pub use editable_auto_value::EditableAutoValue;
+
+pub mod external {
+    pub use re_arrow_store;
+}
 
 // ----------------------------------------------------------------------------
 

--- a/crates/re_data_store/src/lib.rs
+++ b/crates/re_data_store/src/lib.rs
@@ -11,6 +11,8 @@ pub mod store_db;
 mod versioned_instance_path;
 
 #[cfg(feature = "serde")]
+mod blueprint;
+#[cfg(feature = "serde")]
 mod editable_auto_value;
 
 pub use self::entity_properties::*;
@@ -22,6 +24,8 @@ pub use self::versioned_instance_path::{VersionedInstancePath, VersionedInstance
 use re_log_types::DataTableError;
 pub use re_log_types::{EntityPath, EntityPathPart, Index, TimeInt, Timeline};
 
+#[cfg(feature = "serde")]
+pub use blueprint::EntityPropertiesComponent;
 #[cfg(feature = "serde")]
 pub use editable_auto_value::EditableAutoValue;
 

--- a/crates/rerun/src/lib.rs
+++ b/crates/rerun/src/lib.rs
@@ -132,12 +132,25 @@ pub use run::{run, CallSource};
 #[cfg(feature = "sdk")]
 pub use sdk::*;
 
+/// Everything needed to build custom `StoreView`s.
+pub use re_data_store::external::re_arrow_store::{
+    DataStore, StoreDiff, StoreDiffKind, StoreEvent, StoreGeneration, StoreView,
+};
+
 /// Re-exports of other crates.
 pub mod external {
     pub use anyhow;
 
+    pub use re_build_info;
+    pub use re_data_store;
+    pub use re_data_store::external::*;
+    pub use re_format;
+
     #[cfg(all(feature = "sdk", not(target_arch = "wasm32")))]
     pub use clap;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub use tokio;
 
     #[cfg(feature = "native_viewer")]
     pub use re_viewer;

--- a/examples/rust/custom_store_view/Cargo.toml
+++ b/examples/rust/custom_store_view/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "custom_store_view"
+version = "0.11.0-alpha.1+dev"
+edition = "2021"
+rust-version = "1.72"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+rerun = { path = "../../../crates/rerun", features = ["native_viewer"] }
+
+[build-dependencies]
+re_build_tools = { path = "../../../crates/re_build_tools" }

--- a/examples/rust/custom_store_view/README.md
+++ b/examples/rust/custom_store_view/README.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Store View
 tags: [store-event, store-diff, store-view]
-rust: https://github.com/rerun-io/rerun/tree/latest/examples/rust/custom_store_view/src/main.rs
+rust: https://github.com/rerun-io/rerun/tree/latest/examples/rust/custom_store_view/src/main.rs?speculative-link
 ---
 
 <picture>

--- a/examples/rust/custom_store_view/README.md
+++ b/examples/rust/custom_store_view/README.md
@@ -1,0 +1,24 @@
+---
+title: Custom Store View
+tags: [store-event, store-diff, store-view]
+rust: https://github.com/rerun-io/rerun/tree/latest/examples/rust/custom_store_view/src/main.rs
+---
+
+<picture>
+  <img src="https://static.rerun.io/custom_store_view/f7258673486f91d944180bd4a83307bce09b741e/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/custom_store_view/f7258673486f91d944180bd4a83307bce09b741e/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/custom_store_view/f7258673486f91d944180bd4a83307bce09b741e/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/custom_store_view/f7258673486f91d944180bd4a83307bce09b741e/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/custom_store_view/f7258673486f91d944180bd4a83307bce09b741e/1200w.png">
+</picture>
+
+This example demonstrates how to use [`StoreView`]s and [`StoreEvent`]s to implement both custom secondary indices and trigger systems.
+
+Usage:
+```sh
+# Start the Rerun Viewer with our custom view in a terminal:
+$ cargo r -p custom_store_view
+
+# Log any kind of data from another terminal:
+$ cargo r -p objectron -- --connect
+```

--- a/examples/rust/custom_store_view/build.rs
+++ b/examples/rust/custom_store_view/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    re_build_tools::export_build_info_vars_for_crate("custom_store_view");
+}

--- a/examples/rust/custom_store_view/src/main.rs
+++ b/examples/rust/custom_store_view/src/main.rs
@@ -1,0 +1,201 @@
+//! This example demonstrates how to use [`StoreView`]s and [`StoreEvent`]s to implement both
+//! custom secondary indices and trigger systems.
+//!
+//! Usage:
+//! ```sh
+//! # Start the Rerun Viewer with our custom view in a terminal:
+//! $ cargo r -p custom_store_view
+//!
+//! # Log any kind of data from another terminal:
+//! $ cargo r -p objectron -- --connect
+//! ```
+
+use std::collections::BTreeMap;
+
+use rerun::{
+    external::{anyhow, re_arrow_store, re_build_info, re_log, re_log_types::TimeRange, tokio},
+    time::TimeInt,
+    ComponentName, EntityPath, StoreEvent, StoreId, StoreView, Timeline,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<std::process::ExitCode> {
+    re_log::setup_native_logging();
+
+    let _handle = re_arrow_store::DataStore::register_view(Box::<Orchestrator>::default());
+    // Could use the returned handle to get a reference to the view if needed.
+
+    let build_info = re_build_info::build_info!();
+    rerun::run(build_info, rerun::CallSource::Cli, std::env::args())
+        .await
+        .map(std::process::ExitCode::from)
+}
+
+// ---
+
+/// A meta [`StoreView`] that distributes work to our other views.
+///
+/// The order is which registered views are executed is undefined: if you rely on a specific order
+/// of execution between your views, orchestrate it yourself!
+///
+/// Clears the terminal and resets the cursor for every new batch of [`StoreEvent`]s.
+#[derive(Default)]
+struct Orchestrator {
+    components_per_recording: ComponentsPerRecording,
+    time_ranges_per_entity: TimeRangesPerEntity,
+}
+
+impl StoreView for Orchestrator {
+    fn name(&self) -> String {
+        "rerun.store_view.ScreenClearer".into()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn on_events(&mut self, events: &[StoreEvent]) {
+        print!("\x1B[2J\x1B[1;1H"); // terminal clear + cursor reset
+
+        self.components_per_recording.on_events(events);
+        self.time_ranges_per_entity.on_events(events);
+    }
+}
+
+// ---
+
+/// A [`StoreView`] that maintains a secondary index that keeps count of the number of occurrences
+/// of each component in each [`rerun::DataStore`].
+///
+/// It also implements a trigger that prints to the console each time a component is first introduced
+/// and retired.
+///
+/// For every [`StoreEvent`], it displays the state of the secondary index to the terminal.
+#[derive(Default, Debug, PartialEq, Eq)]
+struct ComponentsPerRecording {
+    counters: BTreeMap<StoreId, BTreeMap<ComponentName, u64>>,
+}
+
+impl StoreView for ComponentsPerRecording {
+    fn name(&self) -> String {
+        "rerun.store_view.ComponentsPerRecording".into()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn on_events(&mut self, events: &[StoreEvent]) {
+        for event in events {
+            // update counters
+            let per_component = self.counters.entry(event.store_id.clone()).or_default();
+            for &component_name in event.cells.keys() {
+                let count = per_component.entry(component_name).or_default();
+
+                // if first occurrence, speak!
+                if event.delta() > 0 && *count == 0 {
+                    println!(
+                        "New component introduced in recording {}: {}!",
+                        event.store_id, component_name,
+                    );
+                }
+                // if last occurrence, speak!
+                else if event.delta() < 0 && *count <= event.delta().unsigned_abs() {
+                    println!(
+                        "Component retired from recording {}: {}!",
+                        event.store_id, component_name,
+                    );
+                }
+
+                *count = count.saturating_add_signed(event.delta());
+            }
+        }
+
+        if self.counters.is_empty() {
+            return;
+        }
+
+        println!("Component stats");
+        println!("---------------");
+
+        for (recording, per_component) in &self.counters {
+            println!("  Recording '{recording}':");
+            for (component, counter) in per_component {
+                println!("    {component}: {counter} occurrences");
+            }
+        }
+    }
+}
+
+// ---
+
+/// A [`StoreView`] that maintains a secondary index of the time ranges covered by each entity,
+/// on every timeline, across all recordings (i.e. [`rerun::DataStore`]s).
+///
+/// For every [`StoreEvent`], it displays the state of the secondary index to the terminal.
+#[derive(Default, Debug, PartialEq, Eq)]
+struct TimeRangesPerEntity {
+    times: BTreeMap<EntityPath, BTreeMap<Timeline, BTreeMap<TimeInt, u64>>>,
+}
+
+impl StoreView for TimeRangesPerEntity {
+    fn name(&self) -> String {
+        "rerun.store_view.TimeRangesPerEntity".into()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn on_events(&mut self, events: &[StoreEvent]) {
+        for event in events {
+            for (&timeline, &time) in &event.timepoint {
+                // update counters
+                let per_timeline = self.times.entry(event.entity_path.clone()).or_default();
+                let per_time = per_timeline.entry(timeline).or_default();
+                let count = per_time.entry(time).or_default();
+
+                *count = count.saturating_add_signed(event.delta());
+
+                if *count == 0 {
+                    per_time.remove(&time);
+                }
+            }
+        }
+
+        if self.times.is_empty() {
+            return;
+        }
+
+        println!("Entity time ranges");
+        println!("------------------");
+
+        for (entity_path, per_timeline) in &self.times {
+            println!("  {entity_path}:");
+            for (timeline, times) in per_timeline {
+                let time_range = TimeRange::new(
+                    times
+                        .first_key_value()
+                        .map_or(TimeInt::MIN, |(time, _)| *time),
+                    times
+                        .last_key_value()
+                        .map_or(TimeInt::MAX, |(time, _)| *time),
+                );
+                let time_range = timeline.format_time_range_utc(&time_range);
+                println!("  {time_range}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Standalone example of how to implement and register custom `StoreView`s, even from external code.

<picture>
  <img src="https://static.rerun.io/custom_store_view/f7258673486f91d944180bd4a83307bce09b741e/full.png" alt="">
  <source media="(max-width: 480px)" srcset="https://static.rerun.io/custom_store_view/f7258673486f91d944180bd4a83307bce09b741e/480w.png">
  <source media="(max-width: 768px)" srcset="https://static.rerun.io/custom_store_view/f7258673486f91d944180bd4a83307bce09b741e/768w.png">
  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/custom_store_view/f7258673486f91d944180bd4a83307bce09b741e/1024w.png">
  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/custom_store_view/f7258673486f91d944180bd4a83307bce09b741e/1200w.png">
</picture>


---

`DataStore` changelog PR series:
- #4202
- #4203
- #4205
- #4206
- #4208
- #4209


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4202) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4202)
- [Docs preview](https://rerun.io/preview/5834e90ef26a0566bb316cbebbfa62c1515ce3cf/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5834e90ef26a0566bb316cbebbfa62c1515ce3cf/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)