### PR TITLE
Fix taplo on auto crates release

### DIFF
--- a/.github/workflows/auto_release_crates.yml
+++ b/.github/workflows/auto_release_crates.yml
@@ -20,15 +20,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install taplo-cli
+        uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli
+
       - name: Install dependencies
         shell: bash
         run: |
-          python3 -m pip install -r scripts/ci/requirements.txt
+          python3 -m pip install -r scripts/ci/requirements-crates.txt
 
       - name: Update crate versions
         shell: bash
         run: |
           python3 scripts/ci/crates.py version --bump prerelease
+
+      - run: taplo fmt
+        shell: bash
 
       - name: Get bumped version
         id: versioning


### PR DESCRIPTION
### What

https://github.com/rerun-io/rerun/pull/4470/files - these automatic release PRs keep failing on `Cargo.toml` formatting, we run `taplo fmt` elsewhere on CI to deal with this. This PR adds the same thing to the `auto_release_crates` job.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4473/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4473/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4473)
- [Docs preview](https://rerun.io/preview/0c9867b9462b5031d082b4c9ebdff28741f45ce9/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0c9867b9462b5031d082b4c9ebdff28741f45ce9/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)