### PR TITLE
CI: Don't build web viewer during maturin build

### DIFF
--- a/scripts/ci/build_and_upload_wheels.py
+++ b/scripts/ci/build_and_upload_wheels.py
@@ -89,7 +89,8 @@ def build_and_upload(bucket: Bucket, mode: BuildMode, gcs_dir: str, target: str,
         "--release "
         f"--target {target} "
         f"{maturin_feature_flags} "
-        f"--out {dist}"
+        f"--out {dist}",
+        env={**os.environ, "RERUN_IS_PUBLISHING": True},  # stop `re_web_viewer` from building here
     )
 
     pkg = os.listdir(dist)[0]


### PR DESCRIPTION
### What

https://github.com/rerun-io/rerun/actions/runs/7173059338/job/19531923896

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/{{ pr.number }}/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/{{ pr.number }}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
