### PR TITLE
Silence spammy blueprint warnings and validate blueprint on load

### DIFF
--- a/crates/re_log/src/lib.rs
+++ b/crates/re_log/src/lib.rs
@@ -30,7 +30,7 @@ pub use tracing::{debug, error, info, trace, warn};
 // The `re_log::info_once!(…)` etc are nice helpers, but the `log-once` crate is a bit lacking.
 // In the future we should implement our own macros to de-duplicate based on the callsite,
 // similar to how the log console in a browser will automatically suppress duplicates.
-pub use log_once::{debug_once, error_once, info_once, trace_once, warn_once};
+pub use log_once::{debug_once, error_once, info_once, log_once, trace_once, warn_once};
 
 pub use {
     channel_logger::*,

--- a/crates/re_viewer/src/app_blueprint.rs
+++ b/crates/re_viewer/src/app_blueprint.rs
@@ -130,6 +130,6 @@ fn load_panel_state(path: &EntityPath, blueprint_db: &re_data_store::StoreDb) ->
     re_tracing::profile_function!();
     blueprint_db
         .store()
-        .query_timeless_component::<PanelView>(path)
+        .query_timeless_component_quiet::<PanelView>(path)
         .map(|p| p.is_expanded)
 }

--- a/crates/re_viewer/src/blueprint_validation.rs
+++ b/crates/re_viewer/src/blueprint_validation.rs
@@ -16,7 +16,7 @@ fn validate_component<C: Component>(blueprint: &StoreDb) -> bool {
         if data_type != &C::arrow_datatype() {
             // If the schemas don't match, we definitely have a problem
             re_log::debug!(
-                "Unexpected datatype for component {:?}.\nFound: {:?}\nExpected: {:?}",
+                "Unexpected datatype for component {:?}.\nFound: {:#?}\nExpected: {:#?}",
                 C::name(),
                 data_type,
                 C::arrow_datatype()

--- a/crates/re_viewer/src/blueprint_validation.rs
+++ b/crates/re_viewer/src/blueprint_validation.rs
@@ -1,0 +1,62 @@
+use re_arrow_store::LatestAtQuery;
+use re_data_store::{EntityPropertiesComponent, StoreDb};
+use re_log_types::Timeline;
+use re_types_core::Component;
+use re_viewport::{
+    blueprint::{AutoSpaceViews, SpaceViewComponent, SpaceViewMaximized, ViewportLayout},
+    external::re_space_view::QueryExpressions,
+};
+
+use crate::blueprint::PanelView;
+
+fn validate_component<C: Component>(blueprint: &StoreDb) -> bool {
+    let query = LatestAtQuery::latest(Timeline::default());
+
+    if let Some(data_type) = blueprint.entity_db().data_store.lookup_datatype(&C::name()) {
+        if data_type != &C::arrow_datatype() {
+            // If the schemas don't match, we definitely have a problem
+            re_log::debug!(
+                "Unexpected datatype for component {:?}.\nFound: {:?}\nExpected: {:?}",
+                C::name(),
+                data_type,
+                C::arrow_datatype()
+            );
+            return false;
+        } else {
+            // Otherwise, our usage of serde-fields means we still might have a problem
+            // this can go away once we stop using serde-fields.
+            // Walk the blueprint and see if any cells fail to deserialize for this component type.
+            for path in blueprint.entity_db().entity_paths() {
+                if let Some([Some(cell)]) = blueprint
+                    .entity_db()
+                    .data_store
+                    .latest_at(&query, path, C::name(), &[C::name()])
+                    .map(|(_, cells)| cells)
+                {
+                    if let Err(err) = cell.try_to_native_mono::<C>() {
+                        re_log::debug!(
+                            "Failed to deserialize component {:?}: {:?}",
+                            C::name(),
+                            err
+                        );
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+    true
+}
+
+/// Because blueprints are both read and written the schema must match what
+/// we expect to find or else we will run into all kinds of problems.
+pub fn is_valid_blueprint(blueprint: &StoreDb) -> bool {
+    // TODO(jleibs): Generate this from codegen.
+    validate_component::<AutoSpaceViews>(blueprint)
+        && validate_component::<EntityPropertiesComponent>(blueprint)
+        && validate_component::<PanelView>(blueprint)
+        && validate_component::<QueryExpressions>(blueprint)
+        && validate_component::<SpaceViewComponent>(blueprint)
+        && validate_component::<SpaceViewMaximized>(blueprint)
+        && validate_component::<ViewportLayout>(blueprint)
+}

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -7,6 +7,7 @@ mod app;
 mod app_blueprint;
 mod app_state;
 mod background_tasks;
+#[cfg(not(target_arch = "wasm32"))]
 mod blueprint_validation;
 pub mod env_vars;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -7,6 +7,7 @@ mod app;
 mod app_blueprint;
 mod app_state;
 mod background_tasks;
+mod blueprint_validation;
 pub mod env_vars;
 #[cfg(not(target_arch = "wasm32"))]
 mod loading;

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -360,7 +360,7 @@ impl SpaceViewBlueprint {
         let individual_properties = ctx
             .blueprint
             .store()
-            .query_timeless_component::<EntityPropertiesComponent>(&self.entity_path())
+            .query_timeless_component_quiet::<EntityPropertiesComponent>(&self.entity_path())
             .map(|result| result.value.props);
 
         let resolved_properties = individual_properties.clone().unwrap_or_else(|| {
@@ -401,7 +401,7 @@ impl SpaceViewBlueprint {
             tree.visit_children_recursively(&mut |path: &EntityPath| {
                 if let Some(props) = blueprint
                     .store()
-                    .query_timeless_component::<EntityPropertiesComponent>(path)
+                    .query_timeless_component_quiet::<EntityPropertiesComponent>(path)
                 {
                     let overridden_path =
                         EntityPath::from(&path.as_slice()[props_path.len()..path.len()]);

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -334,7 +334,7 @@ pub fn load_space_view_blueprint(
 
     let mut space_view = blueprint_db
         .store()
-        .query_timeless_component::<SpaceViewComponent>(path)
+        .query_timeless_component_quiet::<SpaceViewComponent>(path)
         .map(|c| c.value.space_view);
 
     // Blueprint data migrations can leave us unable to parse the expected id from the source-data
@@ -374,7 +374,7 @@ pub fn load_viewport_blueprint(blueprint_db: &re_data_store::StoreDb) -> Viewpor
 
     let auto_space_views = blueprint_db
         .store()
-        .query_timeless_component::<AutoSpaceViews>(&VIEWPORT_PATH.into())
+        .query_timeless_component_quiet::<AutoSpaceViews>(&VIEWPORT_PATH.into())
         .map_or_else(
             || {
                 // Only enable auto-space-views if this is the app-default blueprint
@@ -389,13 +389,13 @@ pub fn load_viewport_blueprint(blueprint_db: &re_data_store::StoreDb) -> Viewpor
 
     let space_view_maximized = blueprint_db
         .store()
-        .query_timeless_component::<SpaceViewMaximized>(&VIEWPORT_PATH.into())
+        .query_timeless_component_quiet::<SpaceViewMaximized>(&VIEWPORT_PATH.into())
         .map(|space_view| space_view.value)
         .unwrap_or_default();
 
     let viewport_layout: ViewportLayout = blueprint_db
         .store()
-        .query_timeless_component::<ViewportLayout>(&VIEWPORT_PATH.into())
+        .query_timeless_component_quiet::<ViewportLayout>(&VIEWPORT_PATH.into())
         .map(|space_view| space_view.value)
         .unwrap_or_default();
 


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/4299

Adding a helper to silence the error messages only solved half the problem. Nothing prevented this corrupt data from being removed from the store, and worse, in some cases the corrupt data subsequently prevented new writes.

We now validate that all the data in the blueprint has a valid schema or else we refuse to load it.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4303) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4303)
- [Docs preview](https://rerun.io/preview/5a85ed646d8a7c585804909613689c461fa0929e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5a85ed646d8a7c585804909613689c461fa0929e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)