### PR TITLE
Replace `lazy_static` with `OnceLock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5157,7 +5157,6 @@ dependencies = [
  "glam",
  "half 2.3.1",
  "itertools 0.11.0",
- "lazy_static",
  "macaw",
  "ndarray",
  "nohash-hasher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,11 +132,11 @@ half = "2.3.1"
 hyper = "0.14"
 image = { version = "0.24", default-features = false }
 indent = "0.1"
-indicatif = "0.17.7"
-infer = "0.15" # infer MIME type by checking the magic number signature
+indicatif = "0.17.7"                                               # Progress bar
+infer = "0.15"                                                     # infer MIME type by checking the magic number signaturefer MIME type by checking the magic number signature
 itertools = "0.11"
 js-sys = "0.3"
-lazy_static = "1.4"
+# No lazy_static - use `std::sync::OnceLock` or `once_cell` instead
 lz4_flex = "0.11"
 log = "0.4"
 log-once = "0.4"

--- a/crates/re_viewer_context/Cargo.toml
+++ b/crates/re_viewer_context/Cargo.toml
@@ -37,7 +37,6 @@ egui_tiles.workspace = true
 glam.workspace = true
 half.workspace = true
 itertools.workspace = true
-lazy_static.workspace = true
 macaw.workspace = true
 ndarray.workspace = true
 nohash-hasher.workspace = true

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -24,7 +24,6 @@ pub mod gpu_bridge;
 
 pub use annotations::{
     AnnotationMap, Annotations, ResolvedAnnotationInfo, ResolvedAnnotationInfos,
-    MISSING_ANNOTATIONS,
 };
 pub use app_options::AppOptions;
 pub use blueprint_id::{DataQueryId, SpaceViewId};

--- a/crates/re_viewer_context/src/space_view/highlights.rs
+++ b/crates/re_viewer_context/src/space_view/highlights.rs
@@ -1,4 +1,3 @@
-use lazy_static::lazy_static;
 use nohash_hasher::IntMap;
 
 use re_log_types::EntityPathHash;
@@ -39,11 +38,6 @@ pub struct SpaceViewOutlineMasks {
     pub instances: ahash::HashMap<InstanceKey, OutlineMaskPreference>,
 }
 
-lazy_static! {
-    static ref SPACEVIEW_OUTLINE_MASK_NONE: SpaceViewOutlineMasks =
-        SpaceViewOutlineMasks::default();
-}
-
 impl SpaceViewOutlineMasks {
     pub fn index_outline_mask(&self, instance_key: InstanceKey) -> OutlineMaskPreference {
         self.instances
@@ -72,9 +66,12 @@ impl SpaceViewHighlights {
     }
 
     pub fn entity_outline_mask(&self, entity_path_hash: EntityPathHash) -> &SpaceViewOutlineMasks {
+        use std::sync::OnceLock;
+        static CELL: OnceLock<SpaceViewOutlineMasks> = OnceLock::new();
+
         self.outlines_masks
             .get(&entity_path_hash)
-            .unwrap_or(&SPACEVIEW_OUTLINE_MASK_NONE)
+            .unwrap_or_else(|| CELL.get_or_init(SpaceViewOutlineMasks::default))
     }
 
     pub fn any_outlines(&self) -> bool {


### PR DESCRIPTION
### What
We should prefer `OnceLock` or `once_cell` in all cases.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4429/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4429/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4429)
- [Docs preview](https://rerun.io/preview/e1c17d0a8ee92e802afafdcb9a36052a42902c4d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e1c17d0a8ee92e802afafdcb9a36052a42902c4d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)