### PR TITLE
Fix scripts/lint.py to work on windows

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -640,7 +640,7 @@ class SourceFile:
     def __init__(self, path: str):
         self.path = os.path.abspath(path)
         self.ext = path.split(".")[-1]
-        with open(path) as f:
+        with open(path, encoding="utf8") as f:
             self.lines = f.readlines()
         self._update_content()
 
@@ -856,6 +856,7 @@ def main() -> None:
     if args.files:
         for filepath in args.files:
             filepath = os.path.join(".", os.path.relpath(filepath, root_dirpath))
+            filepath = str(filepath).replace("\\", "/")
             extension = filepath.split(".")[-1]
             if extension in extensions:
                 if should_ignore(filepath) or filepath.startswith(exclude_paths):
@@ -869,6 +870,8 @@ def main() -> None:
                 extension = filename.split(".")[-1]
                 if extension in extensions:
                     filepath = os.path.join(root, filename)
+                    filepath = os.path.join(".", os.path.relpath(filepath, root_dirpath))
+                    filepath = str(filepath).replace("\\", "/")
                     if should_ignore(filepath) or filepath.startswith(exclude_paths):
                         continue
                     num_errors += lint_file(filepath, args)


### PR DESCRIPTION
### What

Makes `pixi run lint-rerun` work on Windows!

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4559/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4559/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4559/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4559)
- [Docs preview](https://rerun.io/preview/be580aa70284e5de760e6fb6b1a2806e43c621a1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/be580aa70284e5de760e6fb6b1a2806e43c621a1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)