### PR TITLE
Move side-panels margins inside of their `ScrollArea`s

### DIFF
--- a/crates/re_viewer/src/ui/blueprint_panel.rs
+++ b/crates/re_viewer/src/ui/blueprint_panel.rs
@@ -18,9 +18,11 @@ pub fn blueprint_panel_ui(
                 reset_button_ui(blueprint, ctx, ui, spaces_info);
             },
         );
-
-        blueprint.tree_ui(ctx, ui);
     });
+
+    // This call is excluded from `panel_content` because it has a ScrollArea, which should not be
+    // inset. Instead, it calls panel_content itself inside the ScrollArea.
+    blueprint.tree_ui(ctx, ui);
 }
 
 fn reset_button_ui(

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -57,31 +57,28 @@ impl SelectionPanel {
             // enclosing frame doesn't have inner margins.
             ui.set_clip_rect(ui.max_rect());
 
-            egui::Frame {
-                inner_margin: re_ui::ReUi::panel_margin(),
-                ..Default::default()
-            }
-            .show(ui, |ui| {
-                let hover = "The Selection View contains information and options about the currently selected object(s)";
-                ctx.re_ui
-                    .panel_title_bar_with_buttons(ui, "Selection", Some(hover), |ui| {
-                        if let Some(selection) = self.selection_state_ui.selection_ui(
-                            ctx.re_ui,
-                            ui,
-                            &viewport.blueprint,
-                            &mut ctx.selection_state_mut().history,
-                        ) {
-                            ctx.selection_state_mut()
-                                .set_selection(selection.iter().cloned());
-                        }
-                    });
+            let hover = "The Selection View contains information and options about the \
+                    currently selected object(s)";
+            ctx.re_ui
+                .panel_title_bar_with_buttons(ui, "Selection", Some(hover), |ui| {
+                    if let Some(selection) = self.selection_state_ui.selection_ui(
+                        ctx.re_ui,
+                        ui,
+                        &viewport.blueprint,
+                        &mut ctx.selection_state_mut().history,
+                    ) {
+                        ctx.selection_state_mut()
+                            .set_selection(selection.iter().cloned());
+                    }
+                });
 
-                egui::ScrollArea::both()
-                    .auto_shrink([false; 2])
-                    .show(ui, |ui| {
+            egui::ScrollArea::both()
+                .auto_shrink([false; 2])
+                .show(ui, |ui| {
+                    ctx.re_ui.panel_content(ui, |_, ui| {
                         self.contents(ctx, ui, viewport);
                     });
-            });
+                });
         });
     }
 

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -57,24 +57,31 @@ impl SelectionPanel {
             // enclosing frame doesn't have inner margins.
             ui.set_clip_rect(ui.max_rect());
 
-            let hover = "The Selection View contains information and options about the \
+            ctx.re_ui.panel_content(ui, |_, ui| {
+                let hover = "The Selection View contains information and options about the \
                     currently selected object(s)";
-            ctx.re_ui
-                .panel_title_bar_with_buttons(ui, "Selection", Some(hover), |ui| {
-                    if let Some(selection) = self.selection_state_ui.selection_ui(
-                        ctx.re_ui,
-                        ui,
-                        &viewport.blueprint,
-                        &mut ctx.selection_state_mut().history,
-                    ) {
-                        ctx.selection_state_mut()
-                            .set_selection(selection.iter().cloned());
-                    }
-                });
+                ctx.re_ui
+                    .panel_title_bar_with_buttons(ui, "Selection", Some(hover), |ui| {
+                        if let Some(selection) = self.selection_state_ui.selection_ui(
+                            ctx.re_ui,
+                            ui,
+                            &viewport.blueprint,
+                            &mut ctx.selection_state_mut().history,
+                        ) {
+                            ctx.selection_state_mut()
+                                .set_selection(selection.iter().cloned());
+                        }
+                    });
+            });
+
+            // move the vertical spacing between the title and the content to _inside_ the scroll
+            // area
+            ui.add_space(-ui.spacing().item_spacing.y);
 
             egui::ScrollArea::both()
                 .auto_shrink([false; 2])
                 .show(ui, |ui| {
+                    ui.add_space(ui.spacing().item_spacing.y);
                     ctx.re_ui.panel_content(ui, |_, ui| {
                         self.contents(ctx, ui, viewport);
                     });

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -22,9 +22,11 @@ impl ViewportBlueprint<'_> {
             .id_source("blueprint_tree_scroll_area")
             .auto_shrink([true, false])
             .show(ui, |ui| {
-                if let Some(root) = self.tree.root() {
-                    self.tile_ui(ctx, ui, root);
-                }
+                ctx.re_ui.panel_content(ui, |_, ui| {
+                    if let Some(root) = self.tree.root() {
+                        self.tile_ui(ctx, ui, root);
+                    }
+                });
             });
 
         let TreeActions { focus_tab, remove } = std::mem::take(&mut self.deferred_tree_actions);


### PR DESCRIPTION
### What

This PR changes the way inner margins and `ScrollAreas` are nested to avoid some visual issues.

- Fixes #3165
- Fixes full span display bug: https://github.com/rerun-io/rerun/pull/4324#issuecomment-1827326061

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4340) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4340)
- [Docs preview](https://rerun.io/preview/71996e8cabf9dc864f4d7240779b3271472876c3/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/71996e8cabf9dc864f4d7240779b3271472876c3/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)