### PR TITLE
Remove unused features from `env_logger` and `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,7 +1796,6 @@ dependencies = [
  "humantime",
  "is-terminal",
  "log",
- "regex",
  "termcolor",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ directories-next = "2"
 document-features = "0.2"
 ehttp = "0.3.1"
 enumset = "1.0.12"
-env_logger = "0.10"
+env_logger = { version = "0.10", default-features = false }
 epaint = "0.23.0"
 ewebsock = "0.4.0"
 futures-channel = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ time = { version = "0.3", default-features = false, features = [
 tinyvec = { version = "1.6", features = ["alloc", "rustc_1_55"] }
 tokio = { version = "1.24", default-features = false }
 tokio-tungstenite = { version = "0.17.1", default-features = false }
-tracing = "0.1"
+tracing = { version = "0.1", default-features = false }
 tungstenite = { version = "0.17", default-features = false }
 type-map = "0.5"
 typenum = "1.15"

--- a/crates/re_log/Cargo.toml
+++ b/crates/re_log/Cargo.toml
@@ -26,7 +26,7 @@ tracing = { workspace = true, features = ["log"] }
 
 # Native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-env_logger.workspace = true
+env_logger = { workspace = true, features = ["auto-color", "humantime"] }
 
 # web dependencies:
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
### What
This improves takes the compilation time of `cargo clean && cargo build --timings -p rerun` on my M1 MacBook Pro from ~80s to ~78s (best of two runs each).

The number of dependencies went from 357 to 353, including the huge `regex` and `tracing-attributes`

The top-10 slowest crates in the dependency tree are now:

![image](https://github.com/rerun-io/rerun/assets/1148717/e12f1b35-7186-4175-a602-9a40e3ab2651)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/{{ pr.number }}/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/{{ pr.number }}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
