### PR TITLE
Add --edition 2021 to lint-rs-files

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -33,7 +33,7 @@ lint-codegen = "cargo run --package re_types_builder -- --check"
 # TODO(jleibs): implement lint-cpp-all
 lint-cpp-files = "clang-format --dry-run -Werror"
 lint-rerun = "python scripts/lint.py"
-lint-rs-files = "rustfmt --check"
+lint-rs-files = "rustfmt --edition 2021 --check"
 lint-rs-all = "cargo fmt --check"
 lint-py-fmt-check = "ruff format --check --config rerun_py/pyproject.toml"
 lint-py-blackdoc = "blackdoc --check"


### PR DESCRIPTION
### What
Without this I get lint errors such as:
```
Diff in /home/jleibs/rerun/crates/re_viewport/src/blueprint/viewport_layout.rs at line 15:
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
 
-use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
-use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
-use ::re_types_core::{DeserializationError, DeserializationResult};
+use re_types_core::external::arrow2;
+use re_types_core::ComponentName;
+use re_types_core::SerializationResult;
+use re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Blueprint**: A view of a space.
 ///
Diff in /home/jleibs/rerun/crates/re_viewport/src/blueprint/viewport_layout.rs at line 90:
         Self: Clone + 'a,
     {
         re_tracing::profile_function!();
-        use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
+        use re_types_core::{Loggable as _, ResultExt as _};
         Ok({
             let (somes, data): (Vec<_>, Vec<_>) = data
                 .into_iter()
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4240) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4240)
- [Docs preview](https://rerun.io/preview/42aa1cea3ca026b56cd684bd3613d4f81135072b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/42aa1cea3ca026b56cd684bd3613d4f81135072b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)