### PR TITLE
Datastore: don't eagerly sort in bucket split rountine on ingestion path

### DIFF
--- a/crates/re_arrow_store/src/store_write.rs
+++ b/crates/re_arrow_store/src/store_write.rs
@@ -551,6 +551,19 @@ impl IndexedBucket {
         } = self;
 
         let mut inner1 = inner.write();
+
+        if inner1.col_time.len() < 2 {
+            return None; // early exit: can't split the unsplittable
+        }
+
+        if inner1.time_range.abs_length() == 0 {
+            // The entire bucket contains only one timepoint, thus it's impossible to find
+            // a split index to begin with.
+            return None;
+        }
+
+        re_tracing::profile_function!();
+
         inner1.sort();
 
         let IndexedBucketInner {
@@ -563,18 +576,6 @@ impl IndexedBucket {
             columns: columns1,
             size_bytes: _, // NOTE: recomputed below
         } = &mut *inner1;
-
-        if col_time1.len() < 2 {
-            return None; // early exit: can't split the unsplittable
-        }
-
-        if col_time1.first() == col_time1.last() {
-            // The entire bucket contains only one timepoint, thus it's impossible to find
-            // a split index to begin with.
-            return None;
-        }
-
-        re_tracing::profile_function!();
 
         let timeline = *timeline;
 


### PR DESCRIPTION
This should fix #4415, although without knowing how exactly the user ended up in that situation it's hard to say for certain.

- #4415 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4417/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4417/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4417)
- [Docs preview](https://rerun.io/preview/de71e897503f2d57a842f4d330ee008b15ea672a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/de71e897503f2d57a842f4d330ee008b15ea672a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)