### PR TITLE
Show e2e latency in metric ui in top panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4462,6 +4462,7 @@ dependencies = [
  "criterion",
  "document-features",
  "egui_plot",
+ "emath",
  "getrandom",
  "itertools 0.11.0",
  "mimalloc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4467,6 +4467,7 @@ dependencies = [
  "itertools 0.11.0",
  "mimalloc",
  "nohash-hasher",
+ "parking_lot 0.12.1",
  "rand",
  "re_arrow_store",
  "re_format",

--- a/crates/re_data_store/Cargo.toml
+++ b/crates/re_data_store/Cargo.toml
@@ -41,6 +41,7 @@ emath.workspace = true
 getrandom.workspace = true
 itertools.workspace = true
 nohash-hasher.workspace = true
+parking_lot.workspace = true
 rmp-serde = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 thiserror.workspace = true

--- a/crates/re_data_store/Cargo.toml
+++ b/crates/re_data_store/Cargo.toml
@@ -37,6 +37,7 @@ re_types_core.workspace = true
 ahash.workspace = true
 document-features.workspace = true
 egui_plot.workspace = true
+emath.workspace = true
 getrandom.workspace = true
 itertools.workspace = true
 nohash-hasher.workspace = true

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -311,24 +311,24 @@ impl StoreDb {
         //
         // This might result in a [`ClearCascade`] if the events trigger one or more immediate
         // and/or pending clears.
-        let store_events = &[store_event];
-        self.times_per_timeline.on_events(store_events);
-        let clear_cascade = self.tree.on_store_additions(store_events);
+        let original_store_events = &[store_event];
+        self.times_per_timeline.on_events(original_store_events);
+        let clear_cascade = self.tree.on_store_additions(original_store_events);
 
         // Second-pass: update the [`DataStore`] by applying the [`ClearCascade`].
         //
         // This will in turn generate new [`StoreEvent`]s that our internal views need to be
         // notified of, again!
-        let store_events = self.on_clear_cascade(clear_cascade);
-        self.times_per_timeline.on_events(&store_events);
-        let clear_cascade = self.tree.on_store_additions(&store_events);
+        let new_store_events = self.on_clear_cascade(clear_cascade);
+        self.times_per_timeline.on_events(&new_store_events);
+        let clear_cascade = self.tree.on_store_additions(&new_store_events);
 
         // Clears don't affect `Clear` components themselves, therefore we cannot have recursive
         // cascades, thus this whole process must stabilize after one iteration.
         debug_assert!(clear_cascade.is_empty());
 
         // We inform the stats last, since it measures e2e latency.
-        self.stats.on_events(&store_events);
+        self.stats.on_events(&original_store_events);
 
         Ok(())
     }

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -328,7 +328,7 @@ impl StoreDb {
         debug_assert!(clear_cascade.is_empty());
 
         // We inform the stats last, since it measures e2e latency.
-        self.stats.on_events(&original_store_events);
+        self.stats.on_events(original_store_events);
 
         Ok(())
     }

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -108,6 +108,8 @@ pub struct StoreDb {
 
     /// Stores all components for all entities for all timelines.
     data_store: DataStore,
+
+    stats: IngestionStatistics,
 }
 
 impl StoreDb {
@@ -125,6 +127,7 @@ impl StoreDb {
                 InstanceKey::name(),
                 DataStoreConfig::default(),
             ),
+            stats: Default::default(),
         }
     }
 
@@ -225,6 +228,11 @@ impl StoreDb {
     }
 
     #[inline]
+    pub fn ingestion_stats(&self) -> &IngestionStatistics {
+        &self.stats
+    }
+
+    #[inline]
     pub fn entity_path_from_hash(&self, entity_path_hash: &EntityPathHash) -> Option<&EntityPath> {
         self.entity_path_from_hash.get(entity_path_hash)
     }
@@ -298,6 +306,8 @@ impl StoreDb {
             DEFAULT_INSERT_ROW_STEP_SIZE,
         )?;
 
+        let row_id = store_event.row_id;
+
         // First-pass: update our internal views by notifying them of resulting [`StoreEvent`]s.
         //
         // This might result in a [`ClearCascade`] if the events trigger one or more immediate
@@ -317,6 +327,8 @@ impl StoreDb {
         // Clears don't affect `Clear` components themselves, therefore we cannot have recursive
         // cascades, thus this whole process must stabilize after one iteration.
         debug_assert!(clear_cascade.is_empty());
+
+        self.stats.on_new_row_id(row_id);
 
         Ok(())
     }
@@ -462,6 +474,7 @@ impl StoreDb {
             times_per_timeline,
             tree,
             data_store: _,
+            stats: _,
         } = self;
 
         times_per_timeline.on_events(store_events);
@@ -475,5 +488,49 @@ impl StoreDb {
     pub fn sort_key(&self) -> impl Ord + '_ {
         self.store_info()
             .map(|info| (info.application_id.0.as_str(), info.started))
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct IngestionStatistics {
+    e2e_latency_sec_history: emath::History<f32>,
+}
+
+impl Default for IngestionStatistics {
+    fn default() -> Self {
+        let min_samples = 0; // 0: we stop displaying e2e latency if input stops
+        let max_samples = 1024; // don't waste too much memory on this - we just need enough to get a good average
+        let max_age = 1.0; // don't keep too long of a rolling average, or the stats get outdated.
+        Self {
+            e2e_latency_sec_history: emath::History::new(min_samples..max_samples, max_age),
+        }
+    }
+}
+
+impl IngestionStatistics {
+    pub fn on_new_row_id(&mut self, row_id: RowId) {
+        if let Ok(duration_since_epoch) = web_time::SystemTime::UNIX_EPOCH.elapsed() {
+            let nanos_since_epoch = duration_since_epoch.as_nanos() as u64;
+
+            // This only makes sense if the clocks are very good, i.e. if the recording was on the same machine!
+            if let Some(nanos_since_log) =
+                nanos_since_epoch.checked_sub(row_id.nanoseconds_since_epoch())
+            {
+                let now = nanos_since_epoch as f64 / 1e9;
+                let sec_since_log = nanos_since_log as f32 / 1e9;
+
+                self.e2e_latency_sec_history.add(now, sec_since_log);
+            }
+        }
+    }
+
+    /// What is the mean latency between the time data was logged in the SDK and the time it was ingested?
+    ///
+    /// This is based on the clocks of the viewer and the SDK being in sync,
+    /// so if the recording was done on another machine, this is likely very inaccurate.
+    pub fn current_e2e_latency_sec(&self) -> Option<f32> {
+        self.e2e_latency_sec_history.average()
     }
 }

--- a/crates/re_log_types/src/data_row.rs
+++ b/crates/re_log_types/src/data_row.rs
@@ -185,6 +185,12 @@ impl RowId {
     pub fn incremented_by(&self, n: u64) -> Self {
         Self(self.0.incremented_by(n))
     }
+
+    /// When the `RowId` was created, in nanoseconds since unix epoch.
+    #[inline]
+    pub fn nanoseconds_since_epoch(&self) -> u64 {
+        self.0.nanoseconds_since_epoch()
+    }
 }
 
 impl SizeBytes for RowId {

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -881,7 +881,11 @@ impl RecordingStream {
         } else {
             splatted.push(DataCell::from_native([InstanceKey::SPLAT]));
             Some(DataRow::from_cells(
-                row_id, timepoint, ent_path, 1, splatted,
+                row_id.incremented_by(1), // we need a unique RowId from what is used for the instanced data
+                timepoint,
+                ent_path,
+                1,
+                splatted,
             )?)
         };
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -206,6 +206,11 @@ impl App {
 
         let component_ui_registry = re_data_ui::create_component_ui_registry();
 
+        // TODO(emilk): `Instant::MIN` when we have our own `Instant` that supports it.;
+        let long_time_ago = web_time::Instant::now()
+            .checked_sub(web_time::Duration::from_secs(1_000_000_000))
+            .unwrap_or(web_time::Instant::now());
+
         Self {
             build_info,
             startup_options,
@@ -230,7 +235,7 @@ impl App {
 
             style_panel_open: false,
 
-            latest_queue_interest: web_time::Instant::now(), // TODO(emilk): `Instant::MIN` when we have our own `Instant` that supports it.
+            latest_queue_interest: long_time_ago,
 
             frame_time_history: egui::util::History::new(1..100, 0.5),
 

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -63,7 +63,8 @@ fn top_bar_ui(
         ui.separator();
         frame_time_label_ui(ui, app);
         memory_use_label_ui(ui, gpu_resource_stats);
-        input_latency_label_ui(ui, app);
+
+        latency_ui(ui, app, store_context);
     }
 
     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -352,7 +353,75 @@ fn memory_use_label_ui(ui: &mut egui::Ui, gpu_resource_stats: &WgpuResourcePoolS
     }
 }
 
-fn input_latency_label_ui(ui: &mut egui::Ui, app: &mut App) {
+fn latency_ui(ui: &mut egui::Ui, app: &mut App, store_context: Option<&StoreContext<'_>>) {
+    if let Some(response) = e2e_latency_ui(ui, app, store_context) {
+        // Show queue latency on hover, as that is part of this.
+        // For instance, if the framerate is really bad we have less time to ingest incoming data,
+        // leading to an ever-increasing input queue.
+        let rx = app.msg_receive_set();
+        let queue_len = rx.queue_len();
+        let latency_sec = rx.latency_ns() as f32 / 1e9;
+        // empty queue == unreliable latency
+        if 0 < queue_len {
+            response.on_hover_ui(|ui| {
+                ui.label(format!(
+                    "Queue latency: {}, length: {}",
+                    latency_text(latency_sec),
+                    format_number(queue_len),
+                ));
+
+                ui.label(
+                    "When more data is arriving over network than the Rerun Viewer can ingest, a queue starts building up, leading to latency and increased RAM use.\n\
+                         We call this the queue latency.");
+            });
+        }
+    } else {
+        // If we don't know the e2e latency we can still show the queue latency.
+        input_queue_latency_ui(ui, app);
+    }
+}
+
+/// Shows the e2e latency.
+fn e2e_latency_ui(
+    ui: &mut egui::Ui,
+    app: &App,
+    store_context: Option<&StoreContext<'_>>,
+) -> Option<egui::Response> {
+    let Some(store_context) = store_context else {
+        return None;
+    };
+
+    let Some(recording) = store_context.recording else {
+        return None;
+    };
+
+    let Some(e2e_latency_sec) = recording.ingestion_stats().current_e2e_latency_sec() else {
+        return None;
+    };
+
+    if e2e_latency_sec > 60.0 {
+        return None; // Probably an old recording and not live data.
+    }
+
+    let text = format!("e2e latency: {}", latency_text(e2e_latency_sec));
+
+    let hover_text = "End-to-end latency from when the data was logged by the SDK to when it is shown in the viewer.\n\
+                      This includes time for encoding, network latency, and decoding.\n\
+                      It is also affected by the framerate of the viewer.\n\
+                      This latency is inaccurate if the logging was done on a different machine, since it is clock-based.";
+
+    let response = if e2e_latency_sec < app.app_options().warn_latency {
+        ui.weak(text).on_hover_text(hover_text)
+    } else {
+        ui.label(app.re_ui().warning_text(text))
+            .on_hover_text(hover_text)
+    };
+
+    Some(response)
+}
+
+/// Shows the latency in the input queue.
+fn input_queue_latency_ui(ui: &mut egui::Ui, app: &mut App) {
     let rx = app.msg_receive_set();
 
     if rx.is_empty() {
@@ -374,12 +443,12 @@ fn input_latency_label_ui(ui: &mut egui::Ui, app: &mut App) {
         ui.separator();
         if is_latency_interesting {
             let text = format!(
-                "Latency: {:.2}s, queue: {}",
-                latency_sec,
+                "Queue latency: {}, length: {}",
+                latency_text(latency_sec),
                 format_number(queue_len),
             );
             let hover_text =
-                    "When more data is arriving over network than the Rerun Viewer can index, a queue starts building up, leading to latency and increased RAM use.\n\
+                    "When more data is arriving over network than the Rerun Viewer can ingest, a queue starts building up, leading to latency and increased RAM use.\n\
                     This latency does NOT include network latency.";
 
             if latency_sec < app.app_options().warn_latency {
@@ -392,5 +461,13 @@ fn input_latency_label_ui(ui: &mut egui::Ui, app: &mut App) {
             ui.weak(format!("Queue: {}", format_number(queue_len)))
                 .on_hover_text("Number of messages in the inbound queue");
         }
+    }
+}
+
+fn latency_text(latency_sec: f32) -> String {
+    if latency_sec < 1.0 {
+        format!("{:.0}ms", 1e3 * latency_sec)
+    } else {
+        format!("{latency_sec:.1}s")
     }
 }

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -402,14 +402,15 @@ fn e2e_latency_ui(
         return None; // Probably an old recording and not live data.
     }
 
-    let text = format!("e2e latency: {}", latency_text(e2e_latency_sec));
+    let text = format!("latency: {}", latency_text(e2e_latency_sec));
+    let response = ui.weak(text);
 
     let hover_text = "End-to-end latency from when the data was logged by the SDK to when it is shown in the viewer.\n\
                       This includes time for encoding, network latency, and decoding.\n\
                       It is also affected by the framerate of the viewer.\n\
                       This latency is inaccurate if the logging was done on a different machine, since it is clock-based.";
 
-    Some(ui.weak(text).on_hover_text(hover_text))
+    Some(response.on_hover_text(hover_text))
 }
 
 /// Shows the latency in the input queue.
@@ -458,8 +459,8 @@ fn input_queue_latency_ui(ui: &mut egui::Ui, app: &mut App) {
 
 fn latency_text(latency_sec: f32) -> String {
     if latency_sec < 1.0 {
-        format!("{:.0}ms", 1e3 * latency_sec)
+        format!("{:.0} ms", 1e3 * latency_sec)
     } else {
-        format!("{latency_sec:.1}s")
+        format!("{latency_sec:.1} s")
     }
 }

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -354,7 +354,7 @@ fn memory_use_label_ui(ui: &mut egui::Ui, gpu_resource_stats: &WgpuResourcePoolS
 }
 
 fn latency_ui(ui: &mut egui::Ui, app: &mut App, store_context: Option<&StoreContext<'_>>) {
-    if let Some(response) = e2e_latency_ui(ui, app, store_context) {
+    if let Some(response) = e2e_latency_ui(ui, store_context) {
         // Show queue latency on hover, as that is part of this.
         // For instance, if the framerate is really bad we have less time to ingest incoming data,
         // leading to an ever-increasing input queue.
@@ -384,7 +384,6 @@ fn latency_ui(ui: &mut egui::Ui, app: &mut App, store_context: Option<&StoreCont
 /// Shows the e2e latency.
 fn e2e_latency_ui(
     ui: &mut egui::Ui,
-    app: &App,
     store_context: Option<&StoreContext<'_>>,
 ) -> Option<egui::Response> {
     let Some(store_context) = store_context else {
@@ -410,14 +409,7 @@ fn e2e_latency_ui(
                       It is also affected by the framerate of the viewer.\n\
                       This latency is inaccurate if the logging was done on a different machine, since it is clock-based.";
 
-    let response = if e2e_latency_sec < app.app_options().warn_latency {
-        ui.weak(text).on_hover_text(hover_text)
-    } else {
-        ui.label(app.re_ui().warning_text(text))
-            .on_hover_text(hover_text)
-    };
-
-    Some(response)
+    Some(ui.weak(text).on_hover_text(hover_text))
 }
 
 /// Shows the latency in the input queue.

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -579,6 +579,8 @@ fn rr_log_impl(
     data_row: CDataRow,
     inject_time: bool,
 ) -> Result<(), CError> {
+    let row_id = re_sdk::log::RowId::new(); // Create row-id as early as possible. It has a timestamp and is used to estimate e2e latency.
+
     let stream = recording_stream(stream)?;
 
     let CDataRow {
@@ -649,7 +651,7 @@ fn rr_log_impl(
     }
 
     let data_row = DataRow::from_cells(
-        re_sdk::log::RowId::new(),
+        row_id,
         TimePoint::default(), // we use the one in the recording stream for now
         entity_path,
         num_instances,

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -579,7 +579,9 @@ fn rr_log_impl(
     data_row: CDataRow,
     inject_time: bool,
 ) -> Result<(), CError> {
-    let row_id = re_sdk::log::RowId::new(); // Create row-id as early as possible. It has a timestamp and is used to estimate e2e latency.
+    // Create row-id as early as possible. It has a timestamp and is used to estimate e2e latency.
+    // TODO(emilk): move to before we arrow-serialize the data
+    let row_id = re_sdk::log::RowId::new();
 
     let stream = recording_stream(stream)?;
 

--- a/rerun_py/src/arrow.rs
+++ b/rerun_py/src/arrow.rs
@@ -50,7 +50,9 @@ pub fn build_data_row_from_components(
     components: &PyDict,
     time_point: &TimePoint,
 ) -> PyResult<DataRow> {
-    let row_id = RowId::new(); // Create row-id as early as possible. It has a timestamp and is used to estimate e2e latency.
+    // Create row-id as early as possible. It has a timestamp and is used to estimate e2e latency.
+    // TODO(emilk): move to before we arrow-serialize the data
+    let row_id = RowId::new();
 
     let (arrays, fields): (Vec<Box<dyn Array>>, Vec<Field>) = itertools::process_results(
         components.iter().map(|(name, array)| {

--- a/rerun_py/src/arrow.rs
+++ b/rerun_py/src/arrow.rs
@@ -50,6 +50,8 @@ pub fn build_data_row_from_components(
     components: &PyDict,
     time_point: &TimePoint,
 ) -> PyResult<DataRow> {
+    let row_id = RowId::new(); // Create row-id as early as possible. It has a timestamp and is used to estimate e2e latency.
+
     let (arrays, fields): (Vec<Box<dyn Array>>, Vec<Field>) = itertools::process_results(
         components.iter().map(|(name, array)| {
             let name = name.downcast::<PyString>()?.to_str()?;
@@ -66,7 +68,7 @@ pub fn build_data_row_from_components(
 
     let num_instances = cells.first().map_or(0, |cell| cell.num_instances());
     let row = DataRow::from_cells(
-        RowId::new(),
+        row_id,
         time_point.clone(),
         entity_path.clone(),
         num_instances,


### PR DESCRIPTION
### What
When the top panel metrics are enabled, you will now see the e2e latency, from when `log` is called in the SDK to when the data is added to the data store in the viewer.

This is only accurate if the logging SDK is running on the same machine as the viewer (or if the clocks on the two machines are very closely synced).

Example when running `examples/python/live_camera_edge_detection/main.py`:

![image](https://github.com/rerun-io/rerun/assets/1148717/ce7bd082-d06b-4220-8f9e-ad2d7513dd2f)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4502/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4502/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4502)
- [Docs preview](https://rerun.io/preview/34843c640f3e411bbca05917de81e68c696a8844/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/34843c640f3e411bbca05917de81e68c696a8844/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)