### PR TITLE
Track separable individual and group overrides for DataResult

### DIFF
--- a/crates/re_space_view/src/data_query.rs
+++ b/crates/re_space_view/src/data_query.rs
@@ -49,13 +49,18 @@ pub struct DataResultNode {
     pub children: SmallVec<[DataResultHandle; 4]>,
 }
 
+pub struct EntityOverrides {
+    pub root: EntityProperties,
+    pub individual: EntityPropertyMap,
+    pub group: EntityPropertyMap,
+}
+
 /// Trait for resolving properties needed by most implementations of [`DataQuery`]
 ///
 /// The `SpaceViewBlueprint` is the only thing that likely implements this today
 /// but we use a trait here so we don't have to pick up a full dependency on `re_viewport`.
 pub trait PropertyResolver {
-    fn resolve_entity_overrides(&self, ctx: &StoreContext<'_>) -> EntityPropertyMap;
-    fn resolve_root_override(&self, ctx: &StoreContext<'_>) -> EntityProperties;
+    fn resolve_entity_overrides(&self, ctx: &StoreContext<'_>) -> EntityOverrides;
 }
 
 /// The common trait implemented for data queries
@@ -87,5 +92,6 @@ pub trait DataQuery {
         ctx: &StoreContext<'_>,
         entities_per_system_per_class: &EntitiesPerSystemPerClass,
         entity_path: &EntityPath,
+        as_group: bool,
     ) -> DataResult;
 }

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -1,6 +1,6 @@
 use nohash_hasher::IntSet;
 use once_cell::sync::Lazy;
-use re_data_store::{EntityProperties, EntityPropertyMap, EntityTree};
+use re_data_store::{EntityProperties, EntityTree};
 use re_log_types::{EntityPath, EntityPathExpr};
 use re_viewer_context::{
     DataResult, EntitiesPerSystem, EntitiesPerSystemPerClass, SpaceViewClassName,
@@ -10,7 +10,7 @@ use smallvec::SmallVec;
 
 use crate::{
     blueprint::QueryExpressions, DataQuery, DataResultHandle, DataResultNode, DataResultTree,
-    PropertyResolver,
+    EntityOverrides, PropertyResolver,
 };
 
 /// An implementation of [`DataQuery`] that is built from a collection of [`QueryExpressions`]
@@ -48,8 +48,7 @@ impl DataQuery for DataQueryBlueprint {
 
         let mut data_results = SlotMap::<DataResultHandle, DataResultNode>::default();
 
-        let query_override = property_resolver.resolve_root_override(ctx);
-        let entity_overrides = property_resolver.resolve_entity_overrides(ctx);
+        let overrides = property_resolver.resolve_entity_overrides(ctx);
 
         let per_system_entity_list = entities_per_system_per_class
             .get(&self.space_view_class_name)
@@ -60,8 +59,8 @@ impl DataQuery for DataQueryBlueprint {
         let root_handle = ctx.recording.and_then(|store| {
             executor.add_entity_tree_to_data_results_recursive(
                 &store.entity_db().tree,
-                &entity_overrides,
-                &query_override,
+                &overrides,
+                &overrides.root,
                 &mut data_results,
                 false,
             )
@@ -79,9 +78,10 @@ impl DataQuery for DataQueryBlueprint {
         ctx: &re_viewer_context::StoreContext<'_>,
         entities_per_system_per_class: &EntitiesPerSystemPerClass,
         entity_path: &re_log_types::EntityPath,
+        as_group: bool,
     ) -> re_viewer_context::DataResult {
         re_tracing::profile_function!();
-        let entity_overrides = property_resolver.resolve_entity_overrides(ctx);
+        let overrides = property_resolver.resolve_entity_overrides(ctx);
 
         let view_parts = if let Some(per_system_entity_list) =
             entities_per_system_per_class.get(&self.space_view_class_name)
@@ -100,16 +100,17 @@ impl DataQuery for DataQueryBlueprint {
             Default::default()
         };
 
-        let mut resolved_properties = property_resolver.resolve_root_override(ctx);
+        let mut resolved_properties = overrides.root.clone();
         for prefix in EntityPath::incremental_walk(None, entity_path) {
-            resolved_properties = resolved_properties.with_child(&entity_overrides.get(&prefix));
+            resolved_properties = resolved_properties.with_child(&overrides.group.get(&prefix));
         }
 
+        // TODO(jleibs): This needs to be updated to accommodate for groups
         DataResult {
             entity_path: entity_path.clone(),
             view_parts,
-            is_group: false,
-            individual_properties: entity_overrides.get_opt(entity_path).cloned(),
+            is_group: as_group,
+            individual_properties: overrides.individual.get_opt(entity_path).cloned(),
             resolved_properties,
             override_path: self
                 .blueprint_path
@@ -171,7 +172,7 @@ impl<'a> QueryExpressionEvaluator<'a> {
     fn add_entity_tree_to_data_results_recursive(
         &self,
         tree: &EntityTree,
-        overrides: &EntityPropertyMap,
+        overrides: &EntityOverrides,
         inherited: &EntityProperties,
         data_results: &mut SlotMap<DataResultHandle, DataResultNode>,
         from_recursive: bool,
@@ -209,7 +210,7 @@ impl<'a> QueryExpressionEvaluator<'a> {
 
         let mut resolved_properties = inherited.clone();
 
-        if let Some(props) = overrides.get_opt(&entity_path) {
+        if let Some(props) = overrides.group.get_opt(&entity_path) {
             resolved_properties = resolved_properties.with_child(props);
         }
 
@@ -223,7 +224,7 @@ impl<'a> QueryExpressionEvaluator<'a> {
                     entity_path: entity_path.clone(),
                     view_parts,
                     is_group: false,
-                    individual_properties: overrides.get_opt(&entity_path).cloned(),
+                    individual_properties: overrides.individual.get_opt(&entity_path).cloned(),
                     resolved_properties: resolved_properties.clone(),
                     override_path: override_path.clone(),
                 },
@@ -255,7 +256,7 @@ impl<'a> QueryExpressionEvaluator<'a> {
         if children.is_empty() || children.len() == 1 && self_leaf.is_some() {
             self_leaf
         } else {
-            let individual_properties = overrides.get_opt(&entity_path).cloned();
+            let individual_properties = overrides.individual.get_opt(&entity_path).cloned();
             Some(data_results.insert(DataResultNode {
                 data_result: DataResult {
                     entity_path,
@@ -274,7 +275,7 @@ impl<'a> QueryExpressionEvaluator<'a> {
 #[cfg(feature = "testing")]
 #[cfg(test)]
 mod tests {
-    use re_data_store::StoreDb;
+    use re_data_store::{EntityPropertyMap, StoreDb};
     use re_log_types::{example_components::MyPoint, DataRow, RowId, StoreId, TimePoint, Timeline};
     use re_viewer_context::StoreContext;
 
@@ -285,12 +286,12 @@ mod tests {
     }
 
     impl PropertyResolver for StaticPropertyResolver {
-        fn resolve_entity_overrides(&self, _ctx: &StoreContext<'_>) -> EntityPropertyMap {
-            self.overrides.clone()
-        }
-
-        fn resolve_root_override(&self, _ctx: &StoreContext<'_>) -> EntityProperties {
-            EntityProperties::default()
+        fn resolve_entity_overrides(&self, _ctx: &StoreContext<'_>) -> EntityOverrides {
+            EntityOverrides {
+                root: Default::default(),
+                individual: self.overrides.clone(),
+                group: self.overrides.clone(),
+            }
         }
     }
 

--- a/crates/re_space_view/src/lib.rs
+++ b/crates/re_space_view/src/lib.rs
@@ -12,7 +12,7 @@ mod unreachable_transform_reason;
 
 pub use blueprint::QueryExpressions;
 pub use data_query::{
-    DataQuery, DataResultHandle, DataResultNode, DataResultTree, PropertyResolver,
+    DataQuery, DataResultHandle, DataResultNode, DataResultTree, EntityOverrides, PropertyResolver,
 };
 pub use data_query_blueprint::DataQueryBlueprint;
 pub use screenshot::ScreenshotMode;

--- a/crates/re_space_view/src/space_view_contents.rs
+++ b/crates/re_space_view/src/space_view_contents.rs
@@ -561,7 +561,7 @@ impl DataQuery for SpaceViewContents {
 impl DataBlueprintGroup {
     /// This recursively walks a `DataBlueprintGroup` and adds every entity / group to the tree.
     ///
-    /// Properties are resolved hierarchically from an [`EntityPropertyMap`] containing all the
+    /// Properties are resolved hierarchically from an `EntityPropertyMap` containing all the
     /// overrides. As we walk down the tree.
     fn add_to_data_results_recursive(
         &self,

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -341,12 +341,14 @@ fn blueprint_ui(
                         // splat - the whole entity
                         let space_view_class = *space_view.class_name();
                         let entity_path = &instance_path.entity_path;
+                        let as_group = false;
 
                         let data_result = space_view.contents.resolve(
                             space_view,
                             ctx.store_context,
                             ctx.entities_per_system_per_class,
                             &instance_path.entity_path,
+                            as_group,
                         );
 
                         let mut props = data_result
@@ -378,11 +380,14 @@ fn blueprint_ui(
             if let Some(space_view) = viewport.blueprint.space_view_mut(space_view_id) {
                 if let Some(group) = space_view.contents.group_mut(*data_blueprint_group_handle) {
                     let group_path = group.group_path.clone();
+                    let as_group = false;
+
                     let data_result = space_view.contents.resolve(
                         space_view,
                         ctx.store_context,
                         ctx.entities_per_system_per_class,
                         &group_path,
+                        as_group,
                     );
 
                     let space_view_class = *space_view.class_name();

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -435,7 +435,7 @@ impl PropertyResolver for SpaceViewBlueprint {
 
 #[cfg(test)]
 mod tests {
-    use re_data_store::{StoreDb, VisibleHistoryBoundary};
+    use re_data_store::StoreDb;
     use re_log_types::{DataCell, DataRow, RowId, StoreId, TimePoint};
     use re_space_view::DataResultTree;
     use re_viewer_context::{EntitiesPerSystemPerClass, StoreContext};

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -432,3 +432,251 @@ impl PropertyResolver for SpaceViewBlueprint {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use re_data_store::{StoreDb, VisibleHistoryBoundary};
+    use re_log_types::{DataCell, DataRow, RowId, StoreId, TimePoint};
+    use re_space_view::DataResultTree;
+    use re_viewer_context::{EntitiesPerSystemPerClass, StoreContext};
+
+    use super::*;
+
+    fn find_in_tree<'a>(
+        tree: &'a DataResultTree,
+        path: &EntityPath,
+        is_group: bool,
+    ) -> Option<&'a DataResult> {
+        let mut return_result = None;
+        tree.visit(&mut |handle| {
+            if let Some(result) = tree.lookup(handle) {
+                if result.entity_path == *path && result.is_group == is_group {
+                    return_result = Some(result);
+                }
+            }
+        });
+        return_result
+    }
+
+    fn save_override(props: EntityProperties, path: &EntityPath, store: &mut StoreDb) {
+        let component = EntityPropertiesComponent { props };
+        let row = DataRow::from_cells1_sized(
+            RowId::random(),
+            path.clone(),
+            TimePoint::timeless(),
+            1,
+            DataCell::from([component]),
+        )
+        .unwrap();
+
+        store.add_data_row(row).unwrap();
+    }
+
+    #[test]
+    fn test_overrides() {
+        let recording = StoreDb::new(StoreId::random(re_log_types::StoreKind::Recording));
+        let mut blueprint = StoreDb::new(StoreId::random(re_log_types::StoreKind::Blueprint));
+
+        let space_view = SpaceViewBlueprint::new(
+            "3D".into(),
+            &EntityPath::root(),
+            [
+                &"parent".into(),
+                &"parent/skip/child1".into(),
+                &"parent/skip/child2".into(),
+            ]
+            .into_iter(),
+        );
+
+        let mut entities_per_system_per_class = EntitiesPerSystemPerClass::default();
+        entities_per_system_per_class
+            .entry("3D".into())
+            .or_default()
+            .entry("Points3D".into())
+            .or_insert_with(|| {
+                [
+                    EntityPath::from("parent"),
+                    EntityPath::from("parent/skipped/child1"),
+                ]
+                .into_iter()
+                .collect()
+            });
+
+        // No overrides set. Everybody has default values.
+        {
+            let ctx = StoreContext {
+                blueprint: &blueprint,
+                recording: Some(&recording),
+                all_recordings: vec![],
+            };
+
+            let result_tree = space_view.contents.execute_query(
+                &space_view,
+                &ctx,
+                &entities_per_system_per_class,
+            );
+
+            let parent = find_in_tree(&result_tree, &EntityPath::from("parent"), false).unwrap();
+            let child1 =
+                find_in_tree(&result_tree, &EntityPath::from("parent/skip/child1"), false).unwrap();
+            let child2 =
+                find_in_tree(&result_tree, &EntityPath::from("parent/skip/child2"), false).unwrap();
+
+            for result in [parent, child1, child2] {
+                assert_eq!(result.resolved_properties, EntityProperties::default(),);
+            }
+
+            // Now, override visibility on parent but not group
+            let mut overrides = parent.individual_properties.clone().unwrap_or_default();
+            overrides.visible = false;
+
+            save_override(overrides, &parent.override_path, &mut blueprint);
+        }
+
+        // Parent is not visible, but children are
+        {
+            let ctx = StoreContext {
+                blueprint: &blueprint,
+                recording: Some(&recording),
+                all_recordings: vec![],
+            };
+
+            let result_tree = space_view.contents.execute_query(
+                &space_view,
+                &ctx,
+                &entities_per_system_per_class,
+            );
+
+            let parent_group =
+                find_in_tree(&result_tree, &EntityPath::from("parent"), true).unwrap();
+            let parent = find_in_tree(&result_tree, &EntityPath::from("parent"), false).unwrap();
+            let child1 =
+                find_in_tree(&result_tree, &EntityPath::from("parent/skip/child1"), false).unwrap();
+            let child2 =
+                find_in_tree(&result_tree, &EntityPath::from("parent/skip/child2"), false).unwrap();
+
+            assert!(!parent.resolved_properties.visible);
+
+            for result in [child1, child2] {
+                assert!(result.resolved_properties.visible);
+            }
+
+            // Override visibility on parent group
+            let mut overrides = parent_group
+                .individual_properties
+                .clone()
+                .unwrap_or_default();
+            overrides.visible = false;
+
+            save_override(overrides, &parent_group.override_path, &mut blueprint);
+        }
+
+        // Nobody is visible
+        {
+            let ctx = StoreContext {
+                blueprint: &blueprint,
+                recording: Some(&recording),
+                all_recordings: vec![],
+            };
+
+            let result_tree = space_view.contents.execute_query(
+                &space_view,
+                &ctx,
+                &entities_per_system_per_class,
+            );
+
+            let parent = find_in_tree(&result_tree, &EntityPath::from("parent"), false).unwrap();
+            let child1 =
+                find_in_tree(&result_tree, &EntityPath::from("parent/skip/child1"), false).unwrap();
+            let child2 =
+                find_in_tree(&result_tree, &EntityPath::from("parent/skip/child2"), false).unwrap();
+
+            for result in [parent, child1, child2] {
+                assert!(!result.resolved_properties.visible);
+            }
+        }
+
+        // Override visible range on root
+        {
+            let root = space_view.root_data_result(&StoreContext {
+                blueprint: &blueprint,
+                recording: Some(&recording),
+                all_recordings: vec![],
+            });
+            let mut overrides = root.individual_properties.clone().unwrap_or_default();
+            overrides.visible_history.enabled = true;
+            overrides.visible_history.nanos = VisibleHistory::ALL;
+
+            save_override(overrides, &root.override_path, &mut blueprint);
+        }
+
+        // Everyone has visible history
+        {
+            let ctx = StoreContext {
+                blueprint: &blueprint,
+                recording: Some(&recording),
+                all_recordings: vec![],
+            };
+
+            let result_tree = space_view.contents.execute_query(
+                &space_view,
+                &ctx,
+                &entities_per_system_per_class,
+            );
+
+            let parent = find_in_tree(&result_tree, &EntityPath::from("parent"), false).unwrap();
+            let child1 =
+                find_in_tree(&result_tree, &EntityPath::from("parent/skip/child1"), false).unwrap();
+            let child2 =
+                find_in_tree(&result_tree, &EntityPath::from("parent/skip/child2"), false).unwrap();
+
+            for result in [parent, child1, child2] {
+                assert!(result.resolved_properties.visible_history.enabled);
+                assert_eq!(
+                    result.resolved_properties.visible_history.nanos,
+                    VisibleHistory::ALL
+                );
+            }
+
+            let mut overrides = child2.individual_properties.clone().unwrap_or_default();
+            overrides.visible_history.enabled = true;
+
+            save_override(overrides, &child2.override_path, &mut blueprint);
+        }
+
+        // Child2 has its own visible history
+        {
+            let ctx = StoreContext {
+                blueprint: &blueprint,
+                recording: Some(&recording),
+                all_recordings: vec![],
+            };
+
+            let result_tree = space_view.contents.execute_query(
+                &space_view,
+                &ctx,
+                &entities_per_system_per_class,
+            );
+
+            let parent = find_in_tree(&result_tree, &EntityPath::from("parent"), false).unwrap();
+            let child1 =
+                find_in_tree(&result_tree, &EntityPath::from("parent/skip/child1"), false).unwrap();
+            let child2 =
+                find_in_tree(&result_tree, &EntityPath::from("parent/skip/child2"), false).unwrap();
+
+            for result in [parent, child1] {
+                assert!(result.resolved_properties.visible_history.enabled);
+                assert_eq!(
+                    result.resolved_properties.visible_history.nanos,
+                    VisibleHistory::ALL
+                );
+            }
+
+            assert!(child2.resolved_properties.visible_history.enabled);
+            assert_eq!(
+                child2.resolved_properties.visible_history.nanos,
+                VisibleHistory::OFF
+            );
+        }
+    }
+}

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -2,7 +2,9 @@ use nohash_hasher::IntMap;
 use re_data_store::{EntityPath, EntityProperties, EntityTree, TimeInt, VisibleHistory};
 use re_data_store::{EntityPropertiesComponent, EntityPropertyMap};
 use re_renderer::ScreenshotProcessor;
-use re_space_view::{DataQuery, PropertyResolver, ScreenshotMode, SpaceViewContents};
+use re_space_view::{
+    DataQuery, EntityOverrides, PropertyResolver, ScreenshotMode, SpaceViewContents,
+};
 use re_space_view_time_series::TimeSeriesSpaceView;
 use re_viewer_context::{
     DataResult, DynSpaceViewClass, EntitiesPerSystem, PerSystemDataResults, SpaceViewClassName,
@@ -383,20 +385,18 @@ impl SpaceViewBlueprint {
     }
 }
 
-impl PropertyResolver for SpaceViewBlueprint {
-    /// Helper function to lookup the properties for a given entity path.
-    ///
-    /// We start with the auto properties for the `SpaceView` as the base layer and
-    /// then incrementally override from there.
-    fn resolve_entity_overrides(&self, ctx: &StoreContext<'_>) -> EntityPropertyMap {
+impl SpaceViewBlueprint {
+    fn resolve_entity_overrides_for_prefix(
+        &self,
+        ctx: &StoreContext<'_>,
+        prefix: EntityPath,
+    ) -> EntityPropertyMap {
         re_tracing::profile_function!();
         let blueprint = ctx.blueprint;
 
         let mut prop_map = self.auto_properties.clone();
 
-        let props_path = self
-            .entity_path()
-            .join(&SpaceViewContents::PROPERTIES_PREFIX.into());
+        let props_path = self.entity_path().join(&prefix);
         if let Some(tree) = blueprint.entity_db().tree.subtree(&props_path) {
             tree.visit_children_recursively(&mut |path: &EntityPath| {
                 if let Some(props) = blueprint
@@ -411,8 +411,24 @@ impl PropertyResolver for SpaceViewBlueprint {
         }
         prop_map
     }
+}
 
-    fn resolve_root_override(&self, ctx: &StoreContext<'_>) -> EntityProperties {
-        self.root_data_result(ctx).resolved_properties
+impl PropertyResolver for SpaceViewBlueprint {
+    /// Helper function to lookup the properties for a given entity path.
+    ///
+    /// We start with the auto properties for the `SpaceView` as the base layer and
+    /// then incrementally override from there.
+    fn resolve_entity_overrides(&self, ctx: &StoreContext<'_>) -> EntityOverrides {
+        EntityOverrides {
+            root: self.root_data_result(ctx).resolved_properties,
+            individual: self.resolve_entity_overrides_for_prefix(
+                ctx,
+                SpaceViewContents::INDIVIDUAL_OVERRIDES_PREFIX.into(),
+            ),
+            group: self.resolve_entity_overrides_for_prefix(
+                ctx,
+                SpaceViewContents::GROUP_OVERRIDES_PREFIX.into(),
+            ),
+        }
     }
 }

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -389,14 +389,14 @@ impl SpaceViewBlueprint {
     fn resolve_entity_overrides_for_prefix(
         &self,
         ctx: &StoreContext<'_>,
-        prefix: EntityPath,
+        prefix: &EntityPath,
     ) -> EntityPropertyMap {
         re_tracing::profile_function!();
         let blueprint = ctx.blueprint;
 
         let mut prop_map = self.auto_properties.clone();
 
-        let props_path = self.entity_path().join(&prefix);
+        let props_path = self.entity_path().join(prefix);
         if let Some(tree) = blueprint.entity_db().tree.subtree(&props_path) {
             tree.visit_children_recursively(&mut |path: &EntityPath| {
                 if let Some(props) = blueprint
@@ -423,11 +423,11 @@ impl PropertyResolver for SpaceViewBlueprint {
             root: self.root_data_result(ctx).resolved_properties,
             individual: self.resolve_entity_overrides_for_prefix(
                 ctx,
-                SpaceViewContents::INDIVIDUAL_OVERRIDES_PREFIX.into(),
+                &SpaceViewContents::INDIVIDUAL_OVERRIDES_PREFIX.into(),
             ),
             group: self.resolve_entity_overrides_for_prefix(
                 ctx,
-                SpaceViewContents::GROUP_OVERRIDES_PREFIX.into(),
+                &SpaceViewContents::GROUP_OVERRIDES_PREFIX.into(),
             ),
         }
     }

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -224,11 +224,13 @@ impl ViewportBlueprint<'_> {
 
         // TODO(jleibs): We should use `query` instead of `resolve` in this function, but doing so
         // requires changing the view layout a little bit, so holding off on that for now.
+        let as_group = true;
         let top_data_result = space_view.contents.resolve(
             space_view,
             ctx.store_context,
             ctx.entities_per_system_per_class,
             &group.group_path,
+            as_group,
         );
 
         let group_is_visible = top_data_result.resolved_properties.visible && space_view_visible;
@@ -250,11 +252,13 @@ impl ViewportBlueprint<'_> {
             let is_item_hovered =
                 ctx.selection_state().highlight_for_ui_element(&item) == HoverHighlight::Hovered;
 
+            let as_group = false;
             let data_result = space_view.contents.resolve(
                 space_view,
                 ctx.store_context,
                 ctx.entities_per_system_per_class,
                 entity_path,
+                as_group,
             );
 
             let mut properties = data_result
@@ -306,11 +310,13 @@ impl ViewportBlueprint<'_> {
             let mut remove_group = false;
             let default_open = Self::default_open_for_group(child_group);
 
+            let as_group = true;
             let child_data_result = space_view.contents.resolve(
                 space_view,
                 ctx.store_context,
                 ctx.entities_per_system_per_class,
                 &child_group.group_path,
+                as_group,
             );
 
             let mut child_properties = child_data_result


### PR DESCRIPTION
### What
 - Resolves: https://github.com/rerun-io/rerun/issues/4281

This gets rid of the regression we temporarily added when introducing DataQuery interface and result tree.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4286) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4286)
- [Docs preview](https://rerun.io/preview/d0369ffe299548a32a9db6f03f626af34e08cdc7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d0369ffe299548a32a9db6f03f626af34e08cdc7/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)