### PR TITLE
Add a new "🪵 Log-API" GitHub label

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -36,4 +36,4 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "📊 analytics, , 🟦 blueprint, 🪳 bug, C/C++ SDK, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 📉 performance, 🐍 python API, ⛃ re_datastore, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🦀 rust SDK, 🔨 testing, ui, 🕸️ web"
+          labels: "📊 analytics, , 🟦 blueprint, 🪳 bug, 🌊 C++ API, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 🪵 Log-API, 📉 performance, 🐍 Python API, ⛃ re_datastore, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🦀 Rust API, 🔨 testing, ui, 🕸️ web"

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -122,7 +122,7 @@ def print_section(title: str, items: list[str]) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate a changelog.")
-    parser.add_argument("--commit-range", default="latest..HEAD", help="e.g. 0.8.0..HEAD")
+    parser.add_argument("--commit-range", help="e.g. 0.11.0..HEAD")
     args = parser.parse_args()
 
     # Because how we branch, we sometimes get duplicate commits in the changelog unless we check for it
@@ -153,6 +153,7 @@ def main() -> None:
     docs = []
     enhancement = []
     examples = []
+    log_api = []
     misc = []
     performance = []
     python = []
@@ -208,16 +209,21 @@ def main() -> None:
 
             added = False
 
-            # Some PRs can show up underm multiple sections:
-            if "C/C++ SDK" in labels:
-                cpp.append(summary)
+            # Some PRs can show up under multiple sections:
+            if "🪵 Log-API" in labels:
+                log_api.append(summary)
                 added = True
-            if "🐍 python API" in labels:
-                python.append(summary)
-                added = True
-            if "🦀 rust SDK" in labels:
-                rust.append(summary)
-                added = True
+            else:
+                if "🌊 C++ API" in labels:
+                    cpp.append(summary)
+                    added = True
+                if "🐍 Python API" in labels:
+                    python.append(summary)
+                    added = True
+                if "🦀 Rust API" in labels:
+                    rust.append(summary)
+                    added = True
+
             if "📊 analytics" in labels:
                 analytics.append(summary)
                 added = True
@@ -255,9 +261,10 @@ def main() -> None:
     print()
 
     # Most interesting first:
-    print_section("🌊 C++ SDK", cpp)
-    print_section("🐍 Python SDK", python)
-    print_section("🦀 Rust SDK", rust)
+    print_section("🪵 Log API", log_api)
+    print_section("🌊 C++ API", cpp)
+    print_section("🐍 Python API", python)
+    print_section("🦀 Rust API", rust)
     print_section("🪳 Bug Fixes", bugs)
     print_section("🌁 Viewer Improvements", viewer)
     print_section("🚀 Performance Improvements", performance)


### PR DESCRIPTION
### What

The new label "🪵 Log API" means "stuff that affects all the APIs". This include changes to `re_types` and (relevantly) changes to how entity paths works (https://github.com/rerun-io/rerun/pull/4476).

I also gave uniform names to the other labels:

* 🌊 C++ API
* 🐍 Python API
* 🦀 Rust API

_some_ of these used "SDK" before, but that felt too over-arching since SDK implies a full kit, including the `rerun` binary, the web viewer, etc - but the language specific things is just the API surface.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4508/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4508/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4508)
- [Docs preview](https://rerun.io/preview/a9278cf8ec9bc1353be9910bd2c4394642a64308/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a9278cf8ec9bc1353be9910bd2c4394642a64308/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)