### PR TITLE
Add `ui_name()` to `SpaceViewClass` so space views may provide a user-facing name

### DIFF
--- a/crates/re_space_view_bar_chart/src/space_view_class.rs
+++ b/crates/re_space_view_bar_chart/src/space_view_class.rs
@@ -18,7 +18,7 @@ impl SpaceViewClass for BarChartSpaceView {
     type State = ();
 
     const NAME: &'static str = "Bar Chart";
-    const UI_NAME: &'static str = "Bar Chart";
+    const DISPLAY_NAME: &'static str = "Bar Chart";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_HISTOGRAM

--- a/crates/re_space_view_bar_chart/src/space_view_class.rs
+++ b/crates/re_space_view_bar_chart/src/space_view_class.rs
@@ -18,6 +18,7 @@ impl SpaceViewClass for BarChartSpaceView {
     type State = ();
 
     const NAME: &'static str = "Bar Chart";
+    const UI_NAME: &'static str = "Bar Chart";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_HISTOGRAM

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -21,7 +21,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
     type State = SpatialSpaceViewState;
 
     const NAME: &'static str = "2D";
-    const UI_NAME: &'static str = "2D";
+    const DISPLAY_NAME: &'static str = "2D";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_2D

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -21,6 +21,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
     type State = SpatialSpaceViewState;
 
     const NAME: &'static str = "2D";
+    const UI_NAME: &'static str = "2D";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_2D

--- a/crates/re_space_view_spatial/src/space_view_3d.rs
+++ b/crates/re_space_view_spatial/src/space_view_3d.rs
@@ -21,7 +21,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
     type State = SpatialSpaceViewState;
 
     const NAME: &'static str = "3D";
-    const UI_NAME: &'static str = "3D";
+    const DISPLAY_NAME: &'static str = "3D";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_3D

--- a/crates/re_space_view_spatial/src/space_view_3d.rs
+++ b/crates/re_space_view_spatial/src/space_view_3d.rs
@@ -21,6 +21,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
     type State = SpatialSpaceViewState;
 
     const NAME: &'static str = "3D";
+    const UI_NAME: &'static str = "3D";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_3D

--- a/crates/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/re_space_view_tensor/src/space_view_class.rs
@@ -137,6 +137,7 @@ impl SpaceViewClass for TensorSpaceView {
     type State = ViewTensorState;
 
     const NAME: &'static str = "Tensor";
+    const UI_NAME: &'static str = "Tensor";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_TENSOR

--- a/crates/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/re_space_view_tensor/src/space_view_class.rs
@@ -137,7 +137,7 @@ impl SpaceViewClass for TensorSpaceView {
     type State = ViewTensorState;
 
     const NAME: &'static str = "Tensor";
-    const UI_NAME: &'static str = "Tensor";
+    const DISPLAY_NAME: &'static str = "Tensor";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_TENSOR

--- a/crates/re_space_view_text_document/src/space_view_class.rs
+++ b/crates/re_space_view_text_document/src/space_view_class.rs
@@ -50,6 +50,7 @@ impl SpaceViewClass for TextDocumentSpaceView {
     type State = TextDocumentSpaceViewState;
 
     const NAME: &'static str = "Text Document";
+    const UI_NAME: &'static str = "Text Document";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_TEXTBOX

--- a/crates/re_space_view_text_document/src/space_view_class.rs
+++ b/crates/re_space_view_text_document/src/space_view_class.rs
@@ -50,7 +50,7 @@ impl SpaceViewClass for TextDocumentSpaceView {
     type State = TextDocumentSpaceViewState;
 
     const NAME: &'static str = "Text Document";
-    const UI_NAME: &'static str = "Text Document";
+    const DISPLAY_NAME: &'static str = "Text Document";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_TEXTBOX

--- a/crates/re_space_view_text_log/src/space_view_class.rs
+++ b/crates/re_space_view_text_log/src/space_view_class.rs
@@ -43,7 +43,7 @@ impl SpaceViewClass for TextSpaceView {
     type State = TextSpaceViewState;
 
     const NAME: &'static str = "TextLog";
-    const UI_NAME: &'static str = "Text Log";
+    const DISPLAY_NAME: &'static str = "Text Log";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_TEXTBOX

--- a/crates/re_space_view_text_log/src/space_view_class.rs
+++ b/crates/re_space_view_text_log/src/space_view_class.rs
@@ -42,7 +42,8 @@ pub struct TextSpaceView;
 impl SpaceViewClass for TextSpaceView {
     type State = TextSpaceViewState;
 
-    const NAME: &'static str = "Text Log";
+    const NAME: &'static str = "TextLog";
+    const UI_NAME: &'static str = "Text Log";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_TEXTBOX

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -38,7 +38,7 @@ impl SpaceViewClass for TimeSeriesSpaceView {
     type State = TimeSeriesSpaceViewState;
 
     const NAME: &'static str = "Time Series";
-    const UI_NAME: &'static str = "Time Series";
+    const DISPLAY_NAME: &'static str = "Time Series";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_CHART

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -38,6 +38,7 @@ impl SpaceViewClass for TimeSeriesSpaceView {
     type State = TimeSeriesSpaceViewState;
 
     const NAME: &'static str = "Time Series";
+    const UI_NAME: &'static str = "Time Series";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_CHART

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -219,7 +219,7 @@ fn what_is_selected_ui(
                     &format!(
                         "Space View {:?} of type {}",
                         space_view.display_name,
-                        space_view_class.ui_name(),
+                        space_view_class.display_name(),
                     ),
                 );
             }
@@ -369,7 +369,11 @@ fn space_view_top_level_properties(
 
                 ui.label("Type")
                     .on_hover_text("The type of this Space View");
-                ui.label(space_view.class(ctx.space_view_class_registry).ui_name());
+                ui.label(
+                    space_view
+                        .class(ctx.space_view_class_registry)
+                        .display_name(),
+                );
                 ui.end_row();
             });
     }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -219,7 +219,7 @@ fn what_is_selected_ui(
                     &format!(
                         "Space View {:?} of type {}",
                         space_view.display_name,
-                        space_view_class.name(),
+                        space_view_class.ui_name(),
                     ),
                 );
             }
@@ -369,7 +369,7 @@ fn space_view_top_level_properties(
 
                 ui.label("Type")
                     .on_hover_text("The type of this Space View");
-                ui.label(&*space_view.class(ctx.space_view_class_registry).name());
+                ui.label(&*space_view.class(ctx.space_view_class_registry).ui_name());
                 ui.end_row();
             });
     }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -369,7 +369,7 @@ fn space_view_top_level_properties(
 
                 ui.label("Type")
                     .on_hover_text("The type of this Space View");
-                ui.label(&*space_view.class(ctx.space_view_class_registry).ui_name());
+                ui.label(space_view.class(ctx.space_view_class_registry).ui_name());
                 ui.end_row();
             });
     }

--- a/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
@@ -44,11 +44,13 @@ pub enum SpaceViewClassLayoutPriority {
 pub trait DynSpaceViewClass {
     /// Name of this space view class.
     ///
-    /// Used for both ui display and identification.
-    /// Must be unique within a viewer session.
-    ///
-    /// TODO(#2336): Display name and identifier should be separate.
+    /// Used for identification. Must be unique within a viewer session.
     fn name(&self) -> SpaceViewClassName;
+
+    /// User-facing name of this space view class.
+    ///
+    /// Used for UI display.
+    fn ui_name(&self) -> &'static str;
 
     /// Icon used to identify this space view class.
     fn icon(&self) -> &'static re_ui::Icon;

--- a/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
@@ -50,7 +50,7 @@ pub trait DynSpaceViewClass {
     /// User-facing name of this space view class.
     ///
     /// Used for UI display.
-    fn ui_name(&self) -> &'static str;
+    fn display_name(&self) -> &'static str;
 
     /// Icon used to identify this space view class.
     fn icon(&self) -> &'static re_ui::Icon;

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -18,14 +18,25 @@ pub trait SpaceViewClass: std::marker::Sized {
     type State: SpaceViewState + Default + 'static;
 
     /// Name for this space view class.
+    ///
+    /// Used as identifier.
     const NAME: &'static str;
+
+    /// User-facing name for this space view class
+    const UI_NAME: &'static str;
 
     /// Name of this space view class.
     ///
-    /// Used for both ui display and identification.
-    /// Must be unique within a viewer session.
+    /// Used for identification. Must be unique within a viewer session.
     fn name(&self) -> SpaceViewClassName {
         Self::NAME.into()
+    }
+
+    /// User-facing name for this space view class.
+    ///
+    /// Used for UI display.
+    fn ui_name(&self) -> &'static str {
+        Self::UI_NAME
     }
 
     /// Icon used to identify this space view class.
@@ -126,6 +137,11 @@ impl<T: SpaceViewClass + 'static> DynSpaceViewClass for T {
     #[inline]
     fn name(&self) -> SpaceViewClassName {
         self.name()
+    }
+
+    #[inline]
+    fn ui_name(&self) -> &'static str {
+        self.ui_name()
     }
 
     #[inline]

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -23,7 +23,7 @@ pub trait SpaceViewClass: std::marker::Sized {
     const NAME: &'static str;
 
     /// User-facing name for this space view class
-    const UI_NAME: &'static str;
+    const DISPLAY_NAME: &'static str;
 
     /// Name of this space view class.
     ///
@@ -35,8 +35,8 @@ pub trait SpaceViewClass: std::marker::Sized {
     /// User-facing name for this space view class.
     ///
     /// Used for UI display.
-    fn ui_name(&self) -> &'static str {
-        Self::UI_NAME
+    fn display_name(&self) -> &'static str {
+        Self::DISPLAY_NAME
     }
 
     /// Icon used to identify this space view class.
@@ -140,8 +140,8 @@ impl<T: SpaceViewClass + 'static> DynSpaceViewClass for T {
     }
 
     #[inline]
-    fn ui_name(&self) -> &'static str {
-        self.ui_name()
+    fn display_name(&self) -> &'static str {
+        self.display_name()
     }
 
     #[inline]

--- a/crates/re_viewer_context/src/space_view/space_view_class_placeholder.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class_placeholder.rs
@@ -12,7 +12,7 @@ impl SpaceViewClass for SpaceViewClassPlaceholder {
     type State = ();
 
     const NAME: &'static str = "Unknown Space View Class";
-    const UI_NAME: &'static str = "Unknown Space View Class";
+    const DISPLAY_NAME: &'static str = "Unknown Space View Class";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_UNKNOWN

--- a/crates/re_viewer_context/src/space_view/space_view_class_placeholder.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class_placeholder.rs
@@ -12,6 +12,7 @@ impl SpaceViewClass for SpaceViewClassPlaceholder {
     type State = ();
 
     const NAME: &'static str = "Unknown Space View Class";
+    const UI_NAME: &'static str = "Unknown Space View Class";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_UNKNOWN

--- a/crates/re_viewer_context/src/space_view/space_view_class_registry.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class_registry.rs
@@ -161,10 +161,12 @@ impl SpaceViewClassRegistry {
     /// Returns the user-facing name for the given space view class.
     ///
     /// If the class is unknown, returns a placeholder name.
-    pub fn ui_name(&self, name: &SpaceViewClassName) -> &'static str {
+    pub fn display_name(&self, name: &SpaceViewClassName) -> &'static str {
         self.registry
             .get(name)
-            .map_or("<unknown space view class>", |boxed| boxed.class.ui_name())
+            .map_or("<unknown space view class>", |boxed| {
+                boxed.class.display_name()
+            })
     }
 
     /// Queries a Space View type's system registry by class name, returning `None` if the class is not registered.

--- a/crates/re_viewer_context/src/space_view/space_view_class_registry.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class_registry.rs
@@ -158,6 +158,15 @@ impl SpaceViewClassRegistry {
         self.registry.get(name).map(|boxed| boxed.class.as_ref())
     }
 
+    /// Returns the user-facing name for the given space view class.
+    ///
+    /// If the class is unknown, returns a placeholder name.
+    pub fn ui_name(&self, name: &SpaceViewClassName) -> &'static str {
+        self.registry
+            .get(name)
+            .map_or("<unknown space view class>", |boxed| boxed.class.ui_name())
+    }
+
     /// Queries a Space View type's system registry by class name, returning `None` if the class is not registered.
     fn get_system_registry(&self, name: &SpaceViewClassName) -> Option<&SpaceViewSystemRegistry> {
         self.registry.get(name).map(|boxed| &boxed.systems)

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -67,7 +67,7 @@ impl SpaceViewBlueprint {
 impl SpaceViewBlueprint {
     pub fn new(
         space_view_class: SpaceViewClassName,
-        space_view_ui_name: &'static str,
+        space_view_class_display_name: &'static str,
         space_path: &EntityPath,
         query: DataQueryBlueprint,
     ) -> Self {
@@ -79,7 +79,7 @@ impl SpaceViewBlueprint {
             name.to_string()
         } else {
             // Include class name in the display for root paths because they look a tad bit too short otherwise.
-            format!("/ ({space_view_ui_name})")
+            format!("/ ({space_view_class_display_name})")
         };
 
         let id = SpaceViewId::random();

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -67,6 +67,7 @@ impl SpaceViewBlueprint {
 impl SpaceViewBlueprint {
     pub fn new(
         space_view_class: SpaceViewClassName,
+        space_view_ui_name: &'static str,
         space_path: &EntityPath,
         query: DataQueryBlueprint,
     ) -> Self {
@@ -78,7 +79,7 @@ impl SpaceViewBlueprint {
             name.to_string()
         } else {
             // Include class name in the display for root paths because they look a tad bit too short otherwise.
-            format!("/ ({space_view_class})")
+            format!("/ ({space_view_ui_name})")
         };
 
         let id = SpaceViewId::random();
@@ -428,6 +429,7 @@ mod tests {
 
         let space_view = SpaceViewBlueprint::new(
             "3D".into(),
+            "3D",
             &EntityPath::root(),
             DataQueryBlueprint::new(
                 "3D".into(),

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -121,13 +121,11 @@ pub fn all_possible_space_views(
                         entities_per_system_per_class,
                     );
 
-                    //let space_view_ui_name = if let Some(space_view_class) =
-
                     if !results.is_empty() {
                         Some((
                             SpaceViewBlueprint::new(
                                 *class_name,
-                                ctx.space_view_class_registry.ui_name(class_name),
+                                ctx.space_view_class_registry.display_name(class_name),
                                 candidate_space_path,
                                 candidate_query,
                             ),
@@ -297,7 +295,7 @@ pub fn default_created_space_views(
                         let mut space_view = SpaceViewBlueprint::new(
                             *candidate.class_name(),
                             ctx.space_view_class_registry
-                                .ui_name(candidate.class_name()),
+                                .display_name(candidate.class_name()),
                             &result.entity_path,
                             query,
                         );
@@ -407,7 +405,7 @@ pub fn default_created_space_views(
                             let mut space_view = SpaceViewBlueprint::new(
                                 *candidate.class_name(),
                                 ctx.space_view_class_registry
-                                    .ui_name(candidate.class_name()),
+                                    .display_name(candidate.class_name()),
                                 &candidate.space_origin,
                                 query,
                             );

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -121,10 +121,13 @@ pub fn all_possible_space_views(
                         entities_per_system_per_class,
                     );
 
+                    //let space_view_ui_name = if let Some(space_view_class) =
+
                     if !results.is_empty() {
                         Some((
                             SpaceViewBlueprint::new(
                                 *class_name,
+                                ctx.space_view_class_registry.ui_name(class_name),
                                 candidate_space_path,
                                 candidate_query,
                             ),
@@ -293,6 +296,8 @@ pub fn default_created_space_views(
                         );
                         let mut space_view = SpaceViewBlueprint::new(
                             *candidate.class_name(),
+                            ctx.space_view_class_registry
+                                .ui_name(candidate.class_name()),
                             &result.entity_path,
                             query,
                         );
@@ -401,6 +406,8 @@ pub fn default_created_space_views(
 
                             let mut space_view = SpaceViewBlueprint::new(
                                 *candidate.class_name(),
+                                ctx.space_view_class_registry
+                                    .ui_name(candidate.class_name()),
                                 &candidate.space_origin,
                                 query,
                             );

--- a/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
@@ -70,6 +70,7 @@ impl SpaceViewClass for ColorCoordinatesSpaceView {
     type State = ColorCoordinatesSpaceViewState;
 
     const NAME: &'static str = "Color Coordinates";
+    const UI_NAME: &'static str = "Color Coordinates";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_SCATTERPLOT

--- a/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
@@ -70,7 +70,7 @@ impl SpaceViewClass for ColorCoordinatesSpaceView {
     type State = ColorCoordinatesSpaceViewState;
 
     const NAME: &'static str = "Color Coordinates";
-    const UI_NAME: &'static str = "Color Coordinates";
+    const DISPLAY_NAME: &'static str = "Color Coordinates";
 
     fn icon(&self) -> &'static re_ui::Icon {
         &re_ui::icons::SPACE_VIEW_SCATTERPLOT


### PR DESCRIPTION
### What

With this change, the user-facing string for a space view class can be changed without breaking blueprint files. This PR also reverts the change from "TextLog" to "Text Log" to avoid breaking last release's blueprint (*)

* Fixes #2336 

(*) Unknown space view class name do not trigger a blueprint rebuild, but instead yield an "unknown space view" in the UI, which is Bad UX™️

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4393) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4393)
- [Docs preview](https://rerun.io/preview/3b3229f5e6a053574a2e94e1f5f63907da8d703c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3b3229f5e6a053574a2e94e1f5f63907da8d703c/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)