### PR TITLE
C++: Allow creating Image/Tensor/DepthImage/SegmentationImage directly from shape & pointer

### DIFF
--- a/crates/re_types/definitions/rerun/archetypes/depth_image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/depth_image.fbs
@@ -11,6 +11,10 @@ namespace rerun.archetypes;
 /// The shape of the `TensorData` must be mappable to an `HxW` tensor.
 /// Each pixel corresponds to a depth value in units specified by `meter`.
 ///
+/// \cpp Since the underlying `rerun::datatypes::TensorData` uses `rerun::Collection` internally,
+/// \cpp data can be passed in without a copy from raw pointers or by reference from `std::vector`/`std::array`/c-arrays.
+/// \cpp If needed, this "borrow-behavior" can be extended by defining your own `rerun::CollectionAdapter`.
+///
 /// \example depth_image_simple !api title="Simple example" image="https://static.rerun.io/depth_image_simple/9598554977873ace2577bddd79184ac120ceb0b0/1200w.png"
 /// \example depth_image_3d title="Depth to 3D example" image="https://static.rerun.io/depth_image_3d/f78674bdae0eb25786c6173307693c5338f38b87/1200w.png"
 table DepthImage (

--- a/crates/re_types/definitions/rerun/archetypes/image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/image.fbs
@@ -16,6 +16,10 @@ namespace rerun.archetypes;
 /// Leading and trailing unit-dimensions are ignored, so that
 /// `1x640x480x3x1` is treated as a `640x480x3` RGB image.
 ///
+/// \cpp Since the underlying `rerun::datatypes::TensorData` uses `rerun::Collection` internally,
+/// \cpp data can be passed in without a copy from raw pointers or by reference from `std::vector`/`std::array`/c-arrays.
+/// \cpp If needed, this "borrow-behavior" can be extended by defining your own `rerun::CollectionAdapter`.
+///
 /// \example image_simple image="https://static.rerun.io/image_simple/06ba7f8582acc1ffb42a7fd0006fad7816f3e4e4/1200w.png"
 table Image (
   "attr.rust.derive": "PartialEq",

--- a/crates/re_types/definitions/rerun/archetypes/segmentation_image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/segmentation_image.fbs
@@ -17,6 +17,10 @@ namespace rerun.archetypes;
 /// \py See also [`AnnotationContext`][rerun.archetypes.AnnotationContext] to associate each class with a color and a label.
 /// \rs See also [`AnnotationContext`][crate::archetypes::AnnotationContext] to associate each class with a color and a label.
 ///
+/// \cpp Since the underlying `rerun::datatypes::TensorData` uses `rerun::Collection` internally,
+/// \cpp data can be passed in without a copy from raw pointers or by reference from `std::vector`/`std::array`/c-arrays.
+/// \cpp If needed, this "borrow-behavior" can be extended by defining your own `rerun::CollectionAdapter`.
+///
 /// \example segmentation_image_simple title="Simple segmentation image" image="https://static.rerun.io/segmentation_image_simple/eb49e0b8cb870c75a69e2a47a2d202e5353115f6/1200w.png"
 table SegmentationImage (
   "attr.rust.derive": "PartialEq",

--- a/crates/re_types/definitions/rerun/archetypes/tensor.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/tensor.fbs
@@ -8,6 +8,10 @@ namespace rerun.archetypes;
 
 /// A generic n-dimensional Tensor.
 ///
+/// \cpp Since the underlying `rerun::datatypes::TensorData` uses `rerun::Collection` internally,
+/// \cpp data can be passed in without a copy from raw pointers or by reference from `std::vector`/`std::array`/c-arrays.
+/// \cpp If needed, this "borrow-behavior" can be extended by defining your own `rerun::CollectionAdapter`.
+///
 /// \example tensor_simple title="Simple Tensor" image="https://static.rerun.io/tensor_simple/baacb07712f7b706e3c80e696f70616c6c20b367/1200w.png"
 table Tensor (
   "attr.rust.derive": "PartialEq"

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -1995,7 +1995,8 @@ fn lines_from_docs(docs: &Docs) -> Vec<String> {
             if let Some(title) = title {
                 lines.push(format!("### {title}"));
             } else {
-                lines.push(format!("### `{name}`:"));
+                // Other languages put the name in backticks but doxygen doesn't support this on headings.
+                lines.push(format!("### {name}:"));
             }
 
             if let Some(image) = image {

--- a/docs/code-examples/depth_image_3d.cpp
+++ b/docs/code-examples/depth_image_3d.cpp
@@ -29,8 +29,5 @@ int main() {
         )
     );
 
-    rec.log(
-        "world/camera/depth",
-        rerun::DepthImage({HEIGHT, WIDTH}, data.data()).with_meter(10000.0)
-    );
+    rec.log("world/camera/depth", rerun::DepthImage({HEIGHT, WIDTH}, data).with_meter(10000.0));
 }

--- a/docs/code-examples/depth_image_3d.cpp
+++ b/docs/code-examples/depth_image_3d.cpp
@@ -31,6 +31,6 @@ int main() {
 
     rec.log(
         "world/camera/depth",
-        rerun::DepthImage({HEIGHT, WIDTH}, std::move(data)).with_meter(10000.0)
+        rerun::DepthImage({HEIGHT, WIDTH}, data.data()).with_meter(10000.0)
     );
 }

--- a/docs/code-examples/depth_image_simple.cpp
+++ b/docs/code-examples/depth_image_simple.cpp
@@ -20,5 +20,5 @@ int main() {
         std::fill_n(data.begin() + y * WIDTH + 100, 180, static_cast<uint16_t>(45000));
     }
 
-    rec.log("depth", rerun::DepthImage({HEIGHT, WIDTH}, data.data()).with_meter(10000.0));
+    rec.log("depth", rerun::DepthImage({HEIGHT, WIDTH}, data).with_meter(10000.0));
 }

--- a/docs/code-examples/depth_image_simple.cpp
+++ b/docs/code-examples/depth_image_simple.cpp
@@ -20,5 +20,5 @@ int main() {
         std::fill_n(data.begin() + y * WIDTH + 100, 180, static_cast<uint16_t>(45000));
     }
 
-    rec.log("depth", rerun::DepthImage({HEIGHT, WIDTH}, std::move(data)).with_meter(10000.0));
+    rec.log("depth", rerun::DepthImage({HEIGHT, WIDTH}, data.data()).with_meter(10000.0));
 }

--- a/docs/code-examples/image_simple.cpp
+++ b/docs/code-examples/image_simple.cpp
@@ -23,5 +23,5 @@ int main() {
         }
     }
 
-    rec.log("image", rerun::Image({HEIGHT, WIDTH, 3}, std::move(data)));
+    rec.log("image", rerun::Image({HEIGHT, WIDTH, 3}, data.data()));
 }

--- a/docs/code-examples/image_simple.cpp
+++ b/docs/code-examples/image_simple.cpp
@@ -23,5 +23,5 @@ int main() {
         }
     }
 
-    rec.log("image", rerun::Image({HEIGHT, WIDTH, 3}, data.data()));
+    rec.log("image", rerun::Image({HEIGHT, WIDTH, 3}, data));
 }

--- a/docs/code-examples/segmentation_image_simple.cpp
+++ b/docs/code-examples/segmentation_image_simple.cpp
@@ -29,5 +29,5 @@ int main() {
         })
     );
 
-    rec.log("image", rerun::SegmentationImage({HEIGHT, WIDTH}, std::move(data)));
+    rec.log("image", rerun::SegmentationImage({HEIGHT, WIDTH}, data.data()));
 }

--- a/docs/code-examples/segmentation_image_simple.cpp
+++ b/docs/code-examples/segmentation_image_simple.cpp
@@ -29,5 +29,5 @@ int main() {
         })
     );
 
-    rec.log("image", rerun::SegmentationImage({HEIGHT, WIDTH}, data.data()));
+    rec.log("image", rerun::SegmentationImage({HEIGHT, WIDTH}, data));
 }

--- a/docs/code-examples/tensor_simple.cpp
+++ b/docs/code-examples/tensor_simple.cpp
@@ -19,7 +19,6 @@ int main() {
 
     rec.log(
         "tensor",
-        rerun::Tensor({8, 6, 3, 5}, data.data())
-            .with_dim_names({"width", "height", "channel", "batch"})
+        rerun::Tensor({8, 6, 3, 5}, data).with_dim_names({"width", "height", "channel", "batch"})
     );
 }

--- a/docs/code-examples/tensor_simple.cpp
+++ b/docs/code-examples/tensor_simple.cpp
@@ -19,6 +19,7 @@ int main() {
 
     rec.log(
         "tensor",
-        rerun::Tensor({8, 6, 3, 5}, data).with_dim_names({"width", "height", "channel", "batch"})
+        rerun::Tensor({8, 6, 3, 5}, data.data())
+            .with_dim_names({"width", "height", "channel", "batch"})
     );
 }

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -60,7 +60,7 @@ namespace rerun::archetypes {
     ///
     ///     rec.log(
     ///         "world/camera/depth",
-    ///         rerun::DepthImage({HEIGHT, WIDTH}, std::move(data)).with_meter(10000.0)
+    ///         rerun::DepthImage({HEIGHT, WIDTH}, data.data()).with_meter(10000.0)
     ///     );
     /// }
     /// ```
@@ -91,16 +91,34 @@ namespace rerun::archetypes {
 
         /// New depth image from height/width and tensor buffer.
         ///
+        /// \param shape
+        /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
         /// Sets the dimension names to "height" and "width" if they are not specified.
-        /// Calls `Error::handle()` if the shape is not rank 2.
+        /// \param buffer
+        /// The tensor buffer containing the image data.
         DepthImage(Collection<datatypes::TensorDimension> shape, datatypes::TensorBuffer buffer)
             : DepthImage(datatypes::TensorData(std::move(shape), std::move(buffer))) {}
 
         /// New depth image from tensor data.
         ///
+        /// \param data_
+        /// The tensor buffer containing the image data.
         /// Sets the dimension names to "height" and "width" if they are not specified.
         /// Calls `Error::handle()` if the shape is not rank 2.
         explicit DepthImage(components::TensorData data_);
+
+        /// New depth image from dimensions and pointer to image data.
+        ///
+        /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
+        /// \param shape
+        /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
+        /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
+        /// Determines the number of elements expected to be in `data`.
+        /// \param data_
+        /// Target of the pointer must outlive the archetype.
+        template <typename TElement>
+        explicit DepthImage(Collection<datatypes::TensorDimension> shape, const TElement* data_)
+            : DepthImage(datatypes::TensorData(std::move(shape), data_)) {}
 
       public:
         DepthImage() = default;

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -23,6 +23,10 @@ namespace rerun::archetypes {
     /// The shape of the `TensorData` must be mappable to an `HxW` tensor.
     /// Each pixel corresponds to a depth value in units specified by `meter`.
     ///
+    /// Since the underlying `rerun::datatypes::TensorData` uses `rerun::Collection` internally,
+    /// data can be passed in without a copy from raw pointers or by reference from `std::vector`/`std::array`/c-arrays.
+    /// If needed, this "borrow-behavior" can be extended by defining your own `rerun::CollectionAdapter`.
+    ///
     /// ## Example
     ///
     /// ### Depth to 3D example
@@ -58,10 +62,7 @@ namespace rerun::archetypes {
     ///         )
     ///     );
     ///
-    ///     rec.log(
-    ///         "world/camera/depth",
-    ///         rerun::DepthImage({HEIGHT, WIDTH}, data.data()).with_meter(10000.0)
-    ///     );
+    ///     rec.log("world/camera/depth", rerun::DepthImage({HEIGHT, WIDTH}, data).with_meter(10000.0));
     /// }
     /// ```
     struct DepthImage {
@@ -95,19 +96,19 @@ namespace rerun::archetypes {
         /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
         /// Sets the dimension names to "height" and "width" if they are not specified.
         /// \param buffer
-        /// The tensor buffer containing the image data.
+        /// The tensor buffer containing the depth image data.
         DepthImage(Collection<datatypes::TensorDimension> shape, datatypes::TensorBuffer buffer)
             : DepthImage(datatypes::TensorData(std::move(shape), std::move(buffer))) {}
 
         /// New depth image from tensor data.
         ///
         /// \param data_
-        /// The tensor buffer containing the image data.
+        /// The tensor buffer containing the depth image data.
         /// Sets the dimension names to "height" and "width" if they are not specified.
         /// Calls `Error::handle()` if the shape is not rank 2.
         explicit DepthImage(components::TensorData data_);
 
-        /// New depth image from dimensions and pointer to image data.
+        /// New depth image from dimensions and pointer to depth image data.
         ///
         /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
         /// \param shape

--- a/rerun_cpp/src/rerun/archetypes/depth_image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image_ext.cpp
@@ -10,16 +10,34 @@ namespace rerun::archetypes {
 
     /// New depth image from height/width and tensor buffer.
     ///
+    /// \param shape
+    /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
     /// Sets the dimension names to "height" and "width" if they are not specified.
-    /// Calls `Error::handle()` if the shape is not rank 2.
+    /// \param buffer
+    /// The tensor buffer containing the image data.
     DepthImage(Collection<datatypes::TensorDimension> shape, datatypes::TensorBuffer buffer)
         : DepthImage(datatypes::TensorData(std::move(shape), std::move(buffer))) {}
 
     /// New depth image from tensor data.
     ///
+    /// \param data_
+    /// The tensor buffer containing the image data.
     /// Sets the dimension names to "height" and "width" if they are not specified.
     /// Calls `Error::handle()` if the shape is not rank 2.
     explicit DepthImage(components::TensorData data_);
+
+    /// New depth image from dimensions and pointer to image data.
+    ///
+    /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
+    /// \param shape
+    /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
+    /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
+    /// Determines the number of elements expected to be in `data`.
+    /// \param data_
+    /// Target of the pointer must outlive the archetype.
+    template <typename TElement>
+    explicit DepthImage(Collection<datatypes::TensorDimension> shape, const TElement* data_)
+        : DepthImage(datatypes::TensorData(std::move(shape), data_)) {}
 
     // </CODEGEN_COPY_TO_HEADER>
 #endif

--- a/rerun_cpp/src/rerun/archetypes/depth_image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image_ext.cpp
@@ -14,19 +14,19 @@ namespace rerun::archetypes {
     /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
     /// Sets the dimension names to "height" and "width" if they are not specified.
     /// \param buffer
-    /// The tensor buffer containing the image data.
+    /// The tensor buffer containing the depth image data.
     DepthImage(Collection<datatypes::TensorDimension> shape, datatypes::TensorBuffer buffer)
         : DepthImage(datatypes::TensorData(std::move(shape), std::move(buffer))) {}
 
     /// New depth image from tensor data.
     ///
     /// \param data_
-    /// The tensor buffer containing the image data.
+    /// The tensor buffer containing the depth image data.
     /// Sets the dimension names to "height" and "width" if they are not specified.
     /// Calls `Error::handle()` if the shape is not rank 2.
     explicit DepthImage(components::TensorData data_);
 
-    /// New depth image from dimensions and pointer to image data.
+    /// New depth image from dimensions and pointer to depth image data.
     ///
     /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
     /// \param shape

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -56,7 +56,7 @@ namespace rerun::archetypes {
     ///         }
     ///     }
     ///
-    ///     rec.log("image", rerun::Image({HEIGHT, WIDTH, 3}, std::move(data)));
+    ///     rec.log("image", rerun::Image({HEIGHT, WIDTH, 3}, data.data()));
     /// }
     /// ```
     struct Image {
@@ -79,16 +79,34 @@ namespace rerun::archetypes {
 
         /// New Image from height/width/channel and tensor buffer.
         ///
-        /// Sets the dimension names to "height",  "width" and "channel" if they are not specified.
-        /// Calls `Error::handle()` if the shape is not rank 2 or 3.
-        Image(Collection<datatypes::TensorDimension> shape, datatypes::TensorBuffer buffer)
+        /// \param shape
+        /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2 or 3.
+        /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
+        /// \param buffer
+        /// The tensor buffer containing the image data.
+        explicit Image(Collection<datatypes::TensorDimension> shape, datatypes::TensorBuffer buffer)
             : Image(datatypes::TensorData(std::move(shape), std::move(buffer))) {}
 
         /// New depth image from tensor data.
         ///
+        /// \param data_
+        /// The tensor buffer containing the image data.
         /// Sets the dimension names to "height",  "width" and "channel" if they are not specified.
         /// Calls `Error::handle()` if the shape is not rank 2 or 3.
         explicit Image(rerun::components::TensorData data_);
+
+        /// New image from dimensions and pointer to image data.
+        ///
+        /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
+        /// \param shape
+        /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2 or 3.
+        /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
+        /// Determines the number of elements expected to be in `data`.
+        /// \param data_
+        /// Target of the pointer must outlive the archetype.
+        template <typename TElement>
+        explicit Image(Collection<datatypes::TensorDimension> shape, const TElement* data_)
+            : Image(datatypes::TensorData(std::move(shape), data_)) {}
 
       public:
         Image() = default;

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -27,6 +27,10 @@ namespace rerun::archetypes {
     /// Leading and trailing unit-dimensions are ignored, so that
     /// `1x640x480x3x1` is treated as a `640x480x3` RGB image.
     ///
+    /// Since the underlying `rerun::datatypes::TensorData` uses `rerun::Collection` internally,
+    /// data can be passed in without a copy from raw pointers or by reference from `std::vector`/`std::array`/c-arrays.
+    /// If needed, this "borrow-behavior" can be extended by defining your own `rerun::CollectionAdapter`.
+    ///
     /// ## Example
     ///
     /// ### `image_simple`:
@@ -56,7 +60,7 @@ namespace rerun::archetypes {
     ///         }
     ///     }
     ///
-    ///     rec.log("image", rerun::Image({HEIGHT, WIDTH, 3}, data.data()));
+    ///     rec.log("image", rerun::Image({HEIGHT, WIDTH, 3}, data));
     /// }
     /// ```
     struct Image {

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -33,7 +33,7 @@ namespace rerun::archetypes {
     ///
     /// ## Example
     ///
-    /// ### `image_simple`:
+    /// ### image_simple:
     /// ![image](https://static.rerun.io/image_simple/06ba7f8582acc1ffb42a7fd0006fad7816f3e4e4/full.png)
     ///
     /// ```cpp

--- a/rerun_cpp/src/rerun/archetypes/image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image_ext.cpp
@@ -13,16 +13,35 @@ namespace rerun::archetypes {
 
     /// New Image from height/width/channel and tensor buffer.
     ///
-    /// Sets the dimension names to "height",  "width" and "channel" if they are not specified.
-    /// Calls `Error::handle()` if the shape is not rank 2 or 3.
-    Image(Collection<datatypes::TensorDimension> shape, datatypes::TensorBuffer buffer)
+    /// \param shape
+    /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2 or 3.
+    /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
+    /// \param buffer
+    /// The tensor buffer containing the image data.
+    explicit Image(Collection<datatypes::TensorDimension> shape, datatypes::TensorBuffer buffer)
         : Image(datatypes::TensorData(std::move(shape), std::move(buffer))) {}
 
     /// New depth image from tensor data.
     ///
+    /// \param data_
+    /// The tensor buffer containing the image data.
     /// Sets the dimension names to "height",  "width" and "channel" if they are not specified.
     /// Calls `Error::handle()` if the shape is not rank 2 or 3.
     explicit Image(rerun::components::TensorData data_);
+
+    /// New image from dimensions and pointer to image data.
+    ///
+    /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
+    /// \param shape
+    /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2 or 3.
+    /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
+    /// Determines the number of elements expected to be in `data`.
+    /// \param data_
+    /// Target of the pointer must outlive the archetype.
+    template <typename TElement>
+    explicit Image(Collection<datatypes::TensorDimension> shape, const TElement* data_)
+        : Image(datatypes::TensorData(std::move(shape), data_)) {}
+
     // </CODEGEN_COPY_TO_HEADER>
 #endif
 

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -26,7 +26,7 @@ namespace rerun::archetypes {
     ///
     /// ## Example
     ///
-    /// ### `line_strip2d_batch`:
+    /// ### line_strip2d_batch:
     /// ![image](https://static.rerun.io/line_strip2d_batch/d8aae7ca3d6c3b0e3b636de60b8067fa2f0b6db9/full.png)
     ///
     /// ```cpp

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -60,7 +60,7 @@ namespace rerun::archetypes {
     ///         })
     ///     );
     ///
-    ///     rec.log("image", rerun::SegmentationImage({HEIGHT, WIDTH}, std::move(data)));
+    ///     rec.log("image", rerun::SegmentationImage({HEIGHT, WIDTH}, data.data()));
     /// }
     /// ```
     struct SegmentationImage {
@@ -84,8 +84,11 @@ namespace rerun::archetypes {
 
         /// New segmentation image from height/width and tensor buffer.
         ///
+        /// \param shape
+        /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
         /// Sets the dimension names to "height" and "width" if they are not specified.
-        /// Calls `Error::handle()` if the shape is not rank 2.
+        /// \param buffer
+        /// The tensor buffer containing the image data.
         SegmentationImage(
             Collection<datatypes::TensorDimension> shape, datatypes::TensorBuffer buffer
         )
@@ -93,9 +96,26 @@ namespace rerun::archetypes {
 
         /// New segmentation image from tensor data.
         ///
+        /// \param data_
+        /// The tensor buffer containing the image data.
         /// Sets the dimension names to "height" and "width" if they are not specified.
         /// Calls `Error::handle()` if the shape is not rank 2.
         explicit SegmentationImage(components::TensorData data_);
+
+        /// New segmentation image from dimensions and pointer to image data.
+        ///
+        /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
+        /// \param shape
+        /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
+        /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
+        /// Determines the number of elements expected to be in `data`.
+        /// \param data_
+        /// Target of the pointer must outlive the archetype.
+        template <typename TElement>
+        explicit SegmentationImage(
+            Collection<datatypes::TensorDimension> shape, const TElement* data_
+        )
+            : SegmentationImage(datatypes::TensorData(std::move(shape), data_)) {}
 
       public:
         SegmentationImage() = default;

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -25,6 +25,10 @@ namespace rerun::archetypes {
     /// Leading and trailing unit-dimensions are ignored, so that
     /// `1x640x480x1` is treated as a `640x480` image.
     ///
+    /// Since the underlying `rerun::datatypes::TensorData` uses `rerun::Collection` internally,
+    /// data can be passed in without a copy from raw pointers or by reference from `std::vector`/`std::array`/c-arrays.
+    /// If needed, this "borrow-behavior" can be extended by defining your own `rerun::CollectionAdapter`.
+    ///
     /// ## Example
     ///
     /// ### Simple segmentation image
@@ -60,7 +64,7 @@ namespace rerun::archetypes {
     ///         })
     ///     );
     ///
-    ///     rec.log("image", rerun::SegmentationImage({HEIGHT, WIDTH}, data.data()));
+    ///     rec.log("image", rerun::SegmentationImage({HEIGHT, WIDTH}, data));
     /// }
     /// ```
     struct SegmentationImage {
@@ -88,7 +92,7 @@ namespace rerun::archetypes {
         /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
         /// Sets the dimension names to "height" and "width" if they are not specified.
         /// \param buffer
-        /// The tensor buffer containing the image data.
+        /// The tensor buffer containing the segmentation image data.
         SegmentationImage(
             Collection<datatypes::TensorDimension> shape, datatypes::TensorBuffer buffer
         )
@@ -97,12 +101,12 @@ namespace rerun::archetypes {
         /// New segmentation image from tensor data.
         ///
         /// \param data_
-        /// The tensor buffer containing the image data.
+        /// The tensor buffer containing the segmentation image data.
         /// Sets the dimension names to "height" and "width" if they are not specified.
         /// Calls `Error::handle()` if the shape is not rank 2.
         explicit SegmentationImage(components::TensorData data_);
 
-        /// New segmentation image from dimensions and pointer to image data.
+        /// New segmentation image from dimensions and pointer to segmentation image data.
         ///
         /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
         /// \param shape

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image_ext.cpp
@@ -14,19 +14,19 @@ namespace rerun::archetypes {
     /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
     /// Sets the dimension names to "height" and "width" if they are not specified.
     /// \param buffer
-    /// The tensor buffer containing the image data.
+    /// The tensor buffer containing the segmentation image data.
     SegmentationImage(Collection<datatypes::TensorDimension> shape, datatypes::TensorBuffer buffer)
         : SegmentationImage(datatypes::TensorData(std::move(shape), std::move(buffer))) {}
 
     /// New segmentation image from tensor data.
     ///
     /// \param data_
-    /// The tensor buffer containing the image data.
+    /// The tensor buffer containing the segmentation image data.
     /// Sets the dimension names to "height" and "width" if they are not specified.
     /// Calls `Error::handle()` if the shape is not rank 2.
     explicit SegmentationImage(components::TensorData data_);
 
-    /// New segmentation image from dimensions and pointer to image data.
+    /// New segmentation image from dimensions and pointer to segmentation image data.
     ///
     /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
     /// \param shape

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image_ext.cpp
@@ -10,16 +10,34 @@ namespace rerun::archetypes {
 
     /// New segmentation image from height/width and tensor buffer.
     ///
+    /// \param shape
+    /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
     /// Sets the dimension names to "height" and "width" if they are not specified.
-    /// Calls `Error::handle()` if the shape is not rank 2.
+    /// \param buffer
+    /// The tensor buffer containing the image data.
     SegmentationImage(Collection<datatypes::TensorDimension> shape, datatypes::TensorBuffer buffer)
         : SegmentationImage(datatypes::TensorData(std::move(shape), std::move(buffer))) {}
 
     /// New segmentation image from tensor data.
     ///
+    /// \param data_
+    /// The tensor buffer containing the image data.
     /// Sets the dimension names to "height" and "width" if they are not specified.
     /// Calls `Error::handle()` if the shape is not rank 2.
     explicit SegmentationImage(components::TensorData data_);
+
+    /// New segmentation image from dimensions and pointer to image data.
+    ///
+    /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
+    /// \param shape
+    /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
+    /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
+    /// Determines the number of elements expected to be in `data`.
+    /// \param data_
+    /// Target of the pointer must outlive the archetype.
+    template <typename TElement>
+    explicit SegmentationImage(Collection<datatypes::TensorDimension> shape, const TElement* data_)
+        : SegmentationImage(datatypes::TensorData(std::move(shape), data_)) {}
 
     // </CODEGEN_COPY_TO_HEADER>
 #endif

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -16,6 +16,10 @@
 namespace rerun::archetypes {
     /// **Archetype**: A generic n-dimensional Tensor.
     ///
+    /// Since the underlying `rerun::datatypes::TensorData` uses `rerun::Collection` internally,
+    /// data can be passed in without a copy from raw pointers or by reference from `std::vector`/`std::array`/c-arrays.
+    /// If needed, this "borrow-behavior" can be extended by defining your own `rerun::CollectionAdapter`.
+    ///
     /// ## Example
     ///
     /// ### Simple Tensor

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -62,6 +62,17 @@ namespace rerun::archetypes {
         Tensor(Collection<datatypes::TensorDimension> shape, datatypes::TensorBuffer buffer)
             : Tensor(datatypes::TensorData(std::move(shape), std::move(buffer))) {}
 
+        /// New tensor from dimensions and pointer to tensor data.
+        ///
+        /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
+        /// \param shape
+        /// Shape of the image. Determines the number of elements expected to be in `data`.
+        /// \param data_
+        /// Target of the pointer must outlive the archetype.
+        template <typename TElement>
+        explicit Tensor(Collection<datatypes::TensorDimension> shape, const TElement* data_)
+            : Tensor(datatypes::TensorData(std::move(shape), data_)) {}
+
         /// Update the `names` of the contained `TensorData` dimensions.
         ///
         /// Any existing Dimension names will be overwritten.

--- a/rerun_cpp/src/rerun/archetypes/tensor_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor_ext.cpp
@@ -16,6 +16,17 @@ namespace rerun::archetypes {
     Tensor(Collection<datatypes::TensorDimension> shape, datatypes::TensorBuffer buffer)
         : Tensor(datatypes::TensorData(std::move(shape), std::move(buffer))) {}
 
+    /// New tensor from dimensions and pointer to tensor data.
+    ///
+    /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
+    /// \param shape
+    /// Shape of the image. Determines the number of elements expected to be in `data`.
+    /// \param data_
+    /// Target of the pointer must outlive the archetype.
+    template <typename TElement>
+    explicit Tensor(Collection<datatypes::TensorDimension> shape, const TElement* data_)
+        : Tensor(datatypes::TensorData(std::move(shape), data_)) {}
+
     /// Update the `names` of the contained `TensorData` dimensions.
     ///
     /// Any existing Dimension names will be overwritten.

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -22,7 +22,7 @@ namespace rerun::archetypes {
     ///
     /// ## Example
     ///
-    /// ### `text_log_integration`:
+    /// ### text_log_integration:
     /// ![image](https://static.rerun.io/text_log_integration/9737d0c986325802a9885499d6fcc773b1736488/full.png)
     ///
     /// ```cpp

--- a/rerun_cpp/src/rerun/collection.hpp
+++ b/rerun_cpp/src/rerun/collection.hpp
@@ -261,6 +261,17 @@ namespace rerun {
             return 0;
         }
 
+        /// Returns true if the collection is empty.
+        bool empty() const {
+            switch (ownership) {
+                case CollectionOwnership::Borrowed:
+                    return storage.borrowed.num_instances == 0;
+                case CollectionOwnership::VectorOwned:
+                    return storage.vector_owned.empty();
+            }
+            return 0;
+        }
+
         /// Returns a raw pointer to the underlying data.
         ///
         /// Do not use this if the data is not continuous in memory!

--- a/rerun_cpp/src/rerun/collection_adapter.hpp
+++ b/rerun_cpp/src/rerun/collection_adapter.hpp
@@ -21,8 +21,6 @@ namespace rerun {
     /// define `Collection<TElement> operator()(const T& input)`.
     /// It is *highly recommended* to also specify `Collection<TElement> operator()(T&&
     /// input)` in order to accidentally borrow data that is passed in as a temporary!
-    ///
-    /// TODO(andreas): Point to an example here and in the assert.
     template <typename TElement, typename TContainer, typename Enable = std::enable_if_t<true>>
     struct CollectionAdapter {
         /// \private

--- a/rerun_cpp/src/rerun/components/tensor_data.hpp
+++ b/rerun_cpp/src/rerun/components/tensor_data.hpp
@@ -24,12 +24,24 @@ namespace rerun::components {
       public:
         // Extensions to generated type defined in 'tensor_data_ext.cpp'
 
-        /// New Tensor from dimensions and tensor buffer.
+        /// New tensor data from shape and tensor buffer.
+        ///
+        /// \param shape Shape of the tensor.
+        /// \param buffer The tensor buffer containing the tensor's data.
         TensorData(
             rerun::Collection<rerun::datatypes::TensorDimension> shape,
             rerun::datatypes::TensorBuffer buffer
         )
             : data(rerun::datatypes::TensorData(std::move(shape), std::move(buffer))) {}
+
+        /// New tensor data from dimensions and pointer to tensor data.
+        ///
+        /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
+        /// \param shape  Shape of the tensor. Determines the number of elements expected to be in `data_`.
+        /// \param data_ Target of the pointer must outlive the archetype.
+        template <typename TElement>
+        explicit TensorData(Collection<datatypes::TensorDimension> shape, const TElement* data_)
+            : data(rerun::datatypes::TensorData(std::move(shape), data_)) {}
 
       public:
         TensorData() = default;

--- a/rerun_cpp/src/rerun/components/tensor_data_ext.cpp
+++ b/rerun_cpp/src/rerun/components/tensor_data_ext.cpp
@@ -1,31 +1,31 @@
 #include "tensor_data.hpp"
 
-// Uncomment for better auto-complete while editing the extension.
-// #define EDIT_EXTENSION
+namespace rerun::components {
 
-namespace rerun {
-    namespace components {
+#if 0
+    struct TensorDataExt {
+        // <CODEGEN_COPY_TO_HEADER>
 
-#ifdef EDIT_EXTENSION
-        struct TensorDataExt {
-#define TensorData TensorDataExt
+        /// New tensor data from shape and tensor buffer.
+        ///
+        /// \param shape Shape of the tensor.
+        /// \param buffer The tensor buffer containing the tensor's data.
+        TensorData(
+            rerun::Collection<rerun::datatypes::TensorDimension> shape,
+            rerun::datatypes::TensorBuffer buffer
+        )
+            : data(rerun::datatypes::TensorData(std::move(shape), std::move(buffer))) {}
 
-            // <CODEGEN_COPY_TO_HEADER>
+        /// New tensor data from dimensions and pointer to tensor data.
+        ///
+        /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
+        /// \param shape  Shape of the tensor. Determines the number of elements expected to be in `data_`.
+        /// \param data_ Target of the pointer must outlive the archetype.
+        template <typename TElement>
+        explicit TensorData(Collection<datatypes::TensorDimension> shape, const TElement* data_)
+            : data(rerun::datatypes::TensorData(std::move(shape), data_)) {}
 
-            /// New Tensor from dimensions and tensor buffer.
-            TensorData(
-                rerun::Collection<rerun::datatypes::TensorDimension> shape,
-                rerun::datatypes::TensorBuffer buffer
-            )
-                : data(rerun::datatypes::TensorData(std::move(shape), std::move(buffer))) {}
-
-            // </CODEGEN_COPY_TO_HEADER>
-        };
-
-#undef TensorData
-#else
-#define TensorDataExt TensorData
+        // </CODEGEN_COPY_TO_HEADER>
+    };
 #endif
-
-    } // namespace components
-} // namespace rerun
+} // namespace rerun::components

--- a/rerun_cpp/src/rerun/datatypes/tensor_data.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_data.hpp
@@ -34,10 +34,29 @@ namespace rerun::datatypes {
       public:
         // Extensions to generated type defined in 'tensor_data_ext.cpp'
 
+        /// New tensor data from shape and tensor buffer.
+        ///
+        /// \param shape Shape of the tensor.
+        /// \param buffer The tensor buffer containing the tensor's data.
         TensorData(
             Collection<rerun::datatypes::TensorDimension> shape_, datatypes::TensorBuffer buffer_
         )
             : shape(std::move(shape_)), buffer(std::move(buffer_)) {}
+
+        /// New tensor data from dimensions and pointer to tensor data.
+        ///
+        /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
+        /// \param shape  Shape of the tensor. Determines the number of elements expected to be in `data`.
+        /// \param data Target of the pointer must outlive the archetype.
+        template <typename TElement>
+        explicit TensorData(Collection<datatypes::TensorDimension> shape_, const TElement* data)
+            : shape(std::move(shape_)) {
+            size_t num_elements = shape.empty() ? 0 : 1;
+            for (const auto& dim : shape) {
+                num_elements *= dim.size;
+            }
+            buffer = rerun::Collection<TElement>::borrow(data, num_elements);
+        }
 
       public:
         TensorData() = default;

--- a/rerun_cpp/src/rerun/datatypes/tensor_data.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_data.hpp
@@ -36,8 +36,8 @@ namespace rerun::datatypes {
 
         /// New tensor data from shape and tensor buffer.
         ///
-        /// \param shape Shape of the tensor.
-        /// \param buffer The tensor buffer containing the tensor's data.
+        /// \param shape_ Shape of the tensor.
+        /// \param buffer_ The tensor buffer containing the tensor's data.
         TensorData(
             Collection<rerun::datatypes::TensorDimension> shape_, datatypes::TensorBuffer buffer_
         )
@@ -46,7 +46,7 @@ namespace rerun::datatypes {
         /// New tensor data from dimensions and pointer to tensor data.
         ///
         /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
-        /// \param shape  Shape of the tensor. Determines the number of elements expected to be in `data`.
+        /// \param shape_ Shape of the tensor. Determines the number of elements expected to be in `data`.
         /// \param data Target of the pointer must outlive the archetype.
         template <typename TElement>
         explicit TensorData(Collection<datatypes::TensorDimension> shape_, const TElement* data)

--- a/rerun_cpp/src/rerun/datatypes/tensor_data_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_data_ext.cpp
@@ -5,10 +5,28 @@ namespace rerun::datatypes {
 #if 0
     // <CODEGEN_COPY_TO_HEADER>
 
+    /// New tensor data from shape and tensor buffer.
+    ///
+    /// \param shape Shape of the tensor.
+    /// \param buffer The tensor buffer containing the tensor's data.
     TensorData(
         Collection<rerun::datatypes::TensorDimension> shape_, datatypes::TensorBuffer buffer_
     )
         : shape(std::move(shape_)), buffer(std::move(buffer_)) {}
+
+    /// New tensor data from dimensions and pointer to tensor data.
+    ///
+    /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
+    /// \param shape  Shape of the tensor. Determines the number of elements expected to be in `data`.
+    /// \param data Target of the pointer must outlive the archetype.
+    template <typename TElement>
+    explicit TensorData(Collection<datatypes::TensorDimension> shape_, const TElement* data) : shape(std::move(shape_)) {
+        size_t num_elements = shape.empty() ? 0 : 1;
+        for (const auto& dim : shape) {
+            num_elements *= dim.size;
+        }
+        buffer = rerun::Collection<TElement>::borrow(data, num_elements);
+    }
 
     // </CODEGEN_COPY_TO_HEADER>
 #endif

--- a/rerun_cpp/src/rerun/datatypes/tensor_data_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_data_ext.cpp
@@ -7,8 +7,8 @@ namespace rerun::datatypes {
 
     /// New tensor data from shape and tensor buffer.
     ///
-    /// \param shape Shape of the tensor.
-    /// \param buffer The tensor buffer containing the tensor's data.
+    /// \param shape_ Shape of the tensor.
+    /// \param buffer_ The tensor buffer containing the tensor's data.
     TensorData(
         Collection<rerun::datatypes::TensorDimension> shape_, datatypes::TensorBuffer buffer_
     )
@@ -17,7 +17,7 @@ namespace rerun::datatypes {
     /// New tensor data from dimensions and pointer to tensor data.
     ///
     /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
-    /// \param shape  Shape of the tensor. Determines the number of elements expected to be in `data`.
+    /// \param shape_ Shape of the tensor. Determines the number of elements expected to be in `data`.
     /// \param data Target of the pointer must outlive the archetype.
     template <typename TElement>
     explicit TensorData(Collection<datatypes::TensorDimension> shape_, const TElement* data) : shape(std::move(shape_)) {

--- a/rerun_cpp/tests/archetypes/image.cpp
+++ b/rerun_cpp/tests/archetypes/image.cpp
@@ -1,4 +1,5 @@
 #include "../error_check.hpp"
+#include "archetype_test.hpp"
 
 #include <rerun/archetypes/image.hpp>
 using namespace rerun::archetypes;
@@ -104,9 +105,9 @@ SCENARIO("Image archetype can be created from tensor data." TEST_TAG) {
 
     GIVEN("tensor data with too low rank") {
         rerun::datatypes::TensorData data(
-            {{
+            {
                 rerun::datatypes::TensorDimension(1, "dr robotnik"),
-            }},
+            },
             std::vector<uint8_t>(1, 0)
         );
         THEN("a warning occurs on image construction") {
@@ -121,6 +122,22 @@ SCENARIO("Image archetype can be created from tensor data." TEST_TAG) {
 
             AND_THEN("serialization succeeds") {
                 CHECK(rerun::AsComponents<decltype(image)>().serialize(image).is_ok());
+            }
+        }
+    }
+
+    GIVEN("constructing image data from a raw pointer") {
+        std::vector<uint8_t> data(100, 100);
+        THEN("no error occurs on image construction") {
+            auto image_from_ptr = check_logged_error([&] {
+                return Image({10, 10, 1}, data.data());
+            });
+
+            AND_THEN("serialization succeeds") {
+                auto image_from_vector = check_logged_error([&] {
+                    return Image({10, 10, 1}, data);
+                });
+                test_compare_archetype_serialization(image_from_ptr, image_from_vector);
             }
         }
     }

--- a/rerun_cpp/tests/archetypes/image.cpp
+++ b/rerun_cpp/tests/archetypes/image.cpp
@@ -126,17 +126,13 @@ SCENARIO("Image archetype can be created from tensor data." TEST_TAG) {
         }
     }
 
-    GIVEN("constructing image data from a raw pointer") {
-        std::vector<uint8_t> data(100, 100);
-        THEN("no error occurs on image construction") {
-            auto image_from_ptr = check_logged_error([&] {
-                return Image({10, 10, 1}, data.data());
-            });
+    GIVEN("a vector of data") {
+        std::vector<uint8_t> data(10 * 10, 0);
+        THEN("no error occurs on image construction with either the vector or a data pointer") {
+            auto image_from_vector = check_logged_error([&] { return Image({10, 10}, data); });
+            auto image_from_ptr = check_logged_error([&] { return Image({10, 10}, data.data()); });
 
             AND_THEN("serialization succeeds") {
-                auto image_from_vector = check_logged_error([&] {
-                    return Image({10, 10, 1}, data);
-                });
                 test_compare_archetype_serialization(image_from_ptr, image_from_vector);
             }
         }

--- a/rerun_cpp/tests/archetypes/segmentation_and_depth_image.cpp
+++ b/rerun_cpp/tests/archetypes/segmentation_and_depth_image.cpp
@@ -1,4 +1,5 @@
 #include "../error_check.hpp"
+#include "archetype_test.hpp"
 
 #include <rerun/archetypes/depth_image.hpp>
 #include <rerun/archetypes/segmentation_image.hpp>
@@ -93,6 +94,22 @@ void run_image_tests() {
 
             AND_THEN("serialization succeeds") {
                 CHECK(rerun::AsComponents<decltype(image)>().serialize(image).is_ok());
+            }
+        }
+    }
+
+    GIVEN("constructing image data from a raw pointer") {
+        std::vector<uint8_t> data(100, 100);
+        THEN("no error occurs on image construction") {
+            auto image_from_ptr = check_logged_error([&] {
+                return ImageType({10, 10}, data.data());
+            });
+
+            AND_THEN("serialization succeeds") {
+                auto image_from_vector = check_logged_error([&] {
+                    return ImageType({10, 10}, data);
+                });
+                test_compare_archetype_serialization(image_from_ptr, image_from_vector);
             }
         }
     }

--- a/rerun_cpp/tests/archetypes/segmentation_and_depth_image.cpp
+++ b/rerun_cpp/tests/archetypes/segmentation_and_depth_image.cpp
@@ -98,17 +98,15 @@ void run_image_tests() {
         }
     }
 
-    GIVEN("constructing image data from a raw pointer") {
-        std::vector<uint8_t> data(100, 100);
-        THEN("no error occurs on image construction") {
+    GIVEN("a vector of data") {
+        std::vector<uint8_t> data(10 * 10, 0);
+        THEN("no error occurs on image construction with either the vector or a data pointer") {
+            auto image_from_vector = check_logged_error([&] { return ImageType({10, 10}, data); });
             auto image_from_ptr = check_logged_error([&] {
                 return ImageType({10, 10}, data.data());
             });
 
             AND_THEN("serialization succeeds") {
-                auto image_from_vector = check_logged_error([&] {
-                    return ImageType({10, 10}, data);
-                });
                 test_compare_archetype_serialization(image_from_ptr, image_from_vector);
             }
         }

--- a/rerun_cpp/tests/archetypes/tensor.cpp
+++ b/rerun_cpp/tests/archetypes/tensor.cpp
@@ -1,0 +1,20 @@
+#include "archetype_test.hpp"
+
+#include <rerun/archetypes/tensor.hpp>
+using namespace rerun::archetypes;
+
+#define TEST_TAG "[tensor][archetypes]"
+
+SCENARIO("Tensor archetype can be created from tensor data." TEST_TAG) {
+    GIVEN("a vector of data") {
+        std::vector<int8_t> data(2 * 2 * 2 * 2, 0);
+        THEN("no error occurs on image construction with either the vector or a data pointer") {
+            auto image_from_vector = Tensor({2, 2, 2, 2}, data);
+            auto image_from_ptr = Tensor({2, 2, 2, 2}, data.data());
+
+            AND_THEN("serialization succeeds") {
+                test_compare_archetype_serialization(image_from_ptr, image_from_vector);
+            }
+        }
+    }
+}

--- a/rerun_cpp/tests/collection.cpp
+++ b/rerun_cpp/tests/collection.cpp
@@ -141,6 +141,20 @@ void check_for_expected_single(const rerun::Collection<Element>& collection) {
     CHECK(collection[0] == expected);
 }
 
+SCENARIO("Default constructing a collection", TEST_TAG) {
+    GIVEN("a default constructed collection") {
+        rerun::Collection<Element> collection;
+
+        THEN("it is empty") {
+            CHECK(collection.size() == 0);
+            CHECK(collection.empty());
+        }
+        THEN("it is borrowed") {
+            CHECK(collection.get_ownership() == rerun::CollectionOwnership::Borrowed);
+        }
+    }
+}
+
 SCENARIO(
     "Collection creation via basic adapters, using the container's value_type as input", TEST_TAG
 ) {
@@ -448,6 +462,8 @@ SCENARIO("Move construction/assignment of collections", TEST_TAG) {
             CHECK(target.size() == 2);
             CHECK(target.get_ownership() == rerun::CollectionOwnership::Borrowed);
             CHECK(borrowed.size() == 0);
+            CHECK(borrowed.empty());
+
             CHECK(borrowed.get_ownership() == rerun::CollectionOwnership::Borrowed);
         }
 
@@ -506,23 +522,29 @@ SCENARIO("Copy/move construction/assignment of collections", TEST_TAG) {
         THEN("it can be move constructed") {
             rerun::Collection<int> collection2(std::move(collection));
             CHECK(collection2.size() == 0);
+            CHECK(collection2.empty());
+
             CHECK(collection2.data() == old_data_ptr);
         }
         THEN("it can be move assigned") {
             rerun::Collection<int> collection2;
             collection2 = std::move(collection);
             CHECK(collection2.size() == 0);
+            CHECK(collection2.empty());
+
             CHECK(collection2.data() == old_data_ptr);
         }
 
         THEN("it can be copy constructed") {
             rerun::Collection<int> collection2(collection);
             CHECK(collection2.size() == 0);
+            CHECK(collection2.empty());
         }
         THEN("it can be copy assigned") {
             rerun::Collection<int> collection2;
             collection2 = collection;
             CHECK(collection2.size() == 0);
+            CHECK(collection2.empty());
         }
     }
 


### PR DESCRIPTION
### What

* Fixes #4343

Also a bunch of doc polish in related areas on the way.

Collection now has an `empty` method.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4345) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4345)
- [Docs preview](https://rerun.io/preview/2453dd78db2a0a8139b1a00060304d97eeef36fe/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2453dd78db2a0a8139b1a00060304d97eeef36fe/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)