### PR TITLE
`re_format`: Make the arrow-features opt-in

### DIFF
--- a/crates/re_arrow_store/Cargo.toml
+++ b/crates/re_arrow_store/Cargo.toml
@@ -33,7 +33,7 @@ core_benchmarks_only = []
 [dependencies]
 # Rerun dependencies:
 re_error.workspace = true
-re_format.workspace = true
+re_format = { workspace = true, features = ["arrow"] }
 re_log_types.workspace = true
 re_log.workspace = true
 re_tracing.workspace = true

--- a/crates/re_format/Cargo.toml
+++ b/crates/re_format/Cargo.toml
@@ -15,7 +15,15 @@ version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[features]
+default = []
+
+# Add support for formatting arrow tables.
+"arrow" = ["dep:arrow2", "dep:comfy-table", "dep:re_tuid"]
+
+
 [dependencies]
-arrow2.workspace = true
-comfy-table.workspace = true
-re_tuid = { workspace = true, features = ["arrow"] }
+arrow2 = { workspace = true, optional = true }
+comfy-table = { workspace = true, optional = true }
+re_tuid = { workspace = true, optional = true, features = ["arrow"] }

--- a/crates/re_format/src/arrow.rs
+++ b/crates/re_format/src/arrow.rs
@@ -19,7 +19,7 @@ use re_tuid::{external::re_types_core::Loggable as _, Tuid};
 
 type CustomFormatter<'a, F> = Box<dyn Fn(&mut F, usize) -> std::fmt::Result + 'a>;
 
-pub fn get_custom_display<'a, F: std::fmt::Write + 'a>(
+fn get_custom_display<'a, F: std::fmt::Write + 'a>(
     _column_name: &'a str,
     array: &'a dyn Array,
     null: &'static str,
@@ -75,7 +75,7 @@ fn parse_tuid(array: &dyn Array, index: usize) -> Option<Tuid> {
 
 //TODO(john) move this and the Display impl upstream into arrow2
 #[repr(transparent)]
-pub struct DisplayTimeUnit(TimeUnit);
+struct DisplayTimeUnit(TimeUnit);
 
 impl std::fmt::Display for DisplayTimeUnit {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -91,7 +91,7 @@ impl std::fmt::Display for DisplayTimeUnit {
 
 //TODO(john) move this and the Display impl upstream into arrow2
 #[repr(transparent)]
-pub struct DisplayIntervalUnit(IntervalUnit);
+struct DisplayIntervalUnit(IntervalUnit);
 
 impl std::fmt::Display for DisplayIntervalUnit {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -106,7 +106,7 @@ impl std::fmt::Display for DisplayIntervalUnit {
 
 //TODO(john) move this and the Display impl upstream into arrow2
 #[repr(transparent)]
-pub struct DisplayDataType(DataType);
+struct DisplayDataType(DataType);
 
 impl std::fmt::Display for DisplayDataType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/crates/re_format/src/lib.rs
+++ b/crates/re_format/src/lib.rs
@@ -1,6 +1,8 @@
 //! Miscellaneous tools to format and parse numbers, durations, etc.
 
+#[cfg(feature = "arrow")]
 pub mod arrow;
+
 mod time;
 
 pub use time::next_grid_tick_magnitude_ns;

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -34,7 +34,7 @@ testing = []
 [dependencies]
 
 # Rerun
-re_format.workspace = true
+re_format = { workspace = true, features = ["arrow"] }
 re_log.workspace = true
 re_string_interner.workspace = true
 re_tracing.workspace = true

--- a/crates/re_query/Cargo.toml
+++ b/crates/re_query/Cargo.toml
@@ -28,7 +28,7 @@ testing = ["re_log_types/testing"]
 # Rerun dependencies:
 re_arrow_store.workspace = true
 re_data_store.workspace = true
-re_format.workspace = true
+re_format = { workspace = true, features = ["arrow"] }
 re_log_types.workspace = true
 re_types_core.workspace = true
 re_log.workspace = true


### PR DESCRIPTION
### What
It shamed me to see that `re_memory` has a transitive dependency on `re_types_core` and `arrow2`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4462/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4462/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4462)
- [Docs preview](https://rerun.io/preview/b84d8238ee393bc23969d77d9752d7bc172be216/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b84d8238ee393bc23969d77d9752d7bc172be216/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)