### PR TITLE
Fix inaccessible entities being incorrectly added to space view

### DIFF
--- a/crates/re_viewport/src/space_info.rs
+++ b/crates/re_viewport/src/space_info.rs
@@ -71,6 +71,10 @@ impl SpaceInfo {
             visitor(space_info);
 
             for (child_path, connection) in &space_info.child_spaces {
+                if matches!(connection, &SpaceInfoConnection::Disconnected) {
+                    continue;
+                }
+
                 let Some(child_space) = space_info_collection.spaces.get(child_path) else {
                     re_log::warn_once!(
                         "Child space info {} not part of space info collection",


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/4221

Although `is_reachable_by_transform` correctly accounts for disconnected spaces, `visit_descendants_with_reachable_transform` was never modified to account for disconnected spaces correctly. The inconsistency leads to creating a space with unreachable content in it.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4226) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4226)
- [Docs preview](https://rerun.io/preview/4a7b44068f90198b8a27ecdb1ff17a85af5bd383/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4a7b44068f90198b8a27ecdb1ff17a85af5bd383/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)