### PR TITLE
Speed up query usage in heuristics by splitting DataQuery into separate query and update_properties passes

### DIFF
--- a/crates/re_space_view/src/data_query.rs
+++ b/crates/re_space_view/src/data_query.rs
@@ -1,7 +1,7 @@
 use re_data_store::{EntityProperties, EntityPropertyMap};
 use re_viewer_context::{DataQueryResult, EntitiesPerSystem, StoreContext};
 
-pub struct EntityOverrides {
+pub struct EntityOverrideContext {
     pub root: EntityProperties,
     pub individual: EntityPropertyMap,
     pub group: EntityPropertyMap,

--- a/crates/re_space_view/src/data_query.rs
+++ b/crates/re_space_view/src/data_query.rs
@@ -15,20 +15,6 @@ pub trait PropertyResolver {
     fn resolve_entity_overrides(&self, ctx: &StoreContext<'_>) -> EntityOverrides;
 }
 
-pub struct NoopResolver {}
-
-impl PropertyResolver for NoopResolver {
-    fn resolve_entity_overrides(&self, _ctx: &StoreContext<'_>) -> EntityOverrides {
-        EntityOverrides {
-            root: EntityProperties::default(),
-            individual: EntityPropertyMap::default(),
-            group: EntityPropertyMap::default(),
-        }
-    }
-}
-
-pub static NOOP_RESOLVER: NoopResolver = NoopResolver {};
-
 /// The common trait implemented for data queries
 ///
 /// Both interfaces return [`re_viewer_context::DataResult`]s, which are self-contained description of the data
@@ -42,6 +28,12 @@ pub trait DataQuery {
     fn execute_query(
         &self,
         property_resolver: &impl PropertyResolver,
+        ctx: &StoreContext<'_>,
+        entities_per_system: &EntitiesPerSystem,
+    ) -> DataQueryResult;
+
+    fn execute_query_fast(
+        &self,
         ctx: &StoreContext<'_>,
         entities_per_system: &EntitiesPerSystem,
     ) -> DataQueryResult;

--- a/crates/re_space_view/src/data_query.rs
+++ b/crates/re_space_view/src/data_query.rs
@@ -12,7 +12,7 @@ pub struct EntityOverrides {
 /// The `SpaceViewBlueprint` is the only thing that likely implements this today
 /// but we use a trait here so we don't have to pick up a full dependency on `re_viewport`.
 pub trait PropertyResolver {
-    fn resolve_entity_overrides(&self, ctx: &StoreContext<'_>) -> EntityOverrides;
+    fn update_overrides(&self, ctx: &StoreContext<'_>, query_result: &mut DataQueryResult);
 }
 
 /// The common trait implemented for data queries
@@ -26,13 +26,6 @@ pub trait DataQuery {
     ///
     /// This is used when building up the contents for a `SpaceView`.
     fn execute_query(
-        &self,
-        property_resolver: &impl PropertyResolver,
-        ctx: &StoreContext<'_>,
-        entities_per_system: &EntitiesPerSystem,
-    ) -> DataQueryResult;
-
-    fn execute_query_fast(
         &self,
         ctx: &StoreContext<'_>,
         entities_per_system: &EntitiesPerSystem,

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -599,8 +599,8 @@ impl DataQueryPropertyResolver<'_> {
                         .individual
                         .get_opt(&node.data_result.entity_path);
 
-                    let accumulated_properties = if let Some(overidden) = overridden_properties {
-                        accumulated.with_child(overidden)
+                    let accumulated_properties = if let Some(overridden) = overridden_properties {
+                        accumulated.with_child(overridden)
                     } else {
                         accumulated.clone()
                     };

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -310,21 +310,34 @@ impl DataQuery for DataQueryBlueprint {
     ) -> DataQueryResult {
         re_tracing::profile_function!();
 
-        let mut data_results = SlotMap::<DataResultHandle, DataResultNode>::default();
+        let mut data_results = {
+            profile_scope!("create slotmap");
+            SlotMap::<DataResultHandle, DataResultNode>::default()
+        };
 
-        let executor = QueryExpressionEvaluator::new(self, entities_per_system);
+        let executor = {
+            profile_scope!("build evaluator");
+            QueryExpressionEvaluator::new(self, entities_per_system)
+        };
 
-        let root_handle = ctx.recording.and_then(|store| {
-            executor.add_entity_tree_to_data_results_recursive_fast(
-                store.tree(),
-                &mut data_results,
-                false,
-            )
-        });
+        let root_handle = {
+            profile_scope!("run queries");
+            ctx.recording.and_then(|store| {
+                executor.add_entity_tree_to_data_results_recursive_fast(
+                    store.tree(),
+                    &mut data_results,
+                    false,
+                )
+            })
+        };
 
-        DataQueryResult {
-            id: self.id,
-            tree: DataResultTree::new(data_results, root_handle),
+        {
+            profile_scope!("return results");
+
+            DataQueryResult {
+                id: self.id,
+                tree: DataResultTree::new(data_results, root_handle),
+            }
         }
     }
 }
@@ -349,7 +362,6 @@ impl<'a> QueryExpressionEvaluator<'a> {
         blueprint: &'a DataQueryBlueprint,
         per_system_entity_list: &'a EntitiesPerSystem,
     ) -> Self {
-        profile_scope!("expression pre-processing");
         let inclusions: Vec<EntityPathExpr> = blueprint
             .expressions
             .inclusions
@@ -483,15 +495,24 @@ impl<'a> QueryExpressionEvaluator<'a> {
         };
 
         let children: SmallVec<_> = maybe_self_iter
-            .chain(tree.children.values().filter_map(|subtree| {
-                self.add_entity_tree_to_data_results_recursive(
-                    subtree,
-                    overrides,
-                    &accumulated_properties,
-                    data_results,
-                    recursive_include, // Once we have hit a recursive match, it's always propagated
-                )
-            }))
+            .chain(
+                tree.children
+                    .values()
+                    .filter(|subtree| {
+                        !(self.recursive_exclusions.contains(&subtree.path)
+                            || !(recursive_include
+                                || self.allowed_prefixes.contains(&subtree.path)))
+                    })
+                    .filter_map(|subtree| {
+                        self.add_entity_tree_to_data_results_recursive(
+                            subtree,
+                            overrides,
+                            &accumulated_properties,
+                            data_results,
+                            recursive_include, // Once we have hit a recursive match, it's always propagated
+                        )
+                    }),
+            )
             .collect();
 
         // If the only child is the self-leaf, then we don't need to create a group
@@ -521,96 +542,138 @@ impl<'a> QueryExpressionEvaluator<'a> {
         data_results: &mut SlotMap<DataResultHandle, DataResultNode>,
         from_recursive: bool,
     ) -> Option<DataResultHandle> {
+        //re_tracing::profile_function!();
         // If we hit a prefix that is not allowed, we terminate. This is
         // a pruned branch of the tree. Can come from either an explicit
         // recursive exclusion, or an implicit missing inclusion.
         // TODO(jleibs): If this space is disconnected, we should terminate here
-        if self.recursive_exclusions.contains(&tree.path)
-            || !(from_recursive || self.allowed_prefixes.contains(&tree.path))
         {
-            return None;
+            //profile_scope!("early_return");
+            if self.recursive_exclusions.contains(&tree.path)
+                || !(from_recursive || self.allowed_prefixes.contains(&tree.path))
+            {
+                return None;
+            }
         }
 
-        let entity_path = tree.path.clone();
+        let entity_path = &tree.path;
 
         // Pre-compute our matches
-        let exact_include = self.exact_inclusions.contains(&entity_path);
-        let recursive_include = self.recursive_inclusions.contains(&entity_path) || from_recursive;
-        let exact_exclude = self.exact_exclusions.contains(&entity_path);
-        let any_match = (exact_include || recursive_include) && !exact_exclude;
+        let (exact_include, recursive_include, any_match) = {
+            //profile_scope!("matchers");
+
+            let exact_include = self.exact_inclusions.contains(entity_path);
+            let recursive_include =
+                self.recursive_inclusions.contains(entity_path) || from_recursive;
+            let exact_exclude = self.exact_exclusions.contains(entity_path);
+            let any_match = (exact_include || recursive_include) && !exact_exclude;
+            (exact_include, recursive_include, any_match)
+        };
 
         // Only populate view_parts if this is a match
         // Note that allowed prefixes that aren't matches can still create groups
-        let view_parts: SmallVec<_> = if any_match {
-            profile_scope!("test_view_parts");
-            self.per_system_entity_list
-                .iter()
-                .filter_map(|(part, ents)| {
-                    if ents.contains(&entity_path) {
-                        Some(*part)
-                    } else {
-                        None
-                    }
-                })
+        let view_parts: SmallVec<_> = {
+            //profile_scope!("test_view_parts");
+            if any_match {
+                self.per_system_entity_list
+                    .iter()
+                    .filter_map(|(part, ents)| {
+                        if ents.contains(entity_path) {
+                            Some(*part)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            } else {
+                Default::default()
+            }
+        };
+
+        let self_leaf = {
+            //profile_scope!("leaf insertion");
+            if !view_parts.is_empty() || exact_include {
+                Some(data_results.insert(DataResultNode {
+                    data_result: DataResult {
+                        entity_path: entity_path.clone(),
+                        view_parts,
+                        is_group: false,
+                        direct_included: any_match,
+                        individual_properties: None,
+                        accumulated_properties: None,
+                        base_override_path: entity_path.clone(), // This is the wrong path but it will never be written to since this is the fast query
+                    },
+                    children: Default::default(),
+                }))
+            } else {
+                None
+            }
+        };
+
+        let maybe_self_iter = {
+            //profile_scope!("maybe iter");
+            if let Some(self_leaf) = self_leaf {
+                itertools::Either::Left(std::iter::once(self_leaf))
+            } else {
+                itertools::Either::Right(std::iter::empty())
+            }
+        };
+
+        let interesting_children: Vec<_> = {
+            if recursive_include {
+                //profile_scope!("recursive pre-filter");
+                tree.children
+                    .values()
+                    .filter(|subtree| {
+                        !(self.recursive_exclusions.contains(&subtree.path)
+                            || !(recursive_include
+                                || self.allowed_prefixes.contains(&subtree.path)))
+                    })
+                    .collect()
+            } else {
+                //profile_scope!("allowed-path pre-filter");
+                self.allowed_prefixes
+                    .iter()
+                    .filter(|prefix| prefix.is_child_of(entity_path))
+                    .filter_map(|prefix| prefix.last().and_then(|part| tree.children.get(part)))
+                    .collect()
+            }
+        };
+
+        let children: SmallVec<_> = {
+            //profile_scope!("tail recursion");
+            maybe_self_iter
+                .chain(interesting_children.iter().filter_map(|subtree| {
+                    self.add_entity_tree_to_data_results_recursive_fast(
+                        subtree,
+                        data_results,
+                        recursive_include, // Once we have hit a recursive match, it's always propagated
+                    )
+                }))
                 .collect()
-        } else {
-            Default::default()
         };
 
-        let base_override_path = self.blueprint.id.as_entity_path().clone();
+        {
+            //profile_scope!("final result insertion");
 
-        let self_leaf = if !view_parts.is_empty() || exact_include {
-            profile_scope!("leaf insertion");
-            Some(data_results.insert(DataResultNode {
-                data_result: DataResult {
-                    entity_path: entity_path.clone(),
-                    view_parts,
-                    is_group: false,
-                    direct_included: any_match,
-                    individual_properties: None,
-                    accumulated_properties: None,
-                    base_override_path: base_override_path.clone(),
-                },
-                children: Default::default(),
-            }))
-        } else {
-            None
-        };
-
-        let maybe_self_iter = if let Some(self_leaf) = self_leaf {
-            itertools::Either::Left(std::iter::once(self_leaf))
-        } else {
-            itertools::Either::Right(std::iter::empty())
-        };
-
-        let children: SmallVec<_> = maybe_self_iter
-            .chain(tree.children.values().filter_map(|subtree| {
-                self.add_entity_tree_to_data_results_recursive_fast(
-                    subtree,
-                    data_results,
-                    recursive_include, // Once we have hit a recursive match, it's always propagated
-                )
-            }))
-            .collect();
-
-        // If the only child is the self-leaf, then we don't need to create a group
-        if children.is_empty() || children.len() == 1 && self_leaf.is_some() {
-            self_leaf
-        } else {
-            profile_scope!("node insertion");
-            // The 'individual' properties of a group are the group overrides
-            Some(data_results.insert(DataResultNode {
-                data_result: DataResult {
-                    entity_path,
-                    view_parts: Default::default(),
-                    is_group: true,
-                    direct_included: any_match,
-                    individual_properties: None,
-                    accumulated_properties: None,
-                    base_override_path,
-                },
-                children,
-            }))
+            // If the only child is the self-leaf, then we don't need to create a group
+            if children.is_empty() || children.len() == 1 && self_leaf.is_some() {
+                self_leaf
+            } else {
+                // The 'individual' properties of a group are the group overrides
+                Some(data_results.insert(DataResultNode {
+                    data_result: DataResult {
+                        entity_path: entity_path.clone(),
+                        view_parts: Default::default(),
+                        is_group: true,
+                        direct_included: any_match,
+                        individual_properties: None,
+                        accumulated_properties: None,
+                        base_override_path: entity_path.clone(), // This is the wrong path but it will never be written to since this is the fast query,
+                    },
+                    children,
+                }))
+            }
         }
     }
 }

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -421,10 +421,10 @@ impl<'a> QueryExpressionEvaluator<'a> {
             Default::default()
         };
 
-        let mut resolved_properties = inherited.clone();
+        let mut accumulated_properties = inherited.clone();
 
         if let Some(props) = overrides.group.get_opt(&entity_path) {
-            resolved_properties = resolved_properties.with_child(props);
+            accumulated_properties = accumulated_properties.with_child(props);
         }
 
         let base_entity_path = self.blueprint.id.as_entity_path().clone();
@@ -438,10 +438,10 @@ impl<'a> QueryExpressionEvaluator<'a> {
 
         let self_leaf = if !view_parts.is_empty() || exact_include {
             let individual_props = overrides.individual.get_opt(&entity_path);
-            let mut leaf_resolved_properties = resolved_properties.clone();
+            let mut leaf_accumulated_properties = accumulated_properties.clone();
 
             if let Some(props) = individual_props {
-                leaf_resolved_properties = leaf_resolved_properties.with_child(props);
+                leaf_accumulated_properties = leaf_accumulated_properties.with_child(props);
             }
             Some(data_results.insert(DataResultNode {
                 data_result: DataResult {
@@ -450,7 +450,7 @@ impl<'a> QueryExpressionEvaluator<'a> {
                     is_group: false,
                     direct_included: any_match,
                     individual_properties: overrides.individual.get_opt(&entity_path).cloned(),
-                    resolved_properties: leaf_resolved_properties,
+                    accumulated_properties: Some(leaf_accumulated_properties),
                     override_path: individual_override_path,
                 },
                 children: Default::default(),
@@ -470,7 +470,7 @@ impl<'a> QueryExpressionEvaluator<'a> {
                 self.add_entity_tree_to_data_results_recursive(
                     subtree,
                     overrides,
-                    &resolved_properties,
+                    &accumulated_properties,
                     data_results,
                     recursive_include, // Once we have hit a recursive match, it's always propagated
                 )
@@ -490,7 +490,7 @@ impl<'a> QueryExpressionEvaluator<'a> {
                     is_group: true,
                     direct_included: any_match,
                     individual_properties,
-                    resolved_properties,
+                    accumulated_properties: Some(accumulated_properties),
                     override_path: recursive_override_path,
                 },
                 children,

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -274,7 +274,7 @@ impl DataQuery for DataQueryBlueprint {
     /// Build up the initial [`DataQueryResult`] for this [`DataQueryBlueprint`]
     ///
     /// Note that this result will not have any resolved [`PropertyOverrides`]. Those can
-    /// be added by separately calling [`DataQueryPropertyResolver::update_overrides`] on
+    /// be added by separately calling [`PropertyResolver::update_overrides`] on
     /// the result.
     fn execute_query(
         &self,

--- a/crates/re_space_view/src/lib.rs
+++ b/crates/re_space_view/src/lib.rs
@@ -9,7 +9,7 @@ mod data_query_blueprint;
 mod screenshot;
 mod unreachable_transform_reason;
 
-pub use data_query::{DataQuery, EntityOverrides, PropertyResolver};
+pub use data_query::{DataQuery, EntityOverrideContext, PropertyResolver};
 pub use data_query_blueprint::DataQueryBlueprint;
 pub use screenshot::ScreenshotMode;
 pub use unreachable_transform_reason::UnreachableTransformReason;

--- a/crates/re_space_view/src/lib.rs
+++ b/crates/re_space_view/src/lib.rs
@@ -9,7 +9,7 @@ mod data_query_blueprint;
 mod screenshot;
 mod unreachable_transform_reason;
 
-pub use data_query::{DataQuery, EntityOverrides, PropertyResolver, NOOP_RESOLVER};
+pub use data_query::{DataQuery, EntityOverrides, PropertyResolver};
 pub use data_query_blueprint::DataQueryBlueprint;
 pub use screenshot::ScreenshotMode;
 pub use unreachable_transform_reason::UnreachableTransformReason;

--- a/crates/re_space_view_dataframe/src/space_view_class.rs
+++ b/crates/re_space_view_dataframe/src/space_view_class.rs
@@ -87,7 +87,7 @@ impl SpaceViewClass for DataframeSpaceView {
         // These are the entity paths whose content we must display.
         let sorted_entity_paths: BTreeSet<_> = query
             .iter_all_data_results()
-            .filter(|data_result| data_result.resolved_properties.visible)
+            .filter(|data_result| data_result.resolved_properties().visible)
             .map(|data_result| &data_result.entity_path)
             .cloned()
             .collect();

--- a/crates/re_space_view_dataframe/src/space_view_class.rs
+++ b/crates/re_space_view_dataframe/src/space_view_class.rs
@@ -87,7 +87,7 @@ impl SpaceViewClass for DataframeSpaceView {
         // These are the entity paths whose content we must display.
         let sorted_entity_paths: BTreeSet<_> = query
             .iter_all_data_results()
-            .filter(|data_result| data_result.resolved_properties().visible)
+            .filter(|data_result| data_result.accumulated_properties().visible)
             .map(|data_result| &data_result.entity_path)
             .cloned()
             .collect();

--- a/crates/re_space_view_spatial/src/contexts/non_interactive_entities.rs
+++ b/crates/re_space_view_spatial/src/contexts/non_interactive_entities.rs
@@ -28,7 +28,7 @@ impl ViewContextSystem for NonInteractiveEntities {
         self.0 = query
             .iter_all_data_results()
             .filter_map(|data_result| {
-                if data_result.resolved_properties().interactive {
+                if data_result.accumulated_properties().interactive {
                     None
                 } else {
                     Some(data_result.entity_path.hash())

--- a/crates/re_space_view_spatial/src/contexts/non_interactive_entities.rs
+++ b/crates/re_space_view_spatial/src/contexts/non_interactive_entities.rs
@@ -28,7 +28,7 @@ impl ViewContextSystem for NonInteractiveEntities {
         self.0 = query
             .iter_all_data_results()
             .filter_map(|data_result| {
-                if data_result.resolved_properties.interactive {
+                if data_result.resolved_properties().interactive {
                     None
                 } else {
                     Some(data_result.entity_path.hash())

--- a/crates/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/re_space_view_spatial/src/contexts/transform_context.rs
@@ -99,7 +99,7 @@ impl ViewContextSystem for TransformContext {
             .map(|results| {
                 results
                     .iter()
-                    .map(|r| (r.entity_path.clone(), r.resolved_properties.clone()))
+                    .map(|r| (r.entity_path.clone(), r.resolved_properties().clone()))
                     .collect()
             })
             .unwrap_or_default();

--- a/crates/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/re_space_view_spatial/src/contexts/transform_context.rs
@@ -99,7 +99,7 @@ impl ViewContextSystem for TransformContext {
             .map(|results| {
                 results
                     .iter()
-                    .map(|r| (r.entity_path.clone(), r.resolved_properties().clone()))
+                    .map(|r| (r.entity_path.clone(), r.accumulated_properties().clone()))
                     .collect()
             })
             .unwrap_or_default();

--- a/crates/re_space_view_spatial/src/parts/cameras.rs
+++ b/crates/re_space_view_spatial/src/parts/cameras.rs
@@ -216,7 +216,7 @@ impl ViewPartSystem for CamerasPart {
                     transforms,
                     shared_render_builders,
                     &data_result.entity_path,
-                    &data_result.resolved_properties,
+                    data_result.resolved_properties(),
                     &pinhole,
                     store
                         .query_latest_component::<Transform3D>(

--- a/crates/re_space_view_spatial/src/parts/cameras.rs
+++ b/crates/re_space_view_spatial/src/parts/cameras.rs
@@ -216,7 +216,7 @@ impl ViewPartSystem for CamerasPart {
                     transforms,
                     shared_render_builders,
                     &data_result.entity_path,
-                    data_result.resolved_properties(),
+                    data_result.accumulated_properties(),
                     &pinhole,
                     store
                         .query_latest_component::<Transform3D>(

--- a/crates/re_space_view_spatial/src/parts/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/parts/entity_iterator.rs
@@ -78,7 +78,7 @@ where
             ctx.store_db.store(),
             &query.timeline,
             &query.latest_at,
-            &data_result.resolved_properties().visible_history,
+            &data_result.accumulated_properties().visible_history,
             &data_result.entity_path,
         )
         .and_then(|entity_views| {
@@ -91,7 +91,7 @@ where
                 fun(
                     ctx,
                     &data_result.entity_path,
-                    data_result.resolved_properties(),
+                    data_result.accumulated_properties(),
                     ent_view,
                     &entity_context,
                 )?;

--- a/crates/re_space_view_spatial/src/parts/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/parts/entity_iterator.rs
@@ -78,7 +78,7 @@ where
             ctx.store_db.store(),
             &query.timeline,
             &query.latest_at,
-            &data_result.resolved_properties.visible_history,
+            &data_result.resolved_properties().visible_history,
             &data_result.entity_path,
         )
         .and_then(|entity_views| {
@@ -91,7 +91,7 @@ where
                 fun(
                     ctx,
                     &data_result.entity_path,
-                    &data_result.resolved_properties,
+                    data_result.resolved_properties(),
                     ent_view,
                     &entity_context,
                 )?;

--- a/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
@@ -67,7 +67,7 @@ impl ViewPartSystem for Transform3DArrowsPart {
                 continue;
             }
 
-            if !*data_result.resolved_properties.transform_3d_visible {
+            if !*data_result.resolved_properties().transform_3d_visible {
                 continue;
             }
 
@@ -91,7 +91,7 @@ impl ViewPartSystem for Transform3DArrowsPart {
                 &mut line_builder,
                 world_from_obj,
                 Some(&data_result.entity_path),
-                *data_result.resolved_properties.transform_3d_size,
+                *data_result.resolved_properties().transform_3d_size,
                 query
                     .highlights
                     .entity_outline_mask(data_result.entity_path.hash())

--- a/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/parts/transform3d_arrows.rs
@@ -67,7 +67,7 @@ impl ViewPartSystem for Transform3DArrowsPart {
                 continue;
             }
 
-            if !*data_result.resolved_properties().transform_3d_visible {
+            if !*data_result.accumulated_properties().transform_3d_visible {
                 continue;
             }
 
@@ -91,7 +91,7 @@ impl ViewPartSystem for Transform3DArrowsPart {
                 &mut line_builder,
                 world_from_obj,
                 Some(&data_result.entity_path),
-                *data_result.resolved_properties().transform_3d_size,
+                *data_result.accumulated_properties().transform_3d_size,
                 query
                     .highlights
                     .entity_outline_mask(data_result.entity_path.hash())

--- a/crates/re_space_view_time_series/src/view_part_system.rs
+++ b/crates/re_space_view_time_series/src/view_part_system.rs
@@ -132,14 +132,14 @@ impl TimeSeriesSystem {
 
             let visible_history = match query.timeline.typ() {
                 re_log_types::TimeType::Time => {
-                    data_result.resolved_properties.visible_history.nanos
+                    data_result.resolved_properties().visible_history.nanos
                 }
                 re_log_types::TimeType::Sequence => {
-                    data_result.resolved_properties.visible_history.sequences
+                    data_result.resolved_properties().visible_history.sequences
                 }
             };
 
-            let (from, to) = if data_result.resolved_properties.visible_history.enabled {
+            let (from, to) = if data_result.resolved_properties().visible_history.enabled {
                 (
                     visible_history.from(query.latest_at),
                     visible_history.to(query.latest_at),

--- a/crates/re_space_view_time_series/src/view_part_system.rs
+++ b/crates/re_space_view_time_series/src/view_part_system.rs
@@ -132,14 +132,17 @@ impl TimeSeriesSystem {
 
             let visible_history = match query.timeline.typ() {
                 re_log_types::TimeType::Time => {
-                    data_result.resolved_properties().visible_history.nanos
+                    data_result.accumulated_properties().visible_history.nanos
                 }
                 re_log_types::TimeType::Sequence => {
-                    data_result.resolved_properties().visible_history.sequences
+                    data_result
+                        .accumulated_properties()
+                        .visible_history
+                        .sequences
                 }
             };
 
-            let (from, to) = if data_result.resolved_properties().visible_history.enabled {
+            let (from, to) = if data_result.accumulated_properties().visible_history.enabled {
                 (
                     visible_history.from(query.latest_at),
                     visible_history.to(query.latest_at),

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -147,18 +147,12 @@ impl AppState {
                 .values()
                 .flat_map(|space_view| {
                     space_view.queries.iter().filter_map(|query| {
-                        let props = viewport.state.space_view_props(space_view.id);
-                        let resolver = query.build_resolver(space_view.id, props);
                         entities_per_system_per_class
                             .get(&query.space_view_class_identifier)
                             .map(|entities_per_system| {
                                 (
                                     query.id,
-                                    query.execute_query(
-                                        &resolver,
-                                        store_context,
-                                        entities_per_system,
-                                    ),
+                                    query.execute_query_fast(store_context, entities_per_system),
                                 )
                             })
                     })

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -3,7 +3,7 @@ use ahash::HashMap;
 use re_data_store::StoreDb;
 use re_log_types::{LogMsg, StoreId, TimeRangeF};
 use re_smart_channel::ReceiveSet;
-use re_space_view::DataQuery as _;
+use re_space_view::{DataQuery as _, PropertyResolver as _};
 use re_viewer_context::{
     AppOptions, Caches, CommandSender, ComponentUiRegistry, PlayState, RecordingConfig,
     SelectionState, SpaceViewClassRegistry, StoreContext, SystemCommandSender as _, ViewerContext,
@@ -139,7 +139,7 @@ impl AppState {
         );
 
         // Execute the queries for every `SpaceView`
-        let query_results = {
+        let mut query_results = {
             re_tracing::profile_scope!("query_results");
             viewport
                 .blueprint
@@ -152,7 +152,7 @@ impl AppState {
                             .map(|entities_per_system| {
                                 (
                                     query.id,
-                                    query.execute_query_fast(store_context, entities_per_system),
+                                    query.execute_query(store_context, entities_per_system),
                                 )
                             })
                     })
@@ -160,7 +160,7 @@ impl AppState {
                 .collect::<_>()
         };
 
-        let mut ctx = ViewerContext {
+        let ctx = ViewerContext {
             app_options,
             cache,
             space_view_class_registry,
@@ -182,36 +182,35 @@ impl AppState {
 
         viewport.on_frame_start(&ctx, &spaces_info);
 
-        // TODO(jleibs): Running the queries a second time is annoying, but we need
-        // to do this or else the auto_properties aren't right since they get populated
-        // in on_frame_start, but on_frame_start also needs the queries.
-        let updated_query_results = {
+        {
             re_tracing::profile_scope!("updated_query_results");
-            viewport
-                .blueprint
-                .space_views
-                .values()
-                .flat_map(|space_view| {
-                    space_view.queries.iter().filter_map(|query| {
+            for space_view in viewport.blueprint.space_views.values() {
+                for query in &space_view.queries {
+                    if let Some(query_result) = query_results.get_mut(&query.id) {
                         let props = viewport.state.space_view_props(space_view.id);
                         let resolver = query.build_resolver(space_view.id, props);
-                        entities_per_system_per_class
-                            .get(&query.space_view_class_identifier)
-                            .map(|entities_per_system| {
-                                (
-                                    query.id,
-                                    query.execute_query(
-                                        &resolver,
-                                        store_context,
-                                        entities_per_system,
-                                    ),
-                                )
-                            })
-                    })
-                })
-                .collect::<_>()
+                        resolver.update_overrides(store_context, query_result);
+                    }
+                }
+            }
         };
-        ctx.query_results = &updated_query_results;
+
+        // TODO(jleibs): The need to rebuild this after updating the queries is kind of annoying,
+        // but it's just a bunch of refs so not really that big of a deal in practice.
+        let ctx = ViewerContext {
+            app_options,
+            cache,
+            space_view_class_registry,
+            component_ui_registry,
+            store_db,
+            store_context,
+            entities_per_system_per_class: &entities_per_system_per_class,
+            query_results: &query_results,
+            rec_cfg,
+            re_ui,
+            render_ctx,
+            command_sender,
+        };
 
         time_panel.show_panel(&ctx, ui, app_blueprint.time_panel_expanded);
         selection_panel.show_panel(

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -603,8 +603,8 @@ fn blueprint_ui(
 
                 let root_data_result = space_view.root_data_result(ctx.store_context);
                 let mut props = root_data_result
-                    .individual_properties
-                    .clone()
+                    .individual_properties()
+                    .cloned()
                     .unwrap_or(resolved_entity_props.clone());
 
                 let cursor = ui.cursor();
@@ -667,8 +667,8 @@ fn blueprint_ui(
                             .cloned()
                         {
                             let mut props = data_result
-                                .individual_properties
-                                .clone()
+                                .individual_properties()
+                                .cloned()
                                 .unwrap_or_default();
                             entity_props_ui(
                                 ctx,
@@ -697,8 +697,8 @@ fn blueprint_ui(
                 {
                     let space_view_class = *space_view.class_identifier();
                     let mut props = data_result
-                        .individual_properties
-                        .clone()
+                        .individual_properties()
+                        .cloned()
                         .unwrap_or_default();
 
                     entity_props_ui(

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -676,7 +676,7 @@ fn blueprint_ui(
                                 &space_view_class,
                                 Some(entity_path),
                                 &mut props,
-                                data_result.resolved_properties(),
+                                data_result.accumulated_properties(),
                             );
                             data_result.save_override(Some(props), ctx);
                         }
@@ -707,7 +707,7 @@ fn blueprint_ui(
                         &space_view_class,
                         None,
                         &mut props,
-                        data_result.resolved_properties(),
+                        data_result.accumulated_properties(),
                     );
                     data_result.save_override(Some(props), ctx);
                 }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -676,7 +676,7 @@ fn blueprint_ui(
                                 &space_view_class,
                                 Some(entity_path),
                                 &mut props,
-                                &data_result.resolved_properties,
+                                data_result.resolved_properties(),
                             );
                             data_result.save_override(Some(props), ctx);
                         }
@@ -707,7 +707,7 @@ fn blueprint_ui(
                         &space_view_class,
                         None,
                         &mut props,
-                        &data_result.resolved_properties,
+                        data_result.resolved_properties(),
                     );
                     data_result.save_override(Some(props), ctx);
                 }

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -44,9 +44,9 @@ pub use selection_state::{
 pub use space_view::{
     default_heuristic_filter, AutoSpawnHeuristic, DataResult, DynSpaceViewClass,
     HeuristicFilterContext, IdentifiedViewSystem, PerSystemDataResults, PerSystemEntities,
-    SpaceViewClass, SpaceViewClassIdentifier, SpaceViewClassLayoutPriority, SpaceViewClassRegistry,
-    SpaceViewClassRegistryError, SpaceViewEntityHighlight, SpaceViewHighlights,
-    SpaceViewOutlineMasks, SpaceViewState, SpaceViewSystemExecutionError,
+    PropertyOverrides, SpaceViewClass, SpaceViewClassIdentifier, SpaceViewClassLayoutPriority,
+    SpaceViewClassRegistry, SpaceViewClassRegistryError, SpaceViewEntityHighlight,
+    SpaceViewHighlights, SpaceViewOutlineMasks, SpaceViewState, SpaceViewSystemExecutionError,
     SpaceViewSystemRegistrator, SystemExecutionOutput, ViewContextCollection, ViewContextSystem,
     ViewPartCollection, ViewPartSystem, ViewQuery, ViewSystemIdentifier,
 };

--- a/crates/re_viewer_context/src/query_context.rs
+++ b/crates/re_viewer_context/src/query_context.rs
@@ -136,6 +136,11 @@ impl DataResultTree {
         self.data_results.get(handle)
     }
 
+    /// Look up a [`DataResultNode`] in the tree based on its handle.
+    pub fn lookup_node_mut(&mut self, handle: DataResultHandle) -> Option<&mut DataResultNode> {
+        self.data_results.get_mut(handle)
+    }
+
     /// Look up a [`DataResultNode`] in the tree based on an [`EntityPath`].
     pub fn lookup_result_by_path_and_group(
         &self,

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -117,6 +117,7 @@ pub struct SelectionState {
 impl SelectionState {
     /// Called at the start of each frame
     pub fn on_frame_start(&mut self, item_retain_condition: impl Fn(&Item) -> bool) {
+        // Use a different name so we don't get a collision in puffin.
         re_tracing::profile_scope!("SelectionState::on_frame_start");
 
         let history = self.history.get_mut();

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -117,7 +117,7 @@ pub struct SelectionState {
 impl SelectionState {
     /// Called at the start of each frame
     pub fn on_frame_start(&mut self, item_retain_condition: impl Fn(&Item) -> bool) {
-        re_tracing::profile_function!();
+        re_tracing::profile_scope!("SelectionState::on_frame_start");
 
         let history = self.history.get_mut();
         history.retain(&item_retain_condition);

--- a/crates/re_viewer_context/src/space_view/mod.rs
+++ b/crates/re_viewer_context/src/space_view/mod.rs
@@ -32,7 +32,7 @@ pub use view_context_system::{ViewContextCollection, ViewContextSystem};
 pub use view_part_system::{
     default_heuristic_filter, HeuristicFilterContext, ViewPartCollection, ViewPartSystem,
 };
-pub use view_query::{DataResult, PerSystemDataResults, ViewQuery};
+pub use view_query::{DataResult, PerSystemDataResults, PropertyOverrides, ViewQuery};
 
 // ---------------------------------------------------------------------------
 

--- a/crates/re_viewer_context/src/space_view/view_query.rs
+++ b/crates/re_viewer_context/src/space_view/view_query.rs
@@ -62,6 +62,7 @@ impl DataResult {
     pub const INDIVIDUAL_OVERRIDES_PREFIX: &'static str = "individual_overrides";
     pub const RECURSIVE_OVERRIDES_PREFIX: &'static str = "recursive_overrides";
 
+    #[inline]
     pub fn override_path(&self) -> Option<EntityPath> {
         self.property_overrides.as_ref().map(|property_overrides| {
             if self.is_group {
@@ -144,12 +145,14 @@ impl DataResult {
             ));
     }
 
-    pub fn resolved_properties(&self) -> &EntityProperties {
+    #[inline]
+    pub fn accumulated_properties(&self) -> &EntityProperties {
         self.property_overrides
             .as_ref()
             .map_or(&DEFAULT_PROPS, |p| &p.accumulated_properties)
     }
 
+    #[inline]
     pub fn individual_properties(&self) -> Option<&EntityProperties> {
         self.property_overrides
             .as_ref()
@@ -195,7 +198,7 @@ impl<'s> ViewQuery<'s> {
                 itertools::Either::Right(
                     results
                         .iter()
-                        .filter(|result| result.resolved_properties().visible)
+                        .filter(|result| result.accumulated_properties().visible)
                         .copied(),
                 )
             },

--- a/crates/re_viewer_context/src/space_view/view_query.rs
+++ b/crates/re_viewer_context/src/space_view/view_query.rs
@@ -24,7 +24,7 @@ pub struct PropertyOverrides {
     pub individual_properties: Option<EntityProperties>,
 
     /// `EntityPath` in the Blueprint store where updated overrides should be written back.
-    pub base_override_path: EntityPath,
+    pub override_path: EntityPath,
 }
 
 /// This is the primary mechanism through which data is passed to a `SpaceView`.
@@ -63,20 +63,8 @@ impl DataResult {
     pub const RECURSIVE_OVERRIDES_PREFIX: &'static str = "recursive_overrides";
 
     #[inline]
-    pub fn override_path(&self) -> Option<EntityPath> {
-        self.property_overrides.as_ref().map(|property_overrides| {
-            if self.is_group {
-                property_overrides
-                    .base_override_path
-                    .join(&Self::INDIVIDUAL_OVERRIDES_PREFIX.into())
-                    .join(&self.entity_path)
-            } else {
-                property_overrides
-                    .base_override_path
-                    .join(&Self::RECURSIVE_OVERRIDES_PREFIX.into())
-                    .join(&self.entity_path)
-            }
-        })
+    pub fn override_path(&self) -> Option<&EntityPath> {
+        self.property_overrides.as_ref().map(|p| &p.override_path)
     }
 
     /// Write the [`EntityProperties`] for this result back to the Blueprint store.

--- a/crates/re_viewer_context/src/space_view/view_query.rs
+++ b/crates/re_viewer_context/src/space_view/view_query.rs
@@ -82,6 +82,8 @@ impl DataResult {
     /// Write the [`EntityProperties`] for this result back to the Blueprint store.
     pub fn save_override(&self, props: Option<EntityProperties>, ctx: &ViewerContext<'_>) {
         // TODO(jleibs): Make it impossible for this to happen with different type structure
+        // This should never happen unless we're doing something with a partially processed
+        // query.
         let Some(override_path) = self.override_path() else {
             re_log::warn!(
                 "Tried to save override for {:?} but it has no override path",
@@ -147,9 +149,18 @@ impl DataResult {
 
     #[inline]
     pub fn accumulated_properties(&self) -> &EntityProperties {
-        self.property_overrides
-            .as_ref()
-            .map_or(&DEFAULT_PROPS, |p| &p.accumulated_properties)
+        // TODO(jleibs): Make it impossible for this to happen with different type structure
+        // This should never happen unless we're doing something with a partially processed
+        // query.
+        let Some(property_overrides) = &self.property_overrides else {
+            re_log::warn!(
+                "Tried to get accumulated properties for {:?} but it has no property overrides",
+                self.entity_path
+            );
+            return &DEFAULT_PROPS;
+        };
+
+        &property_overrides.accumulated_properties
     }
 
     #[inline]

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -422,7 +422,7 @@ impl SpaceViewBlueprint {
             property_overrides: Some(PropertyOverrides {
                 accumulated_properties,
                 individual_properties,
-                base_override_path: entity_path,
+                override_path: entity_path,
             }),
         }
     }
@@ -463,7 +463,7 @@ impl SpaceViewBlueprint {
 mod tests {
     use re_data_store::StoreDb;
     use re_log_types::{DataCell, DataRow, RowId, StoreId, TimePoint};
-    use re_space_view::DataQuery as _;
+    use re_space_view::{DataQuery as _, PropertyResolver as _};
     use re_types::archetypes::Points3D;
     use re_viewer_context::{EntitiesPerSystem, StoreContext};
 
@@ -541,7 +541,8 @@ mod tests {
                 all_recordings: vec![],
             };
 
-            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system);
+            let mut query_result = query.execute_query(&ctx, &entities_per_system);
+            resolver.update_overrides(&ctx, &mut query_result);
 
             let parent = query_result
                 .tree
@@ -567,7 +568,7 @@ mod tests {
             let mut overrides = parent.individual_properties().cloned().unwrap_or_default();
             overrides.visible = false;
 
-            save_override(overrides, &parent.override_path().unwrap(), &mut blueprint);
+            save_override(overrides, parent.override_path().unwrap(), &mut blueprint);
         }
 
         // Parent is not visible, but children are
@@ -578,7 +579,8 @@ mod tests {
                 all_recordings: vec![],
             };
 
-            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system);
+            let mut query_result = query.execute_query(&ctx, &entities_per_system);
+            resolver.update_overrides(&ctx, &mut query_result);
 
             let parent_group = query_result
                 .tree
@@ -612,7 +614,7 @@ mod tests {
 
             save_override(
                 overrides,
-                &parent_group.override_path().unwrap(),
+                parent_group.override_path().unwrap(),
                 &mut blueprint,
             );
         }
@@ -625,7 +627,8 @@ mod tests {
                 all_recordings: vec![],
             };
 
-            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system);
+            let mut query_result = query.execute_query(&ctx, &entities_per_system);
+            resolver.update_overrides(&ctx, &mut query_result);
 
             let parent = query_result
                 .tree
@@ -656,7 +659,7 @@ mod tests {
             overrides.visible_history.enabled = true;
             overrides.visible_history.nanos = VisibleHistory::ALL;
 
-            save_override(overrides, &root.override_path().unwrap(), &mut blueprint);
+            save_override(overrides, root.override_path().unwrap(), &mut blueprint);
         }
 
         // Everyone has visible history
@@ -667,7 +670,8 @@ mod tests {
                 all_recordings: vec![],
             };
 
-            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system);
+            let mut query_result = query.execute_query(&ctx, &entities_per_system);
+            resolver.update_overrides(&ctx, &mut query_result);
 
             let parent = query_result
                 .tree
@@ -693,7 +697,7 @@ mod tests {
             let mut overrides = child2.individual_properties().cloned().unwrap_or_default();
             overrides.visible_history.enabled = true;
 
-            save_override(overrides, &child2.override_path().unwrap(), &mut blueprint);
+            save_override(overrides, child2.override_path().unwrap(), &mut blueprint);
         }
 
         // Child2 has its own visible history
@@ -704,7 +708,8 @@ mod tests {
                 all_recordings: vec![],
             };
 
-            let query_result = query.execute_query(&resolver, &ctx, &entities_per_system);
+            let mut query_result = query.execute_query(&ctx, &entities_per_system);
+            resolver.update_overrides(&ctx, &mut query_result);
 
             let parent = query_result
                 .tree

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -421,7 +421,7 @@ impl SpaceViewBlueprint {
             direct_included: true,
             accumulated_properties: Some(accumulated_properties),
             individual_properties,
-            override_path: entity_path,
+            base_override_path: entity_path,
         }
     }
 
@@ -562,7 +562,7 @@ mod tests {
             let mut overrides = parent.individual_properties.clone().unwrap_or_default();
             overrides.visible = false;
 
-            save_override(overrides, &parent.override_path, &mut blueprint);
+            save_override(overrides, &parent.override_path(), &mut blueprint);
         }
 
         // Parent is not visible, but children are
@@ -605,7 +605,7 @@ mod tests {
                 .unwrap_or_default();
             overrides.visible = false;
 
-            save_override(overrides, &parent_group.override_path, &mut blueprint);
+            save_override(overrides, &parent_group.override_path(), &mut blueprint);
         }
 
         // Nobody is visible
@@ -647,7 +647,7 @@ mod tests {
             overrides.visible_history.enabled = true;
             overrides.visible_history.nanos = VisibleHistory::ALL;
 
-            save_override(overrides, &root.override_path, &mut blueprint);
+            save_override(overrides, &root.override_path(), &mut blueprint);
         }
 
         // Everyone has visible history
@@ -684,7 +684,7 @@ mod tests {
             let mut overrides = child2.individual_properties.clone().unwrap_or_default();
             overrides.visible_history.enabled = true;
 
-            save_override(overrides, &child2.override_path, &mut blueprint);
+            save_override(overrides, &child2.override_path(), &mut blueprint);
         }
 
         // Child2 has its own visible history

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -557,7 +557,10 @@ mod tests {
                 .unwrap();
 
             for result in [parent, child1, child2] {
-                assert_eq!(result.resolved_properties(), &EntityProperties::default(),);
+                assert_eq!(
+                    result.accumulated_properties(),
+                    &EntityProperties::default(),
+                );
             }
 
             // Now, override visibility on parent but not group
@@ -594,10 +597,10 @@ mod tests {
                 .lookup_result_by_path_and_group(&EntityPath::from("parent/skip/child2"), false)
                 .unwrap();
 
-            assert!(!parent.resolved_properties().visible);
+            assert!(!parent.accumulated_properties().visible);
 
             for result in [child1, child2] {
-                assert!(result.resolved_properties().visible);
+                assert!(result.accumulated_properties().visible);
             }
 
             // Override visibility on parent group
@@ -638,7 +641,7 @@ mod tests {
                 .unwrap();
 
             for result in [parent, child1, child2] {
-                assert!(!result.resolved_properties().visible);
+                assert!(!result.accumulated_properties().visible);
             }
         }
 
@@ -680,9 +683,9 @@ mod tests {
                 .unwrap();
 
             for result in [parent, child1, child2] {
-                assert!(result.resolved_properties().visible_history.enabled);
+                assert!(result.accumulated_properties().visible_history.enabled);
                 assert_eq!(
-                    result.resolved_properties().visible_history.nanos,
+                    result.accumulated_properties().visible_history.nanos,
                     VisibleHistory::ALL
                 );
             }
@@ -717,16 +720,16 @@ mod tests {
                 .unwrap();
 
             for result in [parent, child1] {
-                assert!(result.resolved_properties().visible_history.enabled);
+                assert!(result.accumulated_properties().visible_history.enabled);
                 assert_eq!(
-                    result.resolved_properties().visible_history.nanos,
+                    result.accumulated_properties().visible_history.nanos,
                     VisibleHistory::ALL
                 );
             }
 
-            assert!(child2.resolved_properties().visible_history.enabled);
+            assert!(child2.accumulated_properties().visible_history.enabled);
             assert_eq!(
-                child2.resolved_properties().visible_history.nanos,
+                child2.accumulated_properties().visible_history.nanos,
                 VisibleHistory::OFF
             );
         }

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -58,18 +58,6 @@ pub fn all_possible_space_views(
 ) -> Vec<(SpaceViewBlueprint, DataQueryResult)> {
     re_tracing::profile_function!();
 
-    for (class_identifier, entities_per_system) in entities_per_system_per_class {
-        for (system_name, entities) in entities_per_system {
-            if entities.is_empty() {
-                re_log::debug!(
-                    "SpaceViewClassRegistry: No entities for system {:?} of class {:?}",
-                    system_name,
-                    class_identifier
-                );
-            }
-        }
-    }
-
     // For each candidate, create space views for all possible classes.
     candidate_space_view_paths(ctx, spaces_info)
         .flat_map(|candidate_space_path| {

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -87,7 +87,7 @@ pub fn all_possible_space_views(
                     );
 
                     let results =
-                        candidate_query.execute_query_fast(ctx.store_context, entities_per_system);
+                        candidate_query.execute_query(ctx.store_context, entities_per_system);
 
                     if !results.is_empty() {
                         Some((

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -5,7 +5,7 @@ use nohash_hasher::{IntMap, IntSet};
 use re_arrow_store::{LatestAtQuery, Timeline};
 use re_data_store::{EntityPath, EntityTree};
 use re_log_types::{EntityPathExpr, TimeInt};
-use re_space_view::{DataQuery as _, DataQueryBlueprint, NOOP_RESOLVER};
+use re_space_view::{DataQuery as _, DataQueryBlueprint};
 use re_types::components::{DisconnectedSpace, TensorData};
 use re_types::ComponentNameSet;
 use re_viewer_context::{
@@ -86,11 +86,8 @@ pub fn all_possible_space_views(
                         std::iter::once(EntityPathExpr::Recursive(candidate_space_path.clone())),
                     );
 
-                    let results = candidate_query.execute_query(
-                        &NOOP_RESOLVER,
-                        ctx.store_context,
-                        entities_per_system,
-                    );
+                    let results =
+                        candidate_query.execute_query_fast(ctx.store_context, entities_per_system);
 
                     if !results.is_empty() {
                         Some((

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -222,7 +222,7 @@ impl Viewport<'_, '_> {
         };
 
         let group_is_visible =
-            top_node.data_result.resolved_properties.visible && space_view_visible;
+            top_node.data_result.resolved_properties().visible && space_view_visible;
 
         // Always real children ahead of groups
         for child in top_node

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -222,7 +222,7 @@ impl Viewport<'_, '_> {
         };
 
         let group_is_visible =
-            top_node.data_result.resolved_properties().visible && space_view_visible;
+            top_node.data_result.accumulated_properties().visible && space_view_visible;
 
         // Always real children ahead of groups
         for child in top_node

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -265,8 +265,8 @@ impl Viewport<'_, '_> {
                 ctx.selection_state().highlight_for_ui_element(&item) == HoverHighlight::Hovered;
 
             let mut properties = data_result
-                .individual_properties
-                .clone()
+                .individual_properties()
+                .cloned()
                 .unwrap_or_default();
 
             let name = entity_path


### PR DESCRIPTION
### What

- Resolves: https://github.com/rerun-io/rerun/issues/4490

After adding some scopes, found some more wins on query processing. This is a mixture of some optimized short-circuit early-outs, and doing the PropertyOverride logic on a second-pass in order to avoid any overhead related to creating the EntityProperty structures and override entity-paths.

This has the added benefit of also removing the second query and replacing it with a much easier-to-follow override processor.

Before:
![image](https://github.com/rerun-io/rerun/assets/3312232/f7564835-575e-443a-8933-073471d4452f)

After:
![image](https://github.com/rerun-io/rerun/assets/3312232/f555515e-c8a2-491f-a00f-b8f67f79568e)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4563/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4563/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4563/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4563)
- [Docs preview](https://rerun.io/preview/def055e32c466a530ea2c3761b42ae01440f6c20/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/def055e32c466a530ea2c3761b42ae01440f6c20/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)