### PR TITLE
Display Visible History on timeline when the mouse hovers the UI

### DIFF
--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -266,23 +266,7 @@ impl TimePanel {
         let time_bg_area_painter = ui.painter().with_clip_rect(time_bg_area_rect);
         let time_area_painter = ui.painter().with_clip_rect(time_fg_area_rect);
 
-        if let Some(time_range) = ctx.rec_cfg.visible_history_highlight {
-            let x_from = self.time_ranges_ui.x_from_time_f32(time_range.min.into());
-            let x_to = self.time_ranges_ui.x_from_time_f32(time_range.max.into());
-
-            if let (Some(x_from), Some(x_to)) = (x_from, x_to) {
-                let visible_history_area_rect =
-                    Rect::from_x_y_ranges(x_from..=x_to, time_fg_area_rect.y_range())
-                        .intersect(time_fg_area_rect);
-
-                ui.painter().rect(
-                    visible_history_area_rect,
-                    0.0,
-                    egui::Color32::WHITE.gamma_multiply(0.1),
-                    egui::Stroke::NONE,
-                );
-            }
-        }
+        paint_visible_history_range(&self.time_ranges_ui, ctx, ui.painter(), time_fg_area_rect);
 
         ui.painter().hline(
             0.0..=ui.max_rect().right(),
@@ -760,6 +744,9 @@ fn collapsed_time_marker_and_time(ui: &mut egui::Ui, ctx: &mut ViewerContext<'_>
             time_ranges_ui.snap_time_control(ctx);
 
             let painter = ui.painter_at(time_range_rect.expand(4.0));
+
+            paint_visible_history_range(&time_ranges_ui, ctx, &painter, time_range_rect);
+
             painter.hline(
                 time_range_rect.x_range(),
                 time_range_rect.center().y,
@@ -779,6 +766,30 @@ fn collapsed_time_marker_and_time(ui: &mut egui::Ui, ctx: &mut ViewerContext<'_>
     }
 
     current_time_ui(ctx, ui);
+}
+
+fn paint_visible_history_range(
+    time_ranges_ui: &TimeRangesUi,
+    ctx: &mut ViewerContext,
+    painter: &egui::Painter,
+    rect: Rect,
+) {
+    if let Some(time_range) = ctx.rec_cfg.visible_history_highlight {
+        let x_from = time_ranges_ui.x_from_time_f32(time_range.min.into());
+        let x_to = time_ranges_ui.x_from_time_f32(time_range.max.into());
+
+        if let (Some(x_from), Some(x_to)) = (x_from, x_to) {
+            let visible_history_area_rect =
+                Rect::from_x_y_ranges(x_from..=x_to, rect.y_range()).intersect(rect);
+
+            painter.rect(
+                visible_history_area_rect,
+                0.0,
+                egui::Color32::WHITE.gamma_multiply(0.1),
+                egui::Stroke::NONE,
+            );
+        }
+    }
 }
 
 fn help_button(ui: &mut egui::Ui) {

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -266,6 +266,24 @@ impl TimePanel {
         let time_bg_area_painter = ui.painter().with_clip_rect(time_bg_area_rect);
         let time_area_painter = ui.painter().with_clip_rect(time_fg_area_rect);
 
+        if let Some(time_range) = ctx.rec_cfg.visible_history_highlight {
+            let x_from = self.time_ranges_ui.x_from_time_f32(time_range.min.into());
+            let x_to = self.time_ranges_ui.x_from_time_f32(time_range.max.into());
+
+            if let (Some(x_from), Some(x_to)) = (x_from, x_to) {
+                let visible_history_area_rect =
+                    Rect::from_x_y_ranges(x_from..=x_to, time_fg_area_rect.y_range())
+                        .intersect(time_fg_area_rect);
+
+                ui.painter().rect(
+                    visible_history_area_rect,
+                    0.0,
+                    egui::Color32::WHITE.gamma_multiply(0.1),
+                    egui::Stroke::NONE,
+                );
+            }
+        }
+
         ui.painter().hline(
             0.0..=ui.max_rect().right(),
             timeline_rect.bottom(),

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -770,7 +770,7 @@ fn collapsed_time_marker_and_time(ui: &mut egui::Ui, ctx: &mut ViewerContext<'_>
 
 fn paint_visible_history_range(
     time_ranges_ui: &TimeRangesUi,
-    ctx: &mut ViewerContext,
+    ctx: &mut ViewerContext<'_>,
     painter: &egui::Painter,
     rect: Rect,
 ) {

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -48,6 +48,9 @@ impl SelectionPanel {
                 ..Default::default()
             });
 
+        // Always reset the VH highlight, and let the UI re-set it if needed.
+        ctx.rec_cfg.visible_history_highlight = None;
+
         panel.show_animated_inside(ui, expanded, |ui: &mut egui::Ui| {
             // Set the clip rectangle to the panel for the benefit of nested, "full span" widgets
             // like large collapsing headers. Here, no need to extend `ui.max_rect()` as the

--- a/crates/re_viewer/src/ui/visible_history.rs
+++ b/crates/re_viewer/src/ui/visible_history.rs
@@ -225,17 +225,15 @@ pub fn visible_history_ui(
                 } else {
                     visible_history_prop.nanos
                 }
+            } else if sequence_timeline {
+                resolved_visible_history_prop.sequences
             } else {
-                if sequence_timeline {
-                    resolved_visible_history_prop.sequences
-                } else {
-                    resolved_visible_history_prop.nanos
-                }
+                resolved_visible_history_prop.nanos
             };
 
             TimeRange::new(
-                visible_history.from(current_time.into()),
-                visible_history.to(current_time.into()),
+                visible_history.from(current_time),
+                visible_history.to(current_time),
             )
         })
     } else {

--- a/crates/re_viewer/src/ui/visible_history.rs
+++ b/crates/re_viewer/src/ui/visible_history.rs
@@ -482,7 +482,7 @@ fn visible_history_boundary_ui(
     // both boundaries fighting each other in some corner cases (when the user interacts with the
     // current time cursor)
 
-    match visible_history_boundary {
+    let response = match visible_history_boundary {
         VisibleHistoryBoundary::RelativeToTimeCursor(value) => {
             // see note above
             let low_bound_override = if !low_bound {
@@ -492,27 +492,30 @@ fn visible_history_boundary_ui(
             };
 
             if is_sequence_timeline {
-                timeline_spec
-                    .sequence_drag_value(ui, value, false, low_bound_override)
-                    .on_hover_text(
-                        "Number of frames before/after the current time to use a time range \
-                        boundary",
-                    )
-                    .dragged()
+                Some(
+                    timeline_spec
+                        .sequence_drag_value(ui, value, false, low_bound_override)
+                        .on_hover_text(
+                            "Number of frames before/after the current time to use a time \
+                        range boundary",
+                        ),
+                )
             } else {
-                timeline_spec
-                    .temporal_drag_value(
-                        ui,
-                        value,
-                        false,
-                        low_bound_override,
-                        ctx.app_options.time_zone_for_timestamps,
-                    )
-                    .0
-                    .on_hover_text(
-                        "Time duration before/after the current time to use as time range boundary",
-                    )
-                    .dragged()
+                Some(
+                    timeline_spec
+                        .temporal_drag_value(
+                            ui,
+                            value,
+                            false,
+                            low_bound_override,
+                            ctx.app_options.time_zone_for_timestamps,
+                        )
+                        .0
+                        .on_hover_text(
+                            "Time duration before/after the current time to use as time range \
+                                boundary",
+                        ),
+                )
             }
         }
         VisibleHistoryBoundary::Absolute(value) => {
@@ -524,10 +527,11 @@ fn visible_history_boundary_ui(
             };
 
             if is_sequence_timeline {
-                timeline_spec
-                    .sequence_drag_value(ui, value, true, low_bound_override)
-                    .on_hover_text("Absolute frame number to use as time range boundary")
-                    .dragged()
+                Some(
+                    timeline_spec
+                        .sequence_drag_value(ui, value, true, low_bound_override)
+                        .on_hover_text("Absolute frame number to use as time range boundary"),
+                )
             } else {
                 let (drag_resp, base_time_resp) = timeline_spec.temporal_drag_value(
                     ui,
@@ -541,13 +545,13 @@ fn visible_history_boundary_ui(
                     base_time_resp.on_hover_text("Base time used to set time range boundaries");
                 }
 
-                drag_resp
-                    .on_hover_text("Absolute time to use as time range boundary")
-                    .dragged()
+                Some(drag_resp.on_hover_text("Absolute time to use as time range boundary"))
             }
         }
-        VisibleHistoryBoundary::Infinite => false,
-    }
+        VisibleHistoryBoundary::Infinite => None,
+    };
+
+    response.map_or(false, |r| r.dragged() || r.has_focus())
 }
 
 // ---

--- a/crates/re_viewer/src/ui/visible_history.rs
+++ b/crates/re_viewer/src/ui/visible_history.rs
@@ -210,6 +210,7 @@ pub fn visible_history_ui(
     // Decide when to show the visible history highlight in the timeline. The trick is that when
     // interacting with the controls, the mouse might end up outside the collapsing header rect,
     // so we must track these interactions specifically.
+    // Note: visible history highlight is always reset at the beginning of the Selection Panel UI.
 
     let should_display_visible_history = interacting_with_controls
         || collapsing_response.header_response.hovered()
@@ -217,8 +218,8 @@ pub fn visible_history_ui(
             .body_response
             .map_or(false, |r| r.hovered());
 
-    ctx.rec_cfg.visible_history_highlight = if should_display_visible_history {
-        ctx.rec_cfg.time_ctrl.time_int().map(|current_time| {
+    if should_display_visible_history {
+        if let Some(current_time) = ctx.rec_cfg.time_ctrl.time_int() {
             let visible_history = if visible_history_prop.enabled {
                 if sequence_timeline {
                     visible_history_prop.sequences
@@ -231,14 +232,12 @@ pub fn visible_history_ui(
                 resolved_visible_history_prop.nanos
             };
 
-            TimeRange::new(
+            ctx.rec_cfg.visible_history_highlight = Some(TimeRange::new(
                 visible_history.from(current_time),
                 visible_history.to(current_time),
-            )
-        })
-    } else {
-        None
-    };
+            ));
+        }
+    }
 
     collapsing_response.header_response.on_hover_text(
         "Controls the time range used to display data in the Space View.\n\n\

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -1,5 +1,6 @@
 use re_data_store::store_db::StoreDb;
 use re_data_store::{EntityTree, TimeHistogramPerTimeline};
+use re_log_types::TimeRange;
 
 use crate::EntitiesPerSystemPerClass;
 use crate::{
@@ -124,4 +125,10 @@ pub struct RecordingConfig {
 
     /// Selection & hovering state.
     pub selection_state: SelectionState,
+
+    /// Should the visible history time range be highlighted?
+    ///
+    /// This is used during UI interactions to show the range of time that is being edited.
+    #[serde(skip)]
+    pub visible_history_highlight: Option<TimeRange>,
 }


### PR DESCRIPTION
### What

- Fixes #4141

<img width="1791" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/049217b0-2a2b-4204-9394-465045c484e4">
<img width="1835" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/4faf657a-4497-46b4-bad8-dbac4660bc09">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4259) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4259)
- [Docs preview](https://rerun.io/preview/8134b6de51524b7df3556157a202f607c3f3ed63/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8134b6de51524b7df3556157a202f607c3f3ed63/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)