### PR TITLE
`DataLoader`s 0: utility for hierarchical `EntityPath` from file path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4641,6 +4641,7 @@ dependencies = [
  "arrow2",
  "backtrace",
  "bytemuck",
+ "clean-path",
  "criterion",
  "crossbeam",
  "document-features",

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -50,6 +50,7 @@ arrow2 = { workspace = true, features = [
 ] }
 backtrace.workspace = true
 bytemuck.workspace = true
+clean-path.workspace = true
 document-features.workspace = true
 fixed = { workspace = true, default-features = false, features = ["serde"] }
 # `fixed` depends on `half`, so even though `half` is not directly used in this crate,

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -131,9 +131,6 @@ impl EntityPath {
             file_path
                 .clean()
                 .iter()
-                // NOTE: This can only happen when hitting the leading `/` in an absolute path, and
-                // we currently don't support entity paths with leading `/`s.
-                .filter(|p| p != &std::ffi::OsStr::new("/"))
                 .map(|p| EntityPathPart::from(p.to_string_lossy().to_string()))
                 .collect(),
         )

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -118,9 +118,25 @@ impl EntityPath {
     ///
     /// The file path separators will NOT become splits in the new path.
     /// The returned path will only have one part.
-    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_file_path_as_single_string(file_path: &std::path::Path) -> Self {
         Self::from_single_string(file_path.to_string_lossy().to_string())
+    }
+
+    /// Treat the file path as an entity path hierarchy.
+    ///
+    /// The file path separators will become splits in the new path.
+    pub fn from_file_path(file_path: &std::path::Path) -> Self {
+        use clean_path::Clean as _;
+        Self::new(
+            file_path
+                .clean()
+                .iter()
+                // NOTE: This can only happen when hitting the leading `/` in an absolute path, and
+                // we currently don't support entity paths with leading `/`s.
+                .filter(|p| p != &std::ffi::OsStr::new("/"))
+                .map(|p| EntityPathPart::from(p.to_string_lossy().to_string()))
+                .collect(),
+        )
     }
 
     /// Treat the string as one opaque string, NOT splitting on any slashes.


### PR DESCRIPTION
A trivial PR that I extracted into its own in case this ends up being controversial.

---

Part of a series of PRs to make it possible to load _any_ file from the local filesystem, by any means, on web and native:
- #4516
- #4517 
- #4518 
- #4519 
- #4520 
- #4521 
- TODO: register custom loaders
- TODO: high level docs and guides for everything related to loading files

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4516/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4516/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4516)
- [Docs preview](https://rerun.io/preview/4471437b0d0bb6677dc0d92d338818339359f644/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4471437b0d0bb6677dc0d92d338818339359f644/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)