### PR TITLE
Make draw data creation no longer require a mutable re_renderer context 

### DIFF
--- a/crates/re_renderer/examples/2d.rs
+++ b/crates/re_renderer/examples/2d.rs
@@ -24,7 +24,7 @@ impl framework::Example for Render2D {
         "2D Rendering"
     }
 
-    fn new(re_ctx: &mut re_renderer::RenderContext) -> Self {
+    fn new(re_ctx: &re_renderer::RenderContext) -> Self {
         let rerun_logo =
             image::load_from_memory(include_bytes!("../../re_ui/data/logo_dark_mode.png")).unwrap();
 
@@ -53,7 +53,7 @@ impl framework::Example for Render2D {
 
     fn draw(
         &mut self,
-        re_ctx: &mut re_renderer::RenderContext,
+        re_ctx: &re_renderer::RenderContext,
         resolution: [u32; 2],
         time: &framework::Time,
         pixels_from_point: f32,

--- a/crates/re_renderer/examples/depth_cloud.rs
+++ b/crates/re_renderer/examples/depth_cloud.rs
@@ -57,7 +57,7 @@ impl RenderDepthClouds {
     /// Manually backproject the depth texture into a point cloud and render it.
     fn draw_backprojected_point_cloud<FD, ID>(
         &mut self,
-        re_ctx: &mut re_renderer::RenderContext,
+        re_ctx: &re_renderer::RenderContext,
         pixels_from_point: f32,
         resolution_in_pixel: [u32; 2],
         target_location: glam::Vec2,
@@ -143,7 +143,7 @@ impl RenderDepthClouds {
     /// Pass the depth texture to our native depth cloud renderer.
     fn draw_depth_cloud<FD, ID>(
         &mut self,
-        re_ctx: &mut re_renderer::RenderContext,
+        re_ctx: &re_renderer::RenderContext,
         pixels_from_point: f32,
         resolution_in_pixel: [u32; 2],
         target_location: glam::Vec2,
@@ -226,7 +226,7 @@ impl framework::Example for RenderDepthClouds {
         "Depth clouds"
     }
 
-    fn new(re_ctx: &mut re_renderer::RenderContext) -> Self {
+    fn new(re_ctx: &re_renderer::RenderContext) -> Self {
         re_log::info!("Stop camera movement by pressing 'Space'");
 
         let depth = DepthTexture::spiral(re_ctx, glam::uvec2(640, 480));
@@ -260,7 +260,7 @@ impl framework::Example for RenderDepthClouds {
 
     fn draw(
         &mut self,
-        re_ctx: &mut re_renderer::RenderContext,
+        re_ctx: &re_renderer::RenderContext,
         resolution: [u32; 2],
         time: &framework::Time,
         pixels_from_point: f32,

--- a/crates/re_renderer/examples/depth_offset.rs
+++ b/crates/re_renderer/examples/depth_offset.rs
@@ -25,7 +25,7 @@ impl framework::Example for Render2D {
         "Depth Offset"
     }
 
-    fn new(_re_ctx: &mut re_renderer::RenderContext) -> Self {
+    fn new(_re_ctx: &re_renderer::RenderContext) -> Self {
         Render2D {
             distance_scale: 100.0,
             near_plane: 0.1,
@@ -34,7 +34,7 @@ impl framework::Example for Render2D {
 
     fn draw(
         &mut self,
-        re_ctx: &mut re_renderer::RenderContext,
+        re_ctx: &re_renderer::RenderContext,
         resolution: [u32; 2],
         _time: &framework::Time,
         pixels_from_point: f32,

--- a/crates/re_renderer/examples/framework.rs
+++ b/crates/re_renderer/examples/framework.rs
@@ -26,11 +26,11 @@ pub struct ViewDrawResult {
 pub trait Example {
     fn title() -> &'static str;
 
-    fn new(re_ctx: &mut RenderContext) -> Self;
+    fn new(re_ctx: &RenderContext) -> Self;
 
     fn draw(
         &mut self,
-        re_ctx: &mut RenderContext,
+        re_ctx: &RenderContext,
         resolution: [u32; 2],
         time: &Time,
         pixels_from_point: f32,
@@ -160,7 +160,7 @@ impl<E: Example + 'static> Application<E> {
         };
         surface.configure(&device, &surface_config);
 
-        let mut re_ctx = RenderContext::new(
+        let re_ctx = RenderContext::new(
             &adapter,
             device,
             queue,
@@ -170,7 +170,7 @@ impl<E: Example + 'static> Application<E> {
             },
         );
 
-        let example = E::new(&mut re_ctx);
+        let example = E::new(&re_ctx);
 
         Ok(Self {
             event_loop,
@@ -263,7 +263,7 @@ impl<E: Example + 'static> Application<E> {
                         .create_view(&wgpu::TextureViewDescriptor::default());
 
                     let draw_results = self.example.draw(
-                        &mut self.re_ctx,
+                        &self.re_ctx,
                         [self.surface_config.width, self.surface_config.height],
                         &self.time,
                         self.window.scale_factor() as f32,

--- a/crates/re_renderer/examples/multiview.rs
+++ b/crates/re_renderer/examples/multiview.rs
@@ -21,7 +21,7 @@ use winit::event::{ElementState, VirtualKeyCode};
 mod framework;
 
 fn build_mesh_instances(
-    re_ctx: &mut RenderContext,
+    re_ctx: &RenderContext,
     model_mesh_instances: &[MeshInstance],
     mesh_instance_positions_and_colors: &[(glam::Vec3, Color32)],
     seconds_since_startup: f32,
@@ -80,7 +80,7 @@ fn lorenz_points(seconds_since_startup: f32) -> Vec<glam::Vec3> {
     .collect()
 }
 
-fn build_lines(re_ctx: &mut RenderContext, seconds_since_startup: f32) -> LineDrawData {
+fn build_lines(re_ctx: &RenderContext, seconds_since_startup: f32) -> LineDrawData {
     // Calculate some points that look nice for an animated line.
     let lorenz_points = lorenz_points(seconds_since_startup);
 
@@ -211,7 +211,7 @@ fn handle_incoming_screenshots(re_ctx: &RenderContext) {
 impl Multiview {
     fn draw_view<D: 'static + re_renderer::renderer::DrawData + Sync + Send + Clone>(
         &mut self,
-        re_ctx: &mut RenderContext,
+        re_ctx: &RenderContext,
         target_cfg: TargetConfiguration,
         skybox: GenericSkyboxDrawData,
         draw_data: D,
@@ -244,7 +244,7 @@ impl Example for Multiview {
         "Multiple Views"
     }
 
-    fn new(re_ctx: &mut RenderContext) -> Self {
+    fn new(re_ctx: &RenderContext) -> Self {
         re_log::info!("Switch between orthographic & perspective by pressing 'O'");
         re_log::info!("Stop camera movement by pressing 'Space'");
 
@@ -298,7 +298,7 @@ impl Example for Multiview {
 
     fn draw(
         &mut self,
-        re_ctx: &mut RenderContext,
+        re_ctx: &RenderContext,
         resolution: [u32; 2],
         time: &framework::Time,
         pixels_from_point: f32,

--- a/crates/re_renderer/examples/outlines.rs
+++ b/crates/re_renderer/examples/outlines.rs
@@ -25,7 +25,7 @@ impl framework::Example for Outlines {
         "Outlines"
     }
 
-    fn new(re_ctx: &mut re_renderer::RenderContext) -> Self {
+    fn new(re_ctx: &re_renderer::RenderContext) -> Self {
         Outlines {
             is_paused: false,
             seconds_since_startup: 0.0,
@@ -35,7 +35,7 @@ impl framework::Example for Outlines {
 
     fn draw(
         &mut self,
-        re_ctx: &mut re_renderer::RenderContext,
+        re_ctx: &re_renderer::RenderContext,
         resolution: [u32; 2],
         time: &framework::Time,
         pixels_from_point: f32,

--- a/crates/re_renderer/examples/picking.rs
+++ b/crates/re_renderer/examples/picking.rs
@@ -52,7 +52,7 @@ impl framework::Example for Picking {
         self.picking_position = position_in_pixel;
     }
 
-    fn new(re_ctx: &mut re_renderer::RenderContext) -> Self {
+    fn new(re_ctx: &re_renderer::RenderContext) -> Self {
         let mut rnd = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(42);
         let random_point_range = -5.0_f32..5.0_f32;
         let point_count = 1000;
@@ -93,7 +93,7 @@ impl framework::Example for Picking {
 
     fn draw(
         &mut self,
-        re_ctx: &mut re_renderer::RenderContext,
+        re_ctx: &re_renderer::RenderContext,
         resolution: [u32; 2],
         _time: &framework::Time,
         pixels_from_point: f32,

--- a/crates/re_renderer/src/context.rs
+++ b/crates/re_renderer/src/context.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use parking_lot::{Mutex, RwLock};
+use parking_lot::{MappedRwLockReadGuard, Mutex, RwLock, RwLockReadGuard};
 use type_map::concurrent::{self, TypeMap};
 
 use crate::{
@@ -20,7 +20,7 @@ pub struct RenderContext {
     pub queue: Arc<wgpu::Queue>,
 
     pub(crate) shared_renderer_data: SharedRendererData,
-    pub(crate) renderers: RwLock<Renderers>,
+    renderers: RwLock<Renderers>,
     pub(crate) resolver: RecommendedFileResolver,
     #[cfg(all(not(target_arch = "wasm32"), debug_assertions))] // native debug build
     pub(crate) err_tracker: std::sync::Arc<crate::error_tracker::ErrorTracker>,
@@ -60,9 +60,9 @@ impl Renderers {
     pub fn get_or_create<Fs: FileSystem, R: 'static + Renderer + Send + Sync>(
         &mut self,
         shared_data: &SharedRendererData,
-        resource_pools: &mut WgpuResourcePools,
+        resource_pools: &WgpuResourcePools,
         device: &wgpu::Device,
-        resolver: &mut FileResolver<Fs>,
+        resolver: &FileResolver<Fs>,
     ) -> &R {
         self.renderers.entry().or_insert_with(|| {
             re_tracing::profile_scope!("create_renderer", std::any::type_name::<R>());
@@ -398,6 +398,40 @@ impl RenderContext {
             self.inflight_queue_submissions
                 .push(self.queue.submit([command_buffer]));
         }
+    }
+
+    /// Gets a renderer with the specified type, initializing it if necessary.
+    pub fn get_renderer<R: 'static + Renderer + Send + Sync>(
+        &self,
+    ) -> MappedRwLockReadGuard<'_, R> {
+        {
+            // Most likely we already have the renderer. Take a read lock and return it.
+            if let Ok(renderer) =
+                parking_lot::RwLockReadGuard::try_map(self.renderers.read(), |r| r.get::<R>())
+            {
+                return renderer;
+            }
+        }
+
+        // If it wasn't there we have to add it.
+        // This path is rare since it happens only once per renderer type in the lifetime of the ctx.
+        // (we don't discard renderers ever)
+        {
+            self.renderers.write().get_or_create::<_, R>(
+                &self.shared_renderer_data,
+                &self.gpu_resources,
+                &self.device,
+                &self.resolver,
+            );
+        }
+        // Release write lock again and only take a read lock.
+        // safe to unwrap since we just created it.
+        parking_lot::RwLockReadGuard::map(self.renderers.read(), |r| r.get::<R>().unwrap())
+    }
+
+    /// Read access to renderers.
+    pub(crate) fn read_lock_renderers(&self) -> RwLockReadGuard<'_, Renderers> {
+        self.renderers.read()
     }
 }
 

--- a/crates/re_renderer/src/context.rs
+++ b/crates/re_renderer/src/context.rs
@@ -170,16 +170,16 @@ impl RenderContext {
             global_bindings,
         };
 
-        let mut resolver = crate::new_recommended_file_resolver();
+        let resolver = crate::new_recommended_file_resolver();
         let mut renderers = RwLock::new(Renderers {
             renderers: TypeMap::new(),
         });
 
         let mesh_manager = RwLock::new(MeshManager::new(renderers.get_mut().get_or_create(
             &shared_renderer_data,
-            &mut gpu_resources,
+            &gpu_resources,
             &device,
-            &mut resolver,
+            &resolver,
         )));
         let texture_manager_2d =
             TextureManager2D::new(device.clone(), queue.clone(), &gpu_resources.textures);
@@ -325,7 +325,7 @@ impl RenderContext {
         // The set of files on disk that were modified in any way since last frame,
         // ignoring deletions.
         // Always an empty set in release builds.
-        let modified_paths = FileServer::get_mut(|fs| fs.collect(&mut self.resolver));
+        let modified_paths = FileServer::get_mut(|fs| fs.collect(&self.resolver));
         if !modified_paths.is_empty() {
             re_log::debug!(?modified_paths, "got some filesystem events");
         }
@@ -348,12 +348,7 @@ impl RenderContext {
 
             // Shader module maintenance must come before render pipelines because render pipeline
             // recompilation picks up all shaders that have been recompiled this frame.
-            shader_modules.begin_frame(
-                &self.device,
-                &mut self.resolver,
-                frame_index,
-                &modified_paths,
-            );
+            shader_modules.begin_frame(&self.device, &self.resolver, frame_index, &modified_paths);
             render_pipelines.begin_frame(
                 &self.device,
                 frame_index,

--- a/crates/re_renderer/src/draw_phases/outlines.rs
+++ b/crates/re_renderer/src/draw_phases/outlines.rs
@@ -286,7 +286,7 @@ impl OutlineMaskProcessor {
             fragment_entrypoint: "main".into(),
             fragment_handle: ctx.gpu_resources.shader_modules.get_or_create(
                 &ctx.device,
-                &mut ctx.resolver,
+                &ctx.resolver,
                 &jumpflooding_init_shader_module,
             ),
             vertex_buffers: smallvec![],
@@ -315,7 +315,7 @@ impl OutlineMaskProcessor {
                 ),
                 fragment_handle: ctx.gpu_resources.shader_modules.get_or_create(
                     &ctx.device,
-                    &mut ctx.resolver,
+                    &ctx.resolver,
                     &include_shader_module!("../../shader/outlines/jumpflooding_step.wgsl"),
                 ),
                 ..jumpflooding_init_desc

--- a/crates/re_renderer/src/draw_phases/outlines.rs
+++ b/crates/re_renderer/src/draw_phases/outlines.rs
@@ -197,7 +197,7 @@ impl OutlineMaskProcessor {
     }
 
     pub fn new(
-        ctx: &mut RenderContext,
+        ctx: &RenderContext,
         config: &OutlineConfig,
         view_name: &DebugLabel,
         resolution_in_pixel: [u32; 2],
@@ -265,7 +265,7 @@ impl OutlineMaskProcessor {
         // ------------- Render Pipelines -------------
 
         let screen_triangle_vertex_shader =
-            screen_triangle_vertex_shader(&mut ctx.gpu_resources, &ctx.device, &mut ctx.resolver);
+            screen_triangle_vertex_shader(&ctx.gpu_resources, &ctx.device, &ctx.resolver);
         let jumpflooding_init_shader_module = if mask_sample_count == 1 {
             include_shader_module!("../../shader/outlines/jumpflooding_init.wgsl")
         } else {

--- a/crates/re_renderer/src/draw_phases/picking_layer.rs
+++ b/crates/re_renderer/src/draw_phases/picking_layer.rs
@@ -174,7 +174,7 @@ impl PickingLayerProcessor {
     /// It allows to sample the picking layer texture in a shader.
     #[allow(clippy::too_many_arguments)]
     pub fn new<T: 'static + Send + Sync>(
-        ctx: &mut RenderContext,
+        ctx: &RenderContext,
         view_name: &DebugLabel,
         screen_resolution: glam::UVec2,
         picking_rect: RectInt,
@@ -485,7 +485,7 @@ impl DepthReadbackWorkaround {
     const READBACK_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba32Float;
 
     fn new(
-        ctx: &mut RenderContext,
+        ctx: &RenderContext,
         extent: glam::UVec2,
         depth_target_handle: GpuTextureHandle,
     ) -> DepthReadbackWorkaround {
@@ -551,13 +551,13 @@ impl DepthReadbackWorkaround {
                 vertex_entrypoint: "main".into(),
                 vertex_handle: ctx.gpu_resources.shader_modules.get_or_create(
                     &ctx.device,
-                    &mut ctx.resolver,
+                    &ctx.resolver,
                     &include_shader_module!("../../shader/screen_triangle.wgsl"),
                 ),
                 fragment_entrypoint: "main".into(),
                 fragment_handle: ctx.gpu_resources.shader_modules.get_or_create(
                     &ctx.device,
-                    &mut ctx.resolver,
+                    &ctx.resolver,
                     &include_shader_module!("../../shader/copy_texture.wgsl"),
                 ),
                 vertex_buffers: smallvec![],

--- a/crates/re_renderer/src/file_resolver.rs
+++ b/crates/re_renderer/src/file_resolver.rs
@@ -504,11 +504,11 @@ impl<Fs: FileSystem> FileResolver<Fs> {
 }
 
 impl<Fs: FileSystem> FileResolver<Fs> {
-    pub fn populate(&mut self, path: impl AsRef<Path>) -> anyhow::Result<InterpolatedFile> {
+    pub fn populate(&self, path: impl AsRef<Path>) -> anyhow::Result<InterpolatedFile> {
         re_tracing::profile_function!();
 
         fn populate_rec<Fs: FileSystem>(
-            this: &mut FileResolver<Fs>,
+            this: &FileResolver<Fs>,
             path: impl AsRef<Path>,
             interp_files: &mut HashMap<PathBuf, Rc<InterpolatedFile>>,
             path_stack: &mut Vec<PathBuf>,
@@ -705,7 +705,7 @@ mod tests_file_resolver {
             .unwrap();
         }
 
-        let mut resolver = FileResolver::with_search_path(fs, {
+        let resolver = FileResolver::with_search_path(fs, {
             let mut search_path = SearchPath::default();
             search_path.push("/shaders1");
             search_path.push("/shaders1/common");
@@ -811,7 +811,7 @@ mod tests_file_resolver {
             .unwrap();
         }
 
-        let mut resolver = FileResolver::new(fs);
+        let resolver = FileResolver::new(fs);
 
         resolver
             .populate("/shaders2/shader1.wgsl")

--- a/crates/re_renderer/src/file_resolver.rs
+++ b/crates/re_renderer/src/file_resolver.rs
@@ -864,7 +864,7 @@ mod tests_file_resolver {
             .unwrap();
         }
 
-        let mut resolver = FileResolver::new(fs);
+        let resolver = FileResolver::new(fs);
 
         resolver
             .populate("/shaders3/shader1.wgsl")

--- a/crates/re_renderer/src/file_server.rs
+++ b/crates/re_renderer/src/file_server.rs
@@ -183,7 +183,7 @@ mod file_server_impl {
         /// The given `path` is canonicalized.
         pub fn watch<Fs: FileSystem>(
             &mut self,
-            resolver: &mut FileResolver<Fs>,
+            resolver: &FileResolver<Fs>,
             path: impl AsRef<Path>,
             recursive: bool,
         ) -> anyhow::Result<PathBuf> {
@@ -248,10 +248,7 @@ mod file_server_impl {
 
         /// Coalesces all filesystem events since the last call to `collect`,
         /// and returns a set of all modified paths.
-        pub fn collect<Fs: FileSystem>(
-            &mut self,
-            resolver: &mut FileResolver<Fs>,
-        ) -> HashSet<PathBuf> {
+        pub fn collect<Fs: FileSystem>(&mut self, resolver: &FileResolver<Fs>) -> HashSet<PathBuf> {
             fn canonicalize_opt(path: impl AsRef<Path>) -> Option<PathBuf> {
                 let path = path.as_ref();
                 std::fs::canonicalize(path)
@@ -314,7 +311,7 @@ mod file_server_impl {
         #[allow(clippy::unused_self)]
         pub fn collect<Fs: FileSystem>(
             &mut self,
-            _resolver: &mut FileResolver<Fs>,
+            _resolver: &FileResolver<Fs>,
         ) -> HashSet<PathBuf> {
             Default::default()
         }

--- a/crates/re_renderer/src/line_strip_builder.rs
+++ b/crates/re_renderer/src/line_strip_builder.rs
@@ -95,7 +95,7 @@ impl LineStripSeriesBuilder {
     /// Finalizes the builder and returns a line draw data with all the lines added so far.
     pub fn into_draw_data(
         self,
-        ctx: &mut crate::context::RenderContext,
+        ctx: &crate::context::RenderContext,
     ) -> Result<LineDrawData, LineDrawDataError> {
         LineDrawData::new(ctx, self)
     }

--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -106,7 +106,7 @@ impl PointCloudBuilder {
     /// Finalizes the builder and returns a point cloud draw data with all the points added so far.
     pub fn into_draw_data(
         self,
-        ctx: &mut crate::context::RenderContext,
+        ctx: &crate::context::RenderContext,
     ) -> Result<PointCloudDrawData, PointCloudDrawDataError> {
         PointCloudDrawData::new(ctx, self)
     }

--- a/crates/re_renderer/src/renderer/compositor.rs
+++ b/crates/re_renderer/src/renderer/compositor.rs
@@ -49,7 +49,7 @@ impl DrawData for CompositorDrawData {
 
 impl CompositorDrawData {
     pub fn new(
-        ctx: &mut RenderContext,
+        ctx: &RenderContext,
         color_texture: &GpuTexture,
         outline_final_voronoi: Option<&GpuTexture>,
         outline_config: &Option<OutlineConfig>,

--- a/crates/re_renderer/src/renderer/compositor.rs
+++ b/crates/re_renderer/src/renderer/compositor.rs
@@ -54,7 +54,7 @@ impl CompositorDrawData {
         outline_final_voronoi: Option<&GpuTexture>,
         outline_config: &Option<OutlineConfig>,
     ) -> Self {
-        let compositor = ctx.get_renderer::<Compositor>();
+        let compositor = ctx.renderer::<Compositor>();
 
         let outline_config = outline_config.clone().unwrap_or(OutlineConfig {
             outline_radius_pixel: 0.0,

--- a/crates/re_renderer/src/renderer/compositor.rs
+++ b/crates/re_renderer/src/renderer/compositor.rs
@@ -54,13 +54,7 @@ impl CompositorDrawData {
         outline_final_voronoi: Option<&GpuTexture>,
         outline_config: &Option<OutlineConfig>,
     ) -> Self {
-        let mut renderers = ctx.renderers.write();
-        let compositor = renderers.get_or_create::<_, Compositor>(
-            &ctx.shared_renderer_data,
-            &mut ctx.gpu_resources,
-            &ctx.device,
-            &mut ctx.resolver,
-        );
+        let compositor = ctx.get_renderer::<Compositor>();
 
         let outline_config = outline_config.clone().unwrap_or(OutlineConfig {
             outline_radius_pixel: 0.0,
@@ -107,9 +101,9 @@ impl Renderer for Compositor {
 
     fn create_renderer<Fs: FileSystem>(
         shared_data: &SharedRendererData,
-        pools: &mut WgpuResourcePools,
+        pools: &WgpuResourcePools,
         device: &wgpu::Device,
-        resolver: &mut FileResolver<Fs>,
+        resolver: &FileResolver<Fs>,
     ) -> Self {
         let bind_group_layout = pools.bind_group_layouts.get_or_create(
             device,

--- a/crates/re_renderer/src/renderer/debug_overlay.rs
+++ b/crates/re_renderer/src/renderer/debug_overlay.rs
@@ -77,13 +77,7 @@ impl DebugOverlayDrawData {
         screen_resolution: glam::UVec2,
         overlay_rect: RectInt,
     ) -> Result<Self, DebugOverlayError> {
-        let mut renderers = ctx.renderers.write();
-        let debug_overlay = renderers.get_or_create::<_, DebugOverlayRenderer>(
-            &ctx.shared_renderer_data,
-            &mut ctx.gpu_resources,
-            &ctx.device,
-            &mut ctx.resolver,
-        );
+        let debug_overlay = ctx.get_renderer::<DebugOverlayRenderer>();
 
         let mode = match debug_texture
             .texture
@@ -150,9 +144,9 @@ impl Renderer for DebugOverlayRenderer {
 
     fn create_renderer<Fs: FileSystem>(
         shared_data: &SharedRendererData,
-        pools: &mut WgpuResourcePools,
+        pools: &WgpuResourcePools,
         device: &wgpu::Device,
-        resolver: &mut FileResolver<Fs>,
+        resolver: &FileResolver<Fs>,
     ) -> Self {
         let bind_group_layout = pools.bind_group_layouts.get_or_create(
             device,

--- a/crates/re_renderer/src/renderer/debug_overlay.rs
+++ b/crates/re_renderer/src/renderer/debug_overlay.rs
@@ -72,7 +72,7 @@ impl DrawData for DebugOverlayDrawData {
 
 impl DebugOverlayDrawData {
     pub fn new(
-        ctx: &mut RenderContext,
+        ctx: &RenderContext,
         debug_texture: &GpuTexture,
         screen_resolution: glam::UVec2,
         overlay_rect: RectInt,

--- a/crates/re_renderer/src/renderer/debug_overlay.rs
+++ b/crates/re_renderer/src/renderer/debug_overlay.rs
@@ -77,7 +77,7 @@ impl DebugOverlayDrawData {
         screen_resolution: glam::UVec2,
         overlay_rect: RectInt,
     ) -> Result<Self, DebugOverlayError> {
-        let debug_overlay = ctx.get_renderer::<DebugOverlayRenderer>();
+        let debug_overlay = ctx.renderer::<DebugOverlayRenderer>();
 
         let mode = match debug_texture
             .texture

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -243,16 +243,8 @@ impl DepthCloudDrawData {
             radius_boost_in_ui_points_for_outlines,
         } = depth_clouds;
 
-        let bg_layout = ctx
-            .renderers
-            .write()
-            .get_or_create::<_, DepthCloudRenderer>(
-                &ctx.shared_renderer_data,
-                &mut ctx.gpu_resources,
-                &ctx.device,
-                &mut ctx.resolver,
-            )
-            .bind_group_layout;
+        let renderer = ctx.get_renderer::<DepthCloudRenderer>();
+        let bg_layout = renderer.bind_group_layout;
 
         if depth_clouds.is_empty() {
             return Ok(DepthCloudDrawData {
@@ -358,9 +350,9 @@ impl Renderer for DepthCloudRenderer {
 
     fn create_renderer<Fs: FileSystem>(
         shared_data: &SharedRendererData,
-        pools: &mut WgpuResourcePools,
+        pools: &WgpuResourcePools,
         device: &wgpu::Device,
-        resolver: &mut FileResolver<Fs>,
+        resolver: &FileResolver<Fs>,
     ) -> Self {
         re_tracing::profile_function!();
 

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -243,7 +243,7 @@ impl DepthCloudDrawData {
             radius_boost_in_ui_points_for_outlines,
         } = depth_clouds;
 
-        let renderer = ctx.get_renderer::<DepthCloudRenderer>();
+        let renderer = ctx.renderer::<DepthCloudRenderer>();
         let bg_layout = renderer.bind_group_layout;
 
         if depth_clouds.is_empty() {

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -233,7 +233,7 @@ pub enum DepthCloudDrawDataError {
 
 impl DepthCloudDrawData {
     pub fn new(
-        ctx: &mut RenderContext,
+        ctx: &RenderContext,
         depth_clouds: &DepthClouds,
     ) -> Result<Self, DepthCloudDrawDataError> {
         re_tracing::profile_function!();

--- a/crates/re_renderer/src/renderer/generic_skybox.rs
+++ b/crates/re_renderer/src/renderer/generic_skybox.rs
@@ -31,7 +31,7 @@ impl DrawData for GenericSkyboxDrawData {
 
 impl GenericSkyboxDrawData {
     pub fn new(ctx: &RenderContext) -> Self {
-        let _ = ctx.get_renderer::<GenericSkybox>(); // TODO(andreas): This should happen automatically.
+        let _ = ctx.renderer::<GenericSkybox>(); // TODO(andreas): This line ensures that the renderer exists. Currently this needs to be done ahead of time, but should be fully automatic!
         GenericSkyboxDrawData {}
     }
 }

--- a/crates/re_renderer/src/renderer/generic_skybox.rs
+++ b/crates/re_renderer/src/renderer/generic_skybox.rs
@@ -31,13 +31,7 @@ impl DrawData for GenericSkyboxDrawData {
 
 impl GenericSkyboxDrawData {
     pub fn new(ctx: &mut RenderContext) -> Self {
-        ctx.renderers.write().get_or_create::<_, GenericSkybox>(
-            &ctx.shared_renderer_data,
-            &mut ctx.gpu_resources,
-            &ctx.device,
-            &mut ctx.resolver,
-        );
-
+        ctx.get_renderer::<GenericSkybox>();
         GenericSkyboxDrawData {}
     }
 }
@@ -47,9 +41,9 @@ impl Renderer for GenericSkybox {
 
     fn create_renderer<Fs: FileSystem>(
         shared_data: &SharedRendererData,
-        pools: &mut WgpuResourcePools,
+        pools: &WgpuResourcePools,
         device: &wgpu::Device,
-        resolver: &mut FileResolver<Fs>,
+        resolver: &FileResolver<Fs>,
     ) -> Self {
         re_tracing::profile_function!();
 

--- a/crates/re_renderer/src/renderer/generic_skybox.rs
+++ b/crates/re_renderer/src/renderer/generic_skybox.rs
@@ -30,8 +30,8 @@ impl DrawData for GenericSkyboxDrawData {
 }
 
 impl GenericSkyboxDrawData {
-    pub fn new(ctx: &mut RenderContext) -> Self {
-        ctx.get_renderer::<GenericSkybox>();
+    pub fn new(ctx: &RenderContext) -> Self {
+        let _ = ctx.get_renderer::<GenericSkybox>(); // TODO(andreas): This should happen automatically.
         GenericSkyboxDrawData {}
     }
 }

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -373,16 +373,10 @@ impl LineDrawData {
     ///
     /// If no batches are passed, all lines are assumed to be in a single batch with identity transform.
     pub fn new(
-        ctx: &mut RenderContext,
+        ctx: &RenderContext,
         line_builder: LineStripSeriesBuilder,
     ) -> Result<Self, LineDrawDataError> {
-        let mut renderers = ctx.renderers.write();
-        let line_renderer = renderers.get_or_create::<_, LineRenderer>(
-            &ctx.shared_renderer_data,
-            &mut ctx.gpu_resources,
-            &ctx.device,
-            &mut ctx.resolver,
-        );
+        let line_renderer = ctx.get_renderer::<LineRenderer>();
 
         if line_builder.strips.is_empty() {
             return Ok(LineDrawData {
@@ -794,9 +788,9 @@ impl Renderer for LineRenderer {
 
     fn create_renderer<Fs: FileSystem>(
         shared_data: &SharedRendererData,
-        pools: &mut WgpuResourcePools,
+        pools: &WgpuResourcePools,
         device: &wgpu::Device,
-        resolver: &mut FileResolver<Fs>,
+        resolver: &FileResolver<Fs>,
     ) -> Self {
         let bind_group_layout_all_lines = pools.bind_group_layouts.get_or_create(
             device,

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -376,7 +376,7 @@ impl LineDrawData {
         ctx: &RenderContext,
         line_builder: LineStripSeriesBuilder,
     ) -> Result<Self, LineDrawDataError> {
-        let line_renderer = ctx.get_renderer::<LineRenderer>();
+        let line_renderer = ctx.renderer::<LineRenderer>();
 
         if line_builder.strips.is_empty() {
             return Ok(LineDrawData {

--- a/crates/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/re_renderer/src/renderer/mesh_renderer.rs
@@ -157,7 +157,7 @@ impl MeshDrawData {
     pub fn new(ctx: &RenderContext, instances: &[MeshInstance]) -> anyhow::Result<Self> {
         re_tracing::profile_function!();
 
-        let _mesh_renderer = ctx.get_renderer::<MeshRenderer>();
+        let _mesh_renderer = ctx.renderer::<MeshRenderer>();
 
         if instances.is_empty() {
             return Ok(MeshDrawData {

--- a/crates/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/re_renderer/src/renderer/mesh_renderer.rs
@@ -154,7 +154,7 @@ impl MeshDrawData {
     /// Try bundling all mesh instances into a single draw data instance whenever possible.
     /// If you pass zero mesh instances, subsequent drawing will do nothing.
     /// Mesh data itself is gpu uploaded if not already present.
-    pub fn new(ctx: &mut RenderContext, instances: &[MeshInstance]) -> anyhow::Result<Self> {
+    pub fn new(ctx: &RenderContext, instances: &[MeshInstance]) -> anyhow::Result<Self> {
         re_tracing::profile_function!();
 
         let _mesh_renderer = ctx.get_renderer::<MeshRenderer>();

--- a/crates/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/re_renderer/src/renderer/mesh_renderer.rs
@@ -157,12 +157,7 @@ impl MeshDrawData {
     pub fn new(ctx: &mut RenderContext, instances: &[MeshInstance]) -> anyhow::Result<Self> {
         re_tracing::profile_function!();
 
-        let _mesh_renderer = ctx.renderers.write().get_or_create::<_, MeshRenderer>(
-            &ctx.shared_renderer_data,
-            &mut ctx.gpu_resources,
-            &ctx.device,
-            &mut ctx.resolver,
-        );
+        let _mesh_renderer = ctx.get_renderer::<MeshRenderer>();
 
         if instances.is_empty() {
             return Ok(MeshDrawData {
@@ -297,9 +292,9 @@ impl Renderer for MeshRenderer {
 
     fn create_renderer<Fs: FileSystem>(
         shared_data: &SharedRendererData,
-        pools: &mut WgpuResourcePools,
+        pools: &WgpuResourcePools,
         device: &wgpu::Device,
-        resolver: &mut FileResolver<Fs>,
+        resolver: &FileResolver<Fs>,
     ) -> Self {
         re_tracing::profile_function!();
 

--- a/crates/re_renderer/src/renderer/mod.rs
+++ b/crates/re_renderer/src/renderer/mod.rs
@@ -66,9 +66,9 @@ pub trait Renderer {
 
     fn create_renderer<Fs: FileSystem>(
         shared_data: &SharedRendererData,
-        pools: &mut WgpuResourcePools,
+        pools: &WgpuResourcePools,
         device: &wgpu::Device,
-        resolver: &mut FileResolver<Fs>,
+        resolver: &FileResolver<Fs>,
     ) -> Self;
 
     // TODO(andreas): Some Renderers need to create their own passes, need something like this for that.
@@ -88,9 +88,9 @@ pub trait Renderer {
 
 /// Gets or creates a vertex shader module for drawing a screen filling triangle.
 pub fn screen_triangle_vertex_shader<Fs: FileSystem>(
-    pools: &mut WgpuResourcePools,
+    pools: &WgpuResourcePools,
     device: &wgpu::Device,
-    resolver: &mut FileResolver<Fs>,
+    resolver: &FileResolver<Fs>,
 ) -> crate::wgpu_resources::GpuShaderModuleHandle {
     pools.shader_modules.get_or_create(
         device,

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -186,13 +186,7 @@ impl PointCloudDrawData {
     ) -> Result<Self, PointCloudDrawDataError> {
         re_tracing::profile_function!();
 
-        let mut renderers = ctx.renderers.write();
-        let point_renderer = renderers.get_or_create::<_, PointCloudRenderer>(
-            &ctx.shared_renderer_data,
-            &mut ctx.gpu_resources,
-            &ctx.device,
-            &mut ctx.resolver,
-        );
+        let point_renderer = ctx.get_renderer::<PointCloudRenderer>();
 
         let vertices = builder.vertices.as_slice();
         let batches = builder.batches.as_slice();
@@ -541,9 +535,9 @@ impl Renderer for PointCloudRenderer {
 
     fn create_renderer<Fs: FileSystem>(
         shared_data: &SharedRendererData,
-        pools: &mut WgpuResourcePools,
+        pools: &WgpuResourcePools,
         device: &wgpu::Device,
-        resolver: &mut FileResolver<Fs>,
+        resolver: &FileResolver<Fs>,
     ) -> Self {
         re_tracing::profile_function!();
 

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -181,7 +181,7 @@ impl PointCloudDrawData {
     ///
     /// If no batches are passed, all points are assumed to be in a single batch with identity transform.
     pub fn new(
-        ctx: &mut RenderContext,
+        ctx: &RenderContext,
         mut builder: PointCloudBuilder,
     ) -> Result<Self, PointCloudDrawDataError> {
         re_tracing::profile_function!();

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -186,7 +186,7 @@ impl PointCloudDrawData {
     ) -> Result<Self, PointCloudDrawDataError> {
         re_tracing::profile_function!();
 
-        let point_renderer = ctx.get_renderer::<PointCloudRenderer>();
+        let point_renderer = ctx.renderer::<PointCloudRenderer>();
 
         let vertices = builder.vertices.as_slice();
         let batches = builder.batches.as_slice();

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -403,13 +403,7 @@ impl RectangleDrawData {
     ) -> Result<Self, RectangleError> {
         re_tracing::profile_function!();
 
-        let mut renderers = ctx.renderers.write();
-        let rectangle_renderer = renderers.get_or_create::<_, RectangleRenderer>(
-            &ctx.shared_renderer_data,
-            &mut ctx.gpu_resources,
-            &ctx.device,
-            &mut ctx.resolver,
-        );
+        let rectangle_renderer = ctx.get_renderer::<RectangleRenderer>();
 
         if rectangles.is_empty() {
             return Ok(RectangleDrawData {
@@ -507,9 +501,9 @@ impl Renderer for RectangleRenderer {
 
     fn create_renderer<Fs: FileSystem>(
         shared_data: &SharedRendererData,
-        pools: &mut WgpuResourcePools,
+        pools: &WgpuResourcePools,
         device: &wgpu::Device,
-        resolver: &mut FileResolver<Fs>,
+        resolver: &FileResolver<Fs>,
     ) -> Self {
         re_tracing::profile_function!();
 

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -397,10 +397,7 @@ impl DrawData for RectangleDrawData {
 }
 
 impl RectangleDrawData {
-    pub fn new(
-        ctx: &mut RenderContext,
-        rectangles: &[TexturedRect],
-    ) -> Result<Self, RectangleError> {
+    pub fn new(ctx: &RenderContext, rectangles: &[TexturedRect]) -> Result<Self, RectangleError> {
         re_tracing::profile_function!();
 
         let rectangle_renderer = ctx.get_renderer::<RectangleRenderer>();

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -400,7 +400,7 @@ impl RectangleDrawData {
     pub fn new(ctx: &RenderContext, rectangles: &[TexturedRect]) -> Result<Self, RectangleError> {
         re_tracing::profile_function!();
 
-        let rectangle_renderer = ctx.get_renderer::<RectangleRenderer>();
+        let rectangle_renderer = ctx.renderer::<RectangleRenderer>();
 
         if rectangles.is_empty() {
             return Ok(RectangleDrawData {

--- a/crates/re_renderer/src/renderer/test_triangle.rs
+++ b/crates/re_renderer/src/renderer/test_triangle.rs
@@ -21,8 +21,8 @@ impl DrawData for TestTriangleDrawData {
 }
 
 impl TestTriangleDrawData {
-    pub fn new(ctx: &mut RenderContext) -> Self {
-        ctx.get_renderer::<TestTriangle>();
+    pub fn new(ctx: &RenderContext) -> Self {
+        let _ = ctx.get_renderer::<TestTriangle>(); // TODO(andreas): This should happen automatically.
         TestTriangleDrawData {}
     }
 }

--- a/crates/re_renderer/src/renderer/test_triangle.rs
+++ b/crates/re_renderer/src/renderer/test_triangle.rs
@@ -22,7 +22,7 @@ impl DrawData for TestTriangleDrawData {
 
 impl TestTriangleDrawData {
     pub fn new(ctx: &RenderContext) -> Self {
-        let _ = ctx.get_renderer::<TestTriangle>(); // TODO(andreas): This should happen automatically.
+        let _ = ctx.renderer::<TestTriangle>(); // TODO(andreas): This line ensures that the renderer exists. Currently this needs to be done ahead of time, but should be fully automatic!
         TestTriangleDrawData {}
     }
 }

--- a/crates/re_renderer/src/renderer/test_triangle.rs
+++ b/crates/re_renderer/src/renderer/test_triangle.rs
@@ -22,13 +22,7 @@ impl DrawData for TestTriangleDrawData {
 
 impl TestTriangleDrawData {
     pub fn new(ctx: &mut RenderContext) -> Self {
-        ctx.renderers.write().get_or_create::<_, TestTriangle>(
-            &ctx.shared_renderer_data,
-            &mut ctx.gpu_resources,
-            &ctx.device,
-            &mut ctx.resolver,
-        );
-
+        ctx.get_renderer::<TestTriangle>();
         TestTriangleDrawData {}
     }
 }
@@ -38,9 +32,9 @@ impl Renderer for TestTriangle {
 
     fn create_renderer<Fs: FileSystem>(
         shared_data: &SharedRendererData,
-        pools: &mut WgpuResourcePools,
+        pools: &WgpuResourcePools,
         device: &wgpu::Device,
-        resolver: &mut FileResolver<Fs>,
+        resolver: &FileResolver<Fs>,
     ) -> Self {
         let render_pipeline = pools.render_pipelines.get_or_create(
             device,

--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -270,7 +270,7 @@ impl ViewBuilder {
             },
         });
 
-    pub fn new(ctx: &mut RenderContext, config: TargetConfiguration) -> Self {
+    pub fn new(ctx: &RenderContext, config: TargetConfiguration) -> Self {
         re_tracing::profile_function!();
 
         // Can't handle 0 size resolution since this would imply creating zero sized textures.
@@ -727,7 +727,7 @@ impl ViewBuilder {
     /// ```no_run
     /// use re_renderer::{view_builder::ViewBuilder, RectInt, PickingLayerProcessor, RenderContext};
     /// fn schedule_picking_readback(
-    ///     ctx: &mut RenderContext,
+    ///     ctx: &RenderContext,
     ///     view_builder: &mut ViewBuilder,
     ///     picking_rect: RectInt,
     /// ) {
@@ -745,7 +745,7 @@ impl ViewBuilder {
     /// Received data that isn't retrieved for more than a frame will be automatically discarded.
     pub fn schedule_picking_rect<T: 'static + Send + Sync>(
         &mut self,
-        ctx: &mut RenderContext,
+        ctx: &RenderContext,
         picking_rect: RectInt,
         readback_identifier: GpuReadbackIdentifier,
         readback_user_data: T,

--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -558,7 +558,7 @@ impl ViewBuilder {
         // However, having our locking concentrated for the duration of a view draw
         // is also beneficial since it enforces the model of prepare->draw which avoids a lot of repeated
         // locking and unlocking.
-        let renderers = ctx.renderers.read();
+        let renderers = ctx.read_lock_renderers();
         let pipelines = ctx.gpu_resources.render_pipelines.resources();
 
         let setup = &self.setup;
@@ -804,7 +804,7 @@ impl ViewBuilder {
 
         pass.set_bind_group(0, &self.setup.bind_group_0, &[]);
         self.draw_phase(
-            &ctx.renderers.read(),
+            &ctx.read_lock_renderers(),
             render_pipelines,
             DrawPhase::Compositing,
             pass,

--- a/crates/re_renderer/src/wgpu_resources/pipeline_layout_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/pipeline_layout_pool.rs
@@ -24,7 +24,7 @@ pub struct GpuPipelineLayoutPool {
 
 impl GpuPipelineLayoutPool {
     pub fn get_or_create(
-        &mut self,
+        &self,
         device: &wgpu::Device,
         desc: &PipelineLayoutDesc,
         bind_group_layout_pool: &GpuBindGroupLayoutPool,

--- a/crates/re_renderer/src/wgpu_resources/shader_module_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/shader_module_pool.rs
@@ -59,7 +59,7 @@ impl ShaderModuleDesc {
     fn create_shader_module<Fs: FileSystem>(
         &self,
         device: &wgpu::Device,
-        resolver: &mut FileResolver<Fs>,
+        resolver: &FileResolver<Fs>,
         shader_text_workaround_replacements: &[(String, String)],
     ) -> wgpu::ShaderModule {
         let mut source_interpolated = resolver
@@ -114,9 +114,9 @@ pub struct GpuShaderModulePool {
 
 impl GpuShaderModulePool {
     pub fn get_or_create<Fs: FileSystem>(
-        &mut self,
+        &self,
         device: &wgpu::Device,
-        resolver: &mut FileResolver<Fs>,
+        resolver: &FileResolver<Fs>,
         desc: &ShaderModuleDesc,
     ) -> GpuShaderModuleHandle {
         self.pool.get_or_create(desc, |desc| {
@@ -127,7 +127,7 @@ impl GpuShaderModulePool {
     pub fn begin_frame<Fs: FileSystem>(
         &mut self,
         device: &wgpu::Device,
-        resolver: &mut FileResolver<Fs>,
+        resolver: &FileResolver<Fs>,
         frame_index: u64,
         updated_paths: &HashSet<PathBuf>,
     ) {

--- a/crates/re_space_view_spatial/src/contexts/shared_render_builders.rs
+++ b/crates/re_space_view_spatial/src/contexts/shared_render_builders.rs
@@ -32,7 +32,7 @@ impl SharedRenderBuilders {
 
     pub fn queuable_draw_data(
         &self,
-        render_ctx: &mut RenderContext,
+        render_ctx: &RenderContext,
     ) -> Vec<re_renderer::QueueableDrawData> {
         let mut result = Vec::new();
         result.extend(


### PR DESCRIPTION
### What

* Prerequisite for #1325
* Follow-up of #4421
* Followed by #4430

Make draw data (this is in essence resource submission to GPU! e.g. make pointcloud ready to render) an operation that doesn't require a mutable renderer context.

Two pieces to this:
* `FileResolver` resolve needs to be non-mut, this turned out to be trivial
* `Renderer::get_or_create` had to be streamlined. Renderer creation is now done directly on the context and holding a renderer implies holding a read lock. Since Renderers are added **very** rarely, this isn't much of a limitation!

This causes a large trickle of removing `&mut` and gets us _almost_ to having a non-mutable render context reference on the Viewer context!

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4422/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4422/index.html?manifest_url=https://app.rerun.io/version
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4422)
- [Docs preview](https://rerun.io/preview/5a1ad48f35f4cd28bb4dc4cd56f56ac289a50ab3/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5a1ad48f35f4cd28bb4dc4cd56f56ac289a50ab3/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

---
Part of series towards more multithreading in the viewer!
* #4387
* #4404
* #4389
* #4421
* You are here ➡️ #4422
* #4430