### PR TITLE
fix windows test config on main

### DIFF
--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -232,12 +232,12 @@ jobs:
 
   test-wheel-windows:
     needs: [checks, build-wheel-windows]
-    name: "Linux: Test Wheels"
+    name: "Windows: Test Wheels"
     uses: ./.github/workflows/reusable_test_wheels.yml
     with:
-      CONCURRENCY: push-linux-${{ github.ref_name }}
-      PLATFORM: linux
-      WHEEL_ARTIFACT_NAME: linux-wheel
+      CONCURRENCY: push-windows-${{ github.ref_name }}
+      PLATFORM: windows
+      WHEEL_ARTIFACT_NAME: windows-wheel
     secrets: inherit
 
   # NOTE: We currently don't test wheels on macos-arm/macos-intel


### PR DESCRIPTION
### What

https://github.com/rerun-io/rerun/actions/runs/6883118436/job/18723707393 - I gave the `test-wheel-windows` job the same config as linux

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
