### PR TITLE
Add the possibility to add empty space views of all registered types

### DIFF
--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -67,7 +67,7 @@ impl SpaceViewBlueprint {
 impl SpaceViewBlueprint {
     pub fn new(
         space_view_class: SpaceViewClassIdentifier,
-        space_view_class_display_name: &'static str,
+        space_view_class_display_name: &str,
         space_path: &EntityPath,
         query: DataQueryBlueprint,
     ) -> Self {

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -1,4 +1,5 @@
 use egui::{Response, Ui};
+use itertools::Itertools;
 
 use re_data_store::InstancePath;
 use re_data_ui::item_ui;
@@ -440,14 +441,19 @@ impl ViewportBlueprint<'_> {
                 }
 
                 // Empty space views of every available types
-                for space_view in ctx.space_view_class_registry.iter_classes().map(|class| {
-                    SpaceViewBlueprint::new(
-                        class.identifier(),
-                        &format!("empty {}", class.display_name()),
-                        &EntityPath::root(),
-                        DataQueryBlueprint::new(class.identifier(), std::iter::empty()),
-                    )
-                }) {
+                for space_view in ctx
+                    .space_view_class_registry
+                    .iter_classes()
+                    .sorted_by_key(|space_view_class| space_view_class.display_name())
+                    .map(|class| {
+                        SpaceViewBlueprint::new(
+                            class.identifier(),
+                            &format!("empty {}", class.display_name()),
+                            &EntityPath::root(),
+                            DataQueryBlueprint::new(class.identifier(), std::iter::empty()),
+                        )
+                    })
+                {
                     add_space_view_item(ui, space_view);
                 }
             },


### PR DESCRIPTION
### What

What the title says ☝🏻

A list of all space view type is added to the "Add space view" button. They all default to `/` as space origin.

<img width="278" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/6268ece7-b7e7-4779-a366-6f9376339b55">



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4467/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4467/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4467)
- [Docs preview](https://rerun.io/preview/a6a8db17c2e2ecad16b306536b5cf42690d6fc88/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a6a8db17c2e2ecad16b306536b5cf42690d6fc88/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)