### PR TITLE
Fix pixi build (part 2)

### DIFF
--- a/.github/workflows/reusable_build_wheels.yml
+++ b/.github/workflows/reusable_build_wheels.yml
@@ -129,18 +129,33 @@ jobs:
         with:
           pixi-version: v0.6.0
 
-      - name: Build Wheel
+      - name: Install dependencies
         shell: bash
         run: |
           pixi run rustup target add ${{ needs.set-config.outputs.TARGET }}
           pixi run pip install -r rerun_py/requirements-build.txt
-          pixi run maturin build \
-            --manylinux 2_31 \
-            --release \
-            --manifest-path rerun_py/Cargo.toml \
-            --target ${{ needs.set-config.outputs.TARGET }} \
-            --out dist \
+
+      - name: Build web-viewer
+        shell: bash
+        run: |
+          pixi run cargo run --locked -p re_build_web_viewer -- --release
+
+      - name: Build Wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          maturin-version: "0.14.17"
+          manylinux: manylinux_2_31
+          container: off
+          command: build
+          args: |
+            --manifest-path rerun_py/Cargo.toml
+            --release
+            --target ${{ needs.set-config.outputs.TARGET }}
             ${{ inputs.MATURIN_FEATURE_FLAGS }}
+            --out dist
+        env:
+          # we're not actually publishing anything here, this stops `re_web_viewer_server/build.rs` from running
+          RERUN_IS_PUBLISHING: true
 
       - name: Save wheel artifact
         if: ${{ inputs.WHEEL_ARTIFACT_NAME != '' }}

--- a/.github/workflows/reusable_build_wheels.yml
+++ b/.github/workflows/reusable_build_wheels.yml
@@ -136,6 +136,8 @@ jobs:
           pixi run pip install -r rerun_py/requirements-build.txt
 
       - name: Build web-viewer
+        # only build web-viewer when publishing to pypi
+        if: ${{ contains(inputs.MATURIN_FEATURE_FLAGS, 'pypi') }}
         shell: bash
         run: |
           pixi run cargo run --locked -p re_build_web_viewer -- --release

--- a/.github/workflows/reusable_build_wheels.yml
+++ b/.github/workflows/reusable_build_wheels.yml
@@ -132,6 +132,7 @@ jobs:
       - name: Build Wheel
         shell: bash
         run: |
+          pixi run rustup target add ${{ needs.set-config.outputs.TARGET }}
           pixi run pip install -r rerun_py/requirements-build.txt
           pixi run maturin build \
             --manylinux 2_31 \


### PR DESCRIPTION
### What

- Explicitly install target before running maturin
- Try to build `web-viewer` separately from the wheel using `pixi`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4320) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4320)
- [Docs preview](https://rerun.io/preview/716ba9ce5b2f9e5b39b7b9d259fc890f5a029a1a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/716ba9ce5b2f9e5b39b7b9d259fc890f5a029a1a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)