### PR TITLE
Replace uses of `EntityDb` with `StoreDb`

### DIFF
--- a/crates/re_data_store/src/instance_path.rs
+++ b/crates/re_data_store/src/instance_path.rs
@@ -3,7 +3,7 @@ use std::{hash::Hash, str::FromStr};
 use re_log_types::{DataPath, EntityPath, EntityPathHash, PathParseError, RowId};
 use re_types_core::components::InstanceKey;
 
-use crate::{store_db::EntityDb, VersionedInstancePath, VersionedInstancePathHash};
+use crate::{StoreDb, VersionedInstancePath, VersionedInstancePathHash};
 
 // ----------------------------------------------------------------------------
 
@@ -221,8 +221,8 @@ impl InstancePathHash {
         }
     }
 
-    pub fn resolve(&self, entity_db: &EntityDb) -> Option<InstancePath> {
-        let entity_path = entity_db
+    pub fn resolve(&self, store_db: &StoreDb) -> Option<InstancePath> {
+        let entity_path = store_db
             .entity_path_from_hash(&self.entity_path_hash)
             .cloned()?;
 

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -324,6 +324,11 @@ impl StoreDb {
         &self.entity_db
     }
 
+    #[inline]
+    pub fn tree(&self) -> &crate::EntityTree {
+        &self.entity_db.tree
+    }
+
     pub fn store_info_msg(&self) -> Option<&SetStoreInfo> {
         self.set_store_info.as_ref()
     }
@@ -358,7 +363,7 @@ impl StoreDb {
     }
 
     pub fn time_histogram(&self, timeline: &Timeline) -> Option<&crate::TimeHistogram> {
-        self.entity_db().tree.recursive_time_histogram.get(timeline)
+        self.tree().recursive_time_histogram.get(timeline)
     }
 
     pub fn num_timeless_messages(&self) -> u64 {

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -99,31 +99,39 @@ fn insert_row_with_retries(
     Err(re_arrow_store::WriteError::ReusedRowId(row.row_id()))
 }
 
-impl EntityDb {
+impl StoreDb {
     /// A sorted list of all the entity paths in this database.
     pub fn entity_paths(&self) -> Vec<&EntityPath> {
         use itertools::Itertools as _;
-        self.entity_path_from_hash.values().sorted().collect()
+        self.entity_db
+            .entity_path_from_hash
+            .values()
+            .sorted()
+            .collect()
     }
 
     #[inline]
     pub fn entity_path_from_hash(&self, entity_path_hash: &EntityPathHash) -> Option<&EntityPath> {
-        self.entity_path_from_hash.get(entity_path_hash)
+        self.entity_db.entity_path_from_hash.get(entity_path_hash)
     }
 
     /// Returns `true` also for entities higher up in the hierarchy.
     #[inline]
     pub fn is_known_entity(&self, entity_path: &EntityPath) -> bool {
-        self.tree.subtree(entity_path).is_some()
+        self.entity_db.tree.subtree(entity_path).is_some()
     }
 
     /// If you log `world/points`, then that is a logged entity, but `world` is not,
     /// unless you log something to `world` too.
     #[inline]
     pub fn is_logged_entity(&self, entity_path: &EntityPath) -> bool {
-        self.entity_path_from_hash.contains_key(&entity_path.hash())
+        self.entity_db
+            .entity_path_from_hash
+            .contains_key(&entity_path.hash())
     }
+}
 
+impl EntityDb {
     fn register_entity_path(&mut self, entity_path: &EntityPath) {
         self.entity_path_from_hash
             .entry(entity_path.hash())

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -329,6 +329,11 @@ impl StoreDb {
         &self.entity_db.tree
     }
 
+    #[inline]
+    pub fn data_store(&self) -> &DataStore {
+        &self.entity_db.data_store
+    }
+
     pub fn store_info_msg(&self) -> Option<&SetStoreInfo> {
         self.set_store_info.as_ref()
     }

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -19,7 +19,7 @@ use crate::{ClearCascade, CompactedStoreEvents, Error, TimesPerTimeline};
 /// Stored entities with easy indexing of the paths.
 ///
 /// NOTE: don't go mutating the contents of this. Use the public functions instead.
-pub struct EntityDb {
+struct EntityDb {
     /// In many places we just store the hashes, so we need a way to translate back.
     pub entity_path_from_hash: IntMap<EntityPathHash, EntityPath>,
 
@@ -325,11 +325,6 @@ impl StoreDb {
         }
 
         Ok(store_db)
-    }
-
-    #[inline]
-    pub fn entity_db(&self) -> &EntityDb {
-        &self.entity_db
     }
 
     #[inline]

--- a/crates/re_data_store/tests/clear.rs
+++ b/crates/re_data_store/tests/clear.rs
@@ -447,7 +447,7 @@ fn clear_and_gc() -> anyhow::Result<()> {
     // Insert a component, then clear it, then GC.
     {
         // EntityTree is Empty when we start
-        assert_eq!(db.entity_db().tree.num_children_and_fields(), 0);
+        assert_eq!(db.tree().num_children_and_fields(), 0);
 
         let point = MyPoint::new(1.0, 2.0);
 
@@ -484,7 +484,7 @@ fn clear_and_gc() -> anyhow::Result<()> {
         assert_eq!(stats.timeless.num_rows, 0);
 
         // EntityTree should be empty again when we end since everything was GC'd
-        assert_eq!(db.entity_db().tree.num_children_and_fields(), 0);
+        assert_eq!(db.tree().num_children_and_fields(), 0);
     }
 
     Ok(())

--- a/crates/re_data_store/tests/time_histograms.rs
+++ b/crates/re_data_store/tests/time_histograms.rs
@@ -687,8 +687,7 @@ fn assert_histogram_for_component<'a>(
 ) {
     for (timeline, expected_times) in expected {
         let histo = db
-            .entity_db()
-            .tree
+            .tree()
             .subtree(entity_path)
             .and_then(|tree| tree.time_histogram_for_component(timeline, component_name));
 

--- a/crates/re_data_ui/src/component_path.rs
+++ b/crates/re_data_ui/src/component_path.rs
@@ -17,11 +17,7 @@ impl DataUi for ComponentPath {
         } = self;
 
         let store = if ctx.app_options.show_blueprint_in_timeline
-            && ctx
-                .store_context
-                .blueprint
-                .entity_db()
-                .is_logged_entity(entity_path)
+            && ctx.store_context.blueprint.is_logged_entity(entity_path)
         {
             ctx.store_context.blueprint.store()
         } else {

--- a/crates/re_data_ui/src/component_path.rs
+++ b/crates/re_data_ui/src/component_path.rs
@@ -40,7 +40,7 @@ impl DataUi for ComponentPath {
                 component_data,
             }
             .data_ui(ctx, ui, verbosity, query);
-        } else if let Some(entity_tree) = ctx.store_db.entity_db().tree.subtree(entity_path) {
+        } else if let Some(entity_tree) = ctx.store_db.tree().subtree(entity_path) {
             if entity_tree
                 .time_histograms_per_component
                 .contains_key(component_name)

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -20,11 +20,7 @@ impl DataUi for InstancePath {
         } = self;
 
         let store = if ctx.app_options.show_blueprint_in_timeline
-            && ctx
-                .store_context
-                .blueprint
-                .entity_db()
-                .is_logged_entity(entity_path)
+            && ctx.store_context.blueprint.is_logged_entity(entity_path)
         {
             ctx.store_context.blueprint.store()
         } else {
@@ -32,7 +28,7 @@ impl DataUi for InstancePath {
         };
 
         let Some(components) = store.all_components(&query.timeline, entity_path) else {
-            if ctx.store_db.entity_db().is_known_entity(entity_path) {
+            if ctx.store_db.is_known_entity(entity_path) {
                 ui.label(ctx.re_ui.warning_text(format!(
                     "No components logged on timeline {:?}",
                     query.timeline.name()

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -269,7 +269,7 @@ impl DataQuery for DataQueryBlueprint {
 
         let root_handle = ctx.recording.and_then(|store| {
             executor.add_entity_tree_to_data_results_recursive(
-                &store.entity_db().tree,
+                store.tree(),
                 &overrides,
                 &overrides.root,
                 &mut data_results,
@@ -495,7 +495,7 @@ impl DataQueryPropertyResolver<'_> {
 
         let mut prop_map = self.auto_properties.clone();
 
-        if let Some(tree) = blueprint.entity_db().tree.subtree(props_path) {
+        if let Some(tree) = blueprint.tree().subtree(props_path) {
             tree.visit_children_recursively(&mut |path: &EntityPath| {
                 if let Some(props) = blueprint
                     .store()
@@ -533,11 +533,7 @@ impl<'a> PropertyResolver for DataQueryPropertyResolver<'a> {
 
         let mut individual = self.auto_properties.clone();
 
-        if let Some(tree) = blueprint
-            .entity_db()
-            .tree
-            .subtree(&self.individual_override_root)
-        {
+        if let Some(tree) = blueprint.tree().subtree(&self.individual_override_root) {
             tree.visit_children_recursively(&mut |path: &EntityPath| {
                 if let Some(props) = blueprint
                     .store()

--- a/crates/re_space_view_spatial/src/heuristics.rs
+++ b/crates/re_space_view_spatial/src/heuristics.rs
@@ -209,7 +209,7 @@ fn update_transform3d_lines_heuristics(
                 return Some(ent_path);
             } else {
                 // Any direct child has a pinhole camera?
-                if let Some(child_tree) = ctx.store_db.entity_db().tree.subtree(ent_path) {
+                if let Some(child_tree) = ctx.store_db.tree().subtree(ent_path) {
                     for child in child_tree.children.values() {
                         if query_pinhole(store, &ctx.current_query(), &child.path).is_some() {
                             return Some(&child.path);

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -508,8 +508,7 @@ pub fn picking(
     // TODO(#1818): Depth at pointer only works for depth images so far.
     let mut depth_at_pointer = None;
     for hit in &picking_result.hits {
-        let Some(mut instance_path) = hit.instance_path_hash.resolve(ctx.store_db.entity_db())
-        else {
+        let Some(mut instance_path) = hit.instance_path_hash.resolve(ctx.store_db) else {
             continue;
         };
 

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -423,7 +423,7 @@ impl TimePanel {
                         time_area_painter,
                         tree_max_y,
                         None,
-                        &ctx.store_db.entity_db().tree,
+                        ctx.store_db.tree(),
                         ui,
                         "/",
                     );
@@ -434,7 +434,7 @@ impl TimePanel {
                         time_area_response,
                         time_area_painter,
                         tree_max_y,
-                        &ctx.store_db.entity_db().tree,
+                        ctx.store_db.tree(),
                         ui,
                     );
                 }
@@ -446,7 +446,7 @@ impl TimePanel {
                         time_area_painter,
                         tree_max_y,
                         None,
-                        &ctx.store_context.blueprint.entity_db().tree,
+                        ctx.store_context.blueprint.tree(),
                         ui,
                         "/ (blueprint)",
                     );
@@ -874,12 +874,7 @@ fn is_time_safe_to_show(
         return true; // no timeless messages, no problem
     }
 
-    if let Some(times) = store_db
-        .entity_db()
-        .tree
-        .recursive_time_histogram
-        .get(timeline)
-    {
+    if let Some(times) = store_db.tree().recursive_time_histogram.get(timeline) {
         if let Some(first_time) = times.min_key() {
             let margin = match timeline.typ() {
                 re_arrow_store::TimeType::Time => TimeInt::from_seconds(10_000),

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -161,7 +161,7 @@ impl AppState {
         // First update the viewport and thus all active space views.
         // This may update their heuristics, so that all panels that are shown in this frame,
         // have the latest information.
-        let spaces_info = SpaceInfoCollection::new(ctx.store_db.entity_db());
+        let spaces_info = SpaceInfoCollection::new(ctx.store_db);
 
         // If the blueprint is invalid, reset it.
         if viewport.blueprint.is_invalid() {

--- a/crates/re_viewer/src/blueprint_validation.rs
+++ b/crates/re_viewer/src/blueprint_validation.rs
@@ -13,7 +13,7 @@ use crate::blueprint::PanelView;
 fn validate_component<C: Component>(blueprint: &StoreDb) -> bool {
     let query = LatestAtQuery::latest(Timeline::default());
 
-    if let Some(data_type) = blueprint.entity_db().data_store.lookup_datatype(&C::name()) {
+    if let Some(data_type) = blueprint.data_store().lookup_datatype(&C::name()) {
         if data_type != &C::arrow_datatype() {
             // If the schemas don't match, we definitely have a problem
             re_log::debug!(
@@ -29,8 +29,7 @@ fn validate_component<C: Component>(blueprint: &StoreDb) -> bool {
             // Walk the blueprint and see if any cells fail to deserialize for this component type.
             for path in blueprint.entity_db().entity_paths() {
                 if let Some([Some(cell)]) = blueprint
-                    .entity_db()
-                    .data_store
+                    .data_store()
                     .latest_at(&query, path, C::name(), &[C::name()])
                     .map(|(_, cells)| cells)
                 {

--- a/crates/re_viewer/src/blueprint_validation.rs
+++ b/crates/re_viewer/src/blueprint_validation.rs
@@ -27,7 +27,7 @@ fn validate_component<C: Component>(blueprint: &StoreDb) -> bool {
             // Otherwise, our usage of serde-fields means we still might have a problem
             // this can go away once we stop using serde-fields.
             // Walk the blueprint and see if any cells fail to deserialize for this component type.
-            for path in blueprint.entity_db().entity_paths() {
+            for path in blueprint.entity_paths() {
                 if let Some([Some(cell)]) = blueprint
                     .data_store()
                     .latest_at(&query, path, C::name(), &[C::name()])

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -375,7 +375,7 @@ impl SpaceViewBlueprint {
         let mut prop_map = self.auto_properties.clone();
 
         let props_path = self.entity_path().join(prefix);
-        if let Some(tree) = blueprint.entity_db().tree.subtree(&props_path) {
+        if let Some(tree) = blueprint.tree().subtree(&props_path) {
             tree.visit_children_recursively(&mut |path: &EntityPath| {
                 if let Some(props) = blueprint
                     .store()

--- a/crates/re_viewport/src/space_view_entity_picker.rs
+++ b/crates/re_viewport/src/space_view_entity_picker.rs
@@ -89,7 +89,7 @@ fn add_entities_ui(
     space_view: &mut SpaceViewBlueprint,
 ) {
     let spaces_info = SpaceInfoCollection::new(ctx.store_db.entity_db());
-    let tree = &ctx.store_db.entity_db().tree;
+    let tree = &ctx.store_db.tree();
     let heuristic_context_per_entity = compute_heuristic_context_for_entities(ctx.store_db);
     // TODO(jleibs): Avoid clone
     let query_result = ctx.lookup_query_result(space_view.query_id()).clone();

--- a/crates/re_viewport/src/space_view_entity_picker.rs
+++ b/crates/re_viewport/src/space_view_entity_picker.rs
@@ -88,7 +88,7 @@ fn add_entities_ui(
     ui: &mut egui::Ui,
     space_view: &mut SpaceViewBlueprint,
 ) {
-    let spaces_info = SpaceInfoCollection::new(ctx.store_db.entity_db());
+    let spaces_info = SpaceInfoCollection::new(ctx.store_db);
     let tree = &ctx.store_db.tree();
     let heuristic_context_per_entity = compute_heuristic_context_for_entities(ctx.store_db);
     // TODO(jleibs): Avoid clone

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -607,7 +607,7 @@ pub fn identify_entities_per_system_per_class(
 
     let heuristic_context = compute_heuristic_context_for_entities(store_db);
     let store = store_db.store();
-    for ent_path in store_db.entity_db().entity_paths() {
+    for ent_path in store_db.entity_paths() {
         let Some(components) = store.all_components(&re_log_types::Timeline::log_time(), ent_path)
         else {
             continue;

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -538,7 +538,7 @@ pub fn compute_heuristic_context_for_entities(
     visit_children_recursively(
         false,
         tree,
-        &store_db.entity_db().data_store,
+        store_db.data_store(),
         &query,
         &mut heuristic_context,
     );

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -44,7 +44,7 @@ fn candidate_space_view_paths<'a>(
 ) -> impl Iterator<Item = &'a EntityPath> {
     // Everything with a SpaceInfo is a candidate (that is root + whenever there is a transform),
     // as well as all direct descendants of the root.
-    let root_children = &ctx.store_db.entity_db().tree.children;
+    let root_children = &ctx.store_db.tree().children;
     spaces_info
         .iter()
         .map(|info| &info.path)
@@ -510,7 +510,7 @@ pub fn compute_heuristic_context_for_entities(
     let query_time = TimeInt::MAX;
     let query = LatestAtQuery::new(timeline, query_time);
 
-    let tree = &store_db.entity_db().tree;
+    let tree = &store_db.tree();
 
     fn visit_children_recursively(
         has_parent_pinhole: bool,

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -350,10 +350,7 @@ pub fn load_viewport_blueprint(blueprint_db: &re_data_store::StoreDb) -> Viewpor
     re_tracing::profile_function!();
 
     let space_views: HashMap<SpaceViewId, SpaceViewBlueprint> = if let Some(space_views) =
-        blueprint_db
-            .entity_db()
-            .tree
-            .subtree(SpaceViewId::registry())
+        blueprint_db.tree().subtree(SpaceViewId::registry())
     {
         space_views
             .children

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -124,7 +124,7 @@ fn store_db_ui(ui: &mut egui::Ui, store_db: &re_data_store::StoreDb) {
     egui::ScrollArea::vertical()
         .auto_shrink([false, true])
         .show(ui, |ui| {
-            for entity_path in store_db.entity_db().entity_paths() {
+            for entity_path in store_db.entity_paths() {
                 ui.collapsing(entity_path.to_string(), |ui| {
                     entity_ui(ui, store_db, timeline, entity_path);
                 });


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/4437

We want to inline `EntityDb` into `StoreDb`. This is a good first step.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/{{ pr.number }}/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/{{ pr.number }}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
