### PR TITLE
Add `--stdout`/`-o` to our CLI helper library

### DIFF
--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -155,7 +155,7 @@ impl RerunArgs {
 
     #[allow(clippy::unnecessary_wraps)] // False positive on some feature flags
     fn to_behavior(&self) -> anyhow::Result<RerunBehavior> {
-        if dbg!(self.stdout) {
+        if self.stdout {
             return Ok(RerunBehavior::Stdout);
         }
 

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -51,6 +51,7 @@ def script_add_args(parser: ArgumentParser) -> None:
     )
     parser.add_argument("--addr", type=str, default=None, help="Connect to this ip:port")
     parser.add_argument("--save", type=str, default=None, help="Save data to a .rrd file at this path")
+    parser.add_argument("-o", "--stdout", dest="stdout", action="store_true", help="Log data to standard output, to be piped into a Rerun Viewer")
 
 
 def script_setup(
@@ -77,7 +78,9 @@ def script_setup(
     rec: RecordingStream = rr.get_global_data_recording()  # type: ignore[assignment]
 
     # NOTE: mypy thinks these methods don't exist because they're monkey-patched.
-    if args.serve:
+    if args.stdout:
+        rec.stdout()  # type: ignore[attr-defined]
+    elif args.serve:
         rec.serve()  # type: ignore[attr-defined]
     elif args.connect:
         # Send logging data to separate `rerun` process.

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -51,7 +51,13 @@ def script_add_args(parser: ArgumentParser) -> None:
     )
     parser.add_argument("--addr", type=str, default=None, help="Connect to this ip:port")
     parser.add_argument("--save", type=str, default=None, help="Save data to a .rrd file at this path")
-    parser.add_argument("-o", "--stdout", dest="stdout", action="store_true", help="Log data to standard output, to be piped into a Rerun Viewer")
+    parser.add_argument(
+        "-o",
+        "--stdout",
+        dest="stdout",
+        action="store_true",
+        help="Log data to standard output, to be piped into a Rerun Viewer",
+    )
 
 
 def script_setup(


### PR DESCRIPTION
You can now pipe all Python & Rust examples into a Rerun Viewer.

![image](https://github.com/rerun-io/rerun/assets/2910679/ff65e6f9-a5e6-497f-a108-577fcd0c6e57)


Checks:
- [x] python examples/python/minimal_options/main.py -o | rerun -
- [x] cargo r -p minimal_options -- -o | rerun -


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4544/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4544/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4544/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4544)
- [Docs preview](https://rerun.io/preview/1c5a24f327699fcd1dbab9d9ea23dd1cb39dd917/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/1c5a24f327699fcd1dbab9d9ea23dd1cb39dd917/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)