### PR TITLE
Set `clip_rect_margin` to zero by default

### DIFF
--- a/crates/re_ui/src/design_tokens.rs
+++ b/crates/re_ui/src/design_tokens.rs
@@ -171,6 +171,9 @@ fn apply_design_tokens(ctx: &egui::Context) -> DesignTokens {
     egui_style.spacing.item_spacing = egui::vec2(8.0, 8.0);
     egui_style.spacing.menu_margin = crate::ReUi::view_padding().into();
 
+    // avoid some visual glitches with the default non-zero value
+    egui_style.visuals.clip_rect_margin = 0.0;
+
     // Add stripes to grids and tables?
     egui_style.visuals.striped = false;
     egui_style.visuals.indent_has_left_vline = false;


### PR DESCRIPTION
### What

Fix a minor visual glitch due to [`clip_rect_margin`](https://docs.rs/egui/latest/egui/style/struct.Visuals.html#structfield.clip_rect_margin)'s default value of 3.0px. 

Before:
<img width="271" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/e0596797-8907-4e3e-8706-db0490768f01">

After:

<img width="273" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/3f77f3b2-2cb2-454e-9366-f6ae9ea1e438">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4357) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4357)
- [Docs preview](https://rerun.io/preview/267953d399716d700c978a6db7c183f7d45e94d9/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/267953d399716d700c978a6db7c183f7d45e94d9/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)