### PR TITLE
Refactor `EntityTree`

### DIFF
--- a/crates/re_data_store/src/entity_tree.rs
+++ b/crates/re_data_store/src/entity_tree.rs
@@ -446,7 +446,7 @@ impl EntityTree {
         // Only keep events relevant to this branch of the tree.
         let filtered_events = store_events
             .iter()
-            .filter(|e| &e.entity_path == path || e.entity_path.is_descendant_of(path))
+            .filter(|e| e.entity_path.starts_with(path))
             .copied() // NOTE: not actually copying, just removing the superfluous ref layer
             .collect_vec();
 

--- a/crates/re_data_store/src/entity_tree.rs
+++ b/crates/re_data_store/src/entity_tree.rs
@@ -175,7 +175,8 @@ impl EntityTree {
         self.children.len() + self.time_histograms_per_component.len()
     }
 
-    pub fn num_timeless_messages(&self) -> u64 {
+    /// Number of timeless messages in this tree, or any child, recursively.
+    pub fn num_timeless_messages_recursive(&self) -> u64 {
         self.recursive_time_histogram.num_timeless_messages()
     }
 

--- a/crates/re_data_store/src/entity_tree.rs
+++ b/crates/re_data_store/src/entity_tree.rs
@@ -25,7 +25,7 @@ pub struct EntityTree {
     /// Full path prefix to the root of this (sub)tree.
     pub path: EntityPath,
 
-    /// Direct decendants of this (sub)tree.
+    /// Direct descendants of this (sub)tree.
     pub children: BTreeMap<EntityPathPart, EntityTree>,
 
     /// Information about this specific entity (excluding children).
@@ -257,7 +257,7 @@ impl EntityTree {
         for (i, part) in entity_path.iter().enumerate() {
             tree = tree.children.entry(part.clone()).or_insert_with(|| {
                 EntityTree::new(
-                    entity_path.as_slice()[..i + 1].into(),
+                    entity_path.as_slice()[..=i].into(),
                     tree.subtree.clears.clone(),
                 )
             });

--- a/crates/re_data_store/src/entity_tree.rs
+++ b/crates/re_data_store/src/entity_tree.rs
@@ -32,7 +32,7 @@ pub struct EntityTree {
     pub entity: EntityInfo,
 
     /// Info about this subtree, including all children, recursively.
-    pub subtree: RecursiveTreeInfo,
+    pub subtree: SubtreeInfo,
 }
 
 // NOTE: This is only to let people know that this is in fact a [`StoreSubscriber`], so they A) don't try
@@ -76,7 +76,7 @@ pub struct EntityInfo {
 
 /// Info about stuff at a given [`EntityPath`], including all of its children, recursively.
 #[derive(Default)]
-pub struct RecursiveTreeInfo {
+pub struct SubtreeInfo {
     /// Book-keeping around whether we should clear recursively when data is added.
     clears: BTreeMap<RowId, TimePoint>,
 
@@ -90,7 +90,7 @@ pub struct RecursiveTreeInfo {
     pub time_histogram: TimeHistogramPerTimeline,
 }
 
-impl RecursiveTreeInfo {
+impl SubtreeInfo {
     /// Assumes the event has been filtered to be part of this subtree.
     fn on_event(&mut self, event: &StoreEvent) {
         match event.kind {
@@ -196,7 +196,7 @@ impl EntityTree {
                 clears: recursive_clears.clone(),
                 ..Default::default()
             },
-            subtree: RecursiveTreeInfo {
+            subtree: SubtreeInfo {
                 clears: recursive_clears,
                 ..Default::default()
             },

--- a/crates/re_data_store/src/entity_tree.rs
+++ b/crates/re_data_store/src/entity_tree.rs
@@ -29,10 +29,10 @@ pub struct EntityTree {
     pub children: BTreeMap<EntityPathPart, EntityTree>,
 
     /// Book-keeping around whether we should clear fields when data is added.
-    pub flat_clears: BTreeMap<RowId, TimePoint>,
+    flat_clears: BTreeMap<RowId, TimePoint>,
 
     /// Book-keeping around whether we should clear recursively when data is added.
-    pub recursive_clears: BTreeMap<RowId, TimePoint>,
+    recursive_clears: BTreeMap<RowId, TimePoint>,
 
     /// Flat time histograms for each component of this [`EntityTree`].
     ///

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -198,7 +198,7 @@ impl StoreDb {
 
     /// Historgram of all events on the timeeline, of all entities.
     pub fn time_histogram(&self, timeline: &Timeline) -> Option<&crate::TimeHistogram> {
-        self.tree().recursive_info.time_histogram.get(timeline)
+        self.tree().subtree.time_histogram.get(timeline)
     }
 
     /// Total number of timeless messages for any entity.

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -198,7 +198,7 @@ impl StoreDb {
 
     /// Historgram of all events on the timeeline, of all entities.
     pub fn time_histogram(&self, timeline: &Timeline) -> Option<&crate::TimeHistogram> {
-        self.tree().recursive_time_histogram.get(timeline)
+        self.tree().recursive_info.time_histogram.get(timeline)
     }
 
     /// Total number of timeless messages for any entity.

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -196,7 +196,7 @@ impl StoreDb {
         &self.times_per_timeline
     }
 
-    /// Historgram of all events on the timeeline, of all entities.
+    /// Histogram of all events on the timeeline, of all entities.
     pub fn time_histogram(&self, timeline: &Timeline) -> Option<&crate::TimeHistogram> {
         self.tree().subtree.time_histogram.get(timeline)
     }

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -196,6 +196,7 @@ impl StoreDb {
         &self.times_per_timeline
     }
 
+    /// Historgram of all events on the timeeline, of all entities.
     pub fn time_histogram(&self, timeline: &Timeline) -> Option<&crate::TimeHistogram> {
         self.tree().recursive_time_histogram.get(timeline)
     }

--- a/crates/re_data_store/src/store_db.rs
+++ b/crates/re_data_store/src/store_db.rs
@@ -200,8 +200,9 @@ impl StoreDb {
         self.tree().recursive_time_histogram.get(timeline)
     }
 
+    /// Total number of timeless messages for any entity.
     pub fn num_timeless_messages(&self) -> u64 {
-        self.tree.num_timeless_messages()
+        self.tree.num_timeless_messages_recursive()
     }
 
     pub fn num_rows(&self) -> usize {

--- a/crates/re_data_ui/src/component_path.rs
+++ b/crates/re_data_ui/src/component_path.rs
@@ -37,10 +37,7 @@ impl DataUi for ComponentPath {
             }
             .data_ui(ctx, ui, verbosity, query);
         } else if let Some(entity_tree) = ctx.store_db.tree().subtree(entity_path) {
-            if entity_tree
-                .time_histograms_per_component
-                .contains_key(component_name)
-            {
+            if entity_tree.entity.components.contains_key(component_name) {
                 ui.label("<unset>");
             } else {
                 ui.label(format!(

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -76,7 +76,7 @@ impl std::fmt::Debug for EntityPathHash {
 ///
 /// See <https://www.rerun.io/docs/concepts/entity-path> for more on entity paths.
 ///
-/// `EntityPath` is reference-counted internally, so it is cheap to clone.
+/// This is basically implemented as a list of strings, but is reference-counted internally, so it is cheap to clone.
 /// It also has a precomputed hash and implemented [`nohash_hasher::IsEnabled`],
 /// so it is very cheap to use in a [`nohash_hasher::IntMap`] and [`nohash_hasher::IntSet`].
 ///

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -154,6 +154,12 @@ impl EntityPath {
         self.path.is_root()
     }
 
+    /// Is this equals to, or a descendant of, the given path.
+    #[inline]
+    pub fn starts_with(&self, prefix: &EntityPath) -> bool {
+        prefix.len() <= self.len() && self.path.iter().zip(prefix.iter()).all(|(a, b)| a == b)
+    }
+
     /// Is this a strict descendant of the given path.
     #[inline]
     pub fn is_descendant_of(&self, other: &EntityPath) -> bool {

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -544,7 +544,8 @@ impl TimePanel {
             if is_closed {
                 let empty = re_data_store::TimeHistogram::default();
                 let num_messages_at_time = tree
-                    .recursive_time_histogram
+                    .recursive_info
+                    .time_histogram
                     .get(time_ctrl.timeline())
                     .unwrap_or(&empty);
 
@@ -874,7 +875,7 @@ fn is_time_safe_to_show(
         return true; // no timeless messages, no problem
     }
 
-    if let Some(times) = store_db.tree().recursive_time_histogram.get(timeline) {
+    if let Some(times) = store_db.tree().recursive_info.time_histogram.get(timeline) {
         if let Some(first_time) = times.min_key() {
             let margin = match timeline.typ() {
                 re_arrow_store::TimeType::Time => TimeInt::from_seconds(10_000),

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -544,7 +544,7 @@ impl TimePanel {
             if is_closed {
                 let empty = re_data_store::TimeHistogram::default();
                 let num_messages_at_time = tree
-                    .recursive_info
+                    .subtree
                     .time_histogram
                     .get(time_ctrl.timeline())
                     .unwrap_or(&empty);
@@ -592,13 +592,11 @@ impl TimePanel {
         }
 
         // If this is an entity:
-        if !tree.time_histograms_per_component.is_empty() {
+        if !tree.entity.components.is_empty() {
             let clip_rect_save = ui.clip_rect();
 
-            for component_name in
-                re_data_ui::ui_visible_components(tree.time_histograms_per_component.keys())
-            {
-                let data = &tree.time_histograms_per_component[component_name];
+            for component_name in re_data_ui::ui_visible_components(tree.entity.components.keys()) {
+                let data = &tree.entity.components[component_name];
 
                 let component_has_data_in_current_timeline =
                     ctx.component_has_data_in_current_timeline(data);
@@ -875,7 +873,7 @@ fn is_time_safe_to_show(
         return true; // no timeless messages, no problem
     }
 
-    if let Some(times) = store_db.tree().recursive_info.time_histogram.get(timeline) {
+    if let Some(times) = store_db.tree().subtree.time_histogram.get(timeline) {
         if let Some(first_time) = times.min_key() {
             let margin = match timeline.typ() {
                 re_arrow_store::TimeType::Time => TimeInt::from_seconds(10_000),

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -555,7 +555,7 @@ impl TimePanel {
                     time_area_response,
                     time_area_painter,
                     ui,
-                    tree.num_timeless_messages() as usize,
+                    tree.num_timeless_messages_recursive() as usize,
                     num_messages_at_time,
                     row_rect,
                     &self.time_ranges_ui,

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -332,7 +332,7 @@ impl StoreHub {
                     if store.store_kind() == StoreKind::Blueprint && store.app_id() == Some(app_id)
                     {
                         if !is_valid_blueprint(&store) {
-                            re_log::warn!("Blueprint for {app_id} appears invalid - restoring to default. This is expected if you have just upgraded Rerun versions.");
+                            re_log::warn_once!("Blueprint for {app_id} appears invalid - restoring to default. This is expected if you have just upgraded Rerun versions.");
                             continue;
                         }
                         // We found the blueprint we were looking for; make it active.

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -99,7 +99,7 @@ impl<'a> ViewerContext<'a> {
     pub fn tree_has_data_in_current_timeline(&self, tree: &EntityTree) -> bool {
         tree.recursive_time_histogram
             .has_timeline(self.rec_cfg.time_ctrl.read().timeline())
-            || tree.num_timeless_messages() > 0
+            || tree.num_timeless_messages_recursive() > 0
     }
 
     /// Returns whether the given component has any data logged in the current timeline.

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -95,11 +95,12 @@ impl<'a> ViewerContext<'a> {
         self.rec_cfg.time_ctrl.read().current_query()
     }
 
-    /// Returns whether the given tree has any data logged in the current timeline.
+    /// Returns whether the given tree has any data logged in the current timeline,
+    /// or has any timeless messages.
     pub fn tree_has_data_in_current_timeline(&self, tree: &EntityTree) -> bool {
-        tree.recursive_time_histogram
-            .has_timeline(self.rec_cfg.time_ctrl.read().timeline())
-            || tree.num_timeless_messages_recursive() > 0
+        let top_time_histogram = &tree.recursive_info.time_histogram;
+        top_time_histogram.has_timeline(self.rec_cfg.time_ctrl.read().timeline())
+            || top_time_histogram.num_timeless_messages() > 0
     }
 
     /// Returns whether the given component has any data logged in the current timeline.

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -98,7 +98,7 @@ impl<'a> ViewerContext<'a> {
     /// Returns whether the given tree has any data logged in the current timeline,
     /// or has any timeless messages.
     pub fn tree_has_data_in_current_timeline(&self, tree: &EntityTree) -> bool {
-        let top_time_histogram = &tree.recursive_info.time_histogram;
+        let top_time_histogram = &tree.subtree.time_histogram;
         top_time_histogram.has_timeline(self.rec_cfg.time_ctrl.read().timeline())
             || top_time_histogram.num_timeless_messages() > 0
     }

--- a/crates/re_viewport/src/space_view_entity_picker.rs
+++ b/crates/re_viewport/src/space_view_entity_picker.rs
@@ -167,8 +167,7 @@ fn add_entities_tree_ui(
         .body(|ui| {
             for (path_comp, child_tree) in tree.children.iter().sorted_by_key(|(_, child_tree)| {
                 // Put descendants of the space path always first
-                let put_first = child_tree.path == space_view.space_origin
-                    || child_tree.path.is_descendant_of(&space_view.space_origin);
+                let put_first = child_tree.path.starts_with(&space_view.space_origin);
                 !put_first
             }) {
                 add_entities_tree_ui(
@@ -209,9 +208,7 @@ fn add_entities_line_ui(
         // TODO(jleibs): Speed this up
         let excluded = exclusions.iter().any(|expr| match expr {
             EntityPathExpr::Exact(expr) => expr == entity_path,
-            EntityPathExpr::Recursive(expr) => {
-                expr == entity_path || entity_path.is_descendant_of(expr)
-            }
+            EntityPathExpr::Recursive(expr) => entity_path.starts_with(expr),
         });
 
         ui.add_enabled_ui(add_info.can_add_self_or_descendant.is_compatible(), |ui| {

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -445,7 +445,7 @@ pub fn reachable_entities_from_root(
                 space_info
                     .descendants_without_transform
                     .iter()
-                    .filter(|ent_path| (ent_path.is_descendant_of(root) || ent_path == &root))
+                    .filter(|ent_path| ent_path.starts_with(root))
                     .cloned(),
             );
         });


### PR DESCRIPTION
### What
Splits up its content into two buckets:

* `entity`: book-keeping about the entity at that path
* `subtree`: book-keeping about that path and everything below it

This makes it easier to add more book keeping later, e.g. per-subtree memory use (coming soon!)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4534/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4534/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4534)
- [Docs preview](https://rerun.io/preview/fbbd7dcad79824c0d69a5406450959b4c65635fc/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/fbbd7dcad79824c0d69a5406450959b4c65635fc/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)