### PR TITLE
Fix incorrect glob for rerun_c rust dependency

### DIFF
--- a/crates/rerun_c/CMakeLists.txt
+++ b/crates/rerun_c/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(rerun_c STATIC IMPORTED GLOBAL)
 set_target_properties(rerun_c PROPERTIES IMPORTED_LOCATION ${RERUN_C_BUILD_ARTIFACT})
 
 # Just depend on all rust and toml files, it's hard to know which files exactly are relevant.
-file(GLOB_RECURSE RERUN_C_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../crates/*.rs" "${CMAKE_CURRENT_SOURCE_DIR}/../crates/*.toml")
+file(GLOB_RECURSE RERUN_C_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../*.rs" "${CMAKE_CURRENT_SOURCE_DIR}/../../crates/*.toml")
 add_custom_command(
     OUTPUT ${RERUN_C_BUILD_ARTIFACT}
     DEPENDS ${RERUN_C_SOURCES}


### PR DESCRIPTION
### What

Rerun_c didn't correctly build as part of the C++ build because of a wrong path in the CMake glob.
With this fix in place, rerun_c is rebuilt during c++ builds whenever any rust file changes, as it it was intended.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4272) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4272)
- [Docs preview](https://rerun.io/preview/ccbef966d91a7b0ef2433e00d5f53e614c11e09b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ccbef966d91a7b0ef2433e00d5f53e614c11e09b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)