### PR TITLE
Limit the sizes of some of the nightly examples

### DIFF
--- a/examples/python/nuscenes/README.md
+++ b/examples/python/nuscenes/README.md
@@ -6,6 +6,7 @@ description: "Visualize the nuScenes dataset including lidar, radar, images, and
 thumbnail: https://static.rerun.io/nuscenes/64a50a9d67cbb69ae872551989ee807b195f6b5d/480w.png
 thumbnail_dimensions: [480, 282]
 channel: nightly
+build_args: ["--seconds=5"]
 ---
 
 <picture>

--- a/examples/python/objectron/README.md
+++ b/examples/python/objectron/README.md
@@ -6,6 +6,7 @@ tags: [2D, 3D, object-detection, pinhole-camera]
 thumbnail: https://static.rerun.io/objectron/8ea3a37e6b4af2e06f8e2ea5e70c1951af67fea8/480w.png
 thumbnail_dimensions: [480, 268]
 channel: nightly
+build_args: ["--frames=150"]
 ---
 
 <picture>

--- a/examples/python/open_photogrammetry_format/README.md
+++ b/examples/python/open_photogrammetry_format/README.md
@@ -5,6 +5,7 @@ tags: [2d, 3d, camera, photogrammetry]
 thumbnail: https://static.rerun.io/open_photogrammetry_format/603d5605f9670889bc8bce3365f16b831fce1eb1/480w.png
 thumbnail_dimensions: [480, 310]
 channel: nightly
+build_args: ["--jpeg-quality=50"]
 ---
 
 <picture>

--- a/examples/python/open_photogrammetry_format/requirements.txt
+++ b/examples/python/open_photogrammetry_format/requirements.txt
@@ -1,4 +1,5 @@
 numpy
+pillow
 pyopf; python_version >= '3.10'  # silence error if this requirements.txt gets pulled in a <3.10 venv
 requests
 rerun-sdk

--- a/examples/python/rgbd/README.md
+++ b/examples/python/rgbd/README.md
@@ -5,6 +5,7 @@ tags: [2D, 3D, depth, nyud, pinhole-camera]
 thumbnail: https://static.rerun.io/rgbd/4109d29ed52fa0a8f980fcdd0e9673360c76879f/480w.png
 thumbnail_dimensions: [480, 254]
 channel: nightly
+build_args: ["--frames=300"]
 ---
 
 <picture>

--- a/examples/rust/objectron/README.md
+++ b/examples/rust/objectron/README.md
@@ -4,6 +4,7 @@ python: https://github.com/rerun-io/rerun/tree/latest/examples/python/objectron/
 rust: https://github.com/rerun-io/rerun/tree/latest/examples/rust/objectron/src/main.rs
 tags: [2D, 3D, object-detection, pinhole-camera]
 thumbnail: https://static.rerun.io/objectron/8ea3a37e6b4af2e06f8e2ea5e70c1951af67fea8/480w.png
+build_args: ["--frames=100"]
 ---
 
 <picture>


### PR DESCRIPTION
They are still not exactlty _small_, but a lot _smaller_, and since they all stream, it should be pretty fine anyways

```
detect_and_track_objects.rrd (55.3 MiB)
nuscenes.rrd (90.0 MiB)
objectron.rrd (81.1 MiB)
open_photogrammetry_format.rrd (67.6 MiB)
raw_mesh.rrd (116 kiB)
rgbd.rrd (36.8 MiB)
segment_anything_model.rrd (8.5 MiB)
```

This helped in figuring out what to focus on:
* https://github.com/rerun-io/rerun/pull/4542

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4545/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4545/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4545/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4545)
- [Docs preview](https://rerun.io/preview/4aa4c24e403c16b455d8be8b02b98d5c8164fa53/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4aa4c24e403c16b455d8be8b02b98d5c8164fa53/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)