### PR TITLE
Add optional color component to BarChart archetype

### DIFF
--- a/crates/re_space_view_bar_chart/src/space_view_class.rs
+++ b/crates/re_space_view_bar_chart/src/space_view_class.rs
@@ -102,8 +102,10 @@ impl SpaceViewClass for BarChartSpaceView {
                     fn create_bar_chart<N: Into<f64>>(
                         ent_path: &EntityPath,
                         values: impl Iterator<Item = N>,
+                        color: &Option<re_types::components::Color>,
                     ) -> BarChart {
-                        let color = auto_color(hash(ent_path) as _);
+                        let color = color
+                            .map_or_else(|| auto_color(hash(ent_path) as _), |color| color.into());
                         let fill = color.gamma_multiply(0.75).additive(); // make sure overlapping bars are obvious
                         BarChart::new(
                             values
@@ -121,40 +123,44 @@ impl SpaceViewClass for BarChartSpaceView {
                         .color(color)
                     }
 
-                    for (ent_path, tensor) in charts {
+                    for (ent_path, (tensor, color)) in charts {
                         let chart = match &tensor.buffer {
                             TensorBuffer::U8(data) => {
-                                create_bar_chart(ent_path, data.iter().copied())
+                                create_bar_chart(ent_path, data.iter().copied(), color)
                             }
                             TensorBuffer::U16(data) => {
-                                create_bar_chart(ent_path, data.iter().copied())
+                                create_bar_chart(ent_path, data.iter().copied(), color)
                             }
                             TensorBuffer::U32(data) => {
-                                create_bar_chart(ent_path, data.iter().copied())
+                                create_bar_chart(ent_path, data.iter().copied(), color)
                             }
-                            TensorBuffer::U64(data) => {
-                                create_bar_chart(ent_path, data.iter().copied().map(|v| v as f64))
-                            }
+                            TensorBuffer::U64(data) => create_bar_chart(
+                                ent_path,
+                                data.iter().copied().map(|v| v as f64),
+                                color,
+                            ),
                             TensorBuffer::I8(data) => {
-                                create_bar_chart(ent_path, data.iter().copied())
+                                create_bar_chart(ent_path, data.iter().copied(), color)
                             }
                             TensorBuffer::I16(data) => {
-                                create_bar_chart(ent_path, data.iter().copied())
+                                create_bar_chart(ent_path, data.iter().copied(), color)
                             }
                             TensorBuffer::I32(data) => {
-                                create_bar_chart(ent_path, data.iter().copied())
+                                create_bar_chart(ent_path, data.iter().copied(), color)
                             }
-                            TensorBuffer::I64(data) => {
-                                create_bar_chart(ent_path, data.iter().copied().map(|v| v as f64))
-                            }
+                            TensorBuffer::I64(data) => create_bar_chart(
+                                ent_path,
+                                data.iter().copied().map(|v| v as f64),
+                                color,
+                            ),
                             TensorBuffer::F16(data) => {
-                                create_bar_chart(ent_path, data.iter().map(|f| f.to_f32()))
+                                create_bar_chart(ent_path, data.iter().map(|f| f.to_f32()), color)
                             }
                             TensorBuffer::F32(data) => {
-                                create_bar_chart(ent_path, data.iter().copied())
+                                create_bar_chart(ent_path, data.iter().copied(), color)
                             }
                             TensorBuffer::F64(data) => {
-                                create_bar_chart(ent_path, data.iter().copied())
+                                create_bar_chart(ent_path, data.iter().copied(), color)
                             }
                             TensorBuffer::Jpeg(_) => {
                                 re_log::warn_once!(

--- a/crates/re_space_view_bar_chart/src/view_part_system.rs
+++ b/crates/re_space_view_bar_chart/src/view_part_system.rs
@@ -4,6 +4,7 @@ use re_arrow_store::LatestAtQuery;
 use re_data_store::EntityPath;
 use re_types::{
     archetypes::{BarChart, Tensor},
+    components::Color,
     datatypes::TensorData,
     Archetype, ComponentNameSet,
 };
@@ -15,7 +16,7 @@ use re_viewer_context::{
 /// A bar chart system, with everything needed to render it.
 #[derive(Default)]
 pub struct BarChartViewPartSystem {
-    pub charts: BTreeMap<EntityPath, TensorData>,
+    pub charts: BTreeMap<EntityPath, (TensorData, Option<Color>)>,
 }
 
 impl NamedViewSystem for BarChartViewPartSystem {
@@ -82,10 +83,17 @@ impl ViewPartSystem for BarChartViewPartSystem {
                 &query,
             );
 
+            let color = store.query_latest_component::<re_types::components::Color>(
+                &data_result.entity_path,
+                &query,
+            );
+
             if let Some(tensor) = tensor {
                 if tensor.is_vector() {
-                    self.charts
-                        .insert(data_result.entity_path.clone(), tensor.value.0.clone());
+                    self.charts.insert(
+                        data_result.entity_path.clone(),
+                        (tensor.value.0.clone(), color.map(|c| c.value)),
+                    );
                     // shallow clones
                 }
             }

--- a/crates/re_types/definitions/rerun/archetypes/bar_chart.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/bar_chart.fbs
@@ -18,4 +18,9 @@ table BarChart (
 
   /// The values. Should always be a rank-1 tensor.
   values: rerun.components.TensorData ("attr.rerun.component_required", required, order: 1000);
+
+  // --- Optional ---
+
+  /// The color of the bar chart
+  color: rerun.components.Color ("attr.rerun.component_optional", nullable, order: 2000);
 }

--- a/docs/content/reference/types/archetypes/bar_chart.md
+++ b/docs/content/reference/types/archetypes/bar_chart.md
@@ -10,6 +10,8 @@ The x values will be the indices of the array, and the bar heights will be the p
 
 **Required**: [`TensorData`](../components/tensor_data.md)
 
+**Optional**: [`Color`](../components/color.md)
+
 ## Links
  * 🌊 [C++ API docs for `BarChart`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1BarChart.html)
  * 🐍 [Python API docs for `BarChart`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.BarChart)

--- a/docs/content/reference/types/components/color.md
+++ b/docs/content/reference/types/components/color.md
@@ -20,6 +20,7 @@ byte is `R` and the least significant byte is `A`.
 ## Used by
 
 * [`Arrows3D`](../archetypes/arrows3d.md)
+* [`BarChart`](../archetypes/bar_chart.md)
 * [`Boxes2D`](../archetypes/boxes2d.md)
 * [`Boxes3D`](../archetypes/boxes3d.md)
 * [`LineStrips2D`](../archetypes/line_strips2d.md)

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
@@ -14,10 +14,15 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<DataCell> cells;
-        cells.reserve(2);
+        cells.reserve(3);
 
         {
             auto result = DataCell::from_loggable(archetype.values);
+            RR_RETURN_NOT_OK(result.error);
+            cells.push_back(std::move(result.value));
+        }
+        if (archetype.color.has_value()) {
+            auto result = DataCell::from_loggable(archetype.color.value());
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -4,12 +4,15 @@
 #pragma once
 
 #include "../collection.hpp"
+#include "../compiler_utils.hpp"
+#include "../components/color.hpp"
 #include "../components/tensor_data.hpp"
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -36,6 +39,9 @@ namespace rerun::archetypes {
     struct BarChart {
         /// The values. Should always be a rank-1 tensor.
         rerun::components::TensorData values;
+
+        /// The color of the bar chart
+        std::optional<rerun::components::Color> color;
 
       public:
         static constexpr const char IndicatorComponentName[] = "rerun.components.BarChartIndicator";
@@ -161,6 +167,13 @@ namespace rerun::archetypes {
         BarChart(BarChart&& other) = default;
 
         explicit BarChart(rerun::components::TensorData _values) : values(std::move(_values)) {}
+
+        /// The color of the bar chart
+        BarChart with_color(rerun::components::Color _color) && {
+            color = std::move(_color);
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RERUN_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
 
         /// Returns the number of primary instances of this archetype.
         size_t num_instances() const {

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -44,7 +44,7 @@ class BarChart(BarChartExt, Archetype):
     </center>
     """
 
-    def __init__(self: Any, values: datatypes.TensorDataLike):
+    def __init__(self: Any, values: datatypes.TensorDataLike, *, color: datatypes.Rgba32Like | None = None):
         """
         Create a new instance of the BarChart archetype.
 
@@ -52,11 +52,13 @@ class BarChart(BarChartExt, Archetype):
         ----------
         values:
             The values. Should always be a rank-1 tensor.
+        color:
+            The color of the bar chart
         """
 
         # You can define your own __init__ function as a member of BarChartExt in bar_chart_ext.py
         with catch_and_log_exceptions(context=self.__class__.__name__):
-            self.__attrs_init__(values=values)
+            self.__attrs_init__(values=values, color=color)
             return
         self.__attrs_clear__()
 
@@ -64,6 +66,7 @@ class BarChart(BarChartExt, Archetype):
         """Convenience method for calling `__attrs_init__` with all `None`s."""
         self.__attrs_init__(
             values=None,  # type: ignore[arg-type]
+            color=None,  # type: ignore[arg-type]
         )
 
     @classmethod
@@ -78,6 +81,15 @@ class BarChart(BarChartExt, Archetype):
         converter=BarChartExt.values__field_converter_override,  # type: ignore[misc]
     )
     # The values. Should always be a rank-1 tensor.
+    #
+    # (Docstring intentionally commented out to hide this field from the docs)
+
+    color: components.ColorBatch | None = field(
+        metadata={"component": "optional"},
+        default=None,
+        converter=components.ColorBatch._optional,  # type: ignore[misc]
+    )
+    # The color of the bar chart
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/1355

```
"""Create and log a bar chart."""

import rerun as rr

rr.init("rerun_example_bar_chart", spawn=True)
rr.log("bar_chart", rr.BarChart([8, 4, 0, 9, 1, 4, 1, 6, 9, 0], color=(255, 0, 0)))
```

![image](https://github.com/rerun-io/rerun/assets/3312232/6af1ad96-0683-401c-ac82-3f7cf0ade57d)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4372) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4372)
- [Docs preview](https://rerun.io/preview/44d44da7cf0e5ce66a48273fdcd24695bf965331/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/44d44da7cf0e5ce66a48273fdcd24695bf965331/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)