### PR TITLE
Fix runtime error in `2d` example of `re_render`

### DIFF
--- a/crates/re_renderer/examples/2d.rs
+++ b/crates/re_renderer/examples/2d.rs
@@ -225,7 +225,7 @@ impl framework::Example for Render2D {
                 })
                 .collect_vec();
 
-            let sizes = std::iter::repeat(size).take(num_points as usize).collect_vec();
+            let sizes = vec![size; num_points];
 
             let colors = std::iter::repeat(Color32::WHITE).take(num_points as usize).collect_vec();
 

--- a/crates/re_renderer/examples/2d.rs
+++ b/crates/re_renderer/examples/2d.rs
@@ -227,7 +227,7 @@ impl framework::Example for Render2D {
 
             let sizes = vec![size; num_points];
 
-            let colors = std::iter::repeat(Color32::WHITE).take(num_points as usize).collect_vec();
+            let colors = vec![Color32::WHITE; num_points];
 
             let picking_ids =
                 std::iter::repeat(re_renderer::PickingLayerInstanceId::default()).take(num_points as usize).collect_vec();

--- a/crates/re_renderer/examples/2d.rs
+++ b/crates/re_renderer/examples/2d.rs
@@ -225,12 +225,12 @@ impl framework::Example for Render2D {
                 })
                 .collect_vec();
 
-            let sizes = std::iter::repeat(size).collect_vec();
+            let sizes = std::iter::repeat(size).take(num_points as usize).collect_vec();
 
-            let colors = std::iter::repeat(Color32::WHITE).collect_vec();
+            let colors = std::iter::repeat(Color32::WHITE).take(num_points as usize).collect_vec();
 
             let picking_ids =
-                std::iter::repeat(re_renderer::PickingLayerInstanceId::default()).collect_vec();
+                std::iter::repeat(re_renderer::PickingLayerInstanceId::default()).take(num_points as usize).collect_vec();
 
             point_cloud_builder
                 .batch("points overlapping with lines")

--- a/crates/re_renderer/examples/2d.rs
+++ b/crates/re_renderer/examples/2d.rs
@@ -229,8 +229,7 @@ impl framework::Example for Render2D {
 
             let colors = vec![Color32::WHITE; num_points];
 
-            let picking_ids =
-                vec![re_renderer::PickingLayerInstanceId::default(); num_points];
+            let picking_ids = vec![re_renderer::PickingLayerInstanceId::default(); num_points];
 
             point_cloud_builder
                 .batch("points overlapping with lines")

--- a/crates/re_renderer/examples/2d.rs
+++ b/crates/re_renderer/examples/2d.rs
@@ -230,7 +230,7 @@ impl framework::Example for Render2D {
             let colors = vec![Color32::WHITE; num_points];
 
             let picking_ids =
-                std::iter::repeat(re_renderer::PickingLayerInstanceId::default()).take(num_points as usize).collect_vec();
+                vec![re_renderer::PickingLayerInstanceId::default(); num_points];
 
             point_cloud_builder
                 .batch("points overlapping with lines")


### PR DESCRIPTION
### What

Fixed a problem with the [combination of "std::iter::repeat" and "itertools::Itertools::collect_vec"](https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=370af246d203bd50ecf7746ce0311ac4), Fixed a runtime error in the "2d" example of "re_render".

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4334) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4334)
- [Docs preview](https://rerun.io/preview/3b1e4cb90420f3e3d321be4b3f03c57da7560da4/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3b1e4cb90420f3e3d321be4b3f03c57da7560da4/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)