### PR TITLE
Fully clean up SpaceViews as they are removed and then GC'd from blueprint

### DIFF
--- a/crates/re_arrow_store/benches/data_store.rs
+++ b/crates/re_arrow_store/benches/data_store.rs
@@ -285,11 +285,12 @@ fn gc(c: &mut Criterion) {
         let store = insert_table(Default::default(), InstanceKey::name(), &table);
         b.iter(|| {
             let mut store = store.clone();
-            let (_, stats_diff) = store.gc(GarbageCollectionOptions {
+            let (_, stats_diff) = store.gc(&GarbageCollectionOptions {
                 target: GarbageCollectionTarget::DropAtLeastFraction(1.0 / 3.0),
                 gc_timeless: false,
                 protect_latest: 0,
                 purge_empty_tables: false,
+                dont_protect: Default::default(),
             });
             stats_diff
         });
@@ -308,11 +309,12 @@ fn gc(c: &mut Criterion) {
             );
             b.iter(|| {
                 let mut store = store.clone();
-                let (_, stats_diff) = store.gc(GarbageCollectionOptions {
+                let (_, stats_diff) = store.gc(&GarbageCollectionOptions {
                     target: GarbageCollectionTarget::DropAtLeastFraction(1.0 / 3.0),
                     gc_timeless: false,
                     protect_latest: 0,
                     purge_empty_tables: false,
+                    dont_protect: Default::default(),
                 });
                 stats_diff
             });

--- a/crates/re_arrow_store/src/store_event.rs
+++ b/crates/re_arrow_store/src/store_event.rs
@@ -463,7 +463,7 @@ mod tests {
             view,
         );
 
-        view.on_events(&store.gc(GarbageCollectionOptions::gc_everything()).0);
+        view.on_events(&store.gc(&GarbageCollectionOptions::gc_everything()).0);
 
         similar_asserts::assert_eq!(
             GlobalCounts::new(
@@ -521,7 +521,7 @@ mod tests {
             let event = store.insert_row(&row1)?;
             assert!(event.cells.contains_key(&store.cluster_key()));
 
-            let (events, _) = store.gc(GarbageCollectionOptions::gc_everything());
+            let (events, _) = store.gc(&GarbageCollectionOptions::gc_everything());
             assert!(events.len() == 1);
             assert!(events[0].cells.contains_key(&store.cluster_key()));
         }
@@ -538,7 +538,7 @@ mod tests {
             let event = store.insert_row(&row2)?;
             assert!(!event.cells.contains_key(&store.cluster_key()));
 
-            let (events, _) = store.gc(GarbageCollectionOptions::gc_everything());
+            let (events, _) = store.gc(&GarbageCollectionOptions::gc_everything());
             assert!(events.len() == 1);
             assert!(!events[0].cells.contains_key(&store.cluster_key()));
         }

--- a/crates/re_arrow_store/src/store_gc.rs
+++ b/crates/re_arrow_store/src/store_gc.rs
@@ -23,7 +23,7 @@ pub enum GarbageCollectionTarget {
     Everything,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct GarbageCollectionOptions {
     /// What target threshold should the GC try to meet.
     pub target: GarbageCollectionTarget,
@@ -36,6 +36,9 @@ pub struct GarbageCollectionOptions {
 
     /// Whether to purge tables that no longer contain any data
     pub purge_empty_tables: bool,
+
+    /// Components which should not be protected from GC when using `protect_latest`
+    pub dont_protect: HashSet<ComponentName>,
 }
 
 impl GarbageCollectionOptions {
@@ -45,6 +48,7 @@ impl GarbageCollectionOptions {
             gc_timeless: true,
             protect_latest: 0,
             purge_empty_tables: true,
+            dont_protect: Default::default(),
         }
     }
 }
@@ -92,7 +96,7 @@ impl DataStore {
     /// points in time may provide different results pre- and post- GC.
     //
     // TODO(#1823): Workload specific optimizations.
-    pub fn gc(&mut self, options: GarbageCollectionOptions) -> (Vec<StoreEvent>, DataStoreStats) {
+    pub fn gc(&mut self, options: &GarbageCollectionOptions) -> (Vec<StoreEvent>, DataStoreStats) {
         re_tracing::profile_function!();
 
         self.gc_id += 1;
@@ -102,7 +106,8 @@ impl DataStore {
         let (initial_num_rows, initial_num_bytes) =
             stats_before.total_rows_and_bytes_with_timeless(options.gc_timeless);
 
-        let protected_rows = self.find_all_protected_rows(options.protect_latest);
+        let protected_rows =
+            self.find_all_protected_rows(options.protect_latest, &options.dont_protect);
 
         let mut diffs = match options.target {
             GarbageCollectionTarget::DropAtLeastFraction(p) => {
@@ -304,7 +309,11 @@ impl DataStore {
     // HashSet might actually be sub-optimal here. Consider switching to a map of
     // `EntityPath` -> `HashSet<RowId>`.
     // Update: this is true-er than ever before now that RowIds are truly unique!
-    fn find_all_protected_rows(&mut self, target_count: usize) -> HashSet<RowId> {
+    fn find_all_protected_rows(
+        &mut self,
+        target_count: usize,
+        dont_protect: &HashSet<ComponentName>,
+    ) -> HashSet<RowId> {
         re_tracing::profile_function!();
 
         if target_count == 0 {
@@ -322,6 +331,7 @@ impl DataStore {
                 .all_components
                 .iter()
                 .filter(|c| **c != table.cluster_key)
+                .filter(|c| !dont_protect.contains(*c))
                 .map(|c| (*c, target_count))
                 .collect();
 
@@ -359,6 +369,7 @@ impl DataStore {
                 .columns
                 .keys()
                 .filter(|c| **c != table.cluster_key)
+                .filter(|c| !dont_protect.contains(*c))
                 .map(|c| (*c, target_count))
                 .collect();
 

--- a/crates/re_arrow_store/src/store_subscriber.rs
+++ b/crates/re_arrow_store/src/store_subscriber.rs
@@ -259,8 +259,8 @@ mod tests {
 
         expected_events.extend(store1.insert_row(&row));
 
-        expected_events.extend(store1.gc(GarbageCollectionOptions::gc_everything()).0);
-        expected_events.extend(store2.gc(GarbageCollectionOptions::gc_everything()).0);
+        expected_events.extend(store1.gc(&GarbageCollectionOptions::gc_everything()).0);
+        expected_events.extend(store2.gc(&GarbageCollectionOptions::gc_everything()).0);
 
         DataStore::with_subscriber::<AllEvents, _, _>(view_handle, |got| {
             similar_asserts::assert_eq!(expected_events.len(), got.events.len());

--- a/crates/re_arrow_store/tests/correctness.rs
+++ b/crates/re_arrow_store/tests/correctness.rs
@@ -485,7 +485,7 @@ fn gc_correct() {
 
     let stats = DataStoreStats::from_store(&store);
 
-    let (store_events, stats_diff) = store.gc(GarbageCollectionOptions::gc_everything());
+    let (store_events, stats_diff) = store.gc(&GarbageCollectionOptions::gc_everything());
     let stats_diff = stats_diff + stats_empty; // account for fixed overhead
 
     assert_eq!(
@@ -504,7 +504,7 @@ fn gc_correct() {
         assert!(store.get_msg_metadata(&event.row_id).is_none());
     }
 
-    let (store_events, stats_diff) = store.gc(GarbageCollectionOptions::gc_everything());
+    let (store_events, stats_diff) = store.gc(&GarbageCollectionOptions::gc_everything());
     assert!(store_events.is_empty());
     assert_eq!(DataStoreStats::default(), stats_diff);
 
@@ -542,17 +542,19 @@ fn gc_metadata_size() -> anyhow::Result<()> {
     }
 
     for _ in 0..2 {
-        _ = store.gc(GarbageCollectionOptions {
+        _ = store.gc(&GarbageCollectionOptions {
             target: re_arrow_store::GarbageCollectionTarget::DropAtLeastFraction(1.0),
             gc_timeless: false,
             protect_latest: 1,
             purge_empty_tables: false,
+            dont_protect: Default::default(),
         });
-        _ = store.gc(GarbageCollectionOptions {
+        _ = store.gc(&GarbageCollectionOptions {
             target: re_arrow_store::GarbageCollectionTarget::DropAtLeastFraction(1.0),
             gc_timeless: false,
             protect_latest: 1,
             purge_empty_tables: false,
+            dont_protect: Default::default(),
         });
     }
 

--- a/crates/re_arrow_store/tests/data_store.rs
+++ b/crates/re_arrow_store/tests/data_store.rs
@@ -73,7 +73,7 @@ fn all_components() {
             }
 
             // Stress test GC
-            store2.gc(GarbageCollectionOptions::gc_everything());
+            store2.gc(&GarbageCollectionOptions::gc_everything());
             for table in store.to_data_tables(None) {
                 insert_table_with_retries(&mut store2, &table);
             }
@@ -344,7 +344,7 @@ fn latest_at_impl(store: &mut DataStore) {
         insert_table(&mut store2, &table);
     }
     // Stress test GC
-    store2.gc(GarbageCollectionOptions::gc_everything());
+    store2.gc(&GarbageCollectionOptions::gc_everything());
     for table in store.to_data_tables(None) {
         insert_table(&mut store2, &table);
     }
@@ -493,7 +493,7 @@ fn range_impl(store: &mut DataStore) {
             for table in store.to_data_tables(None) {
                 insert_table_with_retries(&mut store2, &table);
             }
-            store2.gc(GarbageCollectionOptions::gc_everything());
+            store2.gc(&GarbageCollectionOptions::gc_everything());
             for table in store.to_data_tables(None) {
                 insert_table_with_retries(&mut store2, &table);
             }
@@ -926,11 +926,12 @@ fn gc_impl(store: &mut DataStore) {
 
         let stats = DataStoreStats::from_store(store);
 
-        let (store_events, stats_diff) = store.gc(GarbageCollectionOptions {
+        let (store_events, stats_diff) = store.gc(&GarbageCollectionOptions {
             target: GarbageCollectionTarget::DropAtLeastFraction(1.0 / 3.0),
             gc_timeless: false,
             protect_latest: 0,
             purge_empty_tables: false,
+            dont_protect: Default::default(),
         });
         for event in store_events {
             assert!(store.get_msg_metadata(&event.row_id).is_none());
@@ -1004,11 +1005,12 @@ fn protected_gc_impl(store: &mut DataStore) {
     table_timeless.col_timelines = Default::default();
     insert_table_with_retries(store, &table_timeless);
 
-    store.gc(GarbageCollectionOptions {
+    store.gc(&GarbageCollectionOptions {
         target: GarbageCollectionTarget::Everything,
         gc_timeless: true,
         protect_latest: 1,
         purge_empty_tables: true,
+        dont_protect: Default::default(),
     });
 
     let mut assert_latest_components = |frame_nr: TimeInt, rows: &[(ComponentName, &DataRow)]| {
@@ -1099,11 +1101,12 @@ fn protected_gc_clear_impl(store: &mut DataStore) {
     table_timeless.col_timelines = Default::default();
     insert_table_with_retries(store, &table_timeless);
 
-    store.gc(GarbageCollectionOptions {
+    store.gc(&GarbageCollectionOptions {
         target: GarbageCollectionTarget::Everything,
         gc_timeless: true,
         protect_latest: 1,
         purge_empty_tables: true,
+        dont_protect: Default::default(),
     });
 
     let mut assert_latest_components = |frame_nr: TimeInt, rows: &[(ComponentName, &DataRow)]| {
@@ -1140,11 +1143,12 @@ fn protected_gc_clear_impl(store: &mut DataStore) {
     table_timeless.col_timelines = Default::default();
     insert_table_with_retries(store, &table_timeless);
 
-    store.gc(GarbageCollectionOptions {
+    store.gc(&GarbageCollectionOptions {
         target: GarbageCollectionTarget::Everything,
         gc_timeless: true,
         protect_latest: 1,
         purge_empty_tables: true,
+        dont_protect: Default::default(),
     });
 
     // No rows should remain because the table should have been purged

--- a/crates/re_arrow_store/tests/dump.rs
+++ b/crates/re_arrow_store/tests/dump.rs
@@ -60,9 +60,9 @@ fn data_store_dump() {
         data_store_dump_impl(&mut store1, &mut store2, &mut store3);
 
         // stress-test GC impl
-        store1.gc(GarbageCollectionOptions::gc_everything());
-        store2.gc(GarbageCollectionOptions::gc_everything());
-        store3.gc(GarbageCollectionOptions::gc_everything());
+        store1.gc(&GarbageCollectionOptions::gc_everything());
+        store2.gc(&GarbageCollectionOptions::gc_everything());
+        store3.gc(&GarbageCollectionOptions::gc_everything());
 
         data_store_dump_impl(&mut store1, &mut store2, &mut store3);
     }
@@ -160,8 +160,8 @@ fn data_store_dump_filtered() {
         data_store_dump_filtered_impl(&mut store1, &mut store2);
 
         // stress-test GC impl
-        store1.gc(GarbageCollectionOptions::gc_everything());
-        store2.gc(GarbageCollectionOptions::gc_everything());
+        store1.gc(&GarbageCollectionOptions::gc_everything());
+        store2.gc(&GarbageCollectionOptions::gc_everything());
 
         data_store_dump_filtered_impl(&mut store1, &mut store2);
     }

--- a/crates/re_data_store/src/entity_tree.rs
+++ b/crates/re_data_store/src/entity_tree.rs
@@ -434,6 +434,9 @@ impl EntityTree {
             for component_name in event.cells.keys() {
                 if let Some(histo) = self.time_histograms_per_component.get_mut(component_name) {
                     histo.remove(&event.timepoint, 1);
+                    if histo.is_empty() {
+                        self.time_histograms_per_component.remove(component_name);
+                    }
                 }
             }
         }
@@ -442,9 +445,10 @@ impl EntityTree {
             recursive_time_histogram.remove(&event.timepoint, event.num_components() as _);
         }
 
-        for child in children.values_mut() {
+        children.retain(|_, child| {
             child.on_store_deletions(&filtered_events, compacted);
-        }
+            child.num_children_and_fields() > 0
+        });
     }
 
     /// Traverse on the tree and creates the missing nodes (if any) in order to reach `full_path`.

--- a/crates/re_data_store/src/time_histogram_per_timeline.rs
+++ b/crates/re_data_store/src/time_histogram_per_timeline.rs
@@ -22,6 +22,11 @@ pub struct TimeHistogramPerTimeline {
 
 impl TimeHistogramPerTimeline {
     #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.times.is_empty() && self.num_timeless_messages == 0
+    }
+
+    #[inline]
     pub fn timelines(&self) -> impl ExactSizeIterator<Item = &Timeline> {
         self.times.keys()
     }
@@ -76,10 +81,15 @@ impl TimeHistogramPerTimeline {
                 });
         } else {
             for (timeline, time_value) in timepoint.iter() {
-                self.times
+                if (self
+                    .times
                     .entry(*timeline)
                     .or_default()
-                    .decrement(time_value.as_i64(), n);
+                    .decrement(time_value.as_i64(), n))
+                    == 0
+                {
+                    self.times.remove(timeline);
+                }
             }
         }
     }

--- a/crates/re_data_store/src/time_histogram_per_timeline.rs
+++ b/crates/re_data_store/src/time_histogram_per_timeline.rs
@@ -81,13 +81,12 @@ impl TimeHistogramPerTimeline {
                 });
         } else {
             for (timeline, time_value) in timepoint.iter() {
-                if (self
+                let remaining_count = self
                     .times
                     .entry(*timeline)
                     .or_default()
-                    .decrement(time_value.as_i64(), n))
-                    == 0
-                {
+                    .decrement(time_value.as_i64(), n);
+                if remaining_count == 0 {
                     self.times.remove(timeline);
                 }
             }

--- a/crates/re_data_store/tests/clear.rs
+++ b/crates/re_data_store/tests/clear.rs
@@ -444,9 +444,11 @@ fn clear_and_gc() -> anyhow::Result<()> {
     let timepoint = TimePoint::timeless();
     let entity_path: EntityPath = "space_view".into();
 
-    // * Insert a 2D point
-    // * Query 'parent' at frame #11 and make sure we find everything back.
+    // Insert a component, then clear it, then GC.
     {
+        // Entity Tree is Empty when we start
+        assert_eq!(db.entity_db().tree.num_children_and_fields(), 0);
+
         let point = MyPoint::new(1.0, 2.0);
 
         let row = DataRow::from_component_batches(
@@ -480,6 +482,9 @@ fn clear_and_gc() -> anyhow::Result<()> {
         // No rows should remain because the table should have been purged
         let stats = DataStoreStats::from_store(db.store());
         assert_eq!(stats.timeless.num_rows, 0);
+
+        // TODO(#4264): Entity Tree should be empty when we end
+        // assert_eq!(db.entity_db().tree.num_children_and_fields(), 0);
     }
 
     Ok(())

--- a/crates/re_data_store/tests/clear.rs
+++ b/crates/re_data_store/tests/clear.rs
@@ -446,7 +446,7 @@ fn clear_and_gc() -> anyhow::Result<()> {
 
     // Insert a component, then clear it, then GC.
     {
-        // Entity Tree is Empty when we start
+        // EntityTree is Empty when we start
         assert_eq!(db.entity_db().tree.num_children_and_fields(), 0);
 
         let point = MyPoint::new(1.0, 2.0);
@@ -483,8 +483,8 @@ fn clear_and_gc() -> anyhow::Result<()> {
         let stats = DataStoreStats::from_store(db.store());
         assert_eq!(stats.timeless.num_rows, 0);
 
-        // TODO(#4264): Entity Tree should be empty when we end
-        // assert_eq!(db.entity_db().tree.num_children_and_fields(), 0);
+        // EntityTree should be empty again when we end since everything was GC'd
+        assert_eq!(db.entity_db().tree.num_children_and_fields(), 0);
     }
 
     Ok(())

--- a/crates/re_data_store/tests/time_histograms.rs
+++ b/crates/re_data_store/tests/time_histograms.rs
@@ -566,7 +566,7 @@ fn time_histograms() -> anyhow::Result<()> {
 
     // Full GC
     {
-        db.gc(GarbageCollectionOptions::gc_everything());
+        db.gc(&GarbageCollectionOptions::gc_everything());
 
         assert_times_per_timeline(
             &db,


### PR DESCRIPTION
### What
The blueprint refactor introduced scoped overrides in a sub-tree under the the space_view entitypath. However, we were only manually clearing the explicit SpaceViewComponent at the root of that tree.

I originally switch to using a recursive clear in order to remove any of the overridden properties as well. This in turn uncovered two more bugs related to GCing cleared entities and cleaning up the clutter left behind. Both of these are addressed in this PR:
 - Resolves: https://github.com/rerun-io/rerun/issues/4263
 - Resolves: https://github.com/rerun-io/rerun/issues/4264

**Best reviewed commit-by-commit.**

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4265) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4265)
- [Docs preview](https://rerun.io/preview/eb6fbac7378141c960cb940358c6a7b2e1389c99/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/eb6fbac7378141c960cb940358c6a7b2e1389c99/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)