### PR TITLE
Add minimal examples in readme C++ api docs

### DIFF
--- a/docs/content/reference/cpp-sdk-cmake.md
+++ b/docs/content/reference/cpp-sdk-cmake.md
@@ -31,10 +31,10 @@ In this case you will also need to make sure the Rerun C static libraries are av
 Pre-built libraries can be downloaded from [the release pages](https://github.com/rerun-io/rerun/releases/latest).
 
 If you want to match the behavior of `rerun_cpp_sdk.zip`, these libraries should be placed in the folder `rerun_cpp/lib`, renamed as:
- - Linux: `librerun_c__linux_x64.a`
- - Windows: `rerun_c__win_x64.lib`
- - Mac: `librerun_c__macos_x64.a`
- - Mac Arm: `librerun_c__macos_arm64.a`
+ - Linux, x64: `librerun_c__linux_x64.a`
+ - Windows, x64: `rerun_c__win_x64.lib`
+ - Mac, Intel: `librerun_c__macos_x64.a`
+ - Mac, Apple Silicon: `librerun_c__macos_arm64.a`
 
 Or if you have a different build/download mechanism, you can point directly to the library by setting `RERUN_C_LIB`
 before adding the subdirectory.

--- a/docs/content/reference/cpp-sdk-cmake.md
+++ b/docs/content/reference/cpp-sdk-cmake.md
@@ -3,7 +3,7 @@ title: C++ SDK CMake
 order: 8
 ---
 
-The Rerun C++ SDK is meant to be built from source.
+The Rerun C++ SDK is meant to be built from source and everything described on this page will do just that.
 Its [CMake build script](https://github.com/rerun-io/rerun/blob/latest/rerun_cpp/CMakeLists.txt)
 is ready to be used from outside of the Rerun repo.
 

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -316,6 +316,7 @@
     "trackpad",
     "trimesh",
     "Trimesh",
+    "trimleft", // doxygen command
     "TUID",
     "turtlebot",
     "TURTLEBOT",

--- a/rerun_cpp/README.md
+++ b/rerun_cpp/README.md
@@ -31,7 +31,7 @@ Instead of spawning a new viewer, you can also try to connect to an already open
 As long as you haven't called `rerun::RecordingStream::save`/`rerun::RecordingStream::connect`/`rerun::RecordingStream::spawn`
 any data will be kept in memory until you call one of these.
 
-\snippet{trimleft}readme_snippets.cpp Buffering
+\snippet{trimleft} readme_snippets.cpp Buffering
 
 
 ## Examples

--- a/rerun_cpp/README.md
+++ b/rerun_cpp/README.md
@@ -57,7 +57,7 @@ Check the [general doc page on types](https://www.rerun.io/docs/reference/types)
 
 ## Build & Distribution
 
-### Overview  ioeb 
+### Overview
 
 To avoid compatibility issues across different platforms, compiler versions and C++ standard library versions
 the C++ SDK is expected to be built from source.

--- a/rerun_cpp/README.md
+++ b/rerun_cpp/README.md
@@ -2,7 +2,37 @@
 
 The Rerun C++ SDK allows logging data to Rerun directly from C++.
 
-Read the [getting started guide](https://www.rerun.io/docs/getting-started/cpp) for information on how to use the Rerun C++ SDK.
+## Getting Started
+
+Read the [getting started guide](https://www.rerun.io/docs/getting-started/cpp) on how to use the Rerun C++ SDK.
+
+### Logging
+
+After you've [installed the viewer](https://www.rerun.io/docs/getting-started/installing-viewer) and [added the SDK to your project](https://www.rerun.io/docs/reference/cpp-sdk-cmake), you can jump right in and try logging some data.
+
+You first create a `rerun::RecordingStream` stream and spawn a viewer. You then use it to log some archetypes to a given entity path using `rerun::RecordingStream::log`:
+
+\snippet{trimleft} readme_snippets.cpp Logging
+
+### Streaming to disk
+
+Streaming data to a file on disk using the .rrd format:
+
+\snippet{trimleft} readme_snippets.cpp Streaming
+
+### Connecting
+
+Instead of spawning a new viewer, you can also try to connect to an already open one.
+
+\snippet{trimleft} readme_snippets.cpp Connecting
+
+### Buffering
+
+As long as you haven't called `rerun::RecordingStream::save`/`rerun::RecordingStream::connect`/`rerun::RecordingStream::spawn`
+any data will be kept in memory until you call one of these.
+
+\snippet{trimleft}readme_snippets.cpp Buffering
+
 
 ## Examples
 
@@ -27,7 +57,7 @@ Check the [general doc page on types](https://www.rerun.io/docs/reference/types)
 
 ## Build & Distribution
 
-### Overview
+### Overview  ioeb 
 
 To avoid compatibility issues across different platforms, compiler versions and C++ standard library versions
 the C++ SDK is expected to be built from source.

--- a/rerun_cpp/docs/Doxyfile
+++ b/rerun_cpp/docs/Doxyfile
@@ -1030,7 +1030,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           =
+EXAMPLE_PATH           = rerun_cpp/tests/readme_snippets.cpp
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/rerun_cpp/tests/readme_snippets.cpp
+++ b/rerun_cpp/tests/readme_snippets.cpp
@@ -1,0 +1,65 @@
+// File used for snippets that are embedded in the documentation.
+// Compiled as part of the tests to make sure everything keeps working!
+
+#include <rerun.hpp>
+#include <vector>
+
+static std::vector<rerun::Position3D> create_positions() {
+    return {};
+}
+
+static std::vector<rerun::Color> create_colors() {
+    return {};
+}
+
+// TODO(#3794): Once image logging is nicer, we should do that in this snippet as well!
+
+[[maybe_unused]] static void log() {
+    /// [Logging]
+    // Create a recording stream.
+    rerun::RecordingStream rec("rerun_example_app");
+    // Spawn the viewer and connect to it.
+    rec.spawn().exit_on_failure();
+
+    std::vector<rerun::Position3D> points = create_positions();
+    std::vector<rerun::Color> colors = create_colors();
+
+    // Log a batch of points.
+    rec.log("path/to/points", rerun::Points3D(points).with_colors(colors));
+    /// [Logging]
+}
+
+[[maybe_unused]] static void streaming() {
+    /// [Streaming]
+    rerun::RecordingStream rec("rerun_example_app");
+    rec.save("example.rrd").exit_on_failure();
+    /// [Streaming]
+}
+
+[[maybe_unused]] static void connecting() {
+    /// [Connecting]
+    rerun::RecordingStream rec("rerun_example_app");
+    auto result = rec.connect(); // Connect to local host with default port.
+    if (result.is_err()) {
+        // Handle error.
+    }
+    /// [Connecting]
+}
+
+[[maybe_unused]] static void buffering() {
+    std::vector<rerun::Position3D> points = create_positions();
+    std::vector<rerun::Color> colors = create_colors();
+
+    /// [Buffering]
+    rerun::RecordingStream rec("rerun_example_app");
+
+    // Log data to the internal buffer.
+    rec.log("path/to/points", rerun::Points3D(points).with_colors(colors));
+
+    // Spawn & connect later.
+    auto result = rec.spawn();
+    if (result.is_err()) {
+        // Handle error.
+    }
+    /// [Buffering]
+}


### PR DESCRIPTION
### What

* Another piece in the series of #3974 

Uses doxygen /snippet magic - this allows us to pick code out of a file that we're otherwise compiling as part of the tests 🥳 

![image](https://github.com/rerun-io/rerun/assets/1220815/1e369eb5-9e2d-42a1-9fc9-deb48b5dc572)


Also a few unrelated C++ doc fixes

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4217) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4217)
- [Docs preview](https://rerun.io/preview/04031671437f20feca904ffa815dace6d7fd73f7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/04031671437f20feca904ffa815dace6d7fd73f7/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)