### PR TITLE
CI: Fix web viewer build on platforms other than linux

### DIFF
--- a/scripts/ci/build_and_upload_wheels.py
+++ b/scripts/ci/build_and_upload_wheels.py
@@ -72,7 +72,7 @@ def build_and_upload(bucket: Bucket, mode: BuildMode, gcs_dir: str, target: str,
 
     if mode is BuildMode.PYPI:
         # Only build web viewer when publishing to pypi
-        run("cargo run --locked -p re_build_web_viewer -- --release")
+        run("pixi run cargo run --locked -p re_build_web_viewer -- --release")
         maturin_feature_flags = "--no-default-features --features pypi"
     elif mode is BuildMode.PR:
         maturin_feature_flags = "--no-default-features --features extension-module"


### PR DESCRIPTION
### What

Fixes the following failure: https://github.com/rerun-io/rerun/actions/runs/7169741024/job/19521308667

The web viewer build should be run under pixi

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/{{ pr.number }}/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/{{ pr.number }}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
