### PR TITLE
Python SDK: introduce deferred garbage collection queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2870,15 +2870,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
@@ -4239,7 +4230,7 @@ checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -4260,7 +4251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.32",
@@ -5583,6 +5574,7 @@ name = "rerun_py"
 version = "0.12.0-alpha.1+dev"
 dependencies = [
  "arrow2",
+ "crossbeam",
  "document-features",
  "itertools 0.12.0",
  "mimalloc",
@@ -7418,13 +7410,14 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
- "libc",
+ "home",
  "once_cell",
+ "rustix 0.38.24",
 ]
 
 [[package]]

--- a/crates/re_log_types/src/arrow_msg.rs
+++ b/crates/re_log_types/src/arrow_msg.rs
@@ -21,6 +21,7 @@ pub struct ArrowChunkReleaseCallback(Arc<dyn Fn(Chunk<Box<dyn Array>>) + Send + 
 impl std::ops::Deref for ArrowChunkReleaseCallback {
     type Target = dyn Fn(Chunk<Box<dyn Array>>) + Send + Sync;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &*self.0
     }

--- a/crates/re_log_types/src/data_table.rs
+++ b/crates/re_log_types/src/data_table.rs
@@ -1048,6 +1048,7 @@ impl DataTable {
             timepoint_max: _,
             schema,
             chunk,
+            on_release: _,
         } = msg;
 
         Self::deserialize(*table_id, schema, chunk)
@@ -1066,6 +1067,7 @@ impl DataTable {
             timepoint_max,
             schema,
             chunk,
+            on_release: None,
         })
     }
 }

--- a/crates/re_log_types/src/data_table_batcher.rs
+++ b/crates/re_log_types/src/data_table_batcher.rs
@@ -65,7 +65,7 @@ pub struct DataTableBatcherConfig {
     /// Unbounded if left unspecified.
     pub max_tables_in_flight: Option<u64>,
 
-    /// Callback to be run when an Arrow [`Chunk`] goes out of scope.
+    /// Callback to be run when an Arrow Chunk` goes out of scope.
     ///
     /// See [`crate::ArrowChunkReleaseCallback`] for more information.
     pub on_release: Option<crate::ArrowChunkReleaseCallback>,

--- a/crates/re_log_types/src/data_table_batcher.rs
+++ b/crates/re_log_types/src/data_table_batcher.rs
@@ -37,7 +37,7 @@ pub type DataTableBatcherResult<T> = Result<T, DataTableBatcherError>;
 /// Defines the different thresholds of the associated [`DataTableBatcher`].
 ///
 /// See [`Self::default`] and [`Self::from_env`].
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DataTableBatcherConfig {
     /// Duration of the periodic tick.
     //
@@ -64,6 +64,11 @@ pub struct DataTableBatcherConfig {
     ///
     /// Unbounded if left unspecified.
     pub max_tables_in_flight: Option<u64>,
+
+    /// Callback to be run when an Arrow [`Chunk`] goes out of scope.
+    ///
+    /// See [`crate::ArrowChunkReleaseCallback`] for more information.
+    pub on_release: Option<crate::ArrowChunkReleaseCallback>,
 }
 
 impl Default for DataTableBatcherConfig {
@@ -80,6 +85,7 @@ impl DataTableBatcherConfig {
         flush_num_rows: u64::MAX,
         max_commands_in_flight: None,
         max_tables_in_flight: None,
+        on_release: None,
     };
 
     /// Always flushes ASAP.
@@ -89,6 +95,7 @@ impl DataTableBatcherConfig {
         flush_num_rows: 0,
         max_commands_in_flight: None,
         max_tables_in_flight: None,
+        on_release: None,
     };
 
     /// Never flushes unless manually told to.
@@ -98,6 +105,7 @@ impl DataTableBatcherConfig {
         flush_num_rows: u64::MAX,
         max_commands_in_flight: None,
         max_tables_in_flight: None,
+        on_release: None,
     };
 
     /// Environment variable to configure [`Self::flush_tick`].

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -37,7 +37,7 @@ mod data_table_batcher;
 
 use std::sync::Arc;
 
-pub use self::arrow_msg::ArrowMsg;
+pub use self::arrow_msg::{ArrowChunkReleaseCallback, ArrowMsg};
 pub use self::data_cell::{DataCell, DataCellError, DataCellInner, DataCellResult};
 pub use self::data_row::{
     DataCellRow, DataCellVec, DataReadError, DataReadResult, DataRow, DataRowError, DataRowResult,

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -53,6 +53,7 @@ re_viewer.workspace = true
 re_viewport.workspace = true
 
 arrow2 = { workspace = true, features = ["io_ipc", "io_print"] }
+crossbeam.workspace = true
 document-features.workspace = true
 itertools = { workspace = true }
 mimalloc = { workspace = true, features = ["local_dynamic_tls"] }

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -902,6 +902,7 @@ fn set_auto_space_views(enabled: bool, blueprint: Option<&PyRecordingStream>) {
     recording=None,
 ))]
 fn log_arrow_msg(
+    py: Python<'_>,
     entity_path: &str,
     components: &PyDict,
     timeless: bool,
@@ -923,6 +924,8 @@ fn log_arrow_msg(
     )?;
 
     recording.record_row(row, !timeless);
+
+    py.allow_threads(flush_garbage_queue);
 
     Ok(())
 }

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -48,11 +48,11 @@ type GarbageReceiver = crossbeam::channel::Receiver<GarbageChunk>;
 ///
 /// This is an issue in this case because running that callback will likely try and grab the GIL,
 /// which is something that should only happen at very specific times, else we end up with deadlocks,
-/// segfaults, aborts...
+/// segfaults, aborts…
 ///
 /// ## The garbage queue
 ///
-/// When a [`LogMsg`] that was logged from Python gets dropped on the Rust side, it will end up
+/// When a [`re_log_types::LogMsg`] that was logged from Python gets dropped on the Rust side, it will end up
 /// in this queue.
 ///
 /// The mere fact that the data still exists in this queue prevents the underlying Arrow refcount
@@ -82,8 +82,10 @@ fn flush_garbage_queue() {
 #[cfg(feature = "web_viewer")]
 fn global_web_viewer_server(
 ) -> parking_lot::MutexGuard<'static, Option<re_web_viewer_server::WebViewerServerHandle>> {
-    static WEB_HANDLE: OnceCell<Mutex<Option<re_web_viewer_server::WebViewerServerHandle>>> =
-        OnceCell::new();
+    use once_cell::sync::OnceCell;
+    static WEB_HANDLE: OnceCell<
+        parking_lot::Mutex<Option<re_web_viewer_server::WebViewerServerHandle>>,
+    > = OnceCell::new();
     WEB_HANDLE.get_or_init(Default::default).lock()
 }
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::borrow_deref_ref)] // False positive due to #[pufunction] macro
 #![allow(unsafe_op_in_unsafe_fn)] // False positive due to #[pufunction] macro
 
-use std::{collections::HashMap, path::PathBuf};
+use std::path::PathBuf;
 
 use itertools::Itertools;
 use pyo3::{
@@ -11,8 +11,6 @@ use pyo3::{
     types::{PyBytes, PyDict},
 };
 
-//use re_viewer_context::SpaceViewId;
-//use re_viewport::{SpaceViewBlueprint, VIEWPORT_PATH};
 use re_viewport::VIEWPORT_PATH;
 
 use re_log_types::{DataRow, EntityPathPart, StoreKind};
@@ -37,8 +35,7 @@ use re_ws_comms::RerunServerPort;
 
 // --- FFI ---
 
-use once_cell::sync::{Lazy, OnceCell};
-use parking_lot::Mutex;
+use once_cell::sync::Lazy;
 
 type GarbageChunk = arrow2::chunk::Chunk<Box<dyn arrow2::array::Array>>;
 type GarbageSender = crossbeam::channel::Sender<GarbageChunk>;
@@ -648,7 +645,6 @@ impl PyMemorySinkStorage {
 #[cfg(feature = "web_viewer")]
 #[must_use = "the tokio_runtime guard must be kept alive while using tokio"]
 fn enter_tokio_runtime() -> tokio::runtime::EnterGuard<'static> {
-    use once_cell::sync::Lazy;
     static TOKIO_RUNTIME: Lazy<tokio::runtime::Runtime> =
         Lazy::new(|| tokio::runtime::Runtime::new().expect("Failed to create tokio runtime"));
     TOKIO_RUNTIME.enter()

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -40,17 +40,6 @@ use re_ws_comms::RerunServerPort;
 use once_cell::sync::{Lazy, OnceCell};
 use parking_lot::Mutex;
 
-// The bridge needs to have complete control over the lifetimes of the individual recordings,
-// otherwise all the recording shutdown machinery (which includes deallocating C, Rust and Python
-// data and joining a bunch of threads) can end up running at any time depending on what the
-// Python GC is doing, which obviously leads to very bad things :tm:.
-//
-// TODO(#2116): drop unused recordings
-fn all_recordings() -> parking_lot::MutexGuard<'static, HashMap<StoreId, RecordingStream>> {
-    static ALL_RECORDINGS: OnceCell<Mutex<HashMap<StoreId, RecordingStream>>> = OnceCell::new();
-    ALL_RECORDINGS.get_or_init(Default::default).lock()
-}
-
 type GarbageChunk = arrow2::chunk::Chunk<Box<dyn arrow2::array::Array>>;
 type GarbageSender = crossbeam::channel::Sender<GarbageChunk>;
 type GarbageReceiver = crossbeam::channel::Receiver<GarbageChunk>;
@@ -275,9 +264,6 @@ fn new_recording(
         );
     }
 
-    // NOTE: The Rust-side of the bindings must be in control of the lifetimes of the recordings!
-    all_recordings().insert(recording_id, recording.clone());
-
     Ok(PyRecordingStream(recording))
 }
 
@@ -331,22 +317,12 @@ fn new_blueprint(
         );
     }
 
-    // NOTE: The Rust-side of the bindings must be in control of the lifetimes of the recordings!
-    all_recordings().insert(blueprint_id, blueprint.clone());
-
     Ok(PyRecordingStream(blueprint))
 }
 
 #[pyfunction]
 fn shutdown() {
     re_log::debug!("Shutting down the Rerun SDK");
-    // Release the GIL in case any flushing behavior needs to cleanup a python object.
-    py.allow_threads(|| {
-        for (_, recording) in all_recordings().drain() {
-            recording.disconnect();
-        }
-        flush_garbage_queue();
-    });
 }
 
 // --- Recordings ---
@@ -413,9 +389,6 @@ fn set_global_data_recording(
     // to zero, which means dropping it, which means flushing it, which potentially means
     // deallocating python-owned data, which means grabbing the GIL, thus we need to release the
     // GIL first.
-    //
-    // NOTE: This cannot happen anymore with the new `ALL_RECORDINGS` thingy, but better safe than
-    // sorry.
     py.allow_threads(|| {
         let rec = RecordingStream::set_global(
             rerun::StoreKind::Recording,
@@ -445,9 +418,6 @@ fn set_thread_local_data_recording(
     // to zero, which means dropping it, which means flushing it, which potentially means
     // deallocating python-owned data, which means grabbing the GIL, thus we need to release the
     // GIL first.
-    //
-    // NOTE: This cannot happen anymore with the new `ALL_RECORDINGS` thingy, but better safe than
-    // sorry.
     py.allow_threads(|| {
         let rec = RecordingStream::set_thread_local(
             rerun::StoreKind::Recording,
@@ -488,9 +458,6 @@ fn set_global_blueprint_recording(
     // to zero, which means dropping it, which means flushing it, which potentially means
     // deallocating python-owned blueprint, which means grabbing the GIL, thus we need to release the
     // GIL first.
-    //
-    // NOTE: This cannot happen anymore with the new `ALL_RECORDINGS` thingy, but better safe than
-    // sorry.
     py.allow_threads(|| {
         let rec = RecordingStream::set_global(
             rerun::StoreKind::Blueprint,
@@ -520,9 +487,6 @@ fn set_thread_local_blueprint_recording(
     // to zero, which means dropping it, which means flushing it, which potentially means
     // deallocating python-owned blueprint, which means grabbing the GIL, thus we need to release the
     // GIL first.
-    //
-    // NOTE: This cannot happen anymore with the new `ALL_RECORDINGS` thingy, but better safe than
-    // sorry.
     py.allow_threads(|| {
         let rec = RecordingStream::set_thread_local(
             rerun::StoreKind::Blueprint,

--- a/tests/python/gil_stress/main.py
+++ b/tests/python/gil_stress/main.py
@@ -1,0 +1,51 @@
+"""
+Stress test for things that tend to GIL deadlock.
+
+Logs many large recordings that contain a lot of large rows.
+
+Usage:
+```
+python main.py
+"""
+from __future__ import annotations
+
+import rerun as rr
+
+rec = rr.new_recording(application_id="test")
+
+rec = rr.new_recording(application_id="test")
+rr.log("test", rr.Points3D([1, 2, 3]), recording=rec.inner)
+
+rec = rr.new_recording(application_id="test", make_default=True)
+rr.log("test", rr.Points3D([1, 2, 3]), recording=rec.inner)
+
+rec = rr.new_recording(application_id="test", make_thread_default=True)
+rr.log("test", rr.Points3D([1, 2, 3]), recording=rec.inner)
+
+rec = rr.new_recording(application_id="test")  # this works
+rr.set_global_data_recording(rec)
+rr.log("test", rr.Points3D([1, 2, 3]), recording=rec.inner)
+
+rec = rr.new_recording(application_id="test")  # this works
+rr.set_thread_local_data_recording(rec)
+rr.log("test", rr.Points3D([1, 2, 3]), recording=rec.inner)
+
+rec = rr.new_recording(application_id="test", spawn=True)
+rr.log("test", rr.Points3D([1, 2, 3]), recording=rec.inner)
+
+rec = rr.new_recording(application_id="test")
+rr.connect(recording=rec)
+rr.log("test", rr.Points3D([1, 2, 3]), recording=rec.inner)
+
+rec = rr.new_recording(application_id="test")
+rr.memory_recording(recording=rec)
+rr.log("test", rr.Points3D([1, 2, 3]), recording=rec.inner)
+
+for _ in range(3):
+    rec = rr.new_recording(application_id="test", make_default=False, make_thread_default=False)
+    mem = rec.memory_recording()
+    rr.log("test", rr.Points3D([1, 2, 3]), recording=rec.inner)
+
+for _ in range(3):
+    rec = rr.new_recording(application_id="test", make_default=False, make_thread_default=False)
+    rr.log("test", rr.Points3D([1, 2, 3]), recording=rec.inner)


### PR DESCRIPTION
This introduces a new deferred system to clear Arrow garbage that was originally allocated in Python land.

This should fix all deadlocks/segfaults/aborts past, present and future... or not :smiling_face_with_tear: 

NOTE: This lives in parallel to the already existing `ALL_RECORDINGS` thingy, which is still needed to avoid killing and joining threads at a bad time.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4583/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4583/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4583/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4583)
- [Docs preview](https://rerun.io/preview/40f8fa545efe7d27848a900ff22ccfe210c2236d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/40f8fa545efe7d27848a900ff22ccfe210c2236d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)