### PR TITLE
Don't let time histograms panic on saturated counters

### DIFF
--- a/crates/re_data_store/src/time_histogram_per_timeline.rs
+++ b/crates/re_data_store/src/time_histogram_per_timeline.rs
@@ -48,12 +48,13 @@ impl TimeHistogramPerTimeline {
 
     pub fn add(&mut self, timepoint: &TimePoint, n: u32) {
         if timepoint.is_timeless() {
-            if let Some(new) = self.num_timeless_messages.checked_add(n as u64) {
-                self.num_timeless_messages = new;
-            } else {
-                re_log::warn_once!("Timeless counter overflowed, store events are bugged!");
-                self.num_timeless_messages = u64::MAX;
-            }
+            self.num_timeless_messages = self
+                .num_timeless_messages
+                .checked_add(n as u64)
+                .unwrap_or_else(|| {
+                    re_log::warn_once!("Timeless counter overflowed, store events are bugged!");
+                    u64::MAX
+                });
         } else {
             for (timeline, time_value) in timepoint.iter() {
                 self.times
@@ -66,12 +67,13 @@ impl TimeHistogramPerTimeline {
 
     pub fn remove(&mut self, timepoint: &TimePoint, n: u32) {
         if timepoint.is_timeless() {
-            if let Some(new) = self.num_timeless_messages.checked_sub(n as u64) {
-                self.num_timeless_messages = new;
-            } else {
-                re_log::warn_once!("Timeless counter underflowed, store events are bugged!");
-                self.num_timeless_messages = 0;
-            }
+            self.num_timeless_messages = self
+                .num_timeless_messages
+                .checked_sub(n as u64)
+                .unwrap_or_else(|| {
+                    re_log::warn_once!("Timeless counter underflowed, store events are bugged!");
+                    0
+                });
         } else {
             for (timeline, time_value) in timepoint.iter() {
                 self.times

--- a/crates/re_data_store/src/times_per_timeline.rs
+++ b/crates/re_data_store/src/times_per_timeline.rs
@@ -60,21 +60,16 @@ impl StoreSubscriber for TimesPerTimeline {
 
                 let delta = event.delta();
 
-                #[allow(clippy::collapsible_else_if)] // readability
                 if delta < 0 {
-                    if let Some(new) = count.checked_sub(delta.unsigned_abs()) {
-                        *count = new;
-                    } else {
+                    *count = count.checked_sub(delta.unsigned_abs()).unwrap_or_else(|| {
                         re_log::warn_once!("Time counter underflowed, store events are bugged!");
-                        *count = 0;
-                    }
+                        0
+                    });
                 } else {
-                    if let Some(new) = count.checked_add(delta.unsigned_abs()) {
-                        *count = new;
-                    } else {
+                    *count = count.checked_add(delta.unsigned_abs()).unwrap_or_else(|| {
                         re_log::warn_once!("Time counter overflowed, store events are bugged!");
-                        *count = u64::MAX;
-                    }
+                        u64::MAX
+                    });
                 }
 
                 if *count == 0 {


### PR DESCRIPTION
Still need to investigate the event discrepancy causing [the issue in the first place](https://rerunio.slack.com/archives/C041NHU952S/p1700070835919879), but this shouldn't be allowed to crash in any case.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4237) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4237)
- [Docs preview](https://rerun.io/preview/80d1219621c464709fcb87f34ec24123dab7d423/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/80d1219621c464709fcb87f34ec24123dab7d423/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)