### PR TITLE
Fix c++ spawn failure by handling empty string properly

### DIFF
--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -42,6 +42,10 @@ impl CStringView {
     pub fn is_null(&self) -> bool {
         self.string.is_null()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
 }
 
 pub type CRecordingStream = u32;
@@ -71,15 +75,15 @@ impl CSpawnOptions {
             spawn_opts.port = self.port;
         }
 
-        if !self.memory_limit.is_null() {
+        if !self.memory_limit.is_empty() {
             spawn_opts.memory_limit = self.memory_limit.as_str("memory_limit")?.to_owned();
         }
 
-        if !self.executable_name.is_null() {
+        if !self.executable_name.is_empty() {
             spawn_opts.executable_name = self.executable_name.as_str("executable_name")?.to_owned();
         }
 
-        if !self.executable_path.is_null() {
+        if !self.executable_path.is_empty() {
             spawn_opts.executable_path =
                 Some(self.executable_path.as_str("executable_path")?.to_owned());
         }

--- a/rerun_cpp/src/rerun/spawn_options.hpp
+++ b/rerun_cpp/src/rerun/spawn_options.hpp
@@ -23,17 +23,19 @@ namespace rerun {
         /// When this limit is reached, Rerun will drop the oldest data.
         /// Example: `16GB` or `50%` (of system total).
         ///
-        /// Defaults to `75%` if null.
+        /// Defaults to `75%` if unset.
         std::string_view memory_limit = "75%";
 
         /// Specifies the name of the Rerun executable.
         ///
         /// You can omit the `.exe` suffix on Windows.
+        ///
+        /// Defaults to `rerun` if unset.
         std::string_view executable_name = "rerun";
 
         /// Enforce a specific executable to use instead of searching though PATH
         /// for `SpawnOptions::executable_name`.
-        std::string_view executable_path = "";
+        std::string_view executable_path;
 
         /// Convert to the corresponding rerun_c struct for internal use.
         ///


### PR DESCRIPTION
### What
Empty is a more robust check than null since it also catches the empty string.

I'm torn on whether to also check for null here -- my inclination is not to since I'd rather raise the unexpected null error since if someone is passing an StringView with a nullptr but non-zero length, they are doing something wrong.

* closes https://github.com/rerun-io/rerun/issues/4348

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4349) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4349)
- [Docs preview](https://rerun.io/preview/91d08d9950b844e4ac02c0214c7bfe3a54d3bee1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/91d08d9950b844e4ac02c0214c7bfe3a54d3bee1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)