### PR TITLE
Use different C++ build directories for debug/release and roundtrips

### DIFF
--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -117,7 +117,7 @@ def main() -> None:
         print("----------------------------------------------------------")
         print("Build rerun_c & rerun_cpp…")
         start_time = time.time()
-        os.makedirs("build", exist_ok=True)
+        os.makedirs(cpp_build_dir, exist_ok=True)
         build_type = "Debug"
         if args.release:
             build_type = "Release"
@@ -129,12 +129,11 @@ def main() -> None:
             cpp_build_dir,
             f"-DCMAKE_BUILD_TYPE={build_type}",
             "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON",
-            "..",
+            ".",
         ]
         run(
             configure_args,
             env=build_env,
-            cwd="build",
         )
         cmake_build("rerun_sdk", args.release)
         elapsed = time.time() - start_time
@@ -310,7 +309,6 @@ def cmake_build(target: str, release: bool) -> None:
     build_process_args = [
         "cmake",
         "--build",
-        cpp_build_dir,
         ".",
         config,
         "--target",

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -56,7 +56,7 @@ extra_args = {
 
 # fmt: on
 
-cpp_build_dir = "build/roundtrips"
+cpp_build_dir = "./build/roundtrips"
 
 
 def run(
@@ -294,7 +294,7 @@ def run_roundtrip_cpp(example: str, release: bool) -> str:
 
     cmake_build(target_name, release)
 
-    cmd = [f"./build/docs/code-examples/{example}"] + (extra_args.get(example) or [])
+    cmd = [f"{cpp_build_dir}/docs/code-examples/{example}"] + (extra_args.get(example) or [])
     env = roundtrip_env(save_path=output_path)
     run(cmd, env=env, timeout=12000)
 
@@ -309,14 +309,14 @@ def cmake_build(target: str, release: bool) -> None:
     build_process_args = [
         "cmake",
         "--build",
-        ".",
+        cpp_build_dir,
         config,
         "--target",
         target,
         "--parallel",
         str(multiprocessing.cpu_count()),
     ]
-    run(build_process_args, cwd=cpp_build_dir)
+    run(build_process_args)
 
 
 def run_comparison(rrd0_path: str, rrd1_path: str, full_dump: bool) -> None:

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -121,10 +121,9 @@ def main() -> None:
         build_type = "Debug"
         if args.release:
             build_type = "Release"
+        # TODO(andreas): We should pixi for the prepare so we can ensure we have build tooling ready
         configure_args = [
             "cmake",
-            "-G",
-            "Ninja",
             "-B",
             cpp_build_dir,
             f"-DCMAKE_BUILD_TYPE={build_type}",

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -56,6 +56,8 @@ extra_args = {
 
 # fmt: on
 
+cpp_build_dir = "build/roundtrips"
+
 
 def run(
     args: list[str], *, env: dict[str, str] | None = None, timeout: int | None = None, cwd: str | None = None
@@ -119,7 +121,16 @@ def main() -> None:
         build_type = "Debug"
         if args.release:
             build_type = "Release"
-        configure_args = ["cmake", f"-DCMAKE_BUILD_TYPE={build_type}", "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON", ".."]
+        configure_args = [
+            "cmake",
+            "-G",
+            "Ninja",
+            "-B",
+            cpp_build_dir,
+            f"-DCMAKE_BUILD_TYPE={build_type}",
+            "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON",
+            "..",
+        ]
         run(
             configure_args,
             env=build_env,
@@ -299,15 +310,15 @@ def cmake_build(target: str, release: bool) -> None:
     build_process_args = [
         "cmake",
         "--build",
+        cpp_build_dir,
         ".",
-        "--config",
         config,
         "--target",
         target,
         "--parallel",
         str(multiprocessing.cpu_count()),
     ]
-    run(build_process_args, cwd="build")
+    run(build_process_args, cwd=cpp_build_dir)
 
 
 def run_comparison(rrd0_path: str, rrd1_path: str, full_dump: bool) -> None:

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -12,7 +12,7 @@ import time
 from os import listdir
 from os.path import isfile, join
 
-sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../scripts/")
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../../scripts/")
 from roundtrip_utils import cmake_build, cmake_configure, cpp_build_dir, roundtrip_env, run, run_comparison  # noqa
 
 # fmt: off

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -310,6 +310,7 @@ def cmake_build(target: str, release: bool) -> None:
         "cmake",
         "--build",
         cpp_build_dir,
+        "--config",
         config,
         "--target",
         target,

--- a/pixi.toml
+++ b/pixi.toml
@@ -48,31 +48,31 @@ py-test = { cmd = "python -m pytest -vv rerun_py/tests/unit", depends_on = [
 ] }
 
 # All the cpp-* tasks can be configured with environment variables, e.g.:  RERUN_WERROR=ON  CXX=clang++
-cpp-prepare-release = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Release"
-cpp-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Debug"
-cpp-build-all = { cmd = "cmake --build build --config Debug --target all", depends_on = [
+cpp-prepare-release = "cmake -G 'Ninja' -B build/release -S . -DCMAKE_BUILD_TYPE=Release"
+cpp-prepare = "cmake -G 'Ninja' -B build/debug -S . -DCMAKE_BUILD_TYPE=Debug"
+cpp-build-all = { cmd = "cmake --build build/debug --config Debug --target all", depends_on = [
   "cpp-prepare",
 ] }
 cpp-clean = "rm -rf build CMakeCache.txt CMakeFiles"
-cpp-build-tests = { cmd = "cmake --build build --config Debug --target rerun_sdk_tests", depends_on = [
+cpp-build-tests = { cmd = "cmake --build build/debug --config Debug --target rerun_sdk_tests", depends_on = [
   "cpp-prepare",
 ] }
-cpp-build-roundtrips = { cmd = "cmake --build build --config Debug --target roundtrips", depends_on = [
+cpp-build-roundtrips = { cmd = "cmake --build build/debug --config Debug --target roundtrips", depends_on = [
   "cpp-prepare",
 ] }
-cpp-build-examples = { cmd = "cmake --build build --config Debug --target examples", depends_on = [
+cpp-build-examples = { cmd = "cmake --build build/debug --config Debug --target examples", depends_on = [
   "cpp-prepare",
 ] }
-cpp-build-doc-examples = { cmd = "cmake --build build --config Debug --target doc_examples", depends_on = [
+cpp-build-doc-examples = { cmd = "cmake --build build/debug --config Debug --target doc_examples", depends_on = [
   "cpp-prepare",
 ] }
-cpp-build-log-benchmark = { cmd = "cmake --build build --config Release --target log_benchmark", depends_on = [
+cpp-build-log-benchmark = { cmd = "cmake --build build/release --config Release --target log_benchmark", depends_on = [
   "cpp-prepare-release",
 ] }
-cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
+cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/debug/rerun_cpp/tests/rerun_sdk_tests", depends_on = [
   "cpp-build-tests",
 ] }
-cpp-log-benchmark = { cmd = "export RERUN_STRICT=1 && ./build/tests/cpp/log_benchmark/log_benchmark", depends_on = [
+cpp-log-benchmark = { cmd = "export RERUN_STRICT=1 && ./build/release/tests/cpp/log_benchmark/log_benchmark", depends_on = [
   "cpp-build-log-benchmark",
 ] }
 cpp-build-and-test-all = { depends_on = ["cpp-build-all", "cpp-test"] }

--- a/scripts/roundtrip_utils.py
+++ b/scripts/roundtrip_utils.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+"""Shared functionality for roundtrip tests."""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import subprocess
+
+cpp_build_dir = "./build/roundtrips"
+repo_root = None
+
+
+def get_repo_root() -> str:
+    global repo_root
+    if repo_root is not None:
+        return repo_root
+    else:
+        get_rev_parse = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True)
+        assert get_rev_parse.returncode == 0
+        repo_root = get_rev_parse.stdout.decode("utf-8").strip()
+        return repo_root
+
+
+def run(
+    args: list[str], *, env: dict[str, str] | None = None, timeout: int | None = None, cwd: str | None = None
+) -> None:
+    # Run from the repo root if not specify otherwise.
+    if cwd is None:
+        cwd = get_repo_root()
+
+    print(f"> {subprocess.list2cmdline(args)}")
+    result = subprocess.run(args, env=env, cwd=cwd, timeout=timeout, check=False, capture_output=True, text=True)
+    assert (
+        result.returncode == 0
+    ), f"{subprocess.list2cmdline(args)} failed with exit-code {result.returncode}. Output:\n{result.stdout}\n{result.stderr}"
+
+
+def roundtrip_env(*, save_path: str | None = None) -> dict[str, str]:
+    env = os.environ.copy()
+
+    # NOTE: Make sure to disable batching, otherwise the Arrow concatenation logic within
+    # the batcher will happily insert uninitialized padding bytes as needed!
+    env["RERUN_FLUSH_NUM_ROWS"] = "0"
+
+    # Turn on strict mode to catch errors early
+    env["RERUN_STRICT"] = "1"
+
+    # Treat any warning as panics
+    env["RERUN_PANIC_ON_WARN"] = "1"
+
+    if save_path:
+        # NOTE: Force the recording stream to write to disk!
+        env["_RERUN_TEST_FORCE_SAVE"] = save_path
+
+    return env
+
+
+def cmake_configure(release: bool, env: dict[str, str]) -> None:
+    os.makedirs(cpp_build_dir, exist_ok=True)
+    build_type = "Debug"
+    if release:
+        build_type = "Release"
+    # TODO(andreas): We should pixi for the prepare so we can ensure we have build tooling ready
+    configure_args = [
+        "cmake",
+        "-B",
+        cpp_build_dir,
+        f"-DCMAKE_BUILD_TYPE={build_type}",
+        "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON",
+        ".",
+    ]
+    run(
+        configure_args,
+        env=env,
+    )
+
+
+def cmake_build(target: str, release: bool) -> None:
+    config = "Debug"
+    if release:
+        config = "Release"
+
+    build_process_args = [
+        "cmake",
+        "--build",
+        cpp_build_dir,
+        "--config",
+        config,
+        "--target",
+        target,
+        "--parallel",
+        str(multiprocessing.cpu_count()),
+    ]
+    run(build_process_args)
+
+
+def run_comparison(rrd0_path: str, rrd1_path: str, full_dump: bool) -> None:
+    cmd = ["rerun", "compare"]
+    if full_dump:
+        cmd += ["--full-dump"]
+    cmd += [rrd0_path, rrd1_path]
+
+    run(cmd, env=roundtrip_env(), timeout=30)

--- a/scripts/roundtrip_utils.py
+++ b/scripts/roundtrip_utils.py
@@ -20,6 +20,7 @@ def get_repo_root() -> str:
         get_rev_parse = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True)
         assert get_rev_parse.returncode == 0
         repo_root = get_rev_parse.stdout.decode("utf-8").strip()
+        print("Respository root:", repo_root)
         return repo_root
 
 

--- a/scripts/roundtrip_utils.py
+++ b/scripts/roundtrip_utils.py
@@ -20,7 +20,7 @@ def get_repo_root() -> str:
         get_rev_parse = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True)
         assert get_rev_parse.returncode == 0
         repo_root = get_rev_parse.stdout.decode("utf-8").strip()
-        print("Respository root:", repo_root)
+        print("Repository root:", repo_root)
         return repo_root
 
 

--- a/tests/cpp/log_benchmark/main.cpp
+++ b/tests/cpp/log_benchmark/main.cpp
@@ -25,7 +25,7 @@
 // For better whole-executable timing capture you can also first build the executable and then run:
 // ```
 // pixi run cpp-build-log-benchmark
-// ./build/tests/cpp/log_benchmark/log_benchmark
+// ./build/release/tests/cpp/log_benchmark/log_benchmark
 // ```
 //
 

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -28,6 +28,8 @@ opt_out = {
     "time_series_scalar": ["cpp", "py", "rust"],  # Don't need it, API example roundtrips cover it all
 }
 
+cpp_build_dir = "build/roundtrips"
+
 
 def run(
     args: list[str], *, env: dict[str, str] | None = None, timeout: int | None = None, cwd: str | None = None
@@ -84,7 +86,16 @@ def main() -> None:
         build_type = "Debug"
         if args.release:
             build_type = "Release"
-        configure_args = ["cmake", f"-DCMAKE_BUILD_TYPE={build_type}", "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON", ".."]
+        configure_args = [
+            "cmake",
+            "-G",
+            "Ninja",
+            "-B",
+            cpp_build_dir,
+            f"-DCMAKE_BUILD_TYPE={build_type}",
+            "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON",
+            "..",
+        ]
         run(
             configure_args,
             env=build_env,
@@ -248,7 +259,7 @@ def cmake_build(target: str, release: bool) -> None:
         "--parallel",
         str(multiprocessing.cpu_count()),
     ]
-    run(build_process_args, cwd="build")
+    run(build_process_args, cwd=cpp_build_dir)
 
 
 def run_comparison(rrd0_path: str, rrd1_path: str, full_dump: bool) -> None:

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -236,7 +236,7 @@ def run_roundtrip_cpp(arch: str, release: bool) -> str:
 
     cmake_build(target_name, release)
 
-    cmd = [f"./build/tests/cpp/roundtrips/{target_name}", output_path]
+    cmd = [f"{cpp_build_dir}/tests/cpp/roundtrips/{target_name}", output_path]
     run(cmd, env=roundtrip_env(), timeout=12000)
 
     return output_path
@@ -250,7 +250,7 @@ def cmake_build(target: str, release: bool) -> None:
     build_process_args = [
         "cmake",
         "--build",
-        ".",
+        cpp_build_dir,
         "--config",
         config,
         "--target",
@@ -258,7 +258,7 @@ def cmake_build(target: str, release: bool) -> None:
         "--parallel",
         str(multiprocessing.cpu_count()),
     ]
-    run(build_process_args, cwd=cpp_build_dir)
+    run(build_process_args)
 
 
 def run_comparison(rrd0_path: str, rrd1_path: str, full_dump: bool) -> None:

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -86,10 +86,9 @@ def main() -> None:
         build_type = "Debug"
         if args.release:
             build_type = "Release"
+        # TODO(andreas): We should pixi for the prepare so we can ensure we have build tooling ready
         configure_args = [
             "cmake",
-            "-G",
-            "Ninja",
             "-B",
             cpp_build_dir,
             f"-DCMAKE_BUILD_TYPE={build_type}",

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -82,7 +82,7 @@ def main() -> None:
         print("----------------------------------------------------------")
         print("Build rerun_c & rerun_cpp…")
         start_time = time.time()
-        os.makedirs("build", exist_ok=True)
+        os.makedirs(cpp_build_dir, exist_ok=True)
         build_type = "Debug"
         if args.release:
             build_type = "Release"
@@ -94,12 +94,11 @@ def main() -> None:
             cpp_build_dir,
             f"-DCMAKE_BUILD_TYPE={build_type}",
             "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON",
-            "..",
+            ".",
         ]
         run(
             configure_args,
             env=build_env,
-            cwd="build",
         )
         cmake_build("rerun_sdk", args.release)
         elapsed = time.time() - start_time

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -12,11 +12,13 @@ from __future__ import annotations
 import argparse
 import multiprocessing
 import os
-import subprocess
 import sys
 import time
 from os import listdir
 from os.path import isfile, join
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../scripts/")
+from roundtrip_utils import cmake_build, cmake_configure, cpp_build_dir, roundtrip_env, run, run_comparison  # noqa
 
 ARCHETYPES_PATH = "crates/re_types/definitions/rerun/archetypes"
 
@@ -27,18 +29,6 @@ opt_out = {
     "mesh3d": ["cpp", "py", "rust"],  # Don't need it, API example roundtrips cover it all
     "time_series_scalar": ["cpp", "py", "rust"],  # Don't need it, API example roundtrips cover it all
 }
-
-cpp_build_dir = "build/roundtrips"
-
-
-def run(
-    args: list[str], *, env: dict[str, str] | None = None, timeout: int | None = None, cwd: str | None = None
-) -> None:
-    print(f"> {subprocess.list2cmdline(args)}")
-    result = subprocess.run(args, env=env, cwd=cwd, timeout=timeout, check=False, capture_output=True, text=True)
-    assert (
-        result.returncode == 0
-    ), f"{subprocess.list2cmdline(args)} failed with exit-code {result.returncode}. Output:\n{result.stdout}\n{result.stderr}"
 
 
 def main() -> None:
@@ -82,23 +72,7 @@ def main() -> None:
         print("----------------------------------------------------------")
         print("Build rerun_c & rerun_cpp…")
         start_time = time.time()
-        os.makedirs(cpp_build_dir, exist_ok=True)
-        build_type = "Debug"
-        if args.release:
-            build_type = "Release"
-        # TODO(andreas): We should pixi for the prepare so we can ensure we have build tooling ready
-        configure_args = [
-            "cmake",
-            "-B",
-            cpp_build_dir,
-            f"-DCMAKE_BUILD_TYPE={build_type}",
-            "-DCMAKE_COMPILE_WARNING_AS_ERROR=ON",
-            ".",
-        ]
-        run(
-            configure_args,
-            env=build_env,
-        )
+        cmake_configure(args.release, build_env)
         cmake_build("rerun_sdk", args.release)
         elapsed = time.time() - start_time
         print(f"rerun-sdk for C++ built in {elapsed:.1f} seconds")
@@ -164,22 +138,6 @@ def main() -> None:
     print("All tests passed!")
 
 
-def roundtrip_env() -> dict[str, str]:
-    env = os.environ.copy()
-
-    # NOTE: Make sure to disable batching, otherwise the Arrow concatenation logic within
-    # the batcher will happily insert uninitialized padding bytes as needed!
-    env["RERUN_FLUSH_NUM_ROWS"] = "0"
-
-    # Turn on strict mode to catch errors early
-    env["RERUN_STRICT"] = "1"
-
-    # Treat any warning as panics
-    env["RERUN_PANIC_ON_WARN"] = "1"
-
-    return env
-
-
 def build(arch: str, language: str, args: argparse.Namespace) -> None:
     if language == "cpp":
         run_roundtrip_cpp(arch, args.release)
@@ -239,34 +197,6 @@ def run_roundtrip_cpp(arch: str, release: bool) -> str:
     run(cmd, env=roundtrip_env(), timeout=12000)
 
     return output_path
-
-
-def cmake_build(target: str, release: bool) -> None:
-    config = "Debug"
-    if release:
-        config = "Release"
-
-    build_process_args = [
-        "cmake",
-        "--build",
-        cpp_build_dir,
-        "--config",
-        config,
-        "--target",
-        target,
-        "--parallel",
-        str(multiprocessing.cpu_count()),
-    ]
-    run(build_process_args)
-
-
-def run_comparison(rrd0_path: str, rrd1_path: str, full_dump: bool) -> None:
-    cmd = ["rerun", "compare"]
-    if full_dump:
-        cmd += ["--full-dump"]
-    cmd += [rrd0_path, rrd1_path]
-
-    run(cmd, env=roundtrip_env(), timeout=30)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What

It got too annoying to rebuild libarrow whenever switching between roundtrips, tests and benchmarks.
This PR puts each of those into a different build folder.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4282) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4282)
- [Docs preview](https://rerun.io/preview/3849601eb18e8cf179ab83db0252ac8d7d2517da/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3849601eb18e8cf179ab83db0252ac8d7d2517da/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)