### PR TITLE
Remove `RowId` collision log spam

### DIFF
--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -796,7 +796,7 @@ impl App {
             }
 
             if let Err(err) = store_db.add(&msg) {
-                re_log::error!("Failed to add incoming msg: {err}");
+                re_log::error_once!("Failed to add incoming msg: {err}");
             };
 
             if is_new_store && store_db.store_kind() == StoreKind::Recording {


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/4469

Lower the log level from `DEBUG` to `TRACE`.

The log spam happened anytime one loaded an .rrd exported from the viewer, or when loading any data with a clear component.

Note that `RUST_LOG=DEBUG` should be a useful debugging experience (even for our users!), and not produce too much spam.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4487/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4487/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4487)
- [Docs preview](https://rerun.io/preview/c926bb1aed5a554e5039cb2cc6dfc63d061566f1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c926bb1aed5a554e5039cb2cc6dfc63d061566f1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)