### PR TITLE
RenderContext usage cleanup

### DIFF
--- a/crates/re_renderer/src/draw_phases/outlines.rs
+++ b/crates/re_renderer/src/draw_phases/outlines.rs
@@ -208,8 +208,7 @@ impl OutlineMaskProcessor {
         // ------------- Textures -------------
         let texture_pool = &ctx.gpu_resources.textures;
 
-        let mask_sample_count =
-            Self::mask_sample_count(&ctx.shared_renderer_data.config.device_caps);
+        let mask_sample_count = Self::mask_sample_count(&ctx.config.device_caps);
         let mask_texture_desc = crate::wgpu_resources::TextureDesc {
             label: format!("{instance_label}::mask_texture").into(),
             size: wgpu::Extent3d {

--- a/crates/re_renderer/src/draw_phases/outlines.rs
+++ b/crates/re_renderer/src/draw_phases/outlines.rs
@@ -264,8 +264,7 @@ impl OutlineMaskProcessor {
 
         // ------------- Render Pipelines -------------
 
-        let screen_triangle_vertex_shader =
-            screen_triangle_vertex_shader(&ctx.gpu_resources, &ctx.device, &ctx.resolver);
+        let screen_triangle_vertex_shader = screen_triangle_vertex_shader(ctx);
         let jumpflooding_init_shader_module = if mask_sample_count == 1 {
             include_shader_module!("../../shader/outlines/jumpflooding_init.wgsl")
         } else {
@@ -274,54 +273,46 @@ impl OutlineMaskProcessor {
         let jumpflooding_init_desc = RenderPipelineDesc {
             label: "OutlineMaskProcessor::jumpflooding_init".into(),
             pipeline_layout: ctx.gpu_resources.pipeline_layouts.get_or_create(
-                &ctx.device,
+                ctx,
                 &PipelineLayoutDesc {
                     label: "OutlineMaskProcessor::jumpflooding_init".into(),
                     entries: vec![bind_group_layout_jumpflooding_init],
                 },
-                &ctx.gpu_resources.bind_group_layouts,
             ),
             vertex_entrypoint: "main".into(),
             vertex_handle: screen_triangle_vertex_shader,
             fragment_entrypoint: "main".into(),
-            fragment_handle: ctx.gpu_resources.shader_modules.get_or_create(
-                &ctx.device,
-                &ctx.resolver,
-                &jumpflooding_init_shader_module,
-            ),
+            fragment_handle: ctx
+                .gpu_resources
+                .shader_modules
+                .get_or_create(ctx, &jumpflooding_init_shader_module),
             vertex_buffers: smallvec![],
             render_targets: smallvec![Some(Self::VORONOI_FORMAT.into())],
             primitive: wgpu::PrimitiveState::default(),
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
         };
-        let render_pipeline_jumpflooding_init = ctx.gpu_resources.render_pipelines.get_or_create(
-            &ctx.device,
-            &jumpflooding_init_desc,
-            &ctx.gpu_resources.pipeline_layouts,
-            &ctx.gpu_resources.shader_modules,
-        );
+        let render_pipeline_jumpflooding_init = ctx
+            .gpu_resources
+            .render_pipelines
+            .get_or_create(ctx, &jumpflooding_init_desc);
         let render_pipeline_jumpflooding_step = ctx.gpu_resources.render_pipelines.get_or_create(
-            &ctx.device,
+            ctx,
             &RenderPipelineDesc {
                 label: "OutlineMaskProcessor::jumpflooding_step".into(),
                 pipeline_layout: ctx.gpu_resources.pipeline_layouts.get_or_create(
-                    &ctx.device,
+                    ctx,
                     &PipelineLayoutDesc {
                         label: "OutlineMaskProcessor::jumpflooding_step".into(),
                         entries: vec![bind_group_layout_jumpflooding_step],
                     },
-                    &ctx.gpu_resources.bind_group_layouts,
                 ),
                 fragment_handle: ctx.gpu_resources.shader_modules.get_or_create(
-                    &ctx.device,
-                    &ctx.resolver,
+                    ctx,
                     &include_shader_module!("../../shader/outlines/jumpflooding_step.wgsl"),
                 ),
                 ..jumpflooding_init_desc
             },
-            &ctx.gpu_resources.pipeline_layouts,
-            &ctx.gpu_resources.shader_modules,
         );
 
         Self {

--- a/crates/re_renderer/src/draw_phases/picking_layer.rs
+++ b/crates/re_renderer/src/draw_phases/picking_layer.rs
@@ -204,11 +204,7 @@ impl PickingLayerProcessor {
             },
         );
 
-        let direct_depth_readback = ctx
-            .shared_renderer_data
-            .config
-            .device_caps
-            .support_depth_readback();
+        let direct_depth_readback = ctx.config.device_caps.support_depth_readback();
 
         let picking_depth_target = ctx.gpu_resources.textures.alloc(
             &ctx.device,
@@ -259,7 +255,7 @@ impl PickingLayerProcessor {
             frame_uniform_buffer_content,
         );
 
-        let bind_group_0 = ctx.shared_renderer_data.global_bindings.create_bind_group(
+        let bind_group_0 = ctx.global_bindings.create_bind_group(
             &ctx.gpu_resources,
             &ctx.device,
             frame_uniform_buffer,
@@ -542,10 +538,7 @@ impl DepthReadbackWorkaround {
                     ctx,
                     &PipelineLayoutDesc {
                         label: "DepthCopyWorkaround::render_pipeline".into(),
-                        entries: vec![
-                            ctx.shared_renderer_data.global_bindings.layout,
-                            bind_group_layout,
-                        ],
+                        entries: vec![ctx.global_bindings.layout, bind_group_layout],
                     },
                 ),
                 vertex_entrypoint: "main".into(),

--- a/crates/re_renderer/src/draw_phases/picking_layer.rs
+++ b/crates/re_renderer/src/draw_phases/picking_layer.rs
@@ -535,11 +535,11 @@ impl DepthReadbackWorkaround {
         );
 
         let render_pipeline = ctx.gpu_resources.render_pipelines.get_or_create(
-            &ctx.device,
+            ctx,
             &RenderPipelineDesc {
                 label: "DepthCopyWorkaround::render_pipeline".into(),
                 pipeline_layout: ctx.gpu_resources.pipeline_layouts.get_or_create(
-                    &ctx.device,
+                    ctx,
                     &PipelineLayoutDesc {
                         label: "DepthCopyWorkaround::render_pipeline".into(),
                         entries: vec![
@@ -547,18 +547,15 @@ impl DepthReadbackWorkaround {
                             bind_group_layout,
                         ],
                     },
-                    &ctx.gpu_resources.bind_group_layouts,
                 ),
                 vertex_entrypoint: "main".into(),
                 vertex_handle: ctx.gpu_resources.shader_modules.get_or_create(
-                    &ctx.device,
-                    &ctx.resolver,
+                    ctx,
                     &include_shader_module!("../../shader/screen_triangle.wgsl"),
                 ),
                 fragment_entrypoint: "main".into(),
                 fragment_handle: ctx.gpu_resources.shader_modules.get_or_create(
-                    &ctx.device,
-                    &ctx.resolver,
+                    ctx,
                     &include_shader_module!("../../shader/copy_texture.wgsl"),
                 ),
                 vertex_buffers: smallvec![],
@@ -571,8 +568,6 @@ impl DepthReadbackWorkaround {
                 depth_stencil: None,
                 multisample: wgpu::MultisampleState::default(),
             },
-            &ctx.gpu_resources.pipeline_layouts,
-            &ctx.gpu_resources.shader_modules,
         );
 
         Self {

--- a/crates/re_renderer/src/renderer/compositor.rs
+++ b/crates/re_renderer/src/renderer/compositor.rs
@@ -1,18 +1,17 @@
 use crate::{
     allocator::create_and_fill_uniform_buffer,
-    context::SharedRendererData,
     include_shader_module,
     renderer::{screen_triangle_vertex_shader, DrawData, DrawError, Renderer},
     view_builder::ViewBuilder,
     wgpu_resources::{
         BindGroupDesc, BindGroupEntry, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
         GpuRenderPipelineHandle, GpuRenderPipelinePoolAccessor, GpuTexture, PipelineLayoutDesc,
-        RenderPipelineDesc, WgpuResourcePools,
+        RenderPipelineDesc,
     },
     OutlineConfig, Rgba,
 };
 
-use crate::{DrawPhase, FileResolver, FileSystem, RenderContext};
+use crate::{DrawPhase, RenderContext};
 
 use smallvec::smallvec;
 
@@ -99,14 +98,9 @@ impl CompositorDrawData {
 impl Renderer for Compositor {
     type RendererDrawData = CompositorDrawData;
 
-    fn create_renderer<Fs: FileSystem>(
-        shared_data: &SharedRendererData,
-        pools: &WgpuResourcePools,
-        device: &wgpu::Device,
-        resolver: &FileResolver<Fs>,
-    ) -> Self {
-        let bind_group_layout = pools.bind_group_layouts.get_or_create(
-            device,
+    fn create_renderer(ctx: &RenderContext) -> Self {
+        let bind_group_layout = ctx.gpu_resources.bind_group_layouts.get_or_create(
+            &ctx.device,
             &BindGroupLayoutDesc {
                 label: "Compositor::bind_group_layout".into(),
                 entries: vec![
@@ -148,47 +142,46 @@ impl Renderer for Compositor {
             },
         );
 
-        let vertex_handle = screen_triangle_vertex_shader(pools, device, resolver);
+        let vertex_handle = screen_triangle_vertex_shader(ctx);
 
         let render_pipeline_descriptor = RenderPipelineDesc {
             label: "CompositorDrawData::render_pipeline_regular".into(),
-            pipeline_layout: pools.pipeline_layouts.get_or_create(
-                device,
+            pipeline_layout: ctx.gpu_resources.pipeline_layouts.get_or_create(
+                ctx,
                 &PipelineLayoutDesc {
                     label: "compositor".into(),
-                    entries: vec![shared_data.global_bindings.layout, bind_group_layout],
+                    entries: vec![
+                        ctx.shared_renderer_data.global_bindings.layout,
+                        bind_group_layout,
+                    ],
                 },
-                &pools.bind_group_layouts,
             ),
             vertex_entrypoint: "main".into(),
             vertex_handle,
             fragment_entrypoint: "main".into(),
-            fragment_handle: pools.shader_modules.get_or_create(
-                device,
-                resolver,
-                &include_shader_module!("../../shader/composite.wgsl"),
-            ),
+            fragment_handle: ctx
+                .gpu_resources
+                .shader_modules
+                .get_or_create(ctx, &include_shader_module!("../../shader/composite.wgsl")),
             vertex_buffers: smallvec![],
-            render_targets: smallvec![Some(shared_data.config.output_format_color.into())],
+            render_targets: smallvec![Some(
+                ctx.shared_renderer_data.config.output_format_color.into()
+            )],
             primitive: wgpu::PrimitiveState::default(),
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
         };
-        let render_pipeline_regular = pools.render_pipelines.get_or_create(
-            device,
-            &render_pipeline_descriptor,
-            &pools.pipeline_layouts,
-            &pools.shader_modules,
-        );
-        let render_pipeline_screenshot = pools.render_pipelines.get_or_create(
-            device,
+        let render_pipeline_regular = ctx
+            .gpu_resources
+            .render_pipelines
+            .get_or_create(ctx, &render_pipeline_descriptor);
+        let render_pipeline_screenshot = ctx.gpu_resources.render_pipelines.get_or_create(
+            ctx,
             &RenderPipelineDesc {
                 label: "CompositorDrawData::render_pipeline_screenshot".into(),
                 render_targets: smallvec![Some(ViewBuilder::SCREENSHOT_COLOR_FORMAT.into())],
                 ..render_pipeline_descriptor
             },
-            &pools.pipeline_layouts,
-            &pools.shader_modules,
         );
 
         Compositor {

--- a/crates/re_renderer/src/renderer/compositor.rs
+++ b/crates/re_renderer/src/renderer/compositor.rs
@@ -150,10 +150,7 @@ impl Renderer for Compositor {
                 ctx,
                 &PipelineLayoutDesc {
                     label: "compositor".into(),
-                    entries: vec![
-                        ctx.shared_renderer_data.global_bindings.layout,
-                        bind_group_layout,
-                    ],
+                    entries: vec![ctx.global_bindings.layout, bind_group_layout],
                 },
             ),
             vertex_entrypoint: "main".into(),
@@ -164,9 +161,7 @@ impl Renderer for Compositor {
                 .shader_modules
                 .get_or_create(ctx, &include_shader_module!("../../shader/composite.wgsl")),
             vertex_buffers: smallvec![],
-            render_targets: smallvec![Some(
-                ctx.shared_renderer_data.config.output_format_color.into()
-            )],
+            render_targets: smallvec![Some(ctx.config.output_format_color.into())],
             primitive: wgpu::PrimitiveState::default(),
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),

--- a/crates/re_renderer/src/renderer/debug_overlay.rs
+++ b/crates/re_renderer/src/renderer/debug_overlay.rs
@@ -199,10 +199,7 @@ impl Renderer for DebugOverlayRenderer {
                     ctx,
                     &PipelineLayoutDesc {
                         label: "DebugOverlay".into(),
-                        entries: vec![
-                            ctx.shared_renderer_data.global_bindings.layout,
-                            bind_group_layout,
-                        ],
+                        entries: vec![ctx.global_bindings.layout, bind_group_layout],
                     },
                 ),
                 vertex_entrypoint: "main_vs".into(),
@@ -210,9 +207,7 @@ impl Renderer for DebugOverlayRenderer {
                 fragment_entrypoint: "main_fs".into(),
                 fragment_handle: shader_module,
                 vertex_buffers: smallvec![],
-                render_targets: smallvec![Some(
-                    ctx.shared_renderer_data.config.output_format_color.into()
-                )],
+                render_targets: smallvec![Some(ctx.config.output_format_color.into())],
                 primitive: wgpu::PrimitiveState {
                     topology: wgpu::PrimitiveTopology::TriangleStrip,
                     cull_mode: None,

--- a/crates/re_renderer/src/renderer/debug_overlay.rs
+++ b/crates/re_renderer/src/renderer/debug_overlay.rs
@@ -1,17 +1,16 @@
 use crate::{
     allocator::create_and_fill_uniform_buffer,
-    context::SharedRendererData,
     draw_phases::DrawPhase,
     include_shader_module,
     wgpu_resources::{
         BindGroupDesc, BindGroupEntry, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
         GpuRenderPipelineHandle, GpuRenderPipelinePoolAccessor, GpuTexture, PipelineLayoutDesc,
-        RenderPipelineDesc, WgpuResourcePools,
+        RenderPipelineDesc,
     },
     RectInt,
 };
 
-use super::{DrawData, DrawError, FileResolver, FileSystem, RenderContext, Renderer};
+use super::{DrawData, DrawError, RenderContext, Renderer};
 
 use smallvec::smallvec;
 
@@ -142,14 +141,11 @@ impl DebugOverlayDrawData {
 impl Renderer for DebugOverlayRenderer {
     type RendererDrawData = DebugOverlayDrawData;
 
-    fn create_renderer<Fs: FileSystem>(
-        shared_data: &SharedRendererData,
-        pools: &WgpuResourcePools,
-        device: &wgpu::Device,
-        resolver: &FileResolver<Fs>,
-    ) -> Self {
-        let bind_group_layout = pools.bind_group_layouts.get_or_create(
-            device,
+    fn create_renderer(ctx: &RenderContext) -> Self {
+        re_tracing::profile_function!();
+
+        let bind_group_layout = ctx.gpu_resources.bind_group_layouts.get_or_create(
+            &ctx.device,
             &BindGroupLayoutDesc {
                 label: "DebugOverlay::bind_group_layout".into(),
                 entries: vec![
@@ -191,29 +187,32 @@ impl Renderer for DebugOverlayRenderer {
             },
         );
 
-        let shader_module = pools.shader_modules.get_or_create(
-            device,
-            resolver,
+        let shader_module = ctx.gpu_resources.shader_modules.get_or_create(
+            ctx,
             &include_shader_module!("../../shader/debug_overlay.wgsl"),
         );
-        let render_pipeline = pools.render_pipelines.get_or_create(
-            device,
+        let render_pipeline = ctx.gpu_resources.render_pipelines.get_or_create(
+            ctx,
             &RenderPipelineDesc {
                 label: "DebugOverlayDrawData::render_pipeline_regular".into(),
-                pipeline_layout: pools.pipeline_layouts.get_or_create(
-                    device,
+                pipeline_layout: ctx.gpu_resources.pipeline_layouts.get_or_create(
+                    ctx,
                     &PipelineLayoutDesc {
                         label: "DebugOverlay".into(),
-                        entries: vec![shared_data.global_bindings.layout, bind_group_layout],
+                        entries: vec![
+                            ctx.shared_renderer_data.global_bindings.layout,
+                            bind_group_layout,
+                        ],
                     },
-                    &pools.bind_group_layouts,
                 ),
                 vertex_entrypoint: "main_vs".into(),
                 vertex_handle: shader_module,
                 fragment_entrypoint: "main_fs".into(),
                 fragment_handle: shader_module,
                 vertex_buffers: smallvec![],
-                render_targets: smallvec![Some(shared_data.config.output_format_color.into())],
+                render_targets: smallvec![Some(
+                    ctx.shared_renderer_data.config.output_format_color.into()
+                )],
                 primitive: wgpu::PrimitiveState {
                     topology: wgpu::PrimitiveTopology::TriangleStrip,
                     cull_mode: None,
@@ -222,8 +221,6 @@ impl Renderer for DebugOverlayRenderer {
                 depth_stencil: None,
                 multisample: wgpu::MultisampleState::default(),
             },
-            &pools.pipeline_layouts,
-            &pools.shader_modules,
         );
         DebugOverlayRenderer {
             render_pipeline,

--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -409,10 +409,7 @@ impl Renderer for DepthCloudRenderer {
             ctx,
             &PipelineLayoutDesc {
                 label: "depth_cloud_rp_layout".into(),
-                entries: vec![
-                    ctx.shared_renderer_data.global_bindings.layout,
-                    bind_group_layout,
-                ],
+                entries: vec![ctx.global_bindings.layout, bind_group_layout],
             },
         );
 
@@ -463,9 +460,7 @@ impl Renderer for DepthCloudRenderer {
                 render_targets: smallvec![Some(OutlineMaskProcessor::MASK_FORMAT.into())],
                 depth_stencil: OutlineMaskProcessor::MASK_DEPTH_STATE,
                 // Alpha to coverage doesn't work with the mask integer target.
-                multisample: OutlineMaskProcessor::mask_default_msaa_state(
-                    &ctx.shared_renderer_data.config.device_caps,
-                ),
+                multisample: OutlineMaskProcessor::mask_default_msaa_state(&ctx.config.device_caps),
                 ..render_pipeline_desc_color
             },
         );

--- a/crates/re_renderer/src/renderer/generic_skybox.rs
+++ b/crates/re_renderer/src/renderer/generic_skybox.rs
@@ -50,7 +50,7 @@ impl Renderer for GenericSkybox {
                     ctx,
                     &PipelineLayoutDesc {
                         label: "GenericSkybox::render_pipeline".into(),
-                        entries: vec![ctx.shared_renderer_data.global_bindings.layout],
+                        entries: vec![ctx.global_bindings.layout],
                     },
                 ),
 

--- a/crates/re_renderer/src/renderer/generic_skybox.rs
+++ b/crates/re_renderer/src/renderer/generic_skybox.rs
@@ -1,18 +1,17 @@
 use smallvec::smallvec;
 
 use crate::{
-    context::SharedRendererData,
     draw_phases::DrawPhase,
     include_shader_module,
     renderer::screen_triangle_vertex_shader,
     view_builder::ViewBuilder,
     wgpu_resources::{
         GpuRenderPipelineHandle, GpuRenderPipelinePoolAccessor, PipelineLayoutDesc,
-        RenderPipelineDesc, WgpuResourcePools,
+        RenderPipelineDesc,
     },
 };
 
-use super::{DrawData, DrawError, FileResolver, FileSystem, RenderContext, Renderer};
+use super::{DrawData, DrawError, RenderContext, Renderer};
 
 /// Renders a generated skybox from a color gradient
 ///
@@ -39,34 +38,27 @@ impl GenericSkyboxDrawData {
 impl Renderer for GenericSkybox {
     type RendererDrawData = GenericSkyboxDrawData;
 
-    fn create_renderer<Fs: FileSystem>(
-        shared_data: &SharedRendererData,
-        pools: &WgpuResourcePools,
-        device: &wgpu::Device,
-        resolver: &FileResolver<Fs>,
-    ) -> Self {
+    fn create_renderer(ctx: &RenderContext) -> Self {
         re_tracing::profile_function!();
 
-        let vertex_handle = screen_triangle_vertex_shader(pools, device, resolver);
-        let render_pipeline = pools.render_pipelines.get_or_create(
-            device,
+        let vertex_handle = screen_triangle_vertex_shader(ctx);
+        let render_pipeline = ctx.gpu_resources.render_pipelines.get_or_create(
+            ctx,
             &RenderPipelineDesc {
                 label: "GenericSkybox::render_pipeline".into(),
-                pipeline_layout: pools.pipeline_layouts.get_or_create(
-                    device,
+                pipeline_layout: ctx.gpu_resources.pipeline_layouts.get_or_create(
+                    ctx,
                     &PipelineLayoutDesc {
                         label: "GenericSkybox::render_pipeline".into(),
-                        entries: vec![shared_data.global_bindings.layout],
+                        entries: vec![ctx.shared_renderer_data.global_bindings.layout],
                     },
-                    &pools.bind_group_layouts,
                 ),
 
                 vertex_entrypoint: "main".into(),
                 vertex_handle,
                 fragment_entrypoint: "main".into(),
-                fragment_handle: pools.shader_modules.get_or_create(
-                    device,
-                    resolver,
+                fragment_handle: ctx.gpu_resources.shader_modules.get_or_create(
+                    ctx,
                     &include_shader_module!("../../shader/generic_skybox.wgsl"),
                 ),
                 vertex_buffers: smallvec![],
@@ -83,8 +75,6 @@ impl Renderer for GenericSkybox {
                 }),
                 multisample: ViewBuilder::MAIN_TARGET_DEFAULT_MSAA_STATE,
             },
-            &pools.pipeline_layouts,
-            &pools.shader_modules,
         );
         GenericSkybox { render_pipeline }
     }

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -864,7 +864,7 @@ impl Renderer for LineRenderer {
             &PipelineLayoutDesc {
                 label: "LineRenderer::pipeline_layout".into(),
                 entries: vec![
-                    ctx.shared_renderer_data.global_bindings.layout,
+                    ctx.global_bindings.layout,
                     bind_group_layout_all_lines,
                     bind_group_layout_batch,
                 ],
@@ -926,9 +926,7 @@ impl Renderer for LineRenderer {
                 },
                 depth_stencil: OutlineMaskProcessor::MASK_DEPTH_STATE,
                 // Alpha to coverage doesn't work with the mask integer target.
-                multisample: OutlineMaskProcessor::mask_default_msaa_state(
-                    &ctx.shared_renderer_data.config.device_caps,
-                ),
+                multisample: OutlineMaskProcessor::mask_default_msaa_state(&ctx.config.device_caps),
             },
         );
 

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -109,6 +109,7 @@ use std::{num::NonZeroU64, ops::Range};
 use bitflags::bitflags;
 use bytemuck::Zeroable;
 use enumset::{enum_set, EnumSet};
+use re_tracing::profile_function;
 use smallvec::smallvec;
 
 use crate::{
@@ -126,10 +127,7 @@ use crate::{
     PickingLayerObjectId, PickingLayerProcessor,
 };
 
-use super::{
-    DrawData, DrawError, FileResolver, FileSystem, LineVertex, RenderContext, Renderer,
-    SharedRendererData, WgpuResourcePools,
-};
+use super::{DrawData, DrawError, LineVertex, RenderContext, Renderer};
 
 pub mod gpu_data {
     // Don't use `wgsl_buffer_types` since none of this data goes into a buffer, so its alignment rules don't apply.
@@ -786,14 +784,13 @@ impl Renderer for LineRenderer {
         ]
     }
 
-    fn create_renderer<Fs: FileSystem>(
-        shared_data: &SharedRendererData,
-        pools: &WgpuResourcePools,
-        device: &wgpu::Device,
-        resolver: &FileResolver<Fs>,
-    ) -> Self {
-        let bind_group_layout_all_lines = pools.bind_group_layouts.get_or_create(
-            device,
+    fn create_renderer(ctx: &RenderContext) -> Self {
+        profile_function!();
+
+        let render_pipelines = &ctx.gpu_resources.render_pipelines;
+
+        let bind_group_layout_all_lines = ctx.gpu_resources.bind_group_layouts.get_or_create(
+            &ctx.device,
             &BindGroupLayoutDesc {
                 label: "LineRenderer::bind_group_layout_all_lines".into(),
                 entries: vec![
@@ -843,8 +840,8 @@ impl Renderer for LineRenderer {
             },
         );
 
-        let bind_group_layout_batch = pools.bind_group_layouts.get_or_create(
-            device,
+        let bind_group_layout_batch = ctx.gpu_resources.bind_group_layouts.get_or_create(
+            &ctx.device,
             &BindGroupLayoutDesc {
                 label: "LineRenderer::bind_group_layout_batch".into(),
                 entries: vec![wgpu::BindGroupLayoutEntry {
@@ -862,24 +859,22 @@ impl Renderer for LineRenderer {
             },
         );
 
-        let pipeline_layout = pools.pipeline_layouts.get_or_create(
-            device,
+        let pipeline_layout = ctx.gpu_resources.pipeline_layouts.get_or_create(
+            ctx,
             &PipelineLayoutDesc {
                 label: "LineRenderer::pipeline_layout".into(),
                 entries: vec![
-                    shared_data.global_bindings.layout,
+                    ctx.shared_renderer_data.global_bindings.layout,
                     bind_group_layout_all_lines,
                     bind_group_layout_batch,
                 ],
             },
-            &pools.bind_group_layouts,
         );
 
-        let shader_module = pools.shader_modules.get_or_create(
-            device,
-            resolver,
-            &include_shader_module!("../../shader/lines.wgsl"),
-        );
+        let shader_module = ctx
+            .gpu_resources
+            .shader_modules
+            .get_or_create(ctx, &include_shader_module!("../../shader/lines.wgsl"));
 
         let render_pipeline_desc_color = RenderPipelineDesc {
             label: "LineRenderer::render_pipeline_color".into(),
@@ -901,14 +896,10 @@ impl Renderer for LineRenderer {
                 ..ViewBuilder::MAIN_TARGET_DEFAULT_MSAA_STATE
             },
         };
-        let render_pipeline_color = pools.render_pipelines.get_or_create(
-            device,
-            &render_pipeline_desc_color,
-            &pools.pipeline_layouts,
-            &pools.shader_modules,
-        );
-        let render_pipeline_picking_layer = pools.render_pipelines.get_or_create(
-            device,
+        let render_pipeline_color =
+            render_pipelines.get_or_create(ctx, &render_pipeline_desc_color);
+        let render_pipeline_picking_layer = render_pipelines.get_or_create(
+            ctx,
             &RenderPipelineDesc {
                 label: "LineRenderer::render_pipeline_picking_layer".into(),
                 fragment_entrypoint: "fs_main_picking_layer".into(),
@@ -917,11 +908,9 @@ impl Renderer for LineRenderer {
                 multisample: PickingLayerProcessor::PICKING_LAYER_MSAA_STATE,
                 ..render_pipeline_desc_color.clone()
             },
-            &pools.pipeline_layouts,
-            &pools.shader_modules,
         );
-        let render_pipeline_outline_mask = pools.render_pipelines.get_or_create(
-            device,
+        let render_pipeline_outline_mask = render_pipelines.get_or_create(
+            ctx,
             &RenderPipelineDesc {
                 label: "LineRenderer::render_pipeline_outline_mask".into(),
                 pipeline_layout,
@@ -938,11 +927,9 @@ impl Renderer for LineRenderer {
                 depth_stencil: OutlineMaskProcessor::MASK_DEPTH_STATE,
                 // Alpha to coverage doesn't work with the mask integer target.
                 multisample: OutlineMaskProcessor::mask_default_msaa_state(
-                    &shared_data.config.device_caps,
+                    &ctx.shared_renderer_data.config.device_caps,
                 ),
             },
-            &pools.pipeline_layouts,
-            &pools.shader_modules,
         );
 
         LineRenderer {

--- a/crates/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/re_renderer/src/renderer/mesh_renderer.rs
@@ -22,10 +22,7 @@ use crate::{
     Color32, OutlineMaskPreference, PickingLayerId, PickingLayerProcessor,
 };
 
-use super::{
-    DrawData, DrawError, FileResolver, FileSystem, RenderContext, Renderer, SharedRendererData,
-    WgpuResourcePools,
-};
+use super::{DrawData, DrawError, RenderContext, Renderer};
 
 mod gpu_data {
     use ecolor::Color32;
@@ -290,16 +287,13 @@ impl Renderer for MeshRenderer {
         ]
     }
 
-    fn create_renderer<Fs: FileSystem>(
-        shared_data: &SharedRendererData,
-        pools: &WgpuResourcePools,
-        device: &wgpu::Device,
-        resolver: &FileResolver<Fs>,
-    ) -> Self {
+    fn create_renderer(ctx: &RenderContext) -> Self {
         re_tracing::profile_function!();
 
-        let bind_group_layout = pools.bind_group_layouts.get_or_create(
-            device,
+        let render_pipelines = &ctx.gpu_resources.render_pipelines;
+
+        let bind_group_layout = ctx.gpu_resources.bind_group_layouts.get_or_create(
+            &ctx.device,
             &BindGroupLayoutDesc {
                 label: "MeshRenderer::bind_group_layout".into(),
                 entries: vec![
@@ -328,18 +322,19 @@ impl Renderer for MeshRenderer {
                 ],
             },
         );
-        let pipeline_layout = pools.pipeline_layouts.get_or_create(
-            device,
+        let pipeline_layout = ctx.gpu_resources.pipeline_layouts.get_or_create(
+            ctx,
             &PipelineLayoutDesc {
                 label: "MeshRenderer::pipeline_layout".into(),
-                entries: vec![shared_data.global_bindings.layout, bind_group_layout],
+                entries: vec![
+                    ctx.shared_renderer_data.global_bindings.layout,
+                    bind_group_layout,
+                ],
             },
-            &pools.bind_group_layouts,
         );
 
-        let shader_module = pools.shader_modules.get_or_create(
-            device,
-            resolver,
+        let shader_module = ctx.gpu_resources.shader_modules.get_or_create(
+            ctx,
             &include_shader_module!("../../shader/instanced_mesh.wgsl"),
         );
 
@@ -367,14 +362,10 @@ impl Renderer for MeshRenderer {
             depth_stencil: ViewBuilder::MAIN_TARGET_DEFAULT_DEPTH_STATE,
             multisample: ViewBuilder::MAIN_TARGET_DEFAULT_MSAA_STATE,
         };
-        let render_pipeline_shaded = pools.render_pipelines.get_or_create(
-            device,
-            &render_pipeline_shaded_desc,
-            &pools.pipeline_layouts,
-            &pools.shader_modules,
-        );
-        let render_pipeline_picking_layer = pools.render_pipelines.get_or_create(
-            device,
+        let render_pipeline_shaded =
+            render_pipelines.get_or_create(ctx, &render_pipeline_shaded_desc);
+        let render_pipeline_picking_layer = render_pipelines.get_or_create(
+            ctx,
             &RenderPipelineDesc {
                 label: "MeshRenderer::render_pipeline_picking_layer".into(),
                 fragment_entrypoint: "fs_main_picking_layer".into(),
@@ -383,23 +374,19 @@ impl Renderer for MeshRenderer {
                 multisample: PickingLayerProcessor::PICKING_LAYER_MSAA_STATE,
                 ..render_pipeline_shaded_desc.clone()
             },
-            &pools.pipeline_layouts,
-            &pools.shader_modules,
         );
-        let render_pipeline_outline_mask = pools.render_pipelines.get_or_create(
-            device,
+        let render_pipeline_outline_mask = render_pipelines.get_or_create(
+            ctx,
             &RenderPipelineDesc {
                 label: "MeshRenderer::render_pipeline_outline_mask".into(),
                 fragment_entrypoint: "fs_main_outline_mask".into(),
                 render_targets: smallvec![Some(OutlineMaskProcessor::MASK_FORMAT.into())],
                 depth_stencil: OutlineMaskProcessor::MASK_DEPTH_STATE,
                 multisample: OutlineMaskProcessor::mask_default_msaa_state(
-                    &shared_data.config.device_caps,
+                    &ctx.shared_renderer_data.config.device_caps,
                 ),
                 ..render_pipeline_shaded_desc
             },
-            &pools.pipeline_layouts,
-            &pools.shader_modules,
         );
 
         MeshRenderer {

--- a/crates/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/re_renderer/src/renderer/mesh_renderer.rs
@@ -326,10 +326,7 @@ impl Renderer for MeshRenderer {
             ctx,
             &PipelineLayoutDesc {
                 label: "MeshRenderer::pipeline_layout".into(),
-                entries: vec![
-                    ctx.shared_renderer_data.global_bindings.layout,
-                    bind_group_layout,
-                ],
+                entries: vec![ctx.global_bindings.layout, bind_group_layout],
             },
         );
 
@@ -382,9 +379,7 @@ impl Renderer for MeshRenderer {
                 fragment_entrypoint: "fs_main_outline_mask".into(),
                 render_targets: smallvec![Some(OutlineMaskProcessor::MASK_FORMAT.into())],
                 depth_stencil: OutlineMaskProcessor::MASK_DEPTH_STATE,
-                multisample: OutlineMaskProcessor::mask_default_msaa_state(
-                    &ctx.shared_renderer_data.config.device_caps,
-                ),
+                multisample: OutlineMaskProcessor::mask_default_msaa_state(&ctx.config.device_caps),
                 ..render_pipeline_shaded_desc
             },
         );

--- a/crates/re_renderer/src/renderer/mod.rs
+++ b/crates/re_renderer/src/renderer/mod.rs
@@ -36,11 +36,10 @@ mod debug_overlay;
 pub use debug_overlay::{DebugOverlayDrawData, DebugOverlayError, DebugOverlayRenderer};
 
 use crate::{
-    context::{RenderContext, SharedRendererData},
+    context::RenderContext,
     draw_phases::DrawPhase,
     include_shader_module,
-    wgpu_resources::{GpuRenderPipelinePoolAccessor, PoolError, WgpuResourcePools},
-    FileResolver, FileSystem,
+    wgpu_resources::{GpuRenderPipelinePoolAccessor, PoolError},
 };
 
 /// GPU sided data used by a [`Renderer`] to draw things to the screen.
@@ -64,12 +63,7 @@ pub enum DrawError {
 pub trait Renderer {
     type RendererDrawData: DrawData;
 
-    fn create_renderer<Fs: FileSystem>(
-        shared_data: &SharedRendererData,
-        pools: &WgpuResourcePools,
-        device: &wgpu::Device,
-        resolver: &FileResolver<Fs>,
-    ) -> Self;
+    fn create_renderer(ctx: &RenderContext) -> Self;
 
     // TODO(andreas): Some Renderers need to create their own passes, need something like this for that.
 
@@ -87,14 +81,11 @@ pub trait Renderer {
 }
 
 /// Gets or creates a vertex shader module for drawing a screen filling triangle.
-pub fn screen_triangle_vertex_shader<Fs: FileSystem>(
-    pools: &WgpuResourcePools,
-    device: &wgpu::Device,
-    resolver: &FileResolver<Fs>,
+pub fn screen_triangle_vertex_shader(
+    ctx: &RenderContext,
 ) -> crate::wgpu_resources::GpuShaderModuleHandle {
-    pools.shader_modules.get_or_create(
-        device,
-        resolver,
+    ctx.gpu_resources.shader_modules.get_or_create(
+        ctx,
         &include_shader_module!("../../shader/screen_triangle.wgsl"),
     )
 }

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -610,7 +610,7 @@ impl Renderer for PointCloudRenderer {
             &PipelineLayoutDesc {
                 label: "PointCloudRenderer::pipeline_layout".into(),
                 entries: vec![
-                    ctx.shared_renderer_data.global_bindings.layout,
+                    ctx.global_bindings.layout,
                     bind_group_layout_all_points,
                     bind_group_layout_batch,
                 ],
@@ -674,9 +674,7 @@ impl Renderer for PointCloudRenderer {
                 render_targets: smallvec![Some(OutlineMaskProcessor::MASK_FORMAT.into())],
                 depth_stencil: OutlineMaskProcessor::MASK_DEPTH_STATE,
                 // Alpha to coverage doesn't work with the mask integer target.
-                multisample: OutlineMaskProcessor::mask_default_msaa_state(
-                    &ctx.shared_renderer_data.config.device_caps,
-                ),
+                multisample: OutlineMaskProcessor::mask_default_msaa_state(&ctx.config.device_caps),
                 ..render_pipeline_desc_color
             },
         );

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -28,10 +28,7 @@ use crate::{
     Colormap, OutlineMaskPreference, PickingLayerProcessor, Rgba,
 };
 
-use super::{
-    DrawData, DrawError, FileResolver, FileSystem, RenderContext, Renderer, SharedRendererData,
-    WgpuResourcePools,
-};
+use super::{DrawData, DrawError, RenderContext, Renderer};
 
 /// Texture filter setting for magnification (a texel covers several pixels).
 #[derive(Debug, Clone, Copy)]
@@ -496,16 +493,13 @@ pub struct RectangleRenderer {
 impl Renderer for RectangleRenderer {
     type RendererDrawData = RectangleDrawData;
 
-    fn create_renderer<Fs: FileSystem>(
-        shared_data: &SharedRendererData,
-        pools: &WgpuResourcePools,
-        device: &wgpu::Device,
-        resolver: &FileResolver<Fs>,
-    ) -> Self {
+    fn create_renderer(ctx: &RenderContext) -> Self {
         re_tracing::profile_function!();
 
-        let bind_group_layout = pools.bind_group_layouts.get_or_create(
-            device,
+        let render_pipelines = &ctx.gpu_resources.render_pipelines;
+
+        let bind_group_layout = ctx.gpu_resources.bind_group_layouts.get_or_create(
+            &ctx.device,
             &(BindGroupLayoutDesc {
                 label: "RectangleRenderer::bind_group_layout".into(),
                 entries: vec![
@@ -572,23 +566,23 @@ impl Renderer for RectangleRenderer {
             }),
         );
 
-        let pipeline_layout = pools.pipeline_layouts.get_or_create(
-            device,
+        let pipeline_layout = ctx.gpu_resources.pipeline_layouts.get_or_create(
+            ctx,
             &(PipelineLayoutDesc {
                 label: "RectangleRenderer::pipeline_layout".into(),
-                entries: vec![shared_data.global_bindings.layout, bind_group_layout],
+                entries: vec![
+                    ctx.shared_renderer_data.global_bindings.layout,
+                    bind_group_layout,
+                ],
             }),
-            &pools.bind_group_layouts,
         );
 
-        let shader_module_vs = pools.shader_modules.get_or_create(
-            device,
-            resolver,
+        let shader_module_vs = ctx.gpu_resources.shader_modules.get_or_create(
+            ctx,
             &include_shader_module!("../../shader/rectangle_vs.wgsl"),
         );
-        let shader_module_fs = pools.shader_modules.get_or_create(
-            device,
-            resolver,
+        let shader_module_fs = ctx.gpu_resources.shader_modules.get_or_create(
+            ctx,
             &include_shader_module!("../../shader/rectangle_fs.wgsl"),
         );
 
@@ -614,14 +608,10 @@ impl Renderer for RectangleRenderer {
             depth_stencil: ViewBuilder::MAIN_TARGET_DEFAULT_DEPTH_STATE,
             multisample: ViewBuilder::MAIN_TARGET_DEFAULT_MSAA_STATE,
         };
-        let render_pipeline_color = pools.render_pipelines.get_or_create(
-            device,
-            &render_pipeline_desc_color,
-            &pools.pipeline_layouts,
-            &pools.shader_modules,
-        );
-        let render_pipeline_picking_layer = pools.render_pipelines.get_or_create(
-            device,
+        let render_pipeline_color =
+            render_pipelines.get_or_create(ctx, &render_pipeline_desc_color);
+        let render_pipeline_picking_layer = render_pipelines.get_or_create(
+            ctx,
             &(RenderPipelineDesc {
                 label: "RectangleRenderer::render_pipeline_picking_layer".into(),
                 fragment_entrypoint: "fs_main_picking_layer".into(),
@@ -630,23 +620,19 @@ impl Renderer for RectangleRenderer {
                 multisample: PickingLayerProcessor::PICKING_LAYER_MSAA_STATE,
                 ..render_pipeline_desc_color.clone()
             }),
-            &pools.pipeline_layouts,
-            &pools.shader_modules,
         );
-        let render_pipeline_outline_mask = pools.render_pipelines.get_or_create(
-            device,
+        let render_pipeline_outline_mask = render_pipelines.get_or_create(
+            ctx,
             &(RenderPipelineDesc {
                 label: "RectangleRenderer::render_pipeline_outline_mask".into(),
                 fragment_entrypoint: "fs_main_outline_mask".into(),
                 render_targets: smallvec![Some(OutlineMaskProcessor::MASK_FORMAT.into())],
                 depth_stencil: OutlineMaskProcessor::MASK_DEPTH_STATE,
                 multisample: OutlineMaskProcessor::mask_default_msaa_state(
-                    &shared_data.config.device_caps,
+                    &ctx.shared_renderer_data.config.device_caps,
                 ),
                 ..render_pipeline_desc_color
             }),
-            &pools.pipeline_layouts,
-            &pools.shader_modules,
         );
 
         RectangleRenderer {

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -570,10 +570,7 @@ impl Renderer for RectangleRenderer {
             ctx,
             &(PipelineLayoutDesc {
                 label: "RectangleRenderer::pipeline_layout".into(),
-                entries: vec![
-                    ctx.shared_renderer_data.global_bindings.layout,
-                    bind_group_layout,
-                ],
+                entries: vec![ctx.global_bindings.layout, bind_group_layout],
             }),
         );
 
@@ -628,9 +625,7 @@ impl Renderer for RectangleRenderer {
                 fragment_entrypoint: "fs_main_outline_mask".into(),
                 render_targets: smallvec![Some(OutlineMaskProcessor::MASK_FORMAT.into())],
                 depth_stencil: OutlineMaskProcessor::MASK_DEPTH_STATE,
-                multisample: OutlineMaskProcessor::mask_default_msaa_state(
-                    &ctx.shared_renderer_data.config.device_caps,
-                ),
+                multisample: OutlineMaskProcessor::mask_default_msaa_state(&ctx.config.device_caps),
                 ..render_pipeline_desc_color
             }),
         );

--- a/crates/re_renderer/src/renderer/test_triangle.rs
+++ b/crates/re_renderer/src/renderer/test_triangle.rs
@@ -39,7 +39,7 @@ impl Renderer for TestTriangle {
                     ctx,
                     &PipelineLayoutDesc {
                         label: "global only".into(),
-                        entries: vec![ctx.shared_renderer_data.global_bindings.layout],
+                        entries: vec![ctx.global_bindings.layout],
                     },
                 ),
                 vertex_entrypoint: "vs_main".into(),

--- a/crates/re_renderer/src/resource_managers/mesh_manager.rs
+++ b/crates/re_renderer/src/resource_managers/mesh_manager.rs
@@ -1,7 +1,6 @@
 use crate::{
     mesh::{GpuMesh, Mesh},
     renderer::MeshRenderer,
-    wgpu_resources::GpuBindGroupLayoutHandle,
     RenderContext,
 };
 
@@ -15,14 +14,12 @@ pub type GpuMeshHandle = ResourceHandle<MeshHandleInner>;
 
 pub struct MeshManager {
     manager: ResourceManager<MeshHandleInner, GpuMesh>,
-    mesh_bind_group_layout: GpuBindGroupLayoutHandle,
 }
 
 impl MeshManager {
-    pub(crate) fn new(mesh_renderer: &MeshRenderer) -> Self {
+    pub(crate) fn new() -> Self {
         MeshManager {
             manager: Default::default(),
-            mesh_bind_group_layout: mesh_renderer.bind_group_layout,
         }
     }
 
@@ -35,7 +32,7 @@ impl MeshManager {
     ) -> Result<GpuMeshHandle, ResourceManagerError> {
         re_tracing::profile_function!();
         Ok(self.manager.store_resource(
-            GpuMesh::new(ctx, self.mesh_bind_group_layout, mesh)?,
+            GpuMesh::new(ctx, ctx.renderer::<MeshRenderer>().bind_group_layout, mesh)?,
             lifetime,
         ))
     }

--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -449,7 +449,7 @@ impl ViewBuilder {
             auto_size_points: auto_size_points.0,
             auto_size_lines: auto_size_lines.0,
 
-            device_tier: (ctx.shared_renderer_data.config.device_caps.tier as u32).into(),
+            device_tier: (ctx.config.device_caps.tier as u32).into(),
         };
         let frame_uniform_buffer = create_and_fill_uniform_buffer(
             ctx,
@@ -457,7 +457,7 @@ impl ViewBuilder {
             frame_uniform_buffer_content,
         );
 
-        let bind_group_0 = ctx.shared_renderer_data.global_bindings.create_bind_group(
+        let bind_group_0 = ctx.global_bindings.create_bind_group(
             &ctx.gpu_resources,
             &ctx.device,
             frame_uniform_buffer,

--- a/crates/re_renderer/src/wgpu_resources/pipeline_layout_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/pipeline_layout_pool.rs
@@ -1,7 +1,7 @@
-use crate::debug_label::DebugLabel;
+use crate::{debug_label::DebugLabel, RenderContext};
 
 use super::{
-    bind_group_layout_pool::{GpuBindGroupLayoutHandle, GpuBindGroupLayoutPool},
+    bind_group_layout_pool::GpuBindGroupLayoutHandle,
     static_resource_pool::{
         StaticResourcePool, StaticResourcePoolAccessor as _, StaticResourcePoolReadLockAccessor,
     },
@@ -25,24 +25,24 @@ pub struct GpuPipelineLayoutPool {
 impl GpuPipelineLayoutPool {
     pub fn get_or_create(
         &self,
-        device: &wgpu::Device,
+        ctx: &RenderContext,
         desc: &PipelineLayoutDesc,
-        bind_group_layout_pool: &GpuBindGroupLayoutPool,
     ) -> GpuPipelineLayoutHandle {
         self.pool.get_or_create(desc, |desc| {
             // TODO(andreas): error handling
 
-            let bind_groups = bind_group_layout_pool.resources();
+            let bind_groups = ctx.gpu_resources.bind_group_layouts.resources();
 
-            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: desc.label.get(),
-                bind_group_layouts: &desc
-                    .entries
-                    .iter()
-                    .map(|handle| bind_groups.get(*handle).unwrap())
-                    .collect::<Vec<_>>(),
-                push_constant_ranges: &[], // Sadly not widely supported
-            })
+            ctx.device
+                .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                    label: desc.label.get(),
+                    bind_group_layouts: &desc
+                        .entries
+                        .iter()
+                        .map(|handle| bind_groups.get(*handle).unwrap())
+                        .collect::<Vec<_>>(),
+                    push_constant_ranges: &[], // Sadly not widely supported
+                })
         })
     }
 

--- a/crates/re_renderer/src/wgpu_resources/render_pipeline_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/render_pipeline_pool.rs
@@ -1,6 +1,6 @@
 use smallvec::SmallVec;
 
-use crate::debug_label::DebugLabel;
+use crate::{debug_label::DebugLabel, RenderContext};
 
 use super::{
     pipeline_layout_pool::{GpuPipelineLayoutHandle, GpuPipelineLayoutPool},
@@ -181,17 +181,19 @@ pub struct GpuRenderPipelinePool {
 impl GpuRenderPipelinePool {
     pub fn get_or_create(
         &self,
-        device: &wgpu::Device,
+        ctx: &RenderContext,
         desc: &RenderPipelineDesc,
-        pipeline_layout_pool: &GpuPipelineLayoutPool,
-        shader_module_pool: &GpuShaderModulePool,
     ) -> GpuRenderPipelineHandle {
         self.pool.get_or_create(desc, |desc| {
             sanity_check_vertex_buffers(&desc.vertex_buffers);
 
             // TODO(cmc): certainly not unwrapping here
-            desc.create_render_pipeline(device, pipeline_layout_pool, shader_module_pool)
-                .unwrap()
+            desc.create_render_pipeline(
+                &ctx.device,
+                &ctx.gpu_resources.pipeline_layouts,
+                &ctx.gpu_resources.shader_modules,
+            )
+            .unwrap()
         })
     }
 

--- a/crates/re_renderer/src/wgpu_resources/shader_module_pool.rs
+++ b/crates/re_renderer/src/wgpu_resources/shader_module_pool.rs
@@ -3,7 +3,7 @@ use std::{hash::Hash, path::PathBuf};
 use ahash::HashSet;
 use anyhow::Context as _;
 
-use crate::{debug_label::DebugLabel, FileResolver, FileSystem};
+use crate::{debug_label::DebugLabel, FileResolver, FileSystem, RenderContext};
 
 use super::static_resource_pool::{StaticResourcePool, StaticResourcePoolReadLockAccessor};
 
@@ -113,14 +113,17 @@ pub struct GpuShaderModulePool {
 }
 
 impl GpuShaderModulePool {
-    pub fn get_or_create<Fs: FileSystem>(
+    pub fn get_or_create(
         &self,
-        device: &wgpu::Device,
-        resolver: &FileResolver<Fs>,
+        ctx: &RenderContext,
         desc: &ShaderModuleDesc,
     ) -> GpuShaderModuleHandle {
         self.pool.get_or_create(desc, |desc| {
-            desc.create_shader_module(device, resolver, &self.shader_text_workaround_replacements)
+            desc.create_shader_module(
+                &ctx.device,
+                &ctx.resolver,
+                &self.shader_text_workaround_replacements,
+            )
         })
     }
 


### PR DESCRIPTION
### What

Some cleanup related to recent interior mutability changes: In a lot of places we can now pass just the RenderContext instead of several arguments, making a lot of code less complex. Also, "shared renderer data" is no longer needed either and is flattened out into the RenderContext.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4446/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4446/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4446)
- [Docs preview](https://rerun.io/preview/032f676245da9bbb08d2f6db1dd7ee33ccd09428/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/032f676245da9bbb08d2f6db1dd7ee33ccd09428/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)