### PR TITLE
Document how to construct an entity path for the Rust logging API

### DIFF
--- a/crates/re_log_types/src/path/mod.rs
+++ b/crates/re_log_types/src/path/mod.rs
@@ -38,10 +38,12 @@ macro_rules! entity_path_vec {
     };
 }
 
-/// Build a `EntityPath`:
+/// Build an [`EntityPath`] from parts that are _not_ escaped:
+///
 /// ```
 /// # use re_log_types::*;
-/// let path: EntityPath = entity_path!("foo", "bar");
+/// let path: EntityPath = entity_path!("world", "my image!");
+/// assert_eq!(path, EntityPath::parse_strict(r"world/my\ image\!").unwrap());
 /// ```
 #[macro_export]
 macro_rules! entity_path {

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -31,7 +31,7 @@ pub use self::recording_stream::{
 
 pub use re_sdk_comms::{default_flush_timeout, default_server_addr};
 
-pub use re_log_types::{ApplicationId, EntityPath, StoreId, StoreKind};
+pub use re_log_types::{entity_path, ApplicationId, EntityPath, StoreId, StoreKind};
 
 pub use global::cleanup_if_forked_child;
 

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -725,6 +725,10 @@ impl RecordingStream {
     /// transport.
     /// See [SDK Micro Batching] for more information.
     ///
+    /// The entity path can either be a string
+    /// (with special characters escaped, split on unescaped slashes)
+    /// or an [`EntityPath`] constructed with [`crate::entity_path`].
+    ///
     /// # Example:
     /// ```ignore
     /// # use rerun;


### PR DESCRIPTION
### What
Python and C++ coming later.

![image](https://github.com/rerun-io/rerun/assets/1148717/3b402336-da52-4148-980b-a8d7a79fa5e5)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4584/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4584/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4584/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4584)
- [Docs preview](https://rerun.io/preview/e704373b374eafdaeec33a9bd6550d6b35ca2011/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e704373b374eafdaeec33a9bd6550d6b35ca2011/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)