### PR TITLE
Don't install python in docs deploy job

### DIFF
--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -66,13 +66,7 @@ jobs:
           fetch-depth: 0 # Don't do a shallow clone since we need to push gh-pages
           ref: ${{ inputs.RELEASE_COMMIT || (github.event_name == 'pull_request' && github.event.pull_request.head.ref || '') }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.8"
-          cache: "pip"
-          cache-dependency-path: "rerun_py/requirements-doc.txt"
-
+      # Note: Python is already installed
       - name: Install Python dependencies
         run: |
           pip install --upgrade pip
@@ -220,3 +214,4 @@ jobs:
           vercel_team_name: ${{ vars.VERCEL_TEAM_NAME }}
           vercel_project_name: ${{ vars.VERCEL_PROJECT_NAME }}
           release_commit: ${{ inputs.RELEASE_COMMIT }}
+


### PR DESCRIPTION
### What

Related to https://github.com/rerun-io/rerun/actions/runs/6875330324/job/18699311307

We've had issues with this in the past. May be worth looking into _why_ `setup-python` fails when used in a job that's running off of `ci_docker`. Here's a bandaid fix, at least!

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4229) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4229)
- [Docs preview](https://rerun.io/preview/ea8378d5a88da2873f04c2f87319c093ebe6c8e6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ea8378d5a88da2873f04c2f87319c093ebe6c8e6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)