### PR TITLE
Wire the remove-entity buttons to query exclusions

### DIFF
--- a/crates/re_log_types/src/path/entity_path_expr.rs
+++ b/crates/re_log_types/src/path/entity_path_expr.rs
@@ -65,13 +65,14 @@ impl From<&str> for EntityPathExpr {
     #[inline]
     fn from(path: &str) -> Self {
         if let Some(path) = path.strip_suffix('/') {
+            let path = path.trim_start_matches('/');
             if path.is_empty() {
                 Self::Recursive(EntityPath::root())
             } else {
                 Self::Recursive(EntityPath::from(path))
             }
         } else {
-            Self::Exact(EntityPath::from(path))
+            Self::Exact(EntityPath::from(path.trim_start_matches('/')))
         }
     }
 }

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -98,7 +98,7 @@ impl DataQueryBlueprint {
         }
     }
 
-    pub fn remove_entity_expr(&self, ctx: &ViewerContext<'_>, expr: EntityPathExpr) {
+    pub fn add_entity_exclusion(&self, ctx: &ViewerContext<'_>, expr: EntityPathExpr) {
         let mut edited = false;
 
         let mut inclusions: Vec<EntityPathExpr> = self

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -392,6 +392,8 @@ fn blueprint_ui(
     match item {
         Item::SpaceView(space_view_id) => {
             ui.horizontal(|ui| {
+                // TODO(#4377): Don't bother showing add/remove entities dialog since it's broken
+                /*
                 if ui
                     .button("Add/remove Entities")
                     .on_hover_text("Manually add or remove Entities from the Space View")
@@ -400,6 +402,7 @@ fn blueprint_ui(
                     viewport
                         .show_add_remove_entities_window(*space_view_id);
                 }
+                */
 
                 if ui
                     .button("Clone Space View")

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -418,7 +418,7 @@ fn blueprint_ui(
                 }
             });
 
-            if let Some(space_view) = viewport.blueprint.space_view(space_view_id) {
+            if let Some(space_view) = viewport.blueprint.space_view_mut(space_view_id) {
                 if let Some(query) = space_view.queries.first() {
                     let inclusions = query.expressions.inclusions.join("\n");
                     let mut edited_inclusions = inclusions.clone();
@@ -452,6 +452,8 @@ fn blueprint_ui(
                                 ctx.store_context.blueprint.store_id().clone(),
                                 vec![row],
                             ));
+
+                        space_view.entities_determined_by_user = true;
                     }
                 }
             }

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -2,6 +2,7 @@ use ahash::HashSet;
 use re_data_store::{EntityPath, EntityProperties, StoreDb, TimeInt, VisibleHistory};
 use re_data_store::{EntityPropertiesComponent, EntityPropertyMap};
 
+use re_log_types::EntityPathExpr;
 use re_renderer::ScreenshotProcessor;
 use re_space_view::{
     DataQueryBlueprint, EntityOverrides, PropertyResolver, ScreenshotMode, SpaceViewContents,
@@ -325,6 +326,12 @@ impl SpaceViewBlueprint {
             resolved_properties,
             individual_properties,
             override_path: entity_path,
+        }
+    }
+
+    pub fn remove_entity_expr(&self, ctx: &ViewerContext<'_>, expr: EntityPathExpr) {
+        if let Some(query) = self.queries.first() {
+            query.remove_entity_expr(ctx, expr);
         }
     }
 }

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -329,9 +329,9 @@ impl SpaceViewBlueprint {
         }
     }
 
-    pub fn remove_entity_expr(&self, ctx: &ViewerContext<'_>, expr: EntityPathExpr) {
+    pub fn add_entity_exclusion(&self, ctx: &ViewerContext<'_>, expr: EntityPathExpr) {
         if let Some(query) = self.queries.first() {
-            query.remove_entity_expr(ctx, expr);
+            query.add_entity_exclusion(ctx, expr);
         }
     }
 }

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -429,13 +429,17 @@ pub fn sync_space_view(
 
         add_delta_from_single_component(deltas, &space_view.entity_path(), &timepoint, component);
 
-        for query in &space_view.queries {
-            add_delta_from_single_component(
-                deltas,
-                &query.id.as_entity_path(),
-                &timepoint,
-                query.expressions.clone(),
-            );
+        // The only time we need to create a query is if this is a new space-view. All other edits
+        // happen directly via `UpdateBlueprint` commands.
+        if snapshot.is_none() {
+            for query in &space_view.queries {
+                add_delta_from_single_component(
+                    deltas,
+                    &query.id.as_entity_path(),
+                    &timepoint,
+                    query.expressions.clone(),
+                );
+            }
         }
     }
 }

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -312,7 +312,7 @@ impl ViewportBlueprint<'_> {
                         let response =
                             remove_button_ui(re_ui, ui, "Remove Entity from the Space View");
                         if response.clicked() {
-                            space_view.remove_entity_expr(
+                            space_view.add_entity_exclusion(
                                 ctx,
                                 EntityPathExpr::Exact(entity_path.clone()),
                             );
@@ -378,7 +378,7 @@ impl ViewportBlueprint<'_> {
 
                 if remove_group {
                     space_view
-                        .remove_entity_expr(ctx, EntityPathExpr::Recursive(entity_path.clone()));
+                        .add_entity_exclusion(ctx, EntityPathExpr::Recursive(entity_path.clone()));
                     space_view.entities_determined_by_user = true;
                 }
 

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -3,6 +3,7 @@ use itertools::Itertools;
 
 use re_data_store::InstancePath;
 use re_data_ui::item_ui;
+use re_log_types::EntityPathExpr;
 use re_ui::list_item::ListItem;
 use re_ui::ReUi;
 use re_viewer_context::{
@@ -311,8 +312,10 @@ impl ViewportBlueprint<'_> {
                         let response =
                             remove_button_ui(re_ui, ui, "Remove Entity from the Space View");
                         if response.clicked() {
-                            // TODO(#4377): Fix entity removal
-                            //space_view.contents.remove_entity(entity_path);
+                            space_view.remove_entity_expr(
+                                ctx,
+                                EntityPathExpr::Exact(entity_path.clone()),
+                            );
                             space_view.entities_determined_by_user = true;
                         }
 
@@ -374,16 +377,9 @@ impl ViewportBlueprint<'_> {
                     });
 
                 if remove_group {
-                    // TODO(#4377): Fix group removal
-                    /*
-                    if let Some(group_handle) = space_view
-                        .contents
-                        .group_handle_for_entity_path(entity_path)
-                    {
-                        space_view.contents.remove_group(group_handle);
-                        space_view.entities_determined_by_user = true;
-                    }
-                    */
+                    space_view
+                        .remove_entity_expr(ctx, EntityPathExpr::Recursive(entity_path.clone()));
+                    space_view.entities_determined_by_user = true;
                 }
 
                 response


### PR DESCRIPTION
### What
- Part of the https://github.com/rerun-io/rerun/issues/4308 stack:
  - https://github.com/rerun-io/rerun/pull/4310
  - https://github.com/rerun-io/rerun/pull/4311
  - https://github.com/rerun-io/rerun/pull/4380
  - THIS PR: https://github.com/rerun-io/rerun/pull/4381

Now that we have functioning query exclusions, wire them up to the remove-entity buttons.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4381) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4381)
- [Docs preview](https://rerun.io/preview/2d33bf3b63da8df3c49e1379ca2af17bd22fc75e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2d33bf3b63da8df3c49e1379ca2af17bd22fc75e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)