### PR TITLE
Add tomlkit to pixi

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -11607,6 +11607,86 @@ package:
   size: 15940
   timestamp: 1644342331069
 - platform: linux-64
+  name: tomlkit
+  version: 0.12.3
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
+  hash:
+    md5: 074d0ce7a6261ab8b497c3518796ef3e
+    sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
+  build: pyha770c72_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 37132
+  timestamp: 1700046842169
+- platform: osx-64
+  name: tomlkit
+  version: 0.12.3
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
+  hash:
+    md5: 074d0ce7a6261ab8b497c3518796ef3e
+    sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
+  build: pyha770c72_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 37132
+  timestamp: 1700046842169
+- platform: osx-arm64
+  name: tomlkit
+  version: 0.12.3
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
+  hash:
+    md5: 074d0ce7a6261ab8b497c3518796ef3e
+    sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
+  build: pyha770c72_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 37132
+  timestamp: 1700046842169
+- platform: win-64
+  name: tomlkit
+  version: 0.12.3
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
+  hash:
+    md5: 074d0ce7a6261ab8b497c3518796ef3e
+    sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
+  build: pyha770c72_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 37132
+  timestamp: 1700046842169
+- platform: linux-64
   name: typing-extensions
   version: 4.8.0
   category: main

--- a/pixi.toml
+++ b/pixi.toml
@@ -114,6 +114,7 @@ doxygen = "1.9.7.*"
 binaryen = "116.*"   # for `wasm-opt`
 nox = "2021.10.1.*"
 prettier = "2.8.8.*"
+tomlkit = "0.12.3.*"
 
 [target.linux-64.dependencies]
 patchelf = ">=0.17"


### PR DESCRIPTION
### What
Showed up as missing dep when running some of the linters.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4586/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4586/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4586/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4586)
- [Docs preview](https://rerun.io/preview/5676d6f2661f6e09d2d1e6e894e59fade48d4f0a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5676d6f2661f6e09d2d1e6e894e59fade48d4f0a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)