### PR TITLE
`DataLoader`s 7: support for custom `DataLoader`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,6 +1429,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom_data_loader"
+version = "0.12.0-alpha.1+dev"
+dependencies = [
+ "re_build_tools",
+ "rerun",
+]
+
+[[package]]
 name = "custom_space_view"
 version = "0.12.0-alpha.1+dev"
 dependencies = [

--- a/crates/re_data_source/src/data_loader/mod.rs
+++ b/crates/re_data_source/src/data_loader/mod.rs
@@ -229,8 +229,26 @@ static BUILTIN_LOADERS: Lazy<Vec<Arc<dyn DataLoader>>> = Lazy::new(|| {
 
 /// Iterator over all registered [`DataLoader`]s.
 #[inline]
-pub fn iter_loaders() -> impl ExactSizeIterator<Item = Arc<dyn DataLoader>> {
-    BUILTIN_LOADERS.clone().into_iter()
+pub fn iter_loaders() -> impl Iterator<Item = Arc<dyn DataLoader>> {
+    BUILTIN_LOADERS
+        .clone()
+        .into_iter()
+        .chain(CUSTOM_LOADERS.read().clone())
+}
+
+/// Keeps track of all custom [`DataLoader`]s.
+///
+/// Use [`register_custom_data_loader`] to add new loaders.
+static CUSTOM_LOADERS: Lazy<parking_lot::RwLock<Vec<Arc<dyn DataLoader>>>> =
+    Lazy::new(parking_lot::RwLock::default);
+
+/// Register a custom [`DataLoader`].
+///
+/// Any time the Rerun Viewer opens a file or directory, this custom loader will be notified.
+/// Refer to [`DataLoader`]'s documentation for more information.
+#[inline]
+pub fn register_custom_data_loader(loader: impl DataLoader + 'static) {
+    CUSTOM_LOADERS.write().push(Arc::new(loader));
 }
 
 // ---

--- a/crates/re_data_source/src/lib.rs
+++ b/crates/re_data_source/src/lib.rs
@@ -15,8 +15,8 @@ mod web_sockets;
 mod load_stdin;
 
 pub use self::data_loader::{
-    iter_loaders, ArchetypeLoader, DataLoader, DataLoaderError, DirectoryLoader, LoadedData,
-    RrdLoader,
+    iter_loaders, register_custom_data_loader, ArchetypeLoader, DataLoader, DataLoaderError,
+    DirectoryLoader, LoadedData, RrdLoader,
 };
 pub use self::data_source::DataSource;
 pub use self::load_file::{extension, load_from_file_contents};

--- a/examples/rust/custom_data_loader/Cargo.toml
+++ b/examples/rust/custom_data_loader/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "custom_data_loader"
+version = "0.12.0-alpha.1+dev"
+edition = "2021"
+rust-version = "1.72"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+rerun = { path = "../../../crates/rerun", features = ["native_viewer"] }
+
+[build-dependencies]
+re_build_tools = { path = "../../../crates/re_build_tools" }

--- a/examples/rust/custom_data_loader/README.md
+++ b/examples/rust/custom_data_loader/README.md
@@ -1,0 +1,20 @@
+---
+title: Custom data-loader
+tags: [data-loader, extension]
+rust: https://github.com/rerun-io/rerun/tree/latest/examples/rust/custom_data_loader/src/main.rs?speculative-link
+---
+
+<picture>
+  <img src="https://static.rerun.io/custom_data_loader/e44aadfa02fade5a3cf5d7cbdd6e0bf65d9f6446/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/custom_data_loader/e44aadfa02fade5a3cf5d7cbdd6e0bf65d9f6446/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/custom_data_loader/e44aadfa02fade5a3cf5d7cbdd6e0bf65d9f6446/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/custom_data_loader/e44aadfa02fade5a3cf5d7cbdd6e0bf65d9f6446/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/custom_data_loader/e44aadfa02fade5a3cf5d7cbdd6e0bf65d9f6446/1200w.png">
+</picture>
+
+This example demonstrates how to implement and register a `DataLoader` into the Rerun Viewer in order to add support for loading arbitrary files.
+
+Usage:
+```sh
+$ cargo r -p custom_data_loader -- path/to/some/file
+```

--- a/examples/rust/custom_data_loader/build.rs
+++ b/examples/rust/custom_data_loader/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    re_build_tools::export_build_info_vars_for_crate("custom_data_loader");
+}

--- a/examples/rust/custom_data_loader/src/main.rs
+++ b/examples/rust/custom_data_loader/src/main.rs
@@ -1,0 +1,82 @@
+//! This example demonstrates how to implement and register a [`re_data_source::DataLoader`] into
+//! the Rerun Viewer in order to add support for loading arbitrary files.
+//!
+//! Usage:
+//! ```sh
+//! $ cargo r -p custom_data_loader -- path/to/some/file
+//! ```
+
+use rerun::{
+    external::{anyhow, re_build_info, re_data_source, re_log, tokio},
+    log::{DataRow, RowId},
+    EntityPath, TimePoint,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<std::process::ExitCode> {
+    re_log::setup_native_logging();
+
+    re_data_source::register_custom_data_loader(HashLoader);
+
+    let build_info = re_build_info::build_info!();
+    rerun::run(build_info, rerun::CallSource::Cli, std::env::args())
+        .await
+        .map(std::process::ExitCode::from)
+}
+
+// ---
+
+/// A custom [`re_data_source::DataLoader`] that logs any file as a [`TextDocument`] of its hash.
+struct HashLoader;
+
+impl re_data_source::DataLoader for HashLoader {
+    fn name(&self) -> String {
+        "rerun.data_loaders.HashLoader".into()
+    }
+
+    fn load_from_path(
+        &self,
+        _store_id: rerun::external::re_log_types::StoreId,
+        path: std::path::PathBuf,
+        tx: std::sync::mpsc::Sender<re_data_source::LoadedData>,
+    ) -> Result<(), re_data_source::DataLoaderError> {
+        let contents = std::fs::read(&path)?;
+        if path.is_dir() {
+            return Err(re_data_source::DataLoaderError::NotSupported(path)); // simply not interested
+        }
+        hash_and_log(&tx, &path, &contents)
+    }
+
+    fn load_from_file_contents(
+        &self,
+        _store_id: rerun::external::re_log_types::StoreId,
+        filepath: std::path::PathBuf,
+        contents: std::borrow::Cow<'_, [u8]>,
+        tx: std::sync::mpsc::Sender<re_data_source::LoadedData>,
+    ) -> Result<(), re_data_source::DataLoaderError> {
+        hash_and_log(&tx, &filepath, &contents)
+    }
+}
+
+fn hash_and_log(
+    tx: &std::sync::mpsc::Sender<re_data_source::LoadedData>,
+    filepath: &std::path::Path,
+    contents: &[u8],
+) -> Result<(), re_data_source::DataLoaderError> {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut h = DefaultHasher::new();
+    contents.hash(&mut h);
+
+    let doc = rerun::TextDocument::new(format!("{:x}", h.finish()))
+        .with_media_type(rerun::MediaType::TEXT);
+
+    let entity_path = EntityPath::from_file_path(filepath);
+    let entity_path = format!("{entity_path}/hashed").into();
+    let row = DataRow::from_archetype(RowId::new(), TimePoint::timeless(), entity_path, &doc)?;
+
+    tx.send(row.into()).ok();
+
+    Ok(())
+}

--- a/examples/rust/custom_data_loader/src/main.rs
+++ b/examples/rust/custom_data_loader/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<std::process::ExitCode> {
 
 // ---
 
-/// A custom [`re_data_source::DataLoader`] that logs any file as a [`TextDocument`] of its hash.
+/// A custom [`re_data_source::DataLoader`] that logs any file as a [`rerun::TextDocument`] of its hash.
 struct HashLoader;
 
 impl re_data_source::DataLoader for HashLoader {

--- a/examples/rust/custom_data_loader/src/main.rs
+++ b/examples/rust/custom_data_loader/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<std::process::ExitCode> {
 
 // ---
 
-/// A custom [`re_data_source::DataLoader`] that logs any file as a [`rerun::TextDocument`] of its hash.
+/// A custom [`re_data_source::DataLoader`] that logs the hash of file as a [`rerun::TextDocument`].
 struct HashLoader;
 
 impl re_data_source::DataLoader for HashLoader {
@@ -42,7 +42,7 @@ impl re_data_source::DataLoader for HashLoader {
     ) -> Result<(), re_data_source::DataLoaderError> {
         let contents = std::fs::read(&path)?;
         if path.is_dir() {
-            return Err(re_data_source::DataLoaderError::NotSupported(path)); // simply not interested
+            return Err(re_data_source::DataLoaderError::Incompatible(path)); // simply not interested
         }
         hash_and_log(&tx, &path, &contents)
     }
@@ -69,7 +69,7 @@ fn hash_and_log(
     let mut h = DefaultHasher::new();
     contents.hash(&mut h);
 
-    let doc = rerun::TextDocument::new(format!("{:x}", h.finish()))
+    let doc = rerun::TextDocument::new(format!("{:08X}", h.finish()))
         .with_media_type(rerun::MediaType::TEXT);
 
     let entity_path = EntityPath::from_file_path(filepath);


### PR DESCRIPTION
Add support for registering custom loaders, the same way we offer support for registering custom space views and store subscribers.

Checks:
- [x] cargo r -p custom_data_loader -- Cargo.toml

---

Part of a series of PRs to make it possible to load _any_ file from the local filesystem, by any means, on web and native:
- #4516
- #4517 
- #4518 
- #4519 
- #4520 
- #4521 
- #4565
- #4566
- #4567

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Full build: [app.rerun.io](https://app.rerun.io/pr/4516/index.html)
  * Partial build: [app.rerun.io](https://app.rerun.io/pr/4516/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) - Useful for quick testing when changes do not affect examples in any way
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4516)
- [Docs preview](https://rerun.io/preview/a3516ee6147b4906b3c264b802abafe48b172ea8/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a3516ee6147b4906b3c264b802abafe48b172ea8/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)