### PR TITLE
Add support for exclusion expressions to the DataQueryBlueprint

### DIFF
--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -478,43 +478,49 @@ mod tests {
             all_recordings: vec![],
         };
 
-        let scenarios: Vec<(Vec<&str>, Vec<&str>, Vec<&str>)> = vec![
-            (
-                vec!["/"],
-                vec![],
-                vec![
+        struct Scenario {
+            inclusions: Vec<&'static str>,
+            exclusions: Vec<&'static str>,
+            outputs: Vec<&'static str>,
+        }
+
+        let scenarios: Vec<Scenario> = vec![
+            Scenario {
+                inclusions: vec!["/"],
+                exclusions: vec![],
+                outputs: vec![
                     "/",
                     "parent/",
                     "parent",
                     "parent/skipped/", // Not an exact match and not found in tree
                     "parent/skipped/child1", // Only child 1 has ViewParts
                 ],
-            ),
-            (
-                vec!["parent/skipped/"],
-                vec![],
-                vec![
+            },
+            Scenario {
+                inclusions: vec!["parent/skipped/"],
+                exclusions: vec![],
+                outputs: vec![
                     "/",
                     "parent/",               // Only included because is a prefix
                     "parent/skipped/",       // Not an exact match and not found in tree
                     "parent/skipped/child1", // Only child 1 has ViewParts
                 ],
-            ),
-            (
-                vec!["parent", "parent/skipped/child2"],
-                vec![],
-                vec![
+            },
+            Scenario {
+                inclusions: vec!["parent", "parent/skipped/child2"],
+                exclusions: vec![],
+                outputs: vec![
                     "/", // Trivial intermediate group -- could be collapsed
                     "parent/",
                     "parent",
                     "parent/skipped/", // Trivial intermediate group -- could be collapsed
                     "parent/skipped/child2",
                 ],
-            ),
-            (
-                vec!["parent/skipped", "parent/skipped/child2", "parent/"],
-                vec![],
-                vec![
+            },
+            Scenario {
+                inclusions: vec!["parent/skipped", "parent/skipped/child2", "parent/"],
+                exclusions: vec![],
+                outputs: vec![
                     "/",
                     "parent/",
                     "parent",
@@ -523,11 +529,11 @@ mod tests {
                     "parent/skipped/child1", // Included because an exact match
                     "parent/skipped/child2",
                 ],
-            ),
-            (
-                vec!["parent/skipped", "parent/skipped/child2", "parent/"],
-                vec!["parent"],
-                vec![
+            },
+            Scenario {
+                inclusions: vec!["parent/skipped", "parent/skipped/child2", "parent/"],
+                exclusions: vec!["parent"],
+                outputs: vec![
                     "/",
                     "parent/", // Parent leaf has been excluded
                     "parent/skipped/",
@@ -535,34 +541,39 @@ mod tests {
                     "parent/skipped/child1", // Included because an exact match
                     "parent/skipped/child2",
                 ],
-            ),
-            (
-                vec!["parent/"],
-                vec!["parent/skipped/"],
-                vec!["/", "parent"], // None of the children are hit since excluded
-            ),
-            (
-                vec!["parent/", "parent/skipped/child2"],
-                vec!["parent/skipped/child1"],
-                vec![
+            },
+            Scenario {
+                inclusions: vec!["parent/"],
+                exclusions: vec!["parent/skipped/"],
+                outputs: vec!["/", "parent"], // None of the children are hit since excluded
+            },
+            Scenario {
+                inclusions: vec!["parent/", "parent/skipped/child2"],
+                exclusions: vec!["parent/skipped/child1"],
+                outputs: vec![
                     "/",
                     "parent/",
                     "parent",
                     "parent/skipped/",
                     "parent/skipped/child2", // No child1 since skipped.
                 ],
-            ),
-            (
-                vec!["not/found"],
-                vec![],
+            },
+            Scenario {
+                inclusions: vec!["not/found"],
+                exclusions: vec![],
                 // TODO(jleibs): Making this work requires merging the EntityTree walk with a minimal-coverage ExactMatchTree walk
                 // not crucial for now until we expose a free-form UI for entering paths.
                 // vec!["/", "not/", "not/found"]),
-                vec![],
-            ),
+                outputs: vec![],
+            },
         ];
 
-        for (inclusions, exclusions, outputs) in scenarios {
+        for Scenario {
+            inclusions,
+            exclusions,
+            outputs,
+        } in scenarios
+        {
             let query = DataQueryBlueprint {
                 id: DataQueryId::random(),
                 space_view_class_name: "3D".into(),

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -50,10 +50,12 @@ impl DataQueryBlueprint {
         Self {
             id: DataQueryId::random(),
             space_view_class_name,
-            expressions: queries_entities
-                .map(|exp| exp.to_string().into())
-                .collect::<Vec<_>>()
-                .into(),
+            expressions: QueryExpressions {
+                inclusions: queries_entities
+                    .map(|exp| exp.to_string().into())
+                    .collect::<Vec<_>>(),
+                exclusions: vec![],
+            },
         }
     }
 
@@ -154,7 +156,7 @@ impl<'a> QueryExpressionEvaluator<'a> {
     ) -> Self {
         let expressions: Vec<EntityPathExpr> = blueprint
             .expressions
-            .expressions
+            .inclusions
             .iter()
             .filter(|exp| !exp.as_str().is_empty())
             .map(|exp| EntityPathExpr::from(exp.as_str()))
@@ -505,11 +507,10 @@ mod tests {
             let query = DataQueryBlueprint {
                 id: DataQueryId::random(),
                 space_view_class_name: "3D".into(),
-                expressions: input
-                    .into_iter()
-                    .map(|s| s.into())
-                    .collect::<Vec<_>>()
-                    .into(),
+                expressions: QueryExpressions {
+                    inclusions: input.into_iter().map(|s| s.into()).collect::<Vec<_>>(),
+                    exclusions: vec![],
+                },
             };
 
             let query_result = query.execute_query(&resolver, &ctx, &entities_per_system_per_class);

--- a/crates/re_types/definitions/rerun/blueprint/query_expressions.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/query_expressions.fbs
@@ -16,6 +16,9 @@ table QueryExpressions (
   "attr.rust.derive": "PartialEq, Eq",
   "attr.rust.override_crate": "re_space_view"
 ) {
-  /// A set of strings that can be parsed as `EntityPathExpression`s.
-  expressions: [string] (order: 100);
+  /// A set of strings representing `EntityPathExpression`s to be included.
+  inclusions: [string] (order: 100);
+
+  /// A set of strings representing `EntityPathExpression`s to be excluded.
+  exclusions: [string] (order: 200);
 }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -417,17 +417,22 @@ fn blueprint_ui(
 
             if let Some(space_view) = viewport.blueprint.space_view(space_view_id) {
                 if let Some(query) = space_view.queries.first() {
-                    let expressions = query.expressions.inclusions.join("\n");
-                    let mut edited_expressions = expressions.clone();
+                    let inclusions = query.expressions.inclusions.join("\n");
+                    let mut edited_inclusions = inclusions.clone();
+                    let exclusions = query.expressions.exclusions.join("\n");
+                    let mut edited_exclusions = exclusions.clone();
 
-                    ui.text_edit_multiline(&mut edited_expressions);
+                    ui.label("Inclusion expressions");
+                    ui.text_edit_multiline(&mut edited_inclusions);
+                    ui.label("Exclusion expressions");
+                    ui.text_edit_multiline(&mut edited_exclusions);
 
-                    if edited_expressions != expressions {
+                    if edited_inclusions != inclusions || edited_exclusions != exclusions {
                         let timepoint = TimePoint::timeless();
 
                         let expressions_component = QueryExpressions {
-                            inclusions: edited_expressions.split('\n').map(|s| s.into()).collect(),
-                            exclusions: vec![],
+                            inclusions: edited_inclusions.split('\n').map(|s| s.into()).collect(),
+                            exclusions: edited_exclusions.split('\n').map(|s| s.into()).collect(),
                         };
 
                         let row = DataRow::from_cells1_sized(

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -417,7 +417,7 @@ fn blueprint_ui(
 
             if let Some(space_view) = viewport.blueprint.space_view(space_view_id) {
                 if let Some(query) = space_view.queries.first() {
-                    let expressions = query.expressions.expressions.join("\n");
+                    let expressions = query.expressions.inclusions.join("\n");
                     let mut edited_expressions = expressions.clone();
 
                     ui.text_edit_multiline(&mut edited_expressions);
@@ -426,7 +426,8 @@ fn blueprint_ui(
                         let timepoint = TimePoint::timeless();
 
                         let expressions_component = QueryExpressions {
-                            expressions: edited_expressions.split('\n').map(|s| s.into()).collect(),
+                            inclusions: edited_expressions.split('\n').map(|s| s.into()).collect(),
+                            exclusions: vec![],
                         };
 
                         let row = DataRow::from_cells1_sized(

--- a/rerun_cpp/src/rerun/blueprint/query_expressions.cpp
+++ b/rerun_cpp/src/rerun/blueprint/query_expressions.cpp
@@ -13,7 +13,12 @@ namespace rerun {
     ) {
         static const auto datatype = arrow::struct_({
             arrow::field(
-                "expressions",
+                "inclusions",
+                arrow::list(arrow::field("item", arrow::utf8(), false)),
+                false
+            ),
+            arrow::field(
+                "exclusions",
                 arrow::list(arrow::field("item", arrow::utf8(), false)),
                 false
             ),
@@ -44,8 +49,22 @@ namespace rerun {
             for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
                 const auto& element = elements[elem_idx];
                 ARROW_RETURN_NOT_OK(field_builder->Append());
-                for (size_t item_idx = 0; item_idx < element.expressions.size(); item_idx += 1) {
-                    ARROW_RETURN_NOT_OK(value_builder->Append(element.expressions[item_idx]));
+                for (size_t item_idx = 0; item_idx < element.inclusions.size(); item_idx += 1) {
+                    ARROW_RETURN_NOT_OK(value_builder->Append(element.inclusions[item_idx]));
+                }
+            }
+        }
+        {
+            auto field_builder = static_cast<arrow::ListBuilder*>(builder->field_builder(1));
+            auto value_builder = static_cast<arrow::StringBuilder*>(field_builder->value_builder());
+            ARROW_RETURN_NOT_OK(field_builder->Reserve(static_cast<int64_t>(num_elements)));
+            ARROW_RETURN_NOT_OK(value_builder->Reserve(static_cast<int64_t>(num_elements * 2)));
+
+            for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                const auto& element = elements[elem_idx];
+                ARROW_RETURN_NOT_OK(field_builder->Append());
+                for (size_t item_idx = 0; item_idx < element.exclusions.size(); item_idx += 1) {
+                    ARROW_RETURN_NOT_OK(value_builder->Append(element.exclusions[item_idx]));
                 }
             }
         }

--- a/rerun_cpp/src/rerun/blueprint/query_expressions.hpp
+++ b/rerun_cpp/src/rerun/blueprint/query_expressions.hpp
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <utility>
 
 namespace arrow {
     class Array;
@@ -22,19 +21,14 @@ namespace rerun::blueprint {
     ///
     /// Unstable. Used for the ongoing blueprint experimentations.
     struct QueryExpressions {
-        /// A set of strings that can be parsed as `EntityPathExpression`s.
-        rerun::Collection<std::string> expressions;
+        /// A set of strings representing `EntityPathExpression`s to be included.
+        rerun::Collection<std::string> inclusions;
+
+        /// A set of strings representing `EntityPathExpression`s to be excluded.
+        rerun::Collection<std::string> exclusions;
 
       public:
         QueryExpressions() = default;
-
-        QueryExpressions(rerun::Collection<std::string> expressions_)
-            : expressions(std::move(expressions_)) {}
-
-        QueryExpressions& operator=(rerun::Collection<std::string> expressions_) {
-            expressions = std::move(expressions_);
-            return *this;
-        }
     };
 } // namespace rerun::blueprint
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/query_expressions.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/query_expressions.py
@@ -28,21 +28,28 @@ class QueryExpressions:
     Unstable. Used for the ongoing blueprint experimentations.
     """
 
-    def __init__(self: Any, expressions: QueryExpressionsLike):
+    def __init__(self: Any, inclusions: list[str], exclusions: list[str]):
         """
         Create a new instance of the QueryExpressions blueprint.
 
         Parameters
         ----------
-        expressions:
-            A set of strings that can be parsed as `EntityPathExpression`s.
+        inclusions:
+            A set of strings representing `EntityPathExpression`s to be included.
+        exclusions:
+            A set of strings representing `EntityPathExpression`s to be excluded.
         """
 
         # You can define your own __init__ function as a member of QueryExpressionsExt in query_expressions_ext.py
-        self.__attrs_init__(expressions=expressions)
+        self.__attrs_init__(inclusions=inclusions, exclusions=exclusions)
 
-    expressions: list[str] = field()
-    # A set of strings that can be parsed as `EntityPathExpression`s.
+    inclusions: list[str] = field()
+    # A set of strings representing `EntityPathExpression`s to be included.
+    #
+    # (Docstring intentionally commented out to hide this field from the docs)
+
+    exclusions: list[str] = field()
+    # A set of strings representing `EntityPathExpression`s to be excluded.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 


### PR DESCRIPTION
### What
- Part of the https://github.com/rerun-io/rerun/issues/4308 stack:
  - https://github.com/rerun-io/rerun/pull/4310
  - https://github.com/rerun-io/rerun/pull/4311
  - THIS PR: https://github.com/rerun-io/rerun/pull/4380
  - https://github.com/rerun-io/rerun/pull/4381
- Resolves: https://github.com/rerun-io/rerun/issues/4158

The query logic is as follows because it was simple and was sufficient to mostly match our existing add/remove semantics. It basically prioritizes exclusions over inclusions. Anything recursively excluded will be pruned, even if explicitly included. We likely want to change this behavior, but we can do so in a future PR.

Expands the query evaluator to support exclusions, and UI mechanism for editing.
![image](https://github.com/rerun-io/rerun/assets/3312232/e35fba49-bbce-48da-8e29-03d0dbb6d985)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4380) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4380)
- [Docs preview](https://rerun.io/preview/45acbc744dddc65ea6682d5c58755ed27e96db78/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/45acbc744dddc65ea6682d5c58755ed27e96db78/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)