### PR TITLE
Pass viewer context always non-mutable

### DIFF
--- a/crates/re_data_ui/src/annotation_context.rs
+++ b/crates/re_data_ui/src/annotation_context.rs
@@ -14,7 +14,7 @@ const TABLE_SCROLL_AREA_HEIGHT: f32 = 500.0; // add scroll-bars when we get to t
 impl crate::EntityDataUi for re_types::components::ClassId {
     fn entity_data_ui(
         &self,
-        ctx: &mut re_viewer_context::ViewerContext<'_>,
+        ctx: &re_viewer_context::ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: re_viewer_context::UiVerbosity,
         entity_path: &re_log_types::EntityPath,
@@ -58,7 +58,7 @@ impl crate::EntityDataUi for re_types::components::ClassId {
 impl crate::EntityDataUi for re_types::components::KeypointId {
     fn entity_data_ui(
         &self,
-        ctx: &mut re_viewer_context::ViewerContext<'_>,
+        ctx: &re_viewer_context::ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: re_viewer_context::UiVerbosity,
         entity_path: &re_log_types::EntityPath,
@@ -97,7 +97,7 @@ fn annotation_info(
 impl DataUi for AnnotationContext {
     fn data_ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,

--- a/crates/re_data_ui/src/component.rs
+++ b/crates/re_data_ui/src/component.rs
@@ -29,7 +29,7 @@ impl EntityComponentWithInstances {
 impl DataUi for EntityComponentWithInstances {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,

--- a/crates/re_data_ui/src/component_path.rs
+++ b/crates/re_data_ui/src/component_path.rs
@@ -6,7 +6,7 @@ use super::DataUi;
 impl DataUi for ComponentPath {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,

--- a/crates/re_data_ui/src/component_ui_registry.rs
+++ b/crates/re_data_ui/src/component_ui_registry.rs
@@ -53,7 +53,7 @@ pub fn create_component_ui_registry() -> ComponentUiRegistry {
 }
 
 fn fallback_component_ui(
-    _ctx: &mut ViewerContext<'_>,
+    _ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     verbosity: UiVerbosity,
     _query: &LatestAtQuery,

--- a/crates/re_data_ui/src/data.rs
+++ b/crates/re_data_ui/src/data.rs
@@ -14,7 +14,7 @@ const DEFAULT_NUMBER_WIDTH: f32 = 52.0;
 impl DataUi for [u8; 4] {
     fn data_ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -34,7 +34,7 @@ impl DataUi for [u8; 4] {
 impl DataUi for Color {
     fn data_ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -54,7 +54,7 @@ impl DataUi for Color {
 impl DataUi for ViewCoordinates {
     fn data_ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -73,7 +73,7 @@ impl DataUi for ViewCoordinates {
 impl DataUi for re_types::datatypes::Mat3x3 {
     fn data_ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -100,7 +100,7 @@ impl DataUi for re_types::datatypes::Mat3x3 {
 impl DataUi for re_types::datatypes::Vec2D {
     fn data_ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -112,7 +112,7 @@ impl DataUi for re_types::datatypes::Vec2D {
 impl DataUi for re_types::datatypes::Vec3D {
     fn data_ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -124,7 +124,7 @@ impl DataUi for re_types::datatypes::Vec3D {
 impl DataUi for LineStrip2D {
     fn data_ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -173,7 +173,7 @@ impl DataUi for LineStrip2D {
 impl DataUi for LineStrip3D {
     fn data_ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -228,12 +228,12 @@ impl DataUi for LineStrip3D {
 impl DataUi for Material {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
     ) {
-        let mut show_optional_albedo_factor = |ui: &mut egui::Ui| {
+        let show_optional_albedo_factor = |ui: &mut egui::Ui| {
             if let Some(albedo_factor) = self.albedo_factor {
                 Color(albedo_factor).data_ui(ctx, ui, verbosity, query);
             } else {
@@ -259,7 +259,7 @@ impl DataUi for Material {
 impl DataUi for MeshProperties {
     fn data_ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,

--- a/crates/re_data_ui/src/entity_path.rs
+++ b/crates/re_data_ui/src/entity_path.rs
@@ -6,7 +6,7 @@ use super::DataUi;
 impl DataUi for re_data_store::EntityPath {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -23,7 +23,7 @@ pub fn format_tensor_shape_single_line(shape: &[TensorDimension]) -> String {
 impl EntityDataUi for re_types::components::TensorData {
     fn entity_data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         entity_path: &re_log_types::EntityPath,

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -9,7 +9,7 @@ use crate::item_ui;
 impl DataUi for InstancePath {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,

--- a/crates/re_data_ui/src/item.rs
+++ b/crates/re_data_ui/src/item.rs
@@ -5,7 +5,7 @@ use crate::DataUi;
 impl DataUi for Item {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,

--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -16,7 +16,7 @@ use super::DataUi;
 //
 // Show a button to an [`Item`] with a given text.
 // pub fn item_button_to(
-//     ctx: &mut ViewerContext<'_>,
+//     ctx: &ViewerContext<'_>,
 //     ui: &mut egui::Ui,
 //     item: &Item,
 //     text: impl Into<egui::WidgetText>,
@@ -39,7 +39,7 @@ use super::DataUi;
 
 /// Show an entity path and make it selectable.
 pub fn entity_path_button(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     space_view_id: Option<SpaceViewId>,
     entity_path: &EntityPath,
@@ -55,7 +55,7 @@ pub fn entity_path_button(
 
 /// Show an entity path and make it selectable.
 pub fn entity_path_button_to(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     space_view_id: Option<SpaceViewId>,
     entity_path: &EntityPath,
@@ -72,7 +72,7 @@ pub fn entity_path_button_to(
 
 /// Show an instance id and make it selectable.
 pub fn instance_path_button(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     space_view_id: Option<SpaceViewId>,
     instance_path: &InstancePath,
@@ -88,7 +88,7 @@ pub fn instance_path_button(
 
 /// Show an instance id and make it selectable.
 pub fn instance_path_button_to(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     space_view_id: Option<SpaceViewId>,
     instance_path: &InstancePath,
@@ -214,7 +214,7 @@ pub fn data_blueprint_group_button_to(
 }
 
 pub fn data_blueprint_button_to(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     text: impl Into<egui::WidgetText>,
     space_view_id: SpaceViewId,
@@ -326,11 +326,7 @@ pub fn select_hovered_on_click(ctx: &ViewerContext<'_>, response: &egui::Respons
 /// Displays the "hover card" (i.e. big tooltip) for an instance or an entity.
 ///
 /// The entity hover card is displayed the provided instance path is a splat.
-pub fn instance_hover_card_ui(
-    ui: &mut Ui,
-    ctx: &mut ViewerContext<'_>,
-    instance_path: &InstancePath,
-) {
+pub fn instance_hover_card_ui(ui: &mut Ui, ctx: &ViewerContext<'_>, instance_path: &InstancePath) {
     let subtype_string = if instance_path.instance_key.is_splat() {
         "Entity"
     } else {
@@ -355,11 +351,7 @@ pub fn instance_hover_card_ui(
 }
 
 /// Displays the "hover card" (i.e. big tooltip) for an entity.
-pub fn entity_hover_card_ui(
-    ui: &mut egui::Ui,
-    ctx: &mut ViewerContext<'_>,
-    entity_path: &EntityPath,
-) {
+pub fn entity_hover_card_ui(ui: &mut egui::Ui, ctx: &ViewerContext<'_>, entity_path: &EntityPath) {
     let instance_path = InstancePath::entity_splat(entity_path.clone());
     instance_hover_card_ui(ui, ctx, &instance_path);
 }

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -80,7 +80,7 @@ pub trait DataUi {
     /// If you need to lookup something in the data store, use the given query to do so.
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
@@ -94,7 +94,7 @@ pub trait EntityDataUi {
     /// If you need to lookup something in the data store, use the given query to do so.
     fn entity_data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         entity_path: &EntityPath,
@@ -108,7 +108,7 @@ where
 {
     fn entity_data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         _entity: &EntityPath,
@@ -123,7 +123,7 @@ where
 impl DataUi for TimePoint {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -144,7 +144,7 @@ impl DataUi for TimePoint {
 impl DataUi for [DataCell] {
     fn data_ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -7,7 +7,7 @@ use crate::item_ui;
 impl DataUi for LogMsg {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
@@ -22,7 +22,7 @@ impl DataUi for LogMsg {
 impl DataUi for SetStoreInfo {
     fn data_ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,
@@ -69,7 +69,7 @@ impl DataUi for SetStoreInfo {
 impl DataUi for ArrowMsg {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,

--- a/crates/re_data_ui/src/pinhole.rs
+++ b/crates/re_data_ui/src/pinhole.rs
@@ -6,7 +6,7 @@ use crate::DataUi;
 impl DataUi for PinholeProjection {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
@@ -35,7 +35,7 @@ impl DataUi for PinholeProjection {
 impl DataUi for Resolution {
     fn data_ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_arrow_store::LatestAtQuery,

--- a/crates/re_data_ui/src/rotation3d.rs
+++ b/crates/re_data_ui/src/rotation3d.rs
@@ -9,7 +9,7 @@ use crate::DataUi;
 impl DataUi for components::Rotation3D {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
@@ -21,7 +21,7 @@ impl DataUi for components::Rotation3D {
 impl DataUi for datatypes::Rotation3D {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,

--- a/crates/re_data_ui/src/transform3d.rs
+++ b/crates/re_data_ui/src/transform3d.rs
@@ -7,7 +7,7 @@ impl DataUi for re_types::components::Transform3D {
     #[allow(clippy::only_used_in_recursion)]
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
@@ -47,7 +47,7 @@ impl DataUi for re_types::components::OutOfTreeTransform3D {
     #[inline]
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
@@ -60,7 +60,7 @@ impl DataUi for Transform3D {
     #[allow(clippy::only_used_in_recursion)]
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
@@ -87,7 +87,7 @@ impl DataUi for Transform3D {
 impl DataUi for TranslationRotationScale3D {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
@@ -128,7 +128,7 @@ impl DataUi for TranslationRotationScale3D {
 impl DataUi for Scale3D {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,
@@ -147,7 +147,7 @@ impl DataUi for Scale3D {
 impl DataUi for TranslationAndMat3x3 {
     fn data_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &re_arrow_store::LatestAtQuery,

--- a/crates/re_space_view_bar_chart/src/space_view_class.rs
+++ b/crates/re_space_view_bar_chart/src/space_view_class.rs
@@ -66,7 +66,7 @@ impl SpaceViewClass for BarChartSpaceView {
 
     fn selection_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         _state: &mut Self::State,
         _space_origin: &EntityPath,
@@ -125,7 +125,7 @@ impl SpaceViewClass for BarChartSpaceView {
 
     fn ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         _state: &mut Self::State,
         root_entity_properties: &EntityProperties,

--- a/crates/re_space_view_bar_chart/src/view_part_system.rs
+++ b/crates/re_space_view_bar_chart/src/view_part_system.rs
@@ -68,7 +68,7 @@ impl ViewPartSystem for BarChartViewPartSystem {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         _view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_spatial/src/contexts/annotation_context.rs
+++ b/crates/re_space_view_spatial/src/contexts/annotation_context.rs
@@ -24,7 +24,7 @@ impl ViewContextSystem for AnnotationSceneContext {
 
     fn execute(
         &mut self,
-        ctx: &mut re_viewer_context::ViewerContext<'_>,
+        ctx: &re_viewer_context::ViewerContext<'_>,
         query: &re_viewer_context::ViewQuery<'_>,
     ) {
         re_tracing::profile_function!();

--- a/crates/re_space_view_spatial/src/contexts/depth_offsets.rs
+++ b/crates/re_space_view_spatial/src/contexts/depth_offsets.rs
@@ -32,7 +32,7 @@ impl ViewContextSystem for EntityDepthOffsets {
 
     fn execute(
         &mut self,
-        ctx: &mut re_viewer_context::ViewerContext<'_>,
+        ctx: &re_viewer_context::ViewerContext<'_>,
         query: &re_viewer_context::ViewQuery<'_>,
     ) {
         #[derive(PartialEq, PartialOrd, Eq, Ord)]

--- a/crates/re_space_view_spatial/src/contexts/mod.rs
+++ b/crates/re_space_view_spatial/src/contexts/mod.rs
@@ -49,7 +49,7 @@ impl ViewContextSystem for PrimitiveCounter {
 
     fn execute(
         &mut self,
-        _ctx: &mut re_viewer_context::ViewerContext<'_>,
+        _ctx: &re_viewer_context::ViewerContext<'_>,
         _query: &re_viewer_context::ViewQuery<'_>,
     ) {
     }

--- a/crates/re_space_view_spatial/src/contexts/non_interactive_entities.rs
+++ b/crates/re_space_view_spatial/src/contexts/non_interactive_entities.rs
@@ -22,7 +22,7 @@ impl ViewContextSystem for NonInteractiveEntities {
 
     fn execute(
         &mut self,
-        _ctx: &mut re_viewer_context::ViewerContext<'_>,
+        _ctx: &re_viewer_context::ViewerContext<'_>,
         query: &re_viewer_context::ViewQuery<'_>,
     ) {
         self.0 = query

--- a/crates/re_space_view_spatial/src/contexts/shared_render_builders.rs
+++ b/crates/re_space_view_spatial/src/contexts/shared_render_builders.rs
@@ -70,7 +70,7 @@ impl ViewContextSystem for SharedRenderBuilders {
 
     fn execute(
         &mut self,
-        ctx: &mut re_viewer_context::ViewerContext<'_>,
+        ctx: &re_viewer_context::ViewerContext<'_>,
         _query: &re_viewer_context::ViewQuery<'_>,
     ) {
         re_tracing::profile_function!();

--- a/crates/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/re_space_view_spatial/src/contexts/transform_context.rs
@@ -81,7 +81,7 @@ impl ViewContextSystem for TransformContext {
     /// entities are transformed relative to it.
     fn execute(
         &mut self,
-        ctx: &mut re_viewer_context::ViewerContext<'_>,
+        ctx: &re_viewer_context::ViewerContext<'_>,
         query: &re_viewer_context::ViewQuery<'_>,
     ) {
         re_tracing::profile_function!();

--- a/crates/re_space_view_spatial/src/parts/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/parts/arrows3d.rs
@@ -182,7 +182,7 @@ impl ViewPartSystem for Arrows3DPart {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_spatial/src/parts/assets3d.rs
+++ b/crates/re_space_view_spatial/src/parts/assets3d.rs
@@ -113,7 +113,7 @@ impl ViewPartSystem for Asset3DPart {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_spatial/src/parts/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes2d.rs
@@ -204,7 +204,7 @@ impl ViewPartSystem for Boxes2DPart {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_spatial/src/parts/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/parts/boxes3d.rs
@@ -137,7 +137,7 @@ impl ViewPartSystem for Boxes3DPart {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_spatial/src/parts/cameras.rs
+++ b/crates/re_space_view_spatial/src/parts/cameras.rs
@@ -195,7 +195,7 @@ impl ViewPartSystem for CamerasPart {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_spatial/src/parts/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/parts/entity_iterator.rs
@@ -22,7 +22,7 @@ use crate::{
 /// various useful information about an entity in the context of the current scene.
 #[allow(dead_code)]
 pub fn process_archetype_views<'a, System: IdentifiedViewSystem, A, const N: usize, F>(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     query: &ViewQuery<'_>,
     view_ctx: &ViewContextCollection,
     default_depth_offset: DepthOffset,
@@ -31,7 +31,7 @@ pub fn process_archetype_views<'a, System: IdentifiedViewSystem, A, const N: usi
 where
     A: Archetype + 'a,
     F: FnMut(
-        &mut ViewerContext<'_>,
+        &ViewerContext<'_>,
         &EntityPath,
         &EntityProperties,
         ArchetypeView<A>,

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -709,7 +709,7 @@ impl ViewPartSystem for ImagesPart {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_spatial/src/parts/lines2d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines2d.rs
@@ -199,7 +199,7 @@ impl ViewPartSystem for Lines2DPart {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_spatial/src/parts/lines3d.rs
+++ b/crates/re_space_view_spatial/src/parts/lines3d.rs
@@ -182,7 +182,7 @@ impl ViewPartSystem for Lines3DPart {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_spatial/src/parts/meshes.rs
+++ b/crates/re_space_view_spatial/src/parts/meshes.rs
@@ -145,7 +145,7 @@ impl ViewPartSystem for Mesh3DPart {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_spatial/src/parts/points2d.rs
+++ b/crates/re_space_view_spatial/src/parts/points2d.rs
@@ -226,7 +226,7 @@ impl ViewPartSystem for Points2DPart {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_spatial/src/parts/points3d.rs
+++ b/crates/re_space_view_spatial/src/parts/points3d.rs
@@ -183,7 +183,7 @@ impl ViewPartSystem for Points3DPart {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
@@ -50,7 +50,7 @@ impl ViewPartSystem for Transform3DArrowsPart {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -52,7 +52,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
 
     fn on_frame_start(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         state: &Self::State,
         ent_paths: &PerSystemEntities,
         entity_properties: &mut re_data_store::EntityPropertyMap,
@@ -125,7 +125,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
 
     fn selection_ui(
         &self,
-        ctx: &mut re_viewer_context::ViewerContext<'_>,
+        ctx: &re_viewer_context::ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         space_origin: &EntityPath,
@@ -137,7 +137,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
 
     fn ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         _root_entity_properties: &EntityProperties,

--- a/crates/re_space_view_spatial/src/space_view_3d.rs
+++ b/crates/re_space_view_spatial/src/space_view_3d.rs
@@ -84,7 +84,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
 
     fn on_frame_start(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         state: &Self::State,
         ent_paths: &PerSystemEntities,
         entity_properties: &mut re_data_store::EntityPropertyMap,
@@ -100,7 +100,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
 
     fn selection_ui(
         &self,
-        ctx: &mut re_viewer_context::ViewerContext<'_>,
+        ctx: &re_viewer_context::ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         space_origin: &EntityPath,
@@ -112,7 +112,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
 
     fn ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         _root_entity_properties: &EntityProperties,

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -440,7 +440,7 @@ pub fn screenshot_context_menu(
 
 #[allow(clippy::too_many_arguments)] // TODO(andreas): Make this method sane.
 pub fn picking(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     mut response: egui::Response,
     space_from_ui: egui::emath::RectTransform,
     ui_clip_rect: egui::Rect,
@@ -666,7 +666,7 @@ pub fn picking(
 fn image_hover_ui(
     ui: &mut egui::Ui,
     instance_path: &re_data_store::InstancePath,
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     tensor: TensorData,
     spatial_kind: SpatialSpaceViewKind,
     ui_clip_rect: egui::Rect,

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -225,7 +225,7 @@ pub fn help_text(re_ui: &re_ui::ReUi) -> egui::WidgetText {
 
 /// Create the outer 2D view, which consists of a scrollable region
 pub fn view_2d(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     state: &mut SpatialSpaceViewState,
     view_ctx: &ViewContextCollection,

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -309,7 +309,7 @@ pub fn help_text(re_ui: &re_ui::ReUi) -> egui::WidgetText {
 
 /// TODO(andreas): Split into smaller parts, more re-use with `ui_2d`
 pub fn view_3d(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     state: &mut SpatialSpaceViewState,
     view_ctx: &ViewContextCollection,

--- a/crates/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/re_space_view_tensor/src/space_view_class.rs
@@ -164,7 +164,7 @@ impl SpaceViewClass for TensorSpaceView {
 
     fn selection_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         _space_origin: &EntityPath,
@@ -180,7 +180,7 @@ impl SpaceViewClass for TensorSpaceView {
 
     fn ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         _root_entity_properties: &EntityProperties,

--- a/crates/re_space_view_tensor/src/view_part_system.rs
+++ b/crates/re_space_view_tensor/src/view_part_system.rs
@@ -58,7 +58,7 @@ impl ViewPartSystem for TensorSystem {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         _view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_text_document/src/space_view_class.rs
+++ b/crates/re_space_view_text_document/src/space_view_class.rs
@@ -73,7 +73,7 @@ impl SpaceViewClass for TextDocumentSpaceView {
 
     fn selection_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         _space_origin: &EntityPath,
@@ -95,7 +95,7 @@ impl SpaceViewClass for TextDocumentSpaceView {
 
     fn ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         _root_entity_properties: &EntityProperties,

--- a/crates/re_space_view_text_document/src/view_part_system.rs
+++ b/crates/re_space_view_text_document/src/view_part_system.rs
@@ -43,7 +43,7 @@ impl ViewPartSystem for TextDocumentSystem {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         _view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_text_log/src/space_view_class.rs
+++ b/crates/re_space_view_text_log/src/space_view_class.rs
@@ -84,7 +84,7 @@ impl SpaceViewClass for TextSpaceView {
 
     fn selection_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         _space_origin: &EntityPath,
@@ -132,7 +132,7 @@ impl SpaceViewClass for TextSpaceView {
 
     fn ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         _root_entity_properties: &EntityProperties,
@@ -263,7 +263,7 @@ fn get_time_point(ctx: &ViewerContext<'_>, entry: &Entry) -> Option<TimePoint> {
 /// as opposed to `scroll_to_offset` (computed below) which is how far down we want to
 /// scroll in terms of actual points.
 fn table_ui(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     state: &TextSpaceViewState,
     entries: &[&Entry],

--- a/crates/re_space_view_text_log/src/view_part_system.rs
+++ b/crates/re_space_view_text_log/src/view_part_system.rs
@@ -55,7 +55,7 @@ impl ViewPartSystem for TextLogSystem {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         _view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -96,7 +96,7 @@ impl SpaceViewClass for TimeSeriesSpaceView {
 
     fn selection_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         _state: &mut Self::State,
         _space_origin: &EntityPath,
@@ -155,7 +155,7 @@ impl SpaceViewClass for TimeSeriesSpaceView {
 
     fn ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         root_entity_properties: &EntityProperties,

--- a/crates/re_space_view_time_series/src/view_part_system.rs
+++ b/crates/re_space_view_time_series/src/view_part_system.rs
@@ -87,7 +87,7 @@ impl ViewPartSystem for TimeSeriesSystem {
 
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         _context: &re_viewer_context::ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {

--- a/crates/re_time_panel/src/data_density_graph.rs
+++ b/crates/re_time_panel/src/data_density_graph.rs
@@ -367,7 +367,7 @@ fn smooth(density: &[f32]) -> Vec<f32> {
 #[allow(clippy::too_many_arguments)]
 pub fn data_density_graph_ui(
     data_dentity_graph_painter: &mut DataDensityGraphPainter,
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     time_ctrl: &mut TimeControl,
     time_area_response: &egui::Response,
     time_area_painter: &egui::Painter,
@@ -522,7 +522,7 @@ fn make_brighter(color: Color32) -> Color32 {
 }
 
 fn show_row_ids_tooltip(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     time_ctrl: &TimeControl,
     egui_ctx: &egui::Context,
     item: &Item,

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -62,7 +62,7 @@ impl Default for TimePanel {
 impl TimePanel {
     pub fn show_panel(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         time_panel_expanded: bool,
     ) {
@@ -211,7 +211,7 @@ impl TimePanel {
 
     fn expanded_ui(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         time_ctrl: &mut TimeControl,
     ) {
@@ -390,7 +390,7 @@ impl TimePanel {
     // All the entity rows and their data density graphs:
     fn tree_ui(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         time_ctrl: &mut TimeControl,
         time_area_response: &egui::Response,
         time_area_painter: &egui::Painter,
@@ -457,7 +457,7 @@ impl TimePanel {
     #[allow(clippy::too_many_arguments)]
     fn show_tree(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         time_ctrl: &mut TimeControl,
         time_area_response: &egui::Response,
         time_area_painter: &egui::Painter,
@@ -568,7 +568,7 @@ impl TimePanel {
     #[allow(clippy::too_many_arguments)]
     fn show_children(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         time_ctrl: &mut TimeControl,
         time_area_response: &egui::Response,
         time_area_painter: &egui::Painter,

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -169,7 +169,7 @@ impl AppState {
             viewport.blueprint.reset(&ctx, &spaces_info);
         }
 
-        viewport.on_frame_start(&mut ctx, &spaces_info);
+        viewport.on_frame_start(&ctx, &spaces_info);
 
         // TODO(jleibs): Running the queries a second time is annoying, but we need
         // to do this or else the auto_properties aren't right since they get populated
@@ -198,9 +198,9 @@ impl AppState {
         };
         ctx.query_results = &updated_query_results;
 
-        time_panel.show_panel(&mut ctx, ui, app_blueprint.time_panel_expanded);
+        time_panel.show_panel(&ctx, ui, app_blueprint.time_panel_expanded);
         selection_panel.show_panel(
-            &mut ctx,
+            &ctx,
             ui,
             &mut viewport,
             app_blueprint.selection_panel_expanded,
@@ -237,13 +237,13 @@ impl AppState {
                         // before drawing the blueprint panel.
                         ui.spacing_mut().item_spacing.y = 0.0;
 
-                        let recording_shown = recordings_panel_ui(&mut ctx, rx, ui);
+                        let recording_shown = recordings_panel_ui(&ctx, rx, ui);
 
                         if recording_shown {
                             ui.add_space(4.0);
                         }
 
-                        blueprint_panel_ui(&mut viewport.blueprint, &mut ctx, ui, &spaces_info);
+                        blueprint_panel_ui(&mut viewport.blueprint, &ctx, ui, &spaces_info);
                     },
                 );
 

--- a/crates/re_viewer/src/ui/blueprint_panel.rs
+++ b/crates/re_viewer/src/ui/blueprint_panel.rs
@@ -4,7 +4,7 @@ use re_viewport::{SpaceInfoCollection, ViewportBlueprint};
 /// Show the Blueprint section of the left panel based on the current [`ViewportBlueprint`]
 pub fn blueprint_panel_ui(
     blueprint: &mut ViewportBlueprint<'_>,
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     spaces_info: &SpaceInfoCollection,
 ) {

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -11,7 +11,7 @@ use re_viewer_context::{
 ///
 /// Returns `true` if any recordings were shown.
 pub fn recordings_panel_ui(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     rx: &ReceiveSet<LogMsg>,
     ui: &mut egui::Ui,
 ) -> bool {
@@ -105,7 +105,7 @@ fn loading_receivers_ui(
 /// Draw the recording list.
 ///
 /// Returns `true` if any recordings were shown.
-fn recording_list_ui(ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) -> bool {
+fn recording_list_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) -> bool {
     let ViewerContext {
         store_context,
         command_sender,

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -35,7 +35,7 @@ pub(crate) struct SelectionPanel {
 impl SelectionPanel {
     pub fn show_panel(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         viewport: &mut Viewport<'_, '_>,
         expanded: bool,
@@ -97,7 +97,7 @@ impl SelectionPanel {
     #[allow(clippy::unused_self)]
     fn contents(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         viewport: &mut Viewport<'_, '_>,
     ) {
@@ -189,7 +189,7 @@ fn space_view_button(
 /// This includes a title bar and contextual information about there this item is located.
 fn what_is_selected_ui(
     ui: &mut egui::Ui,
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     viewport: &mut ViewportBlueprint<'_>,
     item: &Item,
 ) {
@@ -325,7 +325,7 @@ fn item_title_ui(
 /// Display a list of all the space views an entity appears in.
 fn list_existing_data_blueprints(
     ui: &mut egui::Ui,
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     entity_path: &EntityPath,
     blueprint: &ViewportBlueprint<'_>,
 ) {
@@ -359,7 +359,7 @@ fn list_existing_data_blueprints(
 /// shown at the very top.
 fn space_view_top_level_properties(
     ui: &mut egui::Ui,
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     viewport: &mut ViewportBlueprint<'_>,
     space_view_id: &SpaceViewId,
 ) {
@@ -493,7 +493,7 @@ fn has_blueprint_section(item: &Item) -> bool {
 /// What is the blueprint stuff for this item?
 fn blueprint_ui(
     ui: &mut egui::Ui,
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     viewport: &mut Viewport<'_, '_>,
     item: &Item,
 ) {
@@ -702,7 +702,7 @@ fn blueprint_ui(
 }
 
 fn entity_props_ui(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     space_view_class: &SpaceViewClassIdentifier,
     entity_path: Option<&EntityPath>,
@@ -799,7 +799,7 @@ fn pinhole_props_ui(
 }
 
 fn depth_props_ui(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     entity_path: &EntityPath,
     entity_props: &mut EntityProperties,

--- a/crates/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/re_viewer_context/src/component_ui_registry.rs
@@ -24,7 +24,7 @@ pub enum UiVerbosity {
 
 type ComponentUiCallback = Box<
     dyn Fn(
-        &mut ViewerContext<'_>,
+        &ViewerContext<'_>,
         &mut egui::Ui,
         UiVerbosity,
         &LatestAtQuery,
@@ -60,7 +60,7 @@ impl ComponentUiRegistry {
     #[allow(clippy::too_many_arguments)]
     pub fn ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         verbosity: UiVerbosity,
         query: &LatestAtQuery,

--- a/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
@@ -100,7 +100,7 @@ pub trait DynSpaceViewClass {
     /// Passed entity properties are individual properties without propagated values.
     fn on_frame_start(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         state: &mut dyn SpaceViewState,
         ent_paths: &PerSystemEntities,
         entity_properties: &mut EntityPropertyMap,
@@ -111,7 +111,7 @@ pub trait DynSpaceViewClass {
     /// TODO(andreas): Should this be instead implemented via a registered `data_ui` of all blueprint relevant types?
     fn selection_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut dyn SpaceViewState,
         space_origin: &EntityPath,
@@ -124,7 +124,7 @@ pub trait DynSpaceViewClass {
     /// The state passed in was previously created by [`Self::new_state`] and is kept frame-to-frame.
     fn ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut dyn SpaceViewState,
         root_entity_properties: &EntityProperties,

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -88,7 +88,7 @@ pub trait SpaceViewClass: std::marker::Sized {
     /// Passed entity properties are individual properties without propagated values.
     fn on_frame_start(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         _state: &Self::State,
         _ent_paths: &PerSystemEntities,
         _entity_properties: &mut re_data_store::EntityPropertyMap,
@@ -100,7 +100,7 @@ pub trait SpaceViewClass: std::marker::Sized {
     /// TODO(andreas): Should this be instead implemented via a registered `data_ui` of all blueprint relevant types?
     fn selection_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         space_origin: &EntityPath,
@@ -122,7 +122,7 @@ pub trait SpaceViewClass: std::marker::Sized {
     #[allow(clippy::too_many_arguments)]
     fn ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         root_entity_properties: &EntityProperties,
@@ -192,7 +192,7 @@ impl<T: SpaceViewClass + 'static> DynSpaceViewClass for T {
 
     fn on_frame_start(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         state: &mut dyn SpaceViewState,
         ent_paths: &PerSystemEntities,
         entity_properties: &mut EntityPropertyMap,
@@ -205,7 +205,7 @@ impl<T: SpaceViewClass + 'static> DynSpaceViewClass for T {
     #[inline]
     fn selection_ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut dyn SpaceViewState,
         space_origin: &EntityPath,
@@ -227,7 +227,7 @@ impl<T: SpaceViewClass + 'static> DynSpaceViewClass for T {
     #[allow(clippy::for_kv_map)]
     fn ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut dyn SpaceViewState,
         root_entity_properties: &EntityProperties,

--- a/crates/re_viewer_context/src/space_view/space_view_class_placeholder.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class_placeholder.rs
@@ -35,7 +35,7 @@ impl SpaceViewClass for SpaceViewClassPlaceholder {
 
     fn selection_ui(
         &self,
-        _ctx: &mut crate::ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         _ui: &mut egui::Ui,
         _state: &mut (),
         _space_origin: &re_log_types::EntityPath,
@@ -46,7 +46,7 @@ impl SpaceViewClass for SpaceViewClassPlaceholder {
 
     fn ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         _state: &mut Self::State,
         _root_entity_properties: &EntityProperties,

--- a/crates/re_viewer_context/src/space_view/view_context_system.rs
+++ b/crates/re_viewer_context/src/space_view/view_context_system.rs
@@ -23,7 +23,7 @@ pub trait ViewContextSystem {
     fn compatible_component_sets(&self) -> Vec<ComponentNameSet>;
 
     /// Queries the data store and performs data conversions to make it ready for consumption by scene elements.
-    fn execute(&mut self, ctx: &mut ViewerContext<'_>, query: &ViewQuery<'_>);
+    fn execute(&mut self, ctx: &ViewerContext<'_>, query: &ViewQuery<'_>);
 
     /// Converts itself to a reference of [`std::any::Any`], which enables downcasting to concrete types.
     fn as_any(&self) -> &dyn std::any::Any;

--- a/crates/re_viewer_context/src/space_view/view_part_system.rs
+++ b/crates/re_viewer_context/src/space_view/view_part_system.rs
@@ -90,7 +90,7 @@ pub trait ViewPartSystem {
     /// to the `ViewPartSystemImpl` does the query and then passes an `ArchetypeQueryResult` into populate.
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError>;

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -152,11 +152,7 @@ impl SpaceViewBlueprint {
         space_view_class_registry.get_system_registry_or_log_error(&self.class_identifier)
     }
 
-    pub fn on_frame_start(
-        &mut self,
-        ctx: &mut ViewerContext<'_>,
-        view_state: &mut dyn SpaceViewState,
-    ) {
+    pub fn on_frame_start(&mut self, ctx: &ViewerContext<'_>, view_state: &mut dyn SpaceViewState) {
         while ScreenshotProcessor::next_readback_result(
             ctx.render_ctx,
             self.id.gpu_readback_id(),
@@ -236,7 +232,7 @@ impl SpaceViewBlueprint {
     pub(crate) fn scene_ui(
         &mut self,
         view_state: &mut dyn SpaceViewState,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         latest_at: TimeInt,
         highlights: &SpaceViewHighlights,

--- a/crates/re_viewport/src/space_view_entity_picker.rs
+++ b/crates/re_viewport/src/space_view_entity_picker.rs
@@ -25,7 +25,7 @@ impl SpaceViewEntityPicker {
     #[allow(clippy::unused_self)]
     pub fn ui(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &egui::Ui,
         space_view: &mut SpaceViewBlueprint,
     ) -> bool {
@@ -84,7 +84,7 @@ impl SpaceViewEntityPicker {
 }
 
 fn add_entities_ui(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     space_view: &mut SpaceViewBlueprint,
 ) {
@@ -119,7 +119,7 @@ fn add_entities_ui(
 
 #[allow(clippy::too_many_arguments)]
 fn add_entities_tree_ui(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     name: &str,
     tree: &EntityTree,
@@ -189,7 +189,7 @@ fn add_entities_tree_ui(
 
 #[allow(clippy::too_many_arguments)]
 fn add_entities_line_ui(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     name: &str,
     entity_tree: &EntityTree,

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -170,11 +170,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
         });
     }
 
-    pub fn on_frame_start(
-        &mut self,
-        ctx: &mut ViewerContext<'_>,
-        spaces_info: &SpaceInfoCollection,
-    ) {
+    pub fn on_frame_start(&mut self, ctx: &ViewerContext<'_>, spaces_info: &SpaceInfoCollection) {
         re_tracing::profile_function!();
 
         for space_view in self.blueprint.space_views.values_mut() {
@@ -459,7 +455,7 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
 }
 
 fn space_view_ui(
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     space_view_blueprint: &mut SpaceViewBlueprint,
     space_view_state: &mut dyn SpaceViewState,

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -18,7 +18,7 @@ use crate::{
 
 impl ViewportBlueprint<'_> {
     /// Show the blueprint panel tree view.
-    pub fn tree_ui(&mut self, ctx: &mut ViewerContext<'_>, ui: &mut egui::Ui) {
+    pub fn tree_ui(&mut self, ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
         re_tracing::profile_function!();
 
         egui::ScrollArea::both()
@@ -61,12 +61,7 @@ impl ViewportBlueprint<'_> {
         2 <= num_children && num_children <= 3
     }
 
-    fn tile_ui(
-        &mut self,
-        ctx: &mut ViewerContext<'_>,
-        ui: &mut egui::Ui,
-        tile_id: egui_tiles::TileId,
-    ) {
+    fn tile_ui(&mut self, ctx: &ViewerContext<'_>, ui: &mut egui::Ui, tile_id: egui_tiles::TileId) {
         // Temporarily remove the tile so we don't get borrow-checker fights:
         let Some(mut tile) = self.tree.tiles.remove(tile_id) else {
             return;
@@ -87,7 +82,7 @@ impl ViewportBlueprint<'_> {
 
     fn container_tree_ui(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         tile_id: egui_tiles::TileId,
         container: &egui_tiles::Container,
@@ -147,7 +142,7 @@ impl ViewportBlueprint<'_> {
 
     fn space_view_entry_ui(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         tile_id: egui_tiles::TileId,
         space_view_id: &SpaceViewId,
@@ -231,7 +226,7 @@ impl ViewportBlueprint<'_> {
     }
 
     fn space_view_blueprint_ui(
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         query_result: &DataQueryResult,
         result_handle: DataResultHandle,

--- a/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
@@ -102,7 +102,7 @@ impl SpaceViewClass for ColorCoordinatesSpaceView {
     /// In this sample we show a combo box to select the color coordinates mode.
     fn selection_ui(
         &self,
-        _ctx: &mut ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         _space_origin: &EntityPath,
@@ -129,7 +129,7 @@ impl SpaceViewClass for ColorCoordinatesSpaceView {
     /// This is called with freshly created & executed context & part systems.
     fn ui(
         &self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut Self::State,
         _root_entity_properties: &EntityProperties,
@@ -170,7 +170,7 @@ impl SpaceViewClass for ColorCoordinatesSpaceView {
 // Inspired by https://github.com/emilk/egui/blob/0.22.0/crates/egui/src/widgets/color_picker.rs
 fn color_space_ui(
     ui: &mut egui::Ui,
-    ctx: &mut ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
     colors: &InstanceColorSystem,
     query: &ViewQuery<'_>,
     color_at: impl Fn(f32, f32) -> egui::Color32,

--- a/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_view_part_system.rs
@@ -54,7 +54,7 @@ impl ViewPartSystem for InstanceColorSystem {
     /// Populates the scene part with data from the store.
     fn execute(
         &mut self,
-        ctx: &mut ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
         _view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {


### PR DESCRIPTION
### What

* Prerequisite for #1325
* Follow-up of #4430 

What it says on the tin!
No additional review required, just waiting for rust ci to be sure :)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4430/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4430/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4430)
- [Docs preview](https://rerun.io/preview/cc13e9becf363d9f611cfc59c61b41d1135ef411/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/cc13e9becf363d9f611cfc59c61b41d1135ef411/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)


---
Part of series towards more multithreading in the viewer!
* #4387
* #4404
* #4389
* #4421
* #4422 
* #4430
* You are here ➡️  #4438