### PR TITLE
GC improvements 5: `Store{Diff,Event}` optimizations

### DIFF
--- a/crates/re_arrow_store/src/store_event.rs
+++ b/crates/re_arrow_store/src/store_event.rs
@@ -118,6 +118,10 @@ pub struct StoreDiff {
     /// same value for both the insertion and deletion events (if any).
     ///
     /// This is not a [`TimePoint`] for performance reasons.
+    //
+    // NOTE: Empirical testing shows that a SmallVec isn't any better in the best case, and can be a
+    // significant performant drop at worst.
+    // pub times: SmallVec<[(Timeline, TimeInt); 5]>, // "5 timelines ought to be enough for anyone"
     pub times: Vec<(Timeline, TimeInt)>,
 
     /// The [`EntityPath`] associated with that row.

--- a/crates/re_arrow_store/src/store_write.rs
+++ b/crates/re_arrow_store/src/store_write.rs
@@ -189,8 +189,8 @@ impl DataStore {
             }
         }
 
-        let diff = StoreDiff::addition(*row_id, entity_path.clone())
-            .at_timepoint(timepoint.clone())
+        let mut diff = StoreDiff::addition(*row_id, entity_path.clone());
+        diff.at_timepoint(timepoint.clone())
             .with_cells(cells.iter().cloned());
 
         // TODO(#4220): should we fire for auto-generated data?

--- a/crates/re_data_store/src/time_histogram_per_timeline.rs
+++ b/crates/re_data_store/src/time_histogram_per_timeline.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use re_arrow_store::{StoreEvent, StoreSubscriber};
-use re_log_types::{TimePoint, Timeline};
+use re_log_types::{TimeInt, TimePoint, Timeline};
 
 // ---
 
@@ -51,8 +51,8 @@ impl TimeHistogramPerTimeline {
         self.num_timeless_messages
     }
 
-    pub fn add(&mut self, timepoint: &TimePoint, n: u32) {
-        if timepoint.is_timeless() {
+    pub fn add(&mut self, times: &[(Timeline, TimeInt)], n: u32) {
+        if times.is_empty() {
             self.num_timeless_messages = self
                 .num_timeless_messages
                 .checked_add(n as u64)
@@ -61,11 +61,11 @@ impl TimeHistogramPerTimeline {
                     u64::MAX
                 });
         } else {
-            for (timeline, time_value) in timepoint.iter() {
+            for &(timeline, time) in times {
                 self.times
-                    .entry(*timeline)
+                    .entry(timeline)
                     .or_default()
-                    .increment(time_value.as_i64(), n);
+                    .increment(time.as_i64(), n);
             }
         }
     }

--- a/crates/re_data_store/src/times_per_timeline.rs
+++ b/crates/re_data_store/src/times_per_timeline.rs
@@ -54,7 +54,7 @@ impl StoreSubscriber for TimesPerTimeline {
         re_tracing::profile_function!(format!("num_events={}", events.len()));
 
         for event in events {
-            for (&timeline, &time) in &event.timepoint {
+            for &(timeline, time) in &event.times {
                 let per_time = self.0.entry(timeline).or_default();
                 let count = per_time.entry(time).or_default();
 

--- a/examples/rust/custom_store_subscriber/src/main.rs
+++ b/examples/rust/custom_store_subscriber/src/main.rs
@@ -161,7 +161,7 @@ impl StoreSubscriber for TimeRangesPerEntity {
 
     fn on_events(&mut self, events: &[StoreEvent]) {
         for event in events {
-            for (&timeline, &time) in &event.timepoint {
+            for &(timeline, time) in &event.times {
                 // update counters
                 let per_timeline = self.times.entry(event.entity_path.clone()).or_default();
                 let per_time = per_timeline.entry(timeline).or_default();


### PR DESCRIPTION
Optimize the creation of `StoreDiff`s and `StoreEvent`s, which turns out to be a major cost in time series use cases, when it is common to generate several millions of those on any single GC run.

Once again some pretty significant wins.

### Benchmarks

Compared to `main`:
```
group                                                     gc_improvements_0                       gc_improvements_5
-----                                                     -----------------                       -----------------
.../plotting_dashboard/drop_at_least=0.3/bucketsz=1024    13.00  1084.0±4.47ms 54.1 KElem/sec     1.00     83.4±1.16ms 702.9 KElem/sec
.../plotting_dashboard/drop_at_least=0.3/bucketsz=2048    25.37      2.1±0.02s 27.6 KElem/sec     1.00     83.7±0.61ms 700.0 KElem/sec
.../plotting_dashboard/drop_at_least=0.3/bucketsz=256     5.55    465.8±2.50ms 125.8 KElem/sec    1.00     84.0±0.50ms 697.8 KElem/sec
.../plotting_dashboard/drop_at_least=0.3/bucketsz=512     7.94    655.3±2.61ms 89.4 KElem/sec     1.00     82.5±1.33ms 710.0 KElem/sec
.../plotting_dashboard/drop_at_least=0.3/default          8.02    652.8±4.12ms 89.8 KElem/sec     1.00     81.4±0.94ms 720.0 KElem/sec
.../timeless_logs/drop_at_least=0.3/bucketsz=1024         35.87      2.4±0.05s 24.2 KElem/sec     1.00     67.5±2.21ms 867.5 KElem/sec
.../timeless_logs/drop_at_least=0.3/bucketsz=2048         35.91      2.4±0.03s 24.1 KElem/sec     1.00     67.8±1.86ms 863.9 KElem/sec
.../timeless_logs/drop_at_least=0.3/bucketsz=256          37.02      2.5±0.08s 23.5 KElem/sec     1.00     67.5±1.43ms 868.2 KElem/sec
.../timeless_logs/drop_at_least=0.3/bucketsz=512          35.47      2.4±0.02s 24.5 KElem/sec     1.00     67.4±1.40ms 869.4 KElem/sec
.../timeless_logs/drop_at_least=0.3/default               36.00      2.4±0.03s 24.4 KElem/sec     1.00     66.8±0.85ms 877.3 KElem/sec
```

Compared to previous PR:
```
group                                                     gc_improvements_4                       gc_improvements_5
-----                                                     -----------------                       -----------------
.../plotting_dashboard/drop_at_least=0.3/bucketsz=1024    1.26    105.0±0.91ms 558.1 KElem/sec    1.00     83.4±1.16ms 702.9 KElem/sec
.../plotting_dashboard/drop_at_least=0.3/bucketsz=2048    1.28    107.3±0.83ms 546.2 KElem/sec    1.00     83.7±0.61ms 700.0 KElem/sec
.../plotting_dashboard/drop_at_least=0.3/bucketsz=256     1.27    106.3±0.74ms 551.3 KElem/sec    1.00     84.0±0.50ms 697.8 KElem/sec
.../plotting_dashboard/drop_at_least=0.3/bucketsz=512     1.29    106.4±0.94ms 550.6 KElem/sec    1.00     82.5±1.33ms 710.0 KElem/sec
.../plotting_dashboard/drop_at_least=0.3/default          1.26    102.9±0.75ms 569.4 KElem/sec    1.00     81.4±0.94ms 720.0 KElem/sec
.../timeless_logs/drop_at_least=0.3/bucketsz=1024         1.00     65.3±0.81ms 897.6 KElem/sec    1.03     67.5±2.21ms 867.5 KElem/sec
.../timeless_logs/drop_at_least=0.3/bucketsz=2048         1.00     64.9±1.07ms 903.2 KElem/sec    1.05     67.8±1.86ms 863.9 KElem/sec
.../timeless_logs/drop_at_least=0.3/bucketsz=256          1.00     64.4±0.99ms 910.2 KElem/sec    1.05     67.5±1.43ms 868.2 KElem/sec
.../timeless_logs/drop_at_least=0.3/bucketsz=512          1.00     64.6±1.08ms 906.9 KElem/sec    1.04     67.4±1.40ms 869.4 KElem/sec
.../timeless_logs/drop_at_least=0.3/default               1.00     65.3±1.29ms 897.3 KElem/sec    1.02     66.8±0.85ms 877.3 KElem/sec
```

---

Part of the GC improvements series:
- #4394
- #4395
- #4396
- #4397
- #4398
- #4399
- #4400
- #4401


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4394) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4394)
- [Docs preview](https://rerun.io/preview/4e8ed7b66cbb0e91bfefeb9033ed8c907725bce6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4e8ed7b66cbb0e91bfefeb9033ed8c907725bce6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)