### PR TITLE
Expose `wgpu` profiling scopes to puffin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4171,9 +4171,23 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.8"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332cd62e95873ea4f41f3dfd6bbbfc5b52aec892d7e8d534197c4720a0bbbab2"
+checksum = "1de09527cd2ea2c2d59fb6c2f8c1ab8c71709ed9d1b6d60b0e1c9fbb6fdcb33c"
+dependencies = [
+ "profiling-procmacros",
+ "puffin",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8f36e3c621a72254893ed5cc57d1a069162adb3f98bfef610788661db6ad8d"
+dependencies = [
+ "quote",
+ "syn 2.0.32",
+]
 
 [[package]]
 name = "prost"
@@ -4801,6 +4815,7 @@ dependencies = [
  "ordered-float",
  "parking_lot 0.12.1",
  "pathdiff",
+ "profiling",
  "re_build_tools",
  "re_error",
  "re_log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ poll-promise = "0.3"
 pollster = "0.3"
 prettyplease = "0.2"
 proc-macro2 = { version = "1.0", default-features = false }
+profiling = { version = "1.0.12", default-features = false }
 puffin = "0.18"
 puffin_http = "0.15"
 pyo3 = "0.19.0"

--- a/crates/re_renderer/Cargo.toml
+++ b/crates/re_renderer/Cargo.toml
@@ -62,6 +62,9 @@ macaw.workspace = true
 never.workspace = true
 ordered-float.workspace = true
 parking_lot.workspace = true
+# wgpu uses the `profiling` crate for its profiling scopes.
+# This will hook them up to the puffin profiler as backend:
+profiling = { workspace = true, features = ["profile-with-puffin"] }
 slotmap.workspace = true
 smallvec.workspace = true
 static_assertions.workspace = true


### PR DESCRIPTION
### What
![image](https://github.com/rerun-io/rerun/assets/1148717/d29b5cff-162a-45d6-9e60-fd8c465d0e85)

(only CPU profile scopes though, nothing from GPU)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4581/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4581/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4581/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4581)
- [Docs preview](https://rerun.io/preview/3e4a767719690309d769f1a3b5974f8bd7c693bd/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3e4a767719690309d769f1a3b5974f8bd7c693bd/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)