### PR TITLE
Mitigate perf issue in tree-ui by using the DataQuery ResultTree

### DIFF
--- a/crates/re_space_view/src/data_query.rs
+++ b/crates/re_space_view/src/data_query.rs
@@ -22,9 +22,14 @@ impl DataResultTree {
         }
     }
 
-    /// Look up a node in the tree based on its handle.
-    pub fn lookup(&self, handle: DataResultHandle) -> Option<&DataResult> {
+    /// Look up a [`DataResult`] in the tree based on its handle.
+    pub fn lookup_result(&self, handle: DataResultHandle) -> Option<&DataResult> {
         self.data_results.get(handle).map(|node| &node.data_result)
+    }
+
+    /// Look up a [`DataResultNode`] in the tree based on its handle.
+    pub fn lookup_node(&self, handle: DataResultHandle) -> Option<&DataResultNode> {
+        self.data_results.get(handle)
     }
 
     fn visit_recursive(

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -400,7 +400,7 @@ mod tests {
 
             let mut visited = vec![];
             result_tree.visit(&mut |handle| {
-                let result = result_tree.lookup(handle).unwrap();
+                let result = result_tree.lookup_result(handle).unwrap();
                 if result.is_group && result.entity_path != EntityPath::root() {
                     visited.push(format!("{}/", result.entity_path));
                 } else {

--- a/crates/re_space_view/src/space_view_contents.rs
+++ b/crates/re_space_view/src/space_view_contents.rs
@@ -183,6 +183,15 @@ impl SpaceViewContents {
         }
     }
 
+    #[inline]
+    /// Looks up the group handle for an entity path.
+    pub fn group_handle_for_entity_path(
+        &self,
+        path: &EntityPath,
+    ) -> Option<DataBlueprintGroupHandle> {
+        self.path_to_group.get(path).cloned()
+    }
+
     pub fn contains_entity(&self, path: &EntityPath) -> bool {
         // If an entity is in path_to_group it is *likely* also an entity in the Space View.
         // However, it could be that the path *only* refers to a group, not also an entity.

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -247,7 +247,7 @@ impl SpaceViewBlueprint {
             re_tracing::profile_scope!("per_system_data_results");
 
             data_results.visit(&mut |handle| {
-                if let Some(result) = data_results.lookup(handle) {
+                if let Some(result) = data_results.lookup_result(handle) {
                     for system in &result.view_parts {
                         per_system_data_results
                             .entry(*system)
@@ -449,7 +449,7 @@ mod tests {
     ) -> Option<&'a DataResult> {
         let mut return_result = None;
         tree.visit(&mut |handle| {
-            if let Some(result) = tree.lookup(handle) {
+            if let Some(result) = tree.lookup_result(handle) {
                 if result.entity_path == *path && result.is_group == is_group {
                     return_result = Some(result);
                 }


### PR DESCRIPTION
### What
Walk the DataResultTree directly rather than walking the SpaceViewContents and calling `resolve` on each path. This is important for big trees such as OPF.

It is still not as optimized as working with the pre-built data-groups we had before, but is a significant improvement.

In a future refactor we will consolidate query-execution so we can use the same query results as used by the space-view itself.

Profiling:

Original (before introducing DataQuery interface):
![image](https://github.com/rerun-io/rerun/assets/3312232/6e5b617e-c896-481e-8810-316bb852eea4)

Before (after initial migration to DataQuery, sloppily using resolve in a bunch of places):
![image](https://github.com/rerun-io/rerun/assets/3312232/20620a04-1d84-4ca6-9bd1-2155b87fc635)

After (single tree-build / walk of the result tree):
![image](https://github.com/rerun-io/rerun/assets/3312232/d9381771-ccad-4492-be21-d490a73fd21a)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4294) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4294)
- [Docs preview](https://rerun.io/preview/81236d9a4610367e3e4190bdd8d71374e9fc8b69/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/81236d9a4610367e3e4190bdd8d71374e9fc8b69/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)