### PR TITLE
Add conda step in the Release PR template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,10 @@ jobs:
           - Otherwise:
             - For any added commits, run the release workflow in 'rc' mode again
             - After testing, run the release workflow in 'release' mode
-            - Once the final release workflow finishes, [create a GitHub release](https://github.com/rerun-io/rerun/releases/new)
+            - Once the final release workflow finishes,
+              - [ ] [create a GitHub release](https://github.com/rerun-io/rerun/releases/new)
+              - [ ] Make sure the [conda feedstock PR](https://github.com/conda-forge/rerun-sdk-feedstock/pulls) gets
+              merged. This will be created by the `regro-cf-autotick-bot` once the GitHub release is created.
 
           - [ ] Tests
             - [ ] Windows


### PR DESCRIPTION
### What
We forgot to merge the PR for the 0.11 release into the conda feedstock for a couple weeks. Adding this as a checklist item to help us remember.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4449/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4449/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4449)
- [Docs preview](https://rerun.io/preview/0b9e2650feeb6315214f89ff568062879c5f4b3b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0b9e2650feeb6315214f89ff568062879c5f4b3b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)