### PR TITLE
Revert "Merge all doc deploy jobs into a single one to avoid race conditions"

### DIFF
--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -43,8 +43,67 @@ env:
   SCCACHE_GHA_ENABLED: "true"
 
 jobs:
-  deploy-docs:
-    name: Deploy docs for Python, Rust & C++
+  # ---------------------------------------------------------------------------
+
+  py-deploy-docs:
+    name: Python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Don't do a shallow clone
+          ref: ${{ inputs.RELEASE_COMMIT || (github.event_name == 'pull_request' && github.event.pull_request.head.ref || '') }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+          cache: "pip"
+          cache-dependency-path: "rerun_py/requirements-doc.txt"
+
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r rerun_py/requirements-doc.txt
+
+      - name: Set up git author
+        run: |
+          remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Mike will incrementally update the existing gh-pages branch
+      # We then check it out, and reset it to a new orphaned branch, which we force-push to origin
+      # to make sure we don't accumulate unnecessary history in gh-pages branch
+      - name: Deploy via mike # https://github.com/jimporter/mike
+        if: ${{ inputs.UPDATE_LATEST }}
+        run: |
+          git fetch
+          mike deploy -F rerun_py/mkdocs.yml --rebase -b gh-pages --prefix docs/python -u ${{inputs.PY_DOCS_VERSION_NAME}} stable
+          git checkout gh-pages
+          git checkout --orphan gh-pages-orphan
+          git commit -m "Update docs for ${GITHUB_SHA}"
+          git push origin gh-pages-orphan:gh-pages -f
+
+      # Mike will incrementally update the existing gh-pages branch
+      # We then check it out, and reset it to a new orphaned branch, which we force-push to origin
+      # to make sure we don't accumulate unnecessary history in gh-pages branch
+      - name: Deploy tag via mike # https://github.com/jimporter/mike
+        if: ${{ ! inputs.UPDATE_LATEST }}
+        run: |
+          git fetch
+          mike deploy -F rerun_py/mkdocs.yml --rebase -b gh-pages --prefix docs/python ${{inputs.PY_DOCS_VERSION_NAME}}
+          git checkout gh-pages
+          git checkout --orphan gh-pages-orphan
+          git commit -m "Update docs for ${GITHUB_SHA}"
+          git push origin gh-pages-orphan:gh-pages -f
+
+  # ---------------------------------------------------------------------------
+
+  rs-deploy-docs:
+    name: Rust
     runs-on: ubuntu-latest-16-cores
     container:
       image: rerunio/ci_docker:0.10.0
@@ -66,18 +125,6 @@ jobs:
           fetch-depth: 0 # Don't do a shallow clone since we need to push gh-pages
           ref: ${{ inputs.RELEASE_COMMIT || (github.event_name == 'pull_request' && github.event.pull_request.head.ref || '') }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.8"
-          cache: "pip"
-          cache-dependency-path: "rerun_py/requirements-doc.txt"
-
-      - name: Install Python dependencies
-        run: |
-          pip install --upgrade pip
-          pip install -r rerun_py/requirements-doc.txt
-
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -96,14 +143,6 @@ jobs:
           command: doc
           args: --document-private-items --no-deps --all-features --workspace --exclude rerun-cli
 
-      - uses: prefix-dev/setup-pixi@v0.3.0
-        with:
-          pixi-version: v0.6.0
-          cache: true
-
-      - name: Doxygen C++ docs
-        run: pixi run cpp-docs
-
       - name: Set up git author
         run: |
           remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
@@ -120,38 +159,11 @@ jobs:
         env:
           REDIRECT_CRATE: rerun
 
-      # Mike will incrementally update the existing gh-pages branch
-      # We then check it out, and reset it to a new orphaned branch, which we force-push to origin
-      # to make sure we don't accumulate unnecessary history in gh-pages branch
-      - name: Deploy Python docs via mike # https://github.com/jimporter/mike
-        if: ${{ inputs.UPDATE_LATEST }}
-        run: |
-          git fetch
-          mike deploy -F rerun_py/mkdocs.yml --rebase -b gh-pages --prefix docs/python -u ${{inputs.PY_DOCS_VERSION_NAME}} stable
-          git checkout gh-pages
-          git checkout --orphan gh-pages-orphan
-          git commit -m "Update docs for ${GITHUB_SHA}"
-          git push origin gh-pages-orphan:gh-pages -f
-
-      # Mike will incrementally update the existing gh-pages branch
-      # We then check it out, and reset it to a new orphaned branch, which we force-push to origin
-      # to make sure we don't accumulate unnecessary history in gh-pages branch
-      - name: Deploy Python docs tag via mike # https://github.com/jimporter/mike
-        if: ${{ ! inputs.UPDATE_LATEST }}
-        run: |
-          git fetch
-          mike deploy -F rerun_py/mkdocs.yml --rebase -b gh-pages --prefix docs/python ${{inputs.PY_DOCS_VERSION_NAME}}
-          git checkout gh-pages
-          git checkout --orphan gh-pages-orphan
-          git commit -m "Update docs for ${GITHUB_SHA}"
-          git push origin gh-pages-orphan:gh-pages -f
-
       # See: https://github.com/c-w/ghp-import
-      - name: Deploy Rust & C++ docs
+      - name: Deploy the docs
         run: |
           git fetch
           python3 -m ghp_import -n -p -x docs/rust/${{ inputs.RS_AND_CPP_DOCS_VERSION_NAME }} target/doc/ -m "Update the rust docs"
-          python3 -m ghp_import -n -p -x docs/cpp/${{ inputs.RS_AND_CPP_DOCS_VERSION_NAME }} rerun_cpp/docs/html/ -m "Update the C++ docs"
 
   cpp-deploy-docs:
     name: Cpp


### PR DESCRIPTION
If we want to serialize the jobs, we can add a `needs` between them instead. I'll do that in a separate PR

Reverts rerun-io/rerun#4216