### PR TITLE
Add DataUi implementations for Blueprint Components

### DIFF
--- a/crates/re_data_ui/src/blueprint_data.rs
+++ b/crates/re_data_ui/src/blueprint_data.rs
@@ -1,0 +1,43 @@
+use re_types::blueprint::components::IncludedQueries;
+use re_viewer_context::{
+    BlueprintId, BlueprintIdRegistry, DataQueryId, UiVerbosity, ViewerContext,
+};
+
+use crate::{item_ui::entity_path_button_to, DataUi};
+
+impl DataUi for IncludedQueries {
+    #[allow(clippy::only_used_in_recursion)]
+    fn data_ui(
+        &self,
+        _ctx: &ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        verbosity: UiVerbosity,
+        _query: &re_arrow_store::LatestAtQuery,
+    ) {
+        match verbosity {
+            UiVerbosity::Small => {
+                ui.label(format!("{} Queries", self.0.len()));
+            }
+            UiVerbosity::Full | UiVerbosity::LimitHeight | UiVerbosity::Reduced => {
+                for query in &self.0 {
+                    let query: DataQueryId = (*query).into();
+                    query.data_ui(_ctx, ui, verbosity, _query);
+                    ui.end_row();
+                }
+            }
+        }
+    }
+}
+
+impl<T: BlueprintIdRegistry> DataUi for BlueprintId<T> {
+    #[allow(clippy::only_used_in_recursion)]
+    fn data_ui(
+        &self,
+        ctx: &ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        _verbosity: UiVerbosity,
+        _query: &re_arrow_store::LatestAtQuery,
+    ) {
+        entity_path_button_to(ctx, ui, None, &self.as_entity_path(), self.to_string());
+    }
+}

--- a/crates/re_data_ui/src/component_ui_registry.rs
+++ b/crates/re_data_ui/src/component_ui_registry.rs
@@ -9,49 +9,49 @@ use super::EntityDataUi;
 pub fn create_component_ui_registry() -> ComponentUiRegistry {
     re_tracing::profile_function!();
 
-    /// Registers how to show a given component in the ui.
-    pub fn add<C: EntityDataUi + re_types::Component>(registry: &mut ComponentUiRegistry) {
-        registry.add(
-            C::name(),
-            Box::new(
-                |ctx, ui, verbosity, query, entity_path, component, instance| match component
-                    .lookup::<C>(instance)
-                {
-                    Ok(component) => {
-                        component.entity_data_ui(ctx, ui, verbosity, entity_path, query);
-                    }
-                    Err(re_query::QueryError::ComponentNotFound) => {
-                        ui.weak("(not found)");
-                    }
-                    Err(err) => {
-                        re_log::warn_once!("Expected component {}, {}", C::name(), err);
-                    }
-                },
-            ),
-        );
-    }
-
     let mut registry = ComponentUiRegistry::new(Box::new(&fallback_component_ui));
 
-    add::<re_types::components::AnnotationContext>(&mut registry);
-    add::<re_types::components::ClassId>(&mut registry);
-    add::<re_types::components::Color>(&mut registry);
-    add::<re_types::components::PinholeProjection>(&mut registry);
-    add::<re_types::components::KeypointId>(&mut registry);
-    add::<re_types::components::LineStrip2D>(&mut registry);
-    add::<re_types::components::LineStrip3D>(&mut registry);
-    add::<re_types::components::Resolution>(&mut registry);
-    add::<re_types::components::Rotation3D>(&mut registry);
-    add::<re_types::components::Material>(&mut registry);
-    add::<re_types::components::MeshProperties>(&mut registry);
-    add::<re_types::components::TensorData>(&mut registry);
-    add::<re_types::components::Transform3D>(&mut registry);
-    add::<re_types::components::OutOfTreeTransform3D>(&mut registry);
-    add::<re_types::components::ViewCoordinates>(&mut registry);
+    add_to_registry::<re_types::components::AnnotationContext>(&mut registry);
+    add_to_registry::<re_types::components::ClassId>(&mut registry);
+    add_to_registry::<re_types::components::Color>(&mut registry);
+    add_to_registry::<re_types::components::PinholeProjection>(&mut registry);
+    add_to_registry::<re_types::components::KeypointId>(&mut registry);
+    add_to_registry::<re_types::components::LineStrip2D>(&mut registry);
+    add_to_registry::<re_types::components::LineStrip3D>(&mut registry);
+    add_to_registry::<re_types::components::Resolution>(&mut registry);
+    add_to_registry::<re_types::components::Rotation3D>(&mut registry);
+    add_to_registry::<re_types::components::Material>(&mut registry);
+    add_to_registry::<re_types::components::MeshProperties>(&mut registry);
+    add_to_registry::<re_types::components::TensorData>(&mut registry);
+    add_to_registry::<re_types::components::Transform3D>(&mut registry);
+    add_to_registry::<re_types::components::OutOfTreeTransform3D>(&mut registry);
+    add_to_registry::<re_types::components::ViewCoordinates>(&mut registry);
 
-    add::<re_types::blueprint::components::IncludedQueries>(&mut registry);
+    add_to_registry::<re_types::blueprint::components::IncludedQueries>(&mut registry);
 
     registry
+}
+
+/// Registers how to show a given component in the ui.
+pub fn add_to_registry<C: EntityDataUi + re_types::Component>(registry: &mut ComponentUiRegistry) {
+    registry.add(
+        C::name(),
+        Box::new(
+            |ctx, ui, verbosity, query, entity_path, component, instance| match component
+                .lookup::<C>(instance)
+            {
+                Ok(component) => {
+                    component.entity_data_ui(ctx, ui, verbosity, entity_path, query);
+                }
+                Err(re_query::QueryError::ComponentNotFound) => {
+                    ui.weak("(not found)");
+                }
+                Err(err) => {
+                    re_log::warn_once!("Expected component {}, {}", C::name(), err);
+                }
+            },
+        ),
+    );
 }
 
 fn fallback_component_ui(

--- a/crates/re_data_ui/src/component_ui_registry.rs
+++ b/crates/re_data_ui/src/component_ui_registry.rs
@@ -49,6 +49,8 @@ pub fn create_component_ui_registry() -> ComponentUiRegistry {
     add::<re_types::components::OutOfTreeTransform3D>(&mut registry);
     add::<re_types::components::ViewCoordinates>(&mut registry);
 
+    add::<re_types::blueprint::components::IncludedQueries>(&mut registry);
+
     registry
 }
 

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -29,7 +29,7 @@ pub use crate::image::{
     show_zoomed_image_region, show_zoomed_image_region_area_outline,
     tensor_summary_ui_grid_contents,
 };
-pub use component_ui_registry::create_component_ui_registry;
+pub use component_ui_registry::{add_to_registry, create_component_ui_registry};
 pub use image_meaning::image_meaning_for_entity;
 
 /// Filter out components that should not be shown in the UI,

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -9,6 +9,7 @@ use re_types::ComponentName;
 use re_viewer_context::{UiVerbosity, ViewerContext};
 
 mod annotation_context;
+mod blueprint_data;
 mod component;
 mod component_path;
 mod component_ui_registry;

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -205,7 +205,8 @@ impl App {
 
         let (command_sender, command_receiver) = command_channel();
 
-        let component_ui_registry = re_data_ui::create_component_ui_registry();
+        let mut component_ui_registry = re_data_ui::create_component_ui_registry();
+        re_viewport::blueprint::register_ui_components(&mut component_ui_registry);
 
         // TODO(emilk): `Instant::MIN` when we have our own `Instant` that supports it.;
         let long_time_ago = web_time::Instant::now()

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -27,7 +27,7 @@ pub use annotations::{
     AnnotationMap, Annotations, ResolvedAnnotationInfo, ResolvedAnnotationInfos,
 };
 pub use app_options::AppOptions;
-pub use blueprint_id::{DataQueryId, SpaceViewId};
+pub use blueprint_id::{BlueprintId, BlueprintIdRegistry, DataQueryId, SpaceViewId};
 pub use caches::{Cache, Caches};
 pub use command_sender::{
     command_channel, CommandReceiver, CommandSender, SystemCommand, SystemCommandSender,

--- a/crates/re_viewport/src/blueprint/data_ui.rs
+++ b/crates/re_viewport/src/blueprint/data_ui.rs
@@ -1,0 +1,99 @@
+use re_data_ui::{DataUi, EntityDataUi};
+use re_viewer_context::{ComponentUiRegistry, SpaceViewId, UiVerbosity, ViewerContext};
+
+use super::components::{IncludedSpaceViews, SpaceViewMaximized, ViewportLayout};
+
+impl DataUi for IncludedSpaceViews {
+    #[allow(clippy::only_used_in_recursion)]
+    fn data_ui(
+        &self,
+        _ctx: &ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        verbosity: UiVerbosity,
+        _query: &re_arrow_store::LatestAtQuery,
+    ) {
+        match verbosity {
+            UiVerbosity::Small => {
+                ui.label(format!("{} Space Views", self.0.len()));
+            }
+            UiVerbosity::Full | UiVerbosity::LimitHeight | UiVerbosity::Reduced => {
+                for space_view in &self.0 {
+                    let space_view: SpaceViewId = (*space_view).into();
+                    space_view.data_ui(_ctx, ui, verbosity, _query);
+                    ui.end_row();
+                }
+            }
+        }
+    }
+}
+
+impl DataUi for SpaceViewMaximized {
+    #[allow(clippy::only_used_in_recursion)]
+    fn data_ui(
+        &self,
+        ctx: &ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        verbosity: UiVerbosity,
+        query: &re_arrow_store::LatestAtQuery,
+    ) {
+        match self.0 {
+            Some(space_view) => {
+                let space_view: SpaceViewId = space_view.into();
+                space_view.data_ui(ctx, ui, verbosity, query);
+            }
+            None => {
+                ui.label("None");
+            }
+        }
+    }
+}
+
+impl DataUi for ViewportLayout {
+    #[allow(clippy::only_used_in_recursion)]
+    fn data_ui(
+        &self,
+        _ctx: &ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        verbosity: UiVerbosity,
+        _query: &re_arrow_store::LatestAtQuery,
+    ) {
+        match verbosity {
+            UiVerbosity::Small => {
+                ui.label(format!("ViewportLayout with {} tiles", self.0.tiles.len()));
+            }
+            UiVerbosity::Full | UiVerbosity::LimitHeight | UiVerbosity::Reduced => {
+                ui.label(format!("{:?}", self.0));
+            }
+        }
+    }
+}
+
+pub fn register_ui_components(registry: &mut ComponentUiRegistry) {
+    re_tracing::profile_function!();
+
+    /// Registers how to show a given component in the ui.
+    pub fn add<C: EntityDataUi + re_types::Component>(registry: &mut ComponentUiRegistry) {
+        registry.add(
+            C::name(),
+            Box::new(
+                |ctx, ui, verbosity, query, entity_path, component, instance| match component
+                    .lookup::<C>(instance)
+                {
+                    Ok(component) => {
+                        component.entity_data_ui(ctx, ui, verbosity, entity_path, query);
+                    }
+                    Err(re_query::QueryError::ComponentNotFound) => {
+                        ui.weak("(not found)");
+                    }
+                    Err(err) => {
+                        re_log::warn_once!("Expected component {}, {}", C::name(), err);
+                    }
+                },
+            ),
+        );
+    }
+
+    add::<IncludedSpaceViews>(registry);
+    add::<SpaceViewMaximized>(registry);
+    add::<ViewportLayout>(registry);
+}

--- a/crates/re_viewport/src/blueprint/data_ui.rs
+++ b/crates/re_viewport/src/blueprint/data_ui.rs
@@ -1,4 +1,4 @@
-use re_data_ui::{DataUi, EntityDataUi};
+use re_data_ui::{add_to_registry, DataUi};
 use re_viewer_context::{ComponentUiRegistry, SpaceViewId, UiVerbosity, ViewerContext};
 
 use super::components::{IncludedSpaceViews, SpaceViewMaximized, ViewportLayout};
@@ -71,29 +71,7 @@ impl DataUi for ViewportLayout {
 pub fn register_ui_components(registry: &mut ComponentUiRegistry) {
     re_tracing::profile_function!();
 
-    /// Registers how to show a given component in the ui.
-    pub fn add<C: EntityDataUi + re_types::Component>(registry: &mut ComponentUiRegistry) {
-        registry.add(
-            C::name(),
-            Box::new(
-                |ctx, ui, verbosity, query, entity_path, component, instance| match component
-                    .lookup::<C>(instance)
-                {
-                    Ok(component) => {
-                        component.entity_data_ui(ctx, ui, verbosity, entity_path, query);
-                    }
-                    Err(re_query::QueryError::ComponentNotFound) => {
-                        ui.weak("(not found)");
-                    }
-                    Err(err) => {
-                        re_log::warn_once!("Expected component {}, {}", C::name(), err);
-                    }
-                },
-            ),
-        );
-    }
-
-    add::<IncludedSpaceViews>(registry);
-    add::<SpaceViewMaximized>(registry);
-    add::<ViewportLayout>(registry);
+    add_to_registry::<IncludedSpaceViews>(registry);
+    add_to_registry::<SpaceViewMaximized>(registry);
+    add_to_registry::<ViewportLayout>(registry);
 }

--- a/crates/re_viewport/src/blueprint/mod.rs
+++ b/crates/re_viewport/src/blueprint/mod.rs
@@ -1,2 +1,6 @@
 pub mod archetypes;
 pub mod components;
+
+mod data_ui;
+
+pub use data_ui::register_ui_components;


### PR DESCRIPTION
### What
Now that we have archetypified blueprints, make the UI a bit nicer with some DataUi implementations.

![image](https://github.com/rerun-io/rerun/assets/3312232/5ca3d2d4-634a-4a7f-957d-0d2f879d8f55)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4547/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4547/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4547/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4547)
- [Docs preview](https://rerun.io/preview/c3a2d19e766d5cd280e374fef05b8840943470ae/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c3a2d19e766d5cd280e374fef05b8840943470ae/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)