### PR TITLE
Reference doc fixes - ordering, remove outdated link, fix migration guide title

### DIFF
--- a/docs/content/getting-started/cpp.md
+++ b/docs/content/getting-started/cpp.md
@@ -130,6 +130,6 @@ If you'd rather learn from examples, check out the [example gallery](/examples) 
 There's also a stand-alone example that shows [interop with Eigen and OpenCV](https://github.com/rerun-io/cpp-example-opencv-eigen).
 
 To learn more about how to work with your own types, check the [Custom Collection Adapter](https://github.com/rerun-io/rerun/tree/latest/examples/cpp/custom_collection_adapter?speculative-link) example on how to zero-copy adapt to Rerun types
-and the [Use custom data](../howto/custom-data) page for completely custom types.
+and the [Use custom data](../howto/extend/custom-data.md) page for completely custom types.
 
 To learn more about how to configure the C++ SDK's CMake file, check [CMake Setup in Detail](https://ref.rerun.io/docs/cpp/latest/md__cmake__setup__in__detail.html?speculative-link) .

--- a/docs/content/getting-started/cpp.md
+++ b/docs/content/getting-started/cpp.md
@@ -1,6 +1,6 @@
 ---
 title: C++ Quick Start
-order: 2
+order: 1
 ---
 
 ## Setup

--- a/docs/content/getting-started/cpp.md
+++ b/docs/content/getting-started/cpp.md
@@ -129,6 +129,7 @@ Rerun tick and log our first non-trivial dataset.
 If you'd rather learn from examples, check out the [example gallery](/examples) for some more realistic examples, or browse the [Types](../reference/types.md) section for more simple examples of how to use the main datatypes.
 There's also a stand-alone example that shows [interop with Eigen and OpenCV](https://github.com/rerun-io/cpp-example-opencv-eigen).
 
-TODO(#3977): Note that this is still an area of active development and there's going to be major improvements for library interop in upcoming versions.
+To learn more about how to work with your own types, check the [Custom Collection Adapter](https://github.com/rerun-io/rerun/tree/latest/examples/cpp/custom_collection_adapter?speculative-link) example on how to zero-copy adapt to Rerun types
+and the [Use custom data](../howto/custom-data) page for completely custom types.
 
 To learn more about how to configure the C++ SDK's CMake file, check [CMake Setup in Detail](https://ref.rerun.io/docs/cpp/latest/md__cmake__setup__in__detail.html?speculative-link) .

--- a/docs/content/getting-started/logging-cpp.md
+++ b/docs/content/getting-started/logging-cpp.md
@@ -1,6 +1,6 @@
 ---
 title: Logging Data in C++
-order: 6
+order: 5
 ---
 
 In this section we'll log and visualize our first non-trivial dataset, putting many of Rerun's core concepts and features to use.

--- a/docs/content/getting-started/logging-python.md
+++ b/docs/content/getting-started/logging-python.md
@@ -1,6 +1,6 @@
 ---
 title: Logging Data in Python
-order: 5
+order: 6
 ---
 
 In this section we'll log and visualize our first non-trivial dataset, putting many of Rerun's core concepts and features to use.

--- a/docs/content/getting-started/python.md
+++ b/docs/content/getting-started/python.md
@@ -1,6 +1,6 @@
 ---
 title: Python Quick Start
-order: 1
+order: 2
 ---
 
 ## Installing Rerun

--- a/docs/content/howto/cpp-custom-component-batch-adapter.md
+++ b/docs/content/howto/cpp-custom-component-batch-adapter.md
@@ -1,5 +1,0 @@
----
-title: C++ Custom Component Batch Adapter
-order: 7
-redirect: https://github.com/rerun-io/rerun/blob/latest/examples/cpp/custom_component_adapter/README.md
----

--- a/docs/content/reference/cpp.md
+++ b/docs/content/reference/cpp.md
@@ -1,5 +1,5 @@
 ---
 title: 🌊 C++ APIs
-order: 10
+order: 9
 redirect: https://ref.rerun.io/docs/cpp?speculative-link
 ---

--- a/docs/content/reference/migration-0-9.md
+++ b/docs/content/reference/migration-0-9.md
@@ -1,5 +1,5 @@
 ---
-title: Migration to 0.9
+title: Migrating from 0.8
 order: 12
 ---
 

--- a/docs/content/reference/python.md
+++ b/docs/content/reference/python.md
@@ -1,5 +1,5 @@
 ---
 title: 🐍 Python APIs
-order: 9
+order: 10
 redirect: https://ref.rerun.io/docs/python
 ---


### PR DESCRIPTION
### What

Commit by commit. Most important piece is that he outdated link to custom component batch adapters is gone.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4346) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4346)
- [Docs preview](https://rerun.io/preview/4a1056bb4ee35642574545504c9ae8b5cbbbcf76/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4a1056bb4ee35642574545504c9ae8b5cbbbcf76/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)