### PR TITLE
Fix the entity-expression-editor

### DIFF
--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -5,7 +5,7 @@ use re_data_store::{
     ColorMapper, Colormap, EditableAutoValue, EntityPath, EntityProperties, VisibleHistory,
 };
 use re_data_ui::{image_meaning_for_entity, item_ui, DataUi};
-use re_log_types::{DataRow, EntityPathExpr, RowId, TimePoint};
+use re_log_types::{DataRow, RowId, TimePoint};
 use re_space_view_time_series::TimeSeriesSpaceView;
 use re_types::{
     components::{PinholeProjection, Transform3D},
@@ -545,10 +545,23 @@ fn blueprint_ui(
                     if edited_inclusions != inclusions || edited_exclusions != exclusions {
                         let timepoint = TimePoint::timeless();
 
-                        let expressions_component = QueryExpressions::new(
-                            edited_inclusions.split('\n').map(EntityPathExpr::from),
-                            edited_exclusions.split('\n').map(EntityPathExpr::from),
-                        );
+                        // TODO(jleibs): We intentionally avoid passing through a validated
+                        // intermediate state because we want the text-box-edits to be incrementally
+                        // preserved. Normalization instead happens when parsing the expressions.
+                        // This should all get replaced with the EntityFilter refactor coming down the
+                        // pipe.
+                        let expressions_component: QueryExpressions =
+                            re_space_view::blueprint::datatypes::QueryExpressions {
+                                inclusions: edited_inclusions
+                                    .split('\n')
+                                    .map(|s| s.into())
+                                    .collect(),
+                                exclusions: edited_exclusions
+                                    .split('\n')
+                                    .map(|s| s.into())
+                                    .collect(),
+                            }
+                            .into();
 
                         let row = DataRow::from_cells1_sized(
                             RowId::new(),


### PR DESCRIPTION
### What
Was broken during one of the blueprint archetype refactors.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4539/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4539/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4539)
- [Docs preview](https://rerun.io/preview/2fd172669821c958ef608dca8d0b8ca14e6ecbde/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2fd172669821c958ef608dca8d0b8ca14e6ecbde/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)