### PR TITLE
`DataStore` changelog 6: event-driven `EntityTree`

### DIFF
--- a/crates/re_arrow_store/src/store_write.rs
+++ b/crates/re_arrow_store/src/store_write.rs
@@ -185,13 +185,14 @@ impl DataStore {
             }
         }
 
-        let mut diff = StoreDiff::addition(*row_id, ent_path.clone())
+        let diff = StoreDiff::addition(*row_id, ent_path.clone())
             .at_timepoint(timepoint.clone())
             .with_cells(cells.iter().cloned());
 
-        if let Some(cell) = generated_cluster_cell {
-            diff = diff.with_cells([cell]);
-        }
+        // TODO(#4220): should we fire for auto-generated data?
+        // if let Some(cell) = generated_cluster_cell {
+        //     diff = diff.with_cells([cell]);
+        // }
 
         let event = StoreEvent {
             store_id: self.id.clone(),

--- a/crates/re_data_store/src/entity_tree.rs
+++ b/crates/re_data_store/src/entity_tree.rs
@@ -50,6 +50,8 @@ pub struct EntityTree {
     pub time_histograms_per_component: BTreeMap<ComponentName, TimeHistogramPerTimeline>,
 }
 
+// NOTE: This is only to let people know that this is in fact a [`StoreView`], so they A) don't try
+// to implement it on their own and B) don't try to register it.
 impl StoreView for EntityTree {
     fn name(&self) -> String {
         "rerun.store_views.EntityTree".into()

--- a/crates/re_data_store/src/entity_tree.rs
+++ b/crates/re_data_store/src/entity_tree.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use ahash::HashSet;
 use itertools::Itertools;

--- a/crates/re_data_store/src/lib.rs
+++ b/crates/re_data_store/src/lib.rs
@@ -25,7 +25,7 @@ pub use self::time_histogram_per_timeline::{TimeHistogram, TimeHistogramPerTimel
 pub use self::times_per_timeline::{TimeCounts, TimesPerTimeline};
 pub use self::versioned_instance_path::{VersionedInstancePath, VersionedInstancePathHash};
 
-pub(crate) use self::entity_tree::{CompactedStoreEvents, ClearCascade};
+pub(crate) use self::entity_tree::{ClearCascade, CompactedStoreEvents};
 
 use re_log_types::DataTableError;
 pub use re_log_types::{EntityPath, EntityPathPart, Index, TimeInt, Timeline};

--- a/crates/re_data_store/src/lib.rs
+++ b/crates/re_data_store/src/lib.rs
@@ -25,7 +25,7 @@ pub use self::time_histogram_per_timeline::{TimeHistogram, TimeHistogramPerTimel
 pub use self::times_per_timeline::{TimeCounts, TimesPerTimeline};
 pub use self::versioned_instance_path::{VersionedInstancePath, VersionedInstancePathHash};
 
-pub(crate) use self::entity_tree::CompactedStoreEvents;
+pub(crate) use self::entity_tree::{CompactedStoreEvents, ClearCascade};
 
 use re_log_types::DataTableError;
 pub use re_log_types::{EntityPath, EntityPathPart, Index, TimeInt, Timeline};

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -1,15 +1,16 @@
 use std::collections::BTreeMap;
 
+use itertools::Itertools;
 use nohash_hasher::IntMap;
 
 use re_arrow_store::{DataStore, DataStoreConfig, GarbageCollectionOptions, StoreEvent, StoreView};
 use re_log_types::{
-    ApplicationId, ComponentPath, DataCell, DataRow, DataTable, EntityPath, EntityPathHash, LogMsg,
-    PathOp, RowId, SetStoreInfo, StoreId, StoreInfo, StoreKind, TimePoint, Timeline,
+    ApplicationId, DataCell, DataRow, DataTable, EntityPath, EntityPathHash, LogMsg, RowId,
+    SetStoreInfo, StoreId, StoreInfo, StoreKind, TimePoint, Timeline,
 };
 use re_types_core::{components::InstanceKey, Loggable};
 
-use crate::{Error, TimesPerTimeline};
+use crate::{ClearCascade, CompactedStoreEvents, Error, TimesPerTimeline};
 
 // ----------------------------------------------------------------------------
 
@@ -59,7 +60,8 @@ const DEFAULT_INSERT_ROW_STEP_SIZE: u64 = 100;
 /// Inserts a [`DataRow`] into the [`DataStore`], retrying in case of duplicated `RowId`s.
 ///
 /// Retries a maximum of `num_attempts` times if the row couldn't be inserted because of a
-/// duplicated [`RowId`], bumping the [`RowId`]'s internal counter by `step_size` between attempts.
+/// duplicated [`RowId`], bumping the [`RowId`]'s internal counter by a random number
+/// (up to `step_size`) between attempts.
 ///
 /// Returns the actual [`DataRow`] that was successfully inserted, if any.
 ///
@@ -72,7 +74,7 @@ fn insert_row_with_retries(
     mut row: DataRow,
     num_attempts: usize,
     step_size: u64,
-) -> re_arrow_store::WriteResult<DataRow> {
+) -> re_arrow_store::WriteResult<StoreEvent> {
     fn random_u64() -> u64 {
         let mut bytes = [0_u8; 8];
         getrandom::getrandom(&mut bytes).map_or(0, |_| u64::from_le_bytes(bytes))
@@ -80,9 +82,9 @@ fn insert_row_with_retries(
 
     for _ in 0..num_attempts {
         match store.insert_row(&row) {
-            Ok(_) => return Ok(row),
+            Ok(event) => return Ok(event),
             Err(re_arrow_store::WriteError::ReusedRowId(_)) => {
-                re_log::warn!(row_id = %row.row_id(), "Found duplicated RowId, retrying…");
+                re_log::debug!(row_id = %row.row_id(), "Found duplicated RowId, retrying…");
                 row.row_id = row.row_id.increment(random_u64() % step_size + 1);
             }
             Err(err) => return Err(err),
@@ -123,12 +125,14 @@ impl EntityDb {
             .or_insert_with(|| entity_path.clone());
     }
 
-    /// Returns the [`DataRow`] that was inserted. It might have been modified!
-    //
-    // TODO(#374): Updates of secondary datastructures should be the result of subscribing to the
-    // datastore's changelog and reacting to these changes appropriately. We shouldn't be creating
-    // many sources of truth.
-    fn add_data_row(&mut self, row: DataRow) -> Result<DataRow, Error> {
+    /// Inserts a [`DataRow`] into the database.
+    ///
+    /// Updates the [`crate::EntityTree`] and applies [`ClearCascade`]s as needed.
+    pub fn add_data_row(&mut self, row: DataRow) -> Result<(), Error> {
+        re_tracing::profile_function!(format!("num_cells={}", row.num_cells()));
+
+        self.register_entity_path(&row.entity_path);
+
         // ## RowId duplication
         //
         // We shouldn't be attempting to retry in this instance: a duplicated RowId at this stage
@@ -140,170 +144,119 @@ impl EntityDb {
         // across buckets).
         //
         // TODO(#1894): Remove this once the save/load process becomes RowId-driven.
-        let row = insert_row_with_retries(
+        let store_event = insert_row_with_retries(
             &mut self.data_store,
             row,
             MAX_INSERT_ROW_ATTEMPTS,
             DEFAULT_INSERT_ROW_STEP_SIZE,
         )?;
 
-        self.register_entity_path(&row.entity_path);
+        // First-pass: update our internal views by notifying them of resulting [`StoreEvent`]s.
+        //
+        // This might result in a [`ClearCascade`] if the events trigger one or more immediate
+        // and/or pending clears.
+        let store_events = &[store_event];
+        self.times_per_timeline.on_events(store_events);
+        let clear_cascade = self.tree.on_store_additions(store_events);
 
-        for (&timeline, &time_int) in row.timepoint().iter() {
-            *self
-                .times_per_timeline
-                .entry(timeline)
-                .or_default()
-                .entry(time_int)
-                .or_default() += 1;
-        }
+        // Second-pass: update the [`DataStore`] by applying the [`ClearCascade`].
+        //
+        // This will in turn generate new [`StoreEvent`]s that our internal views need to be
+        // notified of, again!
+        let store_events = self.on_clear_cascade(clear_cascade);
+        self.times_per_timeline.on_events(&store_events);
+        let clear_cascade = self.tree.on_store_additions(&store_events);
 
-        for cell in row.cells().iter() {
-            let component_path =
-                ComponentPath::new(row.entity_path().clone(), cell.component_name());
-            let pending_clears = self.tree.add_data_msg(row.timepoint(), &component_path);
+        // Clears don't affect `Clear` components themselves, therefore we cannot have recursive
+        // cascades, thus this whole process must stabilize after one iteration.
+        debug_assert!(clear_cascade.is_empty());
 
-            for (row_id, time_point) in pending_clears {
-                // Create and insert an empty component into the arrow store
-                // TODO(jleibs): Faster empty-array creation
-                let cell =
-                    DataCell::from_arrow_empty(cell.component_name(), cell.datatype().clone());
-
-                let row = DataRow::from_cells1(
-                    row_id.next(), // see comment below
-                    row.entity_path.clone(),
-                    time_point.clone(),
-                    cell.num_instances(),
-                    cell,
-                )?;
-
-                // ## RowId duplication
-                //
-                // We are inserting new data (empty cells) with an old RowId (specifically, the RowId
-                // of the original insertion that was used to register the pending clear in the first
-                // place).
-                // By definition, this is illegal: RowIds are unique.
-                //
-                // On the other hand, the GC process is driven by RowId order, which means we must make
-                // sure that the empty cell we're inserting uses a RowId with a similar timestamp as the
-                // one used in the original Clear component cell, so they roughly get GC'd at the same time.
-                if let Err(err) = insert_row_with_retries(
-                    &mut self.data_store,
-                    row,
-                    MAX_INSERT_ROW_ATTEMPTS,
-                    DEFAULT_INSERT_ROW_STEP_SIZE,
-                ) {
-                    re_log::error!(%err, "Failed to insert pending clear cell");
-                }
-
-                // Also update the tree with the clear-event
-                self.tree.add_data_msg(&time_point, &component_path);
-            }
-        }
-
-        // Look for a `ClearIsRecursive` component, and if it's there, go through the clear path
-        // instead.
-        use re_types_core::components::ClearIsRecursive;
-        if let Some(idx) = row.find_cell(&ClearIsRecursive::name()) {
-            let cell = &row.cells()[idx];
-            let settings = cell.try_to_native_mono::<ClearIsRecursive>().unwrap();
-            let path_op = if settings.map_or(false, |s| s.0) {
-                PathOp::ClearRecursive(row.entity_path.clone())
-            } else {
-                PathOp::ClearComponents(row.entity_path.clone())
-            };
-            self.add_path_op(row.row_id(), row.timepoint(), &path_op);
-        }
-
-        Ok(row)
+        Ok(())
     }
 
-    fn add_path_op(&mut self, mut row_id: RowId, time_point: &TimePoint, path_op: &PathOp) {
-        let cleared_paths = self.tree.add_path_op(row_id, time_point, path_op);
+    fn on_clear_cascade(&mut self, clear_cascade: ClearCascade) -> Vec<StoreEvent> {
+        let mut store_events = Vec::new();
 
-        // NOTE: Btree! We need a stable ordering here!
-        let mut cells = BTreeMap::<EntityPath, Vec<DataCell>>::default();
-        for component_path in cleared_paths {
-            if let Some(data_type) = self
-                .data_store
-                .lookup_datatype(&component_path.component_name)
-            {
-                let cells = cells
-                    .entry(component_path.entity_path.clone())
-                    .or_insert_with(Vec::new);
+        // Create the empty cells to be inserted.
+        //
+        // Reminder: these are the [`RowId`]s of the `Clear` components that triggered the
+        // cascade, they are not unique and may be shared across many entity paths.
+        let mut to_be_inserted =
+            BTreeMap::<RowId, BTreeMap<EntityPath, (TimePoint, Vec<DataCell>)>>::default();
+        for (row_id, per_entity) in clear_cascade.to_be_cleared {
+            for (entity_path, (timepoint, component_paths)) in per_entity {
+                let per_entity = to_be_inserted.entry(row_id).or_default();
+                let (cur_timepoint, cells) = per_entity.entry(entity_path).or_default();
 
-                cells.push(DataCell::from_arrow_empty(
-                    component_path.component_name,
-                    data_type.clone(),
-                ));
-
-                // Update the tree with the clear-event.
-                self.tree.add_data_msg(time_point, &component_path);
-            }
-        }
-
-        row_id = row_id.next(); // see comment below
-
-        // Create and insert empty components into the arrow store.
-        for (ent_path, cells) in cells {
-            // NOTE: It is important we insert all those empty components using a single row (id)!
-            // 1. It'll be much more efficient when querying that data back.
-            // 2. Otherwise we will end up with a flaky row ordering, as we have no way to tie-break
-            //    these rows! This flaky ordering will in turn leak through the public
-            //    API (e.g. range queries)!!
-            row_id = match DataRow::from_cells(row_id, time_point.clone(), ent_path, 0, cells) {
-                Ok(row) => {
-                    // ## RowId duplication
-                    //
-                    // We are inserting new data (empty cells) with an already used RowId (specifically,
-                    // the RowId of the row containing the clear cell itself).
-                    // By definition, this is illegal: RowIds are unique.
-                    //
-                    // On the other hand, the GC process is driven by RowId order, which means we must make
-                    // sure that the empty cell we're inserting uses a RowId with a similar timestamp as the
-                    // one used in the original Clear component cell, so they roughly get GC'd at the same time.
-                    match insert_row_with_retries(
-                        &mut self.data_store,
-                        row,
-                        MAX_INSERT_ROW_ATTEMPTS,
-                        DEFAULT_INSERT_ROW_STEP_SIZE,
-                    ) {
-                        Ok(row) => row.row_id(),
-                        Err(err) => {
-                            re_log::error!(%err, ?path_op, "Failed to insert PathOp");
-                            row_id
-                        }
+                *cur_timepoint = timepoint.union_max(cur_timepoint);
+                for component_path in component_paths {
+                    if let Some(data_type) = self
+                        .data_store
+                        .lookup_datatype(&component_path.component_name)
+                    {
+                        cells.push(DataCell::from_arrow_empty(
+                            component_path.component_name,
+                            data_type.clone(),
+                        ));
                     }
                 }
-                Err(err) => {
-                    re_log::error!(%err, ?path_op, "Failed to insert PathOp");
-                    row_id
-                }
-            };
-
-            row_id = row_id.next(); // see comment above
+            }
         }
+
+        for (row_id, per_entity) in to_be_inserted {
+            let mut row_id = row_id;
+            for (entity_path, (timepoint, cells)) in per_entity {
+                // NOTE: It is important we insert all those empty components using a single row (id)!
+                // 1. It'll be much more efficient when querying that data back.
+                // 2. Otherwise we will end up with a flaky row ordering, as we have no way to tie-break
+                //    these rows! This flaky ordering will in turn leak through the public
+                //    API (e.g. range queries)!
+                match DataRow::from_cells(row_id, timepoint.clone(), entity_path, 0, cells) {
+                    Ok(row) => {
+                        let res = insert_row_with_retries(
+                            &mut self.data_store,
+                            row,
+                            MAX_INSERT_ROW_ATTEMPTS,
+                            DEFAULT_INSERT_ROW_STEP_SIZE,
+                        );
+
+                        match res {
+                            Ok(store_event) => {
+                                row_id = store_event.row_id.next();
+                                store_events.push(store_event);
+                            }
+                            Err(err) => {
+                                re_log::error_once!(
+                                    "Failed to propagate EntityTree cascade: {err}"
+                                );
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        re_log::error_once!("Failed to propagate EntityTree cascade: {err}");
+                    }
+                }
+            }
+        }
+
+        store_events
     }
 
-    pub fn purge(&mut self, store_events: &[StoreEvent]) {
+    pub fn on_store_deletions(&mut self, store_events: &[StoreEvent]) {
         re_tracing::profile_function!();
 
         let Self {
             entity_path_from_hash: _,
             times_per_timeline,
             tree,
-            data_store: _, // purged before this function is called
+            data_store: _,
         } = self;
 
-        let deleted = crate::CompactedStoreEvents::new(store_events);
-        let mut actually_deleted = Default::default();
-
-        {
-            re_tracing::profile_scope!("tree");
-            tree.purge(&deleted, &mut actually_deleted);
-        }
-
         times_per_timeline.on_events(store_events);
+
+        let store_events = store_events.iter().collect_vec();
+        let compacted = CompactedStoreEvents::new(&store_events);
+        tree.on_store_deletions(&store_events, &compacted);
     }
 }
 
@@ -340,7 +293,7 @@ impl StoreDb {
         }
     }
 
-    /// Helper function to create a recording from a [`StoreInfo`] and a some [`DataRow`]s.
+    /// Helper function to create a recording from a [`StoreInfo`] and some [`DataRow`]s.
     ///
     /// This is useful to programmatically create recordings from within the viewer, which cannot
     /// use the `re_sdk`, which is not Wasm-compatible.
@@ -392,7 +345,7 @@ impl StoreDb {
     }
 
     pub fn timelines(&self) -> impl ExactSizeIterator<Item = &Timeline> {
-        self.times_per_timeline().timelines()
+        self.times_per_timeline().keys()
     }
 
     pub fn times_per_timeline(&self) -> &TimesPerTimeline {
@@ -494,21 +447,14 @@ impl StoreDb {
         re_tracing::profile_function!();
 
         let (store_events, stats_diff) = self.entity_db.data_store.gc(gc_options);
+
         re_log::trace!(
             num_row_ids_dropped = store_events.len(),
             size_bytes_dropped = re_format::format_bytes(stats_diff.total.num_bytes as _),
             "purged datastore"
         );
 
-        let Self {
-            store_id: _,
-            data_source: _,
-            set_store_info: _,
-            entity_db,
-            last_modified_at: _,
-        } = self;
-
-        entity_db.purge(&store_events);
+        self.entity_db.on_store_deletions(&store_events);
     }
 
     /// Key used for sorting recordings in the UI.

--- a/crates/re_data_store/src/time_histogram_per_timeline.rs
+++ b/crates/re_data_store/src/time_histogram_per_timeline.rs
@@ -46,30 +46,30 @@ impl TimeHistogramPerTimeline {
         self.num_timeless_messages
     }
 
-    pub fn add(&mut self, timepoint: &TimePoint) {
+    pub fn add(&mut self, timepoint: &TimePoint, n: u32) {
         // If the `timepoint` is timeless…
         if timepoint.is_timeless() {
-            self.num_timeless_messages += 1;
+            self.num_timeless_messages += n as u64;
         } else {
             for (timeline, time_value) in timepoint.iter() {
                 self.times
                     .entry(*timeline)
                     .or_default()
-                    .increment(time_value.as_i64(), 1);
+                    .increment(time_value.as_i64(), n);
             }
         }
     }
 
-    pub fn remove(&mut self, timepoint: &TimePoint) {
+    pub fn remove(&mut self, timepoint: &TimePoint, n: u32) {
         // If the `timepoint` is timeless…
         if timepoint.is_timeless() {
-            self.num_timeless_messages -= 1;
+            self.num_timeless_messages -= n as u64;
         } else {
             for (timeline, time_value) in timepoint.iter() {
                 self.times
                     .entry(*timeline)
                     .or_default()
-                    .decrement(time_value.as_i64(), 1);
+                    .decrement(time_value.as_i64(), n);
             }
         }
     }

--- a/crates/re_data_store/src/time_histogram_per_timeline.rs
+++ b/crates/re_data_store/src/time_histogram_per_timeline.rs
@@ -75,6 +75,8 @@ impl TimeHistogramPerTimeline {
     }
 }
 
+// NOTE: This is only to let people know that this is in fact a [`StoreView`], so they A) don't try
+// to implement it on their own and B) don't try to register it.
 impl StoreView for TimeHistogramPerTimeline {
     #[inline]
     fn name(&self) -> String {

--- a/crates/re_data_store/src/time_histogram_per_timeline.rs
+++ b/crates/re_data_store/src/time_histogram_per_timeline.rs
@@ -16,9 +16,8 @@ pub struct TimeHistogramPerTimeline {
     /// When do we have data? Ignores timeless.
     times: BTreeMap<Timeline, TimeHistogram>,
 
-    // TODO(cmc): pub(crate) is temporary while we turn StoreDb/EntityDb/EntityTree into event subscribers.
     /// Extra book-keeping used to seed any timelines that include timeless msgs.
-    pub(crate) num_timeless_messages: u64,
+    num_timeless_messages: u64,
 }
 
 impl TimeHistogramPerTimeline {
@@ -40,12 +39,6 @@ impl TimeHistogramPerTimeline {
     #[inline]
     pub fn iter(&self) -> impl ExactSizeIterator<Item = (&Timeline, &TimeHistogram)> {
         self.times.iter()
-    }
-
-    // TODO(cmc): temporary while we turn StoreDb/EntityDb/EntityTree into event subscribers.
-    #[inline]
-    pub fn iter_mut(&mut self) -> impl ExactSizeIterator<Item = (&Timeline, &mut TimeHistogram)> {
-        self.times.iter_mut()
     }
 
     #[inline]

--- a/crates/re_data_store/src/times_per_timeline.rs
+++ b/crates/re_data_store/src/times_per_timeline.rs
@@ -19,13 +19,6 @@ impl std::ops::Deref for TimesPerTimeline {
     }
 }
 
-// TODO(cmc): temporary while we turn StoreDb/EntityDb/EntityTree into event subscribers.
-impl std::ops::DerefMut for TimesPerTimeline {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 impl TimesPerTimeline {
     #[inline]
     pub fn timelines(&self) -> impl ExactSizeIterator<Item = &Timeline> {

--- a/crates/re_data_store/tests/time_histograms.rs
+++ b/crates/re_data_store/tests/time_histograms.rs
@@ -487,14 +487,9 @@ fn time_histograms() -> anyhow::Result<()> {
                     &timeline_frame,
                     Some(&[
                         (RangeI64::new(42, 42), 5),
-                        // TODO(cmc): This is wrong, it should be `4`.
-                        //
                         // We're clearing the parent's `InstanceKey` as well as the grandchild's
                         // `MyPoint`, `MyColor` and `InstanceKey`. That's four.
-                        //
-                        // I have no idea where the extra increment comes from, but it doesn't
-                        // really matter, the new event-driven EntityTree fixes it.
-                        (RangeI64::new(1000, 1000), 5),
+                        (RangeI64::new(1000, 1000), 4),
                         (RangeI64::new(1234, 1234), 3),
                     ]),
                 ),

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -4,7 +4,7 @@
 
 use itertools::Itertools;
 
-use re_log_types::{DataCell, EntityPath, PathOp, TimePoint};
+use re_log_types::{DataCell, EntityPath, TimePoint};
 use re_types::ComponentName;
 use re_viewer_context::{UiVerbosity, ViewerContext};
 
@@ -175,25 +175,6 @@ fn format_cell(cell: &DataCell) -> String {
         cell.num_instances(),
         cell.component_name().short_name()
     )
-}
-
-impl DataUi for PathOp {
-    fn data_ui(
-        &self,
-        _ctx: &mut ViewerContext<'_>,
-        ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
-        _query: &re_arrow_store::LatestAtQuery,
-    ) {
-        match self {
-            PathOp::ClearComponents(entity_path) => {
-                ui.label(format!("ClearComponents: {entity_path}"))
-            }
-            PathOp::ClearRecursive(entity_path) => {
-                ui.label(format!("ClearRecursive: {entity_path}"))
-            }
-        };
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -360,35 +360,6 @@ impl std::fmt::Display for StoreSource {
     }
 }
 
-// ----------------------------------------------------------------------------
-
-/// Operation to perform on an [`EntityPath`], e.g. clearing all components.
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub enum PathOp {
-    /// Clear all the components stored at an [`EntityPath`]
-    ClearComponents(EntityPath),
-
-    /// Clear all the components of an `[EntityPath]` and any descendants.
-    ClearRecursive(EntityPath),
-}
-
-impl PathOp {
-    pub fn clear(recursive: bool, entity_path: EntityPath) -> Self {
-        if recursive {
-            PathOp::ClearRecursive(entity_path)
-        } else {
-            PathOp::ClearComponents(entity_path)
-        }
-    }
-
-    pub fn entity_path(&self) -> &EntityPath {
-        match &self {
-            PathOp::ClearComponents(path) | PathOp::ClearRecursive(path) => path,
-        }
-    }
-}
-
 // ---
 
 /// Build a ([`Timeline`], [`TimeInt`]) tuple from `log_time` suitable for inserting in a [`TimePoint`].

--- a/crates/re_log_types/src/path/component_path.rs
+++ b/crates/re_log_types/src/path/component_path.rs
@@ -5,7 +5,7 @@ use crate::path::EntityPath;
 /// A [`EntityPath`] plus a [`ComponentName`].
 ///
 /// Example: `camera / "left" / points / #42`.`color`
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ComponentPath {
     /// `camera / "left" / points / #42`

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -64,8 +64,8 @@ pub mod sink {
 /// Things directly related to logging.
 pub mod log {
     pub use re_log_types::{
-        DataCell, DataRow, DataTable, DataTableBatcher, DataTableBatcherConfig, LogMsg, PathOp,
-        RowId, TableId,
+        DataCell, DataRow, DataTable, DataTableBatcher, DataTableBatcherConfig, LogMsg, RowId,
+        TableId,
     };
 }
 


### PR DESCRIPTION
Turns the `EntityTree` giga-datastructure into a `StoreView`, meaning it now reacts to `StoreEvent`s rather than creating alternate truths.

This introduces the notion of cascading side-effects, and more specifically `ClearCascade`s.
When the `EntityTree` reacts to changes in the store, this might cause cascading effects (e.g. pending clears), that in turn need to write back to the store, which in turn sends more events to react to!
The cycle is guaranteed finite because "clears don't get cleared"!

Cascading side-effects have an interesting requirement: they need to log their cascaded data using a `RowId` _similar_ to the one used in the original event that caused the cascade (so they get GC'd at roughly the same pace).
"Similar" in this cases means that their `TUID` shares the same timestamp and that the new `RowId` is strictly greater than the old one.

`PathOp` has finally been annihilated.

According to our new "Clears" & "Time Histograms" test suites, this behaves exactly like the `main` branch.


---

`DataStore` changelog PR series:
- #4202
- #4203
- #4205
- #4206
- #4208
- #4209


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4202) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4202)
- [Docs preview](https://rerun.io/preview/e328d443f28a0bf8e745d5d24913294a6f0771dc/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e328d443f28a0bf8e745d5d24913294a6f0771dc/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)