### PR TITLE
Ensure `main` is included in `nightly` builds

### DIFF
--- a/crates/re_build_examples/src/example.rs
+++ b/crates/re_build_examples/src/example.rs
@@ -25,6 +25,15 @@ pub enum Channel {
 }
 
 impl Channel {
+    pub fn includes(self, other: Channel) -> bool {
+        match self {
+            Channel::Main => matches!(other, Channel::Main),
+
+            // Include all `main` examples in `nightly`
+            Channel::Nightly => matches!(other, Channel::Main | Channel::Nightly),
+        }
+    }
+
     pub fn examples(self) -> anyhow::Result<Vec<Example>> {
         let mut examples = vec![];
         let dir = Path::new("examples/python");
@@ -59,7 +68,7 @@ impl Channel {
                     continue;
                 };
 
-                if channel != self {
+                if !self.includes(channel) {
                     eprintln!("{name:?}: skipped");
                     continue;
                 }


### PR DESCRIPTION
### What

The build script was incorrectly checking if the example's channel was equal to the requested channel. We want to include all `main` examples in `nightly`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4546/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4546/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4546/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4546)
- [Docs preview](https://rerun.io/preview/b27bf0242fa70de5b31e1730d96988e1274f5b80/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b27bf0242fa70de5b31e1730d96988e1274f5b80/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)