### PR TITLE
Fix puffin connecting on the wrong address

### DIFF
--- a/crates/re_tracing/src/server.rs
+++ b/crates/re_tracing/src/server.rs
@@ -26,7 +26,7 @@ impl Profiler {
 
     fn start_server(&mut self) {
         crate::profile_function!();
-        let bind_addr = format!("0.0.0.0:{PORT}");
+        let bind_addr = format!("0.0.0.0:{PORT}"); // Serve on all addresses.
         self.server = match puffin_http::Server::new(&bind_addr) {
             Ok(puffin_server) => {
                 re_log::info!(
@@ -44,7 +44,7 @@ impl Profiler {
 
 fn start_puffin_viewer() {
     crate::profile_function!();
-    let url = format!("0.0.0.0:{PORT}");
+    let url = format!("127.0.0.1:{PORT}"); // Connect to localhost.
     let child = std::process::Command::new("puffin_viewer")
         .arg("--url")
         .arg(&url)


### PR DESCRIPTION
### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4485/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4485/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4485)
- [Docs preview](https://rerun.io/preview/93a485c7aa0ba8be9eda0fdda16b41e1dc006a23/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/93a485c7aa0ba8be9eda0fdda16b41e1dc006a23/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)