### PR TITLE
Plot legend visibility and position control (part 2): minor UI spacing improvement

### DIFF
--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -438,6 +438,8 @@ fn blueprint_ui(
                     .clone()
                     .unwrap_or(resolved_entity_props.clone());
 
+                let cursor = ui.cursor();
+
                 space_view
                     .class(ctx.space_view_class_registry)
                     .selection_ui(
@@ -448,6 +450,12 @@ fn blueprint_ui(
                         space_view.id,
                         &mut props,
                     );
+
+                if cursor != ui.cursor() {
+                    // add some space if something was rendered by selection_ui
+                    //TODO(ab): use design token
+                    ui.add_space(16.0);
+                }
 
                 visible_history_ui(
                     ctx,


### PR DESCRIPTION
### What

This PR introduce a very minor Selection Panel UI fix where space was missing between the per-space-view blueprint UI and the Visible Time Range UI.

<img width="412" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/f5b2b3cf-a099-4746-864f-ff24cf610b31">


* Prep for https://github.com/rerun-io/rerun/issues/2049

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4364) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4364)
- [Docs preview](https://rerun.io/preview/e082a082518e9e1b70f34e1ade38dafde06e260f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e082a082518e9e1b70f34e1ade38dafde06e260f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)