### PR TITLE
Update to puffin 0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4131,9 +4131,9 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0b84517b2fb755da3a634bc030fcbc7b6337a786aa25a7fb350cdd51ab5e15"
+checksum = "02330f795caafc2007510f742624c10aa813b8c3097c77ff344b1b86eb6be846"
 dependencies = [
  "anyhow",
  "bincode",


### PR DESCRIPTION
Fixes an annoying bug where a `::{{ closure }}` suffix were added to all `profile_function!` scopes.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4475/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4475/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4475)
- [Docs preview](https://rerun.io/preview/516c67c1105ebc31ad8a08477240ce535677f3a1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/516c67c1105ebc31ad8a08477240ce535677f3a1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)