### PR TITLE
Move ResetBlueprint to a SystemCommand

### DIFF
--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -356,6 +356,11 @@ impl App {
             }
 
             SystemCommand::ResetViewer => self.reset(store_hub, egui_ctx),
+            SystemCommand::ResetBlueprint => {
+                // By clearing the blueprint it will be re-populated with the defaults
+                // at the beginning of the next frame.
+                store_hub.clear_blueprint();
+            }
             SystemCommand::UpdateBlueprint(blueprint_id, updates) => {
                 let blueprint_db = store_hub.store_db_mut(&blueprint_id);
                 for row in updates {

--- a/crates/re_viewer/src/ui/blueprint_panel.rs
+++ b/crates/re_viewer/src/ui/blueprint_panel.rs
@@ -1,4 +1,4 @@
-use re_viewer_context::ViewerContext;
+use re_viewer_context::{SystemCommandSender as _, ViewerContext};
 use re_viewport::{SpaceInfoCollection, ViewportBlueprint};
 
 /// Show the Blueprint section of the left panel based on the current [`ViewportBlueprint`]
@@ -15,7 +15,7 @@ pub fn blueprint_panel_ui(
             Some("The Blueprint is where you can configure the Rerun Viewer"),
             |ui| {
                 blueprint.add_new_spaceview_button_ui(ctx, ui, spaces_info);
-                reset_button_ui(blueprint, ctx, ui, spaces_info);
+                reset_blueprint_button_ui(ctx, ui);
             },
         );
     });
@@ -25,18 +25,14 @@ pub fn blueprint_panel_ui(
     blueprint.tree_ui(ctx, ui);
 }
 
-fn reset_button_ui(
-    blueprint: &mut ViewportBlueprint<'_>,
-    ctx: &ViewerContext<'_>,
-    ui: &mut egui::Ui,
-    spaces_info: &SpaceInfoCollection,
-) {
+fn reset_blueprint_button_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
     if ctx
         .re_ui
         .small_icon_button(ui, &re_ui::icons::RESET)
         .on_hover_text("Re-populate Viewport with automatically chosen Space Views")
         .clicked()
     {
-        blueprint.reset(ctx, spaces_info);
+        ctx.command_sender
+            .send_system(re_viewer_context::SystemCommand::ResetBlueprint);
     }
 }

--- a/crates/re_viewer_context/src/command_sender.rs
+++ b/crates/re_viewer_context/src/command_sender.rs
@@ -17,6 +17,9 @@ pub enum SystemCommand {
     /// Reset the `Viewer` to the default state
     ResetViewer,
 
+    /// Reset the `Blueprint` to the default state
+    ResetBlueprint,
+
     /// Change the active recording-id in the `StoreHub`
     SetRecordingId(StoreId),
 


### PR DESCRIPTION
### What
This avoids an annoying warning pop-up where data queries aren't found by making the blueprint life-cycle more deterministic.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4408) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4408)
- [Docs preview](https://rerun.io/preview/fbec79f174b8275a440cc483315edd4bfe269375/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/fbec79f174b8275a440cc483315edd4bfe269375/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)