### PR TITLE
Add C++ doc links on type doc page

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,7 +21,7 @@ for GitHub Actions is highly recommended.
 - [reusable_bench.yml](reusable_bench.yml) - This job runs the benchmarks to check for performance regressions.
   - `SAVE_BENCH` - If true, then the benchmark results are saved to update https://ref.rerun.io/dev/bench/
 - [reusable_deploy_docs](reusable_deploy_docs.yml) - This job deploys the python and rust documentation to https://ref.rerun.io
-  - `PY_DOCS_VERSION_NAME` - The name to use for versioning the python docs. This should generally match the version in
+  - `PY_AND_CPP_DOCS_VERSION_NAME` - The name to use for versioning the python docs. This should generally match the version in
     `Cargo.toml`.
   - `UPDATE_LATEST` - If true, then the docs will be deployed to `latest/` as well as the versioned directory.
 - [reusable_build_and_test_wheels.yml](reusable_build_and_test_wheels.yml) - This job builds the wheels, runs the

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -56,7 +56,7 @@ jobs:
     uses: ./.github/workflows/reusable_deploy_docs.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}
-      PY_DOCS_VERSION_NAME: "nightly"
+      PY_AND_CPP_DOCS_VERSION_NAME: "nightly"
       UPDATE_LATEST: false
     secrets: inherit
 
@@ -393,4 +393,3 @@ jobs:
       CONCURRENCY: push-${{ github.ref_name }}
       RELEASE_VERSION: prerelease
     secrets: inherit
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,8 +201,8 @@ jobs:
     uses: ./.github/workflows/reusable_deploy_docs.yml
     with:
       CONCURRENCY: ${{ github.ref_name }}
-      PY_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && needs.version.outputs.final || 'dev' }}
-      RS_AND_CPP_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && 'stable' || 'dev' }}
+      PY_AND_CPP_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && needs.version.outputs.final || 'dev' }}
+      RS_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && 'stable' || 'dev' }}
       UPDATE_LATEST: ${{ inputs.release-type == 'final' }}
       RELEASE_COMMIT: ${{ needs.version.outputs.release-commit }}
     secrets: inherit
@@ -426,4 +426,3 @@ jobs:
           EOF
 
           gh pr comment $pr_number --body-file comment-body.txt
-

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -6,10 +6,10 @@ on:
       CONCURRENCY:
         required: true
         type: string
-      PY_DOCS_VERSION_NAME:
+      PY_AND_CPP_DOCS_VERSION_NAME:
         required: true
         type: string
-      RS_AND_CPP_DOCS_VERSION_NAME:
+      RS_DOCS_VERSION_NAME:
         required: false
         type: string
         default: "head"
@@ -84,7 +84,7 @@ jobs:
         shell: bash
         run: |
           git fetch
-          mike deploy -F rerun_py/mkdocs.yml --rebase -b gh-pages --prefix docs/python -u ${{inputs.PY_DOCS_VERSION_NAME}} stable
+          mike deploy -F rerun_py/mkdocs.yml --rebase -b gh-pages --prefix docs/python -u ${{inputs.PY_AND_CPP_DOCS_VERSION_NAME}} stable
           git checkout gh-pages
           git checkout --orphan gh-pages-orphan
           git commit -m "Update docs for ${GITHUB_SHA}"
@@ -98,7 +98,7 @@ jobs:
         shell: bash
         run: |
           git fetch
-          mike deploy -F rerun_py/mkdocs.yml --rebase -b gh-pages --prefix docs/python ${{inputs.PY_DOCS_VERSION_NAME}}
+          mike deploy -F rerun_py/mkdocs.yml --rebase -b gh-pages --prefix docs/python ${{inputs.PY_AND_CPP_DOCS_VERSION_NAME}}
           git checkout gh-pages
           git checkout --orphan gh-pages-orphan
           git commit -m "Update docs for ${GITHUB_SHA}"
@@ -174,7 +174,7 @@ jobs:
         shell: bash
         run: |
           git fetch
-          python3 -m ghp_import -n -p -x docs/rust/${{ inputs.RS_AND_CPP_DOCS_VERSION_NAME }} target/doc/ -m "Update the rust docs"
+          python3 -m ghp_import -n -p -x docs/rust/${{ inputs.RS_DOCS_VERSION_NAME }} target/doc/ -m "Update the rust docs"
 
   cpp-deploy-docs:
     name: Cpp
@@ -232,7 +232,7 @@ jobs:
         shell: bash
         run: |
           git fetch
-          python3 -m ghp_import -n -p -x docs/cpp/${{ inputs.RS_AND_CPP_DOCS_VERSION_NAME }} rerun_cpp/docs/html/ -m "Update the C++ docs"
+          python3 -m ghp_import -n -p -x docs/cpp/${{ inputs.PY_AND_CPP_DOCS_VERSION_NAME }} rerun_cpp/docs/html/ -m "Update the C++ docs"
 
   redeploy-rerun-io:
     runs-on: ubuntu-latest
@@ -249,4 +249,3 @@ jobs:
           vercel_team_name: ${{ vars.VERCEL_TEAM_NAME }}
           vercel_project_name: ${{ vars.VERCEL_PROJECT_NAME }}
           release_commit: ${{ inputs.RELEASE_COMMIT }}
-

--- a/BUILD.md
+++ b/BUILD.md
@@ -109,10 +109,9 @@ just cpp-build-all
 
 High-level documentation for rerun can be found at [http://rerun.io/docs](http://rerun.io/docs). It is built from the separate repository [rerun-docs](https://github.com/rerun-io/rerun-docs).
 
-Python API docs can be found at <https://ref.rerun.io/docs/python> and are built via `mkdocs` and hosted on GitHub. For details on the python doc-system, see [Writing Docs](https://github.com/rerun-io/rerun/blob/main/rerun_py/docs/writing_docs.md).
-
-Rust documentation is hosted on <https://docs.rs/rerun/>. You can build them locally with: `cargo doc --all-features --no-deps --open`
-
+- 🌊 [C++ API docs](https://ref.rerun.io/docs/cpp) are built with `doxygen` and hosted on GitHub. Use `pixi run cpp-docs` to build them locally. For details on the C++ doc-system, see [Writing Docs](https://github.com/rerun-io/rerun/blob/main/rerun_cpp/docs/writing_docs.md).
+- 🐍 [Python API docs](https://ref.rerun.io/docs/python) are built via `mkdocs` and hosted on GitHub. For details on the python doc-system, see [Writing Docs](https://github.com/rerun-io/rerun/blob/main/rerun_py/docs/writing_docs.md).
+- 🦀 [Rust API docs](https://docs.rs/rerun/) are hosted on  <https://docs.rs/rerun/>. You can build them locally with: `cargo doc --all-features --no-deps --open`.
 
 ## Building for the Web
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You should now be able to run `rerun --help` in any terminal.
 - 📚 [High-level docs](http://rerun.io/docs)
 - ⏃ [Loggable Types](https://www.rerun.io/docs/reference/types)
 - ⚙️ [Examples](http://rerun.io/examples)
-- 🌊 C++ API docs ([coming soon](https://github.com/rerun-io/rerun/issues/3974))
+- 🌊 [C++ API docs](https://ref.rerun.io/docs/cpp)
 - 🐍 [Python API docs](https://ref.rerun.io/docs/python)
 - 🦀 [Rust API docs](https://docs.rs/rerun/)
 - ⁉️ [Troubleshooting](https://www.rerun.io/docs/getting-started/troubleshooting)

--- a/crates/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/re_types_builder/src/codegen/docs/mod.rs
@@ -163,15 +163,7 @@ fn object_page(reporter: &Reporter, object: &Object, object_map: &ObjectMap) -> 
         };
         putln!(page);
         putln!(page, "## Links");
-        putln!(
-            page,
-            " * 🐍 [Python API docs for `{}`](https://ref.rerun.io/docs/python/stable/common/{}{}#rerun.{}.{})",
-            object.name,
-            object.kind.plural_snake_case(),
-            speculative_marker,
-            object.kind.plural_snake_case(),
-            object.name
-        );
+        // In alphabetical order by language.
         putln!(
             page,
             // `_1` is doxygen's replacement for ':'
@@ -181,6 +173,15 @@ fn object_page(reporter: &Reporter, object: &Object, object_map: &ObjectMap) -> 
             object.kind.plural_snake_case(),
             object.name,
             "?speculative-link", // speculative_marker // TODO(#4267): C++ is not yet released
+        );
+        putln!(
+            page,
+            " * 🐍 [Python API docs for `{}`](https://ref.rerun.io/docs/python/stable/common/{}{}#rerun.{}.{})",
+            object.name,
+            object.kind.plural_snake_case(),
+            speculative_marker,
+            object.kind.plural_snake_case(),
+            object.name
         );
         putln!(
             page,

--- a/crates/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/re_types_builder/src/codegen/docs/mod.rs
@@ -163,7 +163,6 @@ fn object_page(reporter: &Reporter, object: &Object, object_map: &ObjectMap) -> 
         };
         putln!(page);
         putln!(page, "## Links");
-        // TODO(#3974): link to C++ docs
         putln!(
             page,
             " * 🐍 [Python API docs for `{}`](https://ref.rerun.io/docs/python/stable/common/{}{}#rerun.{}.{})",
@@ -172,6 +171,16 @@ fn object_page(reporter: &Reporter, object: &Object, object_map: &ObjectMap) -> 
             speculative_marker,
             object.kind.plural_snake_case(),
             object.name
+        );
+        putln!(
+            page,
+            // `_1` is doxygen's replacement for ':'
+            // https://github.com/doxygen/doxygen/blob/Release_1_9_8/src/util.cpp#L3532
+            " * 🌊 [C++ API docs for `{}`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1{}_1_1{}.html{})",
+            object.name,
+            object.kind.plural_snake_case(),
+            object.name,
+            "?speculative-link", // speculative_marker // TODO(#4267): C++ is not yet released
         );
         putln!(
             page,

--- a/docs/content/reference/types/archetypes/annotation_context.md
+++ b/docs/content/reference/types/archetypes/annotation_context.md
@@ -16,6 +16,7 @@ path.
 
 ## Links
  * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.AnnotationContext)
+ * 🌊 [C++ API docs for `AnnotationContext`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1AnnotationContext.html?speculative-link)
  * 🦀 [Rust API docs for `AnnotationContext`](https://docs.rs/rerun/latest/rerun/archetypes/struct.AnnotationContext.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/annotation_context.md
+++ b/docs/content/reference/types/archetypes/annotation_context.md
@@ -15,8 +15,8 @@ path.
 **Required**: [`AnnotationContext`](../components/annotation_context.md)
 
 ## Links
- * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.AnnotationContext)
  * 🌊 [C++ API docs for `AnnotationContext`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1AnnotationContext.html?speculative-link)
+ * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.AnnotationContext)
  * 🦀 [Rust API docs for `AnnotationContext`](https://docs.rs/rerun/latest/rerun/archetypes/struct.AnnotationContext.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/arrows3d.md
+++ b/docs/content/reference/types/archetypes/arrows3d.md
@@ -13,8 +13,8 @@ title: "Arrows3D"
 **Optional**: [`Radius`](../components/radius.md), [`Color`](../components/color.md), [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `Arrows3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Arrows3D)
  * 🌊 [C++ API docs for `Arrows3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Arrows3D.html?speculative-link)
+ * 🐍 [Python API docs for `Arrows3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Arrows3D)
  * 🦀 [Rust API docs for `Arrows3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Arrows3D.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/arrows3d.md
+++ b/docs/content/reference/types/archetypes/arrows3d.md
@@ -14,6 +14,7 @@ title: "Arrows3D"
 
 ## Links
  * 🐍 [Python API docs for `Arrows3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Arrows3D)
+ * 🌊 [C++ API docs for `Arrows3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Arrows3D.html?speculative-link)
  * 🦀 [Rust API docs for `Arrows3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Arrows3D.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/asset3d.md
+++ b/docs/content/reference/types/archetypes/asset3d.md
@@ -13,8 +13,8 @@ A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
 **Optional**: [`OutOfTreeTransform3D`](../components/out_of_tree_transform3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Asset3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Asset3D)
  * 🌊 [C++ API docs for `Asset3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Asset3D.html?speculative-link)
+ * 🐍 [Python API docs for `Asset3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Asset3D)
  * 🦀 [Rust API docs for `Asset3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Asset3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/asset3d.md
+++ b/docs/content/reference/types/archetypes/asset3d.md
@@ -14,6 +14,7 @@ A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
 
 ## Links
  * 🐍 [Python API docs for `Asset3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Asset3D)
+ * 🌊 [C++ API docs for `Asset3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Asset3D.html?speculative-link)
  * 🦀 [Rust API docs for `Asset3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Asset3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/bar_chart.md
+++ b/docs/content/reference/types/archetypes/bar_chart.md
@@ -12,6 +12,7 @@ The x values will be the indices of the array, and the bar heights will be the p
 
 ## Links
  * 🐍 [Python API docs for `BarChart`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.BarChart)
+ * 🌊 [C++ API docs for `BarChart`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1BarChart.html?speculative-link)
  * 🦀 [Rust API docs for `BarChart`](https://docs.rs/rerun/latest/rerun/archetypes/struct.BarChart.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/bar_chart.md
+++ b/docs/content/reference/types/archetypes/bar_chart.md
@@ -11,8 +11,8 @@ The x values will be the indices of the array, and the bar heights will be the p
 **Required**: [`TensorData`](../components/tensor_data.md)
 
 ## Links
- * 🐍 [Python API docs for `BarChart`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.BarChart)
  * 🌊 [C++ API docs for `BarChart`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1BarChart.html?speculative-link)
+ * 🐍 [Python API docs for `BarChart`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.BarChart)
  * 🦀 [Rust API docs for `BarChart`](https://docs.rs/rerun/latest/rerun/archetypes/struct.BarChart.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/boxes2d.md
+++ b/docs/content/reference/types/archetypes/boxes2d.md
@@ -13,8 +13,8 @@ title: "Boxes2D"
 **Optional**: [`Radius`](../components/radius.md), [`Text`](../components/text.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `Boxes2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Boxes2D)
  * 🌊 [C++ API docs for `Boxes2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Boxes2D.html?speculative-link)
+ * 🐍 [Python API docs for `Boxes2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Boxes2D)
  * 🦀 [Rust API docs for `Boxes2D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Boxes2D.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/boxes2d.md
+++ b/docs/content/reference/types/archetypes/boxes2d.md
@@ -14,6 +14,7 @@ title: "Boxes2D"
 
 ## Links
  * 🐍 [Python API docs for `Boxes2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Boxes2D)
+ * 🌊 [C++ API docs for `Boxes2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Boxes2D.html?speculative-link)
  * 🦀 [Rust API docs for `Boxes2D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Boxes2D.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/boxes3d.md
+++ b/docs/content/reference/types/archetypes/boxes3d.md
@@ -13,8 +13,8 @@ title: "Boxes3D"
 **Optional**: [`Radius`](../components/radius.md), [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `Boxes3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Boxes3D)
  * 🌊 [C++ API docs for `Boxes3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Boxes3D.html?speculative-link)
+ * 🐍 [Python API docs for `Boxes3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Boxes3D)
  * 🦀 [Rust API docs for `Boxes3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Boxes3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/boxes3d.md
+++ b/docs/content/reference/types/archetypes/boxes3d.md
@@ -14,6 +14,7 @@ title: "Boxes3D"
 
 ## Links
  * 🐍 [Python API docs for `Boxes3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Boxes3D)
+ * 🌊 [C++ API docs for `Boxes3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Boxes3D.html?speculative-link)
  * 🦀 [Rust API docs for `Boxes3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Boxes3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/clear.md
+++ b/docs/content/reference/types/archetypes/clear.md
@@ -10,6 +10,7 @@ Empties all the components of an entity.
 
 ## Links
  * 🐍 [Python API docs for `Clear`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Clear)
+ * 🌊 [C++ API docs for `Clear`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Clear.html?speculative-link)
  * 🦀 [Rust API docs for `Clear`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Clear.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/clear.md
+++ b/docs/content/reference/types/archetypes/clear.md
@@ -9,8 +9,8 @@ Empties all the components of an entity.
 **Required**: [`ClearIsRecursive`](../components/clear_is_recursive.md)
 
 ## Links
- * 🐍 [Python API docs for `Clear`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Clear)
  * 🌊 [C++ API docs for `Clear`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Clear.html?speculative-link)
+ * 🐍 [Python API docs for `Clear`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Clear)
  * 🦀 [Rust API docs for `Clear`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Clear.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/depth_image.md
+++ b/docs/content/reference/types/archetypes/depth_image.md
@@ -15,6 +15,7 @@ Each pixel corresponds to a depth value in units specified by `meter`.
 
 ## Links
  * 🐍 [Python API docs for `DepthImage`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.DepthImage)
+ * 🌊 [C++ API docs for `DepthImage`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1DepthImage.html?speculative-link)
  * 🦀 [Rust API docs for `DepthImage`](https://docs.rs/rerun/latest/rerun/archetypes/struct.DepthImage.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/depth_image.md
+++ b/docs/content/reference/types/archetypes/depth_image.md
@@ -14,8 +14,8 @@ Each pixel corresponds to a depth value in units specified by `meter`.
 **Optional**: [`DepthMeter`](../components/depth_meter.md), [`DrawOrder`](../components/draw_order.md)
 
 ## Links
- * 🐍 [Python API docs for `DepthImage`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.DepthImage)
  * 🌊 [C++ API docs for `DepthImage`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1DepthImage.html?speculative-link)
+ * 🐍 [Python API docs for `DepthImage`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.DepthImage)
  * 🦀 [Rust API docs for `DepthImage`](https://docs.rs/rerun/latest/rerun/archetypes/struct.DepthImage.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/disconnected_space.md
+++ b/docs/content/reference/types/archetypes/disconnected_space.md
@@ -15,6 +15,7 @@ will be ignored.
 
 ## Links
  * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.DisconnectedSpace)
+ * 🌊 [C++ API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1DisconnectedSpace.html?speculative-link)
  * 🦀 [Rust API docs for `DisconnectedSpace`](https://docs.rs/rerun/latest/rerun/archetypes/struct.DisconnectedSpace.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/disconnected_space.md
+++ b/docs/content/reference/types/archetypes/disconnected_space.md
@@ -14,8 +14,8 @@ will be ignored.
 **Required**: [`DisconnectedSpace`](../components/disconnected_space.md)
 
 ## Links
- * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.DisconnectedSpace)
  * 🌊 [C++ API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1DisconnectedSpace.html?speculative-link)
+ * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.DisconnectedSpace)
  * 🦀 [Rust API docs for `DisconnectedSpace`](https://docs.rs/rerun/latest/rerun/archetypes/struct.DisconnectedSpace.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/image.md
+++ b/docs/content/reference/types/archetypes/image.md
@@ -19,8 +19,8 @@ Leading and trailing unit-dimensions are ignored, so that
 **Optional**: [`DrawOrder`](../components/draw_order.md)
 
 ## Links
- * 🐍 [Python API docs for `Image`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Image)
  * 🌊 [C++ API docs for `Image`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Image.html?speculative-link)
+ * 🐍 [Python API docs for `Image`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Image)
  * 🦀 [Rust API docs for `Image`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Image.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/image.md
+++ b/docs/content/reference/types/archetypes/image.md
@@ -20,6 +20,7 @@ Leading and trailing unit-dimensions are ignored, so that
 
 ## Links
  * 🐍 [Python API docs for `Image`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Image)
+ * 🌊 [C++ API docs for `Image`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Image.html?speculative-link)
  * 🦀 [Rust API docs for `Image`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Image.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/line_strips2d.md
+++ b/docs/content/reference/types/archetypes/line_strips2d.md
@@ -13,8 +13,8 @@ title: "LineStrips2D"
 **Optional**: [`Text`](../components/text.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `LineStrips2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.LineStrips2D)
  * 🌊 [C++ API docs for `LineStrips2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1LineStrips2D.html?speculative-link)
+ * 🐍 [Python API docs for `LineStrips2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.LineStrips2D)
  * 🦀 [Rust API docs for `LineStrips2D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.LineStrips2D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/line_strips2d.md
+++ b/docs/content/reference/types/archetypes/line_strips2d.md
@@ -14,6 +14,7 @@ title: "LineStrips2D"
 
 ## Links
  * 🐍 [Python API docs for `LineStrips2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.LineStrips2D)
+ * 🌊 [C++ API docs for `LineStrips2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1LineStrips2D.html?speculative-link)
  * 🦀 [Rust API docs for `LineStrips2D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.LineStrips2D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/line_strips3d.md
+++ b/docs/content/reference/types/archetypes/line_strips3d.md
@@ -13,8 +13,8 @@ title: "LineStrips3D"
 **Optional**: [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `LineStrips3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.LineStrips3D)
  * 🌊 [C++ API docs for `LineStrips3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1LineStrips3D.html?speculative-link)
+ * 🐍 [Python API docs for `LineStrips3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.LineStrips3D)
  * 🦀 [Rust API docs for `LineStrips3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.LineStrips3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/line_strips3d.md
+++ b/docs/content/reference/types/archetypes/line_strips3d.md
@@ -14,6 +14,7 @@ title: "LineStrips3D"
 
 ## Links
  * 🐍 [Python API docs for `LineStrips3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.LineStrips3D)
+ * 🌊 [C++ API docs for `LineStrips3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1LineStrips3D.html?speculative-link)
  * 🦀 [Rust API docs for `LineStrips3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.LineStrips3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/mesh3d.md
+++ b/docs/content/reference/types/archetypes/mesh3d.md
@@ -13,8 +13,8 @@ A 3D triangle mesh as specified by its per-mesh and per-vertex properties.
 **Optional**: [`Color`](../components/color.md), [`Material`](../components/material.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `Mesh3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Mesh3D)
  * 🌊 [C++ API docs for `Mesh3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Mesh3D.html?speculative-link)
+ * 🐍 [Python API docs for `Mesh3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Mesh3D)
  * 🦀 [Rust API docs for `Mesh3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Mesh3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/mesh3d.md
+++ b/docs/content/reference/types/archetypes/mesh3d.md
@@ -14,6 +14,7 @@ A 3D triangle mesh as specified by its per-mesh and per-vertex properties.
 
 ## Links
  * 🐍 [Python API docs for `Mesh3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Mesh3D)
+ * 🌊 [C++ API docs for `Mesh3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Mesh3D.html?speculative-link)
  * 🦀 [Rust API docs for `Mesh3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Mesh3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/pinhole.md
+++ b/docs/content/reference/types/archetypes/pinhole.md
@@ -13,8 +13,8 @@ Camera perspective projection (a.k.a. intrinsics).
 **Optional**: [`ViewCoordinates`](../components/view_coordinates.md)
 
 ## Links
- * 🐍 [Python API docs for `Pinhole`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Pinhole)
  * 🌊 [C++ API docs for `Pinhole`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Pinhole.html?speculative-link)
+ * 🐍 [Python API docs for `Pinhole`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Pinhole)
  * 🦀 [Rust API docs for `Pinhole`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Pinhole.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/pinhole.md
+++ b/docs/content/reference/types/archetypes/pinhole.md
@@ -14,6 +14,7 @@ Camera perspective projection (a.k.a. intrinsics).
 
 ## Links
  * 🐍 [Python API docs for `Pinhole`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Pinhole)
+ * 🌊 [C++ API docs for `Pinhole`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Pinhole.html?speculative-link)
  * 🦀 [Rust API docs for `Pinhole`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Pinhole.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/points2d.md
+++ b/docs/content/reference/types/archetypes/points2d.md
@@ -14,6 +14,7 @@ A 2D point cloud with positions and optional colors, radii, labels, etc.
 
 ## Links
  * 🐍 [Python API docs for `Points2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Points2D)
+ * 🌊 [C++ API docs for `Points2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Points2D.html?speculative-link)
  * 🦀 [Rust API docs for `Points2D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Points2D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/points2d.md
+++ b/docs/content/reference/types/archetypes/points2d.md
@@ -13,8 +13,8 @@ A 2D point cloud with positions and optional colors, radii, labels, etc.
 **Optional**: [`Text`](../components/text.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md), [`KeypointId`](../components/keypoint_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `Points2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Points2D)
  * 🌊 [C++ API docs for `Points2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Points2D.html?speculative-link)
+ * 🐍 [Python API docs for `Points2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Points2D)
  * 🦀 [Rust API docs for `Points2D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Points2D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/points3d.md
+++ b/docs/content/reference/types/archetypes/points3d.md
@@ -13,8 +13,8 @@ A 3D point cloud with positions and optional colors, radii, labels, etc.
 **Optional**: [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`KeypointId`](../components/keypoint_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
- * 🐍 [Python API docs for `Points3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Points3D)
  * 🌊 [C++ API docs for `Points3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Points3D.html?speculative-link)
+ * 🐍 [Python API docs for `Points3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Points3D)
  * 🦀 [Rust API docs for `Points3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Points3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/points3d.md
+++ b/docs/content/reference/types/archetypes/points3d.md
@@ -14,6 +14,7 @@ A 3D point cloud with positions and optional colors, radii, labels, etc.
 
 ## Links
  * 🐍 [Python API docs for `Points3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Points3D)
+ * 🌊 [C++ API docs for `Points3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Points3D.html?speculative-link)
  * 🦀 [Rust API docs for `Points3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Points3D.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/segmentation_image.md
+++ b/docs/content/reference/types/archetypes/segmentation_image.md
@@ -18,6 +18,7 @@ Leading and trailing unit-dimensions are ignored, so that
 
 ## Links
  * 🐍 [Python API docs for `SegmentationImage`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.SegmentationImage)
+ * 🌊 [C++ API docs for `SegmentationImage`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1SegmentationImage.html?speculative-link)
  * 🦀 [Rust API docs for `SegmentationImage`](https://docs.rs/rerun/latest/rerun/archetypes/struct.SegmentationImage.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/segmentation_image.md
+++ b/docs/content/reference/types/archetypes/segmentation_image.md
@@ -17,8 +17,8 @@ Leading and trailing unit-dimensions are ignored, so that
 **Optional**: [`DrawOrder`](../components/draw_order.md)
 
 ## Links
- * 🐍 [Python API docs for `SegmentationImage`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.SegmentationImage)
  * 🌊 [C++ API docs for `SegmentationImage`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1SegmentationImage.html?speculative-link)
+ * 🐍 [Python API docs for `SegmentationImage`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.SegmentationImage)
  * 🦀 [Rust API docs for `SegmentationImage`](https://docs.rs/rerun/latest/rerun/archetypes/struct.SegmentationImage.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/tensor.md
+++ b/docs/content/reference/types/archetypes/tensor.md
@@ -10,6 +10,7 @@ A generic n-dimensional Tensor.
 
 ## Links
  * 🐍 [Python API docs for `Tensor`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Tensor)
+ * 🌊 [C++ API docs for `Tensor`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Tensor.html?speculative-link)
  * 🦀 [Rust API docs for `Tensor`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Tensor.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/tensor.md
+++ b/docs/content/reference/types/archetypes/tensor.md
@@ -9,8 +9,8 @@ A generic n-dimensional Tensor.
 **Required**: [`TensorData`](../components/tensor_data.md)
 
 ## Links
- * 🐍 [Python API docs for `Tensor`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Tensor)
  * 🌊 [C++ API docs for `Tensor`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Tensor.html?speculative-link)
+ * 🐍 [Python API docs for `Tensor`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Tensor)
  * 🦀 [Rust API docs for `Tensor`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Tensor.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/text_document.md
+++ b/docs/content/reference/types/archetypes/text_document.md
@@ -14,6 +14,7 @@ Supports raw text and markdown.
 
 ## Links
  * 🐍 [Python API docs for `TextDocument`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.TextDocument)
+ * 🌊 [C++ API docs for `TextDocument`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1TextDocument.html?speculative-link)
  * 🦀 [Rust API docs for `TextDocument`](https://docs.rs/rerun/latest/rerun/archetypes/struct.TextDocument.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/text_document.md
+++ b/docs/content/reference/types/archetypes/text_document.md
@@ -13,8 +13,8 @@ Supports raw text and markdown.
 **Optional**: [`MediaType`](../components/media_type.md)
 
 ## Links
- * 🐍 [Python API docs for `TextDocument`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.TextDocument)
  * 🌊 [C++ API docs for `TextDocument`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1TextDocument.html?speculative-link)
+ * 🐍 [Python API docs for `TextDocument`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.TextDocument)
  * 🦀 [Rust API docs for `TextDocument`](https://docs.rs/rerun/latest/rerun/archetypes/struct.TextDocument.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/text_log.md
+++ b/docs/content/reference/types/archetypes/text_log.md
@@ -11,8 +11,8 @@ A log entry in a text log, comprised of a text body and its log level.
 **Recommended**: [`TextLogLevel`](../components/text_log_level.md)
 
 ## Links
- * 🐍 [Python API docs for `TextLog`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.TextLog)
  * 🌊 [C++ API docs for `TextLog`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1TextLog.html?speculative-link)
+ * 🐍 [Python API docs for `TextLog`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.TextLog)
  * 🦀 [Rust API docs for `TextLog`](https://docs.rs/rerun/latest/rerun/archetypes/struct.TextLog.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/text_log.md
+++ b/docs/content/reference/types/archetypes/text_log.md
@@ -12,6 +12,7 @@ A log entry in a text log, comprised of a text body and its log level.
 
 ## Links
  * 🐍 [Python API docs for `TextLog`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.TextLog)
+ * 🌊 [C++ API docs for `TextLog`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1TextLog.html?speculative-link)
  * 🦀 [Rust API docs for `TextLog`](https://docs.rs/rerun/latest/rerun/archetypes/struct.TextLog.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/time_series_scalar.md
+++ b/docs/content/reference/types/archetypes/time_series_scalar.md
@@ -17,6 +17,7 @@ cannot be timeless!
 
 ## Links
  * 🐍 [Python API docs for `TimeSeriesScalar`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.TimeSeriesScalar)
+ * 🌊 [C++ API docs for `TimeSeriesScalar`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1TimeSeriesScalar.html?speculative-link)
  * 🦀 [Rust API docs for `TimeSeriesScalar`](https://docs.rs/rerun/latest/rerun/archetypes/struct.TimeSeriesScalar.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/time_series_scalar.md
+++ b/docs/content/reference/types/archetypes/time_series_scalar.md
@@ -16,8 +16,8 @@ cannot be timeless!
 **Optional**: [`Text`](../components/text.md), [`ScalarScattering`](../components/scalar_scattering.md)
 
 ## Links
- * 🐍 [Python API docs for `TimeSeriesScalar`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.TimeSeriesScalar)
  * 🌊 [C++ API docs for `TimeSeriesScalar`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1TimeSeriesScalar.html?speculative-link)
+ * 🐍 [Python API docs for `TimeSeriesScalar`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.TimeSeriesScalar)
  * 🦀 [Rust API docs for `TimeSeriesScalar`](https://docs.rs/rerun/latest/rerun/archetypes/struct.TimeSeriesScalar.html)
 
 ## Examples

--- a/docs/content/reference/types/archetypes/transform3d.md
+++ b/docs/content/reference/types/archetypes/transform3d.md
@@ -10,6 +10,7 @@ A 3D transform.
 
 ## Links
  * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Transform3D)
+ * 🌊 [C++ API docs for `Transform3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Transform3D.html?speculative-link)
  * 🦀 [Rust API docs for `Transform3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Transform3D.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/transform3d.md
+++ b/docs/content/reference/types/archetypes/transform3d.md
@@ -9,8 +9,8 @@ A 3D transform.
 **Required**: [`Transform3D`](../components/transform3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Transform3D)
  * 🌊 [C++ API docs for `Transform3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Transform3D.html?speculative-link)
+ * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Transform3D)
  * 🦀 [Rust API docs for `Transform3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Transform3D.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/view_coordinates.md
+++ b/docs/content/reference/types/archetypes/view_coordinates.md
@@ -16,8 +16,8 @@ down, and the Z axis points forward.
 **Required**: [`ViewCoordinates`](../components/view_coordinates.md)
 
 ## Links
- * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.ViewCoordinates)
  * 🌊 [C++ API docs for `ViewCoordinates`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1ViewCoordinates.html?speculative-link)
+ * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.ViewCoordinates)
  * 🦀 [Rust API docs for `ViewCoordinates`](https://docs.rs/rerun/latest/rerun/archetypes/struct.ViewCoordinates.html)
 
 ## Example

--- a/docs/content/reference/types/archetypes/view_coordinates.md
+++ b/docs/content/reference/types/archetypes/view_coordinates.md
@@ -17,6 +17,7 @@ down, and the Z axis points forward.
 
 ## Links
  * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.ViewCoordinates)
+ * 🌊 [C++ API docs for `ViewCoordinates`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1ViewCoordinates.html?speculative-link)
  * 🦀 [Rust API docs for `ViewCoordinates`](https://docs.rs/rerun/latest/rerun/archetypes/struct.ViewCoordinates.html)
 
 ## Example

--- a/docs/content/reference/types/components/annotation_context.md
+++ b/docs/content/reference/types/components/annotation_context.md
@@ -16,6 +16,7 @@ path.
 
 ## Links
  * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.AnnotationContext)
+ * 🌊 [C++ API docs for `AnnotationContext`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1AnnotationContext.html?speculative-link)
  * 🦀 [Rust API docs for `AnnotationContext`](https://docs.rs/rerun/latest/rerun/components/struct.AnnotationContext.html)
 
 

--- a/docs/content/reference/types/components/annotation_context.md
+++ b/docs/content/reference/types/components/annotation_context.md
@@ -15,8 +15,8 @@ path.
 * class_map: [`ClassDescriptionMapElem`](../datatypes/class_description_map_elem.md)
 
 ## Links
- * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.AnnotationContext)
  * 🌊 [C++ API docs for `AnnotationContext`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1AnnotationContext.html?speculative-link)
+ * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.AnnotationContext)
  * 🦀 [Rust API docs for `AnnotationContext`](https://docs.rs/rerun/latest/rerun/components/struct.AnnotationContext.html)
 
 

--- a/docs/content/reference/types/components/blob.md
+++ b/docs/content/reference/types/components/blob.md
@@ -6,8 +6,8 @@ A binary blob of data.
 
 
 ## Links
- * 🐍 [Python API docs for `Blob`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Blob)
  * 🌊 [C++ API docs for `Blob`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Blob.html?speculative-link)
+ * 🐍 [Python API docs for `Blob`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Blob)
  * 🦀 [Rust API docs for `Blob`](https://docs.rs/rerun/latest/rerun/components/struct.Blob.html)
 
 

--- a/docs/content/reference/types/components/blob.md
+++ b/docs/content/reference/types/components/blob.md
@@ -7,6 +7,7 @@ A binary blob of data.
 
 ## Links
  * 🐍 [Python API docs for `Blob`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Blob)
+ * 🌊 [C++ API docs for `Blob`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Blob.html?speculative-link)
  * 🦀 [Rust API docs for `Blob`](https://docs.rs/rerun/latest/rerun/components/struct.Blob.html)
 
 

--- a/docs/content/reference/types/components/class_id.md
+++ b/docs/content/reference/types/components/class_id.md
@@ -10,6 +10,7 @@ A 16-bit ID representing a type of semantic class.
 
 ## Links
  * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ClassId)
+ * 🌊 [C++ API docs for `ClassId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ClassId.html?speculative-link)
  * 🦀 [Rust API docs for `ClassId`](https://docs.rs/rerun/latest/rerun/components/struct.ClassId.html)
 
 

--- a/docs/content/reference/types/components/class_id.md
+++ b/docs/content/reference/types/components/class_id.md
@@ -9,8 +9,8 @@ A 16-bit ID representing a type of semantic class.
 * id: [`ClassId`](../datatypes/class_id.md)
 
 ## Links
- * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ClassId)
  * 🌊 [C++ API docs for `ClassId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ClassId.html?speculative-link)
+ * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ClassId)
  * 🦀 [Rust API docs for `ClassId`](https://docs.rs/rerun/latest/rerun/components/struct.ClassId.html)
 
 

--- a/docs/content/reference/types/components/clear_is_recursive.md
+++ b/docs/content/reference/types/components/clear_is_recursive.md
@@ -6,8 +6,8 @@ Configures how a clear operation should behave - recursive or not.
 
 
 ## Links
- * 🐍 [Python API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ClearIsRecursive)
  * 🌊 [C++ API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ClearIsRecursive.html?speculative-link)
+ * 🐍 [Python API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ClearIsRecursive)
  * 🦀 [Rust API docs for `ClearIsRecursive`](https://docs.rs/rerun/latest/rerun/components/struct.ClearIsRecursive.html)
 
 

--- a/docs/content/reference/types/components/clear_is_recursive.md
+++ b/docs/content/reference/types/components/clear_is_recursive.md
@@ -7,6 +7,7 @@ Configures how a clear operation should behave - recursive or not.
 
 ## Links
  * 🐍 [Python API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ClearIsRecursive)
+ * 🌊 [C++ API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ClearIsRecursive.html?speculative-link)
  * 🦀 [Rust API docs for `ClearIsRecursive`](https://docs.rs/rerun/latest/rerun/components/struct.ClearIsRecursive.html)
 
 

--- a/docs/content/reference/types/components/color.md
+++ b/docs/content/reference/types/components/color.md
@@ -13,6 +13,7 @@ byte is `R` and the least significant byte is `A`.
 
 ## Links
  * 🐍 [Python API docs for `Color`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Color)
+ * 🌊 [C++ API docs for `Color`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Color.html?speculative-link)
  * 🦀 [Rust API docs for `Color`](https://docs.rs/rerun/latest/rerun/components/struct.Color.html)
 
 

--- a/docs/content/reference/types/components/color.md
+++ b/docs/content/reference/types/components/color.md
@@ -12,8 +12,8 @@ byte is `R` and the least significant byte is `A`.
 * rgba: [`Rgba32`](../datatypes/rgba32.md)
 
 ## Links
- * 🐍 [Python API docs for `Color`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Color)
  * 🌊 [C++ API docs for `Color`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Color.html?speculative-link)
+ * 🐍 [Python API docs for `Color`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Color)
  * 🦀 [Rust API docs for `Color`](https://docs.rs/rerun/latest/rerun/components/struct.Color.html)
 
 

--- a/docs/content/reference/types/components/depth_meter.md
+++ b/docs/content/reference/types/components/depth_meter.md
@@ -7,6 +7,7 @@ A component indicating how long a meter is, expressed in native units.
 
 ## Links
  * 🐍 [Python API docs for `DepthMeter`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DepthMeter)
+ * 🌊 [C++ API docs for `DepthMeter`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DepthMeter.html?speculative-link)
  * 🦀 [Rust API docs for `DepthMeter`](https://docs.rs/rerun/latest/rerun/components/struct.DepthMeter.html)
 
 

--- a/docs/content/reference/types/components/depth_meter.md
+++ b/docs/content/reference/types/components/depth_meter.md
@@ -6,8 +6,8 @@ A component indicating how long a meter is, expressed in native units.
 
 
 ## Links
- * 🐍 [Python API docs for `DepthMeter`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DepthMeter)
  * 🌊 [C++ API docs for `DepthMeter`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DepthMeter.html?speculative-link)
+ * 🐍 [Python API docs for `DepthMeter`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DepthMeter)
  * 🦀 [Rust API docs for `DepthMeter`](https://docs.rs/rerun/latest/rerun/components/struct.DepthMeter.html)
 
 

--- a/docs/content/reference/types/components/disconnected_space.md
+++ b/docs/content/reference/types/components/disconnected_space.md
@@ -10,8 +10,8 @@ If a transform or pinhole is logged on the same path, this component will be ign
 
 
 ## Links
- * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DisconnectedSpace)
  * 🌊 [C++ API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DisconnectedSpace.html?speculative-link)
+ * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DisconnectedSpace)
  * 🦀 [Rust API docs for `DisconnectedSpace`](https://docs.rs/rerun/latest/rerun/components/struct.DisconnectedSpace.html)
 
 

--- a/docs/content/reference/types/components/disconnected_space.md
+++ b/docs/content/reference/types/components/disconnected_space.md
@@ -11,6 +11,7 @@ If a transform or pinhole is logged on the same path, this component will be ign
 
 ## Links
  * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DisconnectedSpace)
+ * 🌊 [C++ API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DisconnectedSpace.html?speculative-link)
  * 🦀 [Rust API docs for `DisconnectedSpace`](https://docs.rs/rerun/latest/rerun/components/struct.DisconnectedSpace.html)
 
 

--- a/docs/content/reference/types/components/draw_order.md
+++ b/docs/content/reference/types/components/draw_order.md
@@ -13,6 +13,7 @@ Draw order for entities with the same draw order is generally undefined.
 
 ## Links
  * 🐍 [Python API docs for `DrawOrder`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DrawOrder)
+ * 🌊 [C++ API docs for `DrawOrder`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DrawOrder.html?speculative-link)
  * 🦀 [Rust API docs for `DrawOrder`](https://docs.rs/rerun/latest/rerun/components/struct.DrawOrder.html)
 
 

--- a/docs/content/reference/types/components/draw_order.md
+++ b/docs/content/reference/types/components/draw_order.md
@@ -12,8 +12,8 @@ Draw order for entities with the same draw order is generally undefined.
 
 
 ## Links
- * 🐍 [Python API docs for `DrawOrder`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DrawOrder)
  * 🌊 [C++ API docs for `DrawOrder`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DrawOrder.html?speculative-link)
+ * 🐍 [Python API docs for `DrawOrder`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DrawOrder)
  * 🦀 [Rust API docs for `DrawOrder`](https://docs.rs/rerun/latest/rerun/components/struct.DrawOrder.html)
 
 

--- a/docs/content/reference/types/components/half_sizes2d.md
+++ b/docs/content/reference/types/components/half_sizes2d.md
@@ -13,6 +13,7 @@ Negative sizes indicate that the box is flipped along the respective axis, but t
 
 ## Links
  * 🐍 [Python API docs for `HalfSizes2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.HalfSizes2D)
+ * 🌊 [C++ API docs for `HalfSizes2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1HalfSizes2D.html?speculative-link)
  * 🦀 [Rust API docs for `HalfSizes2D`](https://docs.rs/rerun/latest/rerun/components/struct.HalfSizes2D.html)
 
 

--- a/docs/content/reference/types/components/half_sizes2d.md
+++ b/docs/content/reference/types/components/half_sizes2d.md
@@ -12,8 +12,8 @@ Negative sizes indicate that the box is flipped along the respective axis, but t
 * xy: [`Vec2D`](../datatypes/vec2d.md)
 
 ## Links
- * 🐍 [Python API docs for `HalfSizes2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.HalfSizes2D)
  * 🌊 [C++ API docs for `HalfSizes2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1HalfSizes2D.html?speculative-link)
+ * 🐍 [Python API docs for `HalfSizes2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.HalfSizes2D)
  * 🦀 [Rust API docs for `HalfSizes2D`](https://docs.rs/rerun/latest/rerun/components/struct.HalfSizes2D.html)
 
 

--- a/docs/content/reference/types/components/half_sizes3d.md
+++ b/docs/content/reference/types/components/half_sizes3d.md
@@ -13,6 +13,7 @@ Negative sizes indicate that the box is flipped along the respective axis, but t
 
 ## Links
  * 🐍 [Python API docs for `HalfSizes3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.HalfSizes3D)
+ * 🌊 [C++ API docs for `HalfSizes3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1HalfSizes3D.html?speculative-link)
  * 🦀 [Rust API docs for `HalfSizes3D`](https://docs.rs/rerun/latest/rerun/components/struct.HalfSizes3D.html)
 
 

--- a/docs/content/reference/types/components/half_sizes3d.md
+++ b/docs/content/reference/types/components/half_sizes3d.md
@@ -12,8 +12,8 @@ Negative sizes indicate that the box is flipped along the respective axis, but t
 * xyz: [`Vec3D`](../datatypes/vec3d.md)
 
 ## Links
- * 🐍 [Python API docs for `HalfSizes3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.HalfSizes3D)
  * 🌊 [C++ API docs for `HalfSizes3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1HalfSizes3D.html?speculative-link)
+ * 🐍 [Python API docs for `HalfSizes3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.HalfSizes3D)
  * 🦀 [Rust API docs for `HalfSizes3D`](https://docs.rs/rerun/latest/rerun/components/struct.HalfSizes3D.html)
 
 

--- a/docs/content/reference/types/components/instance_key.md
+++ b/docs/content/reference/types/components/instance_key.md
@@ -6,8 +6,8 @@ A unique numeric identifier for each individual instance within a batch.
 
 
 ## Links
- * 🐍 [Python API docs for `InstanceKey`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.InstanceKey)
  * 🌊 [C++ API docs for `InstanceKey`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1InstanceKey.html?speculative-link)
+ * 🐍 [Python API docs for `InstanceKey`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.InstanceKey)
  * 🦀 [Rust API docs for `InstanceKey`](https://docs.rs/rerun/latest/rerun/components/struct.InstanceKey.html)
 
 

--- a/docs/content/reference/types/components/instance_key.md
+++ b/docs/content/reference/types/components/instance_key.md
@@ -7,6 +7,7 @@ A unique numeric identifier for each individual instance within a batch.
 
 ## Links
  * 🐍 [Python API docs for `InstanceKey`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.InstanceKey)
+ * 🌊 [C++ API docs for `InstanceKey`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1InstanceKey.html?speculative-link)
  * 🦀 [Rust API docs for `InstanceKey`](https://docs.rs/rerun/latest/rerun/components/struct.InstanceKey.html)
 
 

--- a/docs/content/reference/types/components/keypoint_id.md
+++ b/docs/content/reference/types/components/keypoint_id.md
@@ -10,6 +10,7 @@ A 16-bit ID representing a type of semantic keypoint within a class.
 
 ## Links
  * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.KeypointId)
+ * 🌊 [C++ API docs for `KeypointId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1KeypointId.html?speculative-link)
  * 🦀 [Rust API docs for `KeypointId`](https://docs.rs/rerun/latest/rerun/components/struct.KeypointId.html)
 
 

--- a/docs/content/reference/types/components/keypoint_id.md
+++ b/docs/content/reference/types/components/keypoint_id.md
@@ -9,8 +9,8 @@ A 16-bit ID representing a type of semantic keypoint within a class.
 * id: [`KeypointId`](../datatypes/keypoint_id.md)
 
 ## Links
- * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.KeypointId)
  * 🌊 [C++ API docs for `KeypointId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1KeypointId.html?speculative-link)
+ * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.KeypointId)
  * 🦀 [Rust API docs for `KeypointId`](https://docs.rs/rerun/latest/rerun/components/struct.KeypointId.html)
 
 

--- a/docs/content/reference/types/components/line_strip2d.md
+++ b/docs/content/reference/types/components/line_strip2d.md
@@ -20,8 +20,8 @@ The points will be connected in order, like so:
 * points: [`Vec2D`](../datatypes/vec2d.md)
 
 ## Links
- * 🐍 [Python API docs for `LineStrip2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.LineStrip2D)
  * 🌊 [C++ API docs for `LineStrip2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LineStrip2D.html?speculative-link)
+ * 🐍 [Python API docs for `LineStrip2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.LineStrip2D)
  * 🦀 [Rust API docs for `LineStrip2D`](https://docs.rs/rerun/latest/rerun/components/struct.LineStrip2D.html)
 
 

--- a/docs/content/reference/types/components/line_strip2d.md
+++ b/docs/content/reference/types/components/line_strip2d.md
@@ -21,6 +21,7 @@ The points will be connected in order, like so:
 
 ## Links
  * 🐍 [Python API docs for `LineStrip2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.LineStrip2D)
+ * 🌊 [C++ API docs for `LineStrip2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LineStrip2D.html?speculative-link)
  * 🦀 [Rust API docs for `LineStrip2D`](https://docs.rs/rerun/latest/rerun/components/struct.LineStrip2D.html)
 
 

--- a/docs/content/reference/types/components/line_strip3d.md
+++ b/docs/content/reference/types/components/line_strip3d.md
@@ -20,8 +20,8 @@ The points will be connected in order, like so:
 * points: [`Vec3D`](../datatypes/vec3d.md)
 
 ## Links
- * 🐍 [Python API docs for `LineStrip3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.LineStrip3D)
  * 🌊 [C++ API docs for `LineStrip3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LineStrip3D.html?speculative-link)
+ * 🐍 [Python API docs for `LineStrip3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.LineStrip3D)
  * 🦀 [Rust API docs for `LineStrip3D`](https://docs.rs/rerun/latest/rerun/components/struct.LineStrip3D.html)
 
 

--- a/docs/content/reference/types/components/line_strip3d.md
+++ b/docs/content/reference/types/components/line_strip3d.md
@@ -21,6 +21,7 @@ The points will be connected in order, like so:
 
 ## Links
  * 🐍 [Python API docs for `LineStrip3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.LineStrip3D)
+ * 🌊 [C++ API docs for `LineStrip3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LineStrip3D.html?speculative-link)
  * 🦀 [Rust API docs for `LineStrip3D`](https://docs.rs/rerun/latest/rerun/components/struct.LineStrip3D.html)
 
 

--- a/docs/content/reference/types/components/material.md
+++ b/docs/content/reference/types/components/material.md
@@ -10,6 +10,7 @@ Material properties of a mesh.
 
 ## Links
  * 🐍 [Python API docs for `Material`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Material)
+ * 🌊 [C++ API docs for `Material`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Material.html?speculative-link)
  * 🦀 [Rust API docs for `Material`](https://docs.rs/rerun/latest/rerun/components/struct.Material.html)
 
 

--- a/docs/content/reference/types/components/material.md
+++ b/docs/content/reference/types/components/material.md
@@ -9,8 +9,8 @@ Material properties of a mesh.
 * material: [`Material`](../datatypes/material.md)
 
 ## Links
- * 🐍 [Python API docs for `Material`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Material)
  * 🌊 [C++ API docs for `Material`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Material.html?speculative-link)
+ * 🐍 [Python API docs for `Material`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Material)
  * 🦀 [Rust API docs for `Material`](https://docs.rs/rerun/latest/rerun/components/struct.Material.html)
 
 

--- a/docs/content/reference/types/components/media_type.md
+++ b/docs/content/reference/types/components/media_type.md
@@ -12,8 +12,8 @@ consulted at <https://www.iana.org/assignments/media-types/media-types.xhtml>.
 * value: [`Utf8`](../datatypes/utf8.md)
 
 ## Links
- * 🐍 [Python API docs for `MediaType`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MediaType)
  * 🌊 [C++ API docs for `MediaType`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1MediaType.html?speculative-link)
+ * 🐍 [Python API docs for `MediaType`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MediaType)
  * 🦀 [Rust API docs for `MediaType`](https://docs.rs/rerun/latest/rerun/components/struct.MediaType.html)
 
 

--- a/docs/content/reference/types/components/media_type.md
+++ b/docs/content/reference/types/components/media_type.md
@@ -13,6 +13,7 @@ consulted at <https://www.iana.org/assignments/media-types/media-types.xhtml>.
 
 ## Links
  * 🐍 [Python API docs for `MediaType`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MediaType)
+ * 🌊 [C++ API docs for `MediaType`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1MediaType.html?speculative-link)
  * 🦀 [Rust API docs for `MediaType`](https://docs.rs/rerun/latest/rerun/components/struct.MediaType.html)
 
 

--- a/docs/content/reference/types/components/mesh_properties.md
+++ b/docs/content/reference/types/components/mesh_properties.md
@@ -9,8 +9,8 @@ Optional triangle indices for a mesh.
 * props: [`MeshProperties`](../datatypes/mesh_properties.md)
 
 ## Links
- * 🐍 [Python API docs for `MeshProperties`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MeshProperties)
  * 🌊 [C++ API docs for `MeshProperties`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1MeshProperties.html?speculative-link)
+ * 🐍 [Python API docs for `MeshProperties`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MeshProperties)
  * 🦀 [Rust API docs for `MeshProperties`](https://docs.rs/rerun/latest/rerun/components/struct.MeshProperties.html)
 
 

--- a/docs/content/reference/types/components/mesh_properties.md
+++ b/docs/content/reference/types/components/mesh_properties.md
@@ -10,6 +10,7 @@ Optional triangle indices for a mesh.
 
 ## Links
  * 🐍 [Python API docs for `MeshProperties`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MeshProperties)
+ * 🌊 [C++ API docs for `MeshProperties`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1MeshProperties.html?speculative-link)
  * 🦀 [Rust API docs for `MeshProperties`](https://docs.rs/rerun/latest/rerun/components/struct.MeshProperties.html)
 
 

--- a/docs/content/reference/types/components/out_of_tree_transform3d.md
+++ b/docs/content/reference/types/components/out_of_tree_transform3d.md
@@ -11,8 +11,8 @@ An out-of-tree affine transform between two 3D spaces, represented in a given di
 * repr: [`Transform3D`](../datatypes/transform3d.md)
 
 ## Links
- * 🐍 [Python API docs for `OutOfTreeTransform3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.OutOfTreeTransform3D)
  * 🌊 [C++ API docs for `OutOfTreeTransform3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1OutOfTreeTransform3D.html?speculative-link)
+ * 🐍 [Python API docs for `OutOfTreeTransform3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.OutOfTreeTransform3D)
  * 🦀 [Rust API docs for `OutOfTreeTransform3D`](https://docs.rs/rerun/latest/rerun/components/struct.OutOfTreeTransform3D.html)
 
 

--- a/docs/content/reference/types/components/out_of_tree_transform3d.md
+++ b/docs/content/reference/types/components/out_of_tree_transform3d.md
@@ -12,6 +12,7 @@ An out-of-tree affine transform between two 3D spaces, represented in a given di
 
 ## Links
  * 🐍 [Python API docs for `OutOfTreeTransform3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.OutOfTreeTransform3D)
+ * 🌊 [C++ API docs for `OutOfTreeTransform3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1OutOfTreeTransform3D.html?speculative-link)
  * 🦀 [Rust API docs for `OutOfTreeTransform3D`](https://docs.rs/rerun/latest/rerun/components/struct.OutOfTreeTransform3D.html)
 
 

--- a/docs/content/reference/types/components/pinhole_projection.md
+++ b/docs/content/reference/types/components/pinhole_projection.md
@@ -20,6 +20,7 @@ Example:
 
 ## Links
  * 🐍 [Python API docs for `PinholeProjection`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PinholeProjection)
+ * 🌊 [C++ API docs for `PinholeProjection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PinholeProjection.html?speculative-link)
  * 🦀 [Rust API docs for `PinholeProjection`](https://docs.rs/rerun/latest/rerun/components/struct.PinholeProjection.html)
 
 

--- a/docs/content/reference/types/components/pinhole_projection.md
+++ b/docs/content/reference/types/components/pinhole_projection.md
@@ -19,8 +19,8 @@ Example:
 * image_from_camera: [`Mat3x3`](../datatypes/mat3x3.md)
 
 ## Links
- * 🐍 [Python API docs for `PinholeProjection`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PinholeProjection)
  * 🌊 [C++ API docs for `PinholeProjection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PinholeProjection.html?speculative-link)
+ * 🐍 [Python API docs for `PinholeProjection`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PinholeProjection)
  * 🦀 [Rust API docs for `PinholeProjection`](https://docs.rs/rerun/latest/rerun/components/struct.PinholeProjection.html)
 
 

--- a/docs/content/reference/types/components/position2d.md
+++ b/docs/content/reference/types/components/position2d.md
@@ -9,8 +9,8 @@ A position in 2D space.
 * xy: [`Vec2D`](../datatypes/vec2d.md)
 
 ## Links
- * 🐍 [Python API docs for `Position2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Position2D)
  * 🌊 [C++ API docs for `Position2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Position2D.html?speculative-link)
+ * 🐍 [Python API docs for `Position2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Position2D)
  * 🦀 [Rust API docs for `Position2D`](https://docs.rs/rerun/latest/rerun/components/struct.Position2D.html)
 
 

--- a/docs/content/reference/types/components/position2d.md
+++ b/docs/content/reference/types/components/position2d.md
@@ -10,6 +10,7 @@ A position in 2D space.
 
 ## Links
  * 🐍 [Python API docs for `Position2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Position2D)
+ * 🌊 [C++ API docs for `Position2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Position2D.html?speculative-link)
  * 🦀 [Rust API docs for `Position2D`](https://docs.rs/rerun/latest/rerun/components/struct.Position2D.html)
 
 

--- a/docs/content/reference/types/components/position3d.md
+++ b/docs/content/reference/types/components/position3d.md
@@ -10,6 +10,7 @@ A position in 3D space.
 
 ## Links
  * 🐍 [Python API docs for `Position3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Position3D)
+ * 🌊 [C++ API docs for `Position3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Position3D.html?speculative-link)
  * 🦀 [Rust API docs for `Position3D`](https://docs.rs/rerun/latest/rerun/components/struct.Position3D.html)
 
 

--- a/docs/content/reference/types/components/position3d.md
+++ b/docs/content/reference/types/components/position3d.md
@@ -9,8 +9,8 @@ A position in 3D space.
 * xyz: [`Vec3D`](../datatypes/vec3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Position3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Position3D)
  * 🌊 [C++ API docs for `Position3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Position3D.html?speculative-link)
+ * 🐍 [Python API docs for `Position3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Position3D)
  * 🦀 [Rust API docs for `Position3D`](https://docs.rs/rerun/latest/rerun/components/struct.Position3D.html)
 
 

--- a/docs/content/reference/types/components/radius.md
+++ b/docs/content/reference/types/components/radius.md
@@ -7,6 +7,7 @@ A Radius component.
 
 ## Links
  * 🐍 [Python API docs for `Radius`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Radius)
+ * 🌊 [C++ API docs for `Radius`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Radius.html?speculative-link)
  * 🦀 [Rust API docs for `Radius`](https://docs.rs/rerun/latest/rerun/components/struct.Radius.html)
 
 

--- a/docs/content/reference/types/components/radius.md
+++ b/docs/content/reference/types/components/radius.md
@@ -6,8 +6,8 @@ A Radius component.
 
 
 ## Links
- * 🐍 [Python API docs for `Radius`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Radius)
  * 🌊 [C++ API docs for `Radius`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Radius.html?speculative-link)
+ * 🐍 [Python API docs for `Radius`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Radius)
  * 🦀 [Rust API docs for `Radius`](https://docs.rs/rerun/latest/rerun/components/struct.Radius.html)
 
 

--- a/docs/content/reference/types/components/resolution.md
+++ b/docs/content/reference/types/components/resolution.md
@@ -12,6 +12,7 @@ Typically in integer units, but for some use cases floating point may be used.
 
 ## Links
  * 🐍 [Python API docs for `Resolution`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Resolution)
+ * 🌊 [C++ API docs for `Resolution`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Resolution.html?speculative-link)
  * 🦀 [Rust API docs for `Resolution`](https://docs.rs/rerun/latest/rerun/components/struct.Resolution.html)
 
 

--- a/docs/content/reference/types/components/resolution.md
+++ b/docs/content/reference/types/components/resolution.md
@@ -11,8 +11,8 @@ Typically in integer units, but for some use cases floating point may be used.
 * resolution: [`Vec2D`](../datatypes/vec2d.md)
 
 ## Links
- * 🐍 [Python API docs for `Resolution`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Resolution)
  * 🌊 [C++ API docs for `Resolution`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Resolution.html?speculative-link)
+ * 🐍 [Python API docs for `Resolution`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Resolution)
  * 🦀 [Rust API docs for `Resolution`](https://docs.rs/rerun/latest/rerun/components/struct.Resolution.html)
 
 

--- a/docs/content/reference/types/components/rotation3d.md
+++ b/docs/content/reference/types/components/rotation3d.md
@@ -9,8 +9,8 @@ A 3D rotation, represented either by a quaternion or a rotation around axis.
 * repr: [`Rotation3D`](../datatypes/rotation3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Rotation3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Rotation3D)
  * 🌊 [C++ API docs for `Rotation3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Rotation3D.html?speculative-link)
+ * 🐍 [Python API docs for `Rotation3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Rotation3D)
  * 🦀 [Rust API docs for `Rotation3D`](https://docs.rs/rerun/latest/rerun/components/struct.Rotation3D.html)
 
 

--- a/docs/content/reference/types/components/rotation3d.md
+++ b/docs/content/reference/types/components/rotation3d.md
@@ -10,6 +10,7 @@ A 3D rotation, represented either by a quaternion or a rotation around axis.
 
 ## Links
  * 🐍 [Python API docs for `Rotation3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Rotation3D)
+ * 🌊 [C++ API docs for `Rotation3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Rotation3D.html?speculative-link)
  * 🦀 [Rust API docs for `Rotation3D`](https://docs.rs/rerun/latest/rerun/components/struct.Rotation3D.html)
 
 

--- a/docs/content/reference/types/components/scalar.md
+++ b/docs/content/reference/types/components/scalar.md
@@ -9,6 +9,7 @@ Used for time series plots.
 
 ## Links
  * 🐍 [Python API docs for `Scalar`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Scalar)
+ * 🌊 [C++ API docs for `Scalar`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Scalar.html?speculative-link)
  * 🦀 [Rust API docs for `Scalar`](https://docs.rs/rerun/latest/rerun/components/struct.Scalar.html)
 
 

--- a/docs/content/reference/types/components/scalar.md
+++ b/docs/content/reference/types/components/scalar.md
@@ -8,8 +8,8 @@ Used for time series plots.
 
 
 ## Links
- * 🐍 [Python API docs for `Scalar`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Scalar)
  * 🌊 [C++ API docs for `Scalar`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Scalar.html?speculative-link)
+ * 🐍 [Python API docs for `Scalar`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Scalar)
  * 🦀 [Rust API docs for `Scalar`](https://docs.rs/rerun/latest/rerun/components/struct.Scalar.html)
 
 

--- a/docs/content/reference/types/components/scalar_scattering.md
+++ b/docs/content/reference/types/components/scalar_scattering.md
@@ -7,6 +7,7 @@ If true, a scalar will be shown as individual point in a scatter plot.
 
 ## Links
  * 🐍 [Python API docs for `ScalarScattering`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ScalarScattering)
+ * 🌊 [C++ API docs for `ScalarScattering`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ScalarScattering.html?speculative-link)
  * 🦀 [Rust API docs for `ScalarScattering`](https://docs.rs/rerun/latest/rerun/components/struct.ScalarScattering.html)
 
 

--- a/docs/content/reference/types/components/scalar_scattering.md
+++ b/docs/content/reference/types/components/scalar_scattering.md
@@ -6,8 +6,8 @@ If true, a scalar will be shown as individual point in a scatter plot.
 
 
 ## Links
- * 🐍 [Python API docs for `ScalarScattering`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ScalarScattering)
  * 🌊 [C++ API docs for `ScalarScattering`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ScalarScattering.html?speculative-link)
+ * 🐍 [Python API docs for `ScalarScattering`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ScalarScattering)
  * 🦀 [Rust API docs for `ScalarScattering`](https://docs.rs/rerun/latest/rerun/components/struct.ScalarScattering.html)
 
 

--- a/docs/content/reference/types/components/tensor_data.md
+++ b/docs/content/reference/types/components/tensor_data.md
@@ -9,8 +9,8 @@ A multi-dimensional `Tensor` with optionally named arguments.
 * data: [`TensorData`](../datatypes/tensor_data.md)
 
 ## Links
- * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TensorData)
  * 🌊 [C++ API docs for `TensorData`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorData.html?speculative-link)
+ * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TensorData)
  * 🦀 [Rust API docs for `TensorData`](https://docs.rs/rerun/latest/rerun/components/struct.TensorData.html)
 
 

--- a/docs/content/reference/types/components/tensor_data.md
+++ b/docs/content/reference/types/components/tensor_data.md
@@ -10,6 +10,7 @@ A multi-dimensional `Tensor` with optionally named arguments.
 
 ## Links
  * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TensorData)
+ * 🌊 [C++ API docs for `TensorData`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorData.html?speculative-link)
  * 🦀 [Rust API docs for `TensorData`](https://docs.rs/rerun/latest/rerun/components/struct.TensorData.html)
 
 

--- a/docs/content/reference/types/components/text.md
+++ b/docs/content/reference/types/components/text.md
@@ -10,6 +10,7 @@ A string of text, e.g. for labels and text documents.
 
 ## Links
  * 🐍 [Python API docs for `Text`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Text)
+ * 🌊 [C++ API docs for `Text`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Text.html?speculative-link)
  * 🦀 [Rust API docs for `Text`](https://docs.rs/rerun/latest/rerun/components/struct.Text.html)
 
 

--- a/docs/content/reference/types/components/text.md
+++ b/docs/content/reference/types/components/text.md
@@ -9,8 +9,8 @@ A string of text, e.g. for labels and text documents.
 * value: [`Utf8`](../datatypes/utf8.md)
 
 ## Links
- * 🐍 [Python API docs for `Text`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Text)
  * 🌊 [C++ API docs for `Text`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Text.html?speculative-link)
+ * 🐍 [Python API docs for `Text`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Text)
  * 🦀 [Rust API docs for `Text`](https://docs.rs/rerun/latest/rerun/components/struct.Text.html)
 
 

--- a/docs/content/reference/types/components/text_log_level.md
+++ b/docs/content/reference/types/components/text_log_level.md
@@ -17,8 +17,8 @@ Recommended to be one of:
 * value: [`Utf8`](../datatypes/utf8.md)
 
 ## Links
- * 🐍 [Python API docs for `TextLogLevel`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TextLogLevel)
  * 🌊 [C++ API docs for `TextLogLevel`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TextLogLevel.html?speculative-link)
+ * 🐍 [Python API docs for `TextLogLevel`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TextLogLevel)
  * 🦀 [Rust API docs for `TextLogLevel`](https://docs.rs/rerun/latest/rerun/components/struct.TextLogLevel.html)
 
 

--- a/docs/content/reference/types/components/text_log_level.md
+++ b/docs/content/reference/types/components/text_log_level.md
@@ -18,6 +18,7 @@ Recommended to be one of:
 
 ## Links
  * 🐍 [Python API docs for `TextLogLevel`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TextLogLevel)
+ * 🌊 [C++ API docs for `TextLogLevel`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TextLogLevel.html?speculative-link)
  * 🦀 [Rust API docs for `TextLogLevel`](https://docs.rs/rerun/latest/rerun/components/struct.TextLogLevel.html)
 
 

--- a/docs/content/reference/types/components/transform3d.md
+++ b/docs/content/reference/types/components/transform3d.md
@@ -9,8 +9,8 @@ An affine transform between two 3D spaces, represented in a given direction.
 * repr: [`Transform3D`](../datatypes/transform3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Transform3D)
  * 🌊 [C++ API docs for `Transform3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Transform3D.html?speculative-link)
+ * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Transform3D)
  * 🦀 [Rust API docs for `Transform3D`](https://docs.rs/rerun/latest/rerun/components/struct.Transform3D.html)
 
 

--- a/docs/content/reference/types/components/transform3d.md
+++ b/docs/content/reference/types/components/transform3d.md
@@ -10,6 +10,7 @@ An affine transform between two 3D spaces, represented in a given direction.
 
 ## Links
  * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Transform3D)
+ * 🌊 [C++ API docs for `Transform3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Transform3D.html?speculative-link)
  * 🦀 [Rust API docs for `Transform3D`](https://docs.rs/rerun/latest/rerun/components/struct.Transform3D.html)
 
 

--- a/docs/content/reference/types/components/vector3d.md
+++ b/docs/content/reference/types/components/vector3d.md
@@ -10,6 +10,7 @@ A vector in 3D space.
 
 ## Links
  * 🐍 [Python API docs for `Vector3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Vector3D)
+ * 🌊 [C++ API docs for `Vector3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Vector3D.html?speculative-link)
  * 🦀 [Rust API docs for `Vector3D`](https://docs.rs/rerun/latest/rerun/components/struct.Vector3D.html)
 
 

--- a/docs/content/reference/types/components/vector3d.md
+++ b/docs/content/reference/types/components/vector3d.md
@@ -9,8 +9,8 @@ A vector in 3D space.
 * vector: [`Vec3D`](../datatypes/vec3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Vector3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Vector3D)
  * 🌊 [C++ API docs for `Vector3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Vector3D.html?speculative-link)
+ * 🐍 [Python API docs for `Vector3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Vector3D)
  * 🦀 [Rust API docs for `Vector3D`](https://docs.rs/rerun/latest/rerun/components/struct.Vector3D.html)
 
 

--- a/docs/content/reference/types/components/view_coordinates.md
+++ b/docs/content/reference/types/components/view_coordinates.md
@@ -21,8 +21,8 @@ The following constants are used to represent the different directions:
 
 
 ## Links
- * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ViewCoordinates)
  * 🌊 [C++ API docs for `ViewCoordinates`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ViewCoordinates.html?speculative-link)
+ * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ViewCoordinates)
  * 🦀 [Rust API docs for `ViewCoordinates`](https://docs.rs/rerun/latest/rerun/components/struct.ViewCoordinates.html)
 
 

--- a/docs/content/reference/types/components/view_coordinates.md
+++ b/docs/content/reference/types/components/view_coordinates.md
@@ -22,6 +22,7 @@ The following constants are used to represent the different directions:
 
 ## Links
  * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ViewCoordinates)
+ * 🌊 [C++ API docs for `ViewCoordinates`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ViewCoordinates.html?speculative-link)
  * 🦀 [Rust API docs for `ViewCoordinates`](https://docs.rs/rerun/latest/rerun/components/struct.ViewCoordinates.html)
 
 

--- a/docs/content/reference/types/datatypes/angle.md
+++ b/docs/content/reference/types/datatypes/angle.md
@@ -6,8 +6,8 @@ Angle in either radians or degrees.
 
 
 ## Links
- * 🐍 [Python API docs for `Angle`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Angle)
  * 🌊 [C++ API docs for `Angle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Angle.html?speculative-link)
+ * 🐍 [Python API docs for `Angle`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Angle)
  * 🦀 [Rust API docs for `Angle`](https://docs.rs/rerun/latest/rerun/datatypes/enum.Angle.html)
 
 

--- a/docs/content/reference/types/datatypes/angle.md
+++ b/docs/content/reference/types/datatypes/angle.md
@@ -7,6 +7,7 @@ Angle in either radians or degrees.
 
 ## Links
  * 🐍 [Python API docs for `Angle`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Angle)
+ * 🌊 [C++ API docs for `Angle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Angle.html?speculative-link)
  * 🦀 [Rust API docs for `Angle`](https://docs.rs/rerun/latest/rerun/datatypes/enum.Angle.html)
 
 

--- a/docs/content/reference/types/datatypes/annotation_info.md
+++ b/docs/content/reference/types/datatypes/annotation_info.md
@@ -13,8 +13,8 @@ The id refers either to a class or key-point id
 * color: [`Rgba32`](../datatypes/rgba32.md)
 
 ## Links
- * 🐍 [Python API docs for `AnnotationInfo`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.AnnotationInfo)
  * 🌊 [C++ API docs for `AnnotationInfo`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1AnnotationInfo.html?speculative-link)
+ * 🐍 [Python API docs for `AnnotationInfo`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.AnnotationInfo)
  * 🦀 [Rust API docs for `AnnotationInfo`](https://docs.rs/rerun/latest/rerun/datatypes/struct.AnnotationInfo.html)
 
 

--- a/docs/content/reference/types/datatypes/annotation_info.md
+++ b/docs/content/reference/types/datatypes/annotation_info.md
@@ -14,6 +14,7 @@ The id refers either to a class or key-point id
 
 ## Links
  * 🐍 [Python API docs for `AnnotationInfo`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.AnnotationInfo)
+ * 🌊 [C++ API docs for `AnnotationInfo`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1AnnotationInfo.html?speculative-link)
  * 🦀 [Rust API docs for `AnnotationInfo`](https://docs.rs/rerun/latest/rerun/datatypes/struct.AnnotationInfo.html)
 
 

--- a/docs/content/reference/types/datatypes/class_description.md
+++ b/docs/content/reference/types/datatypes/class_description.md
@@ -25,6 +25,7 @@ colored as described by the class's `AnnotationInfo`.
 
 ## Links
  * 🐍 [Python API docs for `ClassDescription`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassDescription)
+ * 🌊 [C++ API docs for `ClassDescription`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassDescription.html?speculative-link)
  * 🦀 [Rust API docs for `ClassDescription`](https://docs.rs/rerun/latest/rerun/datatypes/struct.ClassDescription.html)
 
 

--- a/docs/content/reference/types/datatypes/class_description.md
+++ b/docs/content/reference/types/datatypes/class_description.md
@@ -24,8 +24,8 @@ colored as described by the class's `AnnotationInfo`.
 * keypoint_connections: [`KeypointPair`](../datatypes/keypoint_pair.md)
 
 ## Links
- * 🐍 [Python API docs for `ClassDescription`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassDescription)
  * 🌊 [C++ API docs for `ClassDescription`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassDescription.html?speculative-link)
+ * 🐍 [Python API docs for `ClassDescription`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassDescription)
  * 🦀 [Rust API docs for `ClassDescription`](https://docs.rs/rerun/latest/rerun/datatypes/struct.ClassDescription.html)
 
 

--- a/docs/content/reference/types/datatypes/class_description_map_elem.md
+++ b/docs/content/reference/types/datatypes/class_description_map_elem.md
@@ -12,8 +12,8 @@ This is internal to the `AnnotationContext` structure.
 * class_description: [`ClassDescription`](../datatypes/class_description.md)
 
 ## Links
- * 🐍 [Python API docs for `ClassDescriptionMapElem`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassDescriptionMapElem)
  * 🌊 [C++ API docs for `ClassDescriptionMapElem`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassDescriptionMapElem.html?speculative-link)
+ * 🐍 [Python API docs for `ClassDescriptionMapElem`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassDescriptionMapElem)
  * 🦀 [Rust API docs for `ClassDescriptionMapElem`](https://docs.rs/rerun/latest/rerun/datatypes/struct.ClassDescriptionMapElem.html)
 
 

--- a/docs/content/reference/types/datatypes/class_description_map_elem.md
+++ b/docs/content/reference/types/datatypes/class_description_map_elem.md
@@ -13,6 +13,7 @@ This is internal to the `AnnotationContext` structure.
 
 ## Links
  * 🐍 [Python API docs for `ClassDescriptionMapElem`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassDescriptionMapElem)
+ * 🌊 [C++ API docs for `ClassDescriptionMapElem`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassDescriptionMapElem.html?speculative-link)
  * 🦀 [Rust API docs for `ClassDescriptionMapElem`](https://docs.rs/rerun/latest/rerun/datatypes/struct.ClassDescriptionMapElem.html)
 
 

--- a/docs/content/reference/types/datatypes/class_id.md
+++ b/docs/content/reference/types/datatypes/class_id.md
@@ -7,6 +7,7 @@ A 16-bit ID representing a type of semantic class.
 
 ## Links
  * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassId)
+ * 🌊 [C++ API docs for `ClassId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassId.html?speculative-link)
  * 🦀 [Rust API docs for `ClassId`](https://docs.rs/rerun/latest/rerun/datatypes/struct.ClassId.html)
 
 

--- a/docs/content/reference/types/datatypes/class_id.md
+++ b/docs/content/reference/types/datatypes/class_id.md
@@ -6,8 +6,8 @@ A 16-bit ID representing a type of semantic class.
 
 
 ## Links
- * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassId)
  * 🌊 [C++ API docs for `ClassId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassId.html?speculative-link)
+ * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassId)
  * 🦀 [Rust API docs for `ClassId`](https://docs.rs/rerun/latest/rerun/datatypes/struct.ClassId.html)
 
 

--- a/docs/content/reference/types/datatypes/float32.md
+++ b/docs/content/reference/types/datatypes/float32.md
@@ -6,8 +6,8 @@ A single-precision 32-bit IEEE 754 floating point number.
 
 
 ## Links
- * 🐍 [Python API docs for `Float32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Float32)
  * 🌊 [C++ API docs for `Float32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Float32.html?speculative-link)
+ * 🐍 [Python API docs for `Float32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Float32)
  * 🦀 [Rust API docs for `Float32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Float32.html)
 
 

--- a/docs/content/reference/types/datatypes/float32.md
+++ b/docs/content/reference/types/datatypes/float32.md
@@ -7,6 +7,7 @@ A single-precision 32-bit IEEE 754 floating point number.
 
 ## Links
  * 🐍 [Python API docs for `Float32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Float32)
+ * 🌊 [C++ API docs for `Float32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Float32.html?speculative-link)
  * 🦀 [Rust API docs for `Float32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Float32.html)
 
 

--- a/docs/content/reference/types/datatypes/keypoint_id.md
+++ b/docs/content/reference/types/datatypes/keypoint_id.md
@@ -7,6 +7,7 @@ A 16-bit ID representing a type of semantic keypoint within a class.
 
 ## Links
  * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.KeypointId)
+ * 🌊 [C++ API docs for `KeypointId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1KeypointId.html?speculative-link)
  * 🦀 [Rust API docs for `KeypointId`](https://docs.rs/rerun/latest/rerun/datatypes/struct.KeypointId.html)
 
 

--- a/docs/content/reference/types/datatypes/keypoint_id.md
+++ b/docs/content/reference/types/datatypes/keypoint_id.md
@@ -6,8 +6,8 @@ A 16-bit ID representing a type of semantic keypoint within a class.
 
 
 ## Links
- * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.KeypointId)
  * 🌊 [C++ API docs for `KeypointId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1KeypointId.html?speculative-link)
+ * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.KeypointId)
  * 🦀 [Rust API docs for `KeypointId`](https://docs.rs/rerun/latest/rerun/datatypes/struct.KeypointId.html)
 
 

--- a/docs/content/reference/types/datatypes/keypoint_pair.md
+++ b/docs/content/reference/types/datatypes/keypoint_pair.md
@@ -11,6 +11,7 @@ A connection between two `Keypoints`.
 
 ## Links
  * 🐍 [Python API docs for `KeypointPair`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.KeypointPair)
+ * 🌊 [C++ API docs for `KeypointPair`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1KeypointPair.html?speculative-link)
  * 🦀 [Rust API docs for `KeypointPair`](https://docs.rs/rerun/latest/rerun/datatypes/struct.KeypointPair.html)
 
 

--- a/docs/content/reference/types/datatypes/keypoint_pair.md
+++ b/docs/content/reference/types/datatypes/keypoint_pair.md
@@ -10,8 +10,8 @@ A connection between two `Keypoints`.
 * keypoint1: [`KeypointId`](../datatypes/keypoint_id.md)
 
 ## Links
- * 🐍 [Python API docs for `KeypointPair`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.KeypointPair)
  * 🌊 [C++ API docs for `KeypointPair`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1KeypointPair.html?speculative-link)
+ * 🐍 [Python API docs for `KeypointPair`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.KeypointPair)
  * 🦀 [Rust API docs for `KeypointPair`](https://docs.rs/rerun/latest/rerun/datatypes/struct.KeypointPair.html)
 
 

--- a/docs/content/reference/types/datatypes/mat3x3.md
+++ b/docs/content/reference/types/datatypes/mat3x3.md
@@ -16,6 +16,7 @@ row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
 
 ## Links
  * 🐍 [Python API docs for `Mat3x3`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Mat3x3)
+ * 🌊 [C++ API docs for `Mat3x3`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Mat3x3.html?speculative-link)
  * 🦀 [Rust API docs for `Mat3x3`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Mat3x3.html)
 
 

--- a/docs/content/reference/types/datatypes/mat3x3.md
+++ b/docs/content/reference/types/datatypes/mat3x3.md
@@ -15,8 +15,8 @@ row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
 
 
 ## Links
- * 🐍 [Python API docs for `Mat3x3`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Mat3x3)
  * 🌊 [C++ API docs for `Mat3x3`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Mat3x3.html?speculative-link)
+ * 🐍 [Python API docs for `Mat3x3`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Mat3x3)
  * 🦀 [Rust API docs for `Mat3x3`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Mat3x3.html)
 
 

--- a/docs/content/reference/types/datatypes/mat4x4.md
+++ b/docs/content/reference/types/datatypes/mat4x4.md
@@ -17,6 +17,7 @@ row 3 | flat_columns[3]  flat_columns[7]  flat_columns[11] flat_columns[15]
 
 ## Links
  * 🐍 [Python API docs for `Mat4x4`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Mat4x4)
+ * 🌊 [C++ API docs for `Mat4x4`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Mat4x4.html?speculative-link)
  * 🦀 [Rust API docs for `Mat4x4`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Mat4x4.html)
 
 

--- a/docs/content/reference/types/datatypes/mat4x4.md
+++ b/docs/content/reference/types/datatypes/mat4x4.md
@@ -16,8 +16,8 @@ row 3 | flat_columns[3]  flat_columns[7]  flat_columns[11] flat_columns[15]
 
 
 ## Links
- * 🐍 [Python API docs for `Mat4x4`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Mat4x4)
  * 🌊 [C++ API docs for `Mat4x4`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Mat4x4.html?speculative-link)
+ * 🐍 [Python API docs for `Mat4x4`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Mat4x4)
  * 🦀 [Rust API docs for `Mat4x4`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Mat4x4.html)
 
 

--- a/docs/content/reference/types/datatypes/material.md
+++ b/docs/content/reference/types/datatypes/material.md
@@ -9,8 +9,8 @@ Material properties of a mesh.
 * albedo_factor: [`Rgba32`](../datatypes/rgba32.md)
 
 ## Links
- * 🐍 [Python API docs for `Material`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Material)
  * 🌊 [C++ API docs for `Material`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Material.html?speculative-link)
+ * 🐍 [Python API docs for `Material`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Material)
  * 🦀 [Rust API docs for `Material`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Material.html)
 
 

--- a/docs/content/reference/types/datatypes/material.md
+++ b/docs/content/reference/types/datatypes/material.md
@@ -10,6 +10,7 @@ Material properties of a mesh.
 
 ## Links
  * 🐍 [Python API docs for `Material`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Material)
+ * 🌊 [C++ API docs for `Material`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Material.html?speculative-link)
  * 🦀 [Rust API docs for `Material`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Material.html)
 
 

--- a/docs/content/reference/types/datatypes/mesh_properties.md
+++ b/docs/content/reference/types/datatypes/mesh_properties.md
@@ -6,8 +6,8 @@ Optional triangle indices for a mesh.
 
 
 ## Links
- * 🐍 [Python API docs for `MeshProperties`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.MeshProperties)
  * 🌊 [C++ API docs for `MeshProperties`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1MeshProperties.html?speculative-link)
+ * 🐍 [Python API docs for `MeshProperties`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.MeshProperties)
  * 🦀 [Rust API docs for `MeshProperties`](https://docs.rs/rerun/latest/rerun/datatypes/struct.MeshProperties.html)
 
 

--- a/docs/content/reference/types/datatypes/mesh_properties.md
+++ b/docs/content/reference/types/datatypes/mesh_properties.md
@@ -7,6 +7,7 @@ Optional triangle indices for a mesh.
 
 ## Links
  * 🐍 [Python API docs for `MeshProperties`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.MeshProperties)
+ * 🌊 [C++ API docs for `MeshProperties`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1MeshProperties.html?speculative-link)
  * 🦀 [Rust API docs for `MeshProperties`](https://docs.rs/rerun/latest/rerun/datatypes/struct.MeshProperties.html)
 
 

--- a/docs/content/reference/types/datatypes/quaternion.md
+++ b/docs/content/reference/types/datatypes/quaternion.md
@@ -9,8 +9,8 @@ datastore as provided, when used in the viewer Quaternions will always be normal
 
 
 ## Links
- * 🐍 [Python API docs for `Quaternion`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Quaternion)
  * 🌊 [C++ API docs for `Quaternion`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Quaternion.html?speculative-link)
+ * 🐍 [Python API docs for `Quaternion`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Quaternion)
  * 🦀 [Rust API docs for `Quaternion`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Quaternion.html)
 
 

--- a/docs/content/reference/types/datatypes/quaternion.md
+++ b/docs/content/reference/types/datatypes/quaternion.md
@@ -10,6 +10,7 @@ datastore as provided, when used in the viewer Quaternions will always be normal
 
 ## Links
  * 🐍 [Python API docs for `Quaternion`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Quaternion)
+ * 🌊 [C++ API docs for `Quaternion`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Quaternion.html?speculative-link)
  * 🦀 [Rust API docs for `Quaternion`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Quaternion.html)
 
 

--- a/docs/content/reference/types/datatypes/rgba32.md
+++ b/docs/content/reference/types/datatypes/rgba32.md
@@ -9,8 +9,8 @@ byte is `R` and the least significant byte is `A`.
 
 
 ## Links
- * 🐍 [Python API docs for `Rgba32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Rgba32)
  * 🌊 [C++ API docs for `Rgba32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Rgba32.html?speculative-link)
+ * 🐍 [Python API docs for `Rgba32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Rgba32)
  * 🦀 [Rust API docs for `Rgba32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Rgba32.html)
 
 

--- a/docs/content/reference/types/datatypes/rgba32.md
+++ b/docs/content/reference/types/datatypes/rgba32.md
@@ -10,6 +10,7 @@ byte is `R` and the least significant byte is `A`.
 
 ## Links
  * 🐍 [Python API docs for `Rgba32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Rgba32)
+ * 🌊 [C++ API docs for `Rgba32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Rgba32.html?speculative-link)
  * 🦀 [Rust API docs for `Rgba32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Rgba32.html)
 
 

--- a/docs/content/reference/types/datatypes/rotation3d.md
+++ b/docs/content/reference/types/datatypes/rotation3d.md
@@ -11,6 +11,7 @@ A 3D rotation.
 
 ## Links
  * 🐍 [Python API docs for `Rotation3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Rotation3D)
+ * 🌊 [C++ API docs for `Rotation3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Rotation3D.html?speculative-link)
  * 🦀 [Rust API docs for `Rotation3D`](https://docs.rs/rerun/latest/rerun/datatypes/enum.Rotation3D.html)
 
 

--- a/docs/content/reference/types/datatypes/rotation3d.md
+++ b/docs/content/reference/types/datatypes/rotation3d.md
@@ -10,8 +10,8 @@ A 3D rotation.
 * AxisAngle: [`RotationAxisAngle`](../datatypes/rotation_axis_angle.md)
 
 ## Links
- * 🐍 [Python API docs for `Rotation3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Rotation3D)
  * 🌊 [C++ API docs for `Rotation3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Rotation3D.html?speculative-link)
+ * 🐍 [Python API docs for `Rotation3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Rotation3D)
  * 🦀 [Rust API docs for `Rotation3D`](https://docs.rs/rerun/latest/rerun/datatypes/enum.Rotation3D.html)
 
 

--- a/docs/content/reference/types/datatypes/rotation_axis_angle.md
+++ b/docs/content/reference/types/datatypes/rotation_axis_angle.md
@@ -11,6 +11,7 @@ title: "RotationAxisAngle"
 
 ## Links
  * 🐍 [Python API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.RotationAxisAngle)
+ * 🌊 [C++ API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1RotationAxisAngle.html?speculative-link)
  * 🦀 [Rust API docs for `RotationAxisAngle`](https://docs.rs/rerun/latest/rerun/datatypes/struct.RotationAxisAngle.html)
 
 

--- a/docs/content/reference/types/datatypes/rotation_axis_angle.md
+++ b/docs/content/reference/types/datatypes/rotation_axis_angle.md
@@ -10,8 +10,8 @@ title: "RotationAxisAngle"
 * angle: [`Angle`](../datatypes/angle.md)
 
 ## Links
- * 🐍 [Python API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.RotationAxisAngle)
  * 🌊 [C++ API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1RotationAxisAngle.html?speculative-link)
+ * 🐍 [Python API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.RotationAxisAngle)
  * 🦀 [Rust API docs for `RotationAxisAngle`](https://docs.rs/rerun/latest/rerun/datatypes/struct.RotationAxisAngle.html)
 
 

--- a/docs/content/reference/types/datatypes/scale3d.md
+++ b/docs/content/reference/types/datatypes/scale3d.md
@@ -10,6 +10,7 @@ title: "Scale3D"
 
 ## Links
  * 🐍 [Python API docs for `Scale3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Scale3D)
+ * 🌊 [C++ API docs for `Scale3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Scale3D.html?speculative-link)
  * 🦀 [Rust API docs for `Scale3D`](https://docs.rs/rerun/latest/rerun/datatypes/enum.Scale3D.html)
 
 

--- a/docs/content/reference/types/datatypes/scale3d.md
+++ b/docs/content/reference/types/datatypes/scale3d.md
@@ -9,8 +9,8 @@ title: "Scale3D"
 * ThreeD: [`Vec3D`](../datatypes/vec3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Scale3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Scale3D)
  * 🌊 [C++ API docs for `Scale3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Scale3D.html?speculative-link)
+ * 🐍 [Python API docs for `Scale3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Scale3D)
  * 🦀 [Rust API docs for `Scale3D`](https://docs.rs/rerun/latest/rerun/datatypes/enum.Scale3D.html)
 
 

--- a/docs/content/reference/types/datatypes/tensor_buffer.md
+++ b/docs/content/reference/types/datatypes/tensor_buffer.md
@@ -9,6 +9,7 @@ Tensor elements are stored in a contiguous buffer of a single type.
 
 ## Links
  * 🐍 [Python API docs for `TensorBuffer`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorBuffer)
+ * 🌊 [C++ API docs for `TensorBuffer`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorBuffer.html?speculative-link)
  * 🦀 [Rust API docs for `TensorBuffer`](https://docs.rs/rerun/latest/rerun/datatypes/enum.TensorBuffer.html)
 
 

--- a/docs/content/reference/types/datatypes/tensor_buffer.md
+++ b/docs/content/reference/types/datatypes/tensor_buffer.md
@@ -8,8 +8,8 @@ Tensor elements are stored in a contiguous buffer of a single type.
 
 
 ## Links
- * 🐍 [Python API docs for `TensorBuffer`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorBuffer)
  * 🌊 [C++ API docs for `TensorBuffer`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorBuffer.html?speculative-link)
+ * 🐍 [Python API docs for `TensorBuffer`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorBuffer)
  * 🦀 [Rust API docs for `TensorBuffer`](https://docs.rs/rerun/latest/rerun/datatypes/enum.TensorBuffer.html)
 
 

--- a/docs/content/reference/types/datatypes/tensor_data.md
+++ b/docs/content/reference/types/datatypes/tensor_data.md
@@ -17,8 +17,8 @@ which stores a contiguous array of typed values.
 * buffer: [`TensorBuffer`](../datatypes/tensor_buffer.md)
 
 ## Links
- * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorData)
  * 🌊 [C++ API docs for `TensorData`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorData.html?speculative-link)
+ * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorData)
  * 🦀 [Rust API docs for `TensorData`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TensorData.html)
 
 

--- a/docs/content/reference/types/datatypes/tensor_data.md
+++ b/docs/content/reference/types/datatypes/tensor_data.md
@@ -18,6 +18,7 @@ which stores a contiguous array of typed values.
 
 ## Links
  * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorData)
+ * 🌊 [C++ API docs for `TensorData`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorData.html?speculative-link)
  * 🦀 [Rust API docs for `TensorData`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TensorData.html)
 
 

--- a/docs/content/reference/types/datatypes/tensor_dimension.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension.md
@@ -7,6 +7,7 @@ A single dimension within a multi-dimensional tensor.
 
 ## Links
  * 🐍 [Python API docs for `TensorDimension`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorDimension)
+ * 🌊 [C++ API docs for `TensorDimension`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorDimension.html?speculative-link)
  * 🦀 [Rust API docs for `TensorDimension`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TensorDimension.html)
 
 

--- a/docs/content/reference/types/datatypes/tensor_dimension.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension.md
@@ -6,8 +6,8 @@ A single dimension within a multi-dimensional tensor.
 
 
 ## Links
- * 🐍 [Python API docs for `TensorDimension`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorDimension)
  * 🌊 [C++ API docs for `TensorDimension`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorDimension.html?speculative-link)
+ * 🐍 [Python API docs for `TensorDimension`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorDimension)
  * 🦀 [Rust API docs for `TensorDimension`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TensorDimension.html)
 
 

--- a/docs/content/reference/types/datatypes/transform3d.md
+++ b/docs/content/reference/types/datatypes/transform3d.md
@@ -11,6 +11,7 @@ Representation of a 3D affine transform.
 
 ## Links
  * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Transform3D)
+ * 🌊 [C++ API docs for `Transform3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Transform3D.html?speculative-link)
  * 🦀 [Rust API docs for `Transform3D`](https://docs.rs/rerun/latest/rerun/datatypes/enum.Transform3D.html)
 
 

--- a/docs/content/reference/types/datatypes/transform3d.md
+++ b/docs/content/reference/types/datatypes/transform3d.md
@@ -10,8 +10,8 @@ Representation of a 3D affine transform.
 * TranslationRotationScale: [`TranslationRotationScale3D`](../datatypes/translation_rotation_scale3d.md)
 
 ## Links
- * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Transform3D)
  * 🌊 [C++ API docs for `Transform3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Transform3D.html?speculative-link)
+ * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Transform3D)
  * 🦀 [Rust API docs for `Transform3D`](https://docs.rs/rerun/latest/rerun/datatypes/enum.Transform3D.html)
 
 

--- a/docs/content/reference/types/datatypes/translation_and_mat3x3.md
+++ b/docs/content/reference/types/datatypes/translation_and_mat3x3.md
@@ -12,8 +12,8 @@ First applies the matrix, then the translation.
 * mat3x3: [`Mat3x3`](../datatypes/mat3x3.md)
 
 ## Links
- * 🐍 [Python API docs for `TranslationAndMat3x3`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TranslationAndMat3x3)
  * 🌊 [C++ API docs for `TranslationAndMat3x3`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TranslationAndMat3x3.html?speculative-link)
+ * 🐍 [Python API docs for `TranslationAndMat3x3`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TranslationAndMat3x3)
  * 🦀 [Rust API docs for `TranslationAndMat3x3`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TranslationAndMat3x3.html)
 
 

--- a/docs/content/reference/types/datatypes/translation_and_mat3x3.md
+++ b/docs/content/reference/types/datatypes/translation_and_mat3x3.md
@@ -13,6 +13,7 @@ First applies the matrix, then the translation.
 
 ## Links
  * 🐍 [Python API docs for `TranslationAndMat3x3`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TranslationAndMat3x3)
+ * 🌊 [C++ API docs for `TranslationAndMat3x3`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TranslationAndMat3x3.html?speculative-link)
  * 🦀 [Rust API docs for `TranslationAndMat3x3`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TranslationAndMat3x3.html)
 
 

--- a/docs/content/reference/types/datatypes/translation_rotation_scale3d.md
+++ b/docs/content/reference/types/datatypes/translation_rotation_scale3d.md
@@ -11,8 +11,8 @@ Representation of an affine transform via separate translation, rotation & scale
 * scale: [`Scale3D`](../datatypes/scale3d.md)
 
 ## Links
- * 🐍 [Python API docs for `TranslationRotationScale3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TranslationRotationScale3D)
  * 🌊 [C++ API docs for `TranslationRotationScale3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TranslationRotationScale3D.html?speculative-link)
+ * 🐍 [Python API docs for `TranslationRotationScale3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TranslationRotationScale3D)
  * 🦀 [Rust API docs for `TranslationRotationScale3D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TranslationRotationScale3D.html)
 
 

--- a/docs/content/reference/types/datatypes/translation_rotation_scale3d.md
+++ b/docs/content/reference/types/datatypes/translation_rotation_scale3d.md
@@ -12,6 +12,7 @@ Representation of an affine transform via separate translation, rotation & scale
 
 ## Links
  * 🐍 [Python API docs for `TranslationRotationScale3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TranslationRotationScale3D)
+ * 🌊 [C++ API docs for `TranslationRotationScale3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TranslationRotationScale3D.html?speculative-link)
  * 🦀 [Rust API docs for `TranslationRotationScale3D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TranslationRotationScale3D.html)
 
 

--- a/docs/content/reference/types/datatypes/uint32.md
+++ b/docs/content/reference/types/datatypes/uint32.md
@@ -6,8 +6,8 @@ A 32bit unsigned integer.
 
 
 ## Links
- * 🐍 [Python API docs for `UInt32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UInt32)
  * 🌊 [C++ API docs for `UInt32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UInt32.html?speculative-link)
+ * 🐍 [Python API docs for `UInt32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UInt32)
  * 🦀 [Rust API docs for `UInt32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt32.html)
 
 

--- a/docs/content/reference/types/datatypes/uint32.md
+++ b/docs/content/reference/types/datatypes/uint32.md
@@ -7,6 +7,7 @@ A 32bit unsigned integer.
 
 ## Links
  * 🐍 [Python API docs for `UInt32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UInt32)
+ * 🌊 [C++ API docs for `UInt32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UInt32.html?speculative-link)
  * 🦀 [Rust API docs for `UInt32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt32.html)
 
 

--- a/docs/content/reference/types/datatypes/utf8.md
+++ b/docs/content/reference/types/datatypes/utf8.md
@@ -7,6 +7,7 @@ A string of text, encoded as UTF-8.
 
 ## Links
  * 🐍 [Python API docs for `Utf8`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Utf8)
+ * 🌊 [C++ API docs for `Utf8`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Utf8.html?speculative-link)
  * 🦀 [Rust API docs for `Utf8`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Utf8.html)
 
 

--- a/docs/content/reference/types/datatypes/utf8.md
+++ b/docs/content/reference/types/datatypes/utf8.md
@@ -6,8 +6,8 @@ A string of text, encoded as UTF-8.
 
 
 ## Links
- * 🐍 [Python API docs for `Utf8`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Utf8)
  * 🌊 [C++ API docs for `Utf8`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Utf8.html?speculative-link)
+ * 🐍 [Python API docs for `Utf8`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Utf8)
  * 🦀 [Rust API docs for `Utf8`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Utf8.html)
 
 

--- a/docs/content/reference/types/datatypes/uvec2d.md
+++ b/docs/content/reference/types/datatypes/uvec2d.md
@@ -7,6 +7,7 @@ A uint32 vector in 2D space.
 
 ## Links
  * 🐍 [Python API docs for `UVec2D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec2D)
+ * 🌊 [C++ API docs for `UVec2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec2D.html?speculative-link)
  * 🦀 [Rust API docs for `UVec2D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UVec2D.html)
 
 

--- a/docs/content/reference/types/datatypes/uvec2d.md
+++ b/docs/content/reference/types/datatypes/uvec2d.md
@@ -6,8 +6,8 @@ A uint32 vector in 2D space.
 
 
 ## Links
- * 🐍 [Python API docs for `UVec2D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec2D)
  * 🌊 [C++ API docs for `UVec2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec2D.html?speculative-link)
+ * 🐍 [Python API docs for `UVec2D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec2D)
  * 🦀 [Rust API docs for `UVec2D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UVec2D.html)
 
 

--- a/docs/content/reference/types/datatypes/uvec3d.md
+++ b/docs/content/reference/types/datatypes/uvec3d.md
@@ -7,6 +7,7 @@ A uint32 vector in 3D space.
 
 ## Links
  * 🐍 [Python API docs for `UVec3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec3D)
+ * 🌊 [C++ API docs for `UVec3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec3D.html?speculative-link)
  * 🦀 [Rust API docs for `UVec3D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UVec3D.html)
 
 

--- a/docs/content/reference/types/datatypes/uvec3d.md
+++ b/docs/content/reference/types/datatypes/uvec3d.md
@@ -6,8 +6,8 @@ A uint32 vector in 3D space.
 
 
 ## Links
- * 🐍 [Python API docs for `UVec3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec3D)
  * 🌊 [C++ API docs for `UVec3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec3D.html?speculative-link)
+ * 🐍 [Python API docs for `UVec3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec3D)
  * 🦀 [Rust API docs for `UVec3D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UVec3D.html)
 
 

--- a/docs/content/reference/types/datatypes/uvec4d.md
+++ b/docs/content/reference/types/datatypes/uvec4d.md
@@ -6,8 +6,8 @@ A uint vector in 4D space.
 
 
 ## Links
- * 🐍 [Python API docs for `UVec4D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec4D)
  * 🌊 [C++ API docs for `UVec4D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec4D.html?speculative-link)
+ * 🐍 [Python API docs for `UVec4D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec4D)
  * 🦀 [Rust API docs for `UVec4D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UVec4D.html)
 
 

--- a/docs/content/reference/types/datatypes/uvec4d.md
+++ b/docs/content/reference/types/datatypes/uvec4d.md
@@ -7,6 +7,7 @@ A uint vector in 4D space.
 
 ## Links
  * 🐍 [Python API docs for `UVec4D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec4D)
+ * 🌊 [C++ API docs for `UVec4D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec4D.html?speculative-link)
  * 🦀 [Rust API docs for `UVec4D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UVec4D.html)
 
 

--- a/docs/content/reference/types/datatypes/vec2d.md
+++ b/docs/content/reference/types/datatypes/vec2d.md
@@ -6,8 +6,8 @@ A vector in 2D space.
 
 
 ## Links
- * 🐍 [Python API docs for `Vec2D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec2D)
  * 🌊 [C++ API docs for `Vec2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec2D.html?speculative-link)
+ * 🐍 [Python API docs for `Vec2D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec2D)
  * 🦀 [Rust API docs for `Vec2D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Vec2D.html)
 
 

--- a/docs/content/reference/types/datatypes/vec2d.md
+++ b/docs/content/reference/types/datatypes/vec2d.md
@@ -7,6 +7,7 @@ A vector in 2D space.
 
 ## Links
  * 🐍 [Python API docs for `Vec2D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec2D)
+ * 🌊 [C++ API docs for `Vec2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec2D.html?speculative-link)
  * 🦀 [Rust API docs for `Vec2D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Vec2D.html)
 
 

--- a/docs/content/reference/types/datatypes/vec3d.md
+++ b/docs/content/reference/types/datatypes/vec3d.md
@@ -6,8 +6,8 @@ A vector in 3D space.
 
 
 ## Links
- * 🐍 [Python API docs for `Vec3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec3D)
  * 🌊 [C++ API docs for `Vec3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec3D.html?speculative-link)
+ * 🐍 [Python API docs for `Vec3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec3D)
  * 🦀 [Rust API docs for `Vec3D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Vec3D.html)
 
 

--- a/docs/content/reference/types/datatypes/vec3d.md
+++ b/docs/content/reference/types/datatypes/vec3d.md
@@ -7,6 +7,7 @@ A vector in 3D space.
 
 ## Links
  * 🐍 [Python API docs for `Vec3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec3D)
+ * 🌊 [C++ API docs for `Vec3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec3D.html?speculative-link)
  * 🦀 [Rust API docs for `Vec3D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Vec3D.html)
 
 

--- a/docs/content/reference/types/datatypes/vec4d.md
+++ b/docs/content/reference/types/datatypes/vec4d.md
@@ -7,6 +7,7 @@ A vector in 4D space.
 
 ## Links
  * 🐍 [Python API docs for `Vec4D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec4D)
+ * 🌊 [C++ API docs for `Vec4D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec4D.html?speculative-link)
  * 🦀 [Rust API docs for `Vec4D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Vec4D.html)
 
 

--- a/docs/content/reference/types/datatypes/vec4d.md
+++ b/docs/content/reference/types/datatypes/vec4d.md
@@ -6,8 +6,8 @@ A vector in 4D space.
 
 
 ## Links
- * 🐍 [Python API docs for `Vec4D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec4D)
  * 🌊 [C++ API docs for `Vec4D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec4D.html?speculative-link)
+ * 🐍 [Python API docs for `Vec4D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec4D)
  * 🦀 [Rust API docs for `Vec4D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Vec4D.html)
 
 


### PR DESCRIPTION
### What

* Fixes https://github.com/rerun-io/rerun/issues/4332

Also, now using the python versioning scheme instead of the rust versioning scheme for docs on gh-pages branch.

The Python one seems to keep versions nicely which we leave to docs.rs on Rust
* Python: https://github.com/rerun-io/rerun/tree/gh-pages/docs/python
* Rust: https://github.com/rerun-io/rerun/tree/gh-pages/docs/rust


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4339) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4339)
- [Docs preview](https://rerun.io/preview/57a74625dc5b5015748c224da6b382923361ec71/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/57a74625dc5b5015748c224da6b382923361ec71/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)