### PR TITLE
Add `SizeBytes::is_pod` and related optimizations

### DIFF
--- a/crates/re_arrow_store/src/lib.rs
+++ b/crates/re_arrow_store/src/lib.rs
@@ -48,8 +48,8 @@ pub use self::store_subscriber::{StoreSubscriber, StoreSubscriberHandle};
 pub use self::store_write::{WriteError, WriteResult};
 
 pub(crate) use self::store::{
-    ClusterCellCache, DataTypeRegistry, IndexedBucket, IndexedBucketInner, IndexedTable,
-    MetadataRegistry, PersistentIndexedTable,
+    ClusterCellCache, IndexedBucket, IndexedBucketInner, IndexedTable, MetadataRegistry,
+    PersistentIndexedTable,
 };
 
 #[allow(unused_imports)] // only used with some sets of feature flags atm

--- a/crates/re_arrow_store/src/store_stats.rs
+++ b/crates/re_arrow_store/src/store_stats.rs
@@ -1,10 +1,9 @@
-use nohash_hasher::IntMap;
 use re_log_types::{EntityPathHash, TimePoint, TimeRange};
-use re_types_core::{ComponentName, SizeBytes};
+use re_types_core::SizeBytes;
 
 use crate::{
     store::{IndexedBucketInner, PersistentIndexedTableInner},
-    ClusterCellCache, DataStore, DataTypeRegistry, IndexedBucket, IndexedTable, MetadataRegistry,
+    ClusterCellCache, DataStore, IndexedBucket, IndexedTable, MetadataRegistry,
     PersistentIndexedTable,
 };
 

--- a/crates/re_arrow_store/src/store_stats.rs
+++ b/crates/re_arrow_store/src/store_stats.rs
@@ -166,23 +166,6 @@ impl DataStoreStats {
 
 // --- Data store ---
 
-impl SizeBytes for DataTypeRegistry {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        type K = ComponentName;
-
-        // NOTE: This is only here to make sure this method fails to compile if the inner type
-        // changes, as the following size computation assumes POD types.
-        let inner: &IntMap<K, _> = &self.0;
-
-        let keys_size_bytes = std::mem::size_of::<K>() * inner.len();
-        // NOTE: It's all on the heap at this point.
-        let values_size_bytes = self.values().map(SizeBytes::total_size_bytes).sum::<u64>();
-
-        keys_size_bytes as u64 + values_size_bytes
-    }
-}
-
 impl SizeBytes for MetadataRegistry<(TimePoint, EntityPathHash)> {
     #[inline]
     fn heap_size_bytes(&self) -> u64 {

--- a/crates/re_log_types/src/data_row.rs
+++ b/crates/re_log_types/src/data_row.rs
@@ -198,6 +198,11 @@ impl SizeBytes for RowId {
     fn heap_size_bytes(&self) -> u64 {
         0
     }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
+    }
 }
 
 impl std::ops::Deref for RowId {

--- a/crates/re_log_types/src/data_table.rs
+++ b/crates/re_log_types/src/data_table.rs
@@ -181,6 +181,11 @@ impl SizeBytes for TableId {
     fn heap_size_bytes(&self) -> u64 {
         0
     }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
+    }
 }
 
 impl std::ops::Deref for TableId {

--- a/crates/re_log_types/src/num_instances.rs
+++ b/crates/re_log_types/src/num_instances.rs
@@ -35,6 +35,11 @@ impl SizeBytes for NumInstances {
     fn heap_size_bytes(&self) -> u64 {
         0
     }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
+    }
 }
 
 re_types_core::macros::impl_into_cow!(NumInstances);

--- a/crates/re_types_core/src/size_bytes.rs
+++ b/crates/re_types_core/src/size_bytes.rs
@@ -36,7 +36,7 @@ pub trait SizeBytes {
 }
 
 // TODO(rust-lang/rust#31844): This isn't happening without specialization.
-// impl<T> SizeBytes for T where T: bytemuck::Pod { ... }
+// impl<T> SizeBytes for T where T: bytemuck::Pod { … }
 
 // --- Std ---
 

--- a/crates/re_types_core/src/size_bytes.rs
+++ b/crates/re_types_core/src/size_bytes.rs
@@ -25,7 +25,18 @@ pub trait SizeBytes {
 
     /// Returns the total size of `self` on the heap, in bytes.
     fn heap_size_bytes(&self) -> u64;
+
+    /// Is `Self` just plain old data?
+    ///
+    /// If `true`, this will make most blanket implementations of `SizeBytes` much faster (e.g. `Vec<T>`).
+    #[inline]
+    fn is_pod() -> bool {
+        false
+    }
 }
+
+// TODO(rust-lang/rust#31844): This isn't happening without specialization.
+// impl<T> SizeBytes for T where T: bytemuck::Pod { ... }
 
 // --- Std ---
 


### PR DESCRIPTION
_Starting to cherry-pick some of the stuff buried in my caching branch_

Let `SizeBytes` know when `T` is a POD, which makes computing the sizes of many `T`s much faster.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4573/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4573/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4573/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4573)
- [Docs preview](https://rerun.io/preview/001d8c61e5720d35e4e201ba89acb44c33fd9a0f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/001d8c61e5720d35e4e201ba89acb44c33fd9a0f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)