### PR TITLE
Use `:` instead of `.` as the entity:component separator in paths

### DIFF
--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -178,6 +178,7 @@ pub fn component_path_button(
         component_path.component_name.short_name(),
         component_path,
     )
+    .on_hover_text(component_path.component_name.full_name()) // we should show the full name somewhere
 }
 
 /// Show a component path and make it selectable.

--- a/crates/re_log_types/src/path/data_path.rs
+++ b/crates/re_log_types/src/path/data_path.rs
@@ -10,9 +10,9 @@ use crate::EntityPath;
 /// For instance:
 ///
 /// * `points`
-/// * `points.Color`
+/// * `points:Color`
 /// * `points[#42]`
-/// * `points[#42].Color`
+/// * `points[#42]:Color`
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct DataPath {
     pub entity_path: EntityPath,
@@ -29,7 +29,7 @@ impl std::fmt::Display for DataPath {
             write!(f, "[#{}]", instance_key.0)?;
         }
         if let Some(component_name) = &self.component_name {
-            write!(f, ".{component_name:?}")?;
+            write!(f, ":{component_name:?}")?;
         }
         Ok(())
     }

--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -42,7 +42,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         &rerun::TextDocument::new(
 ///             r#"
 /// # Hello Markdown!
-/// [Click here to see the raw text](recording://markdown.Text).
+/// [Click here to see the raw text](recording://markdown:Text).
 ///
 /// Basic formatting:
 ///
@@ -68,7 +68,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ## Links
 /// You can link to [an entity](recording://markdown),
 /// a [specific instance of an entity](recording://markdown[#0]),
-/// or a [specific component](recording://markdown.Text).
+/// or a [specific component](recording://markdown:Text).
 ///
 /// Of course you can also have [normal https links](https://github.com/rerun-io/rerun), e.g. <https://rerun.io>.
 ///

--- a/docs/code-examples/text_document.cpp
+++ b/docs/code-examples/text_document.cpp
@@ -11,7 +11,7 @@ int main() {
     rec.log(
         "markdown",
         rerun::TextDocument(R"#(# Hello Markdown!
-[Click here to see the raw text](recording://markdown.Text).
+[Click here to see the raw text](recording://markdown:Text).
 
 Basic formatting:
 
@@ -37,7 +37,7 @@ Basic formatting:
 ## Links
 You can link to [an entity](recording://markdown),
 a [specific instance of an entity](recording://markdown[#0]),
-or a [specific component](recording://markdown.Text).
+or a [specific component](recording://markdown:Text).
 
 Of course you can also have [normal https links](https://github.com/rerun-io/rerun), e.g. <https://rerun.io>.
 

--- a/docs/code-examples/text_document.py
+++ b/docs/code-examples/text_document.py
@@ -11,7 +11,7 @@ rr.log(
     rr.TextDocument(
         '''
 # Hello Markdown!
-[Click here to see the raw text](recording://markdown.Text).
+[Click here to see the raw text](recording://markdown:Text).
 
 Basic formatting:
 
@@ -37,7 +37,7 @@ Basic formatting:
 ## Links
 You can link to [an entity](recording://markdown),
 a [specific instance of an entity](recording://markdown[#0]),
-or a [specific component](recording://markdown.Text).
+or a [specific component](recording://markdown:Text).
 
 Of course you can also have [normal https links](https://github.com/rerun-io/rerun), e.g. <https://rerun.io>.
 

--- a/docs/code-examples/text_document.rs
+++ b/docs/code-examples/text_document.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &rerun::TextDocument::new(
             r#"
 # Hello Markdown!
-[Click here to see the raw text](recording://markdown.Text).
+[Click here to see the raw text](recording://markdown:Text).
 
 Basic formatting:
 
@@ -39,7 +39,7 @@ Basic formatting:
 ## Links
 You can link to [an entity](recording://markdown),
 a [specific instance of an entity](recording://markdown[#0]),
-or a [specific component](recording://markdown.Text).
+or a [specific component](recording://markdown:Text).
 
 Of course you can also have [normal https links](https://github.com/rerun-io/rerun), e.g. <https://rerun.io>.
 

--- a/examples/python/dna/main.py
+++ b/examples/python/dna/main.py
@@ -36,7 +36,7 @@ The 3D line strips connecting the 3D point pairs are logged as an
 ### Rotation
 The whole structure is rotated over time by logging a
 [rr.Transform3D archetype](https://www.rerun.io/docs/reference/types/archetypes/transform3d) to the
-[helix/structure entity](recording://helix/structure.Transform3D) that changes over time. This transform determines the rotation of
+[helix/structure entity](recording://helix/structure:Transform3D) that changes over time. This transform determines the rotation of
 the [structure entity](recording://helix/structure) relative to the [helix](recording://helix) entity. Since all other
 entities are children of [helix/structure](recording://helix/structure) they will also rotate based on this transform.
 

--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -70,7 +70,7 @@ to the [points entity](recording://points):
 ```python
 rr.log("points", rr.Points3D(points, colors=point_colors), rr.AnyValues(error=point_errors))
 ```
-**Note:** we added some [custom per-point errors](recording://points.error) that you can see when you
+**Note:** we added some [custom per-point errors](recording://points) that you can see when you
 hover over the points in the 3D view.
 """.strip()
 

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -38,7 +38,7 @@ namespace rerun::archetypes {
     ///     rec.log(
     ///         "markdown",
     ///         rerun::TextDocument(R"#(# Hello Markdown!
-    /// [Click here to see the raw text](recording://markdown.Text).
+    /// [Click here to see the raw text](recording://markdown:Text).
     ///
     /// Basic formatting:
     ///
@@ -64,7 +64,7 @@ namespace rerun::archetypes {
     /// ## Links
     /// You can link to [an entity](recording://markdown),
     /// a [specific instance of an entity](recording://markdown[#0]),
-    /// or a [specific component](recording://markdown.Text).
+    /// or a [specific component](recording://markdown:Text).
     ///
     /// Of course you can also have [normal https links](https://github.com/rerun-io/rerun), e.g. <https://rerun.io>.
     ///

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -38,7 +38,7 @@ class TextDocument(Archetype):
         rr.TextDocument(
             '''
     # Hello Markdown!
-    [Click here to see the raw text](recording://markdown.Text).
+    [Click here to see the raw text](recording://markdown:Text).
 
     Basic formatting:
 
@@ -64,7 +64,7 @@ class TextDocument(Archetype):
     ## Links
     You can link to [an entity](recording://markdown),
     a [specific instance of an entity](recording://markdown[#0]),
-    or a [specific component](recording://markdown.Text).
+    or a [specific component](recording://markdown:Text).
 
     Of course you can also have [normal https links](https://github.com/rerun-io/rerun), e.g. <https://rerun.io>.
 


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/4338

This is a very minor breaking change, where existing links in markdown to specific _components_ of an entity will break.

Before: `recording://helix/structure.Transform3D`
After: `recording://helix/structure:Transform3D`

The purpose is to allow `.` as a valid character in a path part, e.g. as `images/foo.jpg`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4471/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4471/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4471)
- [Docs preview](https://rerun.io/preview/78552b623b964323df5d64e0e17f222ead89866a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/78552b623b964323df5d64e0e17f222ead89866a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)