### PR TITLE
Plot legend visibility and position control (part 1): route `EntityProperties` to `SpaceViewClass` methods

### DIFF
--- a/crates/re_space_view_bar_chart/src/space_view_class.rs
+++ b/crates/re_space_view_bar_chart/src/space_view_class.rs
@@ -1,4 +1,5 @@
 use egui::util::hash;
+use re_data_store::EntityProperties;
 use re_log_types::EntityPath;
 use re_space_view::controls;
 use re_types::datatypes::TensorBuffer;
@@ -71,6 +72,7 @@ impl SpaceViewClass for BarChartSpaceView {
         _state: &mut Self::State,
         _space_origin: &EntityPath,
         _space_view_id: SpaceViewId,
+        _root_entity_properties: &mut EntityProperties,
     ) {
     }
 
@@ -79,6 +81,7 @@ impl SpaceViewClass for BarChartSpaceView {
         _ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         _state: &mut Self::State,
+        _root_entity_properties: &EntityProperties,
         _view_ctx: &ViewContextCollection,
         parts: &ViewPartCollection,
         _query: &ViewQuery<'_>,

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -1,3 +1,4 @@
+use re_data_store::EntityProperties;
 use re_log_types::EntityPath;
 use re_viewer_context::{
     AutoSpawnHeuristic, PerSystemEntities, SpaceViewClass, SpaceViewClassRegistryError,
@@ -134,6 +135,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
         state: &mut Self::State,
         space_origin: &EntityPath,
         _space_view_id: SpaceViewId,
+        _root_entity_properties: &mut EntityProperties,
     ) {
         state.selection_ui(ctx, ui, space_origin, SpatialSpaceViewKind::TwoD);
     }
@@ -143,6 +145,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
+        _root_entity_properties: &EntityProperties,
         view_ctx: &ViewContextCollection,
         parts: &ViewPartCollection,
         query: &ViewQuery<'_>,

--- a/crates/re_space_view_spatial/src/space_view_3d.rs
+++ b/crates/re_space_view_spatial/src/space_view_3d.rs
@@ -1,3 +1,4 @@
+use re_data_store::EntityProperties;
 use re_log_types::EntityPath;
 use re_viewer_context::{
     AutoSpawnHeuristic, NamedViewSystem as _, PerSystemEntities, SpaceViewClass,
@@ -109,6 +110,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
         state: &mut Self::State,
         space_origin: &EntityPath,
         _space_view_id: SpaceViewId,
+        _root_entity_properties: &mut EntityProperties,
     ) {
         state.selection_ui(ctx, ui, space_origin, SpatialSpaceViewKind::ThreeD);
     }
@@ -118,6 +120,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
+        _root_entity_properties: &EntityProperties,
         view_ctx: &ViewContextCollection,
         parts: &ViewPartCollection,
         query: &ViewQuery<'_>,

--- a/crates/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/re_space_view_tensor/src/space_view_class.rs
@@ -2,6 +2,7 @@ use std::{collections::BTreeMap, fmt::Display};
 
 use egui::{epaint::TextShape, Align2, NumExt as _, Vec2};
 use ndarray::Axis;
+use re_data_store::EntityProperties;
 
 use re_data_ui::tensor_summary_ui_grid_contents;
 use re_log_types::{EntityPath, RowId};
@@ -169,6 +170,7 @@ impl SpaceViewClass for TensorSpaceView {
         state: &mut Self::State,
         _space_origin: &EntityPath,
         _space_view_id: SpaceViewId,
+        _root_entity_properties: &mut EntityProperties,
     ) {
         if let Some(selected_tensor) = &state.selected_tensor {
             if let Some(state_tensor) = state.state_tensors.get_mut(selected_tensor) {
@@ -182,6 +184,7 @@ impl SpaceViewClass for TensorSpaceView {
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
+        _root_entity_properties: &EntityProperties,
         _view_ctx: &ViewContextCollection,
         parts: &ViewPartCollection,
         _query: &ViewQuery<'_>,

--- a/crates/re_space_view_text_document/src/space_view_class.rs
+++ b/crates/re_space_view_text_document/src/space_view_class.rs
@@ -1,5 +1,6 @@
 use egui::Label;
 
+use re_viewer_context::external::re_data_store::EntityProperties;
 use re_viewer_context::{
     external::re_log_types::EntityPath, SpaceViewClass, SpaceViewClassName,
     SpaceViewClassRegistryError, SpaceViewId, SpaceViewState, SpaceViewSystemExecutionError,
@@ -78,6 +79,7 @@ impl SpaceViewClass for TextDocumentSpaceView {
         state: &mut Self::State,
         _space_origin: &EntityPath,
         _space_view_id: SpaceViewId,
+        _root_entity_properties: &mut EntityProperties,
     ) {
         ctx.re_ui.selection_grid(ui, "text_config").show(ui, |ui| {
             ctx.re_ui.grid_left_hand_label(ui, "Text style");
@@ -97,6 +99,7 @@ impl SpaceViewClass for TextDocumentSpaceView {
         _ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
+        _root_entity_properties: &EntityProperties,
         _view_ctx: &ViewContextCollection,
         parts: &ViewPartCollection,
         _query: &ViewQuery<'_>,

--- a/crates/re_space_view_text_log/src/space_view_class.rs
+++ b/crates/re_space_view_text_log/src/space_view_class.rs
@@ -1,3 +1,4 @@
+use re_data_store::EntityProperties;
 use std::collections::BTreeMap;
 
 use re_data_ui::item_ui;
@@ -89,6 +90,7 @@ impl SpaceViewClass for TextSpaceView {
         state: &mut Self::State,
         _space_origin: &EntityPath,
         _space_view_id: SpaceViewId,
+        _root_entity_properties: &mut EntityProperties,
     ) {
         let ViewTextFilters {
             col_timelines,
@@ -134,6 +136,7 @@ impl SpaceViewClass for TextSpaceView {
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
+        _root_entity_properties: &EntityProperties,
         _view_ctx: &ViewContextCollection,
         parts: &ViewPartCollection,
         _query: &ViewQuery<'_>,

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -4,6 +4,7 @@ use re_arrow_store::TimeType;
 use re_format::next_grid_tick_magnitude_ns;
 use re_log_types::{EntityPath, TimeZone};
 use re_space_view::controls;
+use re_viewer_context::external::re_data_store::EntityProperties;
 use re_viewer_context::{
     SpaceViewClass, SpaceViewClassName, SpaceViewClassRegistryError, SpaceViewId, SpaceViewState,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewPartCollection, ViewQuery,
@@ -97,6 +98,7 @@ impl SpaceViewClass for TimeSeriesSpaceView {
         _state: &mut Self::State,
         _space_origin: &EntityPath,
         _space_view_id: SpaceViewId,
+        _root_entity_properties: &mut EntityProperties,
     ) {
     }
 
@@ -105,6 +107,7 @@ impl SpaceViewClass for TimeSeriesSpaceView {
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
+        _root_entity_properties: &EntityProperties,
         _view_ctx: &ViewContextCollection,
         parts: &ViewPartCollection,
         _query: &ViewQuery<'_>,

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -446,6 +446,7 @@ fn blueprint_ui(
                         space_view_state,
                         &space_view.space_origin,
                         space_view.id,
+                        &mut props,
                     );
 
                 visible_history_ui(

--- a/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
@@ -1,4 +1,4 @@
-use re_data_store::EntityPropertyMap;
+use re_data_store::{EntityProperties, EntityPropertyMap};
 use re_log_types::EntityPath;
 use re_types::ComponentName;
 
@@ -114,6 +114,7 @@ pub trait DynSpaceViewClass {
         state: &mut dyn SpaceViewState,
         space_origin: &EntityPath,
         space_view_id: SpaceViewId,
+        root_entity_properties: &mut EntityProperties,
     );
 
     /// Draws the ui for this space view type and handles ui events.
@@ -124,6 +125,7 @@ pub trait DynSpaceViewClass {
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut dyn SpaceViewState,
+        root_entity_properties: &EntityProperties,
         systems: &SpaceViewSystemRegistry,
         query: &ViewQuery<'_>,
     );

--- a/crates/re_viewer_context/src/space_view/space_view_class_placeholder.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class_placeholder.rs
@@ -2,6 +2,7 @@ use crate::{
     SpaceViewClass, SpaceViewClassName, SpaceViewClassRegistryError, SpaceViewSystemExecutionError,
     SpaceViewSystemRegistry, ViewContextCollection, ViewPartCollection, ViewQuery, ViewerContext,
 };
+use re_data_store::EntityProperties;
 
 /// A placeholder space view class that can be used when the actual class is not registered.
 #[derive(Default)]
@@ -40,6 +41,7 @@ impl SpaceViewClass for SpaceViewClassPlaceholder {
         _state: &mut (),
         _space_origin: &re_log_types::EntityPath,
         _space_view_id: crate::SpaceViewId,
+        _root_entity_properties: &mut EntityProperties,
     ) {
     }
 
@@ -48,6 +50,7 @@ impl SpaceViewClass for SpaceViewClassPlaceholder {
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         _state: &mut Self::State,
+        _root_entity_properties: &EntityProperties,
         _view_ctx: &ViewContextCollection,
         _parts: &ViewPartCollection,
         _query: &ViewQuery<'_>,

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -268,8 +268,14 @@ impl SpaceViewBlueprint {
             highlights,
         };
 
+        let root_data_result = self.root_data_result(ctx.store_context);
+        let props = root_data_result
+            .individual_properties
+            .clone()
+            .unwrap_or_default();
+
         ui.scope(|ui| {
-            class.ui(ctx, ui, view_state, system_registry, &query);
+            class.ui(ctx, ui, view_state, &props, system_registry, &query);
         });
     }
 

--- a/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
@@ -1,3 +1,4 @@
+use re_viewer::external::re_data_store::EntityProperties;
 use re_viewer::external::{
     egui,
     re_data_store::InstancePath,
@@ -108,6 +109,7 @@ impl SpaceViewClass for ColorCoordinatesSpaceView {
         state: &mut Self::State,
         _space_origin: &EntityPath,
         _space_view_id: SpaceViewId,
+        _root_entity_properties: &mut EntityProperties,
     ) {
         ui.horizontal(|ui| {
             ui.label("Coordinates mode");
@@ -132,6 +134,7 @@ impl SpaceViewClass for ColorCoordinatesSpaceView {
         ctx: &mut ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
+        _root_entity_properties: &EntityProperties,
         _view_ctx: &ViewContextCollection,
         parts: &ViewPartCollection,
         query: &ViewQuery<'_>,


### PR DESCRIPTION
### What

This PR routes the per-space-view, root `EntityProperties` to `SpaceViewClass`'s `selection_ui()` and `ui()` methods. Note that although `EntityProperties` are soon to be replaced by bespoke components, this data path way will remain.

* Prep for https://github.com/rerun-io/rerun/issues/2049

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4363) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4363)
- [Docs preview](https://rerun.io/preview/bec0a99df08ea8d7e1e2dee9d2ef493ee6af96c2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bec0a99df08ea8d7e1e2dee9d2ef493ee6af96c2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)