### PR TITLE
Remove overly aggressive puffin scopes

### DIFF
--- a/crates/re_data_store/src/blueprint/components/entity_properties_component.rs
+++ b/crates/re_data_store/src/blueprint/components/entity_properties_component.rs
@@ -70,7 +70,6 @@ impl ::re_types_core::Loggable for EntityPropertiesComponent {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -139,7 +138,6 @@ impl ::re_types_core::Loggable for EntityPropertiesComponent {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_log_types/src/data_cell.rs
+++ b/crates/re_log_types/src/data_cell.rs
@@ -380,7 +380,7 @@ impl DataCell {
     /// Fails if the underlying arrow data cannot be deserialized into `C`.
     #[inline]
     pub fn try_to_native<'a, C: Component + 'a>(&'a self) -> DataCellResult<Vec<C>> {
-        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+        // NOTE(#3850): Don't add a profile scope here: the profiler overhead is too big for this fast function.
         // re_tracing::profile_function!(C::name().as_str());
 
         Ok(C::from_arrow(self.inner.values.as_ref())?)
@@ -391,7 +391,7 @@ impl DataCell {
     /// Fails if the underlying arrow data cannot be deserialized into `C`.
     #[inline]
     pub fn try_to_native_mono<'a, C: Component + 'a>(&'a self) -> DataCellResult<Option<C>> {
-        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+        // NOTE(#3850): Don't add a profile scope here: the profiler overhead is too big for this fast function.
         // re_tracing::profile_function!(C::name().as_str());
 
         let mut instances = C::from_arrow_opt(self.inner.values.as_ref())?.into_iter();
@@ -431,7 +431,7 @@ impl DataCell {
     /// Fails if the underlying arrow data cannot be deserialized into `C`.
     #[inline]
     pub fn try_to_native_opt<'a, C: Component + 'a>(&'a self) -> DataCellResult<Vec<Option<C>>> {
-        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+        // NOTE(#3850): Don't add a profile scope here: the profiler overhead is too big for this fast function.
         // re_tracing::profile_function!(C::name().as_str());
 
         Ok(C::from_arrow_opt(self.inner.values.as_ref())?)

--- a/crates/re_log_types/src/data_cell.rs
+++ b/crates/re_log_types/src/data_cell.rs
@@ -380,7 +380,9 @@ impl DataCell {
     /// Fails if the underlying arrow data cannot be deserialized into `C`.
     #[inline]
     pub fn try_to_native<'a, C: Component + 'a>(&'a self) -> DataCellResult<Vec<C>> {
-        re_tracing::profile_function!(C::name().as_str());
+        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+        // re_tracing::profile_function!(C::name().as_str());
+
         Ok(C::from_arrow(self.inner.values.as_ref())?)
     }
 
@@ -389,7 +391,8 @@ impl DataCell {
     /// Fails if the underlying arrow data cannot be deserialized into `C`.
     #[inline]
     pub fn try_to_native_mono<'a, C: Component + 'a>(&'a self) -> DataCellResult<Option<C>> {
-        re_tracing::profile_function!(C::name().as_str());
+        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+        // re_tracing::profile_function!(C::name().as_str());
 
         let mut instances = C::from_arrow_opt(self.inner.values.as_ref())?.into_iter();
 
@@ -428,7 +431,9 @@ impl DataCell {
     /// Fails if the underlying arrow data cannot be deserialized into `C`.
     #[inline]
     pub fn try_to_native_opt<'a, C: Component + 'a>(&'a self) -> DataCellResult<Vec<Option<C>>> {
-        re_tracing::profile_function!(C::name().as_str());
+        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+        // re_tracing::profile_function!(C::name().as_str());
+
         Ok(C::from_arrow_opt(self.inner.values.as_ref())?)
     }
 

--- a/crates/re_query/src/archetype_view.rs
+++ b/crates/re_query/src/archetype_view.rs
@@ -215,6 +215,16 @@ where
     }
 }
 
+impl<IIter1, IIter2, VIter, C> ExactSizeIterator
+    for ComponentJoinedIterator<IIter1, IIter2, VIter, C>
+where
+    IIter1: ExactSizeIterator<Item = InstanceKey>,
+    IIter2: ExactSizeIterator<Item = InstanceKey>,
+    VIter: ExactSizeIterator<Item = Option<C>>,
+    C: Clone,
+{
+}
+
 /// A view of an [`Archetype`] at a particular point in time returned by [`crate::get_component_with_instances`]
 ///
 /// The required [`Component`]s of an [`ArchetypeView`] determines the length of an entity
@@ -271,7 +281,7 @@ impl<A: Archetype> ArchetypeView<A> {
 
     /// Returns an iterator over [`InstanceKey`]s.
     #[inline]
-    pub fn iter_instance_keys(&self) -> impl Iterator<Item = InstanceKey> {
+    pub fn iter_instance_keys(&self) -> impl ExactSizeIterator<Item = InstanceKey> {
         re_tracing::profile_function!();
         // TODO(#2750): Maybe make this an intersection instead
         self.required_comp().instance_keys().into_iter()
@@ -288,8 +298,9 @@ impl<A: Archetype> ArchetypeView<A> {
     #[inline]
     pub fn iter_required_component<'a, C: Component + 'a>(
         &'a self,
-    ) -> DeserializationResult<impl Iterator<Item = C> + '_> {
-        re_tracing::profile_function!();
+    ) -> DeserializationResult<impl ExactSizeIterator<Item = C> + '_> {
+        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+        // re_tracing::profile_function!();
 
         debug_assert!(A::required_components()
             .iter()
@@ -315,7 +326,8 @@ impl<A: Archetype> ArchetypeView<A> {
     /// Get a single required mono-component.
     #[inline]
     pub fn required_mono_component<C: Component>(&self) -> DeserializationResult<C> {
-        re_tracing::profile_function!();
+        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+        // re_tracing::profile_function!();
 
         let mut iter = self.iter_required_component::<C>()?;
         let value = iter
@@ -338,8 +350,9 @@ impl<A: Archetype> ArchetypeView<A> {
     #[inline]
     pub fn iter_optional_component<'a, C: Component + Clone + 'a>(
         &'a self,
-    ) -> DeserializationResult<impl Iterator<Item = Option<C>> + '_> {
-        re_tracing::profile_function!(C::name());
+    ) -> DeserializationResult<impl ExactSizeIterator<Item = Option<C>> + '_> {
+        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+        // re_tracing::profile_function!(C::name());
 
         let component = self.components.get(&C::name());
 
@@ -437,7 +450,8 @@ impl<A: Archetype> ArchetypeView<A> {
     pub fn iter_raw_optional_component<'a, C: Component + Clone + 'a>(
         &'a self,
     ) -> DeserializationResult<Option<impl Iterator<Item = C> + '_>> {
-        re_tracing::profile_function!(C::name());
+        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+        // re_tracing::profile_function!(C::name());
 
         let component = self.components.get(&C::name());
 

--- a/crates/re_query/src/archetype_view.rs
+++ b/crates/re_query/src/archetype_view.rs
@@ -299,7 +299,7 @@ impl<A: Archetype> ArchetypeView<A> {
     pub fn iter_required_component<'a, C: Component + 'a>(
         &'a self,
     ) -> DeserializationResult<impl ExactSizeIterator<Item = C> + '_> {
-        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+        // NOTE(#3850): Don't add a profile scope here: the profiler overhead is too big for this fast function.
         // re_tracing::profile_function!();
 
         debug_assert!(A::required_components()
@@ -326,7 +326,7 @@ impl<A: Archetype> ArchetypeView<A> {
     /// Get a single required mono-component.
     #[inline]
     pub fn required_mono_component<C: Component>(&self) -> DeserializationResult<C> {
-        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+        // NOTE(#3850): Don't add a profile scope here: the profiler overhead is too big for this fast function.
         // re_tracing::profile_function!();
 
         let mut iter = self.iter_required_component::<C>()?;
@@ -351,7 +351,7 @@ impl<A: Archetype> ArchetypeView<A> {
     pub fn iter_optional_component<'a, C: Component + Clone + 'a>(
         &'a self,
     ) -> DeserializationResult<impl ExactSizeIterator<Item = Option<C>> + '_> {
-        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+        // NOTE(#3850): Don't add a profile scope here: the profiler overhead is too big for this fast function.
         // re_tracing::profile_function!(C::name());
 
         let component = self.components.get(&C::name());
@@ -450,7 +450,7 @@ impl<A: Archetype> ArchetypeView<A> {
     pub fn iter_raw_optional_component<'a, C: Component + Clone + 'a>(
         &'a self,
     ) -> DeserializationResult<Option<impl Iterator<Item = C> + '_>> {
-        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+        // NOTE(#3850): Don't add a profile scope here: the profiler overhead is too big for this fast function.
         // re_tracing::profile_function!(C::name());
 
         let component = self.components.get(&C::name());

--- a/crates/re_space_view/src/blueprint/components/query_expressions.rs
+++ b/crates/re_space_view/src/blueprint/components/query_expressions.rs
@@ -96,7 +96,6 @@ impl ::re_types_core::Loggable for QueryExpressions {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -129,7 +128,6 @@ impl ::re_types_core::Loggable for QueryExpressions {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_space_view/src/blueprint/datatypes/query_expressions.rs
+++ b/crates/re_space_view/src/blueprint/datatypes/query_expressions.rs
@@ -80,7 +80,6 @@ impl ::re_types_core::Loggable for QueryExpressions {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -256,7 +255,6 @@ impl ::re_types_core::Loggable for QueryExpressions {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/blueprint/components/entities_determined_by_user.rs
+++ b/crates/re_types/src/blueprint/components/entities_determined_by_user.rs
@@ -64,7 +64,6 @@ impl ::re_types_core::Loggable for EntitiesDeterminedByUser {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -99,7 +98,6 @@ impl ::re_types_core::Loggable for EntitiesDeterminedByUser {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/blueprint/components/included_queries.rs
+++ b/crates/re_types/src/blueprint/components/included_queries.rs
@@ -63,7 +63,6 @@ impl ::re_types_core::Loggable for IncludedQueries {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -120,7 +119,6 @@ impl ::re_types_core::Loggable for IncludedQueries {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/blueprint/components/name.rs
+++ b/crates/re_types/src/blueprint/components/name.rs
@@ -64,7 +64,6 @@ impl ::re_types_core::Loggable for Name {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -115,7 +114,6 @@ impl ::re_types_core::Loggable for Name {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/blueprint/components/space_view_class.rs
+++ b/crates/re_types/src/blueprint/components/space_view_class.rs
@@ -64,7 +64,6 @@ impl ::re_types_core::Loggable for SpaceViewClass {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -115,7 +114,6 @@ impl ::re_types_core::Loggable for SpaceViewClass {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/blueprint/components/space_view_origin.rs
+++ b/crates/re_types/src/blueprint/components/space_view_origin.rs
@@ -72,7 +72,6 @@ impl ::re_types_core::Loggable for SpaceViewOrigin {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -133,7 +132,6 @@ impl ::re_types_core::Loggable for SpaceViewOrigin {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -71,7 +71,6 @@ impl ::re_types_core::Loggable for AnnotationContext {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -128,7 +127,6 @@ impl ::re_types_core::Loggable for AnnotationContext {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/blob.rs
+++ b/crates/re_types/src/components/blob.rs
@@ -69,7 +69,6 @@ impl ::re_types_core::Loggable for Blob {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -125,7 +124,6 @@ impl ::re_types_core::Loggable for Blob {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -77,7 +77,6 @@ impl ::re_types_core::Loggable for ClassId {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -122,7 +121,6 @@ impl ::re_types_core::Loggable for ClassId {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -151,7 +149,6 @@ impl ::re_types_core::Loggable for ClassId {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -173,7 +170,6 @@ impl ::re_types_core::Loggable for ClassId {
                 .values()
                 .as_slice();
             {
-                re_tracing::profile_scope!("collect");
                 slice
                     .iter()
                     .copied()

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -75,7 +75,6 @@ impl ::re_types_core::Loggable for Color {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -120,7 +119,6 @@ impl ::re_types_core::Loggable for Color {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -149,7 +147,6 @@ impl ::re_types_core::Loggable for Color {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -171,7 +168,6 @@ impl ::re_types_core::Loggable for Color {
                 .values()
                 .as_slice();
             {
-                re_tracing::profile_scope!("collect");
                 slice
                     .iter()
                     .copied()

--- a/crates/re_types/src/components/depth_meter.rs
+++ b/crates/re_types/src/components/depth_meter.rs
@@ -64,7 +64,6 @@ impl ::re_types_core::Loggable for DepthMeter {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -99,7 +98,6 @@ impl ::re_types_core::Loggable for DepthMeter {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -127,7 +125,6 @@ impl ::re_types_core::Loggable for DepthMeter {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -149,7 +146,6 @@ impl ::re_types_core::Loggable for DepthMeter {
                 .values()
                 .as_slice();
             {
-                re_tracing::profile_scope!("collect");
                 slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
             }
         })

--- a/crates/re_types/src/components/disconnected_space.rs
+++ b/crates/re_types/src/components/disconnected_space.rs
@@ -70,7 +70,6 @@ impl ::re_types_core::Loggable for DisconnectedSpace {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -105,7 +104,6 @@ impl ::re_types_core::Loggable for DisconnectedSpace {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/components/draw_order.rs
+++ b/crates/re_types/src/components/draw_order.rs
@@ -70,7 +70,6 @@ impl ::re_types_core::Loggable for DrawOrder {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -105,7 +104,6 @@ impl ::re_types_core::Loggable for DrawOrder {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -133,7 +131,6 @@ impl ::re_types_core::Loggable for DrawOrder {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -155,7 +152,6 @@ impl ::re_types_core::Loggable for DrawOrder {
                 .values()
                 .as_slice();
             {
-                re_tracing::profile_scope!("collect");
                 slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
             }
         })

--- a/crates/re_types/src/components/half_sizes2d.rs
+++ b/crates/re_types/src/components/half_sizes2d.rs
@@ -82,7 +82,6 @@ impl ::re_types_core::Loggable for HalfSizes2D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -150,7 +149,6 @@ impl ::re_types_core::Loggable for HalfSizes2D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -237,7 +235,6 @@ impl ::re_types_core::Loggable for HalfSizes2D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -282,7 +279,6 @@ impl ::re_types_core::Loggable for HalfSizes2D {
                 )
             };
             {
-                re_tracing::profile_scope!("collect");
                 slice
                     .iter()
                     .copied()

--- a/crates/re_types/src/components/half_sizes3d.rs
+++ b/crates/re_types/src/components/half_sizes3d.rs
@@ -82,7 +82,6 @@ impl ::re_types_core::Loggable for HalfSizes3D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -150,7 +149,6 @@ impl ::re_types_core::Loggable for HalfSizes3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -237,7 +235,6 @@ impl ::re_types_core::Loggable for HalfSizes3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -282,7 +279,6 @@ impl ::re_types_core::Loggable for HalfSizes3D {
                 )
             };
             {
-                re_tracing::profile_scope!("collect");
                 slice
                     .iter()
                     .copied()

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -79,7 +79,6 @@ impl ::re_types_core::Loggable for KeypointId {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -124,7 +123,6 @@ impl ::re_types_core::Loggable for KeypointId {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -153,7 +151,6 @@ impl ::re_types_core::Loggable for KeypointId {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -175,7 +172,6 @@ impl ::re_types_core::Loggable for KeypointId {
                 .values()
                 .as_slice();
             {
-                re_tracing::profile_scope!("collect");
                 slice
                     .iter()
                     .copied()

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -71,7 +71,6 @@ impl ::re_types_core::Loggable for LineStrip2D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -171,7 +170,6 @@ impl ::re_types_core::Loggable for LineStrip2D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -71,7 +71,6 @@ impl ::re_types_core::Loggable for LineStrip3D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -171,7 +170,6 @@ impl ::re_types_core::Loggable for LineStrip3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/material.rs
+++ b/crates/re_types/src/components/material.rs
@@ -76,7 +76,6 @@ impl ::re_types_core::Loggable for Material {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -109,7 +108,6 @@ impl ::re_types_core::Loggable for Material {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(crate::datatypes::Material::from_arrow_opt(arrow_data)

--- a/crates/re_types/src/components/media_type.rs
+++ b/crates/re_types/src/components/media_type.rs
@@ -75,7 +75,6 @@ impl ::re_types_core::Loggable for MediaType {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -136,7 +135,6 @@ impl ::re_types_core::Loggable for MediaType {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/mesh_properties.rs
+++ b/crates/re_types/src/components/mesh_properties.rs
@@ -81,7 +81,6 @@ impl ::re_types_core::Loggable for MeshProperties {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -114,7 +113,6 @@ impl ::re_types_core::Loggable for MeshProperties {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(crate::datatypes::MeshProperties::from_arrow_opt(arrow_data)

--- a/crates/re_types/src/components/out_of_tree_transform3d.rs
+++ b/crates/re_types/src/components/out_of_tree_transform3d.rs
@@ -99,7 +99,6 @@ impl ::re_types_core::Loggable for OutOfTreeTransform3D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -132,7 +131,6 @@ impl ::re_types_core::Loggable for OutOfTreeTransform3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(crate::datatypes::Transform3D::from_arrow_opt(arrow_data)

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -89,7 +89,6 @@ impl ::re_types_core::Loggable for PinholeProjection {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -157,7 +156,6 @@ impl ::re_types_core::Loggable for PinholeProjection {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -244,7 +242,6 @@ impl ::re_types_core::Loggable for PinholeProjection {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -289,7 +286,6 @@ impl ::re_types_core::Loggable for PinholeProjection {
                 )
             };
             {
-                re_tracing::profile_scope!("collect");
                 slice
                     .iter()
                     .copied()

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -80,7 +80,6 @@ impl ::re_types_core::Loggable for Position2D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -148,7 +147,6 @@ impl ::re_types_core::Loggable for Position2D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -235,7 +233,6 @@ impl ::re_types_core::Loggable for Position2D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -280,7 +277,6 @@ impl ::re_types_core::Loggable for Position2D {
                 )
             };
             {
-                re_tracing::profile_scope!("collect");
                 slice
                     .iter()
                     .copied()

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -80,7 +80,6 @@ impl ::re_types_core::Loggable for Position3D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -148,7 +147,6 @@ impl ::re_types_core::Loggable for Position3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -235,7 +233,6 @@ impl ::re_types_core::Loggable for Position3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -280,7 +277,6 @@ impl ::re_types_core::Loggable for Position3D {
                 )
             };
             {
-                re_tracing::profile_scope!("collect");
                 slice
                     .iter()
                     .copied()

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -64,7 +64,6 @@ impl ::re_types_core::Loggable for Radius {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -99,7 +98,6 @@ impl ::re_types_core::Loggable for Radius {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -127,7 +125,6 @@ impl ::re_types_core::Loggable for Radius {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -149,7 +146,6 @@ impl ::re_types_core::Loggable for Radius {
                 .values()
                 .as_slice();
             {
-                re_tracing::profile_scope!("collect");
                 slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
             }
         })

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -81,7 +81,6 @@ impl ::re_types_core::Loggable for Resolution {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -149,7 +148,6 @@ impl ::re_types_core::Loggable for Resolution {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -236,7 +234,6 @@ impl ::re_types_core::Loggable for Resolution {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -281,7 +278,6 @@ impl ::re_types_core::Loggable for Resolution {
                 )
             };
             {
-                re_tracing::profile_scope!("collect");
                 slice
                     .iter()
                     .copied()

--- a/crates/re_types/src/components/rotation3d.rs
+++ b/crates/re_types/src/components/rotation3d.rs
@@ -97,7 +97,6 @@ impl ::re_types_core::Loggable for Rotation3D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -130,7 +129,6 @@ impl ::re_types_core::Loggable for Rotation3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(crate::datatypes::Rotation3D::from_arrow_opt(arrow_data)

--- a/crates/re_types/src/components/scalar.rs
+++ b/crates/re_types/src/components/scalar.rs
@@ -66,7 +66,6 @@ impl ::re_types_core::Loggable for Scalar {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -101,7 +100,6 @@ impl ::re_types_core::Loggable for Scalar {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -129,7 +127,6 @@ impl ::re_types_core::Loggable for Scalar {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -151,7 +148,6 @@ impl ::re_types_core::Loggable for Scalar {
                 .values()
                 .as_slice();
             {
-                re_tracing::profile_scope!("collect");
                 slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
             }
         })

--- a/crates/re_types/src/components/scalar_scattering.rs
+++ b/crates/re_types/src/components/scalar_scattering.rs
@@ -63,7 +63,6 @@ impl ::re_types_core::Loggable for ScalarScattering {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -98,7 +97,6 @@ impl ::re_types_core::Loggable for ScalarScattering {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/components/tensor_data.rs
+++ b/crates/re_types/src/components/tensor_data.rs
@@ -90,7 +90,6 @@ impl ::re_types_core::Loggable for TensorData {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -123,7 +122,6 @@ impl ::re_types_core::Loggable for TensorData {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(crate::datatypes::TensorData::from_arrow_opt(arrow_data)

--- a/crates/re_types/src/components/text.rs
+++ b/crates/re_types/src/components/text.rs
@@ -72,7 +72,6 @@ impl ::re_types_core::Loggable for Text {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -133,7 +132,6 @@ impl ::re_types_core::Loggable for Text {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/text_log_level.rs
+++ b/crates/re_types/src/components/text_log_level.rs
@@ -80,7 +80,6 @@ impl ::re_types_core::Loggable for TextLogLevel {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -141,7 +140,6 @@ impl ::re_types_core::Loggable for TextLogLevel {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -97,7 +97,6 @@ impl ::re_types_core::Loggable for Transform3D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -130,7 +129,6 @@ impl ::re_types_core::Loggable for Transform3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(crate::datatypes::Transform3D::from_arrow_opt(arrow_data)

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -80,7 +80,6 @@ impl ::re_types_core::Loggable for Vector3D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -148,7 +147,6 @@ impl ::re_types_core::Loggable for Vector3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -235,7 +233,6 @@ impl ::re_types_core::Loggable for Vector3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -280,7 +277,6 @@ impl ::re_types_core::Loggable for Vector3D {
                 )
             };
             {
-                re_tracing::profile_scope!("collect");
                 slice
                     .iter()
                     .copied()

--- a/crates/re_types/src/components/view_coordinates.rs
+++ b/crates/re_types/src/components/view_coordinates.rs
@@ -90,7 +90,6 @@ impl ::re_types_core::Loggable for ViewCoordinates {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -155,7 +154,6 @@ impl ::re_types_core::Loggable for ViewCoordinates {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({
@@ -239,7 +237,6 @@ impl ::re_types_core::Loggable for ViewCoordinates {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -284,7 +281,6 @@ impl ::re_types_core::Loggable for ViewCoordinates {
                 )
             };
             {
-                re_tracing::profile_scope!("collect");
                 slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
             }
         })

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -75,7 +75,6 @@ impl ::re_types_core::Loggable for Angle {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -181,7 +180,6 @@ impl ::re_types_core::Loggable for Angle {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -80,7 +80,6 @@ impl ::re_types_core::Loggable for AnnotationInfo {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -221,7 +220,6 @@ impl ::re_types_core::Loggable for AnnotationInfo {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -100,7 +100,6 @@ impl ::re_types_core::Loggable for ClassDescription {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -262,7 +261,6 @@ impl ::re_types_core::Loggable for ClassDescription {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/re_types/src/datatypes/class_description_map_elem.rs
@@ -70,7 +70,6 @@ impl ::re_types_core::Loggable for ClassDescriptionMapElem {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -156,7 +155,6 @@ impl ::re_types_core::Loggable for ClassDescriptionMapElem {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/class_id.rs
+++ b/crates/re_types/src/datatypes/class_id.rs
@@ -79,7 +79,6 @@ impl ::re_types_core::Loggable for ClassId {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -114,7 +113,6 @@ impl ::re_types_core::Loggable for ClassId {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/datatypes/keypoint_id.rs
+++ b/crates/re_types/src/datatypes/keypoint_id.rs
@@ -81,7 +81,6 @@ impl ::re_types_core::Loggable for KeypointId {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -116,7 +115,6 @@ impl ::re_types_core::Loggable for KeypointId {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/re_types/src/datatypes/keypoint_pair.rs
@@ -68,7 +68,6 @@ impl ::re_types_core::Loggable for KeypointPair {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -164,7 +163,6 @@ impl ::re_types_core::Loggable for KeypointPair {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -83,7 +83,6 @@ impl ::re_types_core::Loggable for Mat3x3 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -148,7 +147,6 @@ impl ::re_types_core::Loggable for Mat3x3 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -84,7 +84,6 @@ impl ::re_types_core::Loggable for Mat4x4 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -149,7 +148,6 @@ impl ::re_types_core::Loggable for Mat4x4 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/material.rs
+++ b/crates/re_types/src/datatypes/material.rs
@@ -81,7 +81,6 @@ impl ::re_types_core::Loggable for Material {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -146,7 +145,6 @@ impl ::re_types_core::Loggable for Material {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/mesh_properties.rs
+++ b/crates/re_types/src/datatypes/mesh_properties.rs
@@ -78,7 +78,6 @@ impl ::re_types_core::Loggable for MeshProperties {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -164,7 +163,6 @@ impl ::re_types_core::Loggable for MeshProperties {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -74,7 +74,6 @@ impl ::re_types_core::Loggable for Quaternion {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -139,7 +138,6 @@ impl ::re_types_core::Loggable for Quaternion {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/rgba32.rs
+++ b/crates/re_types/src/datatypes/rgba32.rs
@@ -69,7 +69,6 @@ impl ::re_types_core::Loggable for Rgba32 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -104,7 +103,6 @@ impl ::re_types_core::Loggable for Rgba32 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -78,7 +78,6 @@ impl ::re_types_core::Loggable for Rotation3D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -227,7 +226,6 @@ impl ::re_types_core::Loggable for Rotation3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -72,7 +72,6 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -187,7 +186,6 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -78,7 +78,6 @@ impl ::re_types_core::Loggable for Scale3D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -225,7 +224,6 @@ impl ::re_types_core::Loggable for Scale3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/re_types/src/datatypes/tensor_buffer.rs
@@ -222,7 +222,6 @@ impl ::re_types_core::Loggable for TensorBuffer {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -1057,7 +1056,6 @@ impl ::re_types_core::Loggable for TensorBuffer {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/tensor_data.rs
+++ b/crates/re_types/src/datatypes/tensor_data.rs
@@ -77,7 +77,6 @@ impl ::re_types_core::Loggable for TensorData {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -180,7 +179,6 @@ impl ::re_types_core::Loggable for TensorData {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/tensor_dimension.rs
+++ b/crates/re_types/src/datatypes/tensor_dimension.rs
@@ -68,7 +68,6 @@ impl ::re_types_core::Loggable for TensorDimension {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -162,7 +161,6 @@ impl ::re_types_core::Loggable for TensorDimension {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -78,7 +78,6 @@ impl ::re_types_core::Loggable for Transform3D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -196,7 +195,6 @@ impl ::re_types_core::Loggable for Transform3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -82,7 +82,6 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -271,7 +270,6 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -89,7 +89,6 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -258,7 +257,6 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/uuid.rs
+++ b/crates/re_types/src/datatypes/uuid.rs
@@ -79,7 +79,6 @@ impl ::re_types_core::Loggable for Uuid {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -169,7 +168,6 @@ impl ::re_types_core::Loggable for Uuid {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/uvec2d.rs
+++ b/crates/re_types/src/datatypes/uvec2d.rs
@@ -72,7 +72,6 @@ impl ::re_types_core::Loggable for UVec2D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -137,7 +136,6 @@ impl ::re_types_core::Loggable for UVec2D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/uvec3d.rs
+++ b/crates/re_types/src/datatypes/uvec3d.rs
@@ -72,7 +72,6 @@ impl ::re_types_core::Loggable for UVec3D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -137,7 +136,6 @@ impl ::re_types_core::Loggable for UVec3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/uvec4d.rs
+++ b/crates/re_types/src/datatypes/uvec4d.rs
@@ -72,7 +72,6 @@ impl ::re_types_core::Loggable for UVec4D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -137,7 +136,6 @@ impl ::re_types_core::Loggable for UVec4D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -72,7 +72,6 @@ impl ::re_types_core::Loggable for Vec2D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -137,7 +136,6 @@ impl ::re_types_core::Loggable for Vec2D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -72,7 +72,6 @@ impl ::re_types_core::Loggable for Vec3D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -137,7 +136,6 @@ impl ::re_types_core::Loggable for Vec3D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -72,7 +72,6 @@ impl ::re_types_core::Loggable for Vec4D {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -137,7 +136,6 @@ impl ::re_types_core::Loggable for Vec4D {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer1.rs
@@ -140,7 +140,6 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -173,7 +172,6 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer10.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer10.rs
@@ -62,7 +62,6 @@ impl ::re_types_core::Loggable for AffixFuzzer10 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -115,7 +114,6 @@ impl ::re_types_core::Loggable for AffixFuzzer10 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer11.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer11.rs
@@ -67,7 +67,6 @@ impl ::re_types_core::Loggable for AffixFuzzer11 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -125,7 +124,6 @@ impl ::re_types_core::Loggable for AffixFuzzer11 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer12.rs
@@ -67,7 +67,6 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -145,7 +144,6 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer13.rs
@@ -67,7 +67,6 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -147,7 +146,6 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer14.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer14.rs
@@ -118,7 +118,6 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -151,7 +150,6 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer15.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer15.rs
@@ -118,7 +118,6 @@ impl ::re_types_core::Loggable for AffixFuzzer15 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -153,7 +152,6 @@ impl ::re_types_core::Loggable for AffixFuzzer15 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer16.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer16.rs
@@ -61,7 +61,6 @@ impl ::re_types_core::Loggable for AffixFuzzer16 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -118,7 +117,6 @@ impl ::re_types_core::Loggable for AffixFuzzer16 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer17.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer17.rs
@@ -61,7 +61,6 @@ impl ::re_types_core::Loggable for AffixFuzzer17 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -120,7 +119,6 @@ impl ::re_types_core::Loggable for AffixFuzzer17 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer18.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer18.rs
@@ -61,7 +61,6 @@ impl ::re_types_core::Loggable for AffixFuzzer18 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -120,7 +119,6 @@ impl ::re_types_core::Loggable for AffixFuzzer18 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer19.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer19.rs
@@ -75,7 +75,6 @@ impl ::re_types_core::Loggable for AffixFuzzer19 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -108,7 +107,6 @@ impl ::re_types_core::Loggable for AffixFuzzer19 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer2.rs
@@ -140,7 +140,6 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -173,7 +172,6 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer20.rs
@@ -83,7 +83,6 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -116,7 +115,6 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer21.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer21.rs
@@ -88,7 +88,6 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -121,7 +120,6 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer22.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer22.rs
@@ -83,7 +83,6 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -118,7 +117,6 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer3.rs
@@ -140,7 +140,6 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -173,7 +172,6 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer4.rs
@@ -140,7 +140,6 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -175,7 +174,6 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer5.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer5.rs
@@ -140,7 +140,6 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -175,7 +174,6 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer6.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer6.rs
@@ -140,7 +140,6 @@ impl ::re_types_core::Loggable for AffixFuzzer6 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -175,7 +174,6 @@ impl ::re_types_core::Loggable for AffixFuzzer6 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(

--- a/crates/re_types/src/testing/components/affix_fuzzer7.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer7.rs
@@ -61,7 +61,6 @@ impl ::re_types_core::Loggable for AffixFuzzer7 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -120,7 +119,6 @@ impl ::re_types_core::Loggable for AffixFuzzer7 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/components/affix_fuzzer8.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer8.rs
@@ -62,7 +62,6 @@ impl ::re_types_core::Loggable for AffixFuzzer8 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -99,7 +98,6 @@ impl ::re_types_core::Loggable for AffixFuzzer8 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/testing/components/affix_fuzzer9.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer9.rs
@@ -62,7 +62,6 @@ impl ::re_types_core::Loggable for AffixFuzzer9 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -113,7 +112,6 @@ impl ::re_types_core::Loggable for AffixFuzzer9 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -128,7 +128,6 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -575,7 +574,6 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer2.rs
@@ -62,7 +62,6 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -99,7 +98,6 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
@@ -64,7 +64,6 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -179,7 +178,6 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer21.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer21.rs
@@ -69,7 +69,6 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -179,7 +178,6 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer22.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer22.rs
@@ -77,7 +77,6 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -169,7 +168,6 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -101,7 +101,6 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -348,7 +347,6 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer4.rs
@@ -91,7 +91,6 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -292,7 +291,6 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer5.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer5.rs
@@ -79,7 +79,6 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -137,7 +136,6 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/flattened_scalar.rs
+++ b/crates/re_types/src/testing/datatypes/flattened_scalar.rs
@@ -69,7 +69,6 @@ impl ::re_types_core::Loggable for FlattenedScalar {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -121,7 +120,6 @@ impl ::re_types_core::Loggable for FlattenedScalar {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types/src/testing/datatypes/primitive_component.rs
+++ b/crates/re_types/src/testing/datatypes/primitive_component.rs
@@ -63,7 +63,6 @@ impl ::re_types_core::Loggable for PrimitiveComponent {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -98,7 +97,6 @@ impl ::re_types_core::Loggable for PrimitiveComponent {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types/src/testing/datatypes/string_component.rs
+++ b/crates/re_types/src/testing/datatypes/string_component.rs
@@ -63,7 +63,6 @@ impl ::re_types_core::Loggable for StringComponent {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -114,7 +113,6 @@ impl ::re_types_core::Loggable for StringComponent {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -749,7 +749,7 @@ fn quote_trait_impls_from_obj(
                     where
                         Self: Sized
                     {
-                        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+                        // NOTE(#3850): Don't add a profile scope here: the profiler overhead is too big for this fast function.
                         // re_tracing::profile_function!();
 
                         use arrow2::{datatypes::*, array::*, buffer::*};
@@ -796,7 +796,7 @@ fn quote_trait_impls_from_obj(
                     where
                         Self: Clone + 'a
                     {
-                        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+                        // NOTE(#3850): Don't add a profile scope here: the profiler overhead is too big for this fast function.
                         // re_tracing::profile_function!();
 
                         use arrow2::{datatypes::*, array::*};
@@ -813,7 +813,7 @@ fn quote_trait_impls_from_obj(
                     where
                         Self: Sized
                     {
-                        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+                        // NOTE(#3850): Don't add a profile scope here: the profiler overhead is too big for this fast function.
                         // re_tracing::profile_function!();
 
                         use arrow2::{datatypes::*, array::*, buffer::*};

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -747,8 +747,10 @@ fn quote_trait_impls_from_obj(
                         arrow_data: &dyn arrow2::array::Array,
                     ) -> DeserializationResult<Vec<Self>>
                     where
-                        Self: Sized {
-                        re_tracing::profile_function!();
+                        Self: Sized
+                    {
+                        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+                        // re_tracing::profile_function!();
 
                         use arrow2::{datatypes::*, array::*, buffer::*};
                         use ::re_types_core::{Loggable as _, ResultExt as _};
@@ -794,7 +796,8 @@ fn quote_trait_impls_from_obj(
                     where
                         Self: Clone + 'a
                     {
-                        re_tracing::profile_function!();
+                        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+                        // re_tracing::profile_function!();
 
                         use arrow2::{datatypes::*, array::*};
                         use ::re_types_core::{Loggable as _, ResultExt as _};
@@ -810,7 +813,8 @@ fn quote_trait_impls_from_obj(
                     where
                         Self: Sized
                     {
-                        re_tracing::profile_function!();
+                        // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+                        // re_tracing::profile_function!();
 
                         use arrow2::{datatypes::*, array::*, buffer::*};
                         use ::re_types_core::{Loggable as _, ResultExt as _};

--- a/crates/re_types_builder/src/codegen/rust/deserializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/deserializer.rs
@@ -914,7 +914,7 @@ pub fn quote_arrow_deserializer_buffer_slice(
             let slice = #deserizlized_as_slice;
 
             {
-                // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+                // NOTE(#3850): Don't add a profile scope here: the profiler overhead is too big for this fast function.
                 // re_tracing::profile_scope!("collect");
 
                 slice

--- a/crates/re_types_builder/src/codegen/rust/deserializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/deserializer.rs
@@ -914,7 +914,9 @@ pub fn quote_arrow_deserializer_buffer_slice(
             let slice = #deserizlized_as_slice;
 
             {
-                re_tracing::profile_scope!("collect");
+                // TODO(#3850): Don't, it's way too much and will therefore lie to you.
+                // re_tracing::profile_scope!("collect");
+
                 slice
                     .iter()
                     #quoted_iter_transparency

--- a/crates/re_types_core/src/components/clear_is_recursive.rs
+++ b/crates/re_types_core/src/components/clear_is_recursive.rs
@@ -66,7 +66,6 @@ impl crate::Loggable for ClearIsRecursive {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -101,7 +100,6 @@ impl crate::Loggable for ClearIsRecursive {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types_core/src/components/instance_key.rs
+++ b/crates/re_types_core/src/components/instance_key.rs
@@ -64,7 +64,6 @@ impl crate::Loggable for InstanceKey {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -99,7 +98,6 @@ impl crate::Loggable for InstanceKey {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data
@@ -127,7 +125,6 @@ impl crate::Loggable for InstanceKey {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         if let Some(validity) = arrow_data.validity() {
@@ -149,7 +146,6 @@ impl crate::Loggable for InstanceKey {
                 .values()
                 .as_slice();
             {
-                re_tracing::profile_scope!("collect");
                 slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
             }
         })

--- a/crates/re_types_core/src/datatypes/entity_path.rs
+++ b/crates/re_types_core/src/datatypes/entity_path.rs
@@ -64,7 +64,6 @@ impl crate::Loggable for EntityPath {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -115,7 +114,6 @@ impl crate::Loggable for EntityPath {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_types_core/src/datatypes/float32.rs
+++ b/crates/re_types_core/src/datatypes/float32.rs
@@ -63,7 +63,6 @@ impl crate::Loggable for Float32 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -98,7 +97,6 @@ impl crate::Loggable for Float32 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types_core/src/datatypes/uint32.rs
+++ b/crates/re_types_core/src/datatypes/uint32.rs
@@ -63,7 +63,6 @@ impl crate::Loggable for UInt32 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -98,7 +97,6 @@ impl crate::Loggable for UInt32 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_types_core/src/datatypes/utf8.rs
+++ b/crates/re_types_core/src/datatypes/utf8.rs
@@ -64,7 +64,6 @@ impl crate::Loggable for Utf8 {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -115,7 +114,6 @@ impl crate::Loggable for Utf8 {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_viewer/src/blueprint/components/panel_view.rs
+++ b/crates/re_viewer/src/blueprint/components/panel_view.rs
@@ -65,7 +65,6 @@ impl ::re_types_core::Loggable for PanelView {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -100,7 +99,6 @@ impl ::re_types_core::Loggable for PanelView {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_viewport/src/blueprint/components/auto_layout.rs
+++ b/crates/re_viewport/src/blueprint/components/auto_layout.rs
@@ -66,7 +66,6 @@ impl ::re_types_core::Loggable for AutoLayout {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -101,7 +100,6 @@ impl ::re_types_core::Loggable for AutoLayout {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_viewport/src/blueprint/components/auto_space_views.rs
+++ b/crates/re_viewport/src/blueprint/components/auto_space_views.rs
@@ -66,7 +66,6 @@ impl ::re_types_core::Loggable for AutoSpaceViews {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -101,7 +100,6 @@ impl ::re_types_core::Loggable for AutoSpaceViews {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(arrow_data

--- a/crates/re_viewport/src/blueprint/components/included_space_views.rs
+++ b/crates/re_viewport/src/blueprint/components/included_space_views.rs
@@ -63,7 +63,6 @@ impl ::re_types_core::Loggable for IncludedSpaceViews {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -120,7 +119,6 @@ impl ::re_types_core::Loggable for IncludedSpaceViews {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({

--- a/crates/re_viewport/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_viewport/src/blueprint/components/space_view_maximized.rs
@@ -87,7 +87,6 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -122,7 +121,6 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok(crate::datatypes::Uuid::from_arrow_opt(arrow_data)

--- a/crates/re_viewport/src/blueprint/components/viewport_layout.rs
+++ b/crates/re_viewport/src/blueprint/components/viewport_layout.rs
@@ -70,7 +70,6 @@ impl ::re_types_core::Loggable for ViewportLayout {
     where
         Self: Clone + 'a,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({
@@ -139,7 +138,6 @@ impl ::re_types_core::Loggable for ViewportLayout {
     where
         Self: Sized,
     {
-        re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, buffer::*, datatypes::*};
         Ok({


### PR DESCRIPTION
_Starting to cherry-pick some of the stuff buried in my caching branch_

Removes all the puffin scopes that I've found counter-productive while working on caching: i.e. they actually show wrong results in the profiler since they become the bottleneck rather than the code they are measuring.

- Fixes #3850

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4574/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4574/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4574/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4574)
- [Docs preview](https://rerun.io/preview/0ed4173bd4fe66db234d81f0acc45343fbe5743a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0ed4173bd4fe66db234d81f0acc45343fbe5743a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)