### PR TITLE
Run deploy docs jobs serially

### DIFF
--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -104,6 +104,7 @@ jobs:
 
   rs-deploy-docs:
     name: Rust
+    needs: [py-deploy-docs]
     runs-on: ubuntu-latest-16-cores
     container:
       image: rerunio/ci_docker:0.10.0
@@ -167,6 +168,7 @@ jobs:
 
   cpp-deploy-docs:
     name: Cpp
+    needs: [rs-deploy-docs]
     runs-on: ubuntu-latest
     steps:
       - name: Show context
@@ -232,3 +234,4 @@ jobs:
           vercel_team_name: ${{ vars.VERCEL_TEAM_NAME }}
           vercel_project_name: ${{ vars.VERCEL_PROJECT_NAME }}
           release_commit: ${{ inputs.RELEASE_COMMIT }}
+


### PR DESCRIPTION
### What

This does the same thing as https://github.com/rerun-io/rerun/pull/4216, but instead of merging them, just has them run serially by putting dependencies between them.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://ref.rerun.io/dev/bench/)
- [Wasm size tracking](https://ref.rerun.io/dev/sizes/)
