### PR TITLE
Identify proper sha during pull-request jobs

### DIFF
--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -149,7 +149,7 @@ jobs:
         id: get-sha
         shell: bash
         run: |
-          full_commit="${{ inputs.RELEASE_COMMIT || ((github.event_name == 'pull_request' && github.event.pull_request.head.ref) || github.sha) }}"
+          full_commit="${{ inputs.RELEASE_COMMIT || ((github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha) }}"
           echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
       - name: "Upload rerun_c (commit)"

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -172,7 +172,7 @@ jobs:
         id: get-sha
         shell: bash
         run: |
-          full_commit="${{ inputs.RELEASE_COMMIT || ((github.event_name == 'pull_request' && github.event.pull_request.head.ref) || github.sha) }}"
+          full_commit="${{ inputs.RELEASE_COMMIT || ((github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha) }}"
           echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
       - name: "Upload rerun-cli (commit)"

--- a/.github/workflows/reusable_build_web_demo.yml
+++ b/.github/workflows/reusable_build_web_demo.yml
@@ -76,7 +76,7 @@ jobs:
         id: get-sha
         shell: bash
         run: |
-          full_commit="${{ (github.event_name == 'pull_request' && github.event.pull_request.head.ref) || github.sha }}"
+          full_commit="${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}"
           echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
       - name: Build web demo

--- a/.github/workflows/reusable_bundle_and_upload_rerun_cpp.yml
+++ b/.github/workflows/reusable_bundle_and_upload_rerun_cpp.yml
@@ -50,7 +50,7 @@ jobs:
         id: get-sha
         shell: bash
         run: |
-          full_commit="${{ inputs.RELEASE_COMMIT || ((github.event_name == 'pull_request' && github.event.pull_request.head.ref) || github.sha) }}"
+          full_commit="${{ inputs.RELEASE_COMMIT || ((github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha) }}"
           echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
       - name: "Bundle and upload rerun_cpp_sdk.zip"


### PR DESCRIPTION
### What
This sha logic was previously using the branch name where it was intending to use a sha, in turn leading to bad upload paths, etc. I believe this just happened to work for `andreas` because his username is 7 characters.

Incorrect:
![image](https://github.com/rerun-io/rerun/assets/3312232/470a9717-9312-4282-b300-9bd76b86dbe2)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4352) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4352)
- [Docs preview](https://rerun.io/preview/0f46865f395db1a2356ba8cfc5cccd53c0daed6a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0f46865f395db1a2356ba8cfc5cccd53c0daed6a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)