### PR TITLE
Improve component data table UI in the selection panel

### DIFF
--- a/crates/re_data_ui/src/component.rs
+++ b/crates/re_data_ui/src/component.rs
@@ -97,13 +97,28 @@ impl DataUi for EntityComponentWithInstances {
                 re_format::format_number(num_instances)
             ));
         } else {
-            egui_extras::TableBuilder::new(ui)
+            let mut table = egui_extras::TableBuilder::new(ui)
                 .resizable(false)
-                .vscroll(true)
-                .auto_shrink([true, true])
-                .max_scroll_height(100.0)
                 .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-                .columns(egui_extras::Column::auto(), 2)
+                .columns(egui_extras::Column::auto(), 2);
+
+            if verbosity == UiVerbosity::All {
+                // Use full width in the selection panel.
+                table = table.auto_shrink([false, true]);
+            } else {
+                // Be as small as possible in the hover tooltips.
+                table = table.auto_shrink([true, true]);
+            }
+
+            if verbosity == UiVerbosity::All && ctx.selection().len() <= 1 {
+                // We're alone in the selection panel. Let the outer ScrollArea do the work.
+                table = table.vscroll(false);
+            } else {
+                // Don't take too much vertical space to leave room for other selected items.
+                table = table.vscroll(true).max_scroll_height(100.0);
+            }
+
+            table
                 .header(re_ui::ReUi::table_header_height(), |mut header| {
                     re_ui::ReUi::setup_table_header(&mut header);
                     header.col(|ui| {


### PR DESCRIPTION
### What

Improve the UI of component data tables in the selection panel. The behaviour now depends on how many items are selected. If only one is selected, the table expends to the max and relies on the selection panel's `ScrollArea`.

* Fixes https://github.com/rerun-io/rerun/issues/3228

### Screenshots

Single selection:

<img width="376" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/54eb33b7-21f0-4858-9030-f91ea3df1b53">

Multiple selections:

<img width="384" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/d872c788-4bba-4ed2-b1cf-1566198fe05c">

Hover tooltip are still compact:

<img width="197" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/55e9217a-c9e4-41b0-8d26-96f35c6a24f3">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4370) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4370)
- [Docs preview](https://rerun.io/preview/e51649c650146ac58f3d8df776e242b86ceb5849/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e51649c650146ac58f3d8df776e242b86ceb5849/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)