### PR TITLE
Fix release assets auto-sync

### DIFF
--- a/.github/workflows/on_gh_release.yml
+++ b/.github/workflows/on_gh_release.yml
@@ -11,6 +11,7 @@ concurrency:
 permissions:
   # required for updating the release
   contents: write
+  id-token: write
 
 jobs:
   sync-release-assets:
@@ -20,3 +21,4 @@ jobs:
       CONCURRENCY: "${{ github.event.release.tag_name }}"
       RELEASE_VERSION: "${{ github.event.release.tag_name }}"
     secrets: inherit
+


### PR DESCRIPTION
### What

- Added `id-token: write` permission to the workflow triggered by the GitHub release

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/{{ pr.number }}) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
