### PR TITLE
Use hyphen instead of underscore for example arguments

### DIFF
--- a/examples/python/controlnet/README.md
+++ b/examples/python/controlnet/README.md
@@ -18,5 +18,5 @@ python examples/python/controlnet/main.py
 
 You can specify your own image and prompts using
 ```bash
-main.py [--img_path IMG_PATH] [--prompt PROMPT] [--negative_prompt NEGATIVE_PROMPT]
+main.py [--img-path IMG_PATH] [--prompt PROMPT] [--negative-prompt NEGATIVE_PROMPT]
 ```

--- a/examples/python/controlnet/main.py
+++ b/examples/python/controlnet/main.py
@@ -107,7 +107,7 @@ def run_canny_controlnet(image_path: str, prompt: str, negative_prompt: str) -> 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Use Canny-conditioned ControlNet to generate image.")
     parser.add_argument(
-        "--img_path",
+        "--img-path",
         type=str,
         help="Path to image used as input for Canny edge detector.",
         default=RERUN_LOGO_URL,
@@ -119,7 +119,7 @@ def main() -> None:
         default="aerial view, a futuristic research complex in a bright foggy jungle, hard lighting",
     )
     parser.add_argument(
-        "--negative_prompt",
+        "--negative-prompt",
         type=str,
         help="Negative prompt used as input for ControlNet.",
         default="low quality, bad quality, sketches",

--- a/examples/python/depth_guided_stable_diffusion/main.py
+++ b/examples/python/depth_guided_stable_diffusion/main.py
@@ -60,8 +60,8 @@ def main() -> None:
         choices=IMAGE_NAMES,
         help="The example image to run on.",
     )
-    parser.add_argument("--dataset_dir", type=Path, default=DATASET_DIR, help="Directory to save example images to.")
-    parser.add_argument("--image_path", type=str, default="", help="Full path to image to run on. Overrides `--image`.")
+    parser.add_argument("--dataset-dir", type=Path, default=DATASET_DIR, help="Directory to save example images to.")
+    parser.add_argument("--image-path", type=str, default="", help="Full path to image to run on. Overrides `--image`.")
 
     parser.add_argument(
         "--prompt",
@@ -70,7 +70,7 @@ def main() -> None:
         default="A tired robot sitting down on a dirt floor. Rusty metal. Unreal Engine. Wall-e",
     )
     parser.add_argument(
-        "--n_prompt",
+        "--n-prompt",
         type=str,
         help="Negative prompt describing what you don't want in the image you generate.",
         default="White uniform floor and background",
@@ -88,7 +88,7 @@ be maximum and the denoising process will run for the full number of iterations 
 """,
     )
     parser.add_argument(
-        "--guidance_scale",
+        "--guidance-scale",
         type=float,
         default=11,
         help="""
@@ -100,7 +100,7 @@ usually at the expense of lower image quality.
 """,
     )
     parser.add_argument(
-        "--num_inference_steps",
+        "--num-inference-steps",
         type=int,
         default=10,
         help="""

--- a/examples/python/detect_and_track_objects/main.py
+++ b/examples/python/detect_and_track_objects/main.py
@@ -446,8 +446,8 @@ def main() -> None:
         choices=["horses, driving", "boats"],
         help="The example video to run on.",
     )
-    parser.add_argument("--dataset_dir", type=Path, default=DATASET_DIR, help="Directory to save example videos to.")
-    parser.add_argument("--video_path", type=str, default="", help="Full path to video to run on. Overrides `--video`.")
+    parser.add_argument("--dataset-dir", type=Path, default=DATASET_DIR, help="Directory to save example videos to.")
+    parser.add_argument("--video-path", type=str, default="", help="Full path to video to run on. Overrides `--video`.")
     parser.add_argument(
         "--max-frame",
         type=int,

--- a/examples/python/human_pose_tracking/main.py
+++ b/examples/python/human_pose_tracking/main.py
@@ -203,8 +203,8 @@ def main() -> None:
         choices=["backflip", "soccer"],
         help="The example video to run on.",
     )
-    parser.add_argument("--dataset_dir", type=Path, default=DATASET_DIR, help="Directory to save example videos to.")
-    parser.add_argument("--video_path", type=str, default="", help="Full path to video to run on. Overrides `--video`.")
+    parser.add_argument("--dataset-dir", type=Path, default=DATASET_DIR, help="Directory to save example videos to.")
+    parser.add_argument("--video-path", type=str, default="", help="Full path to video to run on. Overrides `--video`.")
     parser.add_argument("--no-segment", action="store_true", help="Don't run person segmentation.")
     parser.add_argument(
         "--max-frame",

--- a/examples/python/lidar/main.py
+++ b/examples/python/lidar/main.py
@@ -75,18 +75,18 @@ def log_nuscenes_lidar(root_dir: pathlib.Path, dataset_version: str, scene_name:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Visualizes lidar scans using the Rerun SDK.")
     parser.add_argument(
-        "--root_dir",
+        "--root-dir",
         type=pathlib.Path,
         default=DATASET_DIR,
         help="Root directory of nuScenes dataset",
     )
     parser.add_argument(
-        "--scene_name",
+        "--scene-name",
         type=str,
         default="scene-0061",
         help="Scene name to visualize (typically of form 'scene-xxxx')",
     )
-    parser.add_argument("--dataset_version", type=str, default="v1.0-mini", help="Scene id to visualize")
+    parser.add_argument("--dataset-version", type=str, default="v1.0-mini", help="Scene id to visualize")
     rr.script_add_args(parser)
     args = parser.parse_args()
 

--- a/examples/python/nuscenes/main.py
+++ b/examples/python/nuscenes/main.py
@@ -201,18 +201,18 @@ def log_sensor_calibration(sample_data: dict[str, Any], nusc: nuscenes.NuScenes)
 def main() -> None:
     parser = argparse.ArgumentParser(description="Visualizes the nuScenes dataset using the Rerun SDK.")
     parser.add_argument(
-        "--root_dir",
+        "--root-dir",
         type=pathlib.Path,
         default=DATASET_DIR,
         help="Root directory of nuScenes dataset",
     )
     parser.add_argument(
-        "--scene_name",
+        "--scene-name",
         type=str,
         default="scene-0061",
         help="Scene name to visualize (typically of form 'scene-xxxx')",
     )
-    parser.add_argument("--dataset_version", type=str, default="v1.0-mini", help="Scene id to visualize")
+    parser.add_argument("--dataset-version", type=str, default="v1.0-mini", help="Scene id to visualize")
     rr.script_add_args(parser)
     args = parser.parse_args()
 

--- a/examples/python/objectron/main.py
+++ b/examples/python/objectron/main.py
@@ -267,7 +267,7 @@ def main() -> None:
         help="Reprocess video frames even if they already exist",
     )
     parser.add_argument(
-        "--dataset_dir", type=Path, default=LOCAL_DATASET_DIR, help="Directory to save example videos to."
+        "--dataset-dir", type=Path, default=LOCAL_DATASET_DIR, help="Directory to save example videos to."
     )
 
     rr.script_add_args(parser)

--- a/examples/python/raw_mesh/main.py
+++ b/examples/python/raw_mesh/main.py
@@ -93,7 +93,7 @@ def main() -> None:
         help="The name of the scene to load",
     )
     parser.add_argument(
-        "--scene_path",
+        "--scene-path",
         type=Path,
         help="Path to a scene to analyze. If set, overrides the `--scene` argument.",
     )

--- a/examples/python/signed_distance_fields/main.py
+++ b/examples/python/signed_distance_fields/main.py
@@ -187,7 +187,7 @@ def main() -> None:
         help="The name of the mesh to analyze",
     )
     parser.add_argument(
-        "--mesh_path",
+        "--mesh-path",
         type=Path,
         help="Path to a mesh to analyze. If set, overrides the `--mesh` argument.",
     )

--- a/examples/python/structure_from_motion/read_write_model.py
+++ b/examples/python/structure_from_motion/read_write_model.py
@@ -494,10 +494,10 @@ def rotmat2qvec(R):
 
 def main():
     parser = argparse.ArgumentParser(description="Read and write COLMAP binary and text models")
-    parser.add_argument("--input_model", help="path to input model folder")
-    parser.add_argument("--input_format", choices=[".bin", ".txt"], help="input model format", default="")
-    parser.add_argument("--output_model", help="path to output model folder")
-    parser.add_argument("--output_format", choices=[".bin", ".txt"], help="output model format", default=".txt")
+    parser.add_argument("--input-model", help="path to input model folder")
+    parser.add_argument("--input-format", choices=[".bin", ".txt"], help="input model format", default="")
+    parser.add_argument("--output-model", help="path to output model folder")
+    parser.add_argument("--output-format", choices=[".bin", ".txt"], help="output model format", default=".txt")
     args = parser.parse_args()
 
     cameras, images, points3D = read_model(path=args.input_model, ext=args.input_format)


### PR DESCRIPTION
### What

Replaces underscores in example arguments with hyphens.

Closes #4531. 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4543/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4543/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4543/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4543)
- [Docs preview](https://rerun.io/preview/df6c21a2063a91f265cd282e6c6d5005141d7d3b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/df6c21a2063a91f265cd282e6c6d5005141d7d3b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)