### PR TITLE
Reduce input latency by switching to double-buffered rendering

### DIFF
--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -154,6 +154,10 @@ pub(crate) fn wgpu_options() -> egui_wgpu::WgpuConfiguration {
             }),
             supported_backends: re_renderer::config::supported_backends(),
             device_descriptor: std::sync::Arc::new(|adapter| re_renderer::config::DeviceCaps::from_adapter(adapter).device_descriptor()),
+
+            present_mode: wgpu::PresentMode::AutoNoVsync, // double-buffered: low-latency, may have tearing
+            // present_mode: wgpu::PresentMode::AutoVsync, // triple-buffered: high-latency, no tearing
+
             ..Default::default()
         }
 }


### PR DESCRIPTION
This makes a huge difference in perceived latency on my 60 Hz monitor on macOS on a native build, e.g. when hovering buttons, or just the distance between the cursor and the hover-window when hovering an image.

It does produce some tearing, noticable e.g. when quickly panning a 2D image. To me the trade-off is absolutely worth it: tearing is a mild visual glitch that shows up occationally, input latency is a constant irritation, making an application feel sluggish.

It makes no difference on web though, so this does NOT solve https://github.com/rerun-io/rerun/issues/2672

I also switched the defaults in `eguo-wgpu`: https://github.com/emilk/egui/pull/3714

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4575/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4575/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4575/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4575)
- [Docs preview](https://rerun.io/preview/aeacef705a7d22b02b95d858beeab1007b0dcbb1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/aeacef705a7d22b02b95d858beeab1007b0dcbb1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)