### PR TITLE
Don't run queries we know will be empty

### DIFF
--- a/crates/re_space_view/src/data_query.rs
+++ b/crates/re_space_view/src/data_query.rs
@@ -1,5 +1,5 @@
 use re_data_store::{EntityProperties, EntityPropertyMap};
-use re_viewer_context::{DataQueryResult, EntitiesPerSystemPerClass, StoreContext};
+use re_viewer_context::{DataQueryResult, EntitiesPerSystem, StoreContext};
 
 pub struct EntityOverrides {
     pub root: EntityProperties,
@@ -43,6 +43,6 @@ pub trait DataQuery {
         &self,
         property_resolver: &impl PropertyResolver,
         ctx: &StoreContext<'_>,
-        entities_per_system_per_class: &EntitiesPerSystemPerClass,
+        entities_per_system: &EntitiesPerSystem,
     ) -> DataQueryResult;
 }

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -146,17 +146,21 @@ impl AppState {
                 .space_views
                 .values()
                 .flat_map(|space_view| {
-                    space_view.queries.iter().map(|query| {
+                    space_view.queries.iter().filter_map(|query| {
                         let props = viewport.state.space_view_props(space_view.id);
                         let resolver = query.build_resolver(space_view.id, props);
-                        (
-                            query.id,
-                            query.execute_query(
-                                &resolver,
-                                store_context,
-                                &entities_per_system_per_class,
-                            ),
-                        )
+                        entities_per_system_per_class
+                            .get(&query.space_view_class_identifier)
+                            .map(|entities_per_system| {
+                                (
+                                    query.id,
+                                    query.execute_query(
+                                        &resolver,
+                                        store_context,
+                                        entities_per_system,
+                                    ),
+                                )
+                            })
                     })
                 })
                 .collect::<_>()
@@ -194,17 +198,21 @@ impl AppState {
                 .space_views
                 .values()
                 .flat_map(|space_view| {
-                    space_view.queries.iter().map(|query| {
+                    space_view.queries.iter().filter_map(|query| {
                         let props = viewport.state.space_view_props(space_view.id);
                         let resolver = query.build_resolver(space_view.id, props);
-                        (
-                            query.id,
-                            query.execute_query(
-                                &resolver,
-                                store_context,
-                                &entities_per_system_per_class,
-                            ),
-                        )
+                        entities_per_system_per_class
+                            .get(&query.space_view_class_identifier)
+                            .map(|entities_per_system| {
+                                (
+                                    query.id,
+                                    query.execute_query(
+                                        &resolver,
+                                        store_context,
+                                        entities_per_system,
+                                    ),
+                                )
+                            })
                     })
                 })
                 .collect::<_>()

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -463,7 +463,7 @@ mod tests {
     use re_log_types::{DataCell, DataRow, RowId, StoreId, TimePoint};
     use re_space_view::DataQuery as _;
     use re_types::archetypes::Points3D;
-    use re_viewer_context::{EntitiesPerSystemPerClass, StoreContext};
+    use re_viewer_context::{EntitiesPerSystem, StoreContext};
 
     use super::*;
 
@@ -515,10 +515,8 @@ mod tests {
 
         let auto_properties = Default::default();
 
-        let mut entities_per_system_per_class = EntitiesPerSystemPerClass::default();
-        entities_per_system_per_class
-            .entry("3D".into())
-            .or_default()
+        let mut entities_per_system = EntitiesPerSystem::default();
+        entities_per_system
             .entry("Points3D".into())
             .or_insert_with(|| {
                 [
@@ -541,7 +539,7 @@ mod tests {
                 all_recordings: vec![],
             };
 
-            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system_per_class);
+            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system);
 
             let parent = query_result
                 .tree
@@ -575,7 +573,7 @@ mod tests {
                 all_recordings: vec![],
             };
 
-            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system_per_class);
+            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system);
 
             let parent_group = query_result
                 .tree
@@ -618,7 +616,7 @@ mod tests {
                 all_recordings: vec![],
             };
 
-            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system_per_class);
+            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system);
 
             let parent = query_result
                 .tree
@@ -660,7 +658,7 @@ mod tests {
                 all_recordings: vec![],
             };
 
-            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system_per_class);
+            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system);
 
             let parent = query_result
                 .tree
@@ -697,7 +695,7 @@ mod tests {
                 all_recordings: vec![],
             };
 
-            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system_per_class);
+            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system);
 
             let parent = query_result
                 .tree


### PR DESCRIPTION
### What

First trivial performance improvement for heuristic-queries.  If none of the entities_per_system are a child of the query path we would be creating, we can skip the candidate all together.

Also since the Query is always scoped to a class, change the interface to EntitiesPerSystem rather than having it do the lookup internally.

Before:
![image](https://github.com/rerun-io/rerun/assets/3312232/bafd9784-4f96-4552-a04a-611f0db77a8a)


After:
![image](https://github.com/rerun-io/rerun/assets/3312232/f7564835-575e-443a-8933-073471d4452f)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4562/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4562/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4562/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4562)
- [Docs preview](https://rerun.io/preview/f3e06ae1c392d5b37329dd5b1286ec9bb7575c8e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f3e06ae1c392d5b37329dd5b1286ec9bb7575c8e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)