### PR TITLE
C++ SDK sanity checks now header/source version against rerun_c binary version

### DIFF
--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -179,7 +179,7 @@ pub struct CError {
 #[no_mangle]
 pub extern "C" fn rr_version_string() -> *const c_char {
     static VERSION: Lazy<CString> =
-        Lazy::new(|| CString::new(re_sdk::build_info().to_string()).unwrap()); // unwrap: there won't be any NUL bytes in the string
+        Lazy::new(|| CString::new(re_sdk::build_info().version.to_string()).unwrap()); // unwrap: there won't be any NUL bytes in the string
 
     VERSION.as_ptr()
 }

--- a/crates/rerun_c/src/rerun.h
+++ b/crates/rerun_c/src/rerun.h
@@ -223,7 +223,16 @@ typedef struct rr_error {
 // ----------------------------------------------------------------------------
 // Functions:
 
+/// Returns the version of the Rerun C SDK.
+///
+/// This should match the string returned by `rr_version_string`.
+/// If not, the SDK's binary and the C header are out of sync.
+#define RERUN_SDK_HEADER_VERSION "@RERUN_VERSION@"
+
 /// Returns a human-readable version string of the Rerun C SDK.
+///
+/// This should match the string in `RERUN_SDK_HEADER_VERSION`.
+/// If not, the SDK's binary and the C header are out of sync.
 extern const char* rr_version_string(void);
 
 /// Spawns a new Rerun Viewer process from an executable available in PATH, ready to

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -151,8 +151,12 @@ install(EXPORT rerun_sdkTargets
 
 include(CMakePackageConfigHelpers)
 
-# TODO(#3868): Extract version from rerun.h
-set(RERUN_VERSION 0.11.0)
+# Extract the version from rerun.h.
+# Intentionally only grab major.minor.patch, not the full version, since version file can't handle it otherwise.
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/src/rerun/c/rerun.h" RERUN_H_CONTENTS)
+string(REGEX MATCH "\n#define RERUN_SDK_HEADER_VERSION \"([0-9]+.[0-9]+.[0-9]+)" _ ${RERUN_H_CONTENTS})
+set(RERUN_INSTALL_VERSION ${CMAKE_MATCH_1})
+message(STATUS "Rerun SDK install version: ${RERUN_INSTALL_VERSION}")
 
 # Package config file, so find_package(rerun_sdk) produces a target.
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
@@ -165,7 +169,7 @@ configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
 # Version file for find_package.
 write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/rerun_sdkConfigVersion.cmake
-    VERSION ${RERUN_VERSION}
+    VERSION ${RERUN_INSTALL_VERSION}
     COMPATIBILITY ExactVersion
 )
 

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -223,7 +223,16 @@ typedef struct rr_error {
 // ----------------------------------------------------------------------------
 // Functions:
 
+/// Returns the version of the Rerun C SDK.
+///
+/// This should match the string returned by `rr_version_string`.
+/// If not, the SDK's binary and the C header are out of sync.
+#define RERUN_SDK_HEADER_VERSION "0.11.0-alpha.1+dev"
+
 /// Returns a human-readable version string of the Rerun C SDK.
+///
+/// This should match the string in `RERUN_SDK_HEADER_VERSION`.
+/// If not, the SDK's binary and the C header are out of sync.
 extern const char* rr_version_string(void);
 
 /// Spawns a new Rerun Viewer process from an executable available in PATH, ready to

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -223,7 +223,7 @@ typedef struct rr_error {
 // ----------------------------------------------------------------------------
 // Functions:
 
-/// The version of the Rerun C SDK header.
+/// Returns the version of the Rerun C SDK.
 ///
 /// This should match the string returned by `rr_version_string`.
 /// If not, the SDK's binary and the C header are out of sync.

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -223,7 +223,7 @@ typedef struct rr_error {
 // ----------------------------------------------------------------------------
 // Functions:
 
-/// Returns the version of the Rerun C SDK.
+/// The version of the Rerun C SDK header.
 ///
 /// This should match the string returned by `rr_version_string`.
 /// If not, the SDK's binary and the C header are out of sync.

--- a/rerun_cpp/src/rerun/config.cpp
+++ b/rerun_cpp/src/rerun/config.cpp
@@ -1,11 +1,5 @@
 #include "config.hpp"
 
-#include <algorithm>
-#include <cstdlib>
-#include <string>
-
-#include "c/rerun.h"
-
 namespace rerun {
 
     RerunGlobalConfig& RerunGlobalConfig::instance() {
@@ -14,27 +8,4 @@ namespace rerun {
     }
 
     RerunGlobalConfig::RerunGlobalConfig() : default_enabled(true) {}
-
-    const char* const sdk_version_string = RERUN_SDK_HEADER_VERSION;
-
-    Error check_binary_and_header_version_match() {
-        const char* binary_version = rr_version_string();
-
-        if (strcmp(binary_version, sdk_version_string) == 0) {
-            return Error();
-        } else {
-            return Error(
-                ErrorCode::SdkVersionMismatch,
-                std::string(
-                    "Rerun_c SDK version and SDK header/source versions don't match. "
-                    "Make sure to link against the correct version of the rerun_c library.\n"
-                    "Rerun_c version:\n"
-                )
-                    .append(binary_version)
-                    .append("\nSDK header/source version:\n")
-                    .append(sdk_version_string)
-            );
-        }
-    }
-
 } // namespace rerun

--- a/rerun_cpp/src/rerun/config.cpp
+++ b/rerun_cpp/src/rerun/config.cpp
@@ -4,6 +4,8 @@
 #include <cstdlib>
 #include <string>
 
+#include "c/rerun.h"
+
 namespace rerun {
 
     RerunGlobalConfig& RerunGlobalConfig::instance() {
@@ -12,5 +14,27 @@ namespace rerun {
     }
 
     RerunGlobalConfig::RerunGlobalConfig() : default_enabled(true) {}
+
+    const char* const sdk_version_string = RERUN_SDK_HEADER_VERSION;
+
+    Error check_binary_and_header_version_match() {
+        const char* binary_version = rr_version_string();
+
+        if (strcmp(binary_version, sdk_version_string) == 0) {
+            return Error();
+        } else {
+            return Error(
+                ErrorCode::SdkVersionMismatch,
+                std::string(
+                    "Rerun_c SDK version and SDK header/source versions don't match match. "
+                    "Make sure to link against the correct version of the rerun_c library.\n"
+                    "Rerun_c version:\n"
+                )
+                    .append(binary_version)
+                    .append("\nSDK header/source version:\n")
+                    .append(sdk_version_string)
+            );
+        }
+    }
 
 } // namespace rerun

--- a/rerun_cpp/src/rerun/config.cpp
+++ b/rerun_cpp/src/rerun/config.cpp
@@ -26,7 +26,7 @@ namespace rerun {
             return Error(
                 ErrorCode::SdkVersionMismatch,
                 std::string(
-                    "Rerun_c SDK version and SDK header/source versions don't match match. "
+                    "Rerun_c SDK version and SDK header/source versions don't match. "
                     "Make sure to link against the correct version of the rerun_c library.\n"
                     "Rerun_c version:\n"
                 )

--- a/rerun_cpp/src/rerun/config.hpp
+++ b/rerun_cpp/src/rerun/config.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <atomic>
 
+#include "error.hpp"
+
 #ifndef RERUN_ENABLED
 #define RERUN_ENABLED 1
 #endif
@@ -49,4 +51,12 @@ namespace rerun {
         // in a more frequently used code-path.
         return RerunGlobalConfig::instance().default_enabled.load(std::memory_order_seq_cst);
     }
+
+    /// Returns a version string for the SDK's version.
+    extern const char* const sdk_version_string;
+
+    /// Checks whether the version reported by the rerun_c binary matches `sdk_version_string`.
+    ///
+    /// This method is called on various C++ API entry points, calling `Error::handle` on the return value.
+    Error check_binary_and_header_version_match();
 } // namespace rerun

--- a/rerun_cpp/src/rerun/config.hpp
+++ b/rerun_cpp/src/rerun/config.hpp
@@ -1,8 +1,6 @@
 #pragma once
 #include <atomic>
 
-#include "error.hpp"
-
 #ifndef RERUN_ENABLED
 #define RERUN_ENABLED 1
 #endif
@@ -51,12 +49,4 @@ namespace rerun {
         // in a more frequently used code-path.
         return RerunGlobalConfig::instance().default_enabled.load(std::memory_order_seq_cst);
     }
-
-    /// Returns a version string for the SDK's version.
-    extern const char* const sdk_version_string;
-
-    /// Checks whether the version reported by the rerun_c binary matches `sdk_version_string`.
-    ///
-    /// This method is called on various C++ API entry points, calling `Error::handle` on the return value.
-    Error check_binary_and_header_version_match();
 } // namespace rerun

--- a/rerun_cpp/src/rerun/error.hpp
+++ b/rerun_cpp/src/rerun/error.hpp
@@ -28,8 +28,9 @@ namespace rerun {
     /// Category codes are used to group errors together, but are never returned directly.
     enum class ErrorCode : uint32_t {
         Ok = 0x0000'0000,
-        OutOfMemory = 0x0000'0001,
-        NotImplemented = 0x0000'0002,
+        OutOfMemory,
+        NotImplemented,
+        SdkVersionMismatch,
 
         // Invalid argument errors.
         _CategoryArgument = 0x0000'0010,

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -30,6 +30,8 @@ namespace rerun {
 
     RecordingStream::RecordingStream(std::string_view app_id, StoreKind store_kind)
         : _store_kind(store_kind) {
+        check_binary_and_header_version_match().handle();
+
         rr_store_info store_info;
         store_info.application_id = detail::to_rr_string(app_id);
         store_info.store_kind = store_kind_to_c(store_kind);
@@ -54,6 +56,8 @@ namespace rerun {
 
     RecordingStream::RecordingStream(uint32_t id, StoreKind store_kind)
         : _id(id), _store_kind(store_kind) {
+        check_binary_and_header_version_match().handle();
+
         rr_error status = {};
         this->_enabled = rr_recording_stream_is_enabled(this->_id, &status);
         Error(status).handle();

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -3,6 +3,7 @@
 #include "components/instance_key.hpp"
 #include "config.hpp"
 #include "data_cell.hpp"
+#include "sdk_info.hpp"
 #include "string_utils.hpp"
 
 #include <arrow/buffer.h>

--- a/rerun_cpp/src/rerun/sdk_info.cpp
+++ b/rerun_cpp/src/rerun/sdk_info.cpp
@@ -15,7 +15,7 @@ namespace rerun {
         const char* binary_version = version_string();
 
         if (strcmp(binary_version, RERUN_SDK_HEADER_VERSION) == 0) {
-            return Error();
+            return Error::ok();
         } else {
             return Error(
                 ErrorCode::SdkVersionMismatch,

--- a/rerun_cpp/src/rerun/sdk_info.cpp
+++ b/rerun_cpp/src/rerun/sdk_info.cpp
@@ -1,8 +1,33 @@
 #include "sdk_info.hpp"
 #include "c/rerun.h"
 
+#include <cstring> // strcmp
+#include <string>
+
+#include "c/rerun.h"
+
 namespace rerun {
     const char* version_string() {
         return rr_version_string();
+    }
+
+    Error check_binary_and_header_version_match() {
+        const char* binary_version = version_string();
+
+        if (strcmp(binary_version, RERUN_SDK_HEADER_VERSION) == 0) {
+            return Error();
+        } else {
+            return Error(
+                ErrorCode::SdkVersionMismatch,
+                std::string(
+                    "Rerun_c SDK version and SDK header/source versions don't match. "
+                    "Make sure to link against the correct version of the rerun_c library.\n"
+                    "Rerun_c version:\n"
+                )
+                    .append(binary_version)
+                    .append("\nSDK header/source version:\n")
+                    .append(RERUN_SDK_HEADER_VERSION)
+            );
+        }
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/sdk_info.cpp
+++ b/rerun_cpp/src/rerun/sdk_info.cpp
@@ -22,10 +22,10 @@ namespace rerun {
                 std::string(
                     "Rerun_c SDK version and SDK header/source versions don't match. "
                     "Make sure to link against the correct version of the rerun_c library.\n"
-                    "Rerun_c version:\n"
+                    "rerun_c binary version:\n"
                 )
                     .append(binary_version)
-                    .append("\nSDK header/source version:\n")
+                    .append("\nrerun_c header version:\n")
                     .append(RERUN_SDK_HEADER_VERSION)
             );
         }

--- a/rerun_cpp/src/rerun/sdk_info.hpp
+++ b/rerun_cpp/src/rerun/sdk_info.hpp
@@ -7,8 +7,10 @@ namespace rerun {
     /// The Rerun C++ SDK version as a human-readable string.
     const char* version_string();
 
-    /// Checks whether the version reported by the rerun_c binary matches `sdk_version_string`.
+    /// Internal check whether the version reported by the rerun_c binary matches `sdk_version_string`.
     ///
     /// This method is called on various C++ API entry points, calling `Error::handle` on the return value.
+    /// There is no need to call this method yourself unless you want to ensure that rerun_c binary and
+    /// rerun_c header versions match ahead of time.
     Error check_binary_and_header_version_match();
 } // namespace rerun

--- a/rerun_cpp/src/rerun/sdk_info.hpp
+++ b/rerun_cpp/src/rerun/sdk_info.hpp
@@ -1,7 +1,14 @@
 // General information about the SDK.
 #pragma once
 
+#include "error.hpp"
+
 namespace rerun {
     /// The Rerun C++ SDK version as a human-readable string.
     const char* version_string();
+
+    /// Checks whether the version reported by the rerun_c binary matches `sdk_version_string`.
+    ///
+    /// This method is called on various C++ API entry points, calling `Error::handle` on the return value.
+    Error check_binary_and_header_version_match();
 } // namespace rerun

--- a/rerun_cpp/src/rerun/spawn.cpp
+++ b/rerun_cpp/src/rerun/spawn.cpp
@@ -1,6 +1,6 @@
 #include "spawn.hpp"
 #include "c/rerun.h"
-#include "config.hpp"
+#include "sdk_info.hpp"
 
 namespace rerun {
     Error spawn(const SpawnOptions& options) {

--- a/rerun_cpp/src/rerun/spawn.cpp
+++ b/rerun_cpp/src/rerun/spawn.cpp
@@ -1,8 +1,11 @@
 #include "spawn.hpp"
 #include "c/rerun.h"
+#include "config.hpp"
 
 namespace rerun {
     Error spawn(const SpawnOptions& options) {
+        RR_RETURN_NOT_OK(check_binary_and_header_version_match());
+
         rr_spawn_options rerun_c_options = {};
         options.fill_rerun_c_struct(rerun_c_options);
         rr_error error = {};


### PR DESCRIPTION
### What

* Fixes #3868
* Fixes left over to set generic package version from #4326  
   * Yes there's two levels of regex'ing existing files now, but I'm happy with it because it avoids etching the version into more places: The repo cmake setup first figures out the rerun version by taking a look at Cargo.toml and puts that into rerun.h which we commit. Then when doing an install (in repo or outside!) we check rerun.h's version and put that into the CMake Install shenanigans


Tests erro'red correctly when I still had a longer string, looked like this:
```
-------------------------------------------------------------------------------
Scenario: RecordingStream can connect
      Given: a new RecordingStream
-------------------------------------------------------------------------------
/Users/andreas/dev/rerun-io/rerun/rerun_cpp/tests/recording_stream.cpp:433
...............................................................................

/Users/andreas/dev/rerun-io/rerun/rerun_cpp/tests/recording_stream.cpp:433: FAILED:
due to unexpected exception with message:
  Rerun_c SDK version and SDK header/source versions don't match match. Make
  sure to link against the correct version of the rerun_c library.
  Rerun_c version:
  re_sdk 0.11.0-alpha.1+dev [rustc 1.72.1 (d5c2e9c34 2023-09-13), LLVM 16.0.5]
  aarch64-apple-darwin
  SDK header/source version:
  0.11.0-alpha.1+dev
```


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4330) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4330)
- [Docs preview](https://rerun.io/preview/72b1b7eedaa4934a8a34d1ab498c9b7752dd8125/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/72b1b7eedaa4934a8a34d1ab498c9b7752dd8125/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)