### PR TITLE
Fix benchmark jobs

### DIFF
--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -59,11 +59,6 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
 
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:

--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -57,6 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0 # we need full history
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
 
       - name: Set up Rust

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0 # we need full history
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
 
       - name: Get context
@@ -172,6 +173,7 @@ jobs:
           auto-push: false
 
       - name: Render benchmark result
+        if: github.ref == 'refs/heads/main'
         run: |
           python3 -m pip install google-cloud-storage==2.9.0
           scripts/ci/render_bench.py sizes \

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -172,7 +172,6 @@ jobs:
           auto-push: false
 
       - name: Render benchmark result
-        if: github.ref == 'refs/heads/main'
         run: |
           python3 -m pip install google-cloud-storage==2.9.0
           scripts/ci/render_bench.py sizes \

--- a/scripts/ci/render_bench.py
+++ b/scripts/ci/render_bench.py
@@ -282,6 +282,7 @@ class Target(Enum):
 
     def render(self, gcs: storage.Client, after: datetime) -> dict[str, str]:
         commits = get_commits(after)
+        print("commits", commits)
         out: dict[str, str] = {}
 
         if self.includes(Target.CRATES):
@@ -365,9 +366,13 @@ def main() -> None:
     output: str = args.output
     output_kind: Output = Output.parse(output)
 
+    print({"target": str(target), "after": str(after), "output": output, "output_kind": str(output_kind)})
+
     gcs = storage.Client()
 
     benchmarks = target.render(gcs, after)
+
+    print("benchmarks", benchmarks)
 
     if output_kind is Output.STDOUT:
         for benchmark in benchmarks.values():


### PR DESCRIPTION
### What

- [x] Don't use `setup-python` in `reusable_bench`, it's already part of `ci_docker`
- [x] Fetch full history in benchmark jobs

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4233) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4233)
- [Docs preview](https://rerun.io/preview/3b7a228dace22b62a0f577075f8cd5ffac44438e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3b7a228dace22b62a0f577075f8cd5ffac44438e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)