### PR TITLE
fast_lint.py: Always run the full mypy lint

### DIFF
--- a/scripts/fast_lint.py
+++ b/scripts/fast_lint.py
@@ -151,7 +151,9 @@ def main() -> None:
         ),
         LintJob("lint-py-fmt-check", extensions=[".py"], no_filter_args=PY_FOLDERS),
         LintJob("lint-py-blackdoc", extensions=[".py"], no_filter_args=PY_FOLDERS),
-        LintJob("lint-py-mypy", extensions=[".py"]),
+        # Even though mypy will accept a list of files, the results it generates are inconsistent
+        # with running on the full project.
+        LintJob("lint-py-mypy", extensions=[".py"], accepts_files=False),
         LintJob("lint-py-ruff", extensions=[".py"], no_filter_args=PY_FOLDERS),
         LintJob("lint-taplo", extensions=[".toml"]),
         LintJob("lint-typos"),


### PR DESCRIPTION
### What
Avoids annoying false-positives like:
```
fast-lint(INFO): FAIL: lint-py-mypy in 10.79s 
----------
pixi run lint-py-mypy rerun_py/rerun_sdk/rerun/blueprint/space_view_component.py rerun_py/rerun_sdk/rerun/datatypes/__init__.py rerun_py/rerun_sdk/rerun/datatypes/entity_path.py rerun_py/rerun_sdk/rerun/datatypes/uuid.py
rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py:87: error: Cannot determine type of "__repr__"  [has-type]
rerun_py/rerun_sdk/rerun/archetypes/transform3d.py:84: error: Cannot determine type of "__repr__"  [has-type]
rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py:206: error: Cannot determine type of "__repr__"  [has-type]
rerun_py/rerun_sdk/rerun/archetypes/text_log.py:125: error: Cannot determine type of "__repr__"  [has-type]
rerun_py/rerun_sdk/rerun/archetypes/text_document.py:151: error: Cannot determine type of "__repr__"  [has-type]
rerun_py/rerun_sdk/rerun/archetypes/tensor.py:71: error: Cannot determine type of "__repr__"  [has-type]
rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py:117: error: Cannot determine type of "__repr__"  [has-type]
rerun_py/rerun_sdk/rerun/archetypes/points3d.py:145: error: Cannot determine type of "__repr__"  [has-type]
rerun_py/rerun_sdk/rerun/archetypes/points2d.py:160: error: Cannot determine type of "__repr__"  [has-type]
rerun_py/rerun_sdk/rerun/archetypes/pinhole.py:124: error: Cannot determine type of "__repr__"  [has-type]
rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py:144: error: Cannot determine type of "__repr__"  [has-type]
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4376) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4376)
- [Docs preview](https://rerun.io/preview/47d697884d779fe60ddf4d30b673dd110e3abc6f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/47d697884d779fe60ddf4d30b673dd110e3abc6f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)