### PR TITLE
Log wgpu adapter on web

### DIFF
--- a/crates/re_renderer/src/context.rs
+++ b/crates/re_renderer/src/context.rs
@@ -449,17 +449,24 @@ fn log_adapter_info(info: &wgpu::AdapterInfo) {
             backend,
         } = &info;
 
-        // Example outputs:
-        // > wgpu adapter name: "llvmpipe (LLVM 16.0.6, 256 bits)", device_type: Cpu, backend: Vulkan, driver: "llvmpipe", driver_info: "Mesa 23.1.6-arch1.4 (LLVM 16.0.6)"
-        // > wgpu adapter name: "Apple M1 Pro", device_type: IntegratedGpu, backend: Metal, driver: "", driver_info: ""
+        // Example values:
+        // > name: "llvmpipe (LLVM 16.0.6, 256 bits)", device_type: Cpu, backend: Vulkan, driver: "llvmpipe", driver_info: "Mesa 23.1.6-arch1.4 (LLVM 16.0.6)"
+        // > name: "Apple M1 Pro", device_type: IntegratedGpu, backend: Metal, driver: "", driver_info: ""
+        // > name: "ANGLE (Apple, Apple M1 Pro, OpenGL 4.1)", device_type: IntegratedGpu, backend: Gl, driver: "", driver_info: ""
 
-        format!(
-            "wgpu adapter name: {name:?}, \
-             device_type: {device_type:?}, \
-             backend: {backend:?}, \
-             driver: {driver:?}, \
-             driver_info: {driver_info:?}"
-        )
+        let mut summary = format!("wgpu backend: {backend:?}, device_type: {device_type:?}");
+
+        if !name.is_empty() {
+            summary += &format!(", name: {name:?}");
+        }
+        if !driver.is_empty() {
+            summary += &format!(", driver: {driver:?}");
+        }
+        if !driver_info.is_empty() {
+            summary += &format!(", driver_info: {driver_info:?}");
+        }
+
+        summary
     };
 
     let is_software_rasterizer_with_known_crashes = {

--- a/crates/re_renderer/src/context.rs
+++ b/crates/re_renderer/src/context.rs
@@ -113,6 +113,8 @@ impl RenderContext {
     ) -> Self {
         re_tracing::profile_function!();
 
+        log_adapter_info(&adapter.get_info());
+
         let mut gpu_resources = WgpuResourcePools::default();
         let global_bindings = GlobalBindings::new(&mut gpu_resources, &device);
 
@@ -431,4 +433,57 @@ pub struct ActiveFrameContext {
 
     /// Index of this frame. Is incremented for every render frame.
     frame_index: u64,
+}
+
+fn log_adapter_info(info: &wgpu::AdapterInfo) {
+    re_tracing::profile_function!();
+
+    let human_readable_summary = {
+        let wgpu::AdapterInfo {
+            name,
+            vendor: _, // skip integer id
+            device: _, // skip integer id
+            device_type,
+            driver,
+            driver_info,
+            backend,
+        } = &info;
+
+        // Example outputs:
+        // > wgpu adapter name: "llvmpipe (LLVM 16.0.6, 256 bits)", device_type: Cpu, backend: Vulkan, driver: "llvmpipe", driver_info: "Mesa 23.1.6-arch1.4 (LLVM 16.0.6)"
+        // > wgpu adapter name: "Apple M1 Pro", device_type: IntegratedGpu, backend: Metal, driver: "", driver_info: ""
+
+        format!(
+            "wgpu adapter name: {name:?}, \
+             device_type: {device_type:?}, \
+             backend: {backend:?}, \
+             driver: {driver:?}, \
+             driver_info: {driver_info:?}"
+        )
+    };
+
+    let is_software_rasterizer_with_known_crashes = {
+        // See https://github.com/rerun-io/rerun/issues/3089
+        const KNOWN_SOFTWARE_RASTERIZERS: &[&str] = &[
+            "lavapipe", // Vulkan software rasterizer
+            "llvmpipe", // OpenGL software rasterizer
+        ];
+
+        // I'm not sure where the incriminating string will appear, so check all fields at once:
+        let info_string = format!("{info:?}").to_lowercase();
+
+        KNOWN_SOFTWARE_RASTERIZERS
+            .iter()
+            .any(|&software_rasterizer| info_string.contains(software_rasterizer))
+    };
+
+    if is_software_rasterizer_with_known_crashes {
+        re_log::warn!("Software rasterizer detected - expect poor performance and crashes. See: https://www.rerun.io/docs/getting-started/troubleshooting#graphics-issues");
+        re_log::info!("{human_readable_summary}");
+    } else if info.device_type == wgpu::DeviceType::Cpu {
+        re_log::warn!("Software rasterizer detected - expect poor performance. See: https://www.rerun.io/docs/getting-started/troubleshooting#graphics-issues");
+        re_log::info!("{human_readable_summary}");
+    } else {
+        re_log::debug!("{human_readable_summary}");
+    }
 }

--- a/crates/re_viewer/src/native.rs
+++ b/crates/re_viewer/src/native.rs
@@ -15,66 +15,10 @@ pub fn run_native_app(app_creator: AppCreator) -> eframe::Result<()> {
         window_title,
         native_options,
         Box::new(move |cc| {
-            check_graphics_driver(cc.wgpu_render_state.as_ref());
             let re_ui = crate::customize_eframe(cc);
             app_creator(cc, re_ui)
         }),
     )
-}
-
-fn check_graphics_driver(wgpu_render_state: Option<&egui_wgpu::RenderState>) {
-    re_tracing::profile_function!();
-    let wgpu_render_state = wgpu_render_state.expect("Expected wgpu to be enabled");
-    let info = wgpu_render_state.adapter.get_info();
-
-    let human_readable_summary = {
-        let wgpu::AdapterInfo {
-            name,
-            vendor: _, // skip integer id
-            device: _, // skip integer id
-            device_type,
-            driver,
-            driver_info,
-            backend,
-        } = &info;
-
-        // Example outputs:
-        // > wgpu adapter name: "llvmpipe (LLVM 16.0.6, 256 bits)", device_type: Cpu, backend: Vulkan, driver: "llvmpipe", driver_info: "Mesa 23.1.6-arch1.4 (LLVM 16.0.6)"
-        // > wgpu adapter name: "Apple M1 Pro", device_type: IntegratedGpu, backend: Metal, driver: "", driver_info: ""
-
-        format!(
-            "wgpu adapter name: {name:?}, \
-             device_type: {device_type:?}, \
-             backend: {backend:?}, \
-             driver: {driver:?}, \
-             driver_info: {driver_info:?}"
-        )
-    };
-
-    let is_software_rasterizer_with_known_crashes = {
-        // See https://github.com/rerun-io/rerun/issues/3089
-        const KNOWN_SOFTWARE_RASTERIZERS: &[&str] = &[
-            "lavapipe", // Vulkan software rasterizer
-            "llvmpipe", // OpenGL software rasterizer
-        ];
-
-        // I'm not sure where the incriminating string will appear, so check all fields at once:
-        let info_string = format!("{info:?}").to_lowercase();
-
-        KNOWN_SOFTWARE_RASTERIZERS
-            .iter()
-            .any(|&software_rasterizer| info_string.contains(software_rasterizer))
-    };
-
-    if is_software_rasterizer_with_known_crashes {
-        re_log::warn!("Software rasterizer detected - expect poor performance and crashes. See: https://www.rerun.io/docs/getting-started/troubleshooting#graphics-issues");
-        re_log::info!("{human_readable_summary}");
-    } else if info.device_type == wgpu::DeviceType::Cpu {
-        re_log::warn!("Software rasterizer detected - expect poor performance. See: https://www.rerun.io/docs/getting-started/troubleshooting#graphics-issues");
-        re_log::info!("{human_readable_summary}");
-    } else {
-        re_log::debug!("{human_readable_summary}");
-    }
 }
 
 pub fn eframe_options() -> eframe::NativeOptions {


### PR DESCRIPTION
Best reviewed commit-by-commit

### What
We previously only logged the wgpu adapter info on native builds. This means we never logged wether or not the web viewer was using WebGL or WebGPU, for instance. With this PR, I now see this in my `Arc`  browser log:

> wgpu adapter backend: Gl, device_type: IntegratedGpu, name: "ANGLE (Apple, Apple M1 Pro, OpenGL 4.1)"

I also cleaned up the logging, omitting empty strings.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested [app.rerun.io](https://app.rerun.io/pr/4414) (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4414)
- [Docs preview](https://rerun.io/preview/761ba00cd9e0c62441047d94c4e3a289c905e517/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/761ba00cd9e0c62441047d94c4e3a289c905e517/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)