### PR TITLE
Add lint for builder pattern functions and deref impls to be marked `#[inline]`

### DIFF
--- a/crates/re_arrow_store/src/store_event.rs
+++ b/crates/re_arrow_store/src/store_event.rs
@@ -48,6 +48,7 @@ pub struct StoreEvent {
 impl std::ops::Deref for StoreEvent {
     type Target = StoreDiff;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.diff
     }

--- a/crates/re_renderer/src/line_strip_builder.rs
+++ b/crates/re_renderer/src/line_strip_builder.rs
@@ -157,6 +157,7 @@ impl<'a> LineBatchBuilder<'a> {
     }
 
     /// Sets the picking object id for every element in the batch.
+    #[inline]
     pub fn picking_object_id(mut self, picking_object_id: PickingLayerObjectId) -> Self {
         self.batch_mut().picking_object_id = picking_object_id;
         self
@@ -496,6 +497,7 @@ impl<'a> LineStripBuilder<'a> {
         self
     }
 
+    #[inline]
     pub fn picking_instance_id(mut self, instance_id: PickingLayerInstanceId) -> Self {
         self.picking_instance_id = instance_id;
         self

--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -266,12 +266,14 @@ impl<'a> PointCloudBatchBuilder<'a> {
     }
 
     /// Adds (!) flags for this batch.
+    #[inline]
     pub fn flags(mut self, flags: PointCloudBatchFlags) -> Self {
         self.batch_mut().flags |= flags;
         self
     }
 
     /// Sets the picking object id for the current batch.
+    #[inline]
     pub fn picking_object_id(mut self, picking_object_id: PickingLayerObjectId) -> Self {
         self.batch_mut().picking_object_id = picking_object_id;
         self

--- a/crates/re_renderer/src/wgpu_resources/bind_group_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/bind_group_pool.rs
@@ -29,6 +29,7 @@ pub struct GpuBindGroup {
 impl std::ops::Deref for GpuBindGroup {
     type Target = wgpu::BindGroup;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.resource.inner
     }

--- a/crates/re_renderer/src/wgpu_resources/static_resource_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/static_resource_pool.rs
@@ -13,6 +13,7 @@ pub struct StoredResource<Res> {
 impl<Res> Deref for StoredResource<Res> {
     type Target = Res;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.resource
     }

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -142,6 +142,7 @@ impl RecordingStreamBuilder {
     /// If the `RERUN` environment variable is set, it will override this.
     ///
     /// Set also: [`Self::enabled`].
+    #[inline]
     pub fn default_enabled(mut self, default_enabled: bool) -> Self {
         self.default_enabled = default_enabled;
         self
@@ -152,6 +153,7 @@ impl RecordingStreamBuilder {
     /// Setting this will ignore the `RERUN` environment variable.
     ///
     /// Set also: [`Self::default_enabled`].
+    #[inline]
     pub fn enabled(mut self, enabled: bool) -> Self {
         self.enabled = Some(enabled);
         self
@@ -166,6 +168,7 @@ impl RecordingStreamBuilder {
     /// unique `RecordingId`s.
     ///
     /// The default is to use a random `RecordingId`.
+    #[inline]
     pub fn recording_id(mut self, recording_id: impl Into<String>) -> Self {
         self.store_id = Some(StoreId::from_string(
             StoreKind::Recording,
@@ -183,6 +186,7 @@ impl RecordingStreamBuilder {
     /// unique [`StoreId`]s.
     ///
     /// The default is to use a random [`StoreId`].
+    #[inline]
     pub fn store_id(mut self, store_id: StoreId) -> Self {
         self.store_id = Some(store_id);
         self
@@ -191,12 +195,14 @@ impl RecordingStreamBuilder {
     /// Specifies the configuration of the internal data batching mechanism.
     ///
     /// See [`DataTableBatcher`] & [`DataTableBatcherConfig`] for more information.
+    #[inline]
     pub fn batcher_config(mut self, config: DataTableBatcherConfig) -> Self {
         self.batcher_config = Some(config);
         self
     }
 
     #[doc(hidden)]
+    #[inline]
     pub fn store_source(mut self, store_source: StoreSource) -> Self {
         self.store_source = Some(store_source);
         self
@@ -204,12 +210,14 @@ impl RecordingStreamBuilder {
 
     #[allow(clippy::wrong_self_convention)]
     #[doc(hidden)]
+    #[inline]
     pub fn is_official_example(mut self, is_official_example: bool) -> Self {
         self.is_official_example = is_official_example;
         self
     }
 
     #[doc(hidden)]
+    #[inline]
     pub fn blueprint(mut self) -> Self {
         self.store_kind = StoreKind::Blueprint;
         self

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -331,6 +331,7 @@ impl Arrows3D {
         }
     }
 
+    #[inline]
     pub fn with_origins(
         mut self,
         origins: impl IntoIterator<Item = impl Into<crate::components::Position3D>>,
@@ -339,6 +340,7 @@ impl Arrows3D {
         self
     }
 
+    #[inline]
     pub fn with_radii(
         mut self,
         radii: impl IntoIterator<Item = impl Into<crate::components::Radius>>,
@@ -347,6 +349,7 @@ impl Arrows3D {
         self
     }
 
+    #[inline]
     pub fn with_colors(
         mut self,
         colors: impl IntoIterator<Item = impl Into<crate::components::Color>>,
@@ -355,6 +358,7 @@ impl Arrows3D {
         self
     }
 
+    #[inline]
     pub fn with_labels(
         mut self,
         labels: impl IntoIterator<Item = impl Into<crate::components::Text>>,
@@ -363,6 +367,7 @@ impl Arrows3D {
         self
     }
 
+    #[inline]
     pub fn with_class_ids(
         mut self,
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
@@ -371,6 +376,7 @@ impl Arrows3D {
         self
     }
 
+    #[inline]
     pub fn with_instance_keys(
         mut self,
         instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -238,11 +238,13 @@ impl Asset3D {
         }
     }
 
+    #[inline]
     pub fn with_media_type(mut self, media_type: impl Into<crate::components::MediaType>) -> Self {
         self.media_type = Some(media_type.into());
         self
     }
 
+    #[inline]
     pub fn with_transform(
         mut self,
         transform: impl Into<crate::components::OutOfTreeTransform3D>,

--- a/crates/re_types/src/archetypes/bar_chart.rs
+++ b/crates/re_types/src/archetypes/bar_chart.rs
@@ -193,6 +193,7 @@ impl BarChart {
         }
     }
 
+    #[inline]
     pub fn with_color(mut self, color: impl Into<crate::components::Color>) -> Self {
         self.color = Some(color.into());
         self

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -339,6 +339,7 @@ impl Boxes2D {
         }
     }
 
+    #[inline]
     pub fn with_centers(
         mut self,
         centers: impl IntoIterator<Item = impl Into<crate::components::Position2D>>,
@@ -347,6 +348,7 @@ impl Boxes2D {
         self
     }
 
+    #[inline]
     pub fn with_colors(
         mut self,
         colors: impl IntoIterator<Item = impl Into<crate::components::Color>>,
@@ -355,6 +357,7 @@ impl Boxes2D {
         self
     }
 
+    #[inline]
     pub fn with_radii(
         mut self,
         radii: impl IntoIterator<Item = impl Into<crate::components::Radius>>,
@@ -363,6 +366,7 @@ impl Boxes2D {
         self
     }
 
+    #[inline]
     pub fn with_labels(
         mut self,
         labels: impl IntoIterator<Item = impl Into<crate::components::Text>>,
@@ -371,11 +375,13 @@ impl Boxes2D {
         self
     }
 
+    #[inline]
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = Some(draw_order.into());
         self
     }
 
+    #[inline]
     pub fn with_class_ids(
         mut self,
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
@@ -384,6 +390,7 @@ impl Boxes2D {
         self
     }
 
+    #[inline]
     pub fn with_instance_keys(
         mut self,
         instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -344,6 +344,7 @@ impl Boxes3D {
         }
     }
 
+    #[inline]
     pub fn with_centers(
         mut self,
         centers: impl IntoIterator<Item = impl Into<crate::components::Position3D>>,
@@ -352,6 +353,7 @@ impl Boxes3D {
         self
     }
 
+    #[inline]
     pub fn with_rotations(
         mut self,
         rotations: impl IntoIterator<Item = impl Into<crate::components::Rotation3D>>,
@@ -360,6 +362,7 @@ impl Boxes3D {
         self
     }
 
+    #[inline]
     pub fn with_colors(
         mut self,
         colors: impl IntoIterator<Item = impl Into<crate::components::Color>>,
@@ -368,6 +371,7 @@ impl Boxes3D {
         self
     }
 
+    #[inline]
     pub fn with_radii(
         mut self,
         radii: impl IntoIterator<Item = impl Into<crate::components::Radius>>,
@@ -376,6 +380,7 @@ impl Boxes3D {
         self
     }
 
+    #[inline]
     pub fn with_labels(
         mut self,
         labels: impl IntoIterator<Item = impl Into<crate::components::Text>>,
@@ -384,6 +389,7 @@ impl Boxes3D {
         self
     }
 
+    #[inline]
     pub fn with_class_ids(
         mut self,
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
@@ -392,6 +398,7 @@ impl Boxes3D {
         self
     }
 
+    #[inline]
     pub fn with_instance_keys(
         mut self,
         instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -239,11 +239,13 @@ impl DepthImage {
         }
     }
 
+    #[inline]
     pub fn with_meter(mut self, meter: impl Into<crate::components::DepthMeter>) -> Self {
         self.meter = Some(meter.into());
         self
     }
 
+    #[inline]
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = Some(draw_order.into());
         self

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -205,6 +205,7 @@ impl Image {
         }
     }
 
+    #[inline]
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = Some(draw_order.into());
         self

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -324,6 +324,7 @@ impl LineStrips2D {
         }
     }
 
+    #[inline]
     pub fn with_radii(
         mut self,
         radii: impl IntoIterator<Item = impl Into<crate::components::Radius>>,
@@ -332,6 +333,7 @@ impl LineStrips2D {
         self
     }
 
+    #[inline]
     pub fn with_colors(
         mut self,
         colors: impl IntoIterator<Item = impl Into<crate::components::Color>>,
@@ -340,6 +342,7 @@ impl LineStrips2D {
         self
     }
 
+    #[inline]
     pub fn with_labels(
         mut self,
         labels: impl IntoIterator<Item = impl Into<crate::components::Text>>,
@@ -348,11 +351,13 @@ impl LineStrips2D {
         self
     }
 
+    #[inline]
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = Some(draw_order.into());
         self
     }
 
+    #[inline]
     pub fn with_class_ids(
         mut self,
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
@@ -361,6 +366,7 @@ impl LineStrips2D {
         self
     }
 
+    #[inline]
     pub fn with_instance_keys(
         mut self,
         instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -301,6 +301,7 @@ impl LineStrips3D {
         }
     }
 
+    #[inline]
     pub fn with_radii(
         mut self,
         radii: impl IntoIterator<Item = impl Into<crate::components::Radius>>,
@@ -309,6 +310,7 @@ impl LineStrips3D {
         self
     }
 
+    #[inline]
     pub fn with_colors(
         mut self,
         colors: impl IntoIterator<Item = impl Into<crate::components::Color>>,
@@ -317,6 +319,7 @@ impl LineStrips3D {
         self
     }
 
+    #[inline]
     pub fn with_labels(
         mut self,
         labels: impl IntoIterator<Item = impl Into<crate::components::Text>>,
@@ -325,6 +328,7 @@ impl LineStrips3D {
         self
     }
 
+    #[inline]
     pub fn with_class_ids(
         mut self,
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
@@ -333,6 +337,7 @@ impl LineStrips3D {
         self
     }
 
+    #[inline]
     pub fn with_instance_keys(
         mut self,
         instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -322,6 +322,7 @@ impl Mesh3D {
         }
     }
 
+    #[inline]
     pub fn with_mesh_properties(
         mut self,
         mesh_properties: impl Into<crate::components::MeshProperties>,
@@ -330,6 +331,7 @@ impl Mesh3D {
         self
     }
 
+    #[inline]
     pub fn with_vertex_normals(
         mut self,
         vertex_normals: impl IntoIterator<Item = impl Into<crate::components::Vector3D>>,
@@ -338,6 +340,7 @@ impl Mesh3D {
         self
     }
 
+    #[inline]
     pub fn with_vertex_colors(
         mut self,
         vertex_colors: impl IntoIterator<Item = impl Into<crate::components::Color>>,
@@ -346,6 +349,7 @@ impl Mesh3D {
         self
     }
 
+    #[inline]
     pub fn with_mesh_material(
         mut self,
         mesh_material: impl Into<crate::components::Material>,
@@ -354,6 +358,7 @@ impl Mesh3D {
         self
     }
 
+    #[inline]
     pub fn with_class_ids(
         mut self,
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
@@ -362,6 +367,7 @@ impl Mesh3D {
         self
     }
 
+    #[inline]
     pub fn with_instance_keys(
         mut self,
         instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,

--- a/crates/re_types/src/archetypes/pinhole.rs
+++ b/crates/re_types/src/archetypes/pinhole.rs
@@ -261,11 +261,13 @@ impl Pinhole {
         }
     }
 
+    #[inline]
     pub fn with_resolution(mut self, resolution: impl Into<crate::components::Resolution>) -> Self {
         self.resolution = Some(resolution.into());
         self
     }
 
+    #[inline]
     pub fn with_camera_xyz(
         mut self,
         camera_xyz: impl Into<crate::components::ViewCoordinates>,

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -351,6 +351,7 @@ impl Points2D {
         }
     }
 
+    #[inline]
     pub fn with_radii(
         mut self,
         radii: impl IntoIterator<Item = impl Into<crate::components::Radius>>,
@@ -359,6 +360,7 @@ impl Points2D {
         self
     }
 
+    #[inline]
     pub fn with_colors(
         mut self,
         colors: impl IntoIterator<Item = impl Into<crate::components::Color>>,
@@ -367,6 +369,7 @@ impl Points2D {
         self
     }
 
+    #[inline]
     pub fn with_labels(
         mut self,
         labels: impl IntoIterator<Item = impl Into<crate::components::Text>>,
@@ -375,11 +378,13 @@ impl Points2D {
         self
     }
 
+    #[inline]
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = Some(draw_order.into());
         self
     }
 
+    #[inline]
     pub fn with_class_ids(
         mut self,
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
@@ -388,6 +393,7 @@ impl Points2D {
         self
     }
 
+    #[inline]
     pub fn with_keypoint_ids(
         mut self,
         keypoint_ids: impl IntoIterator<Item = impl Into<crate::components::KeypointId>>,
@@ -396,6 +402,7 @@ impl Points2D {
         self
     }
 
+    #[inline]
     pub fn with_instance_keys(
         mut self,
         instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -325,6 +325,7 @@ impl Points3D {
         }
     }
 
+    #[inline]
     pub fn with_radii(
         mut self,
         radii: impl IntoIterator<Item = impl Into<crate::components::Radius>>,
@@ -333,6 +334,7 @@ impl Points3D {
         self
     }
 
+    #[inline]
     pub fn with_colors(
         mut self,
         colors: impl IntoIterator<Item = impl Into<crate::components::Color>>,
@@ -341,6 +343,7 @@ impl Points3D {
         self
     }
 
+    #[inline]
     pub fn with_labels(
         mut self,
         labels: impl IntoIterator<Item = impl Into<crate::components::Text>>,
@@ -349,6 +352,7 @@ impl Points3D {
         self
     }
 
+    #[inline]
     pub fn with_class_ids(
         mut self,
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
@@ -357,6 +361,7 @@ impl Points3D {
         self
     }
 
+    #[inline]
     pub fn with_keypoint_ids(
         mut self,
         keypoint_ids: impl IntoIterator<Item = impl Into<crate::components::KeypointId>>,
@@ -365,6 +370,7 @@ impl Points3D {
         self
     }
 
+    #[inline]
     pub fn with_instance_keys(
         mut self,
         instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -214,6 +214,7 @@ impl SegmentationImage {
         }
     }
 
+    #[inline]
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = Some(draw_order.into());
         self

--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -241,6 +241,7 @@ impl TextDocument {
         }
     }
 
+    #[inline]
     pub fn with_media_type(mut self, media_type: impl Into<crate::components::MediaType>) -> Self {
         self.media_type = Some(media_type.into());
         self

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -227,11 +227,13 @@ impl TextLog {
         }
     }
 
+    #[inline]
     pub fn with_level(mut self, level: impl Into<crate::components::TextLogLevel>) -> Self {
         self.level = Some(level.into());
         self
     }
 
+    #[inline]
     pub fn with_color(mut self, color: impl Into<crate::components::Color>) -> Self {
         self.color = Some(color.into());
         self

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -304,21 +304,25 @@ impl TimeSeriesScalar {
         }
     }
 
+    #[inline]
     pub fn with_radius(mut self, radius: impl Into<crate::components::Radius>) -> Self {
         self.radius = Some(radius.into());
         self
     }
 
+    #[inline]
     pub fn with_color(mut self, color: impl Into<crate::components::Color>) -> Self {
         self.color = Some(color.into());
         self
     }
 
+    #[inline]
     pub fn with_label(mut self, label: impl Into<crate::components::Text>) -> Self {
         self.label = Some(label.into());
         self
     }
 
+    #[inline]
     pub fn with_scattered(
         mut self,
         scattered: impl Into<crate::components::ScalarScattering>,

--- a/crates/re_types/src/archetypes/transform3d_ext.rs
+++ b/crates/re_types/src/archetypes/transform3d_ext.rs
@@ -73,8 +73,8 @@ impl Transform3D {
 
     /// Indicate that this transform is from parent to child.
     /// This is the oppositve of the default, which is from child to parent.
-    #[inline]
     #[allow(clippy::wrong_self_convention)]
+    #[inline]
     pub fn from_parent(mut self) -> Self {
         self.transform = self.transform.from_parent();
         self

--- a/crates/re_types/src/components/transform3d_ext.rs
+++ b/crates/re_types/src/components/transform3d_ext.rs
@@ -66,8 +66,8 @@ impl Transform3D {
 
     /// Indicate that this transform is from parent to child.
     /// This is the oppositve of the default, which is from child to parent.
-    #[inline]
     #[allow(clippy::wrong_self_convention)]
+    #[inline]
     pub fn from_parent(mut self) -> Self {
         self.0 = self.0.from_parent();
         self

--- a/crates/re_types/src/datatypes/transform3d_ext.rs
+++ b/crates/re_types/src/datatypes/transform3d_ext.rs
@@ -58,8 +58,8 @@ impl Transform3D {
 
     /// Indicate that this transform is from parent to child.
     /// This is the oppositve of the default, which is from child to parent.
-    #[inline]
     #[allow(clippy::wrong_self_convention)]
+    #[inline]
     pub fn from_parent(mut self) -> Self {
         match &mut self {
             Self::TranslationAndMat3x3(t) => {

--- a/crates/re_types/src/datatypes/translation_and_mat3x3_ext.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3_ext.rs
@@ -46,6 +46,7 @@ impl TranslationAndMat3x3 {
     /// Indicate that this transform is from parent to child.
     /// This is the oppositve of the default, which is from child to parent.
     #[allow(clippy::wrong_self_convention)]
+    #[inline]
     pub fn from_parent(mut self) -> Self {
         self.from_parent = true;
         self

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d_ext.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d_ext.rs
@@ -84,9 +84,9 @@ impl TranslationRotationScale3D {
     }
 
     /// Indicate that this transform is from parent to child.
-    /// This is the oppositve of the default, which is from child to parent.
-    #[inline]
+    /// This is the opposite of the default, which is from child to parent.
     #[allow(clippy::wrong_self_convention)]
+    #[inline]
     pub fn from_parent(mut self) -> Self {
         self.from_parent = true;
         self

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer3.rs
@@ -522,6 +522,7 @@ impl AffixFuzzer3 {
         }
     }
 
+    #[inline]
     pub fn with_fuzz2001(
         mut self,
         fuzz2001: impl Into<crate::testing::components::AffixFuzzer1>,
@@ -530,6 +531,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2002(
         mut self,
         fuzz2002: impl Into<crate::testing::components::AffixFuzzer2>,
@@ -538,6 +540,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2003(
         mut self,
         fuzz2003: impl Into<crate::testing::components::AffixFuzzer3>,
@@ -546,6 +549,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2004(
         mut self,
         fuzz2004: impl Into<crate::testing::components::AffixFuzzer4>,
@@ -554,6 +558,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2005(
         mut self,
         fuzz2005: impl Into<crate::testing::components::AffixFuzzer5>,
@@ -562,6 +567,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2006(
         mut self,
         fuzz2006: impl Into<crate::testing::components::AffixFuzzer6>,
@@ -570,6 +576,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2007(
         mut self,
         fuzz2007: impl Into<crate::testing::components::AffixFuzzer7>,
@@ -578,6 +585,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2008(
         mut self,
         fuzz2008: impl Into<crate::testing::components::AffixFuzzer8>,
@@ -586,6 +594,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2009(
         mut self,
         fuzz2009: impl Into<crate::testing::components::AffixFuzzer9>,
@@ -594,6 +603,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2010(
         mut self,
         fuzz2010: impl Into<crate::testing::components::AffixFuzzer10>,
@@ -602,6 +612,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2011(
         mut self,
         fuzz2011: impl Into<crate::testing::components::AffixFuzzer11>,
@@ -610,6 +621,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2012(
         mut self,
         fuzz2012: impl Into<crate::testing::components::AffixFuzzer12>,
@@ -618,6 +630,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2013(
         mut self,
         fuzz2013: impl Into<crate::testing::components::AffixFuzzer13>,
@@ -626,6 +639,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2014(
         mut self,
         fuzz2014: impl Into<crate::testing::components::AffixFuzzer14>,
@@ -634,6 +648,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2015(
         mut self,
         fuzz2015: impl Into<crate::testing::components::AffixFuzzer15>,
@@ -642,6 +657,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2016(
         mut self,
         fuzz2016: impl Into<crate::testing::components::AffixFuzzer16>,
@@ -650,6 +666,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2017(
         mut self,
         fuzz2017: impl Into<crate::testing::components::AffixFuzzer17>,
@@ -658,6 +675,7 @@ impl AffixFuzzer3 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2018(
         mut self,
         fuzz2018: impl Into<crate::testing::components::AffixFuzzer18>,

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer4.rs
@@ -504,6 +504,7 @@ impl AffixFuzzer4 {
         }
     }
 
+    #[inline]
     pub fn with_fuzz2101(
         mut self,
         fuzz2101: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer1>>,
@@ -512,6 +513,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2102(
         mut self,
         fuzz2102: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer2>>,
@@ -520,6 +522,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2103(
         mut self,
         fuzz2103: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer3>>,
@@ -528,6 +531,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2104(
         mut self,
         fuzz2104: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer4>>,
@@ -536,6 +540,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2105(
         mut self,
         fuzz2105: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer5>>,
@@ -544,6 +549,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2106(
         mut self,
         fuzz2106: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer6>>,
@@ -552,6 +558,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2107(
         mut self,
         fuzz2107: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer7>>,
@@ -560,6 +567,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2108(
         mut self,
         fuzz2108: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer8>>,
@@ -568,6 +576,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2109(
         mut self,
         fuzz2109: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer9>>,
@@ -576,6 +585,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2110(
         mut self,
         fuzz2110: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer10>>,
@@ -584,6 +594,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2111(
         mut self,
         fuzz2111: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer11>>,
@@ -592,6 +603,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2112(
         mut self,
         fuzz2112: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer12>>,
@@ -600,6 +612,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2113(
         mut self,
         fuzz2113: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer13>>,
@@ -608,6 +621,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2114(
         mut self,
         fuzz2114: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer14>>,
@@ -616,6 +630,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2115(
         mut self,
         fuzz2115: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer15>>,
@@ -624,6 +639,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2116(
         mut self,
         fuzz2116: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer16>>,
@@ -632,6 +648,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2117(
         mut self,
         fuzz2117: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer17>>,
@@ -640,6 +657,7 @@ impl AffixFuzzer4 {
         self
     }
 
+    #[inline]
     pub fn with_fuzz2118(
         mut self,
         fuzz2118: impl IntoIterator<Item = impl Into<crate::testing::components::AffixFuzzer18>>,

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -1253,6 +1253,7 @@ fn quote_builder_from_obj(obj: &Object) -> TokenStream {
         if unwrapped {
             // This was originally a vec/array!
             quote! {
+                #[inline]
                 pub fn #method_name(mut self, #field_name: impl IntoIterator<Item = impl Into<#typ>>) -> Self {
                     self.#field_name = Some(#field_name.into_iter().map(Into::into).collect());
                     self
@@ -1260,6 +1261,7 @@ fn quote_builder_from_obj(obj: &Object) -> TokenStream {
             }
         } else {
             quote! {
+                #[inline]
                 pub fn #method_name(mut self, #field_name: impl Into<#typ>) -> Self {
                     self.#field_name = Some(#field_name.into());
                     self

--- a/crates/re_types_core/src/loggable_batch.rs
+++ b/crates/re_types_core/src/loggable_batch.rs
@@ -81,6 +81,7 @@ impl<'a> AsRef<dyn ComponentBatch + 'a> for MaybeOwnedComponentBatch<'a> {
 impl<'a> std::ops::Deref for MaybeOwnedComponentBatch<'a> {
     type Target = dyn ComponentBatch + 'a;
 
+    #[inline]
     fn deref(&self) -> &(dyn ComponentBatch + 'a) {
         match self {
             MaybeOwnedComponentBatch::Owned(this) => &**this,

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -142,12 +142,14 @@ impl<'a> ListItem<'a> {
     }
 
     /// Set the active state the item.
+    #[inline]
     pub fn active(mut self, active: bool) -> Self {
         self.active = active;
         self
     }
 
     /// Set the selected state of the item.
+    #[inline]
     pub fn selected(mut self, selected: bool) -> Self {
         self.selected = selected;
         self
@@ -158,6 +160,7 @@ impl<'a> ListItem<'a> {
     // widget are displayed in a subdued state (container, hidden space views/entities). One
     // slightly more correct way would be to override the color using a (color, index) pair
     // related to the design system table.
+    #[inline]
     pub fn subdued(mut self, subdued: bool) -> Self {
         self.subdued = subdued;
         self
@@ -168,6 +171,7 @@ impl<'a> ListItem<'a> {
     /// Used to highlight items representing things that are hovered elsewhere in the UI. Note that
     /// the [`egui::Response`] returned by [`Self::show`] and ]`Self::show_collapsing`] will still
     /// reflect the actual hover state.
+    #[inline]
     pub fn force_hovered(mut self, force_hovered: bool) -> Self {
         self.force_hovered = force_hovered;
         self
@@ -177,18 +181,21 @@ impl<'a> ListItem<'a> {
     ///
     /// The default is provided by [`ReUi::list_item_height`] and is suitable for hierarchical
     /// lists.
+    #[inline]
     pub fn with_height(mut self, height: f32) -> Self {
         self.height = height;
         self
     }
 
     /// Set the width allocation mode.
+    #[inline]
     pub fn width_allocation_mode(mut self, mode: WidthAllocationMode) -> Self {
         self.width_allocation_mode = mode;
         self
     }
 
     /// Provide an [`Icon`] to be displayed on the left of the item.
+    #[inline]
     pub fn with_icon(self, icon: &'a Icon) -> Self {
         self.with_icon_fn(|_, ui, rect, visuals| {
             let tint = visuals.fg_stroke.color;
@@ -197,6 +204,7 @@ impl<'a> ListItem<'a> {
     }
 
     /// Provide a custom closure to draw an icon on the left of the item.
+    #[inline]
     pub fn with_icon_fn(
         mut self,
         icon_fn: impl FnOnce(&ReUi, &mut egui::Ui, egui::Rect, egui::style::WidgetVisuals) + 'a,
@@ -212,6 +220,7 @@ impl<'a> ListItem<'a> {
     ///   enclosing UI adapts to the childrens width, it will unnecessarily grow. If buttons aren't
     ///   used, the item will only allocate the width needed for the text and icons if any.
     /// - A right to left layout is used, so the right-most button must be added first.
+    #[inline]
     pub fn with_buttons(
         mut self,
         buttons: impl FnOnce(&ReUi, &mut egui::Ui) -> egui::Response + 'a,

--- a/crates/rerun/src/log_integration.rs
+++ b/crates/rerun/src/log_integration.rs
@@ -44,6 +44,7 @@ impl Logger {
     }
 
     /// Configures the [`Logger`] to prefix the specified `path_prefix` to all events.
+    #[inline]
     pub fn with_path_prefix(mut self, path_prefix: impl Into<String>) -> Self {
         self.path_prefix = Some(path_prefix.into());
         self
@@ -57,6 +58,7 @@ impl Logger {
     /// instead when you [`Logger::init`] it.
     ///
     /// [env_logger syntax]: https://docs.rs/env_logger/latest/env_logger/index.html#enabling-logging
+    #[inline]
     pub fn with_filter(mut self, filter: impl AsRef<str>) -> Self {
         use env_logger::filter::Builder;
         self.filter = Some(Builder::new().parse(filter.as_ref()).build());

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -298,6 +298,7 @@ struct PyRecordingStream(RecordingStream);
 impl std::ops::Deref for PyRecordingStream {
     type Target = RecordingStream;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -48,9 +48,16 @@ def is_valid_todo_part(part: str) -> bool:
     return False
 
 
-def lint_line(line: str, file_extension: str = "rs", is_in_docstring: bool = False) -> str | None:
+def lint_line(
+    line: str, prev_line: str | None, file_extension: str = "rs", is_in_docstring: bool = False
+) -> str | None:
     if line == "":
         return None
+
+    if prev_line is None:
+        prev_line_stripped = ""
+    else:
+        prev_line_stripped = prev_line.strip()
 
     if line[-1].isspace():
         return "Trailing whitespace"
@@ -145,11 +152,21 @@ def lint_line(line: str, file_extension: str = "rs", is_in_docstring: bool = Fal
             if not app_id.startswith("rerun_example_"):
                 return f"All examples should have an app_id starting with 'rerun_example_'. Found '{app_id}'"
 
+    # Methods that return Self should usually be marked #[inline] or #[inline(always)] since they indicate a builder.
+    if re.search(r"\(mut self.*-> Self", line):
+        if prev_line_stripped != "#[inline]" and prev_line_stripped != "#[inline(always)]":
+            return "Builder methods impls should be marked #[inline]"
+
+    # Deref impls should be marked #[inline] or #[inline(always)].
+    if "fn deref(&self)" in line:
+        if prev_line_stripped != "#[inline]" and prev_line_stripped != "#[inline(always)]":
+            return "Deref impls should be marked #[inline]"
+
     return None
 
 
 def test_lint_line() -> None:
-    assert lint_line("hello world") is None
+    assert lint_line("hello world", None) is None
 
     should_pass = [
         "hello world",
@@ -188,6 +205,22 @@ def test_lint_line() -> None:
         "template <typename... Args>",
         'protoc_prebuilt::init("22.0")',
         'rr.init("rerun_example_app")',
+        """
+        #[inline]
+        fn foo(mut self) -> Self {
+""",
+        """
+        #[inline(always)]
+        fn foo_always(mut self) -> Self {
+""",
+        """
+        #[inline]
+        fn deref(&self) -> Self::Target {
+""",
+        """
+        #[inline(always)]
+        fn deref(&self) -> Self::Target {
+""",
     ]
 
     should_error = [
@@ -227,14 +260,22 @@ def test_lint_line() -> None:
         'rr.init("missing_prefix")',
         'rr.script_setup(args, "missing_prefix")',
         "I accidentally wrote the same same word twice",
+        "fn foo(mut self) -> Self {",
+        "fn deref(&self) -> Self::Target {",
     ]
 
-    for line in should_pass:
-        err = lint_line(line)
-        assert err is None, f'expected "{line}" to pass, but got error: "{err}"'
+    for test in should_pass:
+        prev_line = None
+        for line in test.split("\n"):
+            err = lint_line(line, prev_line)
+            assert err is None, f'expected "{line}" to pass, but got error: "{err}"'
+            prev_line = line
 
-    for line in should_error:
-        assert lint_line(line) is not None, f'expected "{line}" to fail'
+    for test in should_error:
+        prev_line = None
+        for line in test.split("\n"):
+            assert lint_line(line, prev_line) is not None, f'expected "{line}" to fail'
+            prev_line = line
 
 
 # -----------------------------------------------------------------------------
@@ -620,6 +661,7 @@ def lint_file(filepath: str, args: Any) -> int:
 
     is_in_docstring = False
 
+    prev_line = None
     for line_nr, line in enumerate(source.lines):
         if line == "" or line[-1] != "\n":
             error = "Missing newline at end of file"
@@ -627,7 +669,8 @@ def lint_file(filepath: str, args: Any) -> int:
             line = line[:-1]
             if line.strip() == '"""':
                 is_in_docstring = not is_in_docstring
-            error = lint_line(line, source.ext, is_in_docstring)
+            error = lint_line(line, prev_line, source.ext, is_in_docstring)
+            prev_line = line
         if error is not None:
             num_errors += 1
             print(source.error(error, line_nr=line_nr))


### PR DESCRIPTION
### What
The Rust compiler is not able to inline across traits unless things are marked inline or link time optimization is enabled. This new lint makes sure we don't forget it on builder pattern functions an deref implementations which are usually very small methods that warrant `#[inline]`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/{{ pr.number }}/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/{{ pr.number }}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
