### PR TITLE
Resolve spurious blueprint panel group collapsing

### DIFF
--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -358,16 +358,21 @@ impl ViewportBlueprint<'_> {
 
                         response | vis_response
                     })
-                    .show_collapsing(ui, ui.id().with(child), default_open, |_, ui| {
-                        Self::space_view_blueprint_ui(
-                            ctx,
-                            ui,
-                            query_result,
-                            *child,
-                            space_view,
-                            space_view_visible,
-                        );
-                    })
+                    .show_collapsing(
+                        ui,
+                        ui.id().with(&child_node.data_result.entity_path),
+                        default_open,
+                        |_, ui| {
+                            Self::space_view_blueprint_ui(
+                                ctx,
+                                ui,
+                                query_result,
+                                *child,
+                                space_view,
+                                space_view_visible,
+                            );
+                        },
+                    )
                     .item_response
                     .on_hover_ui(|ui| {
                         if data_result.is_group {


### PR DESCRIPTION
### What
 - Resolves: https://github.com/rerun-io/rerun/issues/4453

Needed to make the id deterministic since the value of DataResultHandle was basically just a function of how many children the data-result had.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4548/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4548/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4548/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4548)
- [Docs preview](https://rerun.io/preview/456b9b77eb6e2ac6a7be4a0dc28b811f308fb450/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/456b9b77eb6e2ac6a7be4a0dc28b811f308fb450/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)