### PR TITLE
Fix pixi build (part 3)

### DIFF
--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -141,10 +141,20 @@ jobs:
         with:
           pixi-version: v0.6.0
 
-      - name: Build rerun-cli
+      - name: Build web-viewer
         shell: bash
         run: |
-          pixi run cargo build \
+          pixi run cargo run --locked -p re_build_web_viewer -- --release
+
+      # This does not run in the pixi environment, doing so
+      # causes it to select the wrong compiler on macos-arm
+      - name: Build rerun-cli
+        shell: bash
+        env:
+          # this stops `re_web_viewer_server/build.rs` from running
+          RERUN_IS_PUBLISHING: true
+        run: |
+          cargo build \
             --locked \
             -p rerun-cli \
             --no-default-features \

--- a/.github/workflows/reusable_build_wheels.yml
+++ b/.github/workflows/reusable_build_wheels.yml
@@ -142,8 +142,13 @@ jobs:
         run: |
           pixi run cargo run --locked -p re_build_web_viewer -- --release
 
+      # This does not run in the pixi environment, doing so
+      # causes it to select the wrong compiler on macos-arm
       - name: Build Wheel
         uses: PyO3/maturin-action@v1
+        env:
+          # this stops `re_web_viewer_server/build.rs` from running
+          RERUN_IS_PUBLISHING: true
         with:
           maturin-version: "0.14.17"
           manylinux: manylinux_2_31
@@ -155,9 +160,6 @@ jobs:
             --target ${{ needs.set-config.outputs.TARGET }}
             ${{ inputs.MATURIN_FEATURE_FLAGS }}
             --out dist
-        env:
-          # we're not actually publishing anything here, this stops `re_web_viewer_server/build.rs` from running
-          RERUN_IS_PUBLISHING: true
 
       - name: Save wheel artifact
         if: ${{ inputs.WHEEL_ARTIFACT_NAME != '' }}


### PR DESCRIPTION
## What

- don't run `cargo build` in the pixi environment for `rerun-cli`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
