### PR TITLE
Reset accumulated bounding box when resetting camera

### DIFF
--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -167,6 +167,7 @@ impl SpatialSpaceViewState {
                         "Resets camera position & orientation.\nYou can also double-click the 3D view.")
                         .clicked()
                     {
+                        self.scene_bbox_accum = self.scene_bbox;
                         self.state_3d.reset_camera(&self.scene_bbox_accum, &view_coordinates);
                     }
                     let mut spin = self.state_3d.spin();

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -468,6 +468,7 @@ pub fn view_3d(
         }
         // Without hovering, resets the camera.
         else {
+            state.scene_bbox_accum = state.scene_bbox;
             state
                 .state_3d
                 .reset_camera(&state.scene_bbox_accum, &view_coordinates);


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/3750

Initial testing of this feels like a much improved user experience.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4369) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4369)
- [Docs preview](https://rerun.io/preview/fc6d5426727628223150d4675d4d6c4f6bc59f27/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/fc6d5426727628223150d4675d4d6c4f6bc59f27/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)