### PR TITLE
Refactor: `re_tuid` no longer depends on `re_types_core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4535,6 +4535,7 @@ dependencies = [
  "arrow2",
  "comfy-table",
  "re_tuid",
+ "re_types_core",
 ]
 
 [[package]]
@@ -4970,12 +4971,10 @@ dependencies = [
 name = "re_tuid"
 version = "0.12.0-alpha.1+dev"
 dependencies = [
- "arrow2",
  "criterion",
  "document-features",
  "getrandom",
  "once_cell",
- "re_types_core",
  "serde",
  "web-time",
 ]
@@ -5047,11 +5046,13 @@ dependencies = [
  "anyhow",
  "arrow2",
  "backtrace",
+ "criterion",
  "document-features",
  "once_cell",
  "re_error",
  "re_string_interner",
  "re_tracing",
+ "re_tuid",
  "serde",
  "smallvec",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,7 +3055,6 @@ name = "log_benchmark"
 version = "0.12.0-alpha.1+dev"
 dependencies = [
  "anyhow",
- "bytemuck",
  "clap",
  "glam",
  "re_tracing",
@@ -4390,7 +4389,6 @@ dependencies = [
  "rayon",
  "re_build_tools",
  "serde",
- "serde_json",
  "serde_yaml",
 ]
 
@@ -4612,7 +4610,6 @@ dependencies = [
  "re_tracing",
  "re_tuid",
  "re_types_core",
- "rmp-serde",
  "serde",
  "serde_bytes",
  "similar-asserts",
@@ -5090,7 +5087,6 @@ dependencies = [
  "ehttp",
  "image",
  "itertools 0.11.0",
- "nohash-hasher",
  "once_cell",
  "poll-promise",
  "re_analytics",
@@ -5198,8 +5194,6 @@ dependencies = [
  "re_ui",
  "re_viewer_context",
  "rmp-serde",
- "serde",
- "slotmap",
  "tinyvec",
 ]
 
@@ -5382,7 +5376,6 @@ dependencies = [
  "re_log_types",
  "re_memory",
  "re_viewer",
- "re_viewer_context",
  "re_viewport",
  "re_web_viewer_server",
  "re_ws_comms",

--- a/crates/re_build_examples/Cargo.toml
+++ b/crates/re_build_examples/Cargo.toml
@@ -24,5 +24,4 @@ anyhow.workspace = true
 indicatif.workspace = true
 rayon.workspace = true
 serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -53,7 +53,7 @@ fn insert_row_with_retries(
             Ok(event) => return Ok(event),
             Err(re_arrow_store::WriteError::ReusedRowId(_)) => {
                 re_log::debug!(row_id = %row.row_id(), "Found duplicated RowId, retrying…");
-                row.row_id = row.row_id.increment(random_u64() % step_size + 1);
+                row.row_id = row.row_id.incremented_by(random_u64() % step_size + 1);
             }
             Err(err) => return Err(err),
         }

--- a/crates/re_format/Cargo.toml
+++ b/crates/re_format/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 default = []
 
 # Add support for formatting arrow tables.
-"arrow" = ["dep:arrow2", "dep:comfy-table", "dep:re_tuid"]
+"arrow" = ["dep:arrow2", "dep:comfy-table", "dep:re_tuid", "dep:re_types_core"]
 
 
 [dependencies]

--- a/crates/re_format/Cargo.toml
+++ b/crates/re_format/Cargo.toml
@@ -26,4 +26,5 @@ default = []
 [dependencies]
 arrow2 = { workspace = true, optional = true }
 comfy-table = { workspace = true, optional = true }
-re_tuid = { workspace = true, optional = true, features = ["arrow"] }
+re_tuid = { workspace = true, optional = true }
+re_types_core = { workspace = true, optional = true } # tuid serialization

--- a/crates/re_format/src/arrow.rs
+++ b/crates/re_format/src/arrow.rs
@@ -8,7 +8,8 @@ use arrow2::{
 };
 use comfy_table::{presets, Cell, Table};
 
-use re_tuid::{external::re_types_core::Loggable as _, Tuid};
+use re_tuid::Tuid;
+use re_types_core::Loggable as _;
 
 // ---
 

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -21,7 +21,6 @@ default = []
 
 ## Enable (de)serialization using serde.
 serde = [
-  "dep:rmp-serde",
   "dep:serde",
   "dep:serde_bytes",
   "re_string_interner/serde",
@@ -70,7 +69,6 @@ web-time.workspace = true
 
 
 # Optional dependencies:
-rmp-serde = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive", "rc"] }
 serde_bytes = { workspace = true, optional = true }
 

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -38,7 +38,7 @@ re_format = { workspace = true, features = ["arrow"] }
 re_log.workspace = true
 re_string_interner.workspace = true
 re_tracing.workspace = true
-re_tuid = { workspace = true, features = ["arrow"] }
+re_tuid.workspace = true
 re_types_core.workspace = true
 
 # External

--- a/crates/re_log_types/src/data_row.rs
+++ b/crates/re_log_types/src/data_row.rs
@@ -208,7 +208,7 @@ impl std::ops::DerefMut for RowId {
     }
 }
 
-re_tuid::delegate_arrow_tuid!(RowId as "rerun.controls.RowId");
+re_types_core::delegate_arrow_tuid!(RowId as "rerun.controls.RowId");
 
 /// A row's worth of data, i.e. an event: a list of [`DataCell`]s associated with an auto-generated
 /// `RowId`, a user-specified [`TimePoint`] and [`EntityPath`], and an expected number of

--- a/crates/re_log_types/src/data_row.rs
+++ b/crates/re_log_types/src/data_row.rs
@@ -167,6 +167,7 @@ impl RowId {
     ///
     /// Beware: wrong usage can easily lead to conflicts.
     /// Prefer [`RowId::new`] when unsure.
+    #[must_use]
     #[inline]
     pub fn next(&self) -> Self {
         Self(self.0.next())
@@ -179,9 +180,10 @@ impl RowId {
     ///
     /// Beware: wrong usage can easily lead to conflicts.
     /// Prefer [`RowId::new`] when unsure.
+    #[must_use]
     #[inline]
-    pub fn increment(&self, n: u64) -> Self {
-        Self(self.0.increment(n))
+    pub fn incremented_by(&self, n: u64) -> Self {
+        Self(self.0.incremented_by(n))
     }
 }
 

--- a/crates/re_log_types/src/data_table.rs
+++ b/crates/re_log_types/src/data_table.rs
@@ -197,7 +197,7 @@ impl std::ops::DerefMut for TableId {
     }
 }
 
-re_tuid::delegate_arrow_tuid!(TableId as "rerun.controls.TableId");
+re_types_core::delegate_arrow_tuid!(TableId as "rerun.controls.TableId");
 
 /// A sparse table's worth of data, i.e. a batch of events: a collection of [`DataRow`]s.
 /// This is the top-level layer in our data model.

--- a/crates/re_log_types/src/data_table.rs
+++ b/crates/re_log_types/src/data_table.rs
@@ -156,6 +156,7 @@ impl TableId {
     ///
     /// Beware: wrong usage can easily lead to conflicts.
     /// Prefer [`TableId::new`] when unsure.
+    #[must_use]
     #[inline]
     pub fn next(&self) -> Self {
         Self(self.0.next())
@@ -168,9 +169,10 @@ impl TableId {
     ///
     /// Beware: wrong usage can easily lead to conflicts.
     /// Prefer [`TableId::new`] when unsure.
+    #[must_use]
     #[inline]
-    pub fn increment(&self, n: u64) -> Self {
-        Self(self.0.increment(n))
+    pub fn incremented_by(&self, n: u64) -> Self {
+        Self(self.0.incremented_by(n))
     }
 }
 

--- a/crates/re_tuid/Cargo.toml
+++ b/crates/re_tuid/Cargo.toml
@@ -19,11 +19,8 @@ all-features = true
 [features]
 default = []
 
-## Enable (de)serialization using Arrow.
-arrow = ["dep:re_types_core", "dep:arrow2"]
-
 ## Enable (de)serialization using serde.
-serde = ["dep:serde", "re_types_core?/serde"]
+serde = ["dep:serde"]
 
 
 [dependencies]
@@ -33,10 +30,6 @@ once_cell.workspace = true
 web-time.workspace = true
 
 # Optional dependencies
-
-re_types_core = { workspace = true, optional = true }
-
-arrow2 = { workspace = true, optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/crates/re_tuid/benches/bench_tuid.rs
+++ b/crates/re_tuid/benches/bench_tuid.rs
@@ -8,42 +8,5 @@ fn bench_tuid(c: &mut Criterion) {
     });
 }
 
-#[cfg(feature = "arrow")]
-fn bench_arrow(c: &mut Criterion) {
-    use arrow2::array::Array;
-    use re_types_core::Loggable as _;
-
-    for elem_count in [1, 1000] {
-        {
-            let mut group = c.benchmark_group(format!("arrow/serialize/elem_count={elem_count}"));
-            group.throughput(criterion::Throughput::Elements(elem_count));
-
-            let tuids = vec![re_tuid::Tuid::new(); elem_count as usize];
-
-            group.bench_function("arrow2", |b| {
-                b.iter(|| {
-                    let data: Box<dyn Array> = re_tuid::Tuid::to_arrow(tuids.clone()).unwrap();
-                    criterion::black_box(data)
-                });
-            });
-        }
-
-        {
-            let mut group = c.benchmark_group(format!("arrow/deserialize/elem_count={elem_count}"));
-            group.throughput(criterion::Throughput::Elements(elem_count));
-
-            let data: Box<dyn Array> =
-                re_tuid::Tuid::to_arrow(vec![re_tuid::Tuid::new(); elem_count as usize]).unwrap();
-
-            group.bench_function("arrow2", |b| {
-                b.iter(|| {
-                    let tuids = re_tuid::Tuid::from_arrow(data.as_ref()).unwrap();
-                    criterion::black_box(tuids)
-                });
-            });
-        }
-    }
-}
-
-criterion_group!(benches, bench_tuid, bench_arrow);
+criterion_group!(benches, bench_tuid);
 criterion_main!(benches);

--- a/crates/re_tuid/src/lib.rs
+++ b/crates/re_tuid/src/lib.rs
@@ -17,14 +17,6 @@ pub struct Tuid {
     inc: u64,
 }
 
-#[cfg(feature = "arrow")]
-pub mod arrow;
-
-pub mod external {
-    #[cfg(feature = "arrow")]
-    pub use re_types_core;
-}
-
 impl std::fmt::Display for Tuid {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:032X}", self.as_u128())
@@ -34,6 +26,20 @@ impl std::fmt::Display for Tuid {
 impl std::fmt::Debug for Tuid {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:032X}", self.as_u128())
+    }
+}
+
+impl<'a> From<Tuid> for std::borrow::Cow<'a, Tuid> {
+    #[inline]
+    fn from(value: Tuid) -> Self {
+        std::borrow::Cow::Owned(value)
+    }
+}
+
+impl<'a> From<&'a Tuid> for std::borrow::Cow<'a, Tuid> {
+    #[inline]
+    fn from(value: &'a Tuid) -> Self {
+        std::borrow::Cow::Borrowed(value)
     }
 }
 
@@ -82,6 +88,11 @@ impl Tuid {
     }
 
     #[inline]
+    pub fn from_nanos_and_inc(time_ns: u64, inc: u64) -> Self {
+        Self { time_ns, inc }
+    }
+
+    #[inline]
     pub fn as_u128(&self) -> u128 {
         ((self.time_ns as u128) << 64) | (self.inc as u128)
     }
@@ -116,6 +127,11 @@ impl Tuid {
             time_ns,
             inc: inc.wrapping_add(n),
         }
+    }
+
+    #[inline]
+    pub fn inc(&self) -> u64 {
+        self.inc
     }
 
     #[inline]

--- a/crates/re_tuid/src/lib.rs
+++ b/crates/re_tuid/src/lib.rs
@@ -87,7 +87,7 @@ impl Tuid {
         })
     }
 
-    /// Construct a [`Tuid`] from the upper and lower halfs of a u128-bit.
+    /// Construct a [`Tuid`] from the upper and lower halves of a u128-bit.
     /// The first should be nano-seconds since epoch.
     #[inline]
     pub fn from_nanos_and_inc(time_ns: u64, inc: u64) -> Self {
@@ -99,7 +99,7 @@ impl Tuid {
         ((self.time_ns as u128) << 64) | (self.inc as u128)
     }
 
-    /// Aproximate nanoseconds since unix epoch.
+    /// Approximate nanoseconds since unix epoch.
     ///
     /// The upper 64 bits of the [`Tuid`].
     #[inline]

--- a/crates/re_tuid/src/lib.rs
+++ b/crates/re_tuid/src/lib.rs
@@ -87,6 +87,8 @@ impl Tuid {
         })
     }
 
+    /// Construct a [`Tuid`] from the upper and lower halfs of a u128-bit.
+    /// The first should be nano-seconds since epoch.
     #[inline]
     pub fn from_nanos_and_inc(time_ns: u64, inc: u64) -> Self {
         Self { time_ns, inc }
@@ -97,12 +99,29 @@ impl Tuid {
         ((self.time_ns as u128) << 64) | (self.inc as u128)
     }
 
+    /// Aproximate nanoseconds since unix epoch.
+    ///
+    /// The upper 64 bits of the [`Tuid`].
+    #[inline]
+    pub fn nanoseconds_since_epoch(&self) -> u64 {
+        self.time_ns
+    }
+
+    /// The increment part of the [`Tuid`].
+    ///
+    /// The lower 64 bits of the [`Tuid`].
+    #[inline]
+    pub fn inc(&self) -> u64 {
+        self.inc
+    }
+
     /// Returns the next logical [`Tuid`].
     ///
     /// Wraps the monotonically increasing back to zero on overflow.
     ///
     /// Beware: wrong usage can easily lead to conflicts.
     /// Prefer [`Tuid::new`] when unsure.
+    #[must_use]
     #[inline]
     pub fn next(&self) -> Self {
         let Self { time_ns, inc } = *self;
@@ -120,23 +139,14 @@ impl Tuid {
     ///
     /// Beware: wrong usage can easily lead to conflicts.
     /// Prefer [`Tuid::new`] when unsure.
+    #[must_use]
     #[inline]
-    pub fn increment(&self, n: u64) -> Self {
+    pub fn incremented_by(&self, n: u64) -> Self {
         let Self { time_ns, inc } = *self;
         Self {
             time_ns,
             inc: inc.wrapping_add(n),
         }
-    }
-
-    #[inline]
-    pub fn inc(&self) -> u64 {
-        self.inc
-    }
-
-    #[inline]
-    pub fn nanoseconds_since_epoch(&self) -> u64 {
-        self.time_ns
     }
 
     /// A shortened string representation of the `Tuid`.

--- a/crates/re_types_core/Cargo.toml
+++ b/crates/re_types_core/Cargo.toml
@@ -29,6 +29,7 @@ serde = ["dep:serde", "re_string_interner/serde"]
 re_error.workspace = true
 re_string_interner.workspace = true
 re_tracing.workspace = true
+re_tuid.workspace = true
 
 # External
 anyhow.workspace = true
@@ -45,3 +46,13 @@ thiserror.workspace = true
 
 # Optional dependencies
 serde = { workspace = true, optional = true }
+
+[dev-dependencies]
+criterion = "0.5"
+
+[lib]
+bench = false
+
+[[bench]]
+name = "bench_tuid"
+harness = false

--- a/crates/re_types_core/benches/bench_tuid.rs
+++ b/crates/re_types_core/benches/bench_tuid.rs
@@ -1,0 +1,40 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn bench_arrow(c: &mut Criterion) {
+    use arrow2::array::Array;
+    use re_types_core::Loggable as _;
+
+    for elem_count in [1, 1000] {
+        {
+            let mut group = c.benchmark_group(format!("arrow/serialize/elem_count={elem_count}"));
+            group.throughput(criterion::Throughput::Elements(elem_count));
+
+            let tuids = vec![re_tuid::Tuid::new(); elem_count as usize];
+
+            group.bench_function("arrow2", |b| {
+                b.iter(|| {
+                    let data: Box<dyn Array> = re_tuid::Tuid::to_arrow(tuids.clone()).unwrap();
+                    criterion::black_box(data)
+                });
+            });
+        }
+
+        {
+            let mut group = c.benchmark_group(format!("arrow/deserialize/elem_count={elem_count}"));
+            group.throughput(criterion::Throughput::Elements(elem_count));
+
+            let data: Box<dyn Array> =
+                re_tuid::Tuid::to_arrow(vec![re_tuid::Tuid::new(); elem_count as usize]).unwrap();
+
+            group.bench_function("arrow2", |b| {
+                b.iter(|| {
+                    let tuids = re_tuid::Tuid::from_arrow(data.as_ref()).unwrap();
+                    criterion::black_box(tuids)
+                });
+            });
+        }
+    }
+}
+
+criterion_group!(benches, bench_arrow);
+criterion_main!(benches);

--- a/crates/re_types_core/src/lib.rs
+++ b/crates/re_types_core/src/lib.rs
@@ -92,6 +92,7 @@ mod loggable;
 mod loggable_batch;
 mod result;
 mod size_bytes;
+mod tuid;
 
 pub use self::archetype::{
     Archetype, ArchetypeName, GenericIndicatorComponent, NamedIndicatorComponent,
@@ -143,4 +144,5 @@ pub mod macros {
 pub mod external {
     pub use anyhow;
     pub use arrow2;
+    pub use re_tuid;
 }

--- a/crates/re_types_core/src/tuid.rs
+++ b/crates/re_types_core/src/tuid.rs
@@ -1,17 +1,15 @@
+use crate::{DeserializationError, Loggable};
 use arrow2::{
     array::{StructArray, UInt64Array},
     datatypes::{DataType, Field},
 };
-use re_types_core::Loggable;
 
-use crate::Tuid;
+use re_tuid::Tuid;
 
 // ---
 
-re_types_core::macros::impl_into_cow!(Tuid);
-
 impl Loggable for Tuid {
-    type Name = re_types_core::ComponentName;
+    type Name = crate::ComponentName;
 
     #[inline]
     fn name() -> Self::Name {
@@ -28,11 +26,11 @@ impl Loggable for Tuid {
 
     fn to_arrow_opt<'a>(
         _data: impl IntoIterator<Item = Option<impl Into<std::borrow::Cow<'a, Self>>>>,
-    ) -> re_types_core::SerializationResult<Box<dyn arrow2::array::Array>>
+    ) -> crate::SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: 'a,
     {
-        Err(re_types_core::SerializationError::not_implemented(
+        Err(crate::SerializationError::not_implemented(
             Self::name(),
             "TUIDs are never nullable, use `to_arrow()` instead",
         ))
@@ -41,14 +39,14 @@ impl Loggable for Tuid {
     #[inline]
     fn to_arrow<'a>(
         data: impl IntoIterator<Item = impl Into<std::borrow::Cow<'a, Self>>>,
-    ) -> re_types_core::SerializationResult<Box<dyn ::arrow2::array::Array>>
+    ) -> crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: 'a,
     {
         let (time_ns_values, inc_values): (Vec<_>, Vec<_>) = data
             .into_iter()
             .map(Into::into)
-            .map(|tuid| (tuid.time_ns, tuid.inc))
+            .map(|tuid| (tuid.nanoseconds_since_epoch(), tuid.inc()))
             .unzip();
 
         let values = vec![
@@ -61,13 +59,11 @@ impl Loggable for Tuid {
         Ok(StructArray::new(Self::extended_arrow_datatype(), values, validity).boxed())
     }
 
-    fn from_arrow(
-        array: &dyn ::arrow2::array::Array,
-    ) -> re_types_core::DeserializationResult<Vec<Self>> {
+    fn from_arrow(array: &dyn ::arrow2::array::Array) -> crate::DeserializationResult<Vec<Self>> {
         let expected_datatype = Self::arrow_datatype();
         let actual_datatype = array.data_type().to_logical_type();
         if actual_datatype != &expected_datatype {
-            return Err(re_types_core::DeserializationError::datatype_mismatch(
+            return Err(DeserializationError::datatype_mismatch(
                 expected_datatype,
                 actual_datatype.clone(),
             ));
@@ -106,39 +102,37 @@ impl Loggable for Tuid {
         let inc_buffer = get_buffer(inc_index);
 
         if time_ns_buffer.len() != inc_buffer.len() {
-            return Err(
-                re_types_core::DeserializationError::mismatched_struct_field_lengths(
-                    "time_ns",
-                    time_ns_buffer.len(),
-                    "inc",
-                    inc_buffer.len(),
-                ),
-            );
+            return Err(DeserializationError::mismatched_struct_field_lengths(
+                "time_ns",
+                time_ns_buffer.len(),
+                "inc",
+                inc_buffer.len(),
+            ));
         }
 
         Ok(time_ns_buffer
             .iter()
             .copied()
             .zip(inc_buffer.iter().copied())
-            .map(|(time_ns, inc)| Self { time_ns, inc })
+            .map(|(time_ns, inc)| Self::from_nanos_and_inc(time_ns, inc))
             .collect())
     }
 }
 
-/// Implements [`re_types_core::Component`] for any given type that is a simple wrapper
+/// Implements [`crate::Component`] for any given type that is a simple wrapper
 /// (newtype) around a [`Tuid`].
 ///
 /// Usage:
 /// ```ignore
-/// re_tuid::delegate_arrow_tuid!(RowId);
+/// re_types_core::delegate_arrow_tuid!(RowId);
 /// ```
 #[macro_export]
 macro_rules! delegate_arrow_tuid {
     ($typ:ident as $fqname:expr) => {
-        ::re_types_core::macros::impl_into_cow!($typ);
+        $crate::macros::impl_into_cow!($typ);
 
-        impl ::re_types_core::Loggable for $typ {
-            type Name = ::re_types_core::ComponentName;
+        impl $crate::Loggable for $typ {
+            type Name = $crate::ComponentName;
 
             #[inline]
             fn name() -> Self::Name {
@@ -147,17 +141,17 @@ macro_rules! delegate_arrow_tuid {
 
             #[inline]
             fn arrow_datatype() -> ::arrow2::datatypes::DataType {
-                $crate::Tuid::arrow_datatype()
+                $crate::external::re_tuid::Tuid::arrow_datatype()
             }
 
             #[inline]
             fn to_arrow_opt<'a>(
                 values: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
-            ) -> re_types_core::SerializationResult<Box<dyn ::arrow2::array::Array>>
+            ) -> $crate::SerializationResult<Box<dyn ::arrow2::array::Array>>
             where
                 Self: 'a,
             {
-                Err(re_types_core::SerializationError::not_implemented(
+                Err($crate::SerializationError::not_implemented(
                     Self::name(),
                     "TUIDs are never nullable, use `to_arrow()` instead",
                 ))
@@ -166,12 +160,12 @@ macro_rules! delegate_arrow_tuid {
             #[inline]
             fn to_arrow<'a>(
                 values: impl IntoIterator<Item = impl Into<std::borrow::Cow<'a, Self>>>,
-            ) -> re_types_core::SerializationResult<Box<dyn ::arrow2::array::Array>> {
+            ) -> $crate::SerializationResult<Box<dyn ::arrow2::array::Array>> {
                 let values = values.into_iter().map(|value| {
                     let value: ::std::borrow::Cow<'a, Self> = value.into();
                     value.into_owned()
                 });
-                <$crate::Tuid as ::re_types_core::Loggable>::to_arrow(
+                <$crate::external::re_tuid::Tuid as $crate::Loggable>::to_arrow(
                     values.into_iter().map(|$typ(tuid)| tuid),
                 )
             }
@@ -179,9 +173,9 @@ macro_rules! delegate_arrow_tuid {
             #[inline]
             fn from_arrow(
                 array: &dyn arrow2::array::Array,
-            ) -> re_types_core::DeserializationResult<Vec<Self>> {
+            ) -> $crate::DeserializationResult<Vec<Self>> {
                 Ok(
-                    <$crate::Tuid as ::re_types_core::Loggable>::from_arrow(array)?
+                    <$crate::external::re_tuid::Tuid as $crate::Loggable>::from_arrow(array)?
                         .into_iter()
                         .map(|tuid| Self(tuid))
                         .collect(),

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -90,7 +90,6 @@ ehttp.workspace = true
 image = { workspace = true, default-features = false, features = ["png"] }
 itertools = { workspace = true }
 once_cell = { workspace = true }
-nohash-hasher.workspace = true
 poll-promise = { workspace = true, features = ["web"] }
 rfd.workspace = true
 ron.workspace = true

--- a/crates/re_viewport/Cargo.toml
+++ b/crates/re_viewport/Cargo.toml
@@ -44,6 +44,4 @@ image = { workspace = true, default-features = false, features = ["png"] }
 itertools.workspace = true
 nohash-hasher.workspace = true
 rmp-serde.workspace = true
-slotmap.workspace = true
-serde.workspace = true
 tinyvec.workspace = true

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -48,8 +48,7 @@ rerun = { workspace = true, features = ["analytics", "server", "sdk"] }
 re_web_viewer_server = { workspace = true, optional = true }
 re_ws_comms = { workspace = true, optional = true }
 
-# TODO(jleibs): This should go away as part of https://github.com/rerun-io/rerun/issues/2089
-re_viewer_context.workspace = true
+# TODO(jleibs): Dependency on re_viewer and re_viewport should go away as part of https://github.com/rerun-io/rerun/issues/2089
 re_viewer.workspace = true
 re_viewport.workspace = true
 

--- a/tests/rust/log_benchmark/Cargo.toml
+++ b/tests/rust/log_benchmark/Cargo.toml
@@ -11,6 +11,5 @@ rerun = { path = "../../../crates/rerun" }
 re_tracing = { path = "../../../crates/re_tracing", features = ["server"] }
 
 anyhow.workspace = true
-bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 clap = { workspace = true, features = ["derive"] }
 glam.workspace = true


### PR DESCRIPTION
### What
Utility crates such as `re_tuid` should not depend on high-level rerun-specific crates like `re_types_core`.

Ideally, neither should `re_format`. Arrow 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4463/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4463/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4463)
- [Docs preview](https://rerun.io/preview/d03302257e388222086fa75dec97b54cbe6bfc8c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d03302257e388222086fa75dec97b54cbe6bfc8c/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)