### PR TITLE
Generate per-PR web apps

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -121,6 +121,7 @@ jobs:
     with:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}
       UPLOAD_COMMIT_OVERRIDE: ${{ github.event.pull_request.head.sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets: inherit
 
   build-web-demo:

--- a/.github/workflows/reusable_upload_web.yml
+++ b/.github/workflows/reusable_upload_web.yml
@@ -28,6 +28,10 @@ on:
         required: false
         type: boolean
         default: true
+      PR_NUMBER:
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: ${{ inputs.CONCURRENCY }}-upload-web
@@ -109,5 +113,13 @@ jobs:
         with:
           path: "web_viewer"
           destination: "rerun-web-viewer/adhoc/${{inputs.ADHOC_NAME}}"
+          parent: false
+
+      - name: "Upload web demo (pr)"
+        if: ${{ inputs.PR_NUMBER != '' }}
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: "web_viewer"
+          destination: "rerun-web-viewer/pr/${{ inputs.PR_NUMBER }}"
           parent: false
 


### PR DESCRIPTION
### What

Closes https://github.com/rerun-io/rerun/issues/3953

- Upload web app to `gs://rerun-web-viewer/pr/$PR_NUMBER` on every PR
- (Separately) updated GCS config to support `/pr` paths

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
