### PR TITLE
`DataLoader`s 6: first-class support for `NotSupported`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5511,6 +5511,7 @@ dependencies = [
 name = "rerun-loader-rust-file"
 version = "0.12.0-alpha.1+dev"
 dependencies = [
+ "anyhow",
  "argh",
  "rerun",
 ]

--- a/crates/re_data_source/src/data_loader/loader_archetype.rs
+++ b/crates/re_data_source/src/data_loader/loader_archetype.rs
@@ -26,7 +26,7 @@ impl DataLoader for ArchetypeLoader {
         use anyhow::Context as _;
 
         if filepath.is_dir() {
-            return Ok(()); // simply not interested
+            return Err(crate::DataLoaderError::NotSupported(filepath.clone()));
         }
 
         re_tracing::profile_function!(filepath.display().to_string());
@@ -45,6 +45,11 @@ impl DataLoader for ArchetypeLoader {
         contents: std::borrow::Cow<'_, [u8]>,
         tx: std::sync::mpsc::Sender<LoadedData>,
     ) -> Result<(), crate::DataLoaderError> {
+        let extension = crate::extension(&filepath);
+        if !crate::is_supported_file_extension(&extension) {
+            return Err(crate::DataLoaderError::NotSupported(filepath.clone()));
+        }
+
         re_tracing::profile_function!(filepath.display().to_string());
 
         let entity_path = EntityPath::from_file_path(&filepath);
@@ -75,8 +80,6 @@ impl DataLoader for ArchetypeLoader {
                 }
             }
         }
-
-        let extension = crate::extension(&filepath);
 
         let mut rows = Vec::new();
 

--- a/crates/re_data_source/src/data_loader/loader_archetype.rs
+++ b/crates/re_data_source/src/data_loader/loader_archetype.rs
@@ -26,7 +26,7 @@ impl DataLoader for ArchetypeLoader {
         use anyhow::Context as _;
 
         if filepath.is_dir() {
-            return Err(crate::DataLoaderError::NotSupported(filepath.clone()));
+            return Err(crate::DataLoaderError::Incompatible(filepath.clone()));
         }
 
         re_tracing::profile_function!(filepath.display().to_string());
@@ -47,7 +47,7 @@ impl DataLoader for ArchetypeLoader {
     ) -> Result<(), crate::DataLoaderError> {
         let extension = crate::extension(&filepath);
         if !crate::is_supported_file_extension(&extension) {
-            return Err(crate::DataLoaderError::NotSupported(filepath.clone()));
+            return Err(crate::DataLoaderError::Incompatible(filepath.clone()));
         }
 
         re_tracing::profile_function!(filepath.display().to_string());

--- a/crates/re_data_source/src/data_loader/loader_directory.rs
+++ b/crates/re_data_source/src/data_loader/loader_directory.rs
@@ -21,7 +21,7 @@ impl crate::DataLoader for DirectoryLoader {
         tx: std::sync::mpsc::Sender<crate::LoadedData>,
     ) -> Result<(), crate::DataLoaderError> {
         if dirpath.is_file() {
-            return Err(crate::DataLoaderError::NotSupported(dirpath.clone()));
+            return Err(crate::DataLoaderError::Incompatible(dirpath.clone()));
         }
 
         re_tracing::profile_function!(dirpath.display().to_string());
@@ -45,9 +45,9 @@ impl crate::DataLoader for DirectoryLoader {
 
                 // NOTE(1): `spawn` is fine, this whole function is native-only.
                 // NOTE(2): this must spawned on a dedicated thread to avoid a deadlock!
-                // `load` will spawn a bunch of loaders on the common thread pool and wait for
+                // `load` will spawn a bunch of loaders on the common rayon thread pool and wait for
                 // their response via channels: we cannot be waiting for these responses on the
-                // common thread pool.
+                // common rayon thread pool.
                 _ = std::thread::Builder::new()
                     .name(format!("load_dir_entry({filepath:?})"))
                     .spawn(move || {
@@ -80,6 +80,6 @@ impl crate::DataLoader for DirectoryLoader {
         _tx: std::sync::mpsc::Sender<crate::LoadedData>,
     ) -> Result<(), crate::DataLoaderError> {
         // TODO(cmc): This could make sense to implement for e.g. archive formats (zip, tar, …)
-        Err(crate::DataLoaderError::NotSupported(path))
+        Err(crate::DataLoaderError::Incompatible(path))
     }
 }

--- a/crates/re_data_source/src/data_loader/loader_directory.rs
+++ b/crates/re_data_source/src/data_loader/loader_directory.rs
@@ -21,7 +21,7 @@ impl crate::DataLoader for DirectoryLoader {
         tx: std::sync::mpsc::Sender<crate::LoadedData>,
     ) -> Result<(), crate::DataLoaderError> {
         if dirpath.is_file() {
-            return Ok(()); // simply not interested
+            return Err(crate::DataLoaderError::NotSupported(dirpath.clone()));
         }
 
         re_tracing::profile_function!(dirpath.display().to_string());
@@ -43,22 +43,28 @@ impl crate::DataLoader for DirectoryLoader {
                 let filepath = filepath.to_owned();
                 let tx = tx.clone();
 
-                // NOTE: spawn is fine, this whole function is native-only.
-                rayon::spawn(move || {
-                    let data = match crate::load_file::load(&store_id, &filepath, false, None) {
-                        Ok(data) => data,
-                        Err(err) => {
-                            re_log::error!(?filepath, %err, "Failed to load directory entry");
-                            return;
-                        }
-                    };
+                // NOTE(1): `spawn` is fine, this whole function is native-only.
+                // NOTE(2): this must spawned on a dedicated thread to avoid a deadlock!
+                // `load` will spawn a bunch of loaders on the common thread pool and wait for
+                // their response via channels: we cannot be waiting for these responses on the
+                // common thread pool.
+                _ = std::thread::Builder::new()
+                    .name(format!("load_dir_entry({filepath:?})"))
+                    .spawn(move || {
+                        let data = match crate::load_file::load(&store_id, &filepath, None) {
+                            Ok(data) => data,
+                            Err(err) => {
+                                re_log::error!(?filepath, %err, "Failed to load directory entry");
+                                return;
+                            }
+                        };
 
-                    for datum in data {
-                        if tx.send(datum).is_err() {
-                            break;
+                        for datum in data {
+                            if tx.send(datum).is_err() {
+                                break;
+                            }
                         }
-                    }
-                });
+                    });
             }
         }
 
@@ -69,11 +75,11 @@ impl crate::DataLoader for DirectoryLoader {
     fn load_from_file_contents(
         &self,
         _store_id: re_log_types::StoreId,
-        _path: std::path::PathBuf,
+        path: std::path::PathBuf,
         _contents: std::borrow::Cow<'_, [u8]>,
         _tx: std::sync::mpsc::Sender<crate::LoadedData>,
     ) -> Result<(), crate::DataLoaderError> {
         // TODO(cmc): This could make sense to implement for e.g. archive formats (zip, tar, …)
-        Ok(()) // simply not interested
+        Err(crate::DataLoaderError::NotSupported(path))
     }
 }

--- a/crates/re_data_source/src/data_loader/loader_rrd.rs
+++ b/crates/re_data_source/src/data_loader/loader_rrd.rs
@@ -25,7 +25,7 @@ impl crate::DataLoader for RrdLoader {
 
         let extension = crate::extension(&filepath);
         if extension != "rrd" {
-            return Err(crate::DataLoaderError::NotSupported(filepath.clone()));
+            return Err(crate::DataLoaderError::Incompatible(filepath.clone()));
         }
 
         re_log::debug!(
@@ -67,7 +67,7 @@ impl crate::DataLoader for RrdLoader {
 
         let extension = crate::extension(&filepath);
         if extension != "rrd" {
-            return Err(crate::DataLoaderError::NotSupported(filepath));
+            return Err(crate::DataLoaderError::Incompatible(filepath));
         }
 
         let version_policy = re_log_encoding::decoder::VersionPolicy::Warn;

--- a/crates/re_data_source/src/data_loader/mod.rs
+++ b/crates/re_data_source/src/data_loader/mod.rs
@@ -136,7 +136,7 @@ pub enum DataLoaderError {
     Decode(#[from] re_log_encoding::decoder::DecodeError),
 
     #[error("No data-loader support for {0:?}")]
-    NotSupported(std::path::PathBuf),
+    Incompatible(std::path::PathBuf),
 
     #[error(transparent)]
     Other(#[from] anyhow::Error),
@@ -153,8 +153,8 @@ impl DataLoaderError {
     }
 
     #[inline]
-    pub fn is_not_supported(&self) -> bool {
-        matches!(self, Self::NotSupported { .. })
+    pub fn is_incompatible(&self) -> bool {
+        matches!(self, Self::Incompatible { .. })
     }
 }
 
@@ -248,6 +248,6 @@ pub use self::loader_rrd::RrdLoader;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use self::loader_external::{
-    iter_external_loaders, ExternalLoader, EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE,
+    iter_external_loaders, ExternalLoader, EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE,
     EXTERNAL_DATA_LOADER_PREFIX,
 };

--- a/crates/re_data_source/src/data_loader/mod.rs
+++ b/crates/re_data_source/src/data_loader/mod.rs
@@ -31,6 +31,10 @@ use re_log_types::{ArrowMsg, DataRow, LogMsg};
 /// - [`DirectoryLoader`] for recursively loading folders.
 /// - [`ExternalLoader`], which looks for user-defined data loaders in $PATH.
 ///
+/// ## Registering custom loaders
+///
+/// TODO(cmc): web guide in upcoming PR
+///
 /// ## Execution
 ///
 /// **All** registered [`DataLoader`]s get called when a user tries to open a file, unconditionally.
@@ -131,6 +135,9 @@ pub enum DataLoaderError {
     #[error(transparent)]
     Decode(#[from] re_log_encoding::decoder::DecodeError),
 
+    #[error("No data-loader support for {0:?}")]
+    NotSupported(std::path::PathBuf),
+
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -143,6 +150,11 @@ impl DataLoaderError {
             DataLoaderError::IO(err) => err.kind() == std::io::ErrorKind::NotFound,
             _ => false,
         }
+    }
+
+    #[inline]
+    pub fn is_not_supported(&self) -> bool {
+        matches!(self, Self::NotSupported { .. })
     }
 }
 

--- a/crates/re_data_source/src/data_loader/mod.rs
+++ b/crates/re_data_source/src/data_loader/mod.rs
@@ -247,8 +247,7 @@ pub use self::loader_directory::DirectoryLoader;
 pub use self::loader_rrd::RrdLoader;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) use self::loader_external::EXTERNAL_LOADER_PATHS;
-#[cfg(not(target_arch = "wasm32"))]
 pub use self::loader_external::{
-    iter_external_loaders, ExternalLoader, EXTERNAL_DATA_LOADER_PREFIX,
+    iter_external_loaders, ExternalLoader, EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE,
+    EXTERNAL_DATA_LOADER_PREFIX,
 };

--- a/crates/re_data_source/src/lib.rs
+++ b/crates/re_data_source/src/lib.rs
@@ -66,6 +66,7 @@ pub fn supported_extensions() -> impl Iterator<Item = &'static str> {
         .iter()
         .chain(SUPPORTED_IMAGE_EXTENSIONS)
         .chain(SUPPORTED_MESH_EXTENSIONS)
+        .chain(SUPPORTED_POINT_CLOUD_EXTENSIONS)
         .chain(SUPPORTED_TEXT_EXTENSIONS)
         .copied()
 }

--- a/crates/re_data_source/src/lib.rs
+++ b/crates/re_data_source/src/lib.rs
@@ -23,7 +23,10 @@ pub use self::load_file::{extension, load_from_file_contents};
 pub use self::web_sockets::connect_to_ws_url;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use self::data_loader::{iter_external_loaders, ExternalLoader};
+pub use self::data_loader::{
+    iter_external_loaders, ExternalLoader, EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE,
+    EXTERNAL_DATA_LOADER_PREFIX,
+};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use self::load_file::load_from_path;

--- a/crates/re_data_source/src/lib.rs
+++ b/crates/re_data_source/src/lib.rs
@@ -24,7 +24,7 @@ pub use self::web_sockets::connect_to_ws_url;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use self::data_loader::{
-    iter_external_loaders, ExternalLoader, EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE,
+    iter_external_loaders, ExternalLoader, EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE,
     EXTERNAL_DATA_LOADER_PREFIX,
 };
 

--- a/crates/rerun/src/lib.rs
+++ b/crates/rerun/src/lib.rs
@@ -137,6 +137,10 @@ pub use re_data_store::external::re_arrow_store::{
     DataStore, StoreDiff, StoreDiffKind, StoreEvent, StoreGeneration, StoreSubscriber,
 };
 
+pub use re_data_source::{
+    EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE, EXTERNAL_DATA_LOADER_PREFIX,
+};
+
 /// Re-exports of other crates.
 pub mod external {
     pub use anyhow;

--- a/crates/rerun/src/lib.rs
+++ b/crates/rerun/src/lib.rs
@@ -138,7 +138,7 @@ pub use re_data_store::external::re_arrow_store::{
 };
 
 pub use re_data_source::{
-    EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE, EXTERNAL_DATA_LOADER_PREFIX,
+    EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE, EXTERNAL_DATA_LOADER_PREFIX,
 };
 
 /// Re-exports of other crates.

--- a/examples/cpp/external_data_loader/main.cpp
+++ b/examples/cpp/external_data_loader/main.cpp
@@ -59,10 +59,9 @@ int main(int argc, char* argv[]) {
     bool is_file = std::filesystem::is_regular_file(filepath);
     bool is_cpp_file = std::filesystem::path(filepath).extension().string() == ".cpp";
 
-    // We're not interested: just exit silently.
-    // Don't return an error, as that would show up to the end user in the Rerun Viewer!
+    // Inform the Rerun Viewer that we do not support that kind of file.
     if (!(is_file && is_cpp_file)) {
-        return 0;
+        return rerun::EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE;
     }
 
     std::ifstream file(filepath);

--- a/examples/cpp/external_data_loader/main.cpp
+++ b/examples/cpp/external_data_loader/main.cpp
@@ -60,8 +60,8 @@ int main(int argc, char* argv[]) {
     bool is_cpp_file = std::filesystem::path(filepath).extension().string() == ".cpp";
 
     // Inform the Rerun Viewer that we do not support that kind of file.
-    if (!(is_file && is_cpp_file)) {
-        return rerun::EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE;
+    if (!is_file || is_cpp_file) {
+        return rerun::EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE;
     }
 
     std::ifstream file(filepath);

--- a/examples/python/external_data_loader/main.py
+++ b/examples/python/external_data_loader/main.py
@@ -32,8 +32,8 @@ def main() -> None:
     is_python_file = os.path.splitext(args.filepath)[1].lower() == ".py"
 
     # Inform the Rerun Viewer that we do not support that kind of file.
-    if not (is_file and is_python_file):
-        exit(rr.EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE)
+    if not is_file or not is_python_file:
+        exit(rr.EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE)
 
     rr.init("rerun_example_external_data_loader", recording_id=args.recording_id)
     # The most important part of this: log to standard output so the Rerun Viewer can ingest it!

--- a/examples/python/external_data_loader/main.py
+++ b/examples/python/external_data_loader/main.py
@@ -31,10 +31,9 @@ def main() -> None:
     is_file = os.path.isfile(args.filepath)
     is_python_file = os.path.splitext(args.filepath)[1].lower() == ".py"
 
-    # We're not interested: just exit silently.
-    # Don't return an error, as that would show up to the end user in the Rerun Viewer!
+    # Inform the Rerun Viewer that we do not support that kind of file.
     if not (is_file and is_python_file):
-        return
+        exit(rr.EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE)
 
     rr.init("rerun_example_external_data_loader", recording_id=args.recording_id)
     # The most important part of this: log to standard output so the Rerun Viewer can ingest it!

--- a/examples/rust/external_data_loader/Cargo.toml
+++ b/examples/rust/external_data_loader/Cargo.toml
@@ -9,4 +9,5 @@ publish = false
 [dependencies]
 rerun = { path = "../../../crates/rerun" }
 
+anyhow = "1.0"
 argh = "0.1"

--- a/rerun_cpp/src/rerun.hpp
+++ b/rerun_cpp/src/rerun.hpp
@@ -18,6 +18,11 @@
 
 /// All Rerun C++ types and functions are in the `rerun` namespace or one of its nested namespaces.
 namespace rerun {
+    /// When an external [`DataLoader`] is asked to load some data that it doesn't know how to load, it
+    /// should exit with this exit code.
+    // NOTE: Always keep in sync with other languages.
+    const int EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE = 66;
+
     // Archetypes are the quick-and-easy default way of logging data to Rerun.
     // Make them available in the rerun namespace.
     using namespace archetypes;

--- a/rerun_cpp/src/rerun.hpp
+++ b/rerun_cpp/src/rerun.hpp
@@ -21,7 +21,7 @@ namespace rerun {
     /// When an external [`DataLoader`] is asked to load some data that it doesn't know how to load, it
     /// should exit with this exit code.
     // NOTE: Always keep in sync with other languages.
-    const int EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE = 66;
+    const int EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE = 66;
 
     // Archetypes are the quick-and-easy default way of logging data to Rerun.
     // Make them available in the rerun namespace.

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -170,7 +170,7 @@ from . import experimental  # isort: skip
 # UTILITIES
 
 __all__ += [
-    "EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE",
+    "EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE",
     "cleanup_if_forked_child",
     "init",
     "new_recording",
@@ -184,7 +184,7 @@ __all__ += [
 
 
 # NOTE: Always keep in sync with other languages.
-EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE = 66
+EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE = 66
 """
 When an external `DataLoader` is asked to load some data that it doesn't know how to load, it
 should exit with this exit code.

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -170,6 +170,7 @@ from . import experimental  # isort: skip
 # UTILITIES
 
 __all__ += [
+    "EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE",
     "cleanup_if_forked_child",
     "init",
     "new_recording",
@@ -180,6 +181,14 @@ __all__ += [
     "unregister_shutdown",
     "version",
 ]
+
+
+# NOTE: Always keep in sync with other languages.
+EXTERNAL_DATA_LOADER_NOT_SUPPORTED_EXIT_CODE = 66
+"""
+When an external `DataLoader` is asked to load some data that it doesn't know how to load, it
+should exit with this exit code.
+"""
 
 
 def _init_recording_stream() -> None:


### PR DESCRIPTION
Introduce a first-class protocol for `DataLoader`s -- whether they are builtin, custom, or external -- to announce that they don't support loading a given piece of data.

This fixes one of the oldest issue when loading files in Rerun: loading unsupported data would always bottom out in either the image or websocket paths, leading to unrelated errors very confusing to users.

The loading process is now a two-pass process:
1. Dispatch the data to be loaded to all loaders, which will respond ASAP whether they can do it or not.
1.1. If at least one compatible loader is found, go to 2
1.2. Otherwise, fail early with a nice error message for the end user
2. Dispatch the actual data loading.

This has important/subtle ramifications on the threading model, but other than that is what you'd expect.


Checks:
- [x] Native: CLI examples/assets/*
- [x] Native: CLI examples/assets
- [x] Native: CLI examples/assets/* containing unsupported files
- [x] Native: CLI examples/assets containing unsupported files
- [x] Native: File>Open examples/assets/*
- [x] Native: File>Open examples/assets
- [x] Native: File>Open examples/assets/* containing unsupported files
- [x] Native: File>Open examples/assets containing unsupported files
- [x] Native: Drag-n-drop examples/assets/*
- [x] Native: Drag-n-drop examples/assets
- [x] Native: Drag-n-drop examples/assets/* containing unsupported files
- [x] Native: Drag-n-drop examples/assets containing unsupported files
- [x] Web: File>Open examples/assets/*
- [x] Web: Drag-n-drop examples/assets/*
- [x] Web: File>Open examples/assets/* containing unsupported files
- [x] Web: Drag-n-drop examples/assets/* containing unsupported files



---

Part of a series of PRs to make it possible to load _any_ file from the local filesystem, by any means, on web and native:
- #4516
- #4517 
- #4518 
- #4519 
- #4520 
- #4521 
- #4565
- #4566
- #4567

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4516/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4516/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4516)
- [Docs preview](https://rerun.io/preview/9fe37fba6672cfb189911a649210adf92dcaecc7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/9fe37fba6672cfb189911a649210adf92dcaecc7/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)