### PR TITLE
All C++ datatypes & components now implement a new Loggable trait

### DIFF
--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1346,7 +1346,7 @@ fn archetype_serialize(type_ident: &Ident, obj: &Object, hpp_includes: &mut Incl
             #(#push_batches)*
             {
                 auto indicator = #type_ident::IndicatorComponent();
-                auto result = #type_ident::IndicatorComponent::to_data_cell(&indicator, 1);
+                auto result = Loggable<#type_ident::IndicatorComponent>::to_data_cell(&indicator, 1);
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -22,6 +22,21 @@ use self::method::{Method, MethodDeclaration};
 
 use super::common::ExampleInfo;
 
+trait CppObjectExtensions {
+    fn namespace_ident(&self) -> Ident;
+    fn ident(&self) -> Ident;
+}
+
+impl CppObjectExtensions for Object {
+    fn namespace_ident(&self) -> Ident {
+        format_ident!("{}", self.kind.plural_snake_case())
+    }
+
+    fn ident(&self) -> Ident {
+        format_ident!("{}", self.name) // The PascalCase name of the object type.
+    }
+}
+
 // Special strings we insert as tokens, then search-and-replace later.
 // This is so that we can insert comments and whitespace into the generated code.
 // `TokenStream` ignores whitespace (including comments), but we can insert "quoted strings",
@@ -339,7 +354,7 @@ impl QuotedObject {
         mut hpp_includes: Includes,
         hpp_type_extensions: &TokenStream,
     ) -> QuotedObject {
-        let type_ident = format_ident!("{}", &obj.name); // The PascalCase name of the object type.
+        let type_ident = obj.ident();
         let quoted_docs = quote_obj_docs(obj);
 
         let mut cpp_includes = Includes::new(obj.fqname.clone());
@@ -369,8 +384,6 @@ impl QuotedObject {
             })
             .collect_vec();
 
-        let (constants_hpp, constants_cpp) =
-            quote_constants_header_and_cpp(obj, objects, &type_ident);
         let mut methods = Vec::new();
 
         let required_component_fields = obj
@@ -468,22 +481,14 @@ impl QuotedObject {
         let serialize_cpp =
             serialize_method.to_cpp_tokens(&quote!(AsComponents<archetypes::#type_ident>));
 
-        let hpp_method_section = if methods.is_empty() {
-            quote! {}
-        } else {
-            let methods_hpp = methods.iter().map(|m| m.to_hpp_tokens());
-            // TODO(andreas): We should consider optimizing the move ctor - there's a lot of component batches to move.
-            quote! {
-                public:
-                    #type_ident() = default;
-                    #type_ident(#type_ident&& other) = default;
-                    #NEWLINE_TOKEN
-                    #NEWLINE_TOKEN
-                    #(#methods_hpp)*
-            }
-        };
+        let methods_hpp = methods.iter().map(|m| m.to_hpp_tokens());
+        let methods_cpp = methods
+            .iter()
+            .map(|m| m.to_cpp_tokens(&quote!(#type_ident)));
 
         let indicator_comment = quote_doc_comment("Indicator component, used to identify the archetype when converting to a list of components.");
+        let indicator_fqname =
+            format!("{}Indicator", obj.fqname).replace("archetypes", "components");
         let doc_hide_comment = quote_hide_from_docs();
 
         let hpp = quote! {
@@ -494,15 +499,21 @@ impl QuotedObject {
                 struct #type_ident {
                     #(#field_declarations;)*
 
-                    #(#constants_hpp;)*
-
+                public:
+                    static constexpr const char IndicatorComponentName[] = #indicator_fqname;
+                    #NEWLINE_TOKEN
                     #NEWLINE_TOKEN
                     #indicator_comment
-                    using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+                    using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
                     #hpp_type_extensions
 
-                    #hpp_method_section
+                public:
+                    #type_ident() = default;
+                    #type_ident(#type_ident&& other) = default;
+                    #NEWLINE_TOKEN
+                    #NEWLINE_TOKEN
+                    #(#methods_hpp)*
                 };
                 #NEWLINE_TOKEN
                 #NEWLINE_TOKEN
@@ -522,15 +533,10 @@ impl QuotedObject {
             }
         };
 
-        let methods_cpp = methods
-            .iter()
-            .map(|m| m.to_cpp_tokens(&quote!(#type_ident)));
         let cpp = quote! {
             #cpp_includes
 
             namespace rerun::archetypes {
-                #(#constants_cpp;)*
-
                 #(#methods_cpp)*
             }
 
@@ -550,8 +556,8 @@ impl QuotedObject {
         mut hpp_includes: Includes,
         hpp_type_extensions: &TokenStream,
     ) -> QuotedObject {
-        let namespace_ident = format_ident!("{}", obj.kind.plural_snake_case()); // `datatypes` or `components`
-        let type_ident = format_ident!("{}", &obj.name); // The PascalCase name of the object type.
+        let namespace_ident = obj.namespace_ident();
+        let type_ident = obj.ident();
         let quoted_docs = quote_obj_docs(obj);
 
         let mut cpp_includes = Includes::new(obj.fqname.clone());
@@ -573,15 +579,12 @@ impl QuotedObject {
             })
             .collect_vec();
 
-        let (constants_hpp, constants_cpp) =
-            quote_constants_header_and_cpp(obj, objects, &type_ident);
         let mut methods = Vec::new();
 
         if obj.fields.len() == 1 && !obj.is_attr_set(ATTR_CPP_NO_FIELD_CTORS) {
             methods.extend(single_field_constructor_methods(
                 obj,
                 &mut hpp_includes,
-                &type_ident,
                 objects,
             ));
         };
@@ -611,44 +614,19 @@ impl QuotedObject {
             }
         }
 
-        // Arrow serialization methods.
-        // TODO(andreas): These are just utilities for to_data_cell. How do we hide them best from the public header?
-        methods.push(arrow_data_type_method(
+        let methods_hpp = methods.iter().map(|m| m.to_hpp_tokens());
+        let methods_cpp = methods
+            .iter()
+            .map(|m| m.to_cpp_tokens(&quote!(#type_ident)));
+
+        let (hpp_loggable, cpp_loggable) = quote_loggable_hpp_and_cpp(
             obj,
             objects,
             &mut hpp_includes,
             &mut cpp_includes,
             &mut hpp_declarations,
-        ));
-        methods.push(fill_arrow_array_builder_method(
-            obj,
-            &type_ident,
-            &mut cpp_includes,
-            &mut hpp_declarations,
-            objects,
-        ));
+        );
 
-        if obj.kind == ObjectKind::Component {
-            methods.push(component_to_data_cell_method(
-                &type_ident,
-                obj,
-                objects,
-                &mut hpp_includes,
-            ));
-        }
-
-        let hpp_method_section = if methods.is_empty() {
-            quote! {}
-        } else {
-            let methods_hpp = methods.iter().map(|m| m.to_hpp_tokens());
-            quote! {
-                public:
-                    #type_ident() = default;
-                    #NEWLINE_TOKEN
-                    #NEWLINE_TOKEN
-                    #(#methods_hpp)*
-            }
-        };
         let hpp = quote! {
             #hpp_includes
 
@@ -659,26 +637,26 @@ impl QuotedObject {
                 struct #type_ident {
                     #(#field_declarations;)*
 
-                    #(#constants_hpp;)*
-
                     #hpp_type_extensions
 
-                    #hpp_method_section
+                public:
+                    #type_ident() = default;
+                    #NEWLINE_TOKEN
+                    #NEWLINE_TOKEN
+                    #(#methods_hpp)*
                 };
             }
-        };
 
-        let methods_cpp = methods
-            .iter()
-            .map(|m| m.to_cpp_tokens(&quote!(#type_ident)));
+            #hpp_loggable
+        };
         let cpp = quote! {
             #cpp_includes
 
             namespace rerun::#namespace_ident {
-                #(#constants_cpp;)*
-
                 #(#methods_cpp)*
             }
+
+            #cpp_loggable
         };
 
         Self { hpp, cpp }
@@ -714,9 +692,9 @@ impl QuotedObject {
             "Union archetypes are not supported {}",
             obj.fqname
         );
-        let namespace_ident = format_ident!("{}", obj.kind.plural_snake_case()); // `datatypes` or `components`
+        let namespace_ident = obj.namespace_ident();
         let pascal_case_name = &obj.name;
-        let pascal_case_ident = format_ident!("{pascal_case_name}"); // The PascalCase name of the object type.
+        let pascal_case_ident = obj.ident();
         let quoted_docs = quote_obj_docs(obj);
 
         let tag_typename = format_ident!("{pascal_case_name}Tag");
@@ -764,8 +742,6 @@ impl QuotedObject {
             })
             .collect_vec();
 
-        let (constants_hpp, constants_cpp) =
-            quote_constants_header_and_cpp(obj, objects, &pascal_case_ident);
         let mut methods = Vec::new();
 
         if !obj.is_attr_set(ATTR_CPP_NO_FIELD_CTORS) {
@@ -828,21 +804,6 @@ impl QuotedObject {
                 inline: true,
             });
         }
-
-        methods.push(arrow_data_type_method(
-            obj,
-            objects,
-            &mut hpp_includes,
-            &mut cpp_includes,
-            &mut hpp_declarations,
-        ));
-        methods.push(fill_arrow_array_builder_method(
-            obj,
-            &pascal_case_ident,
-            &mut cpp_includes,
-            &mut hpp_declarations,
-            objects,
-        ));
 
         let destructor = if obj.has_default_destructor(objects) {
             // No destructor needed
@@ -976,6 +937,14 @@ impl QuotedObject {
         let swap_comment = quote_comment("This bitwise swap would fail for self-referential types, but we don't have any of those.");
         let hide_from_docs_comment = quote_hide_from_docs();
 
+        let (hpp_loggable, cpp_loggable) = quote_loggable_hpp_and_cpp(
+            obj,
+            objects,
+            &mut hpp_includes,
+            &mut cpp_includes,
+            &mut hpp_declarations,
+        );
+
         let methods_hpp = methods.iter().map(|m| m.to_hpp_tokens());
         let hpp = quote! {
             #hpp_includes
@@ -1016,8 +985,6 @@ impl QuotedObject {
 
                 #quoted_docs
                 struct #pascal_case_ident {
-                    #(#constants_hpp;)*
-
                     #pascal_case_ident() : _tag(detail::#tag_typename::None) {}
 
                     #copy_constructor
@@ -1055,11 +1022,19 @@ impl QuotedObject {
 
                     #(#methods_hpp)*
 
+                    #hide_from_docs_comment
+                    const detail::#data_typename& get_union_data() const { return _data; }
+
+                    #hide_from_docs_comment
+                    detail::#tag_typename get_union_tag() const { return _tag; }
+
                 private:
                     detail::#tag_typename _tag;
                     detail::#data_typename _data;
                 };
             }
+
+            #hpp_loggable
         };
 
         let cpp_methods = methods
@@ -1068,11 +1043,11 @@ impl QuotedObject {
         let cpp = quote! {
             #cpp_includes
 
-            #(#constants_cpp;)*
-
             namespace rerun::#namespace_ident {
                 #(#cpp_methods)*
             }
+
+            #cpp_loggable
         };
 
         Self { hpp, cpp }
@@ -1082,13 +1057,13 @@ impl QuotedObject {
 fn single_field_constructor_methods(
     obj: &Object,
     hpp_includes: &mut Includes,
-    type_ident: &Ident,
     objects: &Objects,
 ) -> Vec<Method> {
     let field = &obj.fields[0];
+    let type_ident = obj.ident();
 
     let mut methods =
-        add_copy_assignment_and_constructor(hpp_includes, field, field, type_ident, objects);
+        add_copy_assignment_and_constructor(hpp_includes, field, field, &type_ident, objects);
 
     // If the field is a custom type as well which in turn has only a single field,
     // provide a constructor for that single field as well.
@@ -1102,7 +1077,7 @@ fn single_field_constructor_methods(
                 hpp_includes,
                 &field_type_obj.fields[0],
                 field,
-                type_ident,
+                &type_ident,
                 objects,
             ));
         }
@@ -1204,7 +1179,6 @@ fn arrow_data_type_method(
 
 fn fill_arrow_array_builder_method(
     obj: &Object,
-    type_ident: &Ident,
     cpp_includes: &mut Includes,
     hpp_declarations: &mut ForwardDecls,
     objects: &Objects,
@@ -1214,8 +1188,10 @@ fn fill_arrow_array_builder_method(
     let builder = format_ident!("builder");
     let arrow_builder_type = arrow_array_builder_type_object(obj, objects, hpp_declarations);
 
-    let fill_builder =
-        quote_fill_arrow_array_builder(type_ident, obj, objects, &builder, cpp_includes);
+    let fill_builder = quote_fill_arrow_array_builder(obj, objects, &builder, cpp_includes);
+
+    let type_ident = obj.ident();
+    let namespace_ident = obj.namespace_ident();
 
     Method {
         docs: "Fills an arrow array builder with an array of this type.".into(),
@@ -1224,7 +1200,7 @@ fn fill_arrow_array_builder_method(
             return_type: quote! { rerun::Error },
             // TODO(andreas): Pass in validity map.
             name_and_parameters: quote! {
-                fill_arrow_array_builder(arrow::#arrow_builder_type* #builder, const #type_ident* elements, size_t num_elements)
+                fill_arrow_array_builder(arrow::#arrow_builder_type* #builder, const #namespace_ident::#type_ident* elements, size_t num_elements)
             },
         },
         definition_body: quote! {
@@ -1237,12 +1213,7 @@ fn fill_arrow_array_builder_method(
     }
 }
 
-fn component_to_data_cell_method(
-    type_ident: &Ident,
-    obj: &Object,
-    objects: &Objects,
-    hpp_includes: &mut Includes,
-) -> Method {
+fn to_data_cell_method(obj: &Object, objects: &Objects, hpp_includes: &mut Includes) -> Method {
     hpp_includes.insert_system("memory"); // std::shared_ptr
     hpp_includes.insert_rerun("data_cell.hpp");
     hpp_includes.insert_rerun("result.hpp");
@@ -1253,13 +1224,16 @@ fn component_to_data_cell_method(
     let arrow_builder_type =
         arrow_array_builder_type_object(obj, objects, &mut ForwardDecls::default());
 
+    let type_ident = obj.ident();
+    let namespace_ident = obj.namespace_ident();
+
     Method {
-        docs: format!("Creates a Rerun DataCell from an array of {type_ident} components.").into(),
+        docs: format!("Creates a Rerun DataCell from an array of `rerun::{namespace_ident}::{type_ident}` components.").into(),
         declaration: MethodDeclaration {
             is_static: true,
             return_type: quote! { Result<rerun::DataCell> },
             name_and_parameters: quote! {
-                to_data_cell(const #type_ident* instances, size_t num_instances)
+                to_data_cell(const #namespace_ident::#type_ident* instances, size_t num_instances)
             },
         },
         definition_body: quote! {
@@ -1271,7 +1245,7 @@ fn component_to_data_cell_method(
             #NEWLINE_TOKEN
             ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
             if (instances && num_instances > 0) {
-                RR_RETURN_NOT_OK(#type_ident::fill_arrow_array_builder(
+                RR_RETURN_NOT_OK(Loggable<#namespace_ident::#type_ident>::fill_arrow_array_builder(
                     static_cast<arrow::#arrow_builder_type*>(builder.get()),
                     instances,
                     num_instances
@@ -1282,7 +1256,7 @@ fn component_to_data_cell_method(
             #NEWLINE_TOKEN
             #NEWLINE_TOKEN
             // Lazily register component type.
-            static const Result<ComponentTypeHandle> component_type = ComponentType(NAME, datatype).register_component();
+            static const Result<ComponentTypeHandle> component_type = ComponentType(Name, datatype).register_component();
             RR_RETURN_NOT_OK(component_type.error);
             #NEWLINE_TOKEN
             #NEWLINE_TOKEN
@@ -1325,14 +1299,14 @@ fn archetype_serialize(type_ident: &Ident, obj: &Object, hpp_includes: &mut Incl
             if field.is_nullable {
                 quote! {
                     if (#field_accessor.has_value()) {
-                        auto result = #field_type::to_data_cell(#field_accessor.value().data(), #field_accessor.value().size());
+                        auto result = Loggable<#field_type>::to_data_cell(#field_accessor.value().data(), #field_accessor.value().size());
                         #emplace_back
                     }
                 }
             } else {
                 quote! {
                     {
-                        auto result = #field_type::to_data_cell(#field_accessor.data(), #field_accessor.size());
+                        auto result = Loggable<#field_type>::to_data_cell(#field_accessor.data(), #field_accessor.size());
                         #emplace_back
                     }
                 }
@@ -1340,14 +1314,14 @@ fn archetype_serialize(type_ident: &Ident, obj: &Object, hpp_includes: &mut Incl
         } else if field.is_nullable {
             quote! {
                 if (#field_accessor.has_value()) {
-                    auto result = #field_type::to_data_cell(&#field_accessor.value(), 1);
+                    auto result = Loggable<#field_type>::to_data_cell(&#field_accessor.value(), 1);
                     #emplace_back
                 }
             }
         } else {
             quote! {
                 {
-                    auto result = #field_type::to_data_cell(&#field_accessor, 1);
+                    auto result = Loggable<#field_type>::to_data_cell(&#field_accessor, 1);
                     #emplace_back
                 }
             }
@@ -1385,12 +1359,14 @@ fn archetype_serialize(type_ident: &Ident, obj: &Object, hpp_includes: &mut Incl
 }
 
 fn quote_fill_arrow_array_builder(
-    type_ident: &Ident,
     obj: &Object,
     objects: &Objects,
     builder: &Ident,
     includes: &mut Includes,
 ) -> TokenStream {
+    let type_ident = obj.ident();
+    let namespace_ident = obj.namespace_ident();
+
     let parameter_check = quote! {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -1418,8 +1394,8 @@ fn quote_fill_arrow_array_builder(
                 // Trivial forwarding to inner type.
                 let quoted_fqname = quote_fqname_as_type_path(includes, fqname);
                 quote! {
-                    static_assert(sizeof(#quoted_fqname) == sizeof(#type_ident));
-                    RR_RETURN_NOT_OK(#quoted_fqname::fill_arrow_array_builder(
+                    static_assert(sizeof(#quoted_fqname) == sizeof(#namespace_ident::#type_ident));
+                    RR_RETURN_NOT_OK(Loggable<#quoted_fqname>::fill_arrow_array_builder(
                         builder, reinterpret_cast<const #quoted_fqname*>(elements), num_elements
                     ));
                 }
@@ -1459,7 +1435,6 @@ fn quote_fill_arrow_array_builder(
             }
             ObjectSpecifics::Union { .. } => {
                 let variant_builder = format_ident!("variant_builder");
-                let tag_name = format_ident!("{}Tag", type_ident);
 
                 let tag_cases = obj.fields
                 .iter()
@@ -1483,10 +1458,10 @@ fn quote_fill_arrow_array_builder(
                                     ARROW_RETURN_NOT_OK(variant_builder->Append());
                                     auto value_builder =
                                         static_cast<arrow::HalfFloatBuilder *>(variant_builder->value_builder());
-                                    const rerun::half* values = union_instance._data.#field_name.data();
+                                    const rerun::half* values = union_instance.get_union_data().#field_name.data();
                                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
                                         reinterpret_cast<const uint16_t*>(values),
-                                        static_cast<int64_t>(union_instance._data.#field_name.size())
+                                        static_cast<int64_t>(union_instance.get_union_data().#field_name.size())
                                     ));
                                 }
                             } else {
@@ -1516,8 +1491,8 @@ fn quote_fill_arrow_array_builder(
                                         auto value_builder =
                                             static_cast<arrow::#typ_builder_ident *>(variant_builder->value_builder());
                                         ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                                            union_instance._data.#field_name.data(),
-                                            static_cast<int64_t>(union_instance._data.#field_name.size())
+                                            union_instance.get_union_data().#field_name.data(),
+                                            static_cast<int64_t>(union_instance.get_union_data().#field_name.size())
                                         ));
                                     }
                                 } else {
@@ -1536,32 +1511,37 @@ fn quote_fill_arrow_array_builder(
                             }
                         }
                     } else {
-                        let variant_accessor = quote!(union_instance._data);
+                        let variant_accessor = quote!(union_instance.get_union_data());
                         quote_append_single_field_to_builder(variant, &variant_builder, &variant_accessor, includes)
                     };
 
                     quote! {
-                        case detail::#tag_name::#variant_name: {
+                        case TagType::#variant_name: {
                             auto #variant_builder = static_cast<arrow::#arrow_builder_type*>(variant_builder_untyped);
                             #variant_append
                         } break;
                     }
                 });
 
+                let tag_name = format_ident!("{}Tag", type_ident);
+
                 quote! {
                     #parameter_check
                     ARROW_RETURN_NOT_OK(#builder->Reserve(static_cast<int64_t>(num_elements)));
                     for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                         const auto& union_instance = elements[elem_idx];
-                        ARROW_RETURN_NOT_OK(#builder->Append(static_cast<int8_t>(union_instance._tag)));
+                        ARROW_RETURN_NOT_OK(#builder->Append(static_cast<int8_t>(union_instance.get_union_tag())));
                         #NEWLINE_TOKEN
                         #NEWLINE_TOKEN
-                        auto variant_index = static_cast<int>(union_instance._tag);
+                        auto variant_index = static_cast<int>(union_instance.get_union_tag());
                         auto variant_builder_untyped = builder->child_builder(variant_index).get();
                         #NEWLINE_TOKEN
                         #NEWLINE_TOKEN
-                        switch (union_instance._tag) {
-                            case detail::#tag_name::None: {
+
+                        using TagType = #namespace_ident::detail::#tag_name;
+
+                        switch (union_instance.get_union_tag()) {
+                            case TagType::None: {
                                 ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                             } break;
                             #(#tag_cases)*
@@ -1789,7 +1769,7 @@ fn quote_append_single_value_to_builder(
                     let field_ptr_accessor = quote_field_ptr_access(typ, value_access);
                     quote! {
                         if (#field_ptr_accessor) {
-                            RR_RETURN_NOT_OK(#fqname::fill_arrow_array_builder(#value_builder, #field_ptr_accessor, #num_items_per_element));
+                            RR_RETURN_NOT_OK(Loggable<#fqname>::fill_arrow_array_builder(#value_builder, #field_ptr_accessor, #num_items_per_element));
                         }
                     }
                 }
@@ -1797,7 +1777,7 @@ fn quote_append_single_value_to_builder(
         }
         Type::Object(fqname) => {
             let fqname = quote_fqname_as_type_path(includes, fqname);
-            quote!(RR_RETURN_NOT_OK(#fqname::fill_arrow_array_builder(#value_builder, &#value_access, 1));)
+            quote!(RR_RETURN_NOT_OK(Loggable<#fqname>::fill_arrow_array_builder(#value_builder, &#value_access, 1));)
         }
     }
 }
@@ -1867,45 +1847,6 @@ fn static_constructor_for_enum_type(
         },
         inline: true,
     }
-}
-
-fn quote_constants_header_and_cpp(
-    obj: &Object,
-    _objects: &Objects,
-    obj_type_ident: &Ident,
-) -> (Vec<TokenStream>, Vec<TokenStream>) {
-    let mut hpp = Vec::new();
-    let mut cpp = Vec::new();
-    match &obj.kind {
-        ObjectKind::Component => {
-            let fqname = &obj.fqname;
-            let comment = quote_doc_comment("Name of the component, used for serialization.");
-            hpp.push(quote! {
-                #NEWLINE_TOKEN
-                #NEWLINE_TOKEN
-                #comment
-                static const char NAME[]
-            });
-            cpp.push(quote!(const char #obj_type_ident::NAME[] = #fqname));
-        }
-        ObjectKind::Archetype => {
-            let indicator_fqname =
-                format!("{}Indicator", obj.fqname).replace("archetypes", "components");
-            let comment = quote_doc_comment("Name of the indicator component, used to identify the archetype when converting to a list of components.");
-            hpp.push(quote! {
-                #NEWLINE_TOKEN
-                #NEWLINE_TOKEN
-                #comment
-                static const char INDICATOR_COMPONENT_NAME[]
-            });
-            cpp.push(
-                quote!(const char #obj_type_ident::INDICATOR_COMPONENT_NAME[] = #indicator_fqname),
-            );
-        }
-        ObjectKind::Datatype | ObjectKind::Blueprint => {}
-    }
-
-    (hpp, cpp)
 }
 
 fn are_types_disjoint(fields: &[ObjectField]) -> bool {
@@ -2161,7 +2102,7 @@ fn quote_arrow_data_type(
             if !is_top_level_type {
                 // If we're not at the top level, we should have already a `arrow_datatype` method that we can relay to.
                 let quoted_fqname = quote_fqname_as_type_path(includes, fqname);
-                quote!(#quoted_fqname::arrow_datatype())
+                quote!(Loggable<#quoted_fqname>::arrow_datatype())
             } else if obj.is_arrow_transparent() {
                 quote_arrow_data_type(&obj.fields[0].typ, objects, includes, false)
             } else {
@@ -2212,4 +2153,66 @@ fn quote_arrow_elem_type(
     quote! {
         arrow::field("item", #datatype, false)
     }
+}
+
+fn quote_loggable_hpp_and_cpp(
+    obj: &Object,
+    objects: &Objects,
+    hpp_includes: &mut Includes,
+    cpp_includes: &mut Includes,
+    hpp_declarations: &mut ForwardDecls,
+) -> (TokenStream, TokenStream) {
+    assert!(obj.kind != ObjectKind::Archetype);
+
+    let namespace_ident = obj.namespace_ident();
+    let type_ident = obj.ident();
+    let fqname = &obj.fqname;
+
+    let mut methods = Vec::new();
+
+    methods.push(arrow_data_type_method(
+        obj,
+        objects,
+        hpp_includes,
+        cpp_includes,
+        hpp_declarations,
+    ));
+    methods.push(fill_arrow_array_builder_method(
+        obj,
+        cpp_includes,
+        hpp_declarations,
+        objects,
+    ));
+    methods.push(to_data_cell_method(obj, objects, hpp_includes));
+
+    let loggable_type_name = quote! { Loggable<#namespace_ident::#type_ident> };
+
+    let methods_hpp = methods.iter().map(|m| m.to_hpp_tokens());
+    let methods_cpp = methods.iter().map(|m| m.to_cpp_tokens(&loggable_type_name));
+    let hide_from_docs_comment = quote_hide_from_docs();
+
+    let hpp = quote! {
+        namespace rerun {
+            // Instead of including loggable.hpp, simply re-declare the template since it's trivial
+            template<typename T>
+            struct Loggable;
+
+            #hide_from_docs_comment
+            template<>
+            struct #loggable_type_name {
+                static constexpr const char Name[] = #fqname;
+                #NEWLINE_TOKEN
+                #NEWLINE_TOKEN
+                #(#methods_hpp)*
+            };
+        }
+    };
+
+    let cpp = quote! {
+        namespace rerun {
+            #(#methods_cpp)*
+        }
+    };
+
+    (hpp, cpp)
 }

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -339,7 +339,7 @@ impl QuotedObject {
                     Self::from_struct(objects, obj, hpp_includes, hpp_type_extensions)
                 }
                 ObjectKind::Archetype => {
-                    Self::from_archetype(objects, obj, hpp_includes, hpp_type_extensions)
+                    Self::from_archetype(obj, hpp_includes, hpp_type_extensions)
                 }
             },
             crate::ObjectSpecifics::Union { .. } => {
@@ -349,7 +349,6 @@ impl QuotedObject {
     }
 
     fn from_archetype(
-        objects: &Objects,
         obj: &Object,
         mut hpp_includes: Includes,
         hpp_type_extensions: &TokenStream,

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -2167,22 +2167,11 @@ fn quote_loggable_hpp_and_cpp(
     let type_ident = obj.ident();
     let fqname = &obj.fqname;
 
-    let mut methods = Vec::new();
-
-    methods.push(arrow_data_type_method(
-        obj,
-        objects,
-        hpp_includes,
-        cpp_includes,
-        hpp_declarations,
-    ));
-    methods.push(fill_arrow_array_builder_method(
-        obj,
-        cpp_includes,
-        hpp_declarations,
-        objects,
-    ));
-    methods.push(to_data_cell_method(obj, objects, hpp_includes));
+    let methods = vec![
+        arrow_data_type_method(obj, objects, hpp_includes, cpp_includes, hpp_declarations),
+        fill_arrow_array_builder_method(obj, cpp_includes, hpp_declarations, objects),
+        to_data_cell_method(obj, objects, hpp_includes),
+    ];
 
     let loggable_type_name = quote! { Loggable<#namespace_ident::#type_ident> };
 

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -5,10 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char AnnotationContext::INDICATOR_COMPONENT_NAME[] =
-        "rerun.components.AnnotationContextIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -20,7 +17,8 @@ namespace rerun {
         cells.reserve(2);
 
         {
-            auto result = rerun::components::AnnotationContext::to_data_cell(&archetype.context, 1);
+            auto result =
+                Loggable<rerun::components::AnnotationContext>::to_data_cell(&archetype.context, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -24,7 +24,8 @@ namespace rerun {
         }
         {
             auto indicator = AnnotationContext::IndicatorComponent();
-            auto result = AnnotationContext::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result =
+                Loggable<AnnotationContext::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -64,10 +64,12 @@ namespace rerun::archetypes {
         /// List of class descriptions, mapping class indices to class names, colors etc.
         rerun::components::AnnotationContext context;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] =
+            "rerun.components.AnnotationContextIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         AnnotationContext() = default;

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char Arrows3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Arrows3DIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,7 +17,7 @@ namespace rerun {
         cells.reserve(8);
 
         {
-            auto result = rerun::components::Vector3D::to_data_cell(
+            auto result = Loggable<rerun::components::Vector3D>::to_data_cell(
                 archetype.vectors.data(),
                 archetype.vectors.size()
             );
@@ -27,7 +25,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.origins.has_value()) {
-            auto result = rerun::components::Position3D::to_data_cell(
+            auto result = Loggable<rerun::components::Position3D>::to_data_cell(
                 archetype.origins.value().data(),
                 archetype.origins.value().size()
             );
@@ -35,7 +33,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radii.has_value()) {
-            auto result = rerun::components::Radius::to_data_cell(
+            auto result = Loggable<rerun::components::Radius>::to_data_cell(
                 archetype.radii.value().data(),
                 archetype.radii.value().size()
             );
@@ -43,7 +41,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.colors.has_value()) {
-            auto result = rerun::components::Color::to_data_cell(
+            auto result = Loggable<rerun::components::Color>::to_data_cell(
                 archetype.colors.value().data(),
                 archetype.colors.value().size()
             );
@@ -51,7 +49,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.labels.has_value()) {
-            auto result = rerun::components::Text::to_data_cell(
+            auto result = Loggable<rerun::components::Text>::to_data_cell(
                 archetype.labels.value().data(),
                 archetype.labels.value().size()
             );
@@ -59,7 +57,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = rerun::components::ClassId::to_data_cell(
+            auto result = Loggable<rerun::components::ClassId>::to_data_cell(
                 archetype.class_ids.value().data(),
                 archetype.class_ids.value().size()
             );
@@ -67,7 +65,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = rerun::components::InstanceKey::to_data_cell(
+            auto result = Loggable<rerun::components::InstanceKey>::to_data_cell(
                 archetype.instance_keys.value().data(),
                 archetype.instance_keys.value().size()
             );

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -74,7 +74,7 @@ namespace rerun {
         }
         {
             auto indicator = Arrows3D::IndicatorComponent();
-            auto result = Arrows3D::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<Arrows3D::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -91,10 +91,11 @@ namespace rerun::archetypes {
         /// Unique identifiers for each individual point in the batch.
         std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] = "rerun.components.Arrows3DIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         // Extensions to generated type defined in 'arrows3d_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/asset3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char Asset3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Asset3DIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,18 +17,20 @@ namespace rerun {
         cells.reserve(4);
 
         {
-            auto result = rerun::components::Blob::to_data_cell(&archetype.blob, 1);
+            auto result = Loggable<rerun::components::Blob>::to_data_cell(&archetype.blob, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.media_type.has_value()) {
-            auto result =
-                rerun::components::MediaType::to_data_cell(&archetype.media_type.value(), 1);
+            auto result = Loggable<rerun::components::MediaType>::to_data_cell(
+                &archetype.media_type.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.transform.has_value()) {
-            auto result = rerun::components::OutOfTreeTransform3D::to_data_cell(
+            auto result = Loggable<rerun::components::OutOfTreeTransform3D>::to_data_cell(
                 &archetype.transform.value(),
                 1
             );

--- a/rerun_cpp/src/rerun/archetypes/asset3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.cpp
@@ -39,7 +39,7 @@ namespace rerun {
         }
         {
             auto indicator = Asset3D::IndicatorComponent();
-            auto result = Asset3D::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<Asset3D::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -67,10 +67,11 @@ namespace rerun::archetypes {
         /// Applies a transformation to the asset itself without impacting its children.
         std::optional<rerun::components::OutOfTreeTransform3D> transform;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] = "rerun.components.Asset3DIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         // Extensions to generated type defined in 'asset3d_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
@@ -24,7 +24,7 @@ namespace rerun {
         }
         {
             auto indicator = BarChart::IndicatorComponent();
-            auto result = BarChart::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<BarChart::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char BarChart::INDICATOR_COMPONENT_NAME[] = "rerun.components.BarChartIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,7 +17,8 @@ namespace rerun {
         cells.reserve(2);
 
         {
-            auto result = rerun::components::TensorData::to_data_cell(&archetype.values, 1);
+            auto result =
+                Loggable<rerun::components::TensorData>::to_data_cell(&archetype.values, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -37,10 +37,11 @@ namespace rerun::archetypes {
         /// The values. Should always be a rank-1 tensor.
         rerun::components::TensorData values;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] = "rerun.components.BarChartIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         // Extensions to generated type defined in 'bar_chart_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char Boxes2D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Boxes2DIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,7 +17,7 @@ namespace rerun {
         cells.reserve(9);
 
         {
-            auto result = rerun::components::HalfSizes2D::to_data_cell(
+            auto result = Loggable<rerun::components::HalfSizes2D>::to_data_cell(
                 archetype.half_sizes.data(),
                 archetype.half_sizes.size()
             );
@@ -27,7 +25,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.centers.has_value()) {
-            auto result = rerun::components::Position2D::to_data_cell(
+            auto result = Loggable<rerun::components::Position2D>::to_data_cell(
                 archetype.centers.value().data(),
                 archetype.centers.value().size()
             );
@@ -35,7 +33,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.colors.has_value()) {
-            auto result = rerun::components::Color::to_data_cell(
+            auto result = Loggable<rerun::components::Color>::to_data_cell(
                 archetype.colors.value().data(),
                 archetype.colors.value().size()
             );
@@ -43,7 +41,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radii.has_value()) {
-            auto result = rerun::components::Radius::to_data_cell(
+            auto result = Loggable<rerun::components::Radius>::to_data_cell(
                 archetype.radii.value().data(),
                 archetype.radii.value().size()
             );
@@ -51,7 +49,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.labels.has_value()) {
-            auto result = rerun::components::Text::to_data_cell(
+            auto result = Loggable<rerun::components::Text>::to_data_cell(
                 archetype.labels.value().data(),
                 archetype.labels.value().size()
             );
@@ -59,13 +57,15 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.draw_order.has_value()) {
-            auto result =
-                rerun::components::DrawOrder::to_data_cell(&archetype.draw_order.value(), 1);
+            auto result = Loggable<rerun::components::DrawOrder>::to_data_cell(
+                &archetype.draw_order.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = rerun::components::ClassId::to_data_cell(
+            auto result = Loggable<rerun::components::ClassId>::to_data_cell(
                 archetype.class_ids.value().data(),
                 archetype.class_ids.value().size()
             );
@@ -73,7 +73,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = rerun::components::InstanceKey::to_data_cell(
+            auto result = Loggable<rerun::components::InstanceKey>::to_data_cell(
                 archetype.instance_keys.value().data(),
                 archetype.instance_keys.value().size()
             );

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
@@ -82,7 +82,7 @@ namespace rerun {
         }
         {
             auto indicator = Boxes2D::IndicatorComponent();
-            auto result = Boxes2D::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<Boxes2D::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -74,10 +74,11 @@ namespace rerun::archetypes {
         /// Unique identifiers for each individual boxes in the batch.
         std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] = "rerun.components.Boxes2DIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         // Extensions to generated type defined in 'boxes2d_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
@@ -82,7 +82,7 @@ namespace rerun {
         }
         {
             auto indicator = Boxes3D::IndicatorComponent();
-            auto result = Boxes3D::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<Boxes3D::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char Boxes3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Boxes3DIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,7 +17,7 @@ namespace rerun {
         cells.reserve(9);
 
         {
-            auto result = rerun::components::HalfSizes3D::to_data_cell(
+            auto result = Loggable<rerun::components::HalfSizes3D>::to_data_cell(
                 archetype.half_sizes.data(),
                 archetype.half_sizes.size()
             );
@@ -27,7 +25,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.centers.has_value()) {
-            auto result = rerun::components::Position3D::to_data_cell(
+            auto result = Loggable<rerun::components::Position3D>::to_data_cell(
                 archetype.centers.value().data(),
                 archetype.centers.value().size()
             );
@@ -35,7 +33,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.rotations.has_value()) {
-            auto result = rerun::components::Rotation3D::to_data_cell(
+            auto result = Loggable<rerun::components::Rotation3D>::to_data_cell(
                 archetype.rotations.value().data(),
                 archetype.rotations.value().size()
             );
@@ -43,7 +41,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.colors.has_value()) {
-            auto result = rerun::components::Color::to_data_cell(
+            auto result = Loggable<rerun::components::Color>::to_data_cell(
                 archetype.colors.value().data(),
                 archetype.colors.value().size()
             );
@@ -51,7 +49,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radii.has_value()) {
-            auto result = rerun::components::Radius::to_data_cell(
+            auto result = Loggable<rerun::components::Radius>::to_data_cell(
                 archetype.radii.value().data(),
                 archetype.radii.value().size()
             );
@@ -59,7 +57,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.labels.has_value()) {
-            auto result = rerun::components::Text::to_data_cell(
+            auto result = Loggable<rerun::components::Text>::to_data_cell(
                 archetype.labels.value().data(),
                 archetype.labels.value().size()
             );
@@ -67,7 +65,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = rerun::components::ClassId::to_data_cell(
+            auto result = Loggable<rerun::components::ClassId>::to_data_cell(
                 archetype.class_ids.value().data(),
                 archetype.class_ids.value().size()
             );
@@ -75,7 +73,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = rerun::components::InstanceKey::to_data_cell(
+            auto result = Loggable<rerun::components::InstanceKey>::to_data_cell(
                 archetype.instance_keys.value().data(),
                 archetype.instance_keys.value().size()
             );

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -85,10 +85,11 @@ namespace rerun::archetypes {
         /// Unique identifiers for each individual boxes in the batch.
         std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] = "rerun.components.Boxes3DIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         // Extensions to generated type defined in 'boxes3d_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/clear.cpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.cpp
@@ -26,7 +26,7 @@ namespace rerun {
         }
         {
             auto indicator = Clear::IndicatorComponent();
-            auto result = Clear::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<Clear::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/clear.cpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char Clear::INDICATOR_COMPONENT_NAME[] = "rerun.components.ClearIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,8 +17,10 @@ namespace rerun {
         cells.reserve(2);
 
         {
-            auto result =
-                rerun::components::ClearIsRecursive::to_data_cell(&archetype.is_recursive, 1);
+            auto result = Loggable<rerun::components::ClearIsRecursive>::to_data_cell(
+                &archetype.is_recursive,
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -73,10 +73,11 @@ namespace rerun::archetypes {
     struct Clear {
         rerun::components::ClearIsRecursive is_recursive;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] = "rerun.components.ClearIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         // Extensions to generated type defined in 'clear_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/depth_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.cpp
@@ -37,7 +37,7 @@ namespace rerun {
         }
         {
             auto indicator = DepthImage::IndicatorComponent();
-            auto result = DepthImage::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<DepthImage::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/depth_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char DepthImage::INDICATOR_COMPONENT_NAME[] = "rerun.components.DepthImageIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,18 +17,21 @@ namespace rerun {
         cells.reserve(4);
 
         {
-            auto result = rerun::components::TensorData::to_data_cell(&archetype.data, 1);
+            auto result = Loggable<rerun::components::TensorData>::to_data_cell(&archetype.data, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.meter.has_value()) {
-            auto result = rerun::components::DepthMeter::to_data_cell(&archetype.meter.value(), 1);
+            auto result =
+                Loggable<rerun::components::DepthMeter>::to_data_cell(&archetype.meter.value(), 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.draw_order.has_value()) {
-            auto result =
-                rerun::components::DrawOrder::to_data_cell(&archetype.draw_order.value(), 1);
+            auto result = Loggable<rerun::components::DrawOrder>::to_data_cell(
+                &archetype.draw_order.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -79,10 +79,12 @@ namespace rerun::archetypes {
         /// Objects with higher values are drawn on top of those with lower values.
         std::optional<rerun::components::DrawOrder> draw_order;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] =
+            "rerun.components.DepthImageIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         // Extensions to generated type defined in 'depth_image_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
@@ -5,10 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char DisconnectedSpace::INDICATOR_COMPONENT_NAME[] =
-        "rerun.components.DisconnectedSpaceIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -20,7 +17,7 @@ namespace rerun {
         cells.reserve(2);
 
         {
-            auto result = rerun::components::DisconnectedSpace::to_data_cell(
+            auto result = Loggable<rerun::components::DisconnectedSpace>::to_data_cell(
                 &archetype.disconnected_space,
                 1
             );

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.cpp
@@ -26,7 +26,8 @@ namespace rerun {
         }
         {
             auto indicator = DisconnectedSpace::IndicatorComponent();
-            auto result = DisconnectedSpace::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result =
+                Loggable<DisconnectedSpace::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -45,10 +45,12 @@ namespace rerun::archetypes {
     struct DisconnectedSpace {
         rerun::components::DisconnectedSpace disconnected_space;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] =
+            "rerun.components.DisconnectedSpaceIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         DisconnectedSpace() = default;

--- a/rerun_cpp/src/rerun/archetypes/image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image.cpp
@@ -31,7 +31,7 @@ namespace rerun {
         }
         {
             auto indicator = Image::IndicatorComponent();
-            auto result = Image::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<Image::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char Image::INDICATOR_COMPONENT_NAME[] = "rerun.components.ImageIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,13 +17,15 @@ namespace rerun {
         cells.reserve(3);
 
         {
-            auto result = rerun::components::TensorData::to_data_cell(&archetype.data, 1);
+            auto result = Loggable<rerun::components::TensorData>::to_data_cell(&archetype.data, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.draw_order.has_value()) {
-            auto result =
-                rerun::components::DrawOrder::to_data_cell(&archetype.draw_order.value(), 1);
+            auto result = Loggable<rerun::components::DrawOrder>::to_data_cell(
+                &archetype.draw_order.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -68,10 +68,11 @@ namespace rerun::archetypes {
         /// Objects with higher values are drawn on top of those with lower values.
         std::optional<rerun::components::DrawOrder> draw_order;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] = "rerun.components.ImageIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         // Extensions to generated type defined in 'image_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char LineStrips2D::INDICATOR_COMPONENT_NAME[] = "rerun.components.LineStrips2DIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,7 +17,7 @@ namespace rerun {
         cells.reserve(8);
 
         {
-            auto result = rerun::components::LineStrip2D::to_data_cell(
+            auto result = Loggable<rerun::components::LineStrip2D>::to_data_cell(
                 archetype.strips.data(),
                 archetype.strips.size()
             );
@@ -27,7 +25,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radii.has_value()) {
-            auto result = rerun::components::Radius::to_data_cell(
+            auto result = Loggable<rerun::components::Radius>::to_data_cell(
                 archetype.radii.value().data(),
                 archetype.radii.value().size()
             );
@@ -35,7 +33,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.colors.has_value()) {
-            auto result = rerun::components::Color::to_data_cell(
+            auto result = Loggable<rerun::components::Color>::to_data_cell(
                 archetype.colors.value().data(),
                 archetype.colors.value().size()
             );
@@ -43,7 +41,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.labels.has_value()) {
-            auto result = rerun::components::Text::to_data_cell(
+            auto result = Loggable<rerun::components::Text>::to_data_cell(
                 archetype.labels.value().data(),
                 archetype.labels.value().size()
             );
@@ -51,13 +49,15 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.draw_order.has_value()) {
-            auto result =
-                rerun::components::DrawOrder::to_data_cell(&archetype.draw_order.value(), 1);
+            auto result = Loggable<rerun::components::DrawOrder>::to_data_cell(
+                &archetype.draw_order.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = rerun::components::ClassId::to_data_cell(
+            auto result = Loggable<rerun::components::ClassId>::to_data_cell(
                 archetype.class_ids.value().data(),
                 archetype.class_ids.value().size()
             );
@@ -65,7 +65,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = rerun::components::InstanceKey::to_data_cell(
+            auto result = Loggable<rerun::components::InstanceKey>::to_data_cell(
                 archetype.instance_keys.value().data(),
                 archetype.instance_keys.value().size()
             );

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -74,7 +74,7 @@ namespace rerun {
         }
         {
             auto indicator = LineStrips2D::IndicatorComponent();
-            auto result = LineStrips2D::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<LineStrips2D::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -79,10 +79,12 @@ namespace rerun::archetypes {
         /// Unique identifiers for each individual line strip in the batch.
         std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] =
+            "rerun.components.LineStrips2DIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         LineStrips2D() = default;

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char LineStrips3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.LineStrips3DIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,7 +17,7 @@ namespace rerun {
         cells.reserve(7);
 
         {
-            auto result = rerun::components::LineStrip3D::to_data_cell(
+            auto result = Loggable<rerun::components::LineStrip3D>::to_data_cell(
                 archetype.strips.data(),
                 archetype.strips.size()
             );
@@ -27,7 +25,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radii.has_value()) {
-            auto result = rerun::components::Radius::to_data_cell(
+            auto result = Loggable<rerun::components::Radius>::to_data_cell(
                 archetype.radii.value().data(),
                 archetype.radii.value().size()
             );
@@ -35,7 +33,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.colors.has_value()) {
-            auto result = rerun::components::Color::to_data_cell(
+            auto result = Loggable<rerun::components::Color>::to_data_cell(
                 archetype.colors.value().data(),
                 archetype.colors.value().size()
             );
@@ -43,7 +41,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.labels.has_value()) {
-            auto result = rerun::components::Text::to_data_cell(
+            auto result = Loggable<rerun::components::Text>::to_data_cell(
                 archetype.labels.value().data(),
                 archetype.labels.value().size()
             );
@@ -51,7 +49,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = rerun::components::ClassId::to_data_cell(
+            auto result = Loggable<rerun::components::ClassId>::to_data_cell(
                 archetype.class_ids.value().data(),
                 archetype.class_ids.value().size()
             );
@@ -59,7 +57,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = rerun::components::InstanceKey::to_data_cell(
+            auto result = Loggable<rerun::components::InstanceKey>::to_data_cell(
                 archetype.instance_keys.value().data(),
                 archetype.instance_keys.value().size()
             );

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -66,7 +66,7 @@ namespace rerun {
         }
         {
             auto indicator = LineStrips3D::IndicatorComponent();
-            auto result = LineStrips3D::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<LineStrips3D::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -83,10 +83,12 @@ namespace rerun::archetypes {
         /// Unique identifiers for each individual line strip in the batch.
         std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] =
+            "rerun.components.LineStrips3DIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         LineStrips3D() = default;

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char Mesh3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Mesh3DIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,7 +17,7 @@ namespace rerun {
         cells.reserve(8);
 
         {
-            auto result = rerun::components::Position3D::to_data_cell(
+            auto result = Loggable<rerun::components::Position3D>::to_data_cell(
                 archetype.vertex_positions.data(),
                 archetype.vertex_positions.size()
             );
@@ -27,7 +25,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.mesh_properties.has_value()) {
-            auto result = rerun::components::MeshProperties::to_data_cell(
+            auto result = Loggable<rerun::components::MeshProperties>::to_data_cell(
                 &archetype.mesh_properties.value(),
                 1
             );
@@ -35,7 +33,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.vertex_normals.has_value()) {
-            auto result = rerun::components::Vector3D::to_data_cell(
+            auto result = Loggable<rerun::components::Vector3D>::to_data_cell(
                 archetype.vertex_normals.value().data(),
                 archetype.vertex_normals.value().size()
             );
@@ -43,7 +41,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.vertex_colors.has_value()) {
-            auto result = rerun::components::Color::to_data_cell(
+            auto result = Loggable<rerun::components::Color>::to_data_cell(
                 archetype.vertex_colors.value().data(),
                 archetype.vertex_colors.value().size()
             );
@@ -51,13 +49,15 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.mesh_material.has_value()) {
-            auto result =
-                rerun::components::Material::to_data_cell(&archetype.mesh_material.value(), 1);
+            auto result = Loggable<rerun::components::Material>::to_data_cell(
+                &archetype.mesh_material.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = rerun::components::ClassId::to_data_cell(
+            auto result = Loggable<rerun::components::ClassId>::to_data_cell(
                 archetype.class_ids.value().data(),
                 archetype.class_ids.value().size()
             );
@@ -65,7 +65,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = rerun::components::InstanceKey::to_data_cell(
+            auto result = Loggable<rerun::components::InstanceKey>::to_data_cell(
                 archetype.instance_keys.value().data(),
                 archetype.instance_keys.value().size()
             );

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
@@ -74,7 +74,7 @@ namespace rerun {
         }
         {
             auto indicator = Mesh3D::IndicatorComponent();
-            auto result = Mesh3D::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<Mesh3D::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -88,10 +88,11 @@ namespace rerun::archetypes {
         /// Unique identifiers for each individual vertex in the mesh.
         std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] = "rerun.components.Mesh3DIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         Mesh3D() = default;

--- a/rerun_cpp/src/rerun/archetypes/pinhole.cpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char Pinhole::INDICATOR_COMPONENT_NAME[] = "rerun.components.PinholeIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,20 +17,26 @@ namespace rerun {
         cells.reserve(4);
 
         {
-            auto result =
-                rerun::components::PinholeProjection::to_data_cell(&archetype.image_from_camera, 1);
+            auto result = Loggable<rerun::components::PinholeProjection>::to_data_cell(
+                &archetype.image_from_camera,
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.resolution.has_value()) {
-            auto result =
-                rerun::components::Resolution::to_data_cell(&archetype.resolution.value(), 1);
+            auto result = Loggable<rerun::components::Resolution>::to_data_cell(
+                &archetype.resolution.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.camera_xyz.has_value()) {
-            auto result =
-                rerun::components::ViewCoordinates::to_data_cell(&archetype.camera_xyz.value(), 1);
+            auto result = Loggable<rerun::components::ViewCoordinates>::to_data_cell(
+                &archetype.camera_xyz.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/pinhole.cpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.cpp
@@ -42,7 +42,7 @@ namespace rerun {
         }
         {
             auto indicator = Pinhole::IndicatorComponent();
-            auto result = Pinhole::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<Pinhole::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -90,10 +90,11 @@ namespace rerun::archetypes {
         /// but will be re-oriented to project along the forward axis of the `camera_xyz` argument.
         std::optional<rerun::components::ViewCoordinates> camera_xyz;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] = "rerun.components.PinholeIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         // Extensions to generated type defined in 'pinhole_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -82,7 +82,7 @@ namespace rerun {
         }
         {
             auto indicator = Points2D::IndicatorComponent();
-            auto result = Points2D::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<Points2D::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char Points2D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points2DIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,7 +17,7 @@ namespace rerun {
         cells.reserve(9);
 
         {
-            auto result = rerun::components::Position2D::to_data_cell(
+            auto result = Loggable<rerun::components::Position2D>::to_data_cell(
                 archetype.positions.data(),
                 archetype.positions.size()
             );
@@ -27,7 +25,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radii.has_value()) {
-            auto result = rerun::components::Radius::to_data_cell(
+            auto result = Loggable<rerun::components::Radius>::to_data_cell(
                 archetype.radii.value().data(),
                 archetype.radii.value().size()
             );
@@ -35,7 +33,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.colors.has_value()) {
-            auto result = rerun::components::Color::to_data_cell(
+            auto result = Loggable<rerun::components::Color>::to_data_cell(
                 archetype.colors.value().data(),
                 archetype.colors.value().size()
             );
@@ -43,7 +41,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.labels.has_value()) {
-            auto result = rerun::components::Text::to_data_cell(
+            auto result = Loggable<rerun::components::Text>::to_data_cell(
                 archetype.labels.value().data(),
                 archetype.labels.value().size()
             );
@@ -51,13 +49,15 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.draw_order.has_value()) {
-            auto result =
-                rerun::components::DrawOrder::to_data_cell(&archetype.draw_order.value(), 1);
+            auto result = Loggable<rerun::components::DrawOrder>::to_data_cell(
+                &archetype.draw_order.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = rerun::components::ClassId::to_data_cell(
+            auto result = Loggable<rerun::components::ClassId>::to_data_cell(
                 archetype.class_ids.value().data(),
                 archetype.class_ids.value().size()
             );
@@ -65,7 +65,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.keypoint_ids.has_value()) {
-            auto result = rerun::components::KeypointId::to_data_cell(
+            auto result = Loggable<rerun::components::KeypointId>::to_data_cell(
                 archetype.keypoint_ids.value().data(),
                 archetype.keypoint_ids.value().size()
             );
@@ -73,7 +73,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = rerun::components::InstanceKey::to_data_cell(
+            auto result = Loggable<rerun::components::InstanceKey>::to_data_cell(
                 archetype.instance_keys.value().data(),
                 archetype.instance_keys.value().size()
             );

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -104,10 +104,11 @@ namespace rerun::archetypes {
         /// Unique identifiers for each individual point in the batch.
         std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] = "rerun.components.Points2DIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         Points2D() = default;

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -74,7 +74,7 @@ namespace rerun {
         }
         {
             auto indicator = Points3D::IndicatorComponent();
-            auto result = Points3D::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<Points3D::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char Points3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Points3DIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,7 +17,7 @@ namespace rerun {
         cells.reserve(8);
 
         {
-            auto result = rerun::components::Position3D::to_data_cell(
+            auto result = Loggable<rerun::components::Position3D>::to_data_cell(
                 archetype.positions.data(),
                 archetype.positions.size()
             );
@@ -27,7 +25,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radii.has_value()) {
-            auto result = rerun::components::Radius::to_data_cell(
+            auto result = Loggable<rerun::components::Radius>::to_data_cell(
                 archetype.radii.value().data(),
                 archetype.radii.value().size()
             );
@@ -35,7 +33,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.colors.has_value()) {
-            auto result = rerun::components::Color::to_data_cell(
+            auto result = Loggable<rerun::components::Color>::to_data_cell(
                 archetype.colors.value().data(),
                 archetype.colors.value().size()
             );
@@ -43,7 +41,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.labels.has_value()) {
-            auto result = rerun::components::Text::to_data_cell(
+            auto result = Loggable<rerun::components::Text>::to_data_cell(
                 archetype.labels.value().data(),
                 archetype.labels.value().size()
             );
@@ -51,7 +49,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.class_ids.has_value()) {
-            auto result = rerun::components::ClassId::to_data_cell(
+            auto result = Loggable<rerun::components::ClassId>::to_data_cell(
                 archetype.class_ids.value().data(),
                 archetype.class_ids.value().size()
             );
@@ -59,7 +57,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.keypoint_ids.has_value()) {
-            auto result = rerun::components::KeypointId::to_data_cell(
+            auto result = Loggable<rerun::components::KeypointId>::to_data_cell(
                 archetype.keypoint_ids.value().data(),
                 archetype.keypoint_ids.value().size()
             );
@@ -67,7 +65,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.instance_keys.has_value()) {
-            auto result = rerun::components::InstanceKey::to_data_cell(
+            auto result = Loggable<rerun::components::InstanceKey>::to_data_cell(
                 archetype.instance_keys.value().data(),
                 archetype.instance_keys.value().size()
             );

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -95,10 +95,11 @@ namespace rerun::archetypes {
         /// Unique identifiers for each individual point in the batch.
         std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] = "rerun.components.Points3DIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         Points3D() = default;

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
@@ -5,10 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char SegmentationImage::INDICATOR_COMPONENT_NAME[] =
-        "rerun.components.SegmentationImageIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -20,13 +17,15 @@ namespace rerun {
         cells.reserve(3);
 
         {
-            auto result = rerun::components::TensorData::to_data_cell(&archetype.data, 1);
+            auto result = Loggable<rerun::components::TensorData>::to_data_cell(&archetype.data, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.draw_order.has_value()) {
-            auto result =
-                rerun::components::DrawOrder::to_data_cell(&archetype.draw_order.value(), 1);
+            auto result = Loggable<rerun::components::DrawOrder>::to_data_cell(
+                &archetype.draw_order.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
@@ -31,7 +31,8 @@ namespace rerun {
         }
         {
             auto indicator = SegmentationImage::IndicatorComponent();
-            auto result = SegmentationImage::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result =
+                Loggable<SegmentationImage::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -72,10 +72,12 @@ namespace rerun::archetypes {
         /// Objects with higher values are drawn on top of those with lower values.
         std::optional<rerun::components::DrawOrder> draw_order;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] =
+            "rerun.components.SegmentationImageIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         // Extensions to generated type defined in 'segmentation_image_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/tensor.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char Tensor::INDICATOR_COMPONENT_NAME[] = "rerun.components.TensorIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,7 +17,7 @@ namespace rerun {
         cells.reserve(2);
 
         {
-            auto result = rerun::components::TensorData::to_data_cell(&archetype.data, 1);
+            auto result = Loggable<rerun::components::TensorData>::to_data_cell(&archetype.data, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/tensor.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.cpp
@@ -23,7 +23,7 @@ namespace rerun {
         }
         {
             auto indicator = Tensor::IndicatorComponent();
-            auto result = Tensor::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<Tensor::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -49,10 +49,11 @@ namespace rerun::archetypes {
         /// The tensor data
         rerun::components::TensorData data;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] = "rerun.components.TensorIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         // Extensions to generated type defined in 'tensor_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/text_document.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.cpp
@@ -31,7 +31,7 @@ namespace rerun {
         }
         {
             auto indicator = TextDocument::IndicatorComponent();
-            auto result = TextDocument::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<TextDocument::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/text_document.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char TextDocument::INDICATOR_COMPONENT_NAME[] = "rerun.components.TextDocumentIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,13 +17,15 @@ namespace rerun {
         cells.reserve(3);
 
         {
-            auto result = rerun::components::Text::to_data_cell(&archetype.text, 1);
+            auto result = Loggable<rerun::components::Text>::to_data_cell(&archetype.text, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.media_type.has_value()) {
-            auto result =
-                rerun::components::MediaType::to_data_cell(&archetype.media_type.value(), 1);
+            auto result = Loggable<rerun::components::MediaType>::to_data_cell(
+                &archetype.media_type.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -87,10 +87,12 @@ namespace rerun::archetypes {
         /// If omitted, `text/plain` is assumed.
         std::optional<rerun::components::MediaType> media_type;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] =
+            "rerun.components.TextDocumentIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         TextDocument() = default;

--- a/rerun_cpp/src/rerun/archetypes/text_log.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.cpp
@@ -37,7 +37,7 @@ namespace rerun {
         }
         {
             auto indicator = TextLog::IndicatorComponent();
-            auto result = TextLog::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<TextLog::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/text_log.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char TextLog::INDICATOR_COMPONENT_NAME[] = "rerun.components.TextLogIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,18 +17,21 @@ namespace rerun {
         cells.reserve(4);
 
         {
-            auto result = rerun::components::Text::to_data_cell(&archetype.text, 1);
+            auto result = Loggable<rerun::components::Text>::to_data_cell(&archetype.text, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.level.has_value()) {
-            auto result =
-                rerun::components::TextLogLevel::to_data_cell(&archetype.level.value(), 1);
+            auto result = Loggable<rerun::components::TextLogLevel>::to_data_cell(
+                &archetype.level.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.color.has_value()) {
-            auto result = rerun::components::Color::to_data_cell(&archetype.color.value(), 1);
+            auto result =
+                Loggable<rerun::components::Color>::to_data_cell(&archetype.color.value(), 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -90,10 +90,11 @@ namespace rerun::archetypes {
         /// Optional color to use for the log line in the Rerun Viewer.
         std::optional<rerun::components::Color> color;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] = "rerun.components.TextLogIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         TextLog() = default;

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
@@ -49,7 +49,8 @@ namespace rerun {
         }
         {
             auto indicator = TimeSeriesScalar::IndicatorComponent();
-            auto result = TimeSeriesScalar::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result =
+                Loggable<TimeSeriesScalar::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
@@ -5,10 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char TimeSeriesScalar::INDICATOR_COMPONENT_NAME[] =
-        "rerun.components.TimeSeriesScalarIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -20,28 +17,33 @@ namespace rerun {
         cells.reserve(6);
 
         {
-            auto result = rerun::components::Scalar::to_data_cell(&archetype.scalar, 1);
+            auto result = Loggable<rerun::components::Scalar>::to_data_cell(&archetype.scalar, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.radius.has_value()) {
-            auto result = rerun::components::Radius::to_data_cell(&archetype.radius.value(), 1);
+            auto result =
+                Loggable<rerun::components::Radius>::to_data_cell(&archetype.radius.value(), 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.color.has_value()) {
-            auto result = rerun::components::Color::to_data_cell(&archetype.color.value(), 1);
+            auto result =
+                Loggable<rerun::components::Color>::to_data_cell(&archetype.color.value(), 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.label.has_value()) {
-            auto result = rerun::components::Text::to_data_cell(&archetype.label.value(), 1);
+            auto result =
+                Loggable<rerun::components::Text>::to_data_cell(&archetype.label.value(), 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.scattered.has_value()) {
-            auto result =
-                rerun::components::ScalarScattering::to_data_cell(&archetype.scattered.value(), 1);
+            auto result = Loggable<rerun::components::ScalarScattering>::to_data_cell(
+                &archetype.scattered.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -91,10 +91,12 @@ namespace rerun::archetypes {
         /// required.
         std::optional<rerun::components::ScalarScattering> scattered;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] =
+            "rerun.components.TimeSeriesScalarIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         TimeSeriesScalar() = default;

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -5,9 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char Transform3D::INDICATOR_COMPONENT_NAME[] = "rerun.components.Transform3DIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -19,7 +17,8 @@ namespace rerun {
         cells.reserve(2);
 
         {
-            auto result = rerun::components::Transform3D::to_data_cell(&archetype.transform, 1);
+            auto result =
+                Loggable<rerun::components::Transform3D>::to_data_cell(&archetype.transform, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -24,7 +24,7 @@ namespace rerun {
         }
         {
             auto indicator = Transform3D::IndicatorComponent();
-            auto result = Transform3D::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<Transform3D::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -52,10 +52,12 @@ namespace rerun::archetypes {
         /// The transform
         rerun::components::Transform3D transform;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] =
+            "rerun.components.Transform3DIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         // Extensions to generated type defined in 'transform3d_ext.cpp'

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
@@ -5,10 +5,7 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-namespace rerun::archetypes {
-    const char ViewCoordinates::INDICATOR_COMPONENT_NAME[] =
-        "rerun.components.ViewCoordinatesIndicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -20,7 +17,8 @@ namespace rerun {
         cells.reserve(2);
 
         {
-            auto result = rerun::components::ViewCoordinates::to_data_cell(&archetype.xyz, 1);
+            auto result =
+                Loggable<rerun::components::ViewCoordinates>::to_data_cell(&archetype.xyz, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
@@ -24,7 +24,8 @@ namespace rerun {
         }
         {
             auto indicator = ViewCoordinates::IndicatorComponent();
-            auto result = ViewCoordinates::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result =
+                Loggable<ViewCoordinates::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -46,10 +46,12 @@ namespace rerun::archetypes {
     struct ViewCoordinates {
         rerun::components::ViewCoordinates xyz;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] =
+            "rerun.components.ViewCoordinatesIndicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         // Extensions to generated type defined in 'view_coordinates_ext.cpp'

--- a/rerun_cpp/src/rerun/as_components.hpp
+++ b/rerun_cpp/src/rerun/as_components.hpp
@@ -3,6 +3,7 @@
 #include "collection.hpp"
 #include "data_cell.hpp"
 #include "indicator_component.hpp"
+#include "loggable.hpp"
 
 namespace rerun {
     /// The AsComponents trait is used to convert a type into a list of serialized component.
@@ -25,23 +26,30 @@ namespace rerun {
             "c-arrays of components. "
             "You can add your own implementation by specializing AsComponents<T> for your type T."
         );
+
+        // TODO(andreas): List methods that the trait should implement.
     };
 
     // Documenting the builtin generic `AsComponents` impls is too much clutter for the doc class overview.
     /// \cond private
 
-    /// AsComponents for a Collection of components.
+    /// `AsComponents` for a Collection of types implementing the `rerun::Loggable` trait.
     template <typename TComponent>
     struct AsComponents<Collection<TComponent>> {
+        static_assert(
+            is_loggable<TComponent>, "The given type does not implement the rerun::Loggable trait."
+        );
+
         static Result<std::vector<DataCell>> serialize(const Collection<TComponent>& components) {
-            auto cell_result = TComponent::to_data_cell(components.data(), components.size());
+            auto cell_result =
+                Loggable<TComponent>::to_data_cell(components.data(), components.size());
             RR_RETURN_NOT_OK(cell_result.error);
 
             return Result<std::vector<DataCell>>({std::move(cell_result.value)});
         }
     };
 
-    /// AsComponents for a std::vector of components.
+    /// `AsComponents` for a `std::vector` of types implementing the `rerun::Loggable` trait.
     template <typename TComponent>
     struct AsComponents<std::vector<TComponent>> {
         static Result<std::vector<DataCell>> serialize(const std::vector<TComponent>& components) {
@@ -49,7 +57,7 @@ namespace rerun {
         }
     };
 
-    /// AsComponents for std::initializer_list
+    /// AsComponents for `std::initializer_list`
     template <typename TComponent>
     struct AsComponents<std::initializer_list<TComponent>> {
         static Result<std::vector<DataCell>> serialize(std::initializer_list<TComponent> components
@@ -58,7 +66,7 @@ namespace rerun {
         }
     };
 
-    /// AsComponents for an std::array of components.
+    /// `AsComponents` for an `std::array` of types implementing the `rerun::Loggable` trait.
     template <typename TComponent, size_t NumInstances>
     struct AsComponents<std::array<TComponent, NumInstances>> {
         static Result<std::vector<DataCell>> serialize(
@@ -68,7 +76,7 @@ namespace rerun {
         }
     };
 
-    /// AsComponents for an c-array of components.
+    /// `AsComponents` for an c-array of types implementing the `rerun::Loggable` trait.
     template <typename TComponent, size_t NumInstances>
     struct AsComponents<TComponent[NumInstances]> {
         static Result<std::vector<DataCell>> serialize(const TComponent (&components)[NumInstances]
@@ -77,7 +85,7 @@ namespace rerun {
         }
     };
 
-    /// AsComponents for single indicators
+    /// `AsComponents` for single indicator components.
     template <const char Name[]>
     struct AsComponents<components::IndicatorComponent<Name>> {
         static Result<std::vector<DataCell>> serialize(

--- a/rerun_cpp/src/rerun/blueprint/auto_space_views.cpp
+++ b/rerun_cpp/src/rerun/blueprint/auto_space_views.cpp
@@ -6,14 +6,17 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::blueprint {
-    const std::shared_ptr<arrow::DataType>& AutoSpaceViews::arrow_datatype() {
+namespace rerun::blueprint {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<blueprint::AutoSpaceViews>::arrow_datatype() {
         static const auto datatype = arrow::boolean();
         return datatype;
     }
 
-    rerun::Error AutoSpaceViews::fill_arrow_array_builder(
-        arrow::BooleanBuilder* builder, const AutoSpaceViews* elements, size_t num_elements
+    rerun::Error Loggable<blueprint::AutoSpaceViews>::fill_arrow_array_builder(
+        arrow::BooleanBuilder* builder, const blueprint::AutoSpaceViews* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -33,4 +36,33 @@ namespace rerun::blueprint {
 
         return Error::ok();
     }
-} // namespace rerun::blueprint
+
+    Result<rerun::DataCell> Loggable<blueprint::AutoSpaceViews>::to_data_cell(
+        const blueprint::AutoSpaceViews* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<blueprint::AutoSpaceViews>::fill_arrow_array_builder(
+                static_cast<arrow::BooleanBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/auto_space_views.hpp
+++ b/rerun_cpp/src/rerun/blueprint/auto_space_views.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -29,13 +30,30 @@ namespace rerun::blueprint {
             enabled = enabled_;
             return *this;
         }
+    };
+} // namespace rerun::blueprint
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<blueprint::AutoSpaceViews> {
+        static constexpr const char Name[] = "rerun.blueprint.AutoSpaceViews";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::BooleanBuilder* builder, const AutoSpaceViews* elements, size_t num_elements
+            arrow::BooleanBuilder* builder, const blueprint::AutoSpaceViews* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::blueprint::AutoSpaceViews` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const blueprint::AutoSpaceViews* instances, size_t num_instances
         );
     };
-} // namespace rerun::blueprint
+} // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/entity_properties_component.cpp
+++ b/rerun_cpp/src/rerun/blueprint/entity_properties_component.cpp
@@ -6,16 +6,19 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::blueprint {
-    const std::shared_ptr<arrow::DataType>& EntityPropertiesComponent::arrow_datatype() {
+namespace rerun::blueprint {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>&
+        Loggable<blueprint::EntityPropertiesComponent>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
             arrow::field("props", arrow::list(arrow::field("item", arrow::uint8(), false)), false),
         });
         return datatype;
     }
 
-    rerun::Error EntityPropertiesComponent::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const EntityPropertiesComponent* elements,
+    rerun::Error Loggable<blueprint::EntityPropertiesComponent>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const blueprint::EntityPropertiesComponent* elements,
         size_t num_elements
     ) {
         if (builder == nullptr) {
@@ -48,4 +51,35 @@ namespace rerun::blueprint {
 
         return Error::ok();
     }
-} // namespace rerun::blueprint
+
+    Result<rerun::DataCell> Loggable<blueprint::EntityPropertiesComponent>::to_data_cell(
+        const blueprint::EntityPropertiesComponent* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(
+                Loggable<blueprint::EntityPropertiesComponent>::fill_arrow_array_builder(
+                    static_cast<arrow::StructBuilder*>(builder.get()),
+                    instances,
+                    num_instances
+                )
+            );
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/entity_properties_component.hpp
+++ b/rerun_cpp/src/rerun/blueprint/entity_properties_component.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../collection.hpp"
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -31,14 +32,30 @@ namespace rerun::blueprint {
             props = std::move(props_);
             return *this;
         }
+    };
+} // namespace rerun::blueprint
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<blueprint::EntityPropertiesComponent> {
+        static constexpr const char Name[] = "rerun.blueprint.EntityPropertiesComponent";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const EntityPropertiesComponent* elements,
+            arrow::StructBuilder* builder, const blueprint::EntityPropertiesComponent* elements,
             size_t num_elements
         );
+
+        /// Creates a Rerun DataCell from an array of `rerun::blueprint::EntityPropertiesComponent` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const blueprint::EntityPropertiesComponent* instances, size_t num_instances
+        );
     };
-} // namespace rerun::blueprint
+} // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/panel_view.cpp
+++ b/rerun_cpp/src/rerun/blueprint/panel_view.cpp
@@ -6,16 +6,18 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::blueprint {
-    const std::shared_ptr<arrow::DataType>& PanelView::arrow_datatype() {
+namespace rerun::blueprint {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<blueprint::PanelView>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
             arrow::field("is_expanded", arrow::boolean(), false),
         });
         return datatype;
     }
 
-    rerun::Error PanelView::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const PanelView* elements, size_t num_elements
+    rerun::Error Loggable<blueprint::PanelView>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const blueprint::PanelView* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -38,4 +40,33 @@ namespace rerun::blueprint {
 
         return Error::ok();
     }
-} // namespace rerun::blueprint
+
+    Result<rerun::DataCell> Loggable<blueprint::PanelView>::to_data_cell(
+        const blueprint::PanelView* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<blueprint::PanelView>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/panel_view.hpp
+++ b/rerun_cpp/src/rerun/blueprint/panel_view.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -29,13 +30,29 @@ namespace rerun::blueprint {
             is_expanded = is_expanded_;
             return *this;
         }
+    };
+} // namespace rerun::blueprint
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<blueprint::PanelView> {
+        static constexpr const char Name[] = "rerun.blueprint.PanelView";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const PanelView* elements, size_t num_elements
+            arrow::StructBuilder* builder, const blueprint::PanelView* elements, size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::blueprint::PanelView` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const blueprint::PanelView* instances, size_t num_instances
         );
     };
-} // namespace rerun::blueprint
+} // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/query_expressions.cpp
+++ b/rerun_cpp/src/rerun/blueprint/query_expressions.cpp
@@ -6,8 +6,11 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::blueprint {
-    const std::shared_ptr<arrow::DataType>& QueryExpressions::arrow_datatype() {
+namespace rerun::blueprint {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<blueprint::QueryExpressions>::arrow_datatype(
+    ) {
         static const auto datatype = arrow::struct_({
             arrow::field(
                 "expressions",
@@ -18,8 +21,9 @@ namespace rerun::blueprint {
         return datatype;
     }
 
-    rerun::Error QueryExpressions::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const QueryExpressions* elements, size_t num_elements
+    rerun::Error Loggable<blueprint::QueryExpressions>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const blueprint::QueryExpressions* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -49,4 +53,33 @@ namespace rerun::blueprint {
 
         return Error::ok();
     }
-} // namespace rerun::blueprint
+
+    Result<rerun::DataCell> Loggable<blueprint::QueryExpressions>::to_data_cell(
+        const blueprint::QueryExpressions* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<blueprint::QueryExpressions>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/query_expressions.hpp
+++ b/rerun_cpp/src/rerun/blueprint/query_expressions.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../collection.hpp"
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -34,13 +35,30 @@ namespace rerun::blueprint {
             expressions = std::move(expressions_);
             return *this;
         }
+    };
+} // namespace rerun::blueprint
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<blueprint::QueryExpressions> {
+        static constexpr const char Name[] = "rerun.blueprint.QueryExpressions";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const QueryExpressions* elements, size_t num_elements
+            arrow::StructBuilder* builder, const blueprint::QueryExpressions* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::blueprint::QueryExpressions` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const blueprint::QueryExpressions* instances, size_t num_instances
         );
     };
-} // namespace rerun::blueprint
+} // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/space_view_component.cpp
+++ b/rerun_cpp/src/rerun/blueprint/space_view_component.cpp
@@ -6,8 +6,11 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::blueprint {
-    const std::shared_ptr<arrow::DataType>& SpaceViewComponent::arrow_datatype() {
+namespace rerun::blueprint {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<blueprint::SpaceViewComponent>::arrow_datatype(
+    ) {
         static const auto datatype = arrow::struct_({
             arrow::field(
                 "space_view",
@@ -18,8 +21,9 @@ namespace rerun::blueprint {
         return datatype;
     }
 
-    rerun::Error SpaceViewComponent::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const SpaceViewComponent* elements, size_t num_elements
+    rerun::Error Loggable<blueprint::SpaceViewComponent>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const blueprint::SpaceViewComponent* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -51,4 +55,33 @@ namespace rerun::blueprint {
 
         return Error::ok();
     }
-} // namespace rerun::blueprint
+
+    Result<rerun::DataCell> Loggable<blueprint::SpaceViewComponent>::to_data_cell(
+        const blueprint::SpaceViewComponent* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<blueprint::SpaceViewComponent>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/space_view_component.hpp
+++ b/rerun_cpp/src/rerun/blueprint/space_view_component.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../collection.hpp"
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -32,13 +33,30 @@ namespace rerun::blueprint {
             space_view = std::move(space_view_);
             return *this;
         }
+    };
+} // namespace rerun::blueprint
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<blueprint::SpaceViewComponent> {
+        static constexpr const char Name[] = "rerun.blueprint.SpaceViewComponent";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const SpaceViewComponent* elements, size_t num_elements
+            arrow::StructBuilder* builder, const blueprint::SpaceViewComponent* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::blueprint::SpaceViewComponent` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const blueprint::SpaceViewComponent* instances, size_t num_instances
         );
     };
-} // namespace rerun::blueprint
+} // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/space_view_maximized.cpp
+++ b/rerun_cpp/src/rerun/blueprint/space_view_maximized.cpp
@@ -6,14 +6,18 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::blueprint {
-    const std::shared_ptr<arrow::DataType>& SpaceViewMaximized::arrow_datatype() {
+namespace rerun::blueprint {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<blueprint::SpaceViewMaximized>::arrow_datatype(
+    ) {
         static const auto datatype = arrow::list(arrow::field("item", arrow::uint8(), false));
         return datatype;
     }
 
-    rerun::Error SpaceViewMaximized::fill_arrow_array_builder(
-        arrow::ListBuilder* builder, const SpaceViewMaximized* elements, size_t num_elements
+    rerun::Error Loggable<blueprint::SpaceViewMaximized>::fill_arrow_array_builder(
+        arrow::ListBuilder* builder, const blueprint::SpaceViewMaximized* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -45,4 +49,33 @@ namespace rerun::blueprint {
 
         return Error::ok();
     }
-} // namespace rerun::blueprint
+
+    Result<rerun::DataCell> Loggable<blueprint::SpaceViewMaximized>::to_data_cell(
+        const blueprint::SpaceViewMaximized* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<blueprint::SpaceViewMaximized>::fill_arrow_array_builder(
+                static_cast<arrow::ListBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/space_view_maximized.hpp
+++ b/rerun_cpp/src/rerun/blueprint/space_view_maximized.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../collection.hpp"
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -32,13 +33,30 @@ namespace rerun::blueprint {
             id = std::move(id_);
             return *this;
         }
+    };
+} // namespace rerun::blueprint
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<blueprint::SpaceViewMaximized> {
+        static constexpr const char Name[] = "rerun.blueprint.SpaceViewMaximized";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const SpaceViewMaximized* elements, size_t num_elements
+            arrow::ListBuilder* builder, const blueprint::SpaceViewMaximized* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::blueprint::SpaceViewMaximized` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const blueprint::SpaceViewMaximized* instances, size_t num_instances
         );
     };
-} // namespace rerun::blueprint
+} // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/viewport_layout.cpp
+++ b/rerun_cpp/src/rerun/blueprint/viewport_layout.cpp
@@ -6,8 +6,10 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::blueprint {
-    const std::shared_ptr<arrow::DataType>& ViewportLayout::arrow_datatype() {
+namespace rerun::blueprint {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<blueprint::ViewportLayout>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
             arrow::field(
                 "space_view_keys",
@@ -20,8 +22,9 @@ namespace rerun::blueprint {
         return datatype;
     }
 
-    rerun::Error ViewportLayout::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const ViewportLayout* elements, size_t num_elements
+    rerun::Error Loggable<blueprint::ViewportLayout>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const blueprint::ViewportLayout* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -76,4 +79,33 @@ namespace rerun::blueprint {
 
         return Error::ok();
     }
-} // namespace rerun::blueprint
+
+    Result<rerun::DataCell> Loggable<blueprint::ViewportLayout>::to_data_cell(
+        const blueprint::ViewportLayout* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<blueprint::ViewportLayout>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/viewport_layout.hpp
+++ b/rerun_cpp/src/rerun/blueprint/viewport_layout.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../collection.hpp"
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -30,13 +31,30 @@ namespace rerun::blueprint {
 
       public:
         ViewportLayout() = default;
+    };
+} // namespace rerun::blueprint
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<blueprint::ViewportLayout> {
+        static constexpr const char Name[] = "rerun.blueprint.ViewportLayout";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const ViewportLayout* elements, size_t num_elements
+            arrow::StructBuilder* builder, const blueprint::ViewportLayout* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::blueprint::ViewportLayout` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const blueprint::ViewportLayout* instances, size_t num_instances
         );
     };
-} // namespace rerun::blueprint
+} // namespace rerun

--- a/rerun_cpp/src/rerun/collection_adapter.hpp
+++ b/rerun_cpp/src/rerun/collection_adapter.hpp
@@ -39,5 +39,7 @@ namespace rerun {
             "rerun::CollectionAdapter<TElement, TContainer> for a given "
             "target type TElement and your input type TContainer."
         );
+
+        // TODO(andreas): List methods that the trait should implement.
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.cpp
@@ -8,18 +8,22 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AnnotationContext::NAME[] = "rerun.components.AnnotationContext";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AnnotationContext::arrow_datatype() {
-        static const auto datatype = arrow::list(
-            arrow::field("item", rerun::datatypes::ClassDescriptionMapElem::arrow_datatype(), false)
-        );
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AnnotationContext>::arrow_datatype(
+    ) {
+        static const auto datatype = arrow::list(arrow::field(
+            "item",
+            Loggable<rerun::datatypes::ClassDescriptionMapElem>::arrow_datatype(),
+            false
+        ));
         return datatype;
     }
 
-    rerun::Error AnnotationContext::fill_arrow_array_builder(
-        arrow::ListBuilder* builder, const AnnotationContext* elements, size_t num_elements
+    rerun::Error Loggable<components::AnnotationContext>::fill_arrow_array_builder(
+        arrow::ListBuilder* builder, const components::AnnotationContext* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -40,7 +44,7 @@ namespace rerun::components {
             ARROW_RETURN_NOT_OK(builder->Append());
             if (element.class_map.data()) {
                 RR_RETURN_NOT_OK(
-                    rerun::datatypes::ClassDescriptionMapElem::fill_arrow_array_builder(
+                    Loggable<rerun::datatypes::ClassDescriptionMapElem>::fill_arrow_array_builder(
                         value_builder,
                         element.class_map.data(),
                         element.class_map.size()
@@ -52,8 +56,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AnnotationContext::to_data_cell(
-        const AnnotationContext* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AnnotationContext>::to_data_cell(
+        const components::AnnotationContext* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -61,7 +65,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AnnotationContext::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AnnotationContext>::fill_arrow_array_builder(
                 static_cast<arrow::ListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -71,7 +75,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -80,4 +84,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.hpp
@@ -30,9 +30,6 @@ namespace rerun::components {
         /// List of class descriptions, mapping class indices to class names, colors etc.
         rerun::Collection<rerun::datatypes::ClassDescriptionMapElem> class_map;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'annotation_context_ext.cpp'
 
@@ -72,18 +69,30 @@ namespace rerun::components {
             class_map = std::move(class_map_);
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AnnotationContext> {
+        static constexpr const char Name[] = "rerun.components.AnnotationContext";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const AnnotationContext* elements, size_t num_elements
+            arrow::ListBuilder* builder, const components::AnnotationContext* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AnnotationContext components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AnnotationContext` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AnnotationContext* instances, size_t num_instances
+            const components::AnnotationContext* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/blob.cpp
+++ b/rerun_cpp/src/rerun/components/blob.cpp
@@ -6,16 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char Blob::NAME[] = "rerun.components.Blob";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& Blob::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::Blob>::arrow_datatype() {
         static const auto datatype = arrow::list(arrow::field("item", arrow::uint8(), false));
         return datatype;
     }
 
-    rerun::Error Blob::fill_arrow_array_builder(
-        arrow::ListBuilder* builder, const Blob* elements, size_t num_elements
+    rerun::Error Loggable<components::Blob>::fill_arrow_array_builder(
+        arrow::ListBuilder* builder, const components::Blob* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -44,14 +44,16 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> Blob::to_data_cell(const Blob* instances, size_t num_instances) {
+    Result<rerun::DataCell> Loggable<components::Blob>::to_data_cell(
+        const components::Blob* instances, size_t num_instances
+    ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
         auto datatype = arrow_datatype();
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(Blob::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::Blob>::fill_arrow_array_builder(
                 static_cast<arrow::ListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -61,7 +63,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -70,4 +72,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/blob.hpp
+++ b/rerun_cpp/src/rerun/components/blob.hpp
@@ -21,9 +21,6 @@ namespace rerun::components {
     struct Blob {
         rerun::Collection<uint8_t> data;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         Blob() = default;
 
@@ -33,16 +30,29 @@ namespace rerun::components {
             data = std::move(data_);
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::Blob> {
+        static constexpr const char Name[] = "rerun.components.Blob";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const Blob* elements, size_t num_elements
+            arrow::ListBuilder* builder, const components::Blob* elements, size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of Blob components.
-        static Result<rerun::DataCell> to_data_cell(const Blob* instances, size_t num_instances);
+        /// Creates a Rerun DataCell from an array of `rerun::components::Blob` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const components::Blob* instances, size_t num_instances
+        );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/class_id.cpp
+++ b/rerun_cpp/src/rerun/components/class_id.cpp
@@ -8,19 +8,19 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char ClassId::NAME[] = "rerun.components.ClassId";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& ClassId::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::ClassId::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::ClassId>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::ClassId>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error ClassId::fill_arrow_array_builder(
-        arrow::UInt16Builder* builder, const ClassId* elements, size_t num_elements
+    rerun::Error Loggable<components::ClassId>::fill_arrow_array_builder(
+        arrow::UInt16Builder* builder, const components::ClassId* elements, size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::ClassId) == sizeof(ClassId));
-        RR_RETURN_NOT_OK(rerun::datatypes::ClassId::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::ClassId) == sizeof(components::ClassId));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::ClassId>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::ClassId*>(elements),
             num_elements
@@ -29,14 +29,16 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> ClassId::to_data_cell(const ClassId* instances, size_t num_instances) {
+    Result<rerun::DataCell> Loggable<components::ClassId>::to_data_cell(
+        const components::ClassId* instances, size_t num_instances
+    ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
         auto datatype = arrow_datatype();
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(ClassId::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::ClassId>::fill_arrow_array_builder(
                 static_cast<arrow::UInt16Builder*>(builder.get()),
                 instances,
                 num_instances
@@ -46,7 +48,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -55,4 +57,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/class_id.hpp
+++ b/rerun_cpp/src/rerun/components/class_id.hpp
@@ -25,9 +25,6 @@ namespace rerun::components {
     struct ClassId {
         rerun::datatypes::ClassId id;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         ClassId() = default;
 
@@ -49,16 +46,29 @@ namespace rerun::components {
         operator rerun::datatypes::ClassId() const {
             return id;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::ClassId> {
+        static constexpr const char Name[] = "rerun.components.ClassId";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::UInt16Builder* builder, const ClassId* elements, size_t num_elements
+            arrow::UInt16Builder* builder, const components::ClassId* elements, size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of ClassId components.
-        static Result<rerun::DataCell> to_data_cell(const ClassId* instances, size_t num_instances);
+        /// Creates a Rerun DataCell from an array of `rerun::components::ClassId` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const components::ClassId* instances, size_t num_instances
+        );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/clear_is_recursive.cpp
+++ b/rerun_cpp/src/rerun/components/clear_is_recursive.cpp
@@ -6,16 +6,18 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char ClearIsRecursive::NAME[] = "rerun.components.ClearIsRecursive";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& ClearIsRecursive::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::ClearIsRecursive>::arrow_datatype(
+    ) {
         static const auto datatype = arrow::boolean();
         return datatype;
     }
 
-    rerun::Error ClearIsRecursive::fill_arrow_array_builder(
-        arrow::BooleanBuilder* builder, const ClearIsRecursive* elements, size_t num_elements
+    rerun::Error Loggable<components::ClearIsRecursive>::fill_arrow_array_builder(
+        arrow::BooleanBuilder* builder, const components::ClearIsRecursive* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -36,8 +38,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> ClearIsRecursive::to_data_cell(
-        const ClearIsRecursive* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::ClearIsRecursive>::to_data_cell(
+        const components::ClearIsRecursive* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -45,7 +47,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(ClearIsRecursive::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::ClearIsRecursive>::fill_arrow_array_builder(
                 static_cast<arrow::BooleanBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -55,7 +57,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -64,4 +66,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/clear_is_recursive.hpp
+++ b/rerun_cpp/src/rerun/components/clear_is_recursive.hpp
@@ -20,9 +20,6 @@ namespace rerun::components {
         /// If true, also clears all recursive children entities.
         bool recursive;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         ClearIsRecursive() = default;
 
@@ -32,18 +29,30 @@ namespace rerun::components {
             recursive = recursive_;
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::ClearIsRecursive> {
+        static constexpr const char Name[] = "rerun.components.ClearIsRecursive";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::BooleanBuilder* builder, const ClearIsRecursive* elements, size_t num_elements
+            arrow::BooleanBuilder* builder, const components::ClearIsRecursive* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of ClearIsRecursive components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::ClearIsRecursive` components.
         static Result<rerun::DataCell> to_data_cell(
-            const ClearIsRecursive* instances, size_t num_instances
+            const components::ClearIsRecursive* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/color.cpp
+++ b/rerun_cpp/src/rerun/components/color.cpp
@@ -8,19 +8,19 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char Color::NAME[] = "rerun.components.Color";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& Color::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Rgba32::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::Color>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::Rgba32>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error Color::fill_arrow_array_builder(
-        arrow::UInt32Builder* builder, const Color* elements, size_t num_elements
+    rerun::Error Loggable<components::Color>::fill_arrow_array_builder(
+        arrow::UInt32Builder* builder, const components::Color* elements, size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Rgba32) == sizeof(Color));
-        RR_RETURN_NOT_OK(rerun::datatypes::Rgba32::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::Rgba32) == sizeof(components::Color));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Rgba32>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Rgba32*>(elements),
             num_elements
@@ -29,14 +29,16 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> Color::to_data_cell(const Color* instances, size_t num_instances) {
+    Result<rerun::DataCell> Loggable<components::Color>::to_data_cell(
+        const components::Color* instances, size_t num_instances
+    ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
         auto datatype = arrow_datatype();
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(Color::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::Color>::fill_arrow_array_builder(
                 static_cast<arrow::UInt32Builder*>(builder.get()),
                 instances,
                 num_instances
@@ -46,7 +48,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -55,4 +57,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/color.hpp
+++ b/rerun_cpp/src/rerun/components/color.hpp
@@ -28,9 +28,6 @@ namespace rerun::components {
     struct Color {
         rerun::datatypes::Rgba32 rgba;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'color_ext.cpp'
 
@@ -74,16 +71,29 @@ namespace rerun::components {
         operator rerun::datatypes::Rgba32() const {
             return rgba;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::Color> {
+        static constexpr const char Name[] = "rerun.components.Color";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::UInt32Builder* builder, const Color* elements, size_t num_elements
+            arrow::UInt32Builder* builder, const components::Color* elements, size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of Color components.
-        static Result<rerun::DataCell> to_data_cell(const Color* instances, size_t num_instances);
+        /// Creates a Rerun DataCell from an array of `rerun::components::Color` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const components::Color* instances, size_t num_instances
+        );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/depth_meter.cpp
+++ b/rerun_cpp/src/rerun/components/depth_meter.cpp
@@ -6,16 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char DepthMeter::NAME[] = "rerun.components.DepthMeter";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& DepthMeter::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::DepthMeter>::arrow_datatype() {
         static const auto datatype = arrow::float32();
         return datatype;
     }
 
-    rerun::Error DepthMeter::fill_arrow_array_builder(
-        arrow::FloatBuilder* builder, const DepthMeter* elements, size_t num_elements
+    rerun::Error Loggable<components::DepthMeter>::fill_arrow_array_builder(
+        arrow::FloatBuilder* builder, const components::DepthMeter* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -35,8 +35,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> DepthMeter::to_data_cell(
-        const DepthMeter* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::DepthMeter>::to_data_cell(
+        const components::DepthMeter* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -44,7 +44,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(DepthMeter::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::DepthMeter>::fill_arrow_array_builder(
                 static_cast<arrow::FloatBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -54,7 +54,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -63,4 +63,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/depth_meter.hpp
+++ b/rerun_cpp/src/rerun/components/depth_meter.hpp
@@ -24,9 +24,6 @@ namespace rerun::components {
     struct DepthMeter {
         float value;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         DepthMeter() = default;
 
@@ -36,18 +33,30 @@ namespace rerun::components {
             value = value_;
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::DepthMeter> {
+        static constexpr const char Name[] = "rerun.components.DepthMeter";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FloatBuilder* builder, const DepthMeter* elements, size_t num_elements
+            arrow::FloatBuilder* builder, const components::DepthMeter* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of DepthMeter components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::DepthMeter` components.
         static Result<rerun::DataCell> to_data_cell(
-            const DepthMeter* instances, size_t num_instances
+            const components::DepthMeter* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/disconnected_space.cpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.cpp
@@ -6,16 +6,18 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char DisconnectedSpace::NAME[] = "rerun.components.DisconnectedSpace";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& DisconnectedSpace::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::DisconnectedSpace>::arrow_datatype(
+    ) {
         static const auto datatype = arrow::boolean();
         return datatype;
     }
 
-    rerun::Error DisconnectedSpace::fill_arrow_array_builder(
-        arrow::BooleanBuilder* builder, const DisconnectedSpace* elements, size_t num_elements
+    rerun::Error Loggable<components::DisconnectedSpace>::fill_arrow_array_builder(
+        arrow::BooleanBuilder* builder, const components::DisconnectedSpace* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -36,8 +38,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> DisconnectedSpace::to_data_cell(
-        const DisconnectedSpace* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::DisconnectedSpace>::to_data_cell(
+        const components::DisconnectedSpace* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -45,7 +47,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(DisconnectedSpace::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::DisconnectedSpace>::fill_arrow_array_builder(
                 static_cast<arrow::BooleanBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -55,7 +57,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -64,4 +66,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.hpp
@@ -24,9 +24,6 @@ namespace rerun::components {
         /// Whether the entity path at which this is logged is disconnected from its parent.
         bool is_disconnected;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         DisconnectedSpace() = default;
 
@@ -36,18 +33,30 @@ namespace rerun::components {
             is_disconnected = is_disconnected_;
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::DisconnectedSpace> {
+        static constexpr const char Name[] = "rerun.components.DisconnectedSpace";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::BooleanBuilder* builder, const DisconnectedSpace* elements, size_t num_elements
+            arrow::BooleanBuilder* builder, const components::DisconnectedSpace* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of DisconnectedSpace components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::DisconnectedSpace` components.
         static Result<rerun::DataCell> to_data_cell(
-            const DisconnectedSpace* instances, size_t num_instances
+            const components::DisconnectedSpace* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/draw_order.cpp
+++ b/rerun_cpp/src/rerun/components/draw_order.cpp
@@ -6,16 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char DrawOrder::NAME[] = "rerun.components.DrawOrder";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& DrawOrder::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::DrawOrder>::arrow_datatype() {
         static const auto datatype = arrow::float32();
         return datatype;
     }
 
-    rerun::Error DrawOrder::fill_arrow_array_builder(
-        arrow::FloatBuilder* builder, const DrawOrder* elements, size_t num_elements
+    rerun::Error Loggable<components::DrawOrder>::fill_arrow_array_builder(
+        arrow::FloatBuilder* builder, const components::DrawOrder* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -35,8 +35,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> DrawOrder::to_data_cell(
-        const DrawOrder* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::DrawOrder>::to_data_cell(
+        const components::DrawOrder* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -44,7 +44,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(DrawOrder::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::DrawOrder>::fill_arrow_array_builder(
                 static_cast<arrow::FloatBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -54,7 +54,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -63,4 +63,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/draw_order.hpp
+++ b/rerun_cpp/src/rerun/components/draw_order.hpp
@@ -30,9 +30,6 @@ namespace rerun::components {
     struct DrawOrder {
         float value;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         DrawOrder() = default;
 
@@ -42,18 +39,29 @@ namespace rerun::components {
             value = value_;
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::DrawOrder> {
+        static constexpr const char Name[] = "rerun.components.DrawOrder";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FloatBuilder* builder, const DrawOrder* elements, size_t num_elements
+            arrow::FloatBuilder* builder, const components::DrawOrder* elements, size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of DrawOrder components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::DrawOrder` components.
         static Result<rerun::DataCell> to_data_cell(
-            const DrawOrder* instances, size_t num_instances
+            const components::DrawOrder* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/half_sizes2d.cpp
+++ b/rerun_cpp/src/rerun/components/half_sizes2d.cpp
@@ -8,19 +8,20 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char HalfSizes2D::NAME[] = "rerun.components.HalfSizes2D";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& HalfSizes2D::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Vec2D::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::HalfSizes2D>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::Vec2D>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error HalfSizes2D::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const HalfSizes2D* elements, size_t num_elements
+    rerun::Error Loggable<components::HalfSizes2D>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const components::HalfSizes2D* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Vec2D) == sizeof(HalfSizes2D));
-        RR_RETURN_NOT_OK(rerun::datatypes::Vec2D::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::Vec2D) == sizeof(components::HalfSizes2D));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Vec2D>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Vec2D*>(elements),
             num_elements
@@ -29,8 +30,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> HalfSizes2D::to_data_cell(
-        const HalfSizes2D* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::HalfSizes2D>::to_data_cell(
+        const components::HalfSizes2D* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +39,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(HalfSizes2D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::HalfSizes2D>::fill_arrow_array_builder(
                 static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +49,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +58,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/half_sizes2d.hpp
+++ b/rerun_cpp/src/rerun/components/half_sizes2d.hpp
@@ -24,9 +24,6 @@ namespace rerun::components {
     struct HalfSizes2D {
         rerun::datatypes::Vec2D xy;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'half_sizes2d_ext.cpp'
 
@@ -62,18 +59,30 @@ namespace rerun::components {
         operator rerun::datatypes::Vec2D() const {
             return xy;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::HalfSizes2D> {
+        static constexpr const char Name[] = "rerun.components.HalfSizes2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const HalfSizes2D* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const components::HalfSizes2D* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of HalfSizes2D components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::HalfSizes2D` components.
         static Result<rerun::DataCell> to_data_cell(
-            const HalfSizes2D* instances, size_t num_instances
+            const components::HalfSizes2D* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/half_sizes3d.cpp
+++ b/rerun_cpp/src/rerun/components/half_sizes3d.cpp
@@ -8,19 +8,20 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char HalfSizes3D::NAME[] = "rerun.components.HalfSizes3D";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& HalfSizes3D::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Vec3D::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::HalfSizes3D>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::Vec3D>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error HalfSizes3D::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const HalfSizes3D* elements, size_t num_elements
+    rerun::Error Loggable<components::HalfSizes3D>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const components::HalfSizes3D* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Vec3D) == sizeof(HalfSizes3D));
-        RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::Vec3D) == sizeof(components::HalfSizes3D));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Vec3D>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Vec3D*>(elements),
             num_elements
@@ -29,8 +30,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> HalfSizes3D::to_data_cell(
-        const HalfSizes3D* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::HalfSizes3D>::to_data_cell(
+        const components::HalfSizes3D* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +39,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(HalfSizes3D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::HalfSizes3D>::fill_arrow_array_builder(
                 static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +49,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +58,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/half_sizes3d.hpp
+++ b/rerun_cpp/src/rerun/components/half_sizes3d.hpp
@@ -24,9 +24,6 @@ namespace rerun::components {
     struct HalfSizes3D {
         rerun::datatypes::Vec3D xyz;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'half_sizes3d_ext.cpp'
 
@@ -66,18 +63,30 @@ namespace rerun::components {
         operator rerun::datatypes::Vec3D() const {
             return xyz;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::HalfSizes3D> {
+        static constexpr const char Name[] = "rerun.components.HalfSizes3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const HalfSizes3D* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const components::HalfSizes3D* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of HalfSizes3D components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::HalfSizes3D` components.
         static Result<rerun::DataCell> to_data_cell(
-            const HalfSizes3D* instances, size_t num_instances
+            const components::HalfSizes3D* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/instance_key.cpp
+++ b/rerun_cpp/src/rerun/components/instance_key.cpp
@@ -6,16 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char InstanceKey::NAME[] = "rerun.components.InstanceKey";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& InstanceKey::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::InstanceKey>::arrow_datatype() {
         static const auto datatype = arrow::uint64();
         return datatype;
     }
 
-    rerun::Error InstanceKey::fill_arrow_array_builder(
-        arrow::UInt64Builder* builder, const InstanceKey* elements, size_t num_elements
+    rerun::Error Loggable<components::InstanceKey>::fill_arrow_array_builder(
+        arrow::UInt64Builder* builder, const components::InstanceKey* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -35,8 +35,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> InstanceKey::to_data_cell(
-        const InstanceKey* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::InstanceKey>::to_data_cell(
+        const components::InstanceKey* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -44,7 +44,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(InstanceKey::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::InstanceKey>::fill_arrow_array_builder(
                 static_cast<arrow::UInt64Builder*>(builder.get()),
                 instances,
                 num_instances
@@ -54,7 +54,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -63,4 +63,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/instance_key.hpp
+++ b/rerun_cpp/src/rerun/components/instance_key.hpp
@@ -24,9 +24,6 @@ namespace rerun::components {
     struct InstanceKey {
         uint64_t value;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         InstanceKey() = default;
 
@@ -36,18 +33,30 @@ namespace rerun::components {
             value = value_;
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::InstanceKey> {
+        static constexpr const char Name[] = "rerun.components.InstanceKey";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::UInt64Builder* builder, const InstanceKey* elements, size_t num_elements
+            arrow::UInt64Builder* builder, const components::InstanceKey* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of InstanceKey components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::InstanceKey` components.
         static Result<rerun::DataCell> to_data_cell(
-            const InstanceKey* instances, size_t num_instances
+            const components::InstanceKey* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/keypoint_id.cpp
+++ b/rerun_cpp/src/rerun/components/keypoint_id.cpp
@@ -8,19 +8,19 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char KeypointId::NAME[] = "rerun.components.KeypointId";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& KeypointId::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::KeypointId::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::KeypointId>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::KeypointId>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error KeypointId::fill_arrow_array_builder(
-        arrow::UInt16Builder* builder, const KeypointId* elements, size_t num_elements
+    rerun::Error Loggable<components::KeypointId>::fill_arrow_array_builder(
+        arrow::UInt16Builder* builder, const components::KeypointId* elements, size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::KeypointId) == sizeof(KeypointId));
-        RR_RETURN_NOT_OK(rerun::datatypes::KeypointId::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::KeypointId) == sizeof(components::KeypointId));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::KeypointId>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::KeypointId*>(elements),
             num_elements
@@ -29,8 +29,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> KeypointId::to_data_cell(
-        const KeypointId* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::KeypointId>::to_data_cell(
+        const components::KeypointId* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +38,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(KeypointId::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::KeypointId>::fill_arrow_array_builder(
                 static_cast<arrow::UInt16Builder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +48,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +57,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/keypoint_id.hpp
+++ b/rerun_cpp/src/rerun/components/keypoint_id.hpp
@@ -25,9 +25,6 @@ namespace rerun::components {
     struct KeypointId {
         rerun::datatypes::KeypointId id;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         KeypointId() = default;
 
@@ -49,18 +46,30 @@ namespace rerun::components {
         operator rerun::datatypes::KeypointId() const {
             return id;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::KeypointId> {
+        static constexpr const char Name[] = "rerun.components.KeypointId";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::UInt16Builder* builder, const KeypointId* elements, size_t num_elements
+            arrow::UInt16Builder* builder, const components::KeypointId* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of KeypointId components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::KeypointId` components.
         static Result<rerun::DataCell> to_data_cell(
-            const KeypointId* instances, size_t num_instances
+            const components::KeypointId* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/line_strip2d.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d.cpp
@@ -8,17 +8,18 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char LineStrip2D::NAME[] = "rerun.components.LineStrip2D";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& LineStrip2D::arrow_datatype() {
-        static const auto datatype =
-            arrow::list(arrow::field("item", rerun::datatypes::Vec2D::arrow_datatype(), false));
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::LineStrip2D>::arrow_datatype() {
+        static const auto datatype = arrow::list(
+            arrow::field("item", Loggable<rerun::datatypes::Vec2D>::arrow_datatype(), false)
+        );
         return datatype;
     }
 
-    rerun::Error LineStrip2D::fill_arrow_array_builder(
-        arrow::ListBuilder* builder, const LineStrip2D* elements, size_t num_elements
+    rerun::Error Loggable<components::LineStrip2D>::fill_arrow_array_builder(
+        arrow::ListBuilder* builder, const components::LineStrip2D* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -38,7 +39,7 @@ namespace rerun::components {
             const auto& element = elements[elem_idx];
             ARROW_RETURN_NOT_OK(builder->Append());
             if (element.points.data()) {
-                RR_RETURN_NOT_OK(rerun::datatypes::Vec2D::fill_arrow_array_builder(
+                RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Vec2D>::fill_arrow_array_builder(
                     value_builder,
                     element.points.data(),
                     element.points.size()
@@ -49,8 +50,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> LineStrip2D::to_data_cell(
-        const LineStrip2D* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::LineStrip2D>::to_data_cell(
+        const components::LineStrip2D* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -58,7 +59,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(LineStrip2D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::LineStrip2D>::fill_arrow_array_builder(
                 static_cast<arrow::ListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -68,7 +69,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -77,4 +78,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/line_strip2d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d.hpp
@@ -33,9 +33,6 @@ namespace rerun::components {
     struct LineStrip2D {
         rerun::Collection<rerun::datatypes::Vec2D> points;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         LineStrip2D() = default;
 
@@ -46,18 +43,30 @@ namespace rerun::components {
             points = std::move(points_);
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::LineStrip2D> {
+        static constexpr const char Name[] = "rerun.components.LineStrip2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const LineStrip2D* elements, size_t num_elements
+            arrow::ListBuilder* builder, const components::LineStrip2D* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of LineStrip2D components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::LineStrip2D` components.
         static Result<rerun::DataCell> to_data_cell(
-            const LineStrip2D* instances, size_t num_instances
+            const components::LineStrip2D* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/line_strip3d.cpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.cpp
@@ -8,17 +8,18 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char LineStrip3D::NAME[] = "rerun.components.LineStrip3D";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& LineStrip3D::arrow_datatype() {
-        static const auto datatype =
-            arrow::list(arrow::field("item", rerun::datatypes::Vec3D::arrow_datatype(), false));
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::LineStrip3D>::arrow_datatype() {
+        static const auto datatype = arrow::list(
+            arrow::field("item", Loggable<rerun::datatypes::Vec3D>::arrow_datatype(), false)
+        );
         return datatype;
     }
 
-    rerun::Error LineStrip3D::fill_arrow_array_builder(
-        arrow::ListBuilder* builder, const LineStrip3D* elements, size_t num_elements
+    rerun::Error Loggable<components::LineStrip3D>::fill_arrow_array_builder(
+        arrow::ListBuilder* builder, const components::LineStrip3D* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -38,7 +39,7 @@ namespace rerun::components {
             const auto& element = elements[elem_idx];
             ARROW_RETURN_NOT_OK(builder->Append());
             if (element.points.data()) {
-                RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+                RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Vec3D>::fill_arrow_array_builder(
                     value_builder,
                     element.points.data(),
                     element.points.size()
@@ -49,8 +50,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> LineStrip3D::to_data_cell(
-        const LineStrip3D* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::LineStrip3D>::to_data_cell(
+        const components::LineStrip3D* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -58,7 +59,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(LineStrip3D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::LineStrip3D>::fill_arrow_array_builder(
                 static_cast<arrow::ListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -68,7 +69,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -77,4 +78,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/line_strip3d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.hpp
@@ -33,9 +33,6 @@ namespace rerun::components {
     struct LineStrip3D {
         rerun::Collection<rerun::datatypes::Vec3D> points;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         LineStrip3D() = default;
 
@@ -46,18 +43,30 @@ namespace rerun::components {
             points = std::move(points_);
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::LineStrip3D> {
+        static constexpr const char Name[] = "rerun.components.LineStrip3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const LineStrip3D* elements, size_t num_elements
+            arrow::ListBuilder* builder, const components::LineStrip3D* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of LineStrip3D components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::LineStrip3D` components.
         static Result<rerun::DataCell> to_data_cell(
-            const LineStrip3D* instances, size_t num_instances
+            const components::LineStrip3D* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/material.cpp
+++ b/rerun_cpp/src/rerun/components/material.cpp
@@ -8,19 +8,19 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char Material::NAME[] = "rerun.components.Material";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& Material::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Material::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::Material>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::Material>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error Material::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const Material* elements, size_t num_elements
+    rerun::Error Loggable<components::Material>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const components::Material* elements, size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Material) == sizeof(Material));
-        RR_RETURN_NOT_OK(rerun::datatypes::Material::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::Material) == sizeof(components::Material));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Material>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Material*>(elements),
             num_elements
@@ -29,8 +29,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> Material::to_data_cell(
-        const Material* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::Material>::to_data_cell(
+        const components::Material* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +38,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(Material::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::Material>::fill_arrow_array_builder(
                 static_cast<arrow::StructBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +48,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +57,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/material.hpp
+++ b/rerun_cpp/src/rerun/components/material.hpp
@@ -22,9 +22,6 @@ namespace rerun::components {
     struct Material {
         rerun::datatypes::Material material;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'material_ext.cpp'
 
@@ -54,18 +51,29 @@ namespace rerun::components {
         operator rerun::datatypes::Material() const {
             return material;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::Material> {
+        static constexpr const char Name[] = "rerun.components.Material";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const Material* elements, size_t num_elements
+            arrow::StructBuilder* builder, const components::Material* elements, size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of Material components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::Material` components.
         static Result<rerun::DataCell> to_data_cell(
-            const Material* instances, size_t num_instances
+            const components::Material* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/media_type.cpp
+++ b/rerun_cpp/src/rerun/components/media_type.cpp
@@ -8,19 +8,19 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char MediaType::NAME[] = "rerun.components.MediaType";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& MediaType::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Utf8::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::MediaType>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::Utf8>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error MediaType::fill_arrow_array_builder(
-        arrow::StringBuilder* builder, const MediaType* elements, size_t num_elements
+    rerun::Error Loggable<components::MediaType>::fill_arrow_array_builder(
+        arrow::StringBuilder* builder, const components::MediaType* elements, size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Utf8) == sizeof(MediaType));
-        RR_RETURN_NOT_OK(rerun::datatypes::Utf8::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::Utf8) == sizeof(components::MediaType));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Utf8>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Utf8*>(elements),
             num_elements
@@ -29,8 +29,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> MediaType::to_data_cell(
-        const MediaType* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::MediaType>::to_data_cell(
+        const components::MediaType* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +38,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(MediaType::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::MediaType>::fill_arrow_array_builder(
                 static_cast<arrow::StringBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +48,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +57,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/media_type.hpp
+++ b/rerun_cpp/src/rerun/components/media_type.hpp
@@ -25,9 +25,6 @@ namespace rerun::components {
     struct MediaType {
         rerun::datatypes::Utf8 value;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'media_type_ext.cpp'
 
@@ -91,18 +88,30 @@ namespace rerun::components {
         operator rerun::datatypes::Utf8() const {
             return value;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::MediaType> {
+        static constexpr const char Name[] = "rerun.components.MediaType";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StringBuilder* builder, const MediaType* elements, size_t num_elements
+            arrow::StringBuilder* builder, const components::MediaType* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of MediaType components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::MediaType` components.
         static Result<rerun::DataCell> to_data_cell(
-            const MediaType* instances, size_t num_instances
+            const components::MediaType* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/mesh_properties.cpp
+++ b/rerun_cpp/src/rerun/components/mesh_properties.cpp
@@ -8,19 +8,22 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char MeshProperties::NAME[] = "rerun.components.MeshProperties";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& MeshProperties::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::MeshProperties::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::MeshProperties>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::MeshProperties>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error MeshProperties::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const MeshProperties* elements, size_t num_elements
+    rerun::Error Loggable<components::MeshProperties>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const components::MeshProperties* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::MeshProperties) == sizeof(MeshProperties));
-        RR_RETURN_NOT_OK(rerun::datatypes::MeshProperties::fill_arrow_array_builder(
+        static_assert(
+            sizeof(rerun::datatypes::MeshProperties) == sizeof(components::MeshProperties)
+        );
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::MeshProperties>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::MeshProperties*>(elements),
             num_elements
@@ -29,8 +32,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> MeshProperties::to_data_cell(
-        const MeshProperties* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::MeshProperties>::to_data_cell(
+        const components::MeshProperties* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +41,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(MeshProperties::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::MeshProperties>::fill_arrow_array_builder(
                 static_cast<arrow::StructBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +51,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +60,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/mesh_properties.hpp
+++ b/rerun_cpp/src/rerun/components/mesh_properties.hpp
@@ -23,9 +23,6 @@ namespace rerun::components {
     struct MeshProperties {
         rerun::datatypes::MeshProperties props;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'mesh_properties_ext.cpp'
 
@@ -55,18 +52,30 @@ namespace rerun::components {
         operator rerun::datatypes::MeshProperties() const {
             return props;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::MeshProperties> {
+        static constexpr const char Name[] = "rerun.components.MeshProperties";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const MeshProperties* elements, size_t num_elements
+            arrow::StructBuilder* builder, const components::MeshProperties* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of MeshProperties components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::MeshProperties` components.
         static Result<rerun::DataCell> to_data_cell(
-            const MeshProperties* instances, size_t num_instances
+            const components::MeshProperties* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/out_of_tree_transform3d.cpp
+++ b/rerun_cpp/src/rerun/components/out_of_tree_transform3d.cpp
@@ -8,19 +8,23 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char OutOfTreeTransform3D::NAME[] = "rerun.components.OutOfTreeTransform3D";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& OutOfTreeTransform3D::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Transform3D::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>&
+        Loggable<components::OutOfTreeTransform3D>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::Transform3D>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error OutOfTreeTransform3D::fill_arrow_array_builder(
-        arrow::DenseUnionBuilder* builder, const OutOfTreeTransform3D* elements, size_t num_elements
+    rerun::Error Loggable<components::OutOfTreeTransform3D>::fill_arrow_array_builder(
+        arrow::DenseUnionBuilder* builder, const components::OutOfTreeTransform3D* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Transform3D) == sizeof(OutOfTreeTransform3D));
-        RR_RETURN_NOT_OK(rerun::datatypes::Transform3D::fill_arrow_array_builder(
+        static_assert(
+            sizeof(rerun::datatypes::Transform3D) == sizeof(components::OutOfTreeTransform3D)
+        );
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Transform3D>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Transform3D*>(elements),
             num_elements
@@ -29,8 +33,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> OutOfTreeTransform3D::to_data_cell(
-        const OutOfTreeTransform3D* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::OutOfTreeTransform3D>::to_data_cell(
+        const components::OutOfTreeTransform3D* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +42,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(OutOfTreeTransform3D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::OutOfTreeTransform3D>::fill_arrow_array_builder(
                 static_cast<arrow::DenseUnionBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +52,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +61,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/out_of_tree_transform3d.hpp
+++ b/rerun_cpp/src/rerun/components/out_of_tree_transform3d.hpp
@@ -23,9 +23,6 @@ namespace rerun::components {
         /// Representation of the transform.
         rerun::datatypes::Transform3D repr;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         OutOfTreeTransform3D() = default;
 
@@ -40,19 +37,30 @@ namespace rerun::components {
         operator rerun::datatypes::Transform3D() const {
             return repr;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::OutOfTreeTransform3D> {
+        static constexpr const char Name[] = "rerun.components.OutOfTreeTransform3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const OutOfTreeTransform3D* elements,
+            arrow::DenseUnionBuilder* builder, const components::OutOfTreeTransform3D* elements,
             size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of OutOfTreeTransform3D components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::OutOfTreeTransform3D` components.
         static Result<rerun::DataCell> to_data_cell(
-            const OutOfTreeTransform3D* instances, size_t num_instances
+            const components::OutOfTreeTransform3D* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/pinhole_projection.cpp
+++ b/rerun_cpp/src/rerun/components/pinhole_projection.cpp
@@ -8,19 +8,21 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char PinholeProjection::NAME[] = "rerun.components.PinholeProjection";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& PinholeProjection::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Mat3x3::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::PinholeProjection>::arrow_datatype(
+    ) {
+        static const auto datatype = Loggable<rerun::datatypes::Mat3x3>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error PinholeProjection::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const PinholeProjection* elements, size_t num_elements
+    rerun::Error Loggable<components::PinholeProjection>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const components::PinholeProjection* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Mat3x3) == sizeof(PinholeProjection));
-        RR_RETURN_NOT_OK(rerun::datatypes::Mat3x3::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::Mat3x3) == sizeof(components::PinholeProjection));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Mat3x3>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Mat3x3*>(elements),
             num_elements
@@ -29,8 +31,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> PinholeProjection::to_data_cell(
-        const PinholeProjection* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::PinholeProjection>::to_data_cell(
+        const components::PinholeProjection* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +40,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(PinholeProjection::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::PinholeProjection>::fill_arrow_array_builder(
                 static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +50,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +59,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/pinhole_projection.hpp
+++ b/rerun_cpp/src/rerun/components/pinhole_projection.hpp
@@ -31,9 +31,6 @@ namespace rerun::components {
     struct PinholeProjection {
         rerun::datatypes::Mat3x3 image_from_camera;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'pinhole_projection_ext.cpp'
 
@@ -64,19 +61,30 @@ namespace rerun::components {
         operator rerun::datatypes::Mat3x3() const {
             return image_from_camera;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::PinholeProjection> {
+        static constexpr const char Name[] = "rerun.components.PinholeProjection";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const PinholeProjection* elements,
+            arrow::FixedSizeListBuilder* builder, const components::PinholeProjection* elements,
             size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of PinholeProjection components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::PinholeProjection` components.
         static Result<rerun::DataCell> to_data_cell(
-            const PinholeProjection* instances, size_t num_instances
+            const components::PinholeProjection* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/position2d.cpp
+++ b/rerun_cpp/src/rerun/components/position2d.cpp
@@ -8,19 +8,20 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char Position2D::NAME[] = "rerun.components.Position2D";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& Position2D::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Vec2D::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::Position2D>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::Vec2D>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error Position2D::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const Position2D* elements, size_t num_elements
+    rerun::Error Loggable<components::Position2D>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const components::Position2D* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Vec2D) == sizeof(Position2D));
-        RR_RETURN_NOT_OK(rerun::datatypes::Vec2D::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::Vec2D) == sizeof(components::Position2D));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Vec2D>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Vec2D*>(elements),
             num_elements
@@ -29,8 +30,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> Position2D::to_data_cell(
-        const Position2D* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::Position2D>::to_data_cell(
+        const components::Position2D* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +39,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(Position2D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::Position2D>::fill_arrow_array_builder(
                 static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +49,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +58,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/position2d.hpp
+++ b/rerun_cpp/src/rerun/components/position2d.hpp
@@ -21,9 +21,6 @@ namespace rerun::components {
     struct Position2D {
         rerun::datatypes::Vec2D xy;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'position2d_ext.cpp'
 
@@ -59,18 +56,30 @@ namespace rerun::components {
         operator rerun::datatypes::Vec2D() const {
             return xy;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::Position2D> {
+        static constexpr const char Name[] = "rerun.components.Position2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const Position2D* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const components::Position2D* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of Position2D components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::Position2D` components.
         static Result<rerun::DataCell> to_data_cell(
-            const Position2D* instances, size_t num_instances
+            const components::Position2D* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/position3d.cpp
+++ b/rerun_cpp/src/rerun/components/position3d.cpp
@@ -8,19 +8,20 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char Position3D::NAME[] = "rerun.components.Position3D";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& Position3D::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Vec3D::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::Position3D>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::Vec3D>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error Position3D::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const Position3D* elements, size_t num_elements
+    rerun::Error Loggable<components::Position3D>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const components::Position3D* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Vec3D) == sizeof(Position3D));
-        RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::Vec3D) == sizeof(components::Position3D));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Vec3D>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Vec3D*>(elements),
             num_elements
@@ -29,8 +30,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> Position3D::to_data_cell(
-        const Position3D* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::Position3D>::to_data_cell(
+        const components::Position3D* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +39,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(Position3D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::Position3D>::fill_arrow_array_builder(
                 static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +49,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +58,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/position3d.hpp
+++ b/rerun_cpp/src/rerun/components/position3d.hpp
@@ -21,9 +21,6 @@ namespace rerun::components {
     struct Position3D {
         rerun::datatypes::Vec3D xyz;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'position3d_ext.cpp'
 
@@ -63,18 +60,30 @@ namespace rerun::components {
         operator rerun::datatypes::Vec3D() const {
             return xyz;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::Position3D> {
+        static constexpr const char Name[] = "rerun.components.Position3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const Position3D* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const components::Position3D* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of Position3D components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::Position3D` components.
         static Result<rerun::DataCell> to_data_cell(
-            const Position3D* instances, size_t num_instances
+            const components::Position3D* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/radius.cpp
+++ b/rerun_cpp/src/rerun/components/radius.cpp
@@ -6,16 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char Radius::NAME[] = "rerun.components.Radius";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& Radius::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::Radius>::arrow_datatype() {
         static const auto datatype = arrow::float32();
         return datatype;
     }
 
-    rerun::Error Radius::fill_arrow_array_builder(
-        arrow::FloatBuilder* builder, const Radius* elements, size_t num_elements
+    rerun::Error Loggable<components::Radius>::fill_arrow_array_builder(
+        arrow::FloatBuilder* builder, const components::Radius* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -35,14 +35,16 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> Radius::to_data_cell(const Radius* instances, size_t num_instances) {
+    Result<rerun::DataCell> Loggable<components::Radius>::to_data_cell(
+        const components::Radius* instances, size_t num_instances
+    ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
         auto datatype = arrow_datatype();
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(Radius::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::Radius>::fill_arrow_array_builder(
                 static_cast<arrow::FloatBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -52,7 +54,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -61,4 +63,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/radius.hpp
+++ b/rerun_cpp/src/rerun/components/radius.hpp
@@ -24,9 +24,6 @@ namespace rerun::components {
     struct Radius {
         float value;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         Radius() = default;
 
@@ -36,16 +33,29 @@ namespace rerun::components {
             value = value_;
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::Radius> {
+        static constexpr const char Name[] = "rerun.components.Radius";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FloatBuilder* builder, const Radius* elements, size_t num_elements
+            arrow::FloatBuilder* builder, const components::Radius* elements, size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of Radius components.
-        static Result<rerun::DataCell> to_data_cell(const Radius* instances, size_t num_instances);
+        /// Creates a Rerun DataCell from an array of `rerun::components::Radius` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const components::Radius* instances, size_t num_instances
+        );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/resolution.cpp
+++ b/rerun_cpp/src/rerun/components/resolution.cpp
@@ -8,19 +8,20 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char Resolution::NAME[] = "rerun.components.Resolution";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& Resolution::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Vec2D::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::Resolution>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::Vec2D>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error Resolution::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const Resolution* elements, size_t num_elements
+    rerun::Error Loggable<components::Resolution>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const components::Resolution* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Vec2D) == sizeof(Resolution));
-        RR_RETURN_NOT_OK(rerun::datatypes::Vec2D::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::Vec2D) == sizeof(components::Resolution));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Vec2D>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Vec2D*>(elements),
             num_elements
@@ -29,8 +30,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> Resolution::to_data_cell(
-        const Resolution* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::Resolution>::to_data_cell(
+        const components::Resolution* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +39,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(Resolution::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::Resolution>::fill_arrow_array_builder(
                 static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +49,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +58,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/resolution.hpp
+++ b/rerun_cpp/src/rerun/components/resolution.hpp
@@ -23,9 +23,6 @@ namespace rerun::components {
     struct Resolution {
         rerun::datatypes::Vec2D resolution;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'resolution_ext.cpp'
 
@@ -59,18 +56,30 @@ namespace rerun::components {
         operator rerun::datatypes::Vec2D() const {
             return resolution;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::Resolution> {
+        static constexpr const char Name[] = "rerun.components.Resolution";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const Resolution* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const components::Resolution* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of Resolution components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::Resolution` components.
         static Result<rerun::DataCell> to_data_cell(
-            const Resolution* instances, size_t num_instances
+            const components::Resolution* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/rotation3d.cpp
+++ b/rerun_cpp/src/rerun/components/rotation3d.cpp
@@ -8,19 +8,20 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char Rotation3D::NAME[] = "rerun.components.Rotation3D";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& Rotation3D::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Rotation3D::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::Rotation3D>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::Rotation3D>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error Rotation3D::fill_arrow_array_builder(
-        arrow::DenseUnionBuilder* builder, const Rotation3D* elements, size_t num_elements
+    rerun::Error Loggable<components::Rotation3D>::fill_arrow_array_builder(
+        arrow::DenseUnionBuilder* builder, const components::Rotation3D* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Rotation3D) == sizeof(Rotation3D));
-        RR_RETURN_NOT_OK(rerun::datatypes::Rotation3D::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::Rotation3D) == sizeof(components::Rotation3D));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Rotation3D>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Rotation3D*>(elements),
             num_elements
@@ -29,8 +30,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> Rotation3D::to_data_cell(
-        const Rotation3D* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::Rotation3D>::to_data_cell(
+        const components::Rotation3D* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +39,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(Rotation3D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::Rotation3D>::fill_arrow_array_builder(
                 static_cast<arrow::DenseUnionBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +49,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +58,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/rotation3d.hpp
+++ b/rerun_cpp/src/rerun/components/rotation3d.hpp
@@ -21,9 +21,6 @@ namespace rerun::components {
         /// Representation of the rotation.
         rerun::datatypes::Rotation3D repr;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'rotation3d_ext.cpp'
 
@@ -49,18 +46,30 @@ namespace rerun::components {
         operator rerun::datatypes::Rotation3D() const {
             return repr;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::Rotation3D> {
+        static constexpr const char Name[] = "rerun.components.Rotation3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const Rotation3D* elements, size_t num_elements
+            arrow::DenseUnionBuilder* builder, const components::Rotation3D* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of Rotation3D components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::Rotation3D` components.
         static Result<rerun::DataCell> to_data_cell(
-            const Rotation3D* instances, size_t num_instances
+            const components::Rotation3D* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/scalar.cpp
+++ b/rerun_cpp/src/rerun/components/scalar.cpp
@@ -6,16 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char Scalar::NAME[] = "rerun.components.Scalar";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& Scalar::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::Scalar>::arrow_datatype() {
         static const auto datatype = arrow::float64();
         return datatype;
     }
 
-    rerun::Error Scalar::fill_arrow_array_builder(
-        arrow::DoubleBuilder* builder, const Scalar* elements, size_t num_elements
+    rerun::Error Loggable<components::Scalar>::fill_arrow_array_builder(
+        arrow::DoubleBuilder* builder, const components::Scalar* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -35,14 +35,16 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> Scalar::to_data_cell(const Scalar* instances, size_t num_instances) {
+    Result<rerun::DataCell> Loggable<components::Scalar>::to_data_cell(
+        const components::Scalar* instances, size_t num_instances
+    ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
         auto datatype = arrow_datatype();
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(Scalar::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::Scalar>::fill_arrow_array_builder(
                 static_cast<arrow::DoubleBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -52,7 +54,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -61,4 +63,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/scalar.hpp
+++ b/rerun_cpp/src/rerun/components/scalar.hpp
@@ -26,9 +26,6 @@ namespace rerun::components {
     struct Scalar {
         double value;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         Scalar() = default;
 
@@ -38,16 +35,29 @@ namespace rerun::components {
             value = value_;
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::Scalar> {
+        static constexpr const char Name[] = "rerun.components.Scalar";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::DoubleBuilder* builder, const Scalar* elements, size_t num_elements
+            arrow::DoubleBuilder* builder, const components::Scalar* elements, size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of Scalar components.
-        static Result<rerun::DataCell> to_data_cell(const Scalar* instances, size_t num_instances);
+        /// Creates a Rerun DataCell from an array of `rerun::components::Scalar` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const components::Scalar* instances, size_t num_instances
+        );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/scalar_scattering.cpp
+++ b/rerun_cpp/src/rerun/components/scalar_scattering.cpp
@@ -6,16 +6,18 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char ScalarScattering::NAME[] = "rerun.components.ScalarScattering";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& ScalarScattering::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::ScalarScattering>::arrow_datatype(
+    ) {
         static const auto datatype = arrow::boolean();
         return datatype;
     }
 
-    rerun::Error ScalarScattering::fill_arrow_array_builder(
-        arrow::BooleanBuilder* builder, const ScalarScattering* elements, size_t num_elements
+    rerun::Error Loggable<components::ScalarScattering>::fill_arrow_array_builder(
+        arrow::BooleanBuilder* builder, const components::ScalarScattering* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -36,8 +38,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> ScalarScattering::to_data_cell(
-        const ScalarScattering* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::ScalarScattering>::to_data_cell(
+        const components::ScalarScattering* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -45,7 +47,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(ScalarScattering::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::ScalarScattering>::fill_arrow_array_builder(
                 static_cast<arrow::BooleanBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -55,7 +57,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -64,4 +66,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/scalar_scattering.hpp
+++ b/rerun_cpp/src/rerun/components/scalar_scattering.hpp
@@ -19,9 +19,6 @@ namespace rerun::components {
     struct ScalarScattering {
         bool scattered;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         ScalarScattering() = default;
 
@@ -31,18 +28,30 @@ namespace rerun::components {
             scattered = scattered_;
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::ScalarScattering> {
+        static constexpr const char Name[] = "rerun.components.ScalarScattering";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::BooleanBuilder* builder, const ScalarScattering* elements, size_t num_elements
+            arrow::BooleanBuilder* builder, const components::ScalarScattering* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of ScalarScattering components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::ScalarScattering` components.
         static Result<rerun::DataCell> to_data_cell(
-            const ScalarScattering* instances, size_t num_instances
+            const components::ScalarScattering* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/tensor_data.cpp
+++ b/rerun_cpp/src/rerun/components/tensor_data.cpp
@@ -8,19 +8,19 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char TensorData::NAME[] = "rerun.components.TensorData";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& TensorData::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::TensorData::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::TensorData>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::TensorData>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error TensorData::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const TensorData* elements, size_t num_elements
+    rerun::Error Loggable<components::TensorData>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const components::TensorData* elements, size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::TensorData) == sizeof(TensorData));
-        RR_RETURN_NOT_OK(rerun::datatypes::TensorData::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::TensorData) == sizeof(components::TensorData));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::TensorData>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::TensorData*>(elements),
             num_elements
@@ -29,8 +29,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> TensorData::to_data_cell(
-        const TensorData* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::TensorData>::to_data_cell(
+        const components::TensorData* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +38,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(TensorData::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::TensorData>::fill_arrow_array_builder(
                 static_cast<arrow::StructBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +48,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +57,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/tensor_data.hpp
+++ b/rerun_cpp/src/rerun/components/tensor_data.hpp
@@ -21,9 +21,6 @@ namespace rerun::components {
     struct TensorData {
         rerun::datatypes::TensorData data;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'tensor_data_ext.cpp'
 
@@ -48,18 +45,30 @@ namespace rerun::components {
         operator rerun::datatypes::TensorData() const {
             return data;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::TensorData> {
+        static constexpr const char Name[] = "rerun.components.TensorData";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const TensorData* elements, size_t num_elements
+            arrow::StructBuilder* builder, const components::TensorData* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of TensorData components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::TensorData` components.
         static Result<rerun::DataCell> to_data_cell(
-            const TensorData* instances, size_t num_instances
+            const components::TensorData* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/text.cpp
+++ b/rerun_cpp/src/rerun/components/text.cpp
@@ -8,19 +8,19 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char Text::NAME[] = "rerun.components.Text";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& Text::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Utf8::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::Text>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::Utf8>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error Text::fill_arrow_array_builder(
-        arrow::StringBuilder* builder, const Text* elements, size_t num_elements
+    rerun::Error Loggable<components::Text>::fill_arrow_array_builder(
+        arrow::StringBuilder* builder, const components::Text* elements, size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Utf8) == sizeof(Text));
-        RR_RETURN_NOT_OK(rerun::datatypes::Utf8::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::Utf8) == sizeof(components::Text));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Utf8>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Utf8*>(elements),
             num_elements
@@ -29,14 +29,16 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> Text::to_data_cell(const Text* instances, size_t num_instances) {
+    Result<rerun::DataCell> Loggable<components::Text>::to_data_cell(
+        const components::Text* instances, size_t num_instances
+    ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
         auto datatype = arrow_datatype();
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(Text::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::Text>::fill_arrow_array_builder(
                 static_cast<arrow::StringBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -46,7 +48,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -55,4 +57,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/text.hpp
+++ b/rerun_cpp/src/rerun/components/text.hpp
@@ -22,9 +22,6 @@ namespace rerun::components {
     struct Text {
         rerun::datatypes::Utf8 value;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'text_ext.cpp'
 
@@ -56,16 +53,29 @@ namespace rerun::components {
         operator rerun::datatypes::Utf8() const {
             return value;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::Text> {
+        static constexpr const char Name[] = "rerun.components.Text";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StringBuilder* builder, const Text* elements, size_t num_elements
+            arrow::StringBuilder* builder, const components::Text* elements, size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of Text components.
-        static Result<rerun::DataCell> to_data_cell(const Text* instances, size_t num_instances);
+        /// Creates a Rerun DataCell from an array of `rerun::components::Text` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const components::Text* instances, size_t num_instances
+        );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/text_log_level.cpp
+++ b/rerun_cpp/src/rerun/components/text_log_level.cpp
@@ -8,19 +8,19 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char TextLogLevel::NAME[] = "rerun.components.TextLogLevel";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& TextLogLevel::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Utf8::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::TextLogLevel>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::Utf8>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error TextLogLevel::fill_arrow_array_builder(
-        arrow::StringBuilder* builder, const TextLogLevel* elements, size_t num_elements
+    rerun::Error Loggable<components::TextLogLevel>::fill_arrow_array_builder(
+        arrow::StringBuilder* builder, const components::TextLogLevel* elements, size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Utf8) == sizeof(TextLogLevel));
-        RR_RETURN_NOT_OK(rerun::datatypes::Utf8::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::Utf8) == sizeof(components::TextLogLevel));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Utf8>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Utf8*>(elements),
             num_elements
@@ -29,8 +29,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> TextLogLevel::to_data_cell(
-        const TextLogLevel* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::TextLogLevel>::to_data_cell(
+        const components::TextLogLevel* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +38,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(TextLogLevel::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::TextLogLevel>::fill_arrow_array_builder(
                 static_cast<arrow::StringBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +48,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +57,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/text_log_level.hpp
+++ b/rerun_cpp/src/rerun/components/text_log_level.hpp
@@ -30,9 +30,6 @@ namespace rerun::components {
     struct TextLogLevel {
         rerun::datatypes::Utf8 value;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'text_log_level_ext.cpp'
 
@@ -82,18 +79,30 @@ namespace rerun::components {
         operator rerun::datatypes::Utf8() const {
             return value;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::TextLogLevel> {
+        static constexpr const char Name[] = "rerun.components.TextLogLevel";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StringBuilder* builder, const TextLogLevel* elements, size_t num_elements
+            arrow::StringBuilder* builder, const components::TextLogLevel* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of TextLogLevel components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::TextLogLevel` components.
         static Result<rerun::DataCell> to_data_cell(
-            const TextLogLevel* instances, size_t num_instances
+            const components::TextLogLevel* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/transform3d.cpp
+++ b/rerun_cpp/src/rerun/components/transform3d.cpp
@@ -8,19 +8,20 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char Transform3D::NAME[] = "rerun.components.Transform3D";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& Transform3D::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Transform3D::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::Transform3D>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::Transform3D>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error Transform3D::fill_arrow_array_builder(
-        arrow::DenseUnionBuilder* builder, const Transform3D* elements, size_t num_elements
+    rerun::Error Loggable<components::Transform3D>::fill_arrow_array_builder(
+        arrow::DenseUnionBuilder* builder, const components::Transform3D* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Transform3D) == sizeof(Transform3D));
-        RR_RETURN_NOT_OK(rerun::datatypes::Transform3D::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::Transform3D) == sizeof(components::Transform3D));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Transform3D>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Transform3D*>(elements),
             num_elements
@@ -29,8 +30,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> Transform3D::to_data_cell(
-        const Transform3D* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::Transform3D>::to_data_cell(
+        const components::Transform3D* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +39,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(Transform3D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::Transform3D>::fill_arrow_array_builder(
                 static_cast<arrow::DenseUnionBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +49,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +58,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/transform3d.hpp
+++ b/rerun_cpp/src/rerun/components/transform3d.hpp
@@ -21,9 +21,6 @@ namespace rerun::components {
         /// Representation of the transform.
         rerun::datatypes::Transform3D repr;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         Transform3D() = default;
 
@@ -38,18 +35,30 @@ namespace rerun::components {
         operator rerun::datatypes::Transform3D() const {
             return repr;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::Transform3D> {
+        static constexpr const char Name[] = "rerun.components.Transform3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const Transform3D* elements, size_t num_elements
+            arrow::DenseUnionBuilder* builder, const components::Transform3D* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of Transform3D components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::Transform3D` components.
         static Result<rerun::DataCell> to_data_cell(
-            const Transform3D* instances, size_t num_instances
+            const components::Transform3D* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/vector3d.cpp
+++ b/rerun_cpp/src/rerun/components/vector3d.cpp
@@ -8,19 +8,20 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char Vector3D::NAME[] = "rerun.components.Vector3D";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& Vector3D::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::Vec3D::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::Vector3D>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::Vec3D>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error Vector3D::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const Vector3D* elements, size_t num_elements
+    rerun::Error Loggable<components::Vector3D>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const components::Vector3D* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::Vec3D) == sizeof(Vector3D));
-        RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::Vec3D) == sizeof(components::Vector3D));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Vec3D>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::Vec3D*>(elements),
             num_elements
@@ -29,8 +30,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> Vector3D::to_data_cell(
-        const Vector3D* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::Vector3D>::to_data_cell(
+        const components::Vector3D* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +39,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(Vector3D::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::Vector3D>::fill_arrow_array_builder(
                 static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +49,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +58,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/vector3d.hpp
+++ b/rerun_cpp/src/rerun/components/vector3d.hpp
@@ -21,9 +21,6 @@ namespace rerun::components {
     struct Vector3D {
         rerun::datatypes::Vec3D vector;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'vector3d_ext.cpp'
 
@@ -66,18 +63,30 @@ namespace rerun::components {
         operator rerun::datatypes::Vec3D() const {
             return vector;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::Vector3D> {
+        static constexpr const char Name[] = "rerun.components.Vector3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const Vector3D* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const components::Vector3D* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of Vector3D components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::Vector3D` components.
         static Result<rerun::DataCell> to_data_cell(
-            const Vector3D* instances, size_t num_instances
+            const components::Vector3D* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/view_coordinates.cpp
+++ b/rerun_cpp/src/rerun/components/view_coordinates.cpp
@@ -6,17 +6,19 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char ViewCoordinates::NAME[] = "rerun.components.ViewCoordinates";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& ViewCoordinates::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::ViewCoordinates>::arrow_datatype(
+    ) {
         static const auto datatype =
             arrow::fixed_size_list(arrow::field("item", arrow::uint8(), false), 3);
         return datatype;
     }
 
-    rerun::Error ViewCoordinates::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const ViewCoordinates* elements, size_t num_elements
+    rerun::Error Loggable<components::ViewCoordinates>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const components::ViewCoordinates* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -41,8 +43,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> ViewCoordinates::to_data_cell(
-        const ViewCoordinates* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::ViewCoordinates>::to_data_cell(
+        const components::ViewCoordinates* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -50,7 +52,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(ViewCoordinates::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::ViewCoordinates>::fill_arrow_array_builder(
                 static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -60,7 +62,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -69,4 +71,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/components/view_coordinates.hpp
@@ -36,9 +36,6 @@ namespace rerun::components {
         /// The directions of the [x, y, z] axes.
         std::array<uint8_t, 3> coordinates;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         // Extensions to generated type defined in 'view_coordinates_ext.cpp'
 
@@ -132,19 +129,30 @@ namespace rerun::components {
             coordinates = coordinates_;
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::ViewCoordinates> {
+        static constexpr const char Name[] = "rerun.components.ViewCoordinates";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const ViewCoordinates* elements,
+            arrow::FixedSizeListBuilder* builder, const components::ViewCoordinates* elements,
             size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of ViewCoordinates components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::ViewCoordinates` components.
         static Result<rerun::DataCell> to_data_cell(
-            const ViewCoordinates* instances, size_t num_instances
+            const components::ViewCoordinates* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/angle.cpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.cpp
@@ -6,8 +6,10 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& Angle::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::Angle>::arrow_datatype() {
         static const auto datatype = arrow::dense_union({
             arrow::field("_null_markers", arrow::null(), true, nullptr),
             arrow::field("Radians", arrow::float32(), false),
@@ -16,8 +18,8 @@ namespace rerun::datatypes {
         return datatype;
     }
 
-    rerun::Error Angle::fill_arrow_array_builder(
-        arrow::DenseUnionBuilder* builder, const Angle* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::Angle>::fill_arrow_array_builder(
+        arrow::DenseUnionBuilder* builder, const datatypes::Angle* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -32,28 +34,63 @@ namespace rerun::datatypes {
         ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
         for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
             const auto& union_instance = elements[elem_idx];
-            ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance._tag)));
+            ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance.get_union_tag()))
+            );
 
-            auto variant_index = static_cast<int>(union_instance._tag);
+            auto variant_index = static_cast<int>(union_instance.get_union_tag());
             auto variant_builder_untyped = builder->child_builder(variant_index).get();
 
-            switch (union_instance._tag) {
-                case detail::AngleTag::None: {
+            using TagType = datatypes::detail::AngleTag;
+            switch (union_instance.get_union_tag()) {
+                case TagType::None: {
                     ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                 } break;
-                case detail::AngleTag::Radians: {
+                case TagType::Radians: {
                     auto variant_builder =
                         static_cast<arrow::FloatBuilder*>(variant_builder_untyped);
-                    ARROW_RETURN_NOT_OK(variant_builder->Append(union_instance._data.radians));
+                    ARROW_RETURN_NOT_OK(
+                        variant_builder->Append(union_instance.get_union_data().radians)
+                    );
                 } break;
-                case detail::AngleTag::Degrees: {
+                case TagType::Degrees: {
                     auto variant_builder =
                         static_cast<arrow::FloatBuilder*>(variant_builder_untyped);
-                    ARROW_RETURN_NOT_OK(variant_builder->Append(union_instance._data.degrees));
+                    ARROW_RETURN_NOT_OK(
+                        variant_builder->Append(union_instance.get_union_data().degrees)
+                    );
                 } break;
             }
         }
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::Angle>::to_data_cell(
+        const datatypes::Angle* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::Angle>::fill_arrow_array_builder(
+                static_cast<arrow::DenseUnionBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -113,16 +114,42 @@ namespace rerun::datatypes {
             }
         }
 
-        /// Returns the arrow data type this type corresponds to.
-        static const std::shared_ptr<arrow::DataType>& arrow_datatype();
+        /// \private
+        const detail::AngleData& get_union_data() const {
+            return _data;
+        }
 
-        /// Fills an arrow array builder with an array of this type.
-        static rerun::Error fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const Angle* elements, size_t num_elements
-        );
+        /// \private
+        detail::AngleTag get_union_tag() const {
+            return _tag;
+        }
 
       private:
         detail::AngleTag _tag;
         detail::AngleData _data;
     };
 } // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::Angle> {
+        static constexpr const char Name[] = "rerun.datatypes.Angle";
+
+        /// Returns the arrow data type this type corresponds to.
+        static const std::shared_ptr<arrow::DataType>& arrow_datatype();
+
+        /// Fills an arrow array builder with an array of this type.
+        static rerun::Error fill_arrow_array_builder(
+            arrow::DenseUnionBuilder* builder, const datatypes::Angle* elements, size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::Angle` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::Angle* instances, size_t num_instances
+        );
+    };
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/annotation_info.cpp
+++ b/rerun_cpp/src/rerun/datatypes/annotation_info.cpp
@@ -9,18 +9,21 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& AnnotationInfo::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::AnnotationInfo>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
             arrow::field("id", arrow::uint16(), false),
-            arrow::field("label", rerun::datatypes::Utf8::arrow_datatype(), true),
-            arrow::field("color", rerun::datatypes::Rgba32::arrow_datatype(), true),
+            arrow::field("label", Loggable<rerun::datatypes::Utf8>::arrow_datatype(), true),
+            arrow::field("color", Loggable<rerun::datatypes::Rgba32>::arrow_datatype(), true),
         });
         return datatype;
     }
 
-    rerun::Error AnnotationInfo::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const AnnotationInfo* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::AnnotationInfo>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::AnnotationInfo* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -45,7 +48,7 @@ namespace rerun::datatypes {
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto& element = elements[elem_idx];
                 if (element.label.has_value()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::Utf8::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Utf8>::fill_arrow_array_builder(
                         field_builder,
                         &element.label.value(),
                         1
@@ -61,7 +64,7 @@ namespace rerun::datatypes {
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto& element = elements[elem_idx];
                 if (element.color.has_value()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::Rgba32::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Rgba32>::fill_arrow_array_builder(
                         field_builder,
                         &element.color.value(),
                         1
@@ -75,4 +78,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::AnnotationInfo>::to_data_cell(
+        const datatypes::AnnotationInfo* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::AnnotationInfo>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/annotation_info.hpp
+++ b/rerun_cpp/src/rerun/datatypes/annotation_info.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 #include "rgba32.hpp"
 #include "utf8.hpp"
@@ -45,13 +46,30 @@ namespace rerun::datatypes {
 
       public:
         AnnotationInfo() = default;
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::AnnotationInfo> {
+        static constexpr const char Name[] = "rerun.datatypes.AnnotationInfo";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AnnotationInfo* elements, size_t num_elements
+            arrow::StructBuilder* builder, const datatypes::AnnotationInfo* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::AnnotationInfo` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::AnnotationInfo* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/class_description.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.cpp
@@ -9,30 +9,42 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& ClassDescription::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::ClassDescription>::arrow_datatype(
+    ) {
         static const auto datatype = arrow::struct_({
-            arrow::field("info", rerun::datatypes::AnnotationInfo::arrow_datatype(), false),
+            arrow::field(
+                "info",
+                Loggable<rerun::datatypes::AnnotationInfo>::arrow_datatype(),
+                false
+            ),
             arrow::field(
                 "keypoint_annotations",
-                arrow::list(
-                    arrow::field("item", rerun::datatypes::AnnotationInfo::arrow_datatype(), false)
-                ),
+                arrow::list(arrow::field(
+                    "item",
+                    Loggable<rerun::datatypes::AnnotationInfo>::arrow_datatype(),
+                    false
+                )),
                 false
             ),
             arrow::field(
                 "keypoint_connections",
-                arrow::list(
-                    arrow::field("item", rerun::datatypes::KeypointPair::arrow_datatype(), false)
-                ),
+                arrow::list(arrow::field(
+                    "item",
+                    Loggable<rerun::datatypes::KeypointPair>::arrow_datatype(),
+                    false
+                )),
                 false
             ),
         });
         return datatype;
     }
 
-    rerun::Error ClassDescription::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const ClassDescription* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::ClassDescription>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::ClassDescription* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -48,11 +60,13 @@ namespace rerun::datatypes {
             auto field_builder = static_cast<arrow::StructBuilder*>(builder->field_builder(0));
             ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                RR_RETURN_NOT_OK(rerun::datatypes::AnnotationInfo::fill_arrow_array_builder(
-                    field_builder,
-                    &elements[elem_idx].info,
-                    1
-                ));
+                RR_RETURN_NOT_OK(
+                    Loggable<rerun::datatypes::AnnotationInfo>::fill_arrow_array_builder(
+                        field_builder,
+                        &elements[elem_idx].info,
+                        1
+                    )
+                );
             }
         }
         {
@@ -65,11 +79,13 @@ namespace rerun::datatypes {
                 const auto& element = elements[elem_idx];
                 ARROW_RETURN_NOT_OK(field_builder->Append());
                 if (element.keypoint_annotations.data()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::AnnotationInfo::fill_arrow_array_builder(
-                        value_builder,
-                        element.keypoint_annotations.data(),
-                        element.keypoint_annotations.size()
-                    ));
+                    RR_RETURN_NOT_OK(
+                        Loggable<rerun::datatypes::AnnotationInfo>::fill_arrow_array_builder(
+                            value_builder,
+                            element.keypoint_annotations.data(),
+                            element.keypoint_annotations.size()
+                        )
+                    );
                 }
             }
         }
@@ -83,11 +99,13 @@ namespace rerun::datatypes {
                 const auto& element = elements[elem_idx];
                 ARROW_RETURN_NOT_OK(field_builder->Append());
                 if (element.keypoint_connections.data()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::KeypointPair::fill_arrow_array_builder(
-                        value_builder,
-                        element.keypoint_connections.data(),
-                        element.keypoint_connections.size()
-                    ));
+                    RR_RETURN_NOT_OK(
+                        Loggable<rerun::datatypes::KeypointPair>::fill_arrow_array_builder(
+                            value_builder,
+                            element.keypoint_connections.data(),
+                            element.keypoint_connections.size()
+                        )
+                    );
                 }
             }
         }
@@ -95,4 +113,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::ClassDescription>::to_data_cell(
+        const datatypes::ClassDescription* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::ClassDescription>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/class_description.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../collection.hpp"
+#include "../data_cell.hpp"
 #include "../result.hpp"
 #include "annotation_info.hpp"
 #include "keypoint_pair.hpp"
@@ -61,13 +62,30 @@ namespace rerun::datatypes {
 
       public:
         ClassDescription() = default;
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::ClassDescription> {
+        static constexpr const char Name[] = "rerun.datatypes.ClassDescription";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const ClassDescription* elements, size_t num_elements
+            arrow::StructBuilder* builder, const datatypes::ClassDescription* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::ClassDescription` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::ClassDescription* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/class_description_map_elem.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description_map_elem.cpp
@@ -9,21 +9,25 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& ClassDescriptionMapElem::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>&
+        Loggable<datatypes::ClassDescriptionMapElem>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
-            arrow::field("class_id", rerun::datatypes::ClassId::arrow_datatype(), false),
+            arrow::field("class_id", Loggable<rerun::datatypes::ClassId>::arrow_datatype(), false),
             arrow::field(
                 "class_description",
-                rerun::datatypes::ClassDescription::arrow_datatype(),
+                Loggable<rerun::datatypes::ClassDescription>::arrow_datatype(),
                 false
             ),
         });
         return datatype;
     }
 
-    rerun::Error ClassDescriptionMapElem::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const ClassDescriptionMapElem* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::ClassDescriptionMapElem>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::ClassDescriptionMapElem* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -39,7 +43,7 @@ namespace rerun::datatypes {
             auto field_builder = static_cast<arrow::UInt16Builder*>(builder->field_builder(0));
             ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                RR_RETURN_NOT_OK(rerun::datatypes::ClassId::fill_arrow_array_builder(
+                RR_RETURN_NOT_OK(Loggable<rerun::datatypes::ClassId>::fill_arrow_array_builder(
                     field_builder,
                     &elements[elem_idx].class_id,
                     1
@@ -50,15 +54,46 @@ namespace rerun::datatypes {
             auto field_builder = static_cast<arrow::StructBuilder*>(builder->field_builder(1));
             ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                RR_RETURN_NOT_OK(rerun::datatypes::ClassDescription::fill_arrow_array_builder(
-                    field_builder,
-                    &elements[elem_idx].class_description,
-                    1
-                ));
+                RR_RETURN_NOT_OK(
+                    Loggable<rerun::datatypes::ClassDescription>::fill_arrow_array_builder(
+                        field_builder,
+                        &elements[elem_idx].class_description,
+                        1
+                    )
+                );
             }
         }
         ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::ClassDescriptionMapElem>::to_data_cell(
+        const datatypes::ClassDescriptionMapElem* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::ClassDescriptionMapElem>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/class_description_map_elem.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description_map_elem.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 #include "class_description.hpp"
 #include "class_id.hpp"
@@ -35,14 +36,30 @@ namespace rerun::datatypes {
 
       public:
         ClassDescriptionMapElem() = default;
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::ClassDescriptionMapElem> {
+        static constexpr const char Name[] = "rerun.datatypes.ClassDescriptionMapElem";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const ClassDescriptionMapElem* elements,
+            arrow::StructBuilder* builder, const datatypes::ClassDescriptionMapElem* elements,
             size_t num_elements
         );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::ClassDescriptionMapElem` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::ClassDescriptionMapElem* instances, size_t num_instances
+        );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/class_id.cpp
+++ b/rerun_cpp/src/rerun/datatypes/class_id.cpp
@@ -6,14 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& ClassId::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::ClassId>::arrow_datatype() {
         static const auto datatype = arrow::uint16();
         return datatype;
     }
 
-    rerun::Error ClassId::fill_arrow_array_builder(
-        arrow::UInt16Builder* builder, const ClassId* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::ClassId>::fill_arrow_array_builder(
+        arrow::UInt16Builder* builder, const datatypes::ClassId* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -31,4 +33,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::ClassId>::to_data_cell(
+        const datatypes::ClassId* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::ClassId>::fill_arrow_array_builder(
+                static_cast<arrow::UInt16Builder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/class_id.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_id.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -32,13 +33,29 @@ namespace rerun::datatypes {
             id = id_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::ClassId> {
+        static constexpr const char Name[] = "rerun.datatypes.ClassId";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::UInt16Builder* builder, const ClassId* elements, size_t num_elements
+            arrow::UInt16Builder* builder, const datatypes::ClassId* elements, size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::ClassId` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::ClassId* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/float32.cpp
+++ b/rerun_cpp/src/rerun/datatypes/float32.cpp
@@ -6,14 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& Float32::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::Float32>::arrow_datatype() {
         static const auto datatype = arrow::float32();
         return datatype;
     }
 
-    rerun::Error Float32::fill_arrow_array_builder(
-        arrow::FloatBuilder* builder, const Float32* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::Float32>::fill_arrow_array_builder(
+        arrow::FloatBuilder* builder, const datatypes::Float32* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -32,4 +34,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::Float32>::to_data_cell(
+        const datatypes::Float32* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::Float32>::fill_arrow_array_builder(
+                static_cast<arrow::FloatBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/float32.hpp
+++ b/rerun_cpp/src/rerun/datatypes/float32.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -32,13 +33,29 @@ namespace rerun::datatypes {
             value = value_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::Float32> {
+        static constexpr const char Name[] = "rerun.datatypes.Float32";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FloatBuilder* builder, const Float32* elements, size_t num_elements
+            arrow::FloatBuilder* builder, const datatypes::Float32* elements, size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::Float32` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::Float32* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/keypoint_id.cpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_id.cpp
@@ -6,14 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& KeypointId::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::KeypointId>::arrow_datatype() {
         static const auto datatype = arrow::uint16();
         return datatype;
     }
 
-    rerun::Error KeypointId::fill_arrow_array_builder(
-        arrow::UInt16Builder* builder, const KeypointId* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::KeypointId>::fill_arrow_array_builder(
+        arrow::UInt16Builder* builder, const datatypes::KeypointId* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -31,4 +33,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::KeypointId>::to_data_cell(
+        const datatypes::KeypointId* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::KeypointId>::fill_arrow_array_builder(
+                static_cast<arrow::UInt16Builder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/keypoint_id.hpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_id.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -32,13 +33,30 @@ namespace rerun::datatypes {
             id = id_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::KeypointId> {
+        static constexpr const char Name[] = "rerun.datatypes.KeypointId";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::UInt16Builder* builder, const KeypointId* elements, size_t num_elements
+            arrow::UInt16Builder* builder, const datatypes::KeypointId* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::KeypointId` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::KeypointId* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/keypoint_pair.cpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_pair.cpp
@@ -8,17 +8,27 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& KeypointPair::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::KeypointPair>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
-            arrow::field("keypoint0", rerun::datatypes::KeypointId::arrow_datatype(), false),
-            arrow::field("keypoint1", rerun::datatypes::KeypointId::arrow_datatype(), false),
+            arrow::field(
+                "keypoint0",
+                Loggable<rerun::datatypes::KeypointId>::arrow_datatype(),
+                false
+            ),
+            arrow::field(
+                "keypoint1",
+                Loggable<rerun::datatypes::KeypointId>::arrow_datatype(),
+                false
+            ),
         });
         return datatype;
     }
 
-    rerun::Error KeypointPair::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const KeypointPair* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::KeypointPair>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::KeypointPair* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -34,7 +44,7 @@ namespace rerun::datatypes {
             auto field_builder = static_cast<arrow::UInt16Builder*>(builder->field_builder(0));
             ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                RR_RETURN_NOT_OK(rerun::datatypes::KeypointId::fill_arrow_array_builder(
+                RR_RETURN_NOT_OK(Loggable<rerun::datatypes::KeypointId>::fill_arrow_array_builder(
                     field_builder,
                     &elements[elem_idx].keypoint0,
                     1
@@ -45,7 +55,7 @@ namespace rerun::datatypes {
             auto field_builder = static_cast<arrow::UInt16Builder*>(builder->field_builder(1));
             ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                RR_RETURN_NOT_OK(rerun::datatypes::KeypointId::fill_arrow_array_builder(
+                RR_RETURN_NOT_OK(Loggable<rerun::datatypes::KeypointId>::fill_arrow_array_builder(
                     field_builder,
                     &elements[elem_idx].keypoint1,
                     1
@@ -56,4 +66,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::KeypointPair>::to_data_cell(
+        const datatypes::KeypointPair* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::KeypointPair>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 #include "keypoint_id.hpp"
 
@@ -34,13 +35,30 @@ namespace rerun::datatypes {
 
       public:
         KeypointPair() = default;
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::KeypointPair> {
+        static constexpr const char Name[] = "rerun.datatypes.KeypointPair";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const KeypointPair* elements, size_t num_elements
+            arrow::StructBuilder* builder, const datatypes::KeypointPair* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::KeypointPair` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::KeypointPair* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.cpp
@@ -6,15 +6,17 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& Mat3x3::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::Mat3x3>::arrow_datatype() {
         static const auto datatype =
             arrow::fixed_size_list(arrow::field("item", arrow::float32(), false), 9);
         return datatype;
     }
 
-    rerun::Error Mat3x3::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const Mat3x3* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::Mat3x3>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const datatypes::Mat3x3* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -38,4 +40,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::Mat3x3>::to_data_cell(
+        const datatypes::Mat3x3* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::Mat3x3>::fill_arrow_array_builder(
+                static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 #include "vec3d.hpp"
 
@@ -72,13 +73,30 @@ namespace rerun::datatypes {
             flat_columns = flat_columns_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::Mat3x3> {
+        static constexpr const char Name[] = "rerun.datatypes.Mat3x3";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const Mat3x3* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const datatypes::Mat3x3* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::Mat3x3` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::Mat3x3* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.cpp
@@ -6,15 +6,17 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& Mat4x4::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::Mat4x4>::arrow_datatype() {
         static const auto datatype =
             arrow::fixed_size_list(arrow::field("item", arrow::float32(), false), 16);
         return datatype;
     }
 
-    rerun::Error Mat4x4::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const Mat4x4* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::Mat4x4>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const datatypes::Mat4x4* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -38,4 +40,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::Mat4x4>::to_data_cell(
+        const datatypes::Mat4x4* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::Mat4x4>::fill_arrow_array_builder(
+                static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 #include "vec4d.hpp"
 
@@ -87,13 +88,30 @@ namespace rerun::datatypes {
             flat_columns = flat_columns_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::Mat4x4> {
+        static constexpr const char Name[] = "rerun.datatypes.Mat4x4";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const Mat4x4* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const datatypes::Mat4x4* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::Mat4x4` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::Mat4x4* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/material.cpp
+++ b/rerun_cpp/src/rerun/datatypes/material.cpp
@@ -8,16 +8,22 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& Material::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::Material>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
-            arrow::field("albedo_factor", rerun::datatypes::Rgba32::arrow_datatype(), true),
+            arrow::field(
+                "albedo_factor",
+                Loggable<rerun::datatypes::Rgba32>::arrow_datatype(),
+                true
+            ),
         });
         return datatype;
     }
 
-    rerun::Error Material::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const Material* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::Material>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::Material* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -35,7 +41,7 @@ namespace rerun::datatypes {
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto& element = elements[elem_idx];
                 if (element.albedo_factor.has_value()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::Rgba32::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Rgba32>::fill_arrow_array_builder(
                         field_builder,
                         &element.albedo_factor.value(),
                         1
@@ -49,4 +55,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::Material>::to_data_cell(
+        const datatypes::Material* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::Material>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/material.hpp
+++ b/rerun_cpp/src/rerun/datatypes/material.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 #include "rgba32.hpp"
 
@@ -38,13 +39,29 @@ namespace rerun::datatypes {
             albedo_factor = rgba_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::Material> {
+        static constexpr const char Name[] = "rerun.datatypes.Material";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const Material* elements, size_t num_elements
+            arrow::StructBuilder* builder, const datatypes::Material* elements, size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::Material` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::Material* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/mesh_properties.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mesh_properties.cpp
@@ -6,8 +6,10 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& MeshProperties::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::MeshProperties>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
             arrow::field(
                 "indices",
@@ -18,8 +20,9 @@ namespace rerun::datatypes {
         return datatype;
     }
 
-    rerun::Error MeshProperties::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const MeshProperties* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::MeshProperties>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::MeshProperties* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -55,4 +58,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::MeshProperties>::to_data_cell(
+        const datatypes::MeshProperties* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::MeshProperties>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/mesh_properties.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mesh_properties.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../collection.hpp"
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -34,13 +35,30 @@ namespace rerun::datatypes {
             indices = std::move(indices_);
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::MeshProperties> {
+        static constexpr const char Name[] = "rerun.datatypes.MeshProperties";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const MeshProperties* elements, size_t num_elements
+            arrow::StructBuilder* builder, const datatypes::MeshProperties* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::MeshProperties` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::MeshProperties* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/quaternion.cpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion.cpp
@@ -6,15 +6,18 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& Quaternion::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::Quaternion>::arrow_datatype() {
         static const auto datatype =
             arrow::fixed_size_list(arrow::field("item", arrow::float32(), false), 4);
         return datatype;
     }
 
-    rerun::Error Quaternion::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const Quaternion* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::Quaternion>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const datatypes::Quaternion* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -38,4 +41,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::Quaternion>::to_data_cell(
+        const datatypes::Quaternion* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::Quaternion>::fill_arrow_array_builder(
+                static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/quaternion.hpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -77,13 +78,30 @@ namespace rerun::datatypes {
 
       public:
         Quaternion() = default;
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::Quaternion> {
+        static constexpr const char Name[] = "rerun.datatypes.Quaternion";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const Quaternion* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const datatypes::Quaternion* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::Quaternion` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::Quaternion* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/rgba32.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rgba32.cpp
@@ -6,14 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& Rgba32::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::Rgba32>::arrow_datatype() {
         static const auto datatype = arrow::uint32();
         return datatype;
     }
 
-    rerun::Error Rgba32::fill_arrow_array_builder(
-        arrow::UInt32Builder* builder, const Rgba32* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::Rgba32>::fill_arrow_array_builder(
+        arrow::UInt32Builder* builder, const datatypes::Rgba32* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -32,4 +34,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::Rgba32>::to_data_cell(
+        const datatypes::Rgba32* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::Rgba32>::fill_arrow_array_builder(
+                static_cast<arrow::UInt32Builder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/rgba32.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rgba32.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -64,13 +65,29 @@ namespace rerun::datatypes {
             rgba = rgba_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::Rgba32> {
+        static constexpr const char Name[] = "rerun.datatypes.Rgba32";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::UInt32Builder* builder, const Rgba32* elements, size_t num_elements
+            arrow::UInt32Builder* builder, const datatypes::Rgba32* elements, size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::Rgba32` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::Rgba32* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.cpp
@@ -9,18 +9,29 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& Rotation3D::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::Rotation3D>::arrow_datatype() {
         static const auto datatype = arrow::dense_union({
             arrow::field("_null_markers", arrow::null(), true, nullptr),
-            arrow::field("Quaternion", rerun::datatypes::Quaternion::arrow_datatype(), false),
-            arrow::field("AxisAngle", rerun::datatypes::RotationAxisAngle::arrow_datatype(), false),
+            arrow::field(
+                "Quaternion",
+                Loggable<rerun::datatypes::Quaternion>::arrow_datatype(),
+                false
+            ),
+            arrow::field(
+                "AxisAngle",
+                Loggable<rerun::datatypes::RotationAxisAngle>::arrow_datatype(),
+                false
+            ),
         });
         return datatype;
     }
 
-    rerun::Error Rotation3D::fill_arrow_array_builder(
-        arrow::DenseUnionBuilder* builder, const Rotation3D* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::Rotation3D>::fill_arrow_array_builder(
+        arrow::DenseUnionBuilder* builder, const datatypes::Rotation3D* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -35,36 +46,71 @@ namespace rerun::datatypes {
         ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
         for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
             const auto& union_instance = elements[elem_idx];
-            ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance._tag)));
+            ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance.get_union_tag()))
+            );
 
-            auto variant_index = static_cast<int>(union_instance._tag);
+            auto variant_index = static_cast<int>(union_instance.get_union_tag());
             auto variant_builder_untyped = builder->child_builder(variant_index).get();
 
-            switch (union_instance._tag) {
-                case detail::Rotation3DTag::None: {
+            using TagType = datatypes::detail::Rotation3DTag;
+            switch (union_instance.get_union_tag()) {
+                case TagType::None: {
                     ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                 } break;
-                case detail::Rotation3DTag::Quaternion: {
+                case TagType::Quaternion: {
                     auto variant_builder =
                         static_cast<arrow::FixedSizeListBuilder*>(variant_builder_untyped);
-                    RR_RETURN_NOT_OK(rerun::datatypes::Quaternion::fill_arrow_array_builder(
-                        variant_builder,
-                        &union_instance._data.quaternion,
-                        1
-                    ));
+                    RR_RETURN_NOT_OK(
+                        Loggable<rerun::datatypes::Quaternion>::fill_arrow_array_builder(
+                            variant_builder,
+                            &union_instance.get_union_data().quaternion,
+                            1
+                        )
+                    );
                 } break;
-                case detail::Rotation3DTag::AxisAngle: {
+                case TagType::AxisAngle: {
                     auto variant_builder =
                         static_cast<arrow::StructBuilder*>(variant_builder_untyped);
-                    RR_RETURN_NOT_OK(rerun::datatypes::RotationAxisAngle::fill_arrow_array_builder(
-                        variant_builder,
-                        &union_instance._data.axis_angle,
-                        1
-                    ));
+                    RR_RETURN_NOT_OK(
+                        Loggable<rerun::datatypes::RotationAxisAngle>::fill_arrow_array_builder(
+                            variant_builder,
+                            &union_instance.get_union_data().axis_angle,
+                            1
+                        )
+                    );
                 } break;
             }
         }
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::Rotation3D>::to_data_cell(
+        const datatypes::Rotation3D* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::Rotation3D>::fill_arrow_array_builder(
+                static_cast<arrow::DenseUnionBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation3d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 #include "quaternion.hpp"
 #include "rotation_axis_angle.hpp"
@@ -134,16 +135,43 @@ namespace rerun::datatypes {
             }
         }
 
-        /// Returns the arrow data type this type corresponds to.
-        static const std::shared_ptr<arrow::DataType>& arrow_datatype();
+        /// \private
+        const detail::Rotation3DData& get_union_data() const {
+            return _data;
+        }
 
-        /// Fills an arrow array builder with an array of this type.
-        static rerun::Error fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const Rotation3D* elements, size_t num_elements
-        );
+        /// \private
+        detail::Rotation3DTag get_union_tag() const {
+            return _tag;
+        }
 
       private:
         detail::Rotation3DTag _tag;
         detail::Rotation3DData _data;
     };
 } // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::Rotation3D> {
+        static constexpr const char Name[] = "rerun.datatypes.Rotation3D";
+
+        /// Returns the arrow data type this type corresponds to.
+        static const std::shared_ptr<arrow::DataType>& arrow_datatype();
+
+        /// Fills an arrow array builder with an array of this type.
+        static rerun::Error fill_arrow_array_builder(
+            arrow::DenseUnionBuilder* builder, const datatypes::Rotation3D* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::Rotation3D` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::Rotation3D* instances, size_t num_instances
+        );
+    };
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.cpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.cpp
@@ -9,17 +9,21 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& RotationAxisAngle::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::RotationAxisAngle>::arrow_datatype(
+    ) {
         static const auto datatype = arrow::struct_({
-            arrow::field("axis", rerun::datatypes::Vec3D::arrow_datatype(), false),
-            arrow::field("angle", rerun::datatypes::Angle::arrow_datatype(), false),
+            arrow::field("axis", Loggable<rerun::datatypes::Vec3D>::arrow_datatype(), false),
+            arrow::field("angle", Loggable<rerun::datatypes::Angle>::arrow_datatype(), false),
         });
         return datatype;
     }
 
-    rerun::Error RotationAxisAngle::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const RotationAxisAngle* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::RotationAxisAngle>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::RotationAxisAngle* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -36,7 +40,7 @@ namespace rerun::datatypes {
                 static_cast<arrow::FixedSizeListBuilder*>(builder->field_builder(0));
             ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+                RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Vec3D>::fill_arrow_array_builder(
                     field_builder,
                     &elements[elem_idx].axis,
                     1
@@ -47,7 +51,7 @@ namespace rerun::datatypes {
             auto field_builder = static_cast<arrow::DenseUnionBuilder*>(builder->field_builder(1));
             ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                RR_RETURN_NOT_OK(rerun::datatypes::Angle::fill_arrow_array_builder(
+                RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Angle>::fill_arrow_array_builder(
                     field_builder,
                     &elements[elem_idx].angle,
                     1
@@ -58,4 +62,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::RotationAxisAngle>::to_data_cell(
+        const datatypes::RotationAxisAngle* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::RotationAxisAngle>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 #include "angle.hpp"
 #include "vec3d.hpp"
@@ -35,13 +36,30 @@ namespace rerun::datatypes {
 
       public:
         RotationAxisAngle() = default;
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::RotationAxisAngle> {
+        static constexpr const char Name[] = "rerun.datatypes.RotationAxisAngle";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const RotationAxisAngle* elements, size_t num_elements
+            arrow::StructBuilder* builder, const datatypes::RotationAxisAngle* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::RotationAxisAngle` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::RotationAxisAngle* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/scale3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.cpp
@@ -8,18 +8,20 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& Scale3D::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::Scale3D>::arrow_datatype() {
         static const auto datatype = arrow::dense_union({
             arrow::field("_null_markers", arrow::null(), true, nullptr),
-            arrow::field("ThreeD", rerun::datatypes::Vec3D::arrow_datatype(), false),
+            arrow::field("ThreeD", Loggable<rerun::datatypes::Vec3D>::arrow_datatype(), false),
             arrow::field("Uniform", arrow::float32(), false),
         });
         return datatype;
     }
 
-    rerun::Error Scale3D::fill_arrow_array_builder(
-        arrow::DenseUnionBuilder* builder, const Scale3D* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::Scale3D>::fill_arrow_array_builder(
+        arrow::DenseUnionBuilder* builder, const datatypes::Scale3D* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -34,32 +36,65 @@ namespace rerun::datatypes {
         ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
         for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
             const auto& union_instance = elements[elem_idx];
-            ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance._tag)));
+            ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance.get_union_tag()))
+            );
 
-            auto variant_index = static_cast<int>(union_instance._tag);
+            auto variant_index = static_cast<int>(union_instance.get_union_tag());
             auto variant_builder_untyped = builder->child_builder(variant_index).get();
 
-            switch (union_instance._tag) {
-                case detail::Scale3DTag::None: {
+            using TagType = datatypes::detail::Scale3DTag;
+            switch (union_instance.get_union_tag()) {
+                case TagType::None: {
                     ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                 } break;
-                case detail::Scale3DTag::ThreeD: {
+                case TagType::ThreeD: {
                     auto variant_builder =
                         static_cast<arrow::FixedSizeListBuilder*>(variant_builder_untyped);
-                    RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Vec3D>::fill_arrow_array_builder(
                         variant_builder,
-                        &union_instance._data.three_d,
+                        &union_instance.get_union_data().three_d,
                         1
                     ));
                 } break;
-                case detail::Scale3DTag::Uniform: {
+                case TagType::Uniform: {
                     auto variant_builder =
                         static_cast<arrow::FloatBuilder*>(variant_builder_untyped);
-                    ARROW_RETURN_NOT_OK(variant_builder->Append(union_instance._data.uniform));
+                    ARROW_RETURN_NOT_OK(
+                        variant_builder->Append(union_instance.get_union_data().uniform)
+                    );
                 } break;
             }
         }
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::Scale3D>::to_data_cell(
+        const datatypes::Scale3D* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::Scale3D>::fill_arrow_array_builder(
+                static_cast<arrow::DenseUnionBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/scale3d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 #include "vec3d.hpp"
 
@@ -128,16 +129,43 @@ namespace rerun::datatypes {
             }
         }
 
-        /// Returns the arrow data type this type corresponds to.
-        static const std::shared_ptr<arrow::DataType>& arrow_datatype();
+        /// \private
+        const detail::Scale3DData& get_union_data() const {
+            return _data;
+        }
 
-        /// Fills an arrow array builder with an array of this type.
-        static rerun::Error fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const Scale3D* elements, size_t num_elements
-        );
+        /// \private
+        detail::Scale3DTag get_union_tag() const {
+            return _tag;
+        }
 
       private:
         detail::Scale3DTag _tag;
         detail::Scale3DData _data;
     };
 } // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::Scale3D> {
+        static constexpr const char Name[] = "rerun.datatypes.Scale3D";
+
+        /// Returns the arrow data type this type corresponds to.
+        static const std::shared_ptr<arrow::DataType>& arrow_datatype();
+
+        /// Fills an arrow array builder with an array of this type.
+        static rerun::Error fill_arrow_array_builder(
+            arrow::DenseUnionBuilder* builder, const datatypes::Scale3D* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::Scale3D` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::Scale3D* instances, size_t num_instances
+        );
+    };
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer.cpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer.cpp
@@ -6,8 +6,10 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& TensorBuffer::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::TensorBuffer>::arrow_datatype() {
         static const auto datatype = arrow::dense_union({
             arrow::field("_null_markers", arrow::null(), true, nullptr),
             arrow::field("U8", arrow::list(arrow::field("item", arrow::uint8(), false)), false),
@@ -27,8 +29,9 @@ namespace rerun::datatypes {
         return datatype;
     }
 
-    rerun::Error TensorBuffer::fill_arrow_array_builder(
-        arrow::DenseUnionBuilder* builder, const TensorBuffer* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::TensorBuffer>::fill_arrow_array_builder(
+        arrow::DenseUnionBuilder* builder, const datatypes::TensorBuffer* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -43,157 +46,159 @@ namespace rerun::datatypes {
         ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
         for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
             const auto& union_instance = elements[elem_idx];
-            ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance._tag)));
+            ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance.get_union_tag()))
+            );
 
-            auto variant_index = static_cast<int>(union_instance._tag);
+            auto variant_index = static_cast<int>(union_instance.get_union_tag());
             auto variant_builder_untyped = builder->child_builder(variant_index).get();
 
-            switch (union_instance._tag) {
-                case detail::TensorBufferTag::None: {
+            using TagType = datatypes::detail::TensorBufferTag;
+            switch (union_instance.get_union_tag()) {
+                case TagType::None: {
                     ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                 } break;
-                case detail::TensorBufferTag::U8: {
+                case TagType::U8: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->Append());
                     auto value_builder =
                         static_cast<arrow::UInt8Builder*>(variant_builder->value_builder());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                        union_instance._data.u8.data(),
-                        static_cast<int64_t>(union_instance._data.u8.size())
+                        union_instance.get_union_data().u8.data(),
+                        static_cast<int64_t>(union_instance.get_union_data().u8.size())
                     ));
                 } break;
-                case detail::TensorBufferTag::U16: {
+                case TagType::U16: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->Append());
                     auto value_builder =
                         static_cast<arrow::UInt16Builder*>(variant_builder->value_builder());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                        union_instance._data.u16.data(),
-                        static_cast<int64_t>(union_instance._data.u16.size())
+                        union_instance.get_union_data().u16.data(),
+                        static_cast<int64_t>(union_instance.get_union_data().u16.size())
                     ));
                 } break;
-                case detail::TensorBufferTag::U32: {
+                case TagType::U32: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->Append());
                     auto value_builder =
                         static_cast<arrow::UInt32Builder*>(variant_builder->value_builder());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                        union_instance._data.u32.data(),
-                        static_cast<int64_t>(union_instance._data.u32.size())
+                        union_instance.get_union_data().u32.data(),
+                        static_cast<int64_t>(union_instance.get_union_data().u32.size())
                     ));
                 } break;
-                case detail::TensorBufferTag::U64: {
+                case TagType::U64: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->Append());
                     auto value_builder =
                         static_cast<arrow::UInt64Builder*>(variant_builder->value_builder());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                        union_instance._data.u64.data(),
-                        static_cast<int64_t>(union_instance._data.u64.size())
+                        union_instance.get_union_data().u64.data(),
+                        static_cast<int64_t>(union_instance.get_union_data().u64.size())
                     ));
                 } break;
-                case detail::TensorBufferTag::I8: {
+                case TagType::I8: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->Append());
                     auto value_builder =
                         static_cast<arrow::Int8Builder*>(variant_builder->value_builder());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                        union_instance._data.i8.data(),
-                        static_cast<int64_t>(union_instance._data.i8.size())
+                        union_instance.get_union_data().i8.data(),
+                        static_cast<int64_t>(union_instance.get_union_data().i8.size())
                     ));
                 } break;
-                case detail::TensorBufferTag::I16: {
+                case TagType::I16: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->Append());
                     auto value_builder =
                         static_cast<arrow::Int16Builder*>(variant_builder->value_builder());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                        union_instance._data.i16.data(),
-                        static_cast<int64_t>(union_instance._data.i16.size())
+                        union_instance.get_union_data().i16.data(),
+                        static_cast<int64_t>(union_instance.get_union_data().i16.size())
                     ));
                 } break;
-                case detail::TensorBufferTag::I32: {
+                case TagType::I32: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->Append());
                     auto value_builder =
                         static_cast<arrow::Int32Builder*>(variant_builder->value_builder());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                        union_instance._data.i32.data(),
-                        static_cast<int64_t>(union_instance._data.i32.size())
+                        union_instance.get_union_data().i32.data(),
+                        static_cast<int64_t>(union_instance.get_union_data().i32.size())
                     ));
                 } break;
-                case detail::TensorBufferTag::I64: {
+                case TagType::I64: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->Append());
                     auto value_builder =
                         static_cast<arrow::Int64Builder*>(variant_builder->value_builder());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                        union_instance._data.i64.data(),
-                        static_cast<int64_t>(union_instance._data.i64.size())
+                        union_instance.get_union_data().i64.data(),
+                        static_cast<int64_t>(union_instance.get_union_data().i64.size())
                     ));
                 } break;
-                case detail::TensorBufferTag::F16: {
+                case TagType::F16: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->Append());
                     auto value_builder =
                         static_cast<arrow::HalfFloatBuilder*>(variant_builder->value_builder());
-                    const rerun::half* values = union_instance._data.f16.data();
+                    const rerun::half* values = union_instance.get_union_data().f16.data();
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
                         reinterpret_cast<const uint16_t*>(values),
-                        static_cast<int64_t>(union_instance._data.f16.size())
+                        static_cast<int64_t>(union_instance.get_union_data().f16.size())
                     ));
                 } break;
-                case detail::TensorBufferTag::F32: {
+                case TagType::F32: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->Append());
                     auto value_builder =
                         static_cast<arrow::FloatBuilder*>(variant_builder->value_builder());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                        union_instance._data.f32.data(),
-                        static_cast<int64_t>(union_instance._data.f32.size())
+                        union_instance.get_union_data().f32.data(),
+                        static_cast<int64_t>(union_instance.get_union_data().f32.size())
                     ));
                 } break;
-                case detail::TensorBufferTag::F64: {
+                case TagType::F64: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->Append());
                     auto value_builder =
                         static_cast<arrow::DoubleBuilder*>(variant_builder->value_builder());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                        union_instance._data.f64.data(),
-                        static_cast<int64_t>(union_instance._data.f64.size())
+                        union_instance.get_union_data().f64.data(),
+                        static_cast<int64_t>(union_instance.get_union_data().f64.size())
                     ));
                 } break;
-                case detail::TensorBufferTag::JPEG: {
+                case TagType::JPEG: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->Append());
                     auto value_builder =
                         static_cast<arrow::UInt8Builder*>(variant_builder->value_builder());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                        union_instance._data.jpeg.data(),
-                        static_cast<int64_t>(union_instance._data.jpeg.size())
+                        union_instance.get_union_data().jpeg.data(),
+                        static_cast<int64_t>(union_instance.get_union_data().jpeg.size())
                     ));
                 } break;
-                case detail::TensorBufferTag::NV12: {
+                case TagType::NV12: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->Append());
                     auto value_builder =
                         static_cast<arrow::UInt8Builder*>(variant_builder->value_builder());
                     ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-                        union_instance._data.nv12.data(),
-                        static_cast<int64_t>(union_instance._data.nv12.size())
+                        union_instance.get_union_data().nv12.data(),
+                        static_cast<int64_t>(union_instance.get_union_data().nv12.size())
                     ));
                 } break;
             }
@@ -201,4 +206,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::TensorBuffer>::to_data_cell(
+        const datatypes::TensorBuffer* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::TensorBuffer>::fill_arrow_array_builder(
+                static_cast<arrow::DenseUnionBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../collection.hpp"
+#include "../data_cell.hpp"
 #include "../half.hpp"
 #include "../result.hpp"
 #include "../type_traits.hpp"
@@ -492,16 +493,43 @@ namespace rerun::datatypes {
             }
         }
 
-        /// Returns the arrow data type this type corresponds to.
-        static const std::shared_ptr<arrow::DataType>& arrow_datatype();
+        /// \private
+        const detail::TensorBufferData& get_union_data() const {
+            return _data;
+        }
 
-        /// Fills an arrow array builder with an array of this type.
-        static rerun::Error fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const TensorBuffer* elements, size_t num_elements
-        );
+        /// \private
+        detail::TensorBufferTag get_union_tag() const {
+            return _tag;
+        }
 
       private:
         detail::TensorBufferTag _tag;
         detail::TensorBufferData _data;
     };
 } // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::TensorBuffer> {
+        static constexpr const char Name[] = "rerun.datatypes.TensorBuffer";
+
+        /// Returns the arrow data type this type corresponds to.
+        static const std::shared_ptr<arrow::DataType>& arrow_datatype();
+
+        /// Fills an arrow array builder with an array of this type.
+        static rerun::Error fill_arrow_array_builder(
+            arrow::DenseUnionBuilder* builder, const datatypes::TensorBuffer* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::TensorBuffer` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::TensorBuffer* instances, size_t num_instances
+        );
+    };
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/tensor_data.cpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_data.cpp
@@ -9,23 +9,31 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& TensorData::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::TensorData>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
             arrow::field(
                 "shape",
-                arrow::list(
-                    arrow::field("item", rerun::datatypes::TensorDimension::arrow_datatype(), false)
-                ),
+                arrow::list(arrow::field(
+                    "item",
+                    Loggable<rerun::datatypes::TensorDimension>::arrow_datatype(),
+                    false
+                )),
                 false
             ),
-            arrow::field("buffer", rerun::datatypes::TensorBuffer::arrow_datatype(), false),
+            arrow::field(
+                "buffer",
+                Loggable<rerun::datatypes::TensorBuffer>::arrow_datatype(),
+                false
+            ),
         });
         return datatype;
     }
 
-    rerun::Error TensorData::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const TensorData* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::TensorData>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::TensorData* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -47,11 +55,13 @@ namespace rerun::datatypes {
                 const auto& element = elements[elem_idx];
                 ARROW_RETURN_NOT_OK(field_builder->Append());
                 if (element.shape.data()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::TensorDimension::fill_arrow_array_builder(
-                        value_builder,
-                        element.shape.data(),
-                        element.shape.size()
-                    ));
+                    RR_RETURN_NOT_OK(
+                        Loggable<rerun::datatypes::TensorDimension>::fill_arrow_array_builder(
+                            value_builder,
+                            element.shape.data(),
+                            element.shape.size()
+                        )
+                    );
                 }
             }
         }
@@ -59,7 +69,7 @@ namespace rerun::datatypes {
             auto field_builder = static_cast<arrow::DenseUnionBuilder*>(builder->field_builder(1));
             ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                RR_RETURN_NOT_OK(rerun::datatypes::TensorBuffer::fill_arrow_array_builder(
+                RR_RETURN_NOT_OK(Loggable<rerun::datatypes::TensorBuffer>::fill_arrow_array_builder(
                     field_builder,
                     &elements[elem_idx].buffer,
                     1
@@ -70,4 +80,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::TensorData>::to_data_cell(
+        const datatypes::TensorData* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::TensorData>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/tensor_data.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_data.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../collection.hpp"
+#include "../data_cell.hpp"
 #include "../result.hpp"
 #include "tensor_buffer.hpp"
 #include "tensor_dimension.hpp"
@@ -40,13 +41,30 @@ namespace rerun::datatypes {
 
       public:
         TensorData() = default;
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::TensorData> {
+        static constexpr const char Name[] = "rerun.datatypes.TensorData";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const TensorData* elements, size_t num_elements
+            arrow::StructBuilder* builder, const datatypes::TensorData* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::TensorData` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::TensorData* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/tensor_dimension.cpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_dimension.cpp
@@ -6,8 +6,10 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& TensorDimension::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::TensorDimension>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
             arrow::field("size", arrow::uint64(), false),
             arrow::field("name", arrow::utf8(), true),
@@ -15,8 +17,9 @@ namespace rerun::datatypes {
         return datatype;
     }
 
-    rerun::Error TensorDimension::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const TensorDimension* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::TensorDimension>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::TensorDimension* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -51,4 +54,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::TensorDimension>::to_data_cell(
+        const datatypes::TensorDimension* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::TensorDimension>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/tensor_dimension.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_dimension.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -35,13 +36,30 @@ namespace rerun::datatypes {
 
       public:
         TensorDimension() = default;
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::TensorDimension> {
+        static constexpr const char Name[] = "rerun.datatypes.TensorDimension";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const TensorDimension* elements, size_t num_elements
+            arrow::StructBuilder* builder, const datatypes::TensorDimension* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::TensorDimension` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::TensorDimension* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.cpp
@@ -9,26 +9,29 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& Transform3D::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::Transform3D>::arrow_datatype() {
         static const auto datatype = arrow::dense_union({
             arrow::field("_null_markers", arrow::null(), true, nullptr),
             arrow::field(
                 "TranslationAndMat3x3",
-                rerun::datatypes::TranslationAndMat3x3::arrow_datatype(),
+                Loggable<rerun::datatypes::TranslationAndMat3x3>::arrow_datatype(),
                 false
             ),
             arrow::field(
                 "TranslationRotationScale",
-                rerun::datatypes::TranslationRotationScale3D::arrow_datatype(),
+                Loggable<rerun::datatypes::TranslationRotationScale3D>::arrow_datatype(),
                 false
             ),
         });
         return datatype;
     }
 
-    rerun::Error Transform3D::fill_arrow_array_builder(
-        arrow::DenseUnionBuilder* builder, const Transform3D* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::Transform3D>::fill_arrow_array_builder(
+        arrow::DenseUnionBuilder* builder, const datatypes::Transform3D* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -43,35 +46,38 @@ namespace rerun::datatypes {
         ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
         for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
             const auto& union_instance = elements[elem_idx];
-            ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance._tag)));
+            ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance.get_union_tag()))
+            );
 
-            auto variant_index = static_cast<int>(union_instance._tag);
+            auto variant_index = static_cast<int>(union_instance.get_union_tag());
             auto variant_builder_untyped = builder->child_builder(variant_index).get();
 
-            switch (union_instance._tag) {
-                case detail::Transform3DTag::None: {
+            using TagType = datatypes::detail::Transform3DTag;
+            switch (union_instance.get_union_tag()) {
+                case TagType::None: {
                     ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                 } break;
-                case detail::Transform3DTag::TranslationAndMat3x3: {
+                case TagType::TranslationAndMat3x3: {
                     auto variant_builder =
                         static_cast<arrow::StructBuilder*>(variant_builder_untyped);
                     RR_RETURN_NOT_OK(
-                        rerun::datatypes::TranslationAndMat3x3::fill_arrow_array_builder(
+                        Loggable<rerun::datatypes::TranslationAndMat3x3>::fill_arrow_array_builder(
                             variant_builder,
-                            &union_instance._data.translation_and_mat3x3,
+                            &union_instance.get_union_data().translation_and_mat3x3,
                             1
                         )
                     );
                 } break;
-                case detail::Transform3DTag::TranslationRotationScale: {
+                case TagType::TranslationRotationScale: {
                     auto variant_builder =
                         static_cast<arrow::StructBuilder*>(variant_builder_untyped);
                     RR_RETURN_NOT_OK(
-                        rerun::datatypes::TranslationRotationScale3D::fill_arrow_array_builder(
-                            variant_builder,
-                            &union_instance._data.translation_rotation_scale,
-                            1
-                        )
+                        Loggable<rerun::datatypes::TranslationRotationScale3D>::
+                            fill_arrow_array_builder(
+                                variant_builder,
+                                &union_instance.get_union_data().translation_rotation_scale,
+                                1
+                            )
                     );
                 } break;
             }
@@ -79,4 +85,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::Transform3D>::to_data_cell(
+        const datatypes::Transform3D* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::Transform3D>::fill_arrow_array_builder(
+                static_cast<arrow::DenseUnionBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/transform3d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 #include "translation_and_mat3x3.hpp"
 #include "translation_rotation_scale3d.hpp"
@@ -130,16 +131,43 @@ namespace rerun::datatypes {
             }
         }
 
-        /// Returns the arrow data type this type corresponds to.
-        static const std::shared_ptr<arrow::DataType>& arrow_datatype();
+        /// \private
+        const detail::Transform3DData& get_union_data() const {
+            return _data;
+        }
 
-        /// Fills an arrow array builder with an array of this type.
-        static rerun::Error fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const Transform3D* elements, size_t num_elements
-        );
+        /// \private
+        detail::Transform3DTag get_union_tag() const {
+            return _tag;
+        }
 
       private:
         detail::Transform3DTag _tag;
         detail::Transform3DData _data;
     };
 } // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::Transform3D> {
+        static constexpr const char Name[] = "rerun.datatypes.Transform3D";
+
+        /// Returns the arrow data type this type corresponds to.
+        static const std::shared_ptr<arrow::DataType>& arrow_datatype();
+
+        /// Fills an arrow array builder with an array of this type.
+        static rerun::Error fill_arrow_array_builder(
+            arrow::DenseUnionBuilder* builder, const datatypes::Transform3D* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::Transform3D` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::Transform3D* instances, size_t num_instances
+        );
+    };
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.cpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.cpp
@@ -9,18 +9,22 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& TranslationAndMat3x3::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>&
+        Loggable<datatypes::TranslationAndMat3x3>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
-            arrow::field("translation", rerun::datatypes::Vec3D::arrow_datatype(), true),
-            arrow::field("mat3x3", rerun::datatypes::Mat3x3::arrow_datatype(), true),
+            arrow::field("translation", Loggable<rerun::datatypes::Vec3D>::arrow_datatype(), true),
+            arrow::field("mat3x3", Loggable<rerun::datatypes::Mat3x3>::arrow_datatype(), true),
             arrow::field("from_parent", arrow::boolean(), false),
         });
         return datatype;
     }
 
-    rerun::Error TranslationAndMat3x3::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const TranslationAndMat3x3* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::TranslationAndMat3x3>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::TranslationAndMat3x3* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -39,7 +43,7 @@ namespace rerun::datatypes {
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto& element = elements[elem_idx];
                 if (element.translation.has_value()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Vec3D>::fill_arrow_array_builder(
                         field_builder,
                         &element.translation.value(),
                         1
@@ -56,7 +60,7 @@ namespace rerun::datatypes {
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto& element = elements[elem_idx];
                 if (element.mat3x3.has_value()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::Mat3x3::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Mat3x3>::fill_arrow_array_builder(
                         field_builder,
                         &element.mat3x3.value(),
                         1
@@ -77,4 +81,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::TranslationAndMat3x3>::to_data_cell(
+        const datatypes::TranslationAndMat3x3* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::TranslationAndMat3x3>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_and_mat3x3.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 #include "mat3x3.hpp"
 #include "vec3d.hpp"
@@ -69,13 +70,30 @@ namespace rerun::datatypes {
 
       public:
         TranslationAndMat3x3() = default;
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::TranslationAndMat3x3> {
+        static constexpr const char Name[] = "rerun.datatypes.TranslationAndMat3x3";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const TranslationAndMat3x3* elements, size_t num_elements
+            arrow::StructBuilder* builder, const datatypes::TranslationAndMat3x3* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::TranslationAndMat3x3` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::TranslationAndMat3x3* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.cpp
@@ -10,19 +10,26 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& TranslationRotationScale3D::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>&
+        Loggable<datatypes::TranslationRotationScale3D>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
-            arrow::field("translation", rerun::datatypes::Vec3D::arrow_datatype(), true),
-            arrow::field("rotation", rerun::datatypes::Rotation3D::arrow_datatype(), true),
-            arrow::field("scale", rerun::datatypes::Scale3D::arrow_datatype(), true),
+            arrow::field("translation", Loggable<rerun::datatypes::Vec3D>::arrow_datatype(), true),
+            arrow::field(
+                "rotation",
+                Loggable<rerun::datatypes::Rotation3D>::arrow_datatype(),
+                true
+            ),
+            arrow::field("scale", Loggable<rerun::datatypes::Scale3D>::arrow_datatype(), true),
             arrow::field("from_parent", arrow::boolean(), false),
         });
         return datatype;
     }
 
-    rerun::Error TranslationRotationScale3D::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const TranslationRotationScale3D* elements,
+    rerun::Error Loggable<datatypes::TranslationRotationScale3D>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::TranslationRotationScale3D* elements,
         size_t num_elements
     ) {
         if (builder == nullptr) {
@@ -42,7 +49,7 @@ namespace rerun::datatypes {
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto& element = elements[elem_idx];
                 if (element.translation.has_value()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::Vec3D::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Vec3D>::fill_arrow_array_builder(
                         field_builder,
                         &element.translation.value(),
                         1
@@ -58,11 +65,13 @@ namespace rerun::datatypes {
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto& element = elements[elem_idx];
                 if (element.rotation.has_value()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::Rotation3D::fill_arrow_array_builder(
-                        field_builder,
-                        &element.rotation.value(),
-                        1
-                    ));
+                    RR_RETURN_NOT_OK(
+                        Loggable<rerun::datatypes::Rotation3D>::fill_arrow_array_builder(
+                            field_builder,
+                            &element.rotation.value(),
+                            1
+                        )
+                    );
                 } else {
                     ARROW_RETURN_NOT_OK(field_builder->AppendNull());
                 }
@@ -74,7 +83,7 @@ namespace rerun::datatypes {
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto& element = elements[elem_idx];
                 if (element.scale.has_value()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::Scale3D::fill_arrow_array_builder(
+                    RR_RETURN_NOT_OK(Loggable<rerun::datatypes::Scale3D>::fill_arrow_array_builder(
                         field_builder,
                         &element.scale.value(),
                         1
@@ -95,4 +104,35 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::TranslationRotationScale3D>::to_data_cell(
+        const datatypes::TranslationRotationScale3D* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(
+                Loggable<datatypes::TranslationRotationScale3D>::fill_arrow_array_builder(
+                    static_cast<arrow::StructBuilder*>(builder.get()),
+                    instances,
+                    num_instances
+                )
+            );
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/translation_rotation_scale3d.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../compiler_utils.hpp"
+#include "../data_cell.hpp"
 #include "../result.hpp"
 #include "rotation3d.hpp"
 #include "scale3d.hpp"
@@ -194,14 +195,30 @@ namespace rerun::datatypes {
 
       public:
         TranslationRotationScale3D() = default;
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::TranslationRotationScale3D> {
+        static constexpr const char Name[] = "rerun.datatypes.TranslationRotationScale3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const TranslationRotationScale3D* elements,
+            arrow::StructBuilder* builder, const datatypes::TranslationRotationScale3D* elements,
             size_t num_elements
         );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::TranslationRotationScale3D` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::TranslationRotationScale3D* instances, size_t num_instances
+        );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/uint32.cpp
+++ b/rerun_cpp/src/rerun/datatypes/uint32.cpp
@@ -6,14 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& UInt32::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::UInt32>::arrow_datatype() {
         static const auto datatype = arrow::uint32();
         return datatype;
     }
 
-    rerun::Error UInt32::fill_arrow_array_builder(
-        arrow::UInt32Builder* builder, const UInt32* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::UInt32>::fill_arrow_array_builder(
+        arrow::UInt32Builder* builder, const datatypes::UInt32* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -32,4 +34,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::UInt32>::to_data_cell(
+        const datatypes::UInt32* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::UInt32>::fill_arrow_array_builder(
+                static_cast<arrow::UInt32Builder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/uint32.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uint32.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -32,13 +33,29 @@ namespace rerun::datatypes {
             value = value_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::UInt32> {
+        static constexpr const char Name[] = "rerun.datatypes.UInt32";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::UInt32Builder* builder, const UInt32* elements, size_t num_elements
+            arrow::UInt32Builder* builder, const datatypes::UInt32* elements, size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::UInt32` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::UInt32* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/utf8.cpp
+++ b/rerun_cpp/src/rerun/datatypes/utf8.cpp
@@ -6,14 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& Utf8::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::Utf8>::arrow_datatype() {
         static const auto datatype = arrow::utf8();
         return datatype;
     }
 
-    rerun::Error Utf8::fill_arrow_array_builder(
-        arrow::StringBuilder* builder, const Utf8* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::Utf8>::fill_arrow_array_builder(
+        arrow::StringBuilder* builder, const datatypes::Utf8* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -32,4 +34,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::Utf8>::to_data_cell(
+        const datatypes::Utf8* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::Utf8>::fill_arrow_array_builder(
+                static_cast<arrow::StringBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/utf8.hpp
+++ b/rerun_cpp/src/rerun/datatypes/utf8.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -39,13 +40,29 @@ namespace rerun::datatypes {
             value = std::move(value_);
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::Utf8> {
+        static constexpr const char Name[] = "rerun.datatypes.Utf8";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StringBuilder* builder, const Utf8* elements, size_t num_elements
+            arrow::StringBuilder* builder, const datatypes::Utf8* elements, size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::Utf8` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::Utf8* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/uvec2d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec2d.cpp
@@ -6,15 +6,17 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& UVec2D::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::UVec2D>::arrow_datatype() {
         static const auto datatype =
             arrow::fixed_size_list(arrow::field("item", arrow::uint32(), false), 2);
         return datatype;
     }
 
-    rerun::Error UVec2D::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const UVec2D* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::UVec2D>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const datatypes::UVec2D* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -38,4 +40,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::UVec2D>::to_data_cell(
+        const datatypes::UVec2D* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::UVec2D>::fill_arrow_array_builder(
+                static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/uvec2d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec2d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -28,13 +29,30 @@ namespace rerun::datatypes {
             xy = xy_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::UVec2D> {
+        static constexpr const char Name[] = "rerun.datatypes.UVec2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const UVec2D* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const datatypes::UVec2D* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::UVec2D` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::UVec2D* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/uvec3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec3d.cpp
@@ -6,15 +6,17 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& UVec3D::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::UVec3D>::arrow_datatype() {
         static const auto datatype =
             arrow::fixed_size_list(arrow::field("item", arrow::uint32(), false), 3);
         return datatype;
     }
 
-    rerun::Error UVec3D::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const UVec3D* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::UVec3D>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const datatypes::UVec3D* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -38,4 +40,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::UVec3D>::to_data_cell(
+        const datatypes::UVec3D* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::UVec3D>::fill_arrow_array_builder(
+                static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/uvec3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec3d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -28,13 +29,30 @@ namespace rerun::datatypes {
             xyz = xyz_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::UVec3D> {
+        static constexpr const char Name[] = "rerun.datatypes.UVec3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const UVec3D* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const datatypes::UVec3D* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::UVec3D` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::UVec3D* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/uvec4d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec4d.cpp
@@ -6,15 +6,17 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& UVec4D::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::UVec4D>::arrow_datatype() {
         static const auto datatype =
             arrow::fixed_size_list(arrow::field("item", arrow::uint32(), false), 4);
         return datatype;
     }
 
-    rerun::Error UVec4D::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const UVec4D* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::UVec4D>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const datatypes::UVec4D* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -38,4 +40,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::UVec4D>::to_data_cell(
+        const datatypes::UVec4D* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::UVec4D>::fill_arrow_array_builder(
+                static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/uvec4d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec4d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -28,13 +29,30 @@ namespace rerun::datatypes {
             xyzw = xyzw_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::UVec4D> {
+        static constexpr const char Name[] = "rerun.datatypes.UVec4D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const UVec4D* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const datatypes::UVec4D* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::UVec4D` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::UVec4D* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec2d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d.cpp
@@ -6,15 +6,17 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& Vec2D::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::Vec2D>::arrow_datatype() {
         static const auto datatype =
             arrow::fixed_size_list(arrow::field("item", arrow::float32(), false), 2);
         return datatype;
     }
 
-    rerun::Error Vec2D::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const Vec2D* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::Vec2D>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const datatypes::Vec2D* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -38,4 +40,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::Vec2D>::to_data_cell(
+        const datatypes::Vec2D* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::Vec2D>::fill_arrow_array_builder(
+                static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec2d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -45,13 +46,30 @@ namespace rerun::datatypes {
             xy = xy_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::Vec2D> {
+        static constexpr const char Name[] = "rerun.datatypes.Vec2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const Vec2D* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const datatypes::Vec2D* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::Vec2D` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::Vec2D* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec3d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d.cpp
@@ -6,15 +6,17 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& Vec3D::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::Vec3D>::arrow_datatype() {
         static const auto datatype =
             arrow::fixed_size_list(arrow::field("item", arrow::float32(), false), 3);
         return datatype;
     }
 
-    rerun::Error Vec3D::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const Vec3D* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::Vec3D>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const datatypes::Vec3D* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -38,4 +40,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::Vec3D>::to_data_cell(
+        const datatypes::Vec3D* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::Vec3D>::fill_arrow_array_builder(
+                static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -49,13 +50,30 @@ namespace rerun::datatypes {
             xyz = xyz_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::Vec3D> {
+        static constexpr const char Name[] = "rerun.datatypes.Vec3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const Vec3D* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const datatypes::Vec3D* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::Vec3D` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::Vec3D* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec4d.cpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d.cpp
@@ -6,15 +6,17 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& Vec4D::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::Vec4D>::arrow_datatype() {
         static const auto datatype =
             arrow::fixed_size_list(arrow::field("item", arrow::float32(), false), 4);
         return datatype;
     }
 
-    rerun::Error Vec4D::fill_arrow_array_builder(
-        arrow::FixedSizeListBuilder* builder, const Vec4D* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::Vec4D>::fill_arrow_array_builder(
+        arrow::FixedSizeListBuilder* builder, const datatypes::Vec4D* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -38,4 +40,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::Vec4D>::to_data_cell(
+        const datatypes::Vec4D* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::Vec4D>::fill_arrow_array_builder(
+                static_cast<arrow::FixedSizeListBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/vec4d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "../data_cell.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -53,13 +54,30 @@ namespace rerun::datatypes {
             xyzw = xyzw_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::Vec4D> {
+        static constexpr const char Name[] = "rerun.datatypes.Vec4D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FixedSizeListBuilder* builder, const Vec4D* elements, size_t num_elements
+            arrow::FixedSizeListBuilder* builder, const datatypes::Vec4D* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::Vec4D` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::Vec4D* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/indicator_component.hpp
+++ b/rerun_cpp/src/rerun/indicator_component.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include "data_cell.hpp"
+#include "loggable.hpp"
 
 namespace arrow {
     class DataType;
@@ -18,19 +19,27 @@ namespace rerun::components {
     ///
     /// This is done in order to track how a collection of component was logged.
     template <const char Name[]>
-    struct IndicatorComponent {
+    struct IndicatorComponent {};
+} // namespace rerun::components
+
+namespace rerun {
+    /// \private
+    template <const char Name[]>
+    struct Loggable<components::IndicatorComponent<Name>> {
         /// Creates a Rerun DataCell from an array of IndicatorComponent components.
-        static Result<rerun::DataCell> to_data_cell(const IndicatorComponent<Name>*, size_t) {
+        static Result<rerun::DataCell> to_data_cell(
+            const components::IndicatorComponent<Name>*, size_t
+        ) {
             // Lazily register the component type (only once).
             static const Result<ComponentTypeHandle> component_type =
-                ComponentType(Name, indicator_arrow_datatype()).register_component();
+                ComponentType(Name, components::indicator_arrow_datatype()).register_component();
             RR_RETURN_NOT_OK(component_type.error);
 
             rerun::DataCell cell;
             cell.num_instances = 1;
-            cell.array = indicator_arrow_array();
+            cell.array = components::indicator_arrow_array();
             cell.component_type = component_type.value;
             return cell;
         }
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/loggable.hpp
+++ b/rerun_cpp/src/rerun/loggable.hpp
@@ -26,12 +26,20 @@ namespace rerun {
 
     /// \private
     namespace detail {
+        /// Helper to check whether a type implements the Loggable trait.
+        ///
+        /// This is used to implement `rerun::is_loggable`.
+        /// Uses SFINAE to ensure that a given type T *specializes* the `rerun::Loggable` trait.
         template <typename T>
-        constexpr auto is_loggable(int = 0)
-            -> decltype(!sizeof(typename Loggable<T>::template NoLoggableFor<T>)) {
+        constexpr auto is_loggable(int = 0) ->
+            typename Loggable<T>::template NoLoggableFor<T>::type {
             return false;
         }
 
+        /// Helper to check whether a type implements the Loggable trait.
+        ///
+        /// This is used to implement `rerun::is_loggable`.
+        /// Uses SFINAE to ensure that a given type T *specializes* the `rerun::Loggable` trait.
         template <typename T>
         constexpr bool is_loggable(...) {
             return true;

--- a/rerun_cpp/src/rerun/loggable.hpp
+++ b/rerun_cpp/src/rerun/loggable.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <type_traits> // std::false_type
+
+namespace rerun {
+    /// The Loggable trait is used by all built-in implementation of `rerun::AsComponents`
+    /// to serialize a collection for logging.
+    ///
+    /// It is implemented for all built-in `rerun::component`s and `rerun::datatype`s.
+    template <typename T>
+    struct Loggable {
+        /// \private
+        /// `NoLoggableFor` always evaluates to false, but in a way that requires template instantiation.
+        template <typename T2>
+        struct NoLoggableFor : std::false_type {};
+
+        static_assert(
+            NoLoggableFor<T>::value,
+            "Loggable is not implemented for this type. "
+            "It is implemented for all built-in datatypes and components. "
+            "To check ahead of template instantiation whether a type is loggable, use `is_loggable<T>`"
+        );
+
+        // TODO(andreas): List methods that the trait should implement.
+    };
+
+    /// \private
+    namespace detail {
+        template <typename T>
+        constexpr auto is_loggable(int = 0)
+            -> decltype(!sizeof(typename Loggable<T>::NoLoggableFor<T>)) {
+            return false;
+        }
+
+        template <typename T>
+        constexpr bool is_loggable(...) {
+            return true;
+        }
+    } // namespace detail
+
+    /// True for any type that implements the Loggable trait.
+    template <typename T>
+    constexpr bool is_loggable = detail::is_loggable<T>();
+} // namespace rerun

--- a/rerun_cpp/src/rerun/loggable.hpp
+++ b/rerun_cpp/src/rerun/loggable.hpp
@@ -28,7 +28,7 @@ namespace rerun {
     namespace detail {
         template <typename T>
         constexpr auto is_loggable(int = 0)
-            -> decltype(!sizeof(typename Loggable<T>::NoLoggableFor<T>)) {
+            -> decltype(!sizeof(typename Loggable<T>::template NoLoggableFor<T>)) {
             return false;
         }
 

--- a/rerun_cpp/src/rerun/loggable.hpp
+++ b/rerun_cpp/src/rerun/loggable.hpp
@@ -28,18 +28,20 @@ namespace rerun {
     namespace detail {
         /// Helper to check whether a type implements the Loggable trait.
         ///
-        /// This is used to implement `rerun::is_loggable`.
         /// Uses SFINAE to ensure that a given type T *specializes* the `rerun::Loggable` trait.
+        /// The non-specialized `Loggable<T>` is the only implementation which contains `NoLoggableFor<T>`,
+        /// so if that type exists we know the type does not specialize the `Loggable` trait.
         template <typename T>
         constexpr auto is_loggable(int = 0) ->
-            typename Loggable<T>::template NoLoggableFor<T>::type {
+            typename Loggable<T>::template NoLoggableFor<T>::value_type {
             return false;
         }
 
         /// Helper to check whether a type implements the Loggable trait.
         ///
-        /// This is used to implement `rerun::is_loggable`.
         /// Uses SFINAE to ensure that a given type T *specializes* the `rerun::Loggable` trait.
+        /// The non-specialized `Loggable<T>` is the only implementation which contains `NoLoggableFor<T>`,
+        /// so if that type exists we know the type does not specialize the `Loggable` trait.
         template <typename T>
         constexpr bool is_loggable(...) {
             return true;

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -198,7 +198,8 @@ namespace rerun {
         bool inject_time = !timeless;
 
         if (!splatted.empty()) {
-            splatted.push_back(components::InstanceKey::to_data_cell(&splat_key, 1).value);
+            splatted.push_back(Loggable<components::InstanceKey>::to_data_cell(&splat_key, 1).value
+            );
             auto result =
                 try_log_data_row(entity_path, 1, splatted.size(), splatted.data(), inject_time);
             if (result.is_err()) {

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -144,7 +144,7 @@ namespace rerun {
         }
         {
             auto indicator = AffixFuzzer1::IndicatorComponent();
-            auto result = AffixFuzzer1::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<AffixFuzzer1::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -5,10 +5,7 @@
 
 #include <rerun/collection_adapter_builtins.hpp>
 
-namespace rerun::archetypes {
-    const char AffixFuzzer1::INDICATOR_COMPONENT_NAME[] =
-        "rerun.testing.components.AffixFuzzer1Indicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -20,107 +17,128 @@ namespace rerun {
         cells.reserve(22);
 
         {
-            auto result = rerun::components::AffixFuzzer1::to_data_cell(&archetype.fuzz1001, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer1>::to_data_cell(&archetype.fuzz1001, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer2::to_data_cell(&archetype.fuzz1002, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer2>::to_data_cell(&archetype.fuzz1002, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer3::to_data_cell(&archetype.fuzz1003, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer3>::to_data_cell(&archetype.fuzz1003, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer4::to_data_cell(&archetype.fuzz1004, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer4>::to_data_cell(&archetype.fuzz1004, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer5::to_data_cell(&archetype.fuzz1005, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer5>::to_data_cell(&archetype.fuzz1005, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer6::to_data_cell(&archetype.fuzz1006, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer6>::to_data_cell(&archetype.fuzz1006, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer7::to_data_cell(&archetype.fuzz1007, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer7>::to_data_cell(&archetype.fuzz1007, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer8::to_data_cell(&archetype.fuzz1008, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer8>::to_data_cell(&archetype.fuzz1008, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer9::to_data_cell(&archetype.fuzz1009, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer9>::to_data_cell(&archetype.fuzz1009, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer10::to_data_cell(&archetype.fuzz1010, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer10>::to_data_cell(&archetype.fuzz1010, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer11::to_data_cell(&archetype.fuzz1011, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer11>::to_data_cell(&archetype.fuzz1011, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer12::to_data_cell(&archetype.fuzz1012, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer12>::to_data_cell(&archetype.fuzz1012, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer13::to_data_cell(&archetype.fuzz1013, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer13>::to_data_cell(&archetype.fuzz1013, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer14::to_data_cell(&archetype.fuzz1014, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer14>::to_data_cell(&archetype.fuzz1014, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer15::to_data_cell(&archetype.fuzz1015, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer15>::to_data_cell(&archetype.fuzz1015, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer16::to_data_cell(&archetype.fuzz1016, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer16>::to_data_cell(&archetype.fuzz1016, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer17::to_data_cell(&archetype.fuzz1017, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer17>::to_data_cell(&archetype.fuzz1017, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer18::to_data_cell(&archetype.fuzz1018, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer18>::to_data_cell(&archetype.fuzz1018, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer19::to_data_cell(&archetype.fuzz1019, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer19>::to_data_cell(&archetype.fuzz1019, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer20::to_data_cell(&archetype.fuzz1020, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer20>::to_data_cell(&archetype.fuzz1020, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer21::to_data_cell(&archetype.fuzz1021, 1);
+            auto result =
+                Loggable<rerun::components::AffixFuzzer21>::to_data_cell(&archetype.fuzz1021, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -77,10 +77,12 @@ namespace rerun::archetypes {
 
         rerun::components::AffixFuzzer21 fuzz1021;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] =
+            "rerun.testing.components.AffixFuzzer1Indicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         AffixFuzzer1() = default;

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
@@ -5,10 +5,7 @@
 
 #include <rerun/collection_adapter_builtins.hpp>
 
-namespace rerun::archetypes {
-    const char AffixFuzzer2::INDICATOR_COMPONENT_NAME[] =
-        "rerun.testing.components.AffixFuzzer2Indicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -20,7 +17,7 @@ namespace rerun {
         cells.reserve(19);
 
         {
-            auto result = rerun::components::AffixFuzzer1::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer1>::to_data_cell(
                 archetype.fuzz1101.data(),
                 archetype.fuzz1101.size()
             );
@@ -28,7 +25,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer2::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer2>::to_data_cell(
                 archetype.fuzz1102.data(),
                 archetype.fuzz1102.size()
             );
@@ -36,7 +33,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer3::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer3>::to_data_cell(
                 archetype.fuzz1103.data(),
                 archetype.fuzz1103.size()
             );
@@ -44,7 +41,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer4::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer4>::to_data_cell(
                 archetype.fuzz1104.data(),
                 archetype.fuzz1104.size()
             );
@@ -52,7 +49,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer5::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer5>::to_data_cell(
                 archetype.fuzz1105.data(),
                 archetype.fuzz1105.size()
             );
@@ -60,7 +57,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer6::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer6>::to_data_cell(
                 archetype.fuzz1106.data(),
                 archetype.fuzz1106.size()
             );
@@ -68,7 +65,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer7::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer7>::to_data_cell(
                 archetype.fuzz1107.data(),
                 archetype.fuzz1107.size()
             );
@@ -76,7 +73,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer8::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer8>::to_data_cell(
                 archetype.fuzz1108.data(),
                 archetype.fuzz1108.size()
             );
@@ -84,7 +81,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer9::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer9>::to_data_cell(
                 archetype.fuzz1109.data(),
                 archetype.fuzz1109.size()
             );
@@ -92,7 +89,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer10::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer10>::to_data_cell(
                 archetype.fuzz1110.data(),
                 archetype.fuzz1110.size()
             );
@@ -100,7 +97,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer11::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer11>::to_data_cell(
                 archetype.fuzz1111.data(),
                 archetype.fuzz1111.size()
             );
@@ -108,7 +105,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer12::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer12>::to_data_cell(
                 archetype.fuzz1112.data(),
                 archetype.fuzz1112.size()
             );
@@ -116,7 +113,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer13::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer13>::to_data_cell(
                 archetype.fuzz1113.data(),
                 archetype.fuzz1113.size()
             );
@@ -124,7 +121,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer14::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer14>::to_data_cell(
                 archetype.fuzz1114.data(),
                 archetype.fuzz1114.size()
             );
@@ -132,7 +129,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer15::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer15>::to_data_cell(
                 archetype.fuzz1115.data(),
                 archetype.fuzz1115.size()
             );
@@ -140,7 +137,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer16::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer16>::to_data_cell(
                 archetype.fuzz1116.data(),
                 archetype.fuzz1116.size()
             );
@@ -148,7 +145,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer17::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer17>::to_data_cell(
                 archetype.fuzz1117.data(),
                 archetype.fuzz1117.size()
             );
@@ -156,7 +153,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         {
-            auto result = rerun::components::AffixFuzzer18::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer18>::to_data_cell(
                 archetype.fuzz1118.data(),
                 archetype.fuzz1118.size()
             );

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
@@ -162,7 +162,7 @@ namespace rerun {
         }
         {
             auto indicator = AffixFuzzer2::IndicatorComponent();
-            auto result = AffixFuzzer2::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<AffixFuzzer2::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
@@ -68,10 +68,12 @@ namespace rerun::archetypes {
 
         Collection<rerun::components::AffixFuzzer18> fuzz1118;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] =
+            "rerun.testing.components.AffixFuzzer2Indicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         AffixFuzzer2() = default;

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
@@ -162,7 +162,7 @@ namespace rerun {
         }
         {
             auto indicator = AffixFuzzer3::IndicatorComponent();
-            auto result = AffixFuzzer3::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<AffixFuzzer3::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
@@ -5,10 +5,7 @@
 
 #include <rerun/collection_adapter_builtins.hpp>
 
-namespace rerun::archetypes {
-    const char AffixFuzzer3::INDICATOR_COMPONENT_NAME[] =
-        "rerun.testing.components.AffixFuzzer3Indicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -20,110 +17,146 @@ namespace rerun {
         cells.reserve(19);
 
         if (archetype.fuzz2001.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer1::to_data_cell(&archetype.fuzz2001.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer1>::to_data_cell(
+                &archetype.fuzz2001.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2002.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer2::to_data_cell(&archetype.fuzz2002.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer2>::to_data_cell(
+                &archetype.fuzz2002.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2003.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer3::to_data_cell(&archetype.fuzz2003.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer3>::to_data_cell(
+                &archetype.fuzz2003.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2004.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer4::to_data_cell(&archetype.fuzz2004.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer4>::to_data_cell(
+                &archetype.fuzz2004.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2005.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer5::to_data_cell(&archetype.fuzz2005.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer5>::to_data_cell(
+                &archetype.fuzz2005.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2006.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer6::to_data_cell(&archetype.fuzz2006.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer6>::to_data_cell(
+                &archetype.fuzz2006.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2007.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer7::to_data_cell(&archetype.fuzz2007.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer7>::to_data_cell(
+                &archetype.fuzz2007.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2008.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer8::to_data_cell(&archetype.fuzz2008.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer8>::to_data_cell(
+                &archetype.fuzz2008.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2009.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer9::to_data_cell(&archetype.fuzz2009.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer9>::to_data_cell(
+                &archetype.fuzz2009.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2010.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer10::to_data_cell(&archetype.fuzz2010.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer10>::to_data_cell(
+                &archetype.fuzz2010.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2011.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer11::to_data_cell(&archetype.fuzz2011.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer11>::to_data_cell(
+                &archetype.fuzz2011.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2012.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer12::to_data_cell(&archetype.fuzz2012.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer12>::to_data_cell(
+                &archetype.fuzz2012.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2013.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer13::to_data_cell(&archetype.fuzz2013.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer13>::to_data_cell(
+                &archetype.fuzz2013.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2014.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer14::to_data_cell(&archetype.fuzz2014.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer14>::to_data_cell(
+                &archetype.fuzz2014.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2015.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer15::to_data_cell(&archetype.fuzz2015.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer15>::to_data_cell(
+                &archetype.fuzz2015.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2016.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer16::to_data_cell(&archetype.fuzz2016.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer16>::to_data_cell(
+                &archetype.fuzz2016.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2017.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer17::to_data_cell(&archetype.fuzz2017.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer17>::to_data_cell(
+                &archetype.fuzz2017.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2018.has_value()) {
-            auto result =
-                rerun::components::AffixFuzzer18::to_data_cell(&archetype.fuzz2018.value(), 1);
+            auto result = Loggable<rerun::components::AffixFuzzer18>::to_data_cell(
+                &archetype.fuzz2018.value(),
+                1
+            );
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -70,10 +70,12 @@ namespace rerun::archetypes {
 
         std::optional<rerun::components::AffixFuzzer18> fuzz2018;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] =
+            "rerun.testing.components.AffixFuzzer3Indicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         AffixFuzzer3() = default;

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
@@ -162,7 +162,7 @@ namespace rerun {
         }
         {
             auto indicator = AffixFuzzer4::IndicatorComponent();
-            auto result = AffixFuzzer4::IndicatorComponent::to_data_cell(&indicator, 1);
+            auto result = Loggable<AffixFuzzer4::IndicatorComponent>::to_data_cell(&indicator, 1);
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
@@ -5,10 +5,7 @@
 
 #include <rerun/collection_adapter_builtins.hpp>
 
-namespace rerun::archetypes {
-    const char AffixFuzzer4::INDICATOR_COMPONENT_NAME[] =
-        "rerun.testing.components.AffixFuzzer4Indicator";
-}
+namespace rerun::archetypes {}
 
 namespace rerun {
 
@@ -20,7 +17,7 @@ namespace rerun {
         cells.reserve(19);
 
         if (archetype.fuzz2101.has_value()) {
-            auto result = rerun::components::AffixFuzzer1::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer1>::to_data_cell(
                 archetype.fuzz2101.value().data(),
                 archetype.fuzz2101.value().size()
             );
@@ -28,7 +25,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2102.has_value()) {
-            auto result = rerun::components::AffixFuzzer2::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer2>::to_data_cell(
                 archetype.fuzz2102.value().data(),
                 archetype.fuzz2102.value().size()
             );
@@ -36,7 +33,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2103.has_value()) {
-            auto result = rerun::components::AffixFuzzer3::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer3>::to_data_cell(
                 archetype.fuzz2103.value().data(),
                 archetype.fuzz2103.value().size()
             );
@@ -44,7 +41,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2104.has_value()) {
-            auto result = rerun::components::AffixFuzzer4::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer4>::to_data_cell(
                 archetype.fuzz2104.value().data(),
                 archetype.fuzz2104.value().size()
             );
@@ -52,7 +49,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2105.has_value()) {
-            auto result = rerun::components::AffixFuzzer5::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer5>::to_data_cell(
                 archetype.fuzz2105.value().data(),
                 archetype.fuzz2105.value().size()
             );
@@ -60,7 +57,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2106.has_value()) {
-            auto result = rerun::components::AffixFuzzer6::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer6>::to_data_cell(
                 archetype.fuzz2106.value().data(),
                 archetype.fuzz2106.value().size()
             );
@@ -68,7 +65,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2107.has_value()) {
-            auto result = rerun::components::AffixFuzzer7::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer7>::to_data_cell(
                 archetype.fuzz2107.value().data(),
                 archetype.fuzz2107.value().size()
             );
@@ -76,7 +73,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2108.has_value()) {
-            auto result = rerun::components::AffixFuzzer8::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer8>::to_data_cell(
                 archetype.fuzz2108.value().data(),
                 archetype.fuzz2108.value().size()
             );
@@ -84,7 +81,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2109.has_value()) {
-            auto result = rerun::components::AffixFuzzer9::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer9>::to_data_cell(
                 archetype.fuzz2109.value().data(),
                 archetype.fuzz2109.value().size()
             );
@@ -92,7 +89,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2110.has_value()) {
-            auto result = rerun::components::AffixFuzzer10::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer10>::to_data_cell(
                 archetype.fuzz2110.value().data(),
                 archetype.fuzz2110.value().size()
             );
@@ -100,7 +97,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2111.has_value()) {
-            auto result = rerun::components::AffixFuzzer11::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer11>::to_data_cell(
                 archetype.fuzz2111.value().data(),
                 archetype.fuzz2111.value().size()
             );
@@ -108,7 +105,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2112.has_value()) {
-            auto result = rerun::components::AffixFuzzer12::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer12>::to_data_cell(
                 archetype.fuzz2112.value().data(),
                 archetype.fuzz2112.value().size()
             );
@@ -116,7 +113,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2113.has_value()) {
-            auto result = rerun::components::AffixFuzzer13::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer13>::to_data_cell(
                 archetype.fuzz2113.value().data(),
                 archetype.fuzz2113.value().size()
             );
@@ -124,7 +121,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2114.has_value()) {
-            auto result = rerun::components::AffixFuzzer14::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer14>::to_data_cell(
                 archetype.fuzz2114.value().data(),
                 archetype.fuzz2114.value().size()
             );
@@ -132,7 +129,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2115.has_value()) {
-            auto result = rerun::components::AffixFuzzer15::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer15>::to_data_cell(
                 archetype.fuzz2115.value().data(),
                 archetype.fuzz2115.value().size()
             );
@@ -140,7 +137,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2116.has_value()) {
-            auto result = rerun::components::AffixFuzzer16::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer16>::to_data_cell(
                 archetype.fuzz2116.value().data(),
                 archetype.fuzz2116.value().size()
             );
@@ -148,7 +145,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2117.has_value()) {
-            auto result = rerun::components::AffixFuzzer17::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer17>::to_data_cell(
                 archetype.fuzz2117.value().data(),
                 archetype.fuzz2117.value().size()
             );
@@ -156,7 +153,7 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
         if (archetype.fuzz2118.has_value()) {
-            auto result = rerun::components::AffixFuzzer18::to_data_cell(
+            auto result = Loggable<rerun::components::AffixFuzzer18>::to_data_cell(
                 archetype.fuzz2118.value().data(),
                 archetype.fuzz2118.value().size()
             );

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -70,10 +70,12 @@ namespace rerun::archetypes {
 
         std::optional<Collection<rerun::components::AffixFuzzer18>> fuzz2118;
 
-        /// Name of the indicator component, used to identify the archetype when converting to a list of components.
-        static const char INDICATOR_COMPONENT_NAME[];
+      public:
+        static constexpr const char IndicatorComponentName[] =
+            "rerun.testing.components.AffixFuzzer4Indicator";
+
         /// Indicator component, used to identify the archetype when converting to a list of components.
-        using IndicatorComponent = components::IndicatorComponent<INDICATOR_COMPONENT_NAME>;
+        using IndicatorComponent = components::IndicatorComponent<IndicatorComponentName>;
 
       public:
         AffixFuzzer4() = default;

--- a/rerun_cpp/tests/generated/components/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer1.cpp
@@ -8,19 +8,19 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer1::NAME[] = "rerun.testing.components.AffixFuzzer1";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer1::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::AffixFuzzer1::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer1>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::AffixFuzzer1>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer1::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const AffixFuzzer1* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer1>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const components::AffixFuzzer1* elements, size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::AffixFuzzer1) == sizeof(AffixFuzzer1));
-        RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::AffixFuzzer1) == sizeof(components::AffixFuzzer1));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::AffixFuzzer1>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::AffixFuzzer1*>(elements),
             num_elements
@@ -29,8 +29,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer1::to_data_cell(
-        const AffixFuzzer1* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer1>::to_data_cell(
+        const components::AffixFuzzer1* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +38,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer1::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer1>::fill_arrow_array_builder(
                 static_cast<arrow::StructBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +48,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +57,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer1.hpp
@@ -20,9 +20,6 @@ namespace rerun::components {
     struct AffixFuzzer1 {
         rerun::datatypes::AffixFuzzer1 single_required;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer1() = default;
 
@@ -38,18 +35,30 @@ namespace rerun::components {
         operator rerun::datatypes::AffixFuzzer1() const {
             return single_required;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer1> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer1";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer1* elements, size_t num_elements
+            arrow::StructBuilder* builder, const components::AffixFuzzer1* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer1 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer1` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer1* instances, size_t num_instances
+            const components::AffixFuzzer1* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer10.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer10.cpp
@@ -6,16 +6,17 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer10::NAME[] = "rerun.testing.components.AffixFuzzer10";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer10::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer10>::arrow_datatype() {
         static const auto datatype = arrow::utf8();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer10::fill_arrow_array_builder(
-        arrow::StringBuilder* builder, const AffixFuzzer10* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer10>::fill_arrow_array_builder(
+        arrow::StringBuilder* builder, const components::AffixFuzzer10* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -40,8 +41,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer10::to_data_cell(
-        const AffixFuzzer10* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer10>::to_data_cell(
+        const components::AffixFuzzer10* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -49,7 +50,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer10::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer10>::fill_arrow_array_builder(
                 static_cast<arrow::StringBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -59,7 +60,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -68,4 +69,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer10.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer10.hpp
@@ -20,9 +20,6 @@ namespace rerun::components {
     struct AffixFuzzer10 {
         std::optional<std::string> single_string_optional;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer10() = default;
 
@@ -33,18 +30,30 @@ namespace rerun::components {
             single_string_optional = std::move(single_string_optional_);
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer10> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer10";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StringBuilder* builder, const AffixFuzzer10* elements, size_t num_elements
+            arrow::StringBuilder* builder, const components::AffixFuzzer10* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer10 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer10` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer10* instances, size_t num_instances
+            const components::AffixFuzzer10* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer11.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer11.cpp
@@ -6,16 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer11::NAME[] = "rerun.testing.components.AffixFuzzer11";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer11::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer11>::arrow_datatype() {
         static const auto datatype = arrow::list(arrow::field("item", arrow::float32(), false));
         return datatype;
     }
 
-    rerun::Error AffixFuzzer11::fill_arrow_array_builder(
-        arrow::ListBuilder* builder, const AffixFuzzer11* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer11>::fill_arrow_array_builder(
+        arrow::ListBuilder* builder, const components::AffixFuzzer11* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -48,8 +48,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer11::to_data_cell(
-        const AffixFuzzer11* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer11>::to_data_cell(
+        const components::AffixFuzzer11* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -57,7 +57,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer11::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer11>::fill_arrow_array_builder(
                 static_cast<arrow::ListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -67,7 +67,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -76,4 +76,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer11.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer11.hpp
@@ -20,9 +20,6 @@ namespace rerun::components {
     struct AffixFuzzer11 {
         std::optional<rerun::Collection<float>> many_floats_optional;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer11() = default;
 
@@ -33,18 +30,30 @@ namespace rerun::components {
             many_floats_optional = std::move(many_floats_optional_);
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer11> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer11";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const AffixFuzzer11* elements, size_t num_elements
+            arrow::ListBuilder* builder, const components::AffixFuzzer11* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer11 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer11` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer11* instances, size_t num_instances
+            const components::AffixFuzzer11* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer12.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer12.cpp
@@ -6,16 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer12::NAME[] = "rerun.testing.components.AffixFuzzer12";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer12::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer12>::arrow_datatype() {
         static const auto datatype = arrow::list(arrow::field("item", arrow::utf8(), false));
         return datatype;
     }
 
-    rerun::Error AffixFuzzer12::fill_arrow_array_builder(
-        arrow::ListBuilder* builder, const AffixFuzzer12* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer12>::fill_arrow_array_builder(
+        arrow::ListBuilder* builder, const components::AffixFuzzer12* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -43,8 +43,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer12::to_data_cell(
-        const AffixFuzzer12* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer12>::to_data_cell(
+        const components::AffixFuzzer12* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -52,7 +52,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer12::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer12>::fill_arrow_array_builder(
                 static_cast<arrow::ListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -62,7 +62,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -71,4 +71,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer12.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer12.hpp
@@ -20,9 +20,6 @@ namespace rerun::components {
     struct AffixFuzzer12 {
         rerun::Collection<std::string> many_strings_required;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer12() = default;
 
@@ -33,18 +30,30 @@ namespace rerun::components {
             many_strings_required = std::move(many_strings_required_);
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer12> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer12";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const AffixFuzzer12* elements, size_t num_elements
+            arrow::ListBuilder* builder, const components::AffixFuzzer12* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer12 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer12` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer12* instances, size_t num_instances
+            const components::AffixFuzzer12* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer13.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer13.cpp
@@ -6,16 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer13::NAME[] = "rerun.testing.components.AffixFuzzer13";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer13::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer13>::arrow_datatype() {
         static const auto datatype = arrow::list(arrow::field("item", arrow::utf8(), false));
         return datatype;
     }
 
-    rerun::Error AffixFuzzer13::fill_arrow_array_builder(
-        arrow::ListBuilder* builder, const AffixFuzzer13* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer13>::fill_arrow_array_builder(
+        arrow::ListBuilder* builder, const components::AffixFuzzer13* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -48,8 +48,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer13::to_data_cell(
-        const AffixFuzzer13* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer13>::to_data_cell(
+        const components::AffixFuzzer13* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -57,7 +57,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer13::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer13>::fill_arrow_array_builder(
                 static_cast<arrow::ListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -67,7 +67,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -76,4 +76,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer13.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer13.hpp
@@ -21,9 +21,6 @@ namespace rerun::components {
     struct AffixFuzzer13 {
         std::optional<rerun::Collection<std::string>> many_strings_optional;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer13() = default;
 
@@ -36,18 +33,30 @@ namespace rerun::components {
             many_strings_optional = std::move(many_strings_optional_);
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer13> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer13";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const AffixFuzzer13* elements, size_t num_elements
+            arrow::ListBuilder* builder, const components::AffixFuzzer13* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer13 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer13` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer13* instances, size_t num_instances
+            const components::AffixFuzzer13* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer14.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer14.cpp
@@ -8,19 +8,20 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer14::NAME[] = "rerun.testing.components.AffixFuzzer14";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer14::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::AffixFuzzer3::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer14>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::AffixFuzzer3>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer14::fill_arrow_array_builder(
-        arrow::DenseUnionBuilder* builder, const AffixFuzzer14* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer14>::fill_arrow_array_builder(
+        arrow::DenseUnionBuilder* builder, const components::AffixFuzzer14* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::AffixFuzzer3) == sizeof(AffixFuzzer14));
-        RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::AffixFuzzer3) == sizeof(components::AffixFuzzer14));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::AffixFuzzer3>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::AffixFuzzer3*>(elements),
             num_elements
@@ -29,8 +30,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer14::to_data_cell(
-        const AffixFuzzer14* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer14>::to_data_cell(
+        const components::AffixFuzzer14* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +39,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer14::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer14>::fill_arrow_array_builder(
                 static_cast<arrow::DenseUnionBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +49,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +58,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer14.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer14.hpp
@@ -20,9 +20,6 @@ namespace rerun::components {
     struct AffixFuzzer14 {
         rerun::datatypes::AffixFuzzer3 single_required_union;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer14() = default;
 
@@ -38,18 +35,30 @@ namespace rerun::components {
         operator rerun::datatypes::AffixFuzzer3() const {
             return single_required_union;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer14> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer14";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const AffixFuzzer14* elements, size_t num_elements
+            arrow::DenseUnionBuilder* builder, const components::AffixFuzzer14* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer14 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer14` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer14* instances, size_t num_instances
+            const components::AffixFuzzer14* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer15.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer15.cpp
@@ -8,16 +8,17 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer15::NAME[] = "rerun.testing.components.AffixFuzzer15";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer15::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::AffixFuzzer3::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer15>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::AffixFuzzer3>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer15::fill_arrow_array_builder(
-        arrow::DenseUnionBuilder* builder, const AffixFuzzer15* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer15>::fill_arrow_array_builder(
+        arrow::DenseUnionBuilder* builder, const components::AffixFuzzer15* elements,
+        size_t num_elements
     ) {
         (void)builder;
         (void)elements;
@@ -32,8 +33,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer15::to_data_cell(
-        const AffixFuzzer15* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer15>::to_data_cell(
+        const components::AffixFuzzer15* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -41,7 +42,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer15::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer15>::fill_arrow_array_builder(
                 static_cast<arrow::DenseUnionBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -51,7 +52,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -60,4 +61,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer15.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer15.hpp
@@ -21,9 +21,6 @@ namespace rerun::components {
     struct AffixFuzzer15 {
         std::optional<rerun::datatypes::AffixFuzzer3> single_optional_union;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer15() = default;
 
@@ -41,18 +38,30 @@ namespace rerun::components {
         operator std::optional<rerun::datatypes::AffixFuzzer3>() const {
             return single_optional_union;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer15> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer15";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const AffixFuzzer15* elements, size_t num_elements
+            arrow::DenseUnionBuilder* builder, const components::AffixFuzzer15* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer15 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer15` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer15* instances, size_t num_instances
+            const components::AffixFuzzer15* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer16.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer16.cpp
@@ -8,18 +8,18 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer16::NAME[] = "rerun.testing.components.AffixFuzzer16";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer16::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer16>::arrow_datatype() {
         static const auto datatype = arrow::list(
-            arrow::field("item", rerun::datatypes::AffixFuzzer3::arrow_datatype(), false)
+            arrow::field("item", Loggable<rerun::datatypes::AffixFuzzer3>::arrow_datatype(), false)
         );
         return datatype;
     }
 
-    rerun::Error AffixFuzzer16::fill_arrow_array_builder(
-        arrow::ListBuilder* builder, const AffixFuzzer16* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer16>::fill_arrow_array_builder(
+        arrow::ListBuilder* builder, const components::AffixFuzzer16* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -39,7 +39,7 @@ namespace rerun::components {
             const auto& element = elements[elem_idx];
             ARROW_RETURN_NOT_OK(builder->Append());
             if (element.many_required_unions.data()) {
-                RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
+                RR_RETURN_NOT_OK(Loggable<rerun::datatypes::AffixFuzzer3>::fill_arrow_array_builder(
                     value_builder,
                     element.many_required_unions.data(),
                     element.many_required_unions.size()
@@ -50,8 +50,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer16::to_data_cell(
-        const AffixFuzzer16* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer16>::to_data_cell(
+        const components::AffixFuzzer16* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -59,7 +59,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer16::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer16>::fill_arrow_array_builder(
                 static_cast<arrow::ListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -69,7 +69,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -78,4 +78,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer16.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer16.hpp
@@ -21,9 +21,6 @@ namespace rerun::components {
     struct AffixFuzzer16 {
         rerun::Collection<rerun::datatypes::AffixFuzzer3> many_required_unions;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer16() = default;
 
@@ -36,18 +33,30 @@ namespace rerun::components {
             many_required_unions = std::move(many_required_unions_);
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer16> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer16";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const AffixFuzzer16* elements, size_t num_elements
+            arrow::ListBuilder* builder, const components::AffixFuzzer16* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer16 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer16` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer16* instances, size_t num_instances
+            const components::AffixFuzzer16* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer17.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer17.cpp
@@ -8,18 +8,18 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer17::NAME[] = "rerun.testing.components.AffixFuzzer17";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer17::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer17>::arrow_datatype() {
         static const auto datatype = arrow::list(
-            arrow::field("item", rerun::datatypes::AffixFuzzer3::arrow_datatype(), false)
+            arrow::field("item", Loggable<rerun::datatypes::AffixFuzzer3>::arrow_datatype(), false)
         );
         return datatype;
     }
 
-    rerun::Error AffixFuzzer17::fill_arrow_array_builder(
-        arrow::ListBuilder* builder, const AffixFuzzer17* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer17>::fill_arrow_array_builder(
+        arrow::ListBuilder* builder, const components::AffixFuzzer17* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -40,11 +40,13 @@ namespace rerun::components {
             if (element.many_optional_unions.has_value()) {
                 ARROW_RETURN_NOT_OK(builder->Append());
                 if (element.many_optional_unions.value().data()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
-                        value_builder,
-                        element.many_optional_unions.value().data(),
-                        element.many_optional_unions.value().size()
-                    ));
+                    RR_RETURN_NOT_OK(
+                        Loggable<rerun::datatypes::AffixFuzzer3>::fill_arrow_array_builder(
+                            value_builder,
+                            element.many_optional_unions.value().data(),
+                            element.many_optional_unions.value().size()
+                        )
+                    );
                 }
             } else {
                 ARROW_RETURN_NOT_OK(builder->AppendNull());
@@ -54,8 +56,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer17::to_data_cell(
-        const AffixFuzzer17* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer17>::to_data_cell(
+        const components::AffixFuzzer17* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -63,7 +65,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer17::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer17>::fill_arrow_array_builder(
                 static_cast<arrow::ListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -73,7 +75,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -82,4 +84,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer17.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer17.hpp
@@ -22,9 +22,6 @@ namespace rerun::components {
     struct AffixFuzzer17 {
         std::optional<rerun::Collection<rerun::datatypes::AffixFuzzer3>> many_optional_unions;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer17() = default;
 
@@ -39,18 +36,30 @@ namespace rerun::components {
             many_optional_unions = std::move(many_optional_unions_);
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer17> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer17";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const AffixFuzzer17* elements, size_t num_elements
+            arrow::ListBuilder* builder, const components::AffixFuzzer17* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer17 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer17` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer17* instances, size_t num_instances
+            const components::AffixFuzzer17* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer18.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer18.cpp
@@ -8,18 +8,18 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer18::NAME[] = "rerun.testing.components.AffixFuzzer18";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer18::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer18>::arrow_datatype() {
         static const auto datatype = arrow::list(
-            arrow::field("item", rerun::datatypes::AffixFuzzer4::arrow_datatype(), false)
+            arrow::field("item", Loggable<rerun::datatypes::AffixFuzzer4>::arrow_datatype(), false)
         );
         return datatype;
     }
 
-    rerun::Error AffixFuzzer18::fill_arrow_array_builder(
-        arrow::ListBuilder* builder, const AffixFuzzer18* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer18>::fill_arrow_array_builder(
+        arrow::ListBuilder* builder, const components::AffixFuzzer18* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -40,11 +40,13 @@ namespace rerun::components {
             if (element.many_optional_unions.has_value()) {
                 ARROW_RETURN_NOT_OK(builder->Append());
                 if (element.many_optional_unions.value().data()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer4::fill_arrow_array_builder(
-                        value_builder,
-                        element.many_optional_unions.value().data(),
-                        element.many_optional_unions.value().size()
-                    ));
+                    RR_RETURN_NOT_OK(
+                        Loggable<rerun::datatypes::AffixFuzzer4>::fill_arrow_array_builder(
+                            value_builder,
+                            element.many_optional_unions.value().data(),
+                            element.many_optional_unions.value().size()
+                        )
+                    );
                 }
             } else {
                 ARROW_RETURN_NOT_OK(builder->AppendNull());
@@ -54,8 +56,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer18::to_data_cell(
-        const AffixFuzzer18* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer18>::to_data_cell(
+        const components::AffixFuzzer18* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -63,7 +65,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer18::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer18>::fill_arrow_array_builder(
                 static_cast<arrow::ListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -73,7 +75,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -82,4 +84,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer18.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer18.hpp
@@ -22,9 +22,6 @@ namespace rerun::components {
     struct AffixFuzzer18 {
         std::optional<rerun::Collection<rerun::datatypes::AffixFuzzer4>> many_optional_unions;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer18() = default;
 
@@ -39,18 +36,30 @@ namespace rerun::components {
             many_optional_unions = std::move(many_optional_unions_);
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer18> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer18";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const AffixFuzzer18* elements, size_t num_elements
+            arrow::ListBuilder* builder, const components::AffixFuzzer18* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer18 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer18` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer18* instances, size_t num_instances
+            const components::AffixFuzzer18* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer19.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer19.cpp
@@ -8,19 +8,20 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer19::NAME[] = "rerun.testing.components.AffixFuzzer19";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer19::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::AffixFuzzer5::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer19>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::AffixFuzzer5>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer19::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const AffixFuzzer19* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer19>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const components::AffixFuzzer19* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::AffixFuzzer5) == sizeof(AffixFuzzer19));
-        RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer5::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::AffixFuzzer5) == sizeof(components::AffixFuzzer19));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::AffixFuzzer5>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::AffixFuzzer5*>(elements),
             num_elements
@@ -29,8 +30,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer19::to_data_cell(
-        const AffixFuzzer19* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer19>::to_data_cell(
+        const components::AffixFuzzer19* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +39,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer19::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer19>::fill_arrow_array_builder(
                 static_cast<arrow::StructBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +49,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +58,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer19.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer19.hpp
@@ -22,9 +22,6 @@ namespace rerun::components {
     struct AffixFuzzer19 {
         rerun::datatypes::AffixFuzzer5 just_a_table_nothing_shady;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer19() = default;
 
@@ -50,18 +47,30 @@ namespace rerun::components {
         operator rerun::datatypes::AffixFuzzer5() const {
             return just_a_table_nothing_shady;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer19> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer19";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer19* elements, size_t num_elements
+            arrow::StructBuilder* builder, const components::AffixFuzzer19* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer19 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer19` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer19* instances, size_t num_instances
+            const components::AffixFuzzer19* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer2.cpp
@@ -8,19 +8,19 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer2::NAME[] = "rerun.testing.components.AffixFuzzer2";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer2::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::AffixFuzzer1::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer2>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::AffixFuzzer1>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer2::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const AffixFuzzer2* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer2>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const components::AffixFuzzer2* elements, size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::AffixFuzzer1) == sizeof(AffixFuzzer2));
-        RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::AffixFuzzer1) == sizeof(components::AffixFuzzer2));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::AffixFuzzer1>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::AffixFuzzer1*>(elements),
             num_elements
@@ -29,8 +29,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer2::to_data_cell(
-        const AffixFuzzer2* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer2>::to_data_cell(
+        const components::AffixFuzzer2* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +38,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer2::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer2>::fill_arrow_array_builder(
                 static_cast<arrow::StructBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +48,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +57,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer2.hpp
@@ -20,9 +20,6 @@ namespace rerun::components {
     struct AffixFuzzer2 {
         rerun::datatypes::AffixFuzzer1 single_required;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer2() = default;
 
@@ -38,18 +35,30 @@ namespace rerun::components {
         operator rerun::datatypes::AffixFuzzer1() const {
             return single_required;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer2> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer2";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer2* elements, size_t num_elements
+            arrow::StructBuilder* builder, const components::AffixFuzzer2* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer2 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer2` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer2* instances, size_t num_instances
+            const components::AffixFuzzer2* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer20.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer20.cpp
@@ -8,19 +8,20 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer20::NAME[] = "rerun.testing.components.AffixFuzzer20";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer20::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::AffixFuzzer20::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer20>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::AffixFuzzer20>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer20::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const AffixFuzzer20* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer20>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const components::AffixFuzzer20* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::AffixFuzzer20) == sizeof(AffixFuzzer20));
-        RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer20::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::AffixFuzzer20) == sizeof(components::AffixFuzzer20));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::AffixFuzzer20>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::AffixFuzzer20*>(elements),
             num_elements
@@ -29,8 +30,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer20::to_data_cell(
-        const AffixFuzzer20* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer20>::to_data_cell(
+        const components::AffixFuzzer20* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +39,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer20::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer20>::fill_arrow_array_builder(
                 static_cast<arrow::StructBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +49,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +58,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer20.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer20.hpp
@@ -20,9 +20,6 @@ namespace rerun::components {
     struct AffixFuzzer20 {
         rerun::datatypes::AffixFuzzer20 nested_transparent;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer20() = default;
 
@@ -38,18 +35,30 @@ namespace rerun::components {
         operator rerun::datatypes::AffixFuzzer20() const {
             return nested_transparent;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer20> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer20";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer20* elements, size_t num_elements
+            arrow::StructBuilder* builder, const components::AffixFuzzer20* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer20 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer20` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer20* instances, size_t num_instances
+            const components::AffixFuzzer20* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer21.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer21.cpp
@@ -8,19 +8,20 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer21::NAME[] = "rerun.testing.components.AffixFuzzer21";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer21::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::AffixFuzzer21::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer21>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::AffixFuzzer21>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer21::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const AffixFuzzer21* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer21>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const components::AffixFuzzer21* elements,
+        size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::AffixFuzzer21) == sizeof(AffixFuzzer21));
-        RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer21::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::AffixFuzzer21) == sizeof(components::AffixFuzzer21));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::AffixFuzzer21>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::AffixFuzzer21*>(elements),
             num_elements
@@ -29,8 +30,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer21::to_data_cell(
-        const AffixFuzzer21* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer21>::to_data_cell(
+        const components::AffixFuzzer21* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +39,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer21::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer21>::fill_arrow_array_builder(
                 static_cast<arrow::StructBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +49,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +58,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer21.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer21.hpp
@@ -20,9 +20,6 @@ namespace rerun::components {
     struct AffixFuzzer21 {
         rerun::datatypes::AffixFuzzer21 nested_halves;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer21() = default;
 
@@ -38,18 +35,30 @@ namespace rerun::components {
         operator rerun::datatypes::AffixFuzzer21() const {
             return nested_halves;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer21> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer21";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer21* elements, size_t num_elements
+            arrow::StructBuilder* builder, const components::AffixFuzzer21* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer21 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer21` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer21* instances, size_t num_instances
+            const components::AffixFuzzer21* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer3.cpp
@@ -8,19 +8,19 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer3::NAME[] = "rerun.testing.components.AffixFuzzer3";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer3::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::AffixFuzzer1::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer3>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::AffixFuzzer1>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer3::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const AffixFuzzer3* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer3>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const components::AffixFuzzer3* elements, size_t num_elements
     ) {
-        static_assert(sizeof(rerun::datatypes::AffixFuzzer1) == sizeof(AffixFuzzer3));
-        RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
+        static_assert(sizeof(rerun::datatypes::AffixFuzzer1) == sizeof(components::AffixFuzzer3));
+        RR_RETURN_NOT_OK(Loggable<rerun::datatypes::AffixFuzzer1>::fill_arrow_array_builder(
             builder,
             reinterpret_cast<const rerun::datatypes::AffixFuzzer1*>(elements),
             num_elements
@@ -29,8 +29,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer3::to_data_cell(
-        const AffixFuzzer3* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer3>::to_data_cell(
+        const components::AffixFuzzer3* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -38,7 +38,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer3::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer3>::fill_arrow_array_builder(
                 static_cast<arrow::StructBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -48,7 +48,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -57,4 +57,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer3.hpp
@@ -20,9 +20,6 @@ namespace rerun::components {
     struct AffixFuzzer3 {
         rerun::datatypes::AffixFuzzer1 single_required;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer3() = default;
 
@@ -38,18 +35,30 @@ namespace rerun::components {
         operator rerun::datatypes::AffixFuzzer1() const {
             return single_required;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer3> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer3";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer3* elements, size_t num_elements
+            arrow::StructBuilder* builder, const components::AffixFuzzer3* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer3 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer3` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer3* instances, size_t num_instances
+            const components::AffixFuzzer3* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer4.cpp
@@ -8,16 +8,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer4::NAME[] = "rerun.testing.components.AffixFuzzer4";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer4::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::AffixFuzzer1::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer4>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::AffixFuzzer1>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer4::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const AffixFuzzer4* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer4>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const components::AffixFuzzer4* elements, size_t num_elements
     ) {
         (void)builder;
         (void)elements;
@@ -32,8 +32,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer4::to_data_cell(
-        const AffixFuzzer4* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer4>::to_data_cell(
+        const components::AffixFuzzer4* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -41,7 +41,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer4::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer4>::fill_arrow_array_builder(
                 static_cast<arrow::StructBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -51,7 +51,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -60,4 +60,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer4.hpp
@@ -21,9 +21,6 @@ namespace rerun::components {
     struct AffixFuzzer4 {
         std::optional<rerun::datatypes::AffixFuzzer1> single_optional;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer4() = default;
 
@@ -39,18 +36,30 @@ namespace rerun::components {
         operator std::optional<rerun::datatypes::AffixFuzzer1>() const {
             return single_optional;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer4> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer4";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer4* elements, size_t num_elements
+            arrow::StructBuilder* builder, const components::AffixFuzzer4* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer4 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer4` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer4* instances, size_t num_instances
+            const components::AffixFuzzer4* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer5.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer5.cpp
@@ -8,16 +8,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer5::NAME[] = "rerun.testing.components.AffixFuzzer5";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer5::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::AffixFuzzer1::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer5>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::AffixFuzzer1>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer5::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const AffixFuzzer5* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer5>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const components::AffixFuzzer5* elements, size_t num_elements
     ) {
         (void)builder;
         (void)elements;
@@ -32,8 +32,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer5::to_data_cell(
-        const AffixFuzzer5* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer5>::to_data_cell(
+        const components::AffixFuzzer5* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -41,7 +41,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer5::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer5>::fill_arrow_array_builder(
                 static_cast<arrow::StructBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -51,7 +51,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -60,4 +60,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer5.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer5.hpp
@@ -21,9 +21,6 @@ namespace rerun::components {
     struct AffixFuzzer5 {
         std::optional<rerun::datatypes::AffixFuzzer1> single_optional;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer5() = default;
 
@@ -39,18 +36,30 @@ namespace rerun::components {
         operator std::optional<rerun::datatypes::AffixFuzzer1>() const {
             return single_optional;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer5> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer5";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer5* elements, size_t num_elements
+            arrow::StructBuilder* builder, const components::AffixFuzzer5* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer5 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer5` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer5* instances, size_t num_instances
+            const components::AffixFuzzer5* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer6.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer6.cpp
@@ -8,16 +8,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer6::NAME[] = "rerun.testing.components.AffixFuzzer6";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer6::arrow_datatype() {
-        static const auto datatype = rerun::datatypes::AffixFuzzer1::arrow_datatype();
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer6>::arrow_datatype() {
+        static const auto datatype = Loggable<rerun::datatypes::AffixFuzzer1>::arrow_datatype();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer6::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const AffixFuzzer6* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer6>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const components::AffixFuzzer6* elements, size_t num_elements
     ) {
         (void)builder;
         (void)elements;
@@ -32,8 +32,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer6::to_data_cell(
-        const AffixFuzzer6* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer6>::to_data_cell(
+        const components::AffixFuzzer6* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -41,7 +41,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer6::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer6>::fill_arrow_array_builder(
                 static_cast<arrow::StructBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -51,7 +51,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -60,4 +60,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer6.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer6.hpp
@@ -21,9 +21,6 @@ namespace rerun::components {
     struct AffixFuzzer6 {
         std::optional<rerun::datatypes::AffixFuzzer1> single_optional;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer6() = default;
 
@@ -39,18 +36,30 @@ namespace rerun::components {
         operator std::optional<rerun::datatypes::AffixFuzzer1>() const {
             return single_optional;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer6> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer6";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer6* elements, size_t num_elements
+            arrow::StructBuilder* builder, const components::AffixFuzzer6* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer6 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer6` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer6* instances, size_t num_instances
+            const components::AffixFuzzer6* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer7.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer7.cpp
@@ -8,18 +8,18 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer7::NAME[] = "rerun.testing.components.AffixFuzzer7";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer7::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer7>::arrow_datatype() {
         static const auto datatype = arrow::list(
-            arrow::field("item", rerun::datatypes::AffixFuzzer1::arrow_datatype(), false)
+            arrow::field("item", Loggable<rerun::datatypes::AffixFuzzer1>::arrow_datatype(), false)
         );
         return datatype;
     }
 
-    rerun::Error AffixFuzzer7::fill_arrow_array_builder(
-        arrow::ListBuilder* builder, const AffixFuzzer7* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer7>::fill_arrow_array_builder(
+        arrow::ListBuilder* builder, const components::AffixFuzzer7* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -40,11 +40,13 @@ namespace rerun::components {
             if (element.many_optional.has_value()) {
                 ARROW_RETURN_NOT_OK(builder->Append());
                 if (element.many_optional.value().data()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer1::fill_arrow_array_builder(
-                        value_builder,
-                        element.many_optional.value().data(),
-                        element.many_optional.value().size()
-                    ));
+                    RR_RETURN_NOT_OK(
+                        Loggable<rerun::datatypes::AffixFuzzer1>::fill_arrow_array_builder(
+                            value_builder,
+                            element.many_optional.value().data(),
+                            element.many_optional.value().size()
+                        )
+                    );
                 }
             } else {
                 ARROW_RETURN_NOT_OK(builder->AppendNull());
@@ -54,8 +56,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer7::to_data_cell(
-        const AffixFuzzer7* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer7>::to_data_cell(
+        const components::AffixFuzzer7* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -63,7 +65,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer7::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer7>::fill_arrow_array_builder(
                 static_cast<arrow::ListBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -73,7 +75,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -82,4 +84,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer7.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer7.hpp
@@ -22,9 +22,6 @@ namespace rerun::components {
     struct AffixFuzzer7 {
         std::optional<rerun::Collection<rerun::datatypes::AffixFuzzer1>> many_optional;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer7() = default;
 
@@ -38,18 +35,30 @@ namespace rerun::components {
             many_optional = std::move(many_optional_);
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer7> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer7";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::ListBuilder* builder, const AffixFuzzer7* elements, size_t num_elements
+            arrow::ListBuilder* builder, const components::AffixFuzzer7* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer7 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer7` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer7* instances, size_t num_instances
+            const components::AffixFuzzer7* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer8.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer8.cpp
@@ -6,16 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer8::NAME[] = "rerun.testing.components.AffixFuzzer8";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer8::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer8>::arrow_datatype() {
         static const auto datatype = arrow::float32();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer8::fill_arrow_array_builder(
-        arrow::FloatBuilder* builder, const AffixFuzzer8* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer8>::fill_arrow_array_builder(
+        arrow::FloatBuilder* builder, const components::AffixFuzzer8* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -40,8 +40,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer8::to_data_cell(
-        const AffixFuzzer8* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer8>::to_data_cell(
+        const components::AffixFuzzer8* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -49,7 +49,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer8::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer8>::fill_arrow_array_builder(
                 static_cast<arrow::FloatBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -59,7 +59,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -68,4 +68,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer8.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer8.hpp
@@ -23,9 +23,6 @@ namespace rerun::components {
     struct AffixFuzzer8 {
         std::optional<float> single_float_optional;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer8() = default;
 
@@ -36,18 +33,30 @@ namespace rerun::components {
             single_float_optional = single_float_optional_;
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer8> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer8";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FloatBuilder* builder, const AffixFuzzer8* elements, size_t num_elements
+            arrow::FloatBuilder* builder, const components::AffixFuzzer8* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer8 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer8` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer8* instances, size_t num_instances
+            const components::AffixFuzzer8* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer9.cpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer9.cpp
@@ -6,16 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::components {
-    const char AffixFuzzer9::NAME[] = "rerun.testing.components.AffixFuzzer9";
+namespace rerun::components {}
 
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer9::arrow_datatype() {
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<components::AffixFuzzer9>::arrow_datatype() {
         static const auto datatype = arrow::utf8();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer9::fill_arrow_array_builder(
-        arrow::StringBuilder* builder, const AffixFuzzer9* elements, size_t num_elements
+    rerun::Error Loggable<components::AffixFuzzer9>::fill_arrow_array_builder(
+        arrow::StringBuilder* builder, const components::AffixFuzzer9* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -35,8 +35,8 @@ namespace rerun::components {
         return Error::ok();
     }
 
-    Result<rerun::DataCell> AffixFuzzer9::to_data_cell(
-        const AffixFuzzer9* instances, size_t num_instances
+    Result<rerun::DataCell> Loggable<components::AffixFuzzer9>::to_data_cell(
+        const components::AffixFuzzer9* instances, size_t num_instances
     ) {
         // TODO(andreas): Allow configuring the memory pool.
         arrow::MemoryPool* pool = arrow::default_memory_pool();
@@ -44,7 +44,7 @@ namespace rerun::components {
 
         ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
         if (instances && num_instances > 0) {
-            RR_RETURN_NOT_OK(AffixFuzzer9::fill_arrow_array_builder(
+            RR_RETURN_NOT_OK(Loggable<components::AffixFuzzer9>::fill_arrow_array_builder(
                 static_cast<arrow::StringBuilder*>(builder.get()),
                 instances,
                 num_instances
@@ -54,7 +54,7 @@ namespace rerun::components {
         ARROW_RETURN_NOT_OK(builder->Finish(&array));
 
         static const Result<ComponentTypeHandle> component_type =
-            ComponentType(NAME, datatype).register_component();
+            ComponentType(Name, datatype).register_component();
         RR_RETURN_NOT_OK(component_type.error);
 
         DataCell cell;
@@ -63,4 +63,4 @@ namespace rerun::components {
         cell.component_type = component_type.value;
         return cell;
     }
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer9.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer9.hpp
@@ -19,9 +19,6 @@ namespace rerun::components {
     struct AffixFuzzer9 {
         std::string single_string_required;
 
-        /// Name of the component, used for serialization.
-        static const char NAME[];
-
       public:
         AffixFuzzer9() = default;
 
@@ -32,18 +29,30 @@ namespace rerun::components {
             single_string_required = std::move(single_string_required_);
             return *this;
         }
+    };
+} // namespace rerun::components
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<components::AffixFuzzer9> {
+        static constexpr const char Name[] = "rerun.testing.components.AffixFuzzer9";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StringBuilder* builder, const AffixFuzzer9* elements, size_t num_elements
+            arrow::StringBuilder* builder, const components::AffixFuzzer9* elements,
+            size_t num_elements
         );
 
-        /// Creates a Rerun DataCell from an array of AffixFuzzer9 components.
+        /// Creates a Rerun DataCell from an array of `rerun::components::AffixFuzzer9` components.
         static Result<rerun::DataCell> to_data_cell(
-            const AffixFuzzer9* instances, size_t num_instances
+            const components::AffixFuzzer9* instances, size_t num_instances
         );
     };
-} // namespace rerun::components
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.cpp
@@ -8,8 +8,10 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer1::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::AffixFuzzer1>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
             arrow::field("single_float_optional", arrow::float32(), true),
             arrow::field("single_string_required", arrow::utf8(), false),
@@ -32,7 +34,7 @@ namespace rerun::datatypes {
             arrow::field("flattened_scalar", arrow::float32(), false),
             arrow::field(
                 "almost_flattened_scalar",
-                rerun::datatypes::FlattenedScalar::arrow_datatype(),
+                Loggable<rerun::datatypes::FlattenedScalar>::arrow_datatype(),
                 false
             ),
             arrow::field("from_parent", arrow::boolean(), true),
@@ -40,8 +42,8 @@ namespace rerun::datatypes {
         return datatype;
     }
 
-    rerun::Error AffixFuzzer1::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const AffixFuzzer1* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::AffixFuzzer1>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::AffixFuzzer1* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -157,11 +159,13 @@ namespace rerun::datatypes {
             auto field_builder = static_cast<arrow::StructBuilder*>(builder->field_builder(7));
             ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                RR_RETURN_NOT_OK(rerun::datatypes::FlattenedScalar::fill_arrow_array_builder(
-                    field_builder,
-                    &elements[elem_idx].almost_flattened_scalar,
-                    1
-                ));
+                RR_RETURN_NOT_OK(
+                    Loggable<rerun::datatypes::FlattenedScalar>::fill_arrow_array_builder(
+                        field_builder,
+                        &elements[elem_idx].almost_flattened_scalar,
+                        1
+                    )
+                );
             }
         }
         {
@@ -180,4 +184,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::AffixFuzzer1>::to_data_cell(
+        const datatypes::AffixFuzzer1* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::AffixFuzzer1>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <rerun/collection.hpp>
+#include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <string>
 
@@ -39,13 +40,30 @@ namespace rerun::datatypes {
 
       public:
         AffixFuzzer1() = default;
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::AffixFuzzer1> {
+        static constexpr const char Name[] = "rerun.testing.datatypes.AffixFuzzer1";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer1* elements, size_t num_elements
+            arrow::StructBuilder* builder, const datatypes::AffixFuzzer1* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::AffixFuzzer1` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::AffixFuzzer1* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.cpp
@@ -6,14 +6,16 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer2::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::AffixFuzzer2>::arrow_datatype() {
         static const auto datatype = arrow::float32();
         return datatype;
     }
 
-    rerun::Error AffixFuzzer2::fill_arrow_array_builder(
-        arrow::FloatBuilder* builder, const AffixFuzzer2* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::AffixFuzzer2>::fill_arrow_array_builder(
+        arrow::FloatBuilder* builder, const datatypes::AffixFuzzer2* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -37,4 +39,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::AffixFuzzer2>::to_data_cell(
+        const datatypes::AffixFuzzer2* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::AffixFuzzer2>::fill_arrow_array_builder(
+                static_cast<arrow::FloatBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -32,13 +33,30 @@ namespace rerun::datatypes {
             single_float_optional = single_float_optional_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::AffixFuzzer2> {
+        static constexpr const char Name[] = "rerun.testing.datatypes.AffixFuzzer2";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::FloatBuilder* builder, const AffixFuzzer2* elements, size_t num_elements
+            arrow::FloatBuilder* builder, const datatypes::AffixFuzzer2* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::AffixFuzzer2` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::AffixFuzzer2* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.cpp
@@ -9,17 +9,23 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer20::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::AffixFuzzer20>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
-            arrow::field("p", rerun::datatypes::PrimitiveComponent::arrow_datatype(), false),
-            arrow::field("s", rerun::datatypes::StringComponent::arrow_datatype(), false),
+            arrow::field(
+                "p",
+                Loggable<rerun::datatypes::PrimitiveComponent>::arrow_datatype(),
+                false
+            ),
+            arrow::field("s", Loggable<rerun::datatypes::StringComponent>::arrow_datatype(), false),
         });
         return datatype;
     }
 
-    rerun::Error AffixFuzzer20::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const AffixFuzzer20* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::AffixFuzzer20>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::AffixFuzzer20* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -35,26 +41,59 @@ namespace rerun::datatypes {
             auto field_builder = static_cast<arrow::UInt32Builder*>(builder->field_builder(0));
             ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                RR_RETURN_NOT_OK(rerun::datatypes::PrimitiveComponent::fill_arrow_array_builder(
-                    field_builder,
-                    &elements[elem_idx].p,
-                    1
-                ));
+                RR_RETURN_NOT_OK(
+                    Loggable<rerun::datatypes::PrimitiveComponent>::fill_arrow_array_builder(
+                        field_builder,
+                        &elements[elem_idx].p,
+                        1
+                    )
+                );
             }
         }
         {
             auto field_builder = static_cast<arrow::StringBuilder*>(builder->field_builder(1));
             ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
-                RR_RETURN_NOT_OK(rerun::datatypes::StringComponent::fill_arrow_array_builder(
-                    field_builder,
-                    &elements[elem_idx].s,
-                    1
-                ));
+                RR_RETURN_NOT_OK(
+                    Loggable<rerun::datatypes::StringComponent>::fill_arrow_array_builder(
+                        field_builder,
+                        &elements[elem_idx].s,
+                        1
+                    )
+                );
             }
         }
         ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::AffixFuzzer20>::to_data_cell(
+        const datatypes::AffixFuzzer20* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::AffixFuzzer20>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.hpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -23,13 +24,30 @@ namespace rerun::datatypes {
 
       public:
         AffixFuzzer20() = default;
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::AffixFuzzer20> {
+        static constexpr const char Name[] = "rerun.testing.datatypes.AffixFuzzer20";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer20* elements, size_t num_elements
+            arrow::StructBuilder* builder, const datatypes::AffixFuzzer20* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::AffixFuzzer20` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::AffixFuzzer20* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer21.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer21.cpp
@@ -6,8 +6,10 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer21::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::AffixFuzzer21>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
             arrow::field("single_half", arrow::float16(), false),
             arrow::field(
@@ -19,8 +21,8 @@ namespace rerun::datatypes {
         return datatype;
     }
 
-    rerun::Error AffixFuzzer21::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const AffixFuzzer21* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::AffixFuzzer21>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::AffixFuzzer21* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -62,4 +64,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::AffixFuzzer21>::to_data_cell(
+        const datatypes::AffixFuzzer21* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::AffixFuzzer21>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer21.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer21.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <memory>
 #include <rerun/collection.hpp>
+#include <rerun/data_cell.hpp>
 #include <rerun/half.hpp>
 #include <rerun/result.hpp>
 
@@ -22,13 +23,30 @@ namespace rerun::datatypes {
 
       public:
         AffixFuzzer21() = default;
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::AffixFuzzer21> {
+        static constexpr const char Name[] = "rerun.testing.datatypes.AffixFuzzer21";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer21* elements, size_t num_elements
+            arrow::StructBuilder* builder, const datatypes::AffixFuzzer21* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::AffixFuzzer21` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::AffixFuzzer21* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
@@ -8,17 +8,21 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer3::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::AffixFuzzer3>::arrow_datatype() {
         static const auto datatype = arrow::dense_union({
             arrow::field("_null_markers", arrow::null(), true, nullptr),
             arrow::field("degrees", arrow::float32(), false),
             arrow::field("radians", arrow::float32(), true),
             arrow::field(
                 "craziness",
-                arrow::list(
-                    arrow::field("item", rerun::datatypes::AffixFuzzer1::arrow_datatype(), false)
-                ),
+                arrow::list(arrow::field(
+                    "item",
+                    Loggable<rerun::datatypes::AffixFuzzer1>::arrow_datatype(),
+                    false
+                )),
                 false
             ),
             arrow::field(
@@ -30,8 +34,9 @@ namespace rerun::datatypes {
         return datatype;
     }
 
-    rerun::Error AffixFuzzer3::fill_arrow_array_builder(
-        arrow::DenseUnionBuilder* builder, const AffixFuzzer3* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::AffixFuzzer3>::fill_arrow_array_builder(
+        arrow::DenseUnionBuilder* builder, const datatypes::AffixFuzzer3* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -46,31 +51,35 @@ namespace rerun::datatypes {
         ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
         for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
             const auto& union_instance = elements[elem_idx];
-            ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance._tag)));
+            ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance.get_union_tag()))
+            );
 
-            auto variant_index = static_cast<int>(union_instance._tag);
+            auto variant_index = static_cast<int>(union_instance.get_union_tag());
             auto variant_builder_untyped = builder->child_builder(variant_index).get();
 
-            switch (union_instance._tag) {
-                case detail::AffixFuzzer3Tag::None: {
+            using TagType = datatypes::detail::AffixFuzzer3Tag;
+            switch (union_instance.get_union_tag()) {
+                case TagType::None: {
                     ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                 } break;
-                case detail::AffixFuzzer3Tag::degrees: {
+                case TagType::degrees: {
                     auto variant_builder =
                         static_cast<arrow::FloatBuilder*>(variant_builder_untyped);
-                    ARROW_RETURN_NOT_OK(variant_builder->Append(union_instance._data.degrees));
+                    ARROW_RETURN_NOT_OK(
+                        variant_builder->Append(union_instance.get_union_data().degrees)
+                    );
                 } break;
-                case detail::AffixFuzzer3Tag::radians: {
+                case TagType::radians: {
                     auto variant_builder =
                         static_cast<arrow::FloatBuilder*>(variant_builder_untyped);
-                    const auto& element = union_instance._data;
+                    const auto& element = union_instance.get_union_data();
                     if (element.radians.has_value()) {
                         ARROW_RETURN_NOT_OK(variant_builder->Append(element.radians.value()));
                     } else {
                         ARROW_RETURN_NOT_OK(variant_builder->AppendNull());
                     }
                 } break;
-                case detail::AffixFuzzer3Tag::craziness: {
+                case TagType::craziness: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     (void)variant_builder;
@@ -79,7 +88,7 @@ namespace rerun::datatypes {
                         "Failed to serialize AffixFuzzer3::craziness: objects (Object(\"rerun.testing.datatypes.AffixFuzzer1\")) in unions not yet implemented"
                     );
                 } break;
-                case detail::AffixFuzzer3Tag::fixed_size_shenanigans: {
+                case TagType::fixed_size_shenanigans: {
                     auto variant_builder =
                         static_cast<arrow::FixedSizeListBuilder*>(variant_builder_untyped);
                     (void)variant_builder;
@@ -93,4 +102,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::AffixFuzzer3>::to_data_cell(
+        const datatypes::AffixFuzzer3* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::AffixFuzzer3>::fill_arrow_array_builder(
+                static_cast<arrow::DenseUnionBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
@@ -12,6 +12,7 @@
 #include <new>
 #include <optional>
 #include <rerun/collection.hpp>
+#include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -189,16 +190,43 @@ namespace rerun::datatypes {
             }
         }
 
-        /// Returns the arrow data type this type corresponds to.
-        static const std::shared_ptr<arrow::DataType>& arrow_datatype();
+        /// \private
+        const detail::AffixFuzzer3Data& get_union_data() const {
+            return _data;
+        }
 
-        /// Fills an arrow array builder with an array of this type.
-        static rerun::Error fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const AffixFuzzer3* elements, size_t num_elements
-        );
+        /// \private
+        detail::AffixFuzzer3Tag get_union_tag() const {
+            return _tag;
+        }
 
       private:
         detail::AffixFuzzer3Tag _tag;
         detail::AffixFuzzer3Data _data;
     };
 } // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::AffixFuzzer3> {
+        static constexpr const char Name[] = "rerun.testing.datatypes.AffixFuzzer3";
+
+        /// Returns the arrow data type this type corresponds to.
+        static const std::shared_ptr<arrow::DataType>& arrow_datatype();
+
+        /// Fills an arrow array builder with an array of this type.
+        static rerun::Error fill_arrow_array_builder(
+            arrow::DenseUnionBuilder* builder, const datatypes::AffixFuzzer3* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::AffixFuzzer3` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::AffixFuzzer3* instances, size_t num_instances
+        );
+    };
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
@@ -8,35 +8,42 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer4::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::AffixFuzzer4>::arrow_datatype() {
         static const auto datatype = arrow::dense_union({
             arrow::field("_null_markers", arrow::null(), true, nullptr),
             arrow::field(
                 "single_required",
-                rerun::datatypes::AffixFuzzer3::arrow_datatype(),
+                Loggable<rerun::datatypes::AffixFuzzer3>::arrow_datatype(),
                 false
             ),
             arrow::field(
                 "many_required",
-                arrow::list(
-                    arrow::field("item", rerun::datatypes::AffixFuzzer3::arrow_datatype(), false)
-                ),
+                arrow::list(arrow::field(
+                    "item",
+                    Loggable<rerun::datatypes::AffixFuzzer3>::arrow_datatype(),
+                    false
+                )),
                 false
             ),
             arrow::field(
                 "many_optional",
-                arrow::list(
-                    arrow::field("item", rerun::datatypes::AffixFuzzer3::arrow_datatype(), false)
-                ),
+                arrow::list(arrow::field(
+                    "item",
+                    Loggable<rerun::datatypes::AffixFuzzer3>::arrow_datatype(),
+                    false
+                )),
                 true
             ),
         });
         return datatype;
     }
 
-    rerun::Error AffixFuzzer4::fill_arrow_array_builder(
-        arrow::DenseUnionBuilder* builder, const AffixFuzzer4* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::AffixFuzzer4>::fill_arrow_array_builder(
+        arrow::DenseUnionBuilder* builder, const datatypes::AffixFuzzer4* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -51,25 +58,29 @@ namespace rerun::datatypes {
         ARROW_RETURN_NOT_OK(builder->Reserve(static_cast<int64_t>(num_elements)));
         for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
             const auto& union_instance = elements[elem_idx];
-            ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance._tag)));
+            ARROW_RETURN_NOT_OK(builder->Append(static_cast<int8_t>(union_instance.get_union_tag()))
+            );
 
-            auto variant_index = static_cast<int>(union_instance._tag);
+            auto variant_index = static_cast<int>(union_instance.get_union_tag());
             auto variant_builder_untyped = builder->child_builder(variant_index).get();
 
-            switch (union_instance._tag) {
-                case detail::AffixFuzzer4Tag::None: {
+            using TagType = datatypes::detail::AffixFuzzer4Tag;
+            switch (union_instance.get_union_tag()) {
+                case TagType::None: {
                     ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                 } break;
-                case detail::AffixFuzzer4Tag::single_required: {
+                case TagType::single_required: {
                     auto variant_builder =
                         static_cast<arrow::DenseUnionBuilder*>(variant_builder_untyped);
-                    RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer3::fill_arrow_array_builder(
-                        variant_builder,
-                        &union_instance._data.single_required,
-                        1
-                    ));
+                    RR_RETURN_NOT_OK(
+                        Loggable<rerun::datatypes::AffixFuzzer3>::fill_arrow_array_builder(
+                            variant_builder,
+                            &union_instance.get_union_data().single_required,
+                            1
+                        )
+                    );
                 } break;
-                case detail::AffixFuzzer4Tag::many_required: {
+                case TagType::many_required: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     (void)variant_builder;
@@ -78,7 +89,7 @@ namespace rerun::datatypes {
                         "Failed to serialize AffixFuzzer4::many_required: objects (Object(\"rerun.testing.datatypes.AffixFuzzer3\")) in unions not yet implemented"
                     );
                 } break;
-                case detail::AffixFuzzer4Tag::many_optional: {
+                case TagType::many_optional: {
                     auto variant_builder =
                         static_cast<arrow::ListBuilder*>(variant_builder_untyped);
                     (void)variant_builder;
@@ -92,4 +103,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::AffixFuzzer4>::to_data_cell(
+        const datatypes::AffixFuzzer4* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::AffixFuzzer4>::fill_arrow_array_builder(
+                static_cast<arrow::DenseUnionBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
@@ -11,6 +11,7 @@
 #include <new>
 #include <optional>
 #include <rerun/collection.hpp>
+#include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -179,16 +180,43 @@ namespace rerun::datatypes {
             }
         }
 
-        /// Returns the arrow data type this type corresponds to.
-        static const std::shared_ptr<arrow::DataType>& arrow_datatype();
+        /// \private
+        const detail::AffixFuzzer4Data& get_union_data() const {
+            return _data;
+        }
 
-        /// Fills an arrow array builder with an array of this type.
-        static rerun::Error fill_arrow_array_builder(
-            arrow::DenseUnionBuilder* builder, const AffixFuzzer4* elements, size_t num_elements
-        );
+        /// \private
+        detail::AffixFuzzer4Tag get_union_tag() const {
+            return _tag;
+        }
 
       private:
         detail::AffixFuzzer4Tag _tag;
         detail::AffixFuzzer4Data _data;
     };
 } // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::AffixFuzzer4> {
+        static constexpr const char Name[] = "rerun.testing.datatypes.AffixFuzzer4";
+
+        /// Returns the arrow data type this type corresponds to.
+        static const std::shared_ptr<arrow::DataType>& arrow_datatype();
+
+        /// Fills an arrow array builder with an array of this type.
+        static rerun::Error fill_arrow_array_builder(
+            arrow::DenseUnionBuilder* builder, const datatypes::AffixFuzzer4* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::AffixFuzzer4` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::AffixFuzzer4* instances, size_t num_instances
+        );
+    };
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.cpp
@@ -8,20 +8,22 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& AffixFuzzer5::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::AffixFuzzer5>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
             arrow::field(
                 "single_optional_union",
-                rerun::datatypes::AffixFuzzer4::arrow_datatype(),
+                Loggable<rerun::datatypes::AffixFuzzer4>::arrow_datatype(),
                 true
             ),
         });
         return datatype;
     }
 
-    rerun::Error AffixFuzzer5::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const AffixFuzzer5* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::AffixFuzzer5>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::AffixFuzzer5* elements, size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -39,11 +41,13 @@ namespace rerun::datatypes {
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto& element = elements[elem_idx];
                 if (element.single_optional_union.has_value()) {
-                    RR_RETURN_NOT_OK(rerun::datatypes::AffixFuzzer4::fill_arrow_array_builder(
-                        field_builder,
-                        &element.single_optional_union.value(),
-                        1
-                    ));
+                    RR_RETURN_NOT_OK(
+                        Loggable<rerun::datatypes::AffixFuzzer4>::fill_arrow_array_builder(
+                            field_builder,
+                            &element.single_optional_union.value(),
+                            1
+                        )
+                    );
                 } else {
                     ARROW_RETURN_NOT_OK(field_builder->AppendNull());
                 }
@@ -53,4 +57,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::AffixFuzzer5>::to_data_cell(
+        const datatypes::AffixFuzzer5* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::AffixFuzzer5>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -31,13 +32,30 @@ namespace rerun::datatypes {
             single_optional_union = std::move(single_optional_union_);
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::AffixFuzzer5> {
+        static constexpr const char Name[] = "rerun.testing.datatypes.AffixFuzzer5";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const AffixFuzzer5* elements, size_t num_elements
+            arrow::StructBuilder* builder, const datatypes::AffixFuzzer5* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::AffixFuzzer5` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::AffixFuzzer5* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/flattened_scalar.cpp
+++ b/rerun_cpp/tests/generated/datatypes/flattened_scalar.cpp
@@ -6,16 +6,19 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& FlattenedScalar::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::FlattenedScalar>::arrow_datatype() {
         static const auto datatype = arrow::struct_({
             arrow::field("value", arrow::float32(), false),
         });
         return datatype;
     }
 
-    rerun::Error FlattenedScalar::fill_arrow_array_builder(
-        arrow::StructBuilder* builder, const FlattenedScalar* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::FlattenedScalar>::fill_arrow_array_builder(
+        arrow::StructBuilder* builder, const datatypes::FlattenedScalar* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -38,4 +41,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::FlattenedScalar>::to_data_cell(
+        const datatypes::FlattenedScalar* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::FlattenedScalar>::fill_arrow_array_builder(
+                static_cast<arrow::StructBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/flattened_scalar.hpp
+++ b/rerun_cpp/tests/generated/datatypes/flattened_scalar.hpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -25,13 +26,30 @@ namespace rerun::datatypes {
             value = value_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::FlattenedScalar> {
+        static constexpr const char Name[] = "rerun.testing.datatypes.FlattenedScalar";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StructBuilder* builder, const FlattenedScalar* elements, size_t num_elements
+            arrow::StructBuilder* builder, const datatypes::FlattenedScalar* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::FlattenedScalar` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::FlattenedScalar* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/primitive_component.cpp
+++ b/rerun_cpp/tests/generated/datatypes/primitive_component.cpp
@@ -6,14 +6,18 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& PrimitiveComponent::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::PrimitiveComponent>::arrow_datatype(
+    ) {
         static const auto datatype = arrow::uint32();
         return datatype;
     }
 
-    rerun::Error PrimitiveComponent::fill_arrow_array_builder(
-        arrow::UInt32Builder* builder, const PrimitiveComponent* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::PrimitiveComponent>::fill_arrow_array_builder(
+        arrow::UInt32Builder* builder, const datatypes::PrimitiveComponent* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -32,4 +36,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::PrimitiveComponent>::to_data_cell(
+        const datatypes::PrimitiveComponent* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::PrimitiveComponent>::fill_arrow_array_builder(
+                static_cast<arrow::UInt32Builder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/primitive_component.hpp
+++ b/rerun_cpp/tests/generated/datatypes/primitive_component.hpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -30,13 +31,30 @@ namespace rerun::datatypes {
             value = value_;
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::PrimitiveComponent> {
+        static constexpr const char Name[] = "rerun.testing.datatypes.PrimitiveComponent";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::UInt32Builder* builder, const PrimitiveComponent* elements, size_t num_elements
+            arrow::UInt32Builder* builder, const datatypes::PrimitiveComponent* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::PrimitiveComponent` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::PrimitiveComponent* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/string_component.cpp
+++ b/rerun_cpp/tests/generated/datatypes/string_component.cpp
@@ -6,14 +6,17 @@
 #include <arrow/builder.h>
 #include <arrow/type_fwd.h>
 
-namespace rerun::datatypes {
-    const std::shared_ptr<arrow::DataType>& StringComponent::arrow_datatype() {
+namespace rerun::datatypes {}
+
+namespace rerun {
+    const std::shared_ptr<arrow::DataType>& Loggable<datatypes::StringComponent>::arrow_datatype() {
         static const auto datatype = arrow::utf8();
         return datatype;
     }
 
-    rerun::Error StringComponent::fill_arrow_array_builder(
-        arrow::StringBuilder* builder, const StringComponent* elements, size_t num_elements
+    rerun::Error Loggable<datatypes::StringComponent>::fill_arrow_array_builder(
+        arrow::StringBuilder* builder, const datatypes::StringComponent* elements,
+        size_t num_elements
     ) {
         if (builder == nullptr) {
             return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array builder is null.");
@@ -32,4 +35,33 @@ namespace rerun::datatypes {
 
         return Error::ok();
     }
-} // namespace rerun::datatypes
+
+    Result<rerun::DataCell> Loggable<datatypes::StringComponent>::to_data_cell(
+        const datatypes::StringComponent* instances, size_t num_instances
+    ) {
+        // TODO(andreas): Allow configuring the memory pool.
+        arrow::MemoryPool* pool = arrow::default_memory_pool();
+        auto datatype = arrow_datatype();
+
+        ARROW_ASSIGN_OR_RAISE(auto builder, arrow::MakeBuilder(datatype, pool))
+        if (instances && num_instances > 0) {
+            RR_RETURN_NOT_OK(Loggable<datatypes::StringComponent>::fill_arrow_array_builder(
+                static_cast<arrow::StringBuilder*>(builder.get()),
+                instances,
+                num_instances
+            ));
+        }
+        std::shared_ptr<arrow::Array> array;
+        ARROW_RETURN_NOT_OK(builder->Finish(&array));
+
+        static const Result<ComponentTypeHandle> component_type =
+            ComponentType(Name, datatype).register_component();
+        RR_RETURN_NOT_OK(component_type.error);
+
+        DataCell cell;
+        cell.num_instances = num_instances;
+        cell.array = std::move(array);
+        cell.component_type = component_type.value;
+        return cell;
+    }
+} // namespace rerun

--- a/rerun_cpp/tests/generated/datatypes/string_component.hpp
+++ b/rerun_cpp/tests/generated/datatypes/string_component.hpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <rerun/data_cell.hpp>
 #include <rerun/result.hpp>
 #include <string>
 #include <utility>
@@ -27,13 +28,30 @@ namespace rerun::datatypes {
             value = std::move(value_);
             return *this;
         }
+    };
+} // namespace rerun::datatypes
+
+namespace rerun {
+    template <typename T>
+    struct Loggable;
+
+    /// \private
+    template <>
+    struct Loggable<datatypes::StringComponent> {
+        static constexpr const char Name[] = "rerun.testing.datatypes.StringComponent";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();
 
         /// Fills an arrow array builder with an array of this type.
         static rerun::Error fill_arrow_array_builder(
-            arrow::StringBuilder* builder, const StringComponent* elements, size_t num_elements
+            arrow::StringBuilder* builder, const datatypes::StringComponent* elements,
+            size_t num_elements
+        );
+
+        /// Creates a Rerun DataCell from an array of `rerun::datatypes::StringComponent` components.
+        static Result<rerun::DataCell> to_data_cell(
+            const datatypes::StringComponent* instances, size_t num_instances
         );
     };
-} // namespace rerun::datatypes
+} // namespace rerun


### PR DESCRIPTION
### What

This moves all serialization related methods off of the respective structs themselves, leading to better auto complete.
`AsComponents`.
The default implementations of `AsComponents` now all require input types to implement this new trait - before they just required the to_data_cell method to be there (that's still the case, but now with an indirection ;))

This makes our interface cleaner and paves the way to a good fix for:
* #3260

(there's a few details still missing for this to allow custom types without dragging in arrow headers, but one thing at a time!)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4305) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4305)
- [Docs preview](https://rerun.io/preview/c494b2e513d28ed53b456caaf890901bd2d7c6b4/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c494b2e513d28ed53b456caaf890901bd2d7c6b4/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)