### PR TITLE
Expose Rerun source/include dir in CMakeLists.txt (`RERUN_CPP_SOURCE_DIR`)

### DIFF
--- a/docs/content/reference/cpp-sdk-cmake.md
+++ b/docs/content/reference/cpp-sdk-cmake.md
@@ -74,6 +74,17 @@ It provides a minimalistic C interface that encapsulates the shared building blo
 By default points to where a pre-built library for the currently active platform
 is expected to be found in the Rerun C++ SDK distribution zip.
 
+### `RERUN_CPP_SOURCE_DIR`
+Path to the Rerun include and source directory, i.e. the directory that contains `rerun.hpp`.
+
+Note that rerun does not have separate folders for header (\*.hpp) and source (\*.cpp) files,
+both are found inside `RERUN_CPP_SOURCE_DIR`.
+
+By default is set to an absolute path that is determined by the location of Rerun's `CMakeLists.txt` itself.
+Setting this is rarely needed, but reading it may be useful for build setups that can not rely on
+the `rerun_cpp` target or for some reason aren't able to inherit the public target include path
+set on `rerun_cpp`.
+
 
 ## Tested compilers
 

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -8,18 +8,17 @@ cmake_minimum_required(VERSION 3.16...3.27)
 
 message("Compiler: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} (${CMAKE_CXX_COMPILER})")
 
-# ------------------------------------------------------------------------------
-# Base setup for rerun_sdk C++ library.
+set(RERUN_CPP_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src" CACHE PATH "Rerun include & source directory")
 
 file(GLOB_RECURSE rerun_sdk_SRC CONFIGURE_DEPENDS
-    "src/*.hpp"
-    "src/*.cpp"
+    "${RERUN_CPP_SOURCE_DIR}/*.hpp"
+    "${RERUN_CPP_SOURCE_DIR}/*.cpp"
 )
 
 add_library(rerun_sdk ${rerun_sdk_SRC})
 
 # Make sure the compiler can find include files for rerun when other libraries or executables link to rerun:
-target_include_directories(rerun_sdk PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_include_directories(rerun_sdk PUBLIC ${RERUN_CPP_SOURCE_DIR})
 
 # Rerun needs at least C++17.
 set_target_properties(rerun_sdk PROPERTIES CXX_STANDARD 17)
@@ -30,7 +29,7 @@ if(MSVC)
 endif()
 
 # Set default warning settings if defined.
-if (COMMAND rerun_strict_warning_settings)
+if(COMMAND rerun_strict_warning_settings)
     message("Building Rerun C++ SDK with strict compilation warnings.")
     rerun_strict_warning_settings(rerun_sdk)
 endif()
@@ -105,7 +104,6 @@ else()
 endif()
 
 target_link_libraries(rerun_sdk PRIVATE rerun_arrow_target)
-
 
 # -----------------------------------------------------------------------------
 # Add tests if they exist (they are not part of the distribution zip).


### PR DESCRIPTION
### What

* Fixes #4195

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4313) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4313)
- [Docs preview](https://rerun.io/preview/0ce2671010a22af30ab79746401b352ee0726ab4/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0ce2671010a22af30ab79746401b352ee0726ab4/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)