### PR TITLE
Do not use `rerun`'s `demo` and `sdk` features in `rerun_cli`

### DIFF
--- a/crates/rerun-cli/Cargo.toml
+++ b/crates/rerun-cli/Cargo.toml
@@ -50,10 +50,8 @@ re_log.workspace = true
 re_memory.workspace = true
 rerun = { workspace = true, features = [
   "analytics",
-  "demo",
   "glam",
   "image",
-  "sdk",
   "server",
 ] }
 

--- a/crates/rerun-cli/Cargo.toml
+++ b/crates/rerun-cli/Cargo.toml
@@ -42,6 +42,7 @@ native_viewer = ["rerun/native_viewer"]
 #
 # You also need to install some additional tools, which you can do by running
 # [`scripts/setup_web.sh`](https://github.com/rerun-io/rerun/blob/main/scripts/setup_web.sh).
+# TODO(#4295): web_viewer shouldn't require rerun/sdk
 web_viewer = ["rerun/web_viewer", "rerun/sdk"]
 
 [dependencies]

--- a/crates/rerun-cli/Cargo.toml
+++ b/crates/rerun-cli/Cargo.toml
@@ -42,7 +42,7 @@ native_viewer = ["rerun/native_viewer"]
 #
 # You also need to install some additional tools, which you can do by running
 # [`scripts/setup_web.sh`](https://github.com/rerun-io/rerun/blob/main/scripts/setup_web.sh).
-web_viewer = ["rerun/web_viewer"]
+web_viewer = ["rerun/web_viewer", "rerun/sdk"]
 
 [dependencies]
 re_build_info.workspace = true


### PR DESCRIPTION
### What

As the title says ☝🏻. Shaves some compilation time.

For some reason, `web_viewer` requires `rerun/sdk`, so it's enabled in that case.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4289) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4289)
- [Docs preview](https://rerun.io/preview/7b62b1b23119699c42dff77fa0954ff3fd7e8eda/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7b62b1b23119699c42dff77fa0954ff3fd7e8eda/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)