### PR TITLE
`DataStore` changelog 5: event-driven time histograms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4144,6 +4144,7 @@ dependencies = [
 name = "re_data_store"
 version = "0.11.0-alpha.1+dev"
 dependencies = [
+ "ahash 0.8.5",
  "anyhow",
  "criterion",
  "document-features",

--- a/crates/re_arrow_store/src/lib.rs
+++ b/crates/re_arrow_store/src/lib.rs
@@ -40,7 +40,7 @@ pub mod test_util;
 pub use self::arrow_util::ArrayExt;
 pub use self::store::{DataStore, DataStoreConfig, StoreGeneration};
 pub use self::store_event::{StoreDiff, StoreDiffKind, StoreEvent};
-pub use self::store_gc::{Deleted, GarbageCollectionOptions, GarbageCollectionTarget};
+pub use self::store_gc::{GarbageCollectionOptions, GarbageCollectionTarget};
 pub use self::store_helpers::VersionedComponent;
 pub use self::store_read::{LatestAtQuery, RangeQuery};
 pub use self::store_stats::{DataStoreRowStats, DataStoreStats, EntityStats};

--- a/crates/re_arrow_store/tests/correctness.rs
+++ b/crates/re_arrow_store/tests/correctness.rs
@@ -485,10 +485,9 @@ fn gc_correct() {
 
     let stats = DataStoreStats::from_store(&store);
 
-    let (deleted, stats_diff) = store.gc(GarbageCollectionOptions::gc_everything());
+    let (store_events, stats_diff) = store.gc(GarbageCollectionOptions::gc_everything());
     let stats_diff = stats_diff + stats_empty; // account for fixed overhead
 
-    assert_eq!(deleted.row_ids.len() as u64, stats.total.num_rows);
     assert_eq!(
         stats.metadata_registry.num_rows,
         stats_diff.metadata_registry.num_rows
@@ -501,12 +500,12 @@ fn gc_correct() {
 
     sanity_unwrap(&mut store);
     check_still_readable(&store);
-    for row_id in &deleted.row_ids {
-        assert!(store.get_msg_metadata(row_id).is_none());
+    for event in store_events {
+        assert!(store.get_msg_metadata(&event.row_id).is_none());
     }
 
-    let (deleted, stats_diff) = store.gc(GarbageCollectionOptions::gc_everything());
-    assert!(deleted.row_ids.is_empty());
+    let (store_events, stats_diff) = store.gc(GarbageCollectionOptions::gc_everything());
+    assert!(store_events.is_empty());
     assert_eq!(DataStoreStats::default(), stats_diff);
 
     sanity_unwrap(&mut store);

--- a/crates/re_arrow_store/tests/data_store.rs
+++ b/crates/re_arrow_store/tests/data_store.rs
@@ -926,14 +926,14 @@ fn gc_impl(store: &mut DataStore) {
 
         let stats = DataStoreStats::from_store(store);
 
-        let (deleted, stats_diff) = store.gc(GarbageCollectionOptions {
+        let (store_events, stats_diff) = store.gc(GarbageCollectionOptions {
             target: GarbageCollectionTarget::DropAtLeastFraction(1.0 / 3.0),
             gc_timeless: false,
             protect_latest: 0,
             purge_empty_tables: false,
         });
-        for row_id in &deleted.row_ids {
-            assert!(store.get_msg_metadata(row_id).is_none());
+        for event in store_events {
+            assert!(store.get_msg_metadata(&event.row_id).is_none());
         }
 
         // NOTE: only temporal data and row metadata get purged!

--- a/crates/re_data_store/Cargo.toml
+++ b/crates/re_data_store/Cargo.toml
@@ -34,6 +34,7 @@ re_smart_channel.workspace = true
 re_tracing.workspace = true
 re_types_core.workspace = true
 
+ahash.workspace = true
 document-features.workspace = true
 getrandom.workspace = true
 itertools.workspace = true

--- a/crates/re_data_store/src/lib.rs
+++ b/crates/re_data_store/src/lib.rs
@@ -8,6 +8,8 @@ pub mod entity_properties;
 pub mod entity_tree;
 mod instance_path;
 pub mod store_db;
+mod time_histogram_per_timeline;
+mod times_per_timeline;
 mod versioned_instance_path;
 
 #[cfg(feature = "serde")]
@@ -16,10 +18,14 @@ mod blueprint;
 mod editable_auto_value;
 
 pub use self::entity_properties::*;
-pub use self::entity_tree::{ComponentStats, EntityTree, TimeHistogram, TimesPerTimeline};
+pub use self::entity_tree::EntityTree;
 pub use self::instance_path::{InstancePath, InstancePathHash};
 pub use self::store_db::StoreDb;
+pub use self::time_histogram_per_timeline::{TimeHistogram, TimeHistogramPerTimeline};
+pub use self::times_per_timeline::{TimeCounts, TimesPerTimeline};
 pub use self::versioned_instance_path::{VersionedInstancePath, VersionedInstancePathHash};
+
+pub(crate) use self::entity_tree::CompactedStoreEvents;
 
 use re_log_types::DataTableError;
 pub use re_log_types::{EntityPath, EntityPathPart, Index, TimeInt, Timeline};

--- a/crates/re_data_store/src/time_histogram_per_timeline.rs
+++ b/crates/re_data_store/src/time_histogram_per_timeline.rs
@@ -1,0 +1,107 @@
+use std::collections::BTreeMap;
+
+use re_arrow_store::{StoreEvent, StoreView};
+use re_log_types::{TimePoint, Timeline};
+
+// ---
+
+/// Number of messages per time.
+pub type TimeHistogram = re_int_histogram::Int64Histogram;
+
+/// Number of messages per time per timeline.
+///
+/// Does NOT include timeless.
+#[derive(Default)]
+pub struct TimeHistogramPerTimeline {
+    /// When do we have data? Ignores timeless.
+    times: BTreeMap<Timeline, TimeHistogram>,
+
+    // TODO(cmc): pub(crate) is temporary while we turn StoreDb/EntityDb/EntityTree into event subscribers.
+    /// Extra book-keeping used to seed any timelines that include timeless msgs.
+    pub(crate) num_timeless_messages: u64,
+}
+
+impl TimeHistogramPerTimeline {
+    #[inline]
+    pub fn timelines(&self) -> impl ExactSizeIterator<Item = &Timeline> {
+        self.times.keys()
+    }
+
+    #[inline]
+    pub fn get(&self, timeline: &Timeline) -> Option<&TimeHistogram> {
+        self.times.get(timeline)
+    }
+
+    #[inline]
+    pub fn has_timeline(&self, timeline: &Timeline) -> bool {
+        self.times.contains_key(timeline)
+    }
+
+    #[inline]
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (&Timeline, &TimeHistogram)> {
+        self.times.iter()
+    }
+
+    // TODO(cmc): temporary while we turn StoreDb/EntityDb/EntityTree into event subscribers.
+    #[inline]
+    pub fn iter_mut(&mut self) -> impl ExactSizeIterator<Item = (&Timeline, &mut TimeHistogram)> {
+        self.times.iter_mut()
+    }
+
+    #[inline]
+    pub fn num_timeless_messages(&self) -> u64 {
+        self.num_timeless_messages
+    }
+
+    pub fn add(&mut self, timepoint: &TimePoint) {
+        // If the `timepoint` is timeless…
+        if timepoint.is_timeless() {
+            self.num_timeless_messages += 1;
+        } else {
+            for (timeline, time_value) in timepoint.iter() {
+                self.times
+                    .entry(*timeline)
+                    .or_default()
+                    .increment(time_value.as_i64(), 1);
+            }
+        }
+    }
+
+    pub fn remove(&mut self, timepoint: &TimePoint) {
+        // If the `timepoint` is timeless…
+        if timepoint.is_timeless() {
+            self.num_timeless_messages -= 1;
+        } else {
+            for (timeline, time_value) in timepoint.iter() {
+                self.times
+                    .entry(*timeline)
+                    .or_default()
+                    .decrement(time_value.as_i64(), 1);
+            }
+        }
+    }
+}
+
+impl StoreView for TimeHistogramPerTimeline {
+    #[inline]
+    fn name(&self) -> String {
+        "rerun.store_view.TimeHistogramPerTimeline".into()
+    }
+
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    #[allow(clippy::unimplemented)]
+    fn on_events(&mut self, _events: &[StoreEvent]) {
+        unimplemented!(
+            r"TimeHistogramPerTimeline view is maintained as a sub-view of `EntityTree`",
+        );
+    }
+}

--- a/crates/re_data_store/src/times_per_timeline.rs
+++ b/crates/re_data_store/src/times_per_timeline.rs
@@ -1,0 +1,75 @@
+use std::collections::BTreeMap;
+
+use re_arrow_store::{StoreEvent, StoreView};
+use re_log_types::{TimeInt, Timeline};
+
+// ---
+
+pub type TimeCounts = BTreeMap<TimeInt, u64>;
+
+/// A [`StoreView`] that keeps track of all unique timestamps on each [`Timeline`].
+pub struct TimesPerTimeline(BTreeMap<Timeline, TimeCounts>);
+
+impl std::ops::Deref for TimesPerTimeline {
+    type Target = BTreeMap<Timeline, TimeCounts>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// TODO(cmc): temporary while we turn StoreDb/EntityDb/EntityTree into event subscribers.
+impl std::ops::DerefMut for TimesPerTimeline {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl TimesPerTimeline {
+    #[inline]
+    pub fn timelines(&self) -> impl ExactSizeIterator<Item = &Timeline> {
+        self.0.keys()
+    }
+}
+
+// Always ensure we have a default "log_time" timeline.
+impl Default for TimesPerTimeline {
+    fn default() -> Self {
+        Self(BTreeMap::from([(Timeline::log_time(), Default::default())]))
+    }
+}
+
+impl StoreView for TimesPerTimeline {
+    #[inline]
+    fn name(&self) -> String {
+        "rerun.store_view.TimesPerTimeline".into()
+    }
+
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn on_events(&mut self, events: &[StoreEvent]) {
+        re_tracing::profile_function!(format!("num_events={}", events.len()));
+
+        for event in events {
+            for (&timeline, &time) in &event.timepoint {
+                let per_time = self.0.entry(timeline).or_default();
+                let count = per_time.entry(time).or_default();
+                *count = count.saturating_add_signed(event.delta());
+
+                if *count == 0 {
+                    per_time.remove(&time);
+                }
+            }
+        }
+    }
+}

--- a/crates/re_data_store/tests/time_histograms.rs
+++ b/crates/re_data_store/tests/time_histograms.rs
@@ -655,9 +655,9 @@ fn assert_times_per_timeline<'a>(
         let times = db.times_per_timeline().get(timeline);
 
         if let Some(expected) = expected_times {
-            let times = times.unwrap();
+            let times: BTreeSet<_> = times.unwrap().keys().copied().collect();
             let expected: BTreeSet<_> = expected.iter().map(|t| (*t).into()).collect();
-            similar_asserts::assert_eq!(&expected, times);
+            similar_asserts::assert_eq!(expected, times);
         } else {
             assert!(times.is_none());
         }

--- a/crates/re_data_ui/src/component_path.rs
+++ b/crates/re_data_ui/src/component_path.rs
@@ -41,7 +41,10 @@ impl DataUi for ComponentPath {
             }
             .data_ui(ctx, ui, verbosity, query);
         } else if let Some(entity_tree) = ctx.store_db.entity_db().tree.subtree(entity_path) {
-            if entity_tree.components.contains_key(component_name) {
+            if entity_tree
+                .time_histograms_per_component
+                .contains_key(component_name)
+            {
                 ui.label("<unset>");
             } else {
                 ui.label(format!(

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -1,5 +1,5 @@
 use re_data_store::store_db::StoreDb;
-use re_data_store::{ComponentStats, EntityTree};
+use re_data_store::{EntityTree, TimeHistogramPerTimeline};
 
 use crate::{
     item::resolve_mono_instance_path_item, AppOptions, Caches, CommandSender, ComponentUiRegistry,
@@ -94,16 +94,17 @@ impl<'a> ViewerContext<'a> {
 
     /// Returns whether the given tree has any data logged in the current timeline.
     pub fn tree_has_data_in_current_timeline(&self, tree: &EntityTree) -> bool {
-        tree.prefix_times
+        tree.recursive_time_histogram
             .has_timeline(self.rec_cfg.time_ctrl.timeline())
             || tree.num_timeless_messages() > 0
     }
 
     /// Returns whether the given component has any data logged in the current timeline.
-    pub fn component_has_data_in_current_timeline(&self, component_stat: &ComponentStats) -> bool {
-        component_stat
-            .times
-            .has_timeline(self.rec_cfg.time_ctrl.timeline())
+    pub fn component_has_data_in_current_timeline(
+        &self,
+        component_stat: &TimeHistogramPerTimeline,
+    ) -> bool {
+        component_stat.has_timeline(self.rec_cfg.time_ctrl.timeline())
             || component_stat.num_timeless_messages() > 0
     }
 }


### PR DESCRIPTION
This is mostly preliminary work for #4209, which makes this PR a bit weird. Basically just trying to offload complexity from #4209.

`TimesPerTimeline` as well as `TimeHistogramPerTimeline` are now living on their own and are maintained as `StoreView`s, i.e. they react to changes to the `DataStore` rather than constructing alternate truths.

This is the first step towards turning the `EntityTree` giga-structure into an event-driven view in the next PR.

---

`DataStore` changelog PR series:
- #4202
- #4203
- #4205
- #4206
- #4208
- #4209


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4202) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4202)
- [Docs preview](https://rerun.io/preview/452875bd7b403ef49365556bbf9aaa657bd38831/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/452875bd7b403ef49365556bbf9aaa657bd38831/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)