### PR TITLE
Fix GC decrementing metadata size trackers _before_ getting deletion confirmation

### DIFF
--- a/crates/re_arrow_store/src/store_gc.rs
+++ b/crates/re_arrow_store/src/store_gc.rs
@@ -266,7 +266,16 @@ impl DataStore {
             if diff.is_some() {
                 let metadata_dropped_size_bytes =
                     row_id.total_size_bytes() + timepoint.total_size_bytes();
-                self.metadata_registry.heap_size_bytes -= metadata_dropped_size_bytes;
+                self.metadata_registry.heap_size_bytes = self
+                    .metadata_registry
+                    .heap_size_bytes
+                    .checked_sub(metadata_dropped_size_bytes)
+                    .unwrap_or_else(|| {
+                        re_log::warn_once!(
+                            "GC metadata_registry size tracker underflowed, this is a bug!"
+                        );
+                        0
+                    });
                 num_bytes_to_drop -= metadata_dropped_size_bytes as f64;
             }
 


### PR DESCRIPTION
Title :point_up:.

Surprising we've never hit this until now, but then again this is a very peculiar situation to get into I guess.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4261) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4261)
- [Docs preview](https://rerun.io/preview/c99fd7195f1c21fcc1b8938119bd38738d0fdc3a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c99fd7195f1c21fcc1b8938119bd38738d0fdc3a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)