### PR TITLE
Improve C++ example page entries

### DIFF
--- a/examples/cpp/eigen_opencv/README.md
+++ b/examples/cpp/eigen_opencv/README.md
@@ -1,23 +1,19 @@
 ---
-title: "Eigen and OpenCV C++ integration"
-cpp: https://github.com/rerun-io/cpp-example-opencv-eigen/edit/main/README.md
+title: "Eigen and OpenCV C++ Integration"
+cpp: https://github.com/rerun-io/cpp-example-opencv-eigen
 tags: [2D, 3D, C++, Eigen, OpenCV]
-thumbnail: https://static.rerun.io/cpp-example-opencv-eigen/80ec7c698224eccb5ba1928136ba0a522d79b60a/480w.png
-thumbnail_dimensions: [480, 261]
+thumbnail: https://static.rerun.io/cpp-example-opencv-eigen/2fc6355fd87fbb4d07cda384ee8805edb68b5e01/480w.png
+thumbnail_dimensions: [480, 267]
 ---
-
-# Eigen and OpenCV C++ integration
 
 This is a minimal CMake project that shows how to use Rerun in your code in conjunction with [Eigen](https://eigen.tuxfamily.org/) and [OpenCV](https://opencv.org/).
 
 You can find the example at <https://github.com/rerun-io/cpp-example-opencv-eigen/edit/main/README.md>.
 
-<center>
-  <picture>
-    <img src="https://static.rerun.io/cpp-example-opencv-eigen/80ec7c698224eccb5ba1928136ba0a522d79b60a/full.png" alt="">
-    <source media="(max-width: 480px)" srcset="https://static.rerun.io/cpp-example-opencv-eigen/80ec7c698224eccb5ba1928136ba0a522d79b60a/480w.png">
-    <source media="(max-width: 768px)" srcset="https://static.rerun.io/cpp-example-opencv-eigen/80ec7c698224eccb5ba1928136ba0a522d79b60a/768w.png">
-    <source media="(max-width: 1024px)" srcset="https://static.rerun.io/cpp-example-opencv-eigen/80ec7c698224eccb5ba1928136ba0a522d79b60a/1024w.png">
-    <source media="(max-width: 1200px)" srcset="https://static.rerun.io/cpp-example-opencv-eigen/80ec7c698224eccb5ba1928136ba0a522d79b60a/1200w.png">
-  </picture>
-</center>
+<picture>
+  <img src="https://static.rerun.io/cpp-example-opencv-eigen/2fc6355fd87fbb4d07cda384ee8805edb68b5e01/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/cpp-example-opencv-eigen/2fc6355fd87fbb4d07cda384ee8805edb68b5e01/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/cpp-example-opencv-eigen/2fc6355fd87fbb4d07cda384ee8805edb68b5e01/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/cpp-example-opencv-eigen/2fc6355fd87fbb4d07cda384ee8805edb68b5e01/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/cpp-example-opencv-eigen/2fc6355fd87fbb4d07cda384ee8805edb68b5e01/1200w.png">
+</picture>

--- a/examples/cpp/vrs/README.md
+++ b/examples/cpp/vrs/README.md
@@ -2,11 +2,9 @@
 title: "VRS Viewer"
 cpp: https://github.com/rerun-io/cpp-example-vrs
 tags: [2D, 3D, vrs, viewer, C++]
-thumbnail: https://static.rerun.io/cpp-example-vrs/c13ed42c13ecb65b0ef689533c0525ab97471e21/480w.png
-thumbnail_dimensions: [480, 405]
+thumbnail: https://static.rerun.io/cpp-example-vrs/c765460d4448da27bb9ee2a2a15f092f82a402d2/480w.png
+thumbnail_dimensions: [480, 286]
 ---
-
-# C++ Example: VRS Viewer
 
 This is an example that shows how to use [Rerun](https://github.com/rerun-io/rerun)'s C++ API to log and view [VRS](https://github.com/facebookresearch/vrs) files.
 
@@ -15,9 +13,8 @@ This is an example that shows how to use [Rerun](https://github.com/rerun-io/rer
 You can find the example at <https://github.com/rerun-io/cpp-example-vrs>.
 
 <picture>
-  <img src="https://static.rerun.io/cpp-example-vrs/c13ed42c13ecb65b0ef689533c0525ab97471e21/full.png" alt="">
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/cpp-example-vrs/c13ed42c13ecb65b0ef689533c0525ab97471e21/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/cpp-example-vrs/c13ed42c13ecb65b0ef689533c0525ab97471e21/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/cpp-example-vrs/c13ed42c13ecb65b0ef689533c0525ab97471e21/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/cpp-example-vrs/c13ed42c13ecb65b0ef689533c0525ab97471e21/1200w.png">
+  <img src="https://static.rerun.io/cpp-example-vrs/c765460d4448da27bb9ee2a2a15f092f82a402d2/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/cpp-example-vrs/c765460d4448da27bb9ee2a2a15f092f82a402d2/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/cpp-example-vrs/c765460d4448da27bb9ee2a2a15f092f82a402d2/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/cpp-example-vrs/c765460d4448da27bb9ee2a2a15f092f82a402d2/1024w.png">
 </picture>

--- a/examples/manifest.yml
+++ b/examples/manifest.yml
@@ -136,7 +136,7 @@ root:
           rust: rust/clock
 
         - name: eigen-opencv
-          python: cpp/eigen_opencv
+          cpp: cpp/eigen_opencv
 
         - name: multithreading
           python: python/multithreading

--- a/examples/manifest.yml
+++ b/examples/manifest.yml
@@ -111,7 +111,7 @@ root:
           python: python/structure_from_motion
 
         - name: vrs
-          python: cpp/vrs
+          cpp: cpp/vrs
 
     - name: artificial-data
       title: Examples with Artificial Data
@@ -136,7 +136,7 @@ root:
           rust: rust/clock
 
         - name: eigen-opencv
-          python: cpp/eigen_opencv
+          cpp: cpp/eigen_opencv
 
         - name: multithreading
           python: python/multithreading

--- a/examples/manifest.yml
+++ b/examples/manifest.yml
@@ -9,7 +9,9 @@
 #       python: string?
 #       # path to the rust example
 #       rust: string?
-#       # at least one of `python` or `rust` should be set
+#       # path to the cpp example
+#       cpp: string?
+#       # at least one of `python`, `rust`, or `cpp` should be set
 #     }
 #     OR
 #     {
@@ -25,6 +27,7 @@
 #           name: string
 #           python: string?
 #           rust: string?
+#           cpp: string?
 #         }
 #       ]
 #     }

--- a/examples/manifest.yml
+++ b/examples/manifest.yml
@@ -136,7 +136,7 @@ root:
           rust: rust/clock
 
         - name: eigen-opencv
-          cpp: cpp/eigen_opencv
+          python: cpp/eigen_opencv
 
         - name: multithreading
           python: python/multithreading


### PR DESCRIPTION
### What

A few minor fixes to improve consistency of the example page.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4459/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4459/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4459)
- [Docs preview](https://rerun.io/preview/795fe5d1d3aac0dbc5335fedf37805a3b262c99d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/795fe5d1d3aac0dbc5335fedf37805a3b262c99d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)