### PR TITLE
DataStore: unjustified `debug_assert` & mutability shenanigans 

### DIFF
--- a/crates/re_arrow_store/src/store_dump.rs
+++ b/crates/re_arrow_store/src/store_dump.rs
@@ -80,9 +80,8 @@ impl DataStore {
                 col_row_id,
                 col_num_instances,
                 columns,
-                is_sorted,
+                is_sorted: _,
             } = inner;
-            debug_assert!(is_sorted);
 
             DataTable {
                 table_id: TableId::random(),
@@ -113,7 +112,7 @@ impl DataStore {
                 } = bucket;
 
                 let IndexedBucketInner {
-                    is_sorted,
+                    is_sorted: _,
                     time_range: _,
                     col_time,
                     col_insert_id: _,
@@ -123,7 +122,6 @@ impl DataStore {
                     columns,
                     size_bytes: _,
                 } = &*inner.read();
-                debug_assert!(is_sorted);
 
                 DataTable {
                     table_id: TableId::random(),
@@ -165,7 +163,7 @@ impl DataStore {
                     } = bucket;
 
                     let IndexedBucketInner {
-                        is_sorted,
+                        is_sorted: _,
                         time_range,
                         col_time,
                         col_insert_id: _,
@@ -175,7 +173,6 @@ impl DataStore {
                         columns,
                         size_bytes: _,
                     } = &*inner.read();
-                    debug_assert!(is_sorted);
 
                     if !time_range.intersects(time_filter) {
                         return None;

--- a/crates/re_arrow_store/src/store_read.rs
+++ b/crates/re_arrow_store/src/store_read.rs
@@ -503,11 +503,11 @@ impl DataStore {
     }
 
     /// Sort all unsorted indices in the store.
-    pub fn sort_indices_if_needed(&mut self) {
-        for index in self.tables.values_mut() {
+    pub fn sort_indices_if_needed(&self) {
+        for index in self.tables.values() {
             index.sort_indices_if_needed();
         }
-        for index in self.timeless_tables.values_mut() {
+        for index in self.timeless_tables.values() {
             index.sort_indices_if_needed();
         }
     }

--- a/crates/re_arrow_store/src/test_util.rs
+++ b/crates/re_arrow_store/src/test_util.rs
@@ -54,7 +54,7 @@ pub fn all_configs() -> impl Iterator<Item = DataStoreConfig> {
     })
 }
 
-pub fn sanity_unwrap(store: &mut DataStore) {
+pub fn sanity_unwrap(store: &DataStore) {
     if let err @ Err(_) = store.sanity_check() {
         store.sort_indices_if_needed();
         eprintln!("{store}");

--- a/crates/re_arrow_store/tests/correctness.rs
+++ b/crates/re_arrow_store/tests/correctness.rs
@@ -520,7 +520,7 @@ fn gc_correct() {
         }
     }
 
-    sanity_unwrap(&mut store);
+    sanity_unwrap(&store);
     check_still_readable(&store);
 
     let stats = DataStoreStats::from_store(&store);
@@ -538,7 +538,7 @@ fn gc_correct() {
     );
     assert_eq!(stats.temporal.num_rows, stats_diff.temporal.num_rows);
 
-    sanity_unwrap(&mut store);
+    sanity_unwrap(&store);
     check_still_readable(&store);
     for event in store_events {
         assert!(store.get_msg_metadata(&event.row_id).is_none());
@@ -548,7 +548,7 @@ fn gc_correct() {
     assert!(store_events.is_empty());
     assert_eq!(DataStoreStats::default(), stats_diff);
 
-    sanity_unwrap(&mut store);
+    sanity_unwrap(&store);
     check_still_readable(&store);
 }
 

--- a/crates/re_arrow_store/tests/data_store.rs
+++ b/crates/re_arrow_store/tests/data_store.rs
@@ -78,7 +78,7 @@ fn all_components() {
                 insert_table_with_retries(&mut store2, &table);
             }
 
-            let mut store = store2;
+            let store = store2;
             let timeline = Timeline::new("frame_nr", TimeType::Sequence);
 
             let components = store.all_components(&timeline, ent_path);
@@ -142,7 +142,7 @@ fn all_components() {
 
         assert_latest_components_at(&mut store, &ent_path, Some(components_b));
 
-        sanity_unwrap(&mut store);
+        sanity_unwrap(&store);
     }
 
     // Tiny buckets, demonstrating the harder-to-reason-about cases.
@@ -202,7 +202,7 @@ fn all_components() {
 
         assert_latest_components_at(&mut store, &ent_path, Some(components_b));
 
-        sanity_unwrap(&mut store);
+        sanity_unwrap(&store);
     }
 
     // Tiny buckets and tricky splits, demonstrating a case that is not only extremely hard to
@@ -272,7 +272,7 @@ fn all_components() {
 
         assert_latest_components_at(&mut store, &ent_path, Some(components_b));
 
-        sanity_unwrap(&mut store);
+        sanity_unwrap(&store);
     }
 }
 
@@ -348,11 +348,11 @@ fn latest_at_impl(store: &mut DataStore) {
     for table in store.to_data_tables(None) {
         insert_table(&mut store2, &table);
     }
-    let mut store = store2;
+    let store = store2;
 
-    sanity_unwrap(&mut store);
+    sanity_unwrap(&store);
 
-    let mut assert_latest_components = |frame_nr: TimeInt, rows: &[(ComponentName, &DataRow)]| {
+    let assert_latest_components = |frame_nr: TimeInt, rows: &[(ComponentName, &DataRow)]| {
         let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
         let components_all = &[Color::name(), Position2D::name()];
 
@@ -497,7 +497,7 @@ fn range_impl(store: &mut DataStore) {
             for table in store.to_data_tables(None) {
                 insert_table_with_retries(&mut store2, &table);
             }
-            let mut store = store2;
+            let store = store2;
 
             let mut expected_timeless = Vec::<DataFrame>::new();
             let mut expected_at_times: IntMap<TimeInt, Vec<DataFrame>> = Default::default();
@@ -1017,7 +1017,7 @@ fn protected_gc_impl(store: &mut DataStore) {
         time_budget: std::time::Duration::MAX,
     });
 
-    let mut assert_latest_components = |frame_nr: TimeInt, rows: &[(ComponentName, &DataRow)]| {
+    let assert_latest_components = |frame_nr: TimeInt, rows: &[(ComponentName, &DataRow)]| {
         let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
         let components_all = &[Color::name(), Position2D::name()];
 
@@ -1115,7 +1115,7 @@ fn protected_gc_clear_impl(store: &mut DataStore) {
         time_budget: std::time::Duration::MAX,
     });
 
-    let mut assert_latest_components = |frame_nr: TimeInt, rows: &[(ComponentName, &DataRow)]| {
+    let assert_latest_components = |frame_nr: TimeInt, rows: &[(ComponentName, &DataRow)]| {
         let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
         let components_all = &[Color::name(), Position2D::name()];
 

--- a/crates/re_viewer/src/saving.rs
+++ b/crates/re_viewer/src/saving.rs
@@ -85,6 +85,8 @@ pub fn save_database_to_file(
 
     re_tracing::profile_function!();
 
+    store_db.store().sort_indices_if_needed();
+
     let set_store_info_msg = store_db
         .store_info_msg()
         .map(|msg| LogMsg::SetStoreInfo(msg.clone()));


### PR DESCRIPTION
- Removed mutability in places where it wasn't needed
- Removed a debug assertion that wasn't justified
- Sort the store when dumping to disk, as a courtesy

<details>
  <summary>Fixes this backtrace</summary>
  
```
thread 'ThreadId(1)' panicked at 'assertion failed: is_sorted'
re_arrow_store/src/store_dump.rs:85
stack backtrace:
   8: core::panicking::panic_fmt
             at core/src/panicking.rs:72:14
   9: core::panicking::panic
             at core/src/panicking.rs:127:5
  10: re_arrow_store::store_dump::<impl re_arrow_store::store::DataStore>::dump_timeless_tables::{{closure}}
             at re_arrow_store/src/store_dump.rs:85:13
      core::iter::adapters::map::map_try_fold::{{closure}}
             at core/src/iter/adapters/map.rs:91:28
      core::iter::traits::iterator::Iterator::try_fold
             at core/src/iter/traits/iterator.rs:2461:21
      <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
             at core/src/iter/adapters/map.rs:117:9
  11: <core::iter::adapters::chain::Chain<A,B> as core::iter::traits::iterator::Iterator>::try_fold
             at core/src/iter/adapters/chain.rs:75:19
  12: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
             at core/src/iter/adapters/map.rs:117:9
      <core::iter::adapters::GenericShunt<I,R> as core::iter::traits::iterator::Iterator>::try_fold
             at core/src/iter/adapters/mod.rs:199:9
      core::iter::traits::iterator::Iterator::try_for_each
             at core/src/iter/traits/iterator.rs:2523:9
      <core::iter::adapters::GenericShunt<I,R> as core::iter::traits::iterator::Iterator>::next
             at core/src/iter/adapters/mod.rs:182:14
      alloc::vec::Vec<T,A>::extend_desugared
             at alloc/src/vec/mod.rs:2849:35
      <alloc::vec::Vec<T,A> as alloc::vec::spec_extend::SpecExtend<T,I>>::spec_extend
             at alloc/src/vec/spec_extend.rs:17:9
      <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
             at alloc/src/vec/spec_from_iter_nested.rs:43:9
  13: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
             at alloc/src/vec/spec_from_iter.rs:33:9
      <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
             at alloc/src/vec/mod.rs:2749:9
      core::iter::traits::iterator::Iterator::collect
             at core/src/iter/traits/iterator.rs:2053:9
      <core::result::Result<V,E> as core::iter::traits::collect::FromIterator<core::result::Result<A,E>>>::from_iter::{{closure}}
             at core/src/result.rs:1933:51
      core::iter::adapters::try_process
             at core/src/iter/adapters/mod.rs:168:17
      <core::result::Result<V,E> as core::iter::traits::collect::FromIterator<core::result::Result<A,E>>>::from_iter
             at core/src/result.rs:1933:9
      core::iter::traits::iterator::Iterator::collect
             at core/src/iter/traits/iterator.rs:2053:9
      re_viewer::saving::save_database_to_file
             at re_viewer/src/saving.rs:98:40
  14: re_viewer::store_hub::StoreHub::gc_and_persist_app_blueprints
             at re_viewer/src/store_hub.rs:298:42
  15: <re_viewer::app::App as eframe::epi::App>::save
             at re_viewer/src/app.rs:1012:23
  16: eframe::native::epi_integration::EpiIntegration::save
             at eframe-0.24.1/src/native/epi_integration.rs:359:17
  17: eframe::native::epi_integration::EpiIntegration::maybe_autosave
             at eframe-0.24.1/src/native/epi_integration.rs:331:13
  18: eframe::native::wgpu_integration::WgpuWinitRunning::run_ui_and_paint
             at eframe-0.24.1/src/native/wgpu_integration.rs:645:9
      <eframe::native::wgpu_integration::WgpuWinitApp as eframe::native::winit_integration::WinitApp>::run_ui_and_paint
             at eframe-0.24.1/src/native/wgpu_integration.rs:354:13
  19: eframe::native::run::run_and_return::{{closure}}
             at eframe-0.24.1/src/native/run.rs:94:17
  20: <winit::platform_impl::platform::app_state::EventLoopHandler<T> as winit::platform_impl::platform::app_state::EventHandler>::handle_nonuser_event::{{closure}}
      winit::platform_impl::platform::app_state::EventLoopHandler<T>::with_callback
             at winit-0.28.7/src/platform_impl/macos/app_state.rs:70:13
      <winit::platform_impl::platform::app_state::EventLoopHandler<T> as winit::platform_impl::platform::app_state::EventHandler>::handle_nonuser_event
             at winit-0.28.7/src/platform_impl/macos/app_state.rs:91:9
  21: winit::platform_impl::platform::app_state::Handler::handle_nonuser_event
             at winit-0.28.7/src/platform_impl/macos/app_state.rs:199:21
  22: winit::platform_impl::platform::app_state::AppState::cleared
             at winit-0.28.7/src/platform_impl/macos/app_state.rs:388:13
  23: winit::platform_impl::platform::observer::control_flow_end_handler::{{closure}}
             at winit-0.28.7/src/platform_impl/macos/observer.rs:79:21
      winit::platform_impl::platform::observer::control_flow_handler::{{closure}}
             at winit-0.28.7/src/platform_impl/macos/observer.rs:41:9
      std::panicking::try::do_call
             at std/src/panicking.rs:504:40
      std::panicking::try
             at std/src/panicking.rs:468:19
      std::panic::catch_unwind
             at std/src/panic.rs:142:14
      winit::platform_impl::platform::event_loop::stop_app_on_panic
             at winit-0.28.7/src/platform_impl/macos/event_loop.rs:245:11
      winit::platform_impl::platform::observer::control_flow_handler
             at winit-0.28.7/src/platform_impl/macos/observer.rs:39:5
      winit::platform_impl::platform::observer::control_flow_end_handler
             at winit-0.28.7/src/platform_impl/macos/observer.rs:74:9
  24: <unknown>
  25: <unknown>
  26: <unknown>
  27: <unknown>
  28: <unknown>
  29: <unknown>
  30: <unknown>
  31: <unknown>
  32: <unknown>
  33: <unknown>
  34: winit::platform_impl::platform::event_loop::EventLoop<T>::run_return::{{closure}}
             at winit-0.28.7/src/platform_impl/macos/event_loop.rs:220:22
      objc2::rc::autorelease::autoreleasepool
             at objc2-0.3.0-beta.3.patch-leaks.3/src/rc/autorelease.rs:313:5
      winit::platform_impl::platform::event_loop::EventLoop<T>::run_return
             at winit-0.28.7/src/platform_impl/macos/event_loop.rs:211:25
      <winit::event_loop::EventLoop<T> as winit::platform::run_return::EventLoopExtRunReturn>::run_return
             at winit-0.28.7/src/platform/run_return.rs:51:9
      eframe::native::run::run_and_return
             at eframe-0.24.1/src/native/run.rs:79:16
      eframe::native::run::run_wgpu::{{closure}}
             at eframe-0.24.1/src/native/run.rs:395:13
      eframe::native::run::with_event_loop::{{closure}}
             at eframe-0.24.1/src/native/run.rs:61:9
      std::thread::local::LocalKey<T>::try_with
             at std/src/thread/local.rs:270:16
      std::thread::local::LocalKey<T>::with
             at std/src/thread/local.rs:246:9
      eframe::native::run::with_event_loop
             at eframe-0.24.1/src/native/run.rs:55:16
      eframe::native::run::run_wgpu
             at eframe-0.24.1/src/native/run.rs:393:16
      eframe::run_native
             at eframe-0.24.1/src/lib.rs:255:
```
  
</details>

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4434/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4434/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4434)
- [Docs preview](https://rerun.io/preview/e24f04b9b2687ecdb5270b7f0cc0f8818e950797/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e24f04b9b2687ecdb5270b7f0cc0f8818e950797/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)