### PR TITLE
Fix bug where selecting group would instead select the individual entity

### DIFF
--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -512,7 +512,7 @@ fn blueprint_ui(
             if let Some(space_view) = viewport.blueprint.space_view_mut(space_view_id) {
                 if let Some(group) = space_view.contents.group_mut(*data_blueprint_group_handle) {
                     let group_path = group.group_path.clone();
-                    let as_group = false;
+                    let as_group = true;
 
                     let data_result = space_view.contents.resolve(
                         space_view,


### PR DESCRIPTION
### What

Was accidentally looking up groups as individual entities. In particular this broke visible history configuration on a group selection.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4354) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4354)
- [Docs preview](https://rerun.io/preview/200482e934335f0c7169e62aa934e1011b996366/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/200482e934335f0c7169e62aa934e1011b996366/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)