### PR TITLE
GC improvements 0: use-case driven benchmarks

### DIFF
--- a/crates/re_arrow_store/Cargo.toml
+++ b/crates/re_arrow_store/Cargo.toml
@@ -19,9 +19,6 @@ all-features = true
 [features]
 default = []
 
-## Enables access to re_types' test components/datatypes.
-testing = ["re_log_types/testing", "re_types/testing"]
-
 ## Enables `parking_lot`'s deadlock detection background thread.
 deadlock_detection = ["parking_lot/deadlock_detection"]
 
@@ -73,7 +70,7 @@ polars-ops = { workspace = true, optional = true, features = [
 
 [dev-dependencies]
 re_log_types = { workspace = true, features = ["testing"] }
-re_types = { workspace = true, features = ["datagen"] }
+re_types = { workspace = true, features = ["datagen", "testing"] }
 
 anyhow.workspace = true
 criterion.workspace = true
@@ -98,7 +95,7 @@ bench = false
 [[example]]
 name = "dump_dataframe"
 path = "examples/dump_dataframe.rs"
-required-features = ["polars", "testing"]
+required-features = ["polars"]
 
 [[example]]
 name = "latest_component"
@@ -119,12 +116,10 @@ required-features = ["polars"]
 [[bench]]
 name = "data_store"
 harness = false
-required-features = ["testing"]
 
 [[bench]]
 name = "arrow2"
 harness = false
-required-features = ["testing"]
 
 [[bench]]
 name = "vectors"

--- a/crates/re_arrow_store/Cargo.toml
+++ b/crates/re_arrow_store/Cargo.toml
@@ -114,11 +114,15 @@ required-features = ["polars"]
 
 
 [[bench]]
+name = "arrow2"
+harness = false
+
+[[bench]]
 name = "data_store"
 harness = false
 
 [[bench]]
-name = "arrow2"
+name = "gc"
 harness = false
 
 [[bench]]

--- a/crates/re_arrow_store/benches/gc.rs
+++ b/crates/re_arrow_store/benches/gc.rs
@@ -8,7 +8,7 @@ use re_arrow_store::{
     DataStore, DataStoreConfig, GarbageCollectionOptions, GarbageCollectionTarget,
 };
 use re_log_types::{
-    build_frame_nr, build_log_time, DataRow, DataTable, EntityPath, RowId, TableId, Time,
+    build_frame_nr, build_log_time, DataRow, DataTable, EntityPath, RowId, TableId, Time, TimePoint,
 };
 use re_types::components::InstanceKey;
 use re_types_core::{AsComponents, ComponentBatch, ComponentName, Loggable as _};
@@ -20,15 +20,15 @@ criterion_main!(benches);
 
 #[cfg(not(debug_assertions))]
 mod constants {
-    pub const NUM_ENTITY_PATHS: i64 = 20;
-    pub const NUM_ROWS_PER_ENTITY_PATH: i64 = 10_000;
+    pub const NUM_ENTITY_PATHS: usize = 20;
+    pub const NUM_ROWS_PER_ENTITY_PATH: usize = 10_000;
 }
 
 // `cargo test` also runs the benchmark setup code, so make sure they run quickly:
 #[cfg(debug_assertions)]
 mod constants {
-    pub const NUM_ENTITY_PATHS: i64 = 1;
-    pub const NUM_ROWS_PER_ENTITY_PATH: i64 = 1;
+    pub const NUM_ENTITY_PATHS: usize = 1;
+    pub const NUM_ROWS_PER_ENTITY_PATH: usize = 1;
 }
 
 use constants::{NUM_ENTITY_PATHS, NUM_ROWS_PER_ENTITY_PATH};
@@ -50,7 +50,7 @@ fn plotting_dashboard(c: &mut Criterion) {
     const DROP_AT_LEAST: f64 = 0.3;
 
     let mut group = c.benchmark_group(format!(
-        "datastore/num_entities={NUM_ENTITY_PATHS}/num_rows_per_entity={NUM_ROWS_PER_ENTITY_PATH}/scalar_gc/drop_at_least={DROP_AT_LEAST}"
+        "datastore/num_entities={NUM_ENTITY_PATHS}/num_rows_per_entity={NUM_ROWS_PER_ENTITY_PATH}/plotting_dashboard/drop_at_least={DROP_AT_LEAST}"
     ));
     group.throughput(criterion::Throughput::Elements(
         ((NUM_ENTITY_PATHS * NUM_ROWS_PER_ENTITY_PATH) as f64 * DROP_AT_LEAST) as _,
@@ -65,12 +65,26 @@ fn plotting_dashboard(c: &mut Criterion) {
         dont_protect: Default::default(),
     };
 
+    let mut timegen = |i| {
+        [
+            build_log_time(Time::from_seconds_since_epoch(i as _)),
+            build_frame_nr((i as i64).into()),
+        ]
+        .into()
+    };
+
+    let mut datagen = |i| {
+        Box::new(re_types::archetypes::TimeSeriesScalar::new(i as f64)) as Box<dyn AsComponents>
+    };
+
     // Default config
     group.bench_function("default", |b| {
         let store = build_store(
             Default::default(),
             InstanceKey::name(),
-            false, // TODO: packed
+            false,
+            &mut timegen,
+            &mut datagen,
         );
         b.iter_batched(
             || store.clone(),
@@ -91,7 +105,9 @@ fn plotting_dashboard(c: &mut Criterion) {
                     ..Default::default()
                 },
                 InstanceKey::name(),
-                false, // TODO: packed
+                false,
+                &mut timegen,
+                &mut datagen,
             );
             b.iter_batched(
                 || store.clone(),
@@ -107,7 +123,17 @@ fn plotting_dashboard(c: &mut Criterion) {
 
 // --- Helpers ---
 
-fn build_store(config: DataStoreConfig, cluster_key: ComponentName, packed: bool) -> DataStore {
+fn build_store<FT, FD>(
+    config: DataStoreConfig,
+    cluster_key: ComponentName,
+    packed: bool,
+    timegen: &mut FT,
+    datagen: &mut FD,
+) -> DataStore
+where
+    FT: FnMut(usize) -> TimePoint,
+    FD: FnMut(usize) -> Box<dyn AsComponents>,
+{
     let mut store = DataStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
         cluster_key,
@@ -115,14 +141,15 @@ fn build_store(config: DataStoreConfig, cluster_key: ComponentName, packed: bool
     );
 
     let tables = (0..NUM_ENTITY_PATHS)
-        .map(|i| build_table(format!("entity_path_{i}").into(), packed))
+        .map(|i| build_table(format!("entity_path_{i}").into(), packed, timegen, datagen))
         .collect_vec();
     let mut rows_per_table = tables.iter().map(|table| table.to_rows()).collect_vec();
 
     // NOTE: interleave insertions between entities to more closely match real world scenarios.
     for _ in 0..NUM_ROWS_PER_ENTITY_PATH {
+        #[allow(clippy::needless_range_loop)] // readability
         for i in 0..NUM_ENTITY_PATHS {
-            let row = rows_per_table[i as usize].next().unwrap();
+            let row = rows_per_table[i].next().unwrap();
             store.insert_row(&row.unwrap()).unwrap();
         }
     }
@@ -130,20 +157,25 @@ fn build_store(config: DataStoreConfig, cluster_key: ComponentName, packed: bool
     store
 }
 
-fn build_table(entity_path: EntityPath, packed: bool) -> DataTable {
+fn build_table<FT, FD>(
+    entity_path: EntityPath,
+    packed: bool,
+    timegen: &mut FT,
+    datagen: &mut FD,
+) -> DataTable
+where
+    FT: FnMut(usize) -> TimePoint,
+    FD: FnMut(usize) -> Box<dyn AsComponents>,
+{
     let mut table = DataTable::from_rows(
         TableId::ZERO,
         (0..NUM_ROWS_PER_ENTITY_PATH).map(move |i| {
             DataRow::from_component_batches(
                 RowId::random(),
                 // NOTE: insert in multiple timelines to more closely match real world scenarios.
-                [
-                    build_log_time(Time::from_seconds_since_epoch(i as _)),
-                    build_frame_nr(i.into()),
-                ]
-                .into(),
+                timegen(i),
                 entity_path.clone(),
-                re_types::archetypes::TimeSeriesScalar::new(i as f64)
+                datagen(i)
                     .as_component_batches()
                     .iter()
                     .map(|batch| batch as &dyn ComponentBatch),

--- a/crates/re_arrow_store/benches/gc.rs
+++ b/crates/re_arrow_store/benches/gc.rs
@@ -1,0 +1,164 @@
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+
+use itertools::Itertools;
+use re_arrow_store::{
+    DataStore, DataStoreConfig, GarbageCollectionOptions, GarbageCollectionTarget,
+};
+use re_log_types::{
+    build_frame_nr, build_log_time, DataRow, DataTable, EntityPath, RowId, TableId, Time,
+};
+use re_types::components::InstanceKey;
+use re_types_core::{AsComponents, ComponentBatch, ComponentName, Loggable as _};
+
+criterion_group!(benches, plotting_dashboard);
+criterion_main!(benches);
+
+// ---
+
+#[cfg(not(debug_assertions))]
+mod constants {
+    pub const NUM_ENTITY_PATHS: i64 = 20;
+    pub const NUM_ROWS_PER_ENTITY_PATH: i64 = 10_000;
+}
+
+// `cargo test` also runs the benchmark setup code, so make sure they run quickly:
+#[cfg(debug_assertions)]
+mod constants {
+    pub const NUM_ENTITY_PATHS: i64 = 1;
+    pub const NUM_ROWS_PER_ENTITY_PATH: i64 = 1;
+}
+
+use constants::{NUM_ENTITY_PATHS, NUM_ROWS_PER_ENTITY_PATH};
+
+fn num_rows_per_bucket() -> &'static [u64] {
+    #[cfg(feature = "core_benchmarks_only")]
+    {
+        &[]
+    }
+    #[cfg(not(feature = "core_benchmarks_only"))]
+    {
+        &[256, 512, 1024, 2048]
+    }
+}
+
+// --- Benchmarks ---
+
+fn plotting_dashboard(c: &mut Criterion) {
+    const DROP_AT_LEAST: f64 = 0.3;
+
+    let mut group = c.benchmark_group(format!(
+        "datastore/num_entities={NUM_ENTITY_PATHS}/num_rows_per_entity={NUM_ROWS_PER_ENTITY_PATH}/scalar_gc/drop_at_least={DROP_AT_LEAST}"
+    ));
+    group.throughput(criterion::Throughput::Elements(
+        ((NUM_ENTITY_PATHS * NUM_ROWS_PER_ENTITY_PATH) as f64 * DROP_AT_LEAST) as _,
+    ));
+    group.sample_size(10);
+
+    let gc_settings = GarbageCollectionOptions {
+        target: GarbageCollectionTarget::DropAtLeastFraction(DROP_AT_LEAST),
+        gc_timeless: true,
+        protect_latest: 1,
+        purge_empty_tables: false,
+        dont_protect: Default::default(),
+    };
+
+    // Default config
+    group.bench_function("default", |b| {
+        let store = build_store(
+            Default::default(),
+            InstanceKey::name(),
+            false, // TODO: packed
+        );
+        b.iter_batched(
+            || store.clone(),
+            |mut store| {
+                let (_, stats_diff) = store.gc(&gc_settings);
+                stats_diff
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    // Emulate more or less bucket
+    for &num_rows_per_bucket in num_rows_per_bucket() {
+        group.bench_function(format!("bucketsz={num_rows_per_bucket}"), |b| {
+            let store = build_store(
+                DataStoreConfig {
+                    indexed_bucket_num_rows: num_rows_per_bucket,
+                    ..Default::default()
+                },
+                InstanceKey::name(),
+                false, // TODO: packed
+            );
+            b.iter_batched(
+                || store.clone(),
+                |mut store| {
+                    let (_, stats_diff) = store.gc(&gc_settings);
+                    stats_diff
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+}
+
+// --- Helpers ---
+
+fn build_store(config: DataStoreConfig, cluster_key: ComponentName, packed: bool) -> DataStore {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        cluster_key,
+        config,
+    );
+
+    let tables = (0..NUM_ENTITY_PATHS)
+        .map(|i| build_table(format!("entity_path_{i}").into(), packed))
+        .collect_vec();
+    let mut rows_per_table = tables.iter().map(|table| table.to_rows()).collect_vec();
+
+    // NOTE: interleave insertions between entities to more closely match real world scenarios.
+    for _ in 0..NUM_ROWS_PER_ENTITY_PATH {
+        for i in 0..NUM_ENTITY_PATHS {
+            let row = rows_per_table[i as usize].next().unwrap();
+            store.insert_row(&row.unwrap()).unwrap();
+        }
+    }
+
+    store
+}
+
+fn build_table(entity_path: EntityPath, packed: bool) -> DataTable {
+    let mut table = DataTable::from_rows(
+        TableId::ZERO,
+        (0..NUM_ROWS_PER_ENTITY_PATH).map(move |i| {
+            DataRow::from_component_batches(
+                RowId::random(),
+                // NOTE: insert in multiple timelines to more closely match real world scenarios.
+                [
+                    build_log_time(Time::from_seconds_since_epoch(i as _)),
+                    build_frame_nr(i.into()),
+                ]
+                .into(),
+                entity_path.clone(),
+                re_types::archetypes::TimeSeriesScalar::new(i as f64)
+                    .as_component_batches()
+                    .iter()
+                    .map(|batch| batch as &dyn ComponentBatch),
+            )
+            .unwrap()
+        }),
+    );
+
+    // Do a serialization roundtrip to pack everything in contiguous memory.
+    if packed {
+        let (schema, columns) = table.serialize().unwrap();
+        table = DataTable::deserialize(TableId::ZERO, &schema, &columns).unwrap();
+    }
+
+    table.compute_all_size_bytes();
+
+    table
+}

--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -68,7 +68,7 @@ webbrowser = { workspace = true, optional = true }
 
 
 [dev-dependencies]
-re_arrow_store = { workspace = true, features = ["testing"] }
+re_arrow_store.workspace = true
 
 itertools.workspace = true
 ndarray-rand.workspace = true

--- a/crates/re_types_core/src/loggable_batch.rs
+++ b/crates/re_types_core/src/loggable_batch.rs
@@ -89,6 +89,32 @@ impl<'a> std::ops::Deref for MaybeOwnedComponentBatch<'a> {
     }
 }
 
+impl<'a> LoggableBatch for MaybeOwnedComponentBatch<'a> {
+    type Name = ComponentName;
+
+    #[inline]
+    fn name(&self) -> Self::Name {
+        self.as_ref().name()
+    }
+
+    #[inline]
+    fn num_instances(&self) -> usize {
+        self.as_ref().num_instances()
+    }
+
+    #[inline]
+    fn arrow_field(&self) -> arrow2::datatypes::Field {
+        self.as_ref().arrow_field()
+    }
+
+    #[inline]
+    fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
+        self.as_ref().to_arrow()
+    }
+}
+
+impl<'a> ComponentBatch for MaybeOwnedComponentBatch<'a> {}
+
 // --- Unary ---
 
 impl<L: Clone + Loggable> LoggableBatch for L {


### PR DESCRIPTION
Introduce 2 new benchmark suites that drive the development of this PR series:
1. Logging a tons of scalars, in order, across a bunch of series, themselves scattered across a bunch of plots.
2. Logging a tons of timeless data, across a bunch of entities.

### Benchmarks

Hint: it's bad.

```
.../plotting_dashboard/drop_at_least=0.3/bucketsz=1024    1.00   1084.0±4.47ms 54.1 KElem/sec
.../plotting_dashboard/drop_at_least=0.3/bucketsz=2048    1.00       2.1±0.02s 27.6 KElem/sec
.../plotting_dashboard/drop_at_least=0.3/bucketsz=256     1.00    465.8±2.50ms 125.8 KElem/sec
.../plotting_dashboard/drop_at_least=0.3/bucketsz=512     1.00    655.3±2.61ms 89.4 KElem/sec
.../plotting_dashboard/drop_at_least=0.3/default          1.00    652.8±4.12ms 89.8 KElem/sec
.../timeless_logs/drop_at_least=0.3/bucketsz=1024         1.00       2.4±0.05s 24.2 KElem/sec
.../timeless_logs/drop_at_least=0.3/bucketsz=2048         1.00       2.4±0.03s 24.1 KElem/sec
.../timeless_logs/drop_at_least=0.3/bucketsz=256          1.00       2.5±0.08s 23.5 KElem/sec
.../timeless_logs/drop_at_least=0.3/bucketsz=512          1.00       2.4±0.02s 24.5 KElem/sec
.../timeless_logs/drop_at_least=0.3/default               1.00       2.4±0.03s 24.4 KElem/sec
```

---

Part of the GC improvements series:
- #4394
- #4395
- #4396
- #4397
- #4398
- #4399
- #4400
- #4401


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4394) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4394)
- [Docs preview](https://rerun.io/preview/dc130210001958e7ad3b07374eadd68b029fb5f6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/dc130210001958e7ad3b07374eadd68b029fb5f6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)