### PR TITLE
Standard input/output support 2: Rust SDK stdout impl/examples/docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4768,6 +4768,7 @@ version = "0.12.0-alpha.1+dev"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
+ "atty",
  "crossbeam",
  "document-features",
  "itertools 0.11.0",
@@ -6144,6 +6145,13 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdio"
+version = "0.12.0-alpha.1+dev"
+dependencies = [
+ "rerun",
+]
 
 [[package]]
 name = "str-buf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,6 +2542,15 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"

--- a/crates/re_data_source/src/load_stdin.rs
+++ b/crates/re_data_source/src/load_stdin.rs
@@ -4,7 +4,7 @@ use re_smart_channel::Sender;
 /// Asynchronously loads RRD data streaming in from standard input.
 ///
 /// This fails synchronously iff the standard input stream could not be opened, otherwise errors
-/// are handlded asynchronously (as in: they're logged).
+/// are handled asynchronously (as in: they're logged).
 pub fn load_stdin(tx: Sender<LogMsg>) -> anyhow::Result<()> {
     let version_policy = re_log_encoding::decoder::VersionPolicy::Warn;
 

--- a/crates/re_log_encoding/src/file_sink.rs
+++ b/crates/re_log_encoding/src/file_sink.rs
@@ -116,6 +116,7 @@ impl FileSink {
     }
 }
 
+/// Set `filepath` to `None` to stream to standard output.
 fn spawn_and_stream<W: std::io::Write + Send + 'static>(
     filepath: Option<&std::path::Path>,
     mut encoder: crate::encoder::Encoder<W>,
@@ -159,7 +160,7 @@ impl fmt::Debug for FileSink {
         f.debug_struct("FileSink")
             .field(
                 "path",
-                &self.path.as_ref().cloned().unwrap_or("stdin".into()),
+                &self.path.as_ref().cloned().unwrap_or("stdout".into()),
             )
             .finish_non_exhaustive()
     }

--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -51,6 +51,7 @@ re_sdk_comms = { workspace = true, features = ["client"] }
 re_types_core.workspace = true
 
 ahash.workspace = true
+atty.workspace = true
 crossbeam.workspace = true
 document-features.workspace = true
 once_cell.workspace = true

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -356,6 +356,9 @@ impl RecordingStreamBuilder {
 
     /// Creates a new [`RecordingStream`] that is pre-configured to stream the data through to stdout.
     ///
+    /// If there isn't any listener at the other end of the pipe, the [`RecordingStream`] will
+    /// default back to `buffered` mode, in order not to break the user's terminal.
+    ///
     /// ## Example
     ///
     /// ```no_run
@@ -1354,6 +1357,9 @@ impl RecordingStream {
 
     /// Swaps the underlying sink for a [`crate::sink::FileSink`] pointed at stdout.
     ///
+    /// If there isn't any listener at the other end of the pipe, the [`RecordingStream`] will
+    /// default back to `buffered` mode, in order not to break the user's terminal.
+    ///
     /// This is a convenience wrapper for [`Self::set_sink`] that upholds the same guarantees in
     /// terms of data durability and ordering.
     /// See [`Self::set_sink`] for more information.
@@ -1365,6 +1371,7 @@ impl RecordingStream {
 
         let is_stdout_listening = !atty::is(atty::Stream::Stdout);
         if !is_stdout_listening {
+            self.set_sink(Box::new(crate::log_sink::BufferedSink::new()));
             return Ok(());
         }
 

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -354,6 +354,35 @@ impl RecordingStreamBuilder {
         }
     }
 
+    /// Creates a new [`RecordingStream`] that is pre-configured to stream the data through to stdout.
+    ///
+    /// ## Example
+    ///
+    /// ```no_run
+    /// let rec = re_sdk::RecordingStreamBuilder::new("rerun_example_app").stdout()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn stdout(self) -> RecordingStreamResult<RecordingStream> {
+        let is_stdout_listening = !atty::is(atty::Stream::Stdout);
+        if !is_stdout_listening {
+            return self.buffered();
+        }
+
+        let (enabled, store_info, batcher_config) = self.into_args();
+
+        if enabled {
+            RecordingStream::new(
+                store_info,
+                batcher_config,
+                Box::new(crate::sink::FileSink::stdout()?),
+            )
+        } else {
+            re_log::debug!("Rerun disabled - call to stdout() ignored");
+            Ok(RecordingStream::disabled())
+        }
+    }
+
     /// Spawns a new Rerun Viewer process from an executable available in PATH, then creates a new
     /// [`RecordingStream`] that is pre-configured to stream the data through to that viewer over TCP.
     ///
@@ -1318,6 +1347,28 @@ impl RecordingStream {
         }
 
         let sink = crate::sink::FileSink::new(path)?;
+        self.set_sink(Box::new(sink));
+
+        Ok(())
+    }
+
+    /// Swaps the underlying sink for a [`crate::sink::FileSink`] pointed at stdout.
+    ///
+    /// This is a convenience wrapper for [`Self::set_sink`] that upholds the same guarantees in
+    /// terms of data durability and ordering.
+    /// See [`Self::set_sink`] for more information.
+    pub fn stdout(&self) -> Result<(), crate::sink::FileSinkError> {
+        if forced_sink_path().is_some() {
+            re_log::debug!("Ignored setting new file since _RERUN_FORCE_SINK is set");
+            return Ok(());
+        }
+
+        let is_stdout_listening = !atty::is(atty::Stream::Stdout);
+        if !is_stdout_listening {
+            return Ok(());
+        }
+
+        let sink = crate::sink::FileSink::stdout()?;
         self.set_sink(Box::new(sink));
 
         Ok(())

--- a/docs/content/reference/sdk-operating-modes.md
+++ b/docs/content/reference/sdk-operating-modes.md
@@ -76,7 +76,7 @@ Use [`rr.save`](https://ref.rerun.io/docs/python/stable/common/initialization_fu
 Use [`RecordingStream::save`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.save).
 
 
-## Standard Input/Ouput
+## Standard Input/Output
 
 Streams all logging data to standard output, which can then be loaded by the Rerun Viewer by streaming it from standard input.
 

--- a/docs/content/reference/sdk-operating-modes.md
+++ b/docs/content/reference/sdk-operating-modes.md
@@ -75,6 +75,18 @@ Use [`rr.save`](https://ref.rerun.io/docs/python/stable/common/initialization_fu
 #### Rust
 Use [`RecordingStream::save`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.save).
 
+
+## Standard Input/Ouput
+
+Streams all logging data to standard output, which can then be loaded by the Rerun Viewer by streaming it from standard input.
+
+#### Rust
+
+Use [`RecordingStream::stdout`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.stdout?speculative-link).
+
+Check out our [dedicated example](https://github.com/rerun-io/rerun/tree/latest/examples/rust/stdio/src/main.rs?speculative-link).
+
+
 ## Adding the standard flags to your programs
 
 We provide helpers for both Python & Rust to effortlessly add and properly handle all of these flags in your programs.

--- a/examples/rust/stdio/Cargo.toml
+++ b/examples/rust/stdio/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "stdio"
+version = "0.12.0-alpha.1+dev"
+edition = "2021"
+rust-version = "1.72"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+rerun = { path = "../../../crates/rerun" }

--- a/examples/rust/stdio/README.md
+++ b/examples/rust/stdio/README.md
@@ -1,0 +1,21 @@
+---
+title: Standard Input/Output example
+python: https://github.com/rerun-io/rerun/tree/latest/examples/python/stdio/main.py?speculative-link
+rust: https://github.com/rerun-io/rerun/tree/latest/examples/rust/stdio/src/main.rs?speculative-link
+cpp: https://github.com/rerun-io/rerun/tree/latest/examples/cpp/stdio/main.cpp?speculative-link
+thumbnail: https://static.rerun.io/stdio/25c5aba992d4c8b3861386d8d9539a4823dca117/480w.png
+---
+
+<picture>
+  <img src="https://static.rerun.io/stdio/25c5aba992d4c8b3861386d8d9539a4823dca117/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/stdio/25c5aba992d4c8b3861386d8d9539a4823dca117/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/stdio/25c5aba992d4c8b3861386d8d9539a4823dca117/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/stdio/25c5aba992d4c8b3861386d8d9539a4823dca117/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/stdio/25c5aba992d4c8b3861386d8d9539a4823dca117/1200w.png">
+</picture>
+
+Demonstrates how to log data to standard output with the Rerun SDK, and then visualize it from standard input with the Rerun Viewer.
+
+```bash
+echo 'hello from stdin!' | cargo run | rerun
+```

--- a/examples/rust/stdio/README.md
+++ b/examples/rust/stdio/README.md
@@ -17,5 +17,5 @@ thumbnail: https://static.rerun.io/stdio/25c5aba992d4c8b3861386d8d9539a4823dca11
 Demonstrates how to log data to standard output with the Rerun SDK, and then visualize it from standard input with the Rerun Viewer.
 
 ```bash
-echo 'hello from stdin!' | cargo run | rerun
+echo 'hello from stdin!' | cargo run | rerun -
 ```

--- a/examples/rust/stdio/src/main.rs
+++ b/examples/rust/stdio/src/main.rs
@@ -1,5 +1,10 @@
 //! Demonstrates how to log data to standard output with the Rerun SDK, and then visualize it
 //! from standard input with the Rerun Viewer.
+//!
+//! Usage:
+//! ```text
+//! echo 'hello from stdin!' | cargo run | rerun -
+//! ```
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_stdio").stdout()?;

--- a/examples/rust/stdio/src/main.rs
+++ b/examples/rust/stdio/src/main.rs
@@ -1,0 +1,15 @@
+//! Demonstrates how to log data to standard output with the Rerun SDK, and then visualize it
+//! from standard input with the Rerun Viewer.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_stdio").stdout()?;
+
+    let input = std::io::stdin()
+        .lines()
+        .collect::<Result<Vec<_>, _>>()?
+        .join("\n");
+
+    rec.log("stdin", &rerun::TextDocument::new(input))?;
+
+    Ok(())
+}


### PR DESCRIPTION
Allow the Rust SDK to stream RRD data to stdout.

Checks:
- [x] `just py-build && echo 'hello from stdin!' | cargo run -p stdio | rerun -`

---

Part of a small PR series to add stdio streaming support to our Viewer and SDKs:
- #4511
- #4512 
- #4513
- #4514

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4511/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4511/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4511)
- [Docs preview](https://rerun.io/preview/01986039192584ae9a81cb5d678efb64f6ac00f7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/01986039192584ae9a81cb5d678efb64f6ac00f7/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)