### PR TITLE
Add more examples to `manifest.yml`

### DIFF
--- a/examples/cpp/eigen_opencv/README.md
+++ b/examples/cpp/eigen_opencv/README.md
@@ -1,0 +1,23 @@
+---
+title: "Eigen and OpenCV C++ integration"
+cpp: https://github.com/rerun-io/cpp-example-opencv-eigen/edit/main/README.md
+tags: [2D, 3D, C++, Eigen, OpenCV]
+thumbnail: https://static.rerun.io/cpp-example-opencv-eigen/80ec7c698224eccb5ba1928136ba0a522d79b60a/480w.png
+thumbnail_dimensions: [480, 261]
+---
+
+# Eigen and OpenCV C++ integration
+
+This is a minimal CMake project that shows how to use Rerun in your code in conjunction with [Eigen](https://eigen.tuxfamily.org/) and [OpenCV](https://opencv.org/).
+
+You can find the example at <https://github.com/rerun-io/cpp-example-opencv-eigen/edit/main/README.md>.
+
+<center>
+  <picture>
+    <img src="https://static.rerun.io/cpp-example-opencv-eigen/80ec7c698224eccb5ba1928136ba0a522d79b60a/full.png" alt="">
+    <source media="(max-width: 480px)" srcset="https://static.rerun.io/cpp-example-opencv-eigen/80ec7c698224eccb5ba1928136ba0a522d79b60a/480w.png">
+    <source media="(max-width: 768px)" srcset="https://static.rerun.io/cpp-example-opencv-eigen/80ec7c698224eccb5ba1928136ba0a522d79b60a/768w.png">
+    <source media="(max-width: 1024px)" srcset="https://static.rerun.io/cpp-example-opencv-eigen/80ec7c698224eccb5ba1928136ba0a522d79b60a/1024w.png">
+    <source media="(max-width: 1200px)" srcset="https://static.rerun.io/cpp-example-opencv-eigen/80ec7c698224eccb5ba1928136ba0a522d79b60a/1200w.png">
+  </picture>
+</center>

--- a/examples/cpp/vrs/README.md
+++ b/examples/cpp/vrs/README.md
@@ -1,0 +1,23 @@
+---
+title: "VRS Viewer"
+cpp: https://github.com/rerun-io/cpp-example-vrs
+tags: [2D, 3D, vrs, viewer, C++]
+thumbnail: https://static.rerun.io/cpp-example-vrs/c13ed42c13ecb65b0ef689533c0525ab97471e21/480w.png
+thumbnail_dimensions: [480, 405]
+---
+
+# C++ Example: VRS Viewer
+
+This is an example that shows how to use [Rerun](https://github.com/rerun-io/rerun)'s C++ API to log and view [VRS](https://github.com/facebookresearch/vrs) files.
+
+> VRS is a file format optimized to record & playback streams of sensor data, such as images, audio samples, and any other discrete sensors (IMU, temperature, etc), stored in per-device streams of time-stamped records.
+
+You can find the example at <https://github.com/rerun-io/cpp-example-vrs>.
+
+<picture>
+  <img src="https://static.rerun.io/cpp-example-vrs/c13ed42c13ecb65b0ef689533c0525ab97471e21/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/cpp-example-vrs/c13ed42c13ecb65b0ef689533c0525ab97471e21/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/cpp-example-vrs/c13ed42c13ecb65b0ef689533c0525ab97471e21/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/cpp-example-vrs/c13ed42c13ecb65b0ef689533c0525ab97471e21/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/cpp-example-vrs/c13ed42c13ecb65b0ef689533c0525ab97471e21/1200w.png">
+</picture>

--- a/examples/manifest.yml
+++ b/examples/manifest.yml
@@ -104,6 +104,9 @@ root:
         - name: structure-from-motion
           python: python/structure_from_motion
 
+        - name: vrs
+          python: cpp/vrs
+
     - name: artificial-data
       title: Examples with Artificial Data
       prelude: |

--- a/examples/manifest.yml
+++ b/examples/manifest.yml
@@ -77,6 +77,9 @@ root:
           python: python/objectron
           rust: rust/objectron
 
+        - name: open-photogrammetry-format
+          python: python/open_photogrammetry_format
+
         - name: ros-node
           python: python/ros_node
 

--- a/examples/manifest.yml
+++ b/examples/manifest.yml
@@ -129,6 +129,9 @@ root:
           python: python/clock
           rust: rust/clock
 
+        - name: eigen-opencv
+          python: cpp/eigen_opencv
+
         - name: multithreading
           python: python/multithreading
 

--- a/examples/manifest.yml
+++ b/examples/manifest.yml
@@ -49,17 +49,25 @@ root:
         For the simplest possible examples showing how to use each api,
         check out [Types](/docs/reference/types).
       children:
+        # Keep this list lexicographically sorted:
+
         - name: arkit_scenes
           python: python/arkit_scenes
 
-        - name: structure-from-motion
-          python: python/structure_from_motion
+        - name: controlnet
+          python: python/controlnet
 
-        - name: signed-distance-fields
-          python: python/signed_distance_fields
+        - name: depth-guided-stable-diffusion
+          python: python/depth_guided_stable_diffusion
+
+        - name: detect-and-track-objects
+          python: python/detect_and_track_objects
 
         - name: dicom-mri
           python: python/dicom_mri
+
+        - name: face-tracking
+          python: python/face_tracking
 
         - name: human-pose-tracking
           python: python/human_pose_tracking
@@ -70,9 +78,6 @@ root:
         - name: live-depth-sensor
           python: python/live_depth_sensor
 
-        - name: rgbd
-          python: python/rgbd
-
         - name: objectron
           python: python/objectron
           rust: rust/objectron
@@ -80,27 +85,24 @@ root:
         - name: open-photogrammetry-format
           python: python/open_photogrammetry_format
 
-        - name: ros-node
-          python: python/ros_node
-
         - name: raw-mesh
           python: python/raw_mesh
           rust: rust/raw_mesh
 
+        - name: rgbd
+          python: python/rgbd
+
+        - name: ros-node
+          python: python/ros_node
+
         - name: segment-anything-model
           python: python/segment_anything_model
 
-        - name: depth-guided-stable-diffusion
-          python: python/depth_guided_stable_diffusion
+        - name: signed-distance-fields
+          python: python/signed_distance_fields
 
-        - name: controlnet
-          python: python/controlnet
-
-        - name: detect-and-track-objects
-          python: python/detect_and_track_objects
-
-        - name: face-tracking
-          python: python/face_tracking
+        - name: structure-from-motion
+          python: python/structure_from_motion
 
     - name: artificial-data
       title: Examples with Artificial Data
@@ -110,9 +112,12 @@ root:
         For the simplest possible examples showing how to use each api,
         check out [Types](/docs/reference/types).
       children:
+        # Always show the simple "minimal" example first:
         - name: minimal
           python: python/minimal
           rust: rust/minimal
+
+        # Keep the following examples lexicographically sorted:
 
         - name: car
           python: python/car
@@ -121,11 +126,11 @@ root:
           python: python/clock
           rust: rust/clock
 
-        - name: multiprocessing
-          python: python/multiprocessing
-
         - name: multithreading
           python: python/multithreading
+
+        - name: multiprocessing
+          python: python/multiprocessing
 
         - name: plots
           python: python/plots
@@ -139,22 +144,23 @@ root:
         For the simplest possible examples showing how to use each api,
         check out [Types](/docs/reference/types).
       children:
+        # Keep this list lexicographically sorted:
         - name: differentiable_blocks_world
           python: python/differentiable_blocks_world
+        - name: limap
+          python: python/limap
+        - name: mcc
+          python: python/mcc
+        - name: shape_pointe
+          python: python/shape_pointe
+        - name: simplerecon
+          python: python/simplerecon
+        - name: slahmr
+          python: python/slahmr
         - name: tapir
           python: python/tapir
         - name: widebaseline
           python: python/widebaseline
-        - name: shape_pointe
-          python: python/shape_pointe
-        - name: limap
-          python: python/limap
-        - name: simplerecon
-          python: python/simplerecon
-        - name: mcc
-          python: python/mcc
-        - name: slahmr
-          python: python/slahmr
 
     - name: setup
       title: Setup

--- a/examples/python/open_photogrammetry_format/README.md
+++ b/examples/python/open_photogrammetry_format/README.md
@@ -15,7 +15,7 @@ thumbnail_dimensions: [480, 310]
 </picture>
 
 
-Use [pyopf](https://github.com/Pix4D/pyopf) to load and display a photogrammetrically reconstructed 3D point cloud in the Open Photogrammetry Format (OPF).
+Uses [`pyopf`](https://github.com/Pix4D/pyopf) to load and display a photogrammetrically reconstructed 3D point cloud in the [Open Photogrammetry Format (OPF)](https://www.pix4d.com/open-photogrammetry-format/).
 
 
 ```bash
@@ -23,4 +23,4 @@ pip install -r examples/python/open_photogrammetry_format/requirements.txt
 python examples/python/open_photogrammetry_format/main.py
 ```
 
-Requires Python 3.10 or higher because of [pyopf](https://pypi.org/project/pyopf/).
+Requires Python 3.10 or higher because of [`pyopf`](https://pypi.org/project/pyopf/).

--- a/justfile
+++ b/justfile
@@ -155,6 +155,10 @@ rerun-release *ARGS:
 rerun-web *ARGS:
     cargo run --package rerun-cli --no-default-features --features web_viewer -- --web-viewer {{ARGS}}
 
+# like `rerun-web-release`, but with --release
+rerun-web-release *ARGS:
+    cargo run --package rerun-cli --no-default-features --features web_viewer --release -- --web-viewer {{ARGS}}
+
 # Run the codegen. Optionally pass `--profile` argument if you want.
 codegen *ARGS:
     pixi run codegen {{ARGS}}


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/4315

Adds:
* Open Photogrammetry Example
* External C++ VRS example
* External C++ Eigen/OpenCV exaple

I also opted to sort the examples in lexicographical order because it's in my DNA to do so.

Check the "Examples preview" below

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [demo.rerun.io](https://demo.rerun.io/pr/4342) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4342)
- [Docs preview](https://rerun.io/preview/1598cc75e9a913ae43866e2ab570ea9cce0d4110/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/1598cc75e9a913ae43866e2ab570ea9cce0d4110/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)