### PR TITLE
3D->2D & 2D->3D selection visualizations stick now around on selection

### DIFF
--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -10,7 +10,7 @@ use re_space_view::ScreenshotMode;
 use re_types::components::{DepthMeter, InstanceKey, TensorData};
 use re_types::tensor_data::TensorDataMeaning;
 use re_viewer_context::{
-    resolve_mono_instance_path, HoverHighlight, HoveredSpace, Item, SelectionHighlight,
+    resolve_mono_instance_path, HoverHighlight, Item, SelectedSpaceContext, SelectionHighlight,
     SpaceViewHighlights, SpaceViewState, SpaceViewSystemExecutionError, TensorDecodeCache,
     TensorStatsCache, UiVerbosity, ViewContextCollection, ViewPartCollection, ViewQuery,
     ViewerContext,
@@ -630,7 +630,7 @@ pub fn picking(
     item_ui::select_hovered_on_click(ctx, &response, &hovered_items);
 
     let hovered_space = match spatial_kind {
-        SpatialSpaceViewKind::TwoD => HoveredSpace::TwoD {
+        SpatialSpaceViewKind::TwoD => SelectedSpaceContext::TwoD {
             space_2d: query.space_origin.clone(),
             pos: picking_context
                 .pointer_in_space2d
@@ -638,7 +638,7 @@ pub fn picking(
         },
         SpatialSpaceViewKind::ThreeD => {
             let hovered_point = picking_result.space_position();
-            HoveredSpace::ThreeD {
+            SelectedSpaceContext::ThreeD {
                 space_3d: query.space_origin.clone(),
                 pos: hovered_point,
                 tracked_space_camera: state.state_3d.tracked_camera.clone(),
@@ -656,7 +656,12 @@ pub fn picking(
             }
         }
     };
-    ctx.selection_state().set_hovered_space(hovered_space);
+    ctx.selection_state()
+        .set_hovered_space_context(hovered_space.clone());
+    if response.clicked() {
+        ctx.selection_state()
+            .set_selected_space_context(hovered_space);
+    }
 
     Ok(response)
 }

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -370,20 +370,24 @@ pub fn view_2d(
         ));
 
         // Make sure to _first_ draw the selected, and *then* the hovered context on top!
-        painter.extend(show_projections_from_3d_space(
-            ui,
-            query.space_origin,
-            &ui_from_canvas,
-            ctx.selection_state().selected_space_context(),
-            ui.style().visuals.selection.bg_fill,
-        ));
-        painter.extend(show_projections_from_3d_space(
-            ui,
-            query.space_origin,
-            &ui_from_canvas,
-            ctx.selection_state().hovered_space_context(),
-            egui::Color32::WHITE,
-        ));
+        for selected_context in ctx.selection_state().selected_space_context() {
+            painter.extend(show_projections_from_3d_space(
+                ui,
+                query.space_origin,
+                &ui_from_canvas,
+                selected_context,
+                ui.style().visuals.selection.bg_fill,
+            ));
+        }
+        if let Some(hovered_context) = ctx.selection_state().hovered_space_context() {
+            painter.extend(show_projections_from_3d_space(
+                ui,
+                query.space_origin,
+                &ui_from_canvas,
+                hovered_context,
+                egui::Color32::WHITE,
+            ));
+        }
 
         // Add egui driven labels on top of re_renderer content.
         painter.extend(label_shapes);

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -369,11 +369,20 @@ pub fn view_2d(
             ui.visuals().extreme_bg_color.into(),
         ));
 
+        // Make sure to _first_ draw the selected, and *then* the hovered context on top!
         painter.extend(show_projections_from_3d_space(
-            ctx,
             ui,
             query.space_origin,
             &ui_from_canvas,
+            ctx.selection_state().selected_space_context(),
+            ui.style().visuals.selection.bg_fill,
+        ));
+        painter.extend(show_projections_from_3d_space(
+            ui,
+            query.space_origin,
+            &ui_from_canvas,
+            ctx.selection_state().hovered_space_context(),
+            egui::Color32::WHITE,
         ));
 
         // Add egui driven labels on top of re_renderer content.
@@ -497,16 +506,17 @@ fn re_render_rect_from_egui_rect(rect: egui::Rect) -> re_renderer::RectF32 {
 // ------------------------------------------------------------------------
 
 fn show_projections_from_3d_space(
-    ctx: &ViewerContext<'_>,
     ui: &egui::Ui,
     space: &EntityPath,
     ui_from_canvas: &RectTransform,
+    space_context: &SelectedSpaceContext,
+    color: egui::Color32,
 ) -> Vec<Shape> {
     let mut shapes = Vec::new();
     if let SelectedSpaceContext::ThreeD {
         point_in_space_cameras: target_spaces,
         ..
-    } = ctx.selection_state().hovered_space_context()
+    } = space_context
     {
         for (space_2d, pos_2d) in target_spaces {
             if space_2d == space {
@@ -519,7 +529,7 @@ fn show_projections_from_3d_space(
                         radius + 2.0,
                         Color32::BLACK,
                     ));
-                    shapes.push(Shape::circle_filled(pos_in_ui, radius, Color32::WHITE));
+                    shapes.push(Shape::circle_filled(pos_in_ui, radius, color));
 
                     let text = format!("Depth: {:.3} m", pos_2d.z);
                     let font_id = egui::TextStyle::Body.resolve(ui.style());

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -9,8 +9,8 @@ use re_renderer::view_builder::{TargetConfiguration, ViewBuilder};
 use re_space_view::controls::{DRAG_PAN2D_BUTTON, RESET_VIEW_BUTTON_TEXT, ZOOM_SCROLL_MODIFIER};
 use re_types::{archetypes::Pinhole, components::ViewCoordinates};
 use re_viewer_context::{
-    gpu_bridge, HoveredSpace, SpaceViewSystemExecutionError, SystemExecutionOutput, ViewQuery,
-    ViewerContext,
+    gpu_bridge, SelectedSpaceContext, SpaceViewSystemExecutionError, SystemExecutionOutput,
+    ViewQuery, ViewerContext,
 };
 
 use super::{
@@ -503,10 +503,10 @@ fn show_projections_from_3d_space(
     ui_from_canvas: &RectTransform,
 ) -> Vec<Shape> {
     let mut shapes = Vec::new();
-    if let HoveredSpace::ThreeD {
+    if let SelectedSpaceContext::ThreeD {
         point_in_space_cameras: target_spaces,
         ..
-    } = ctx.selection_state().hovered_space()
+    } = ctx.selection_state().hovered_space_context()
     {
         for (space_2d, pos_2d) in target_spaces {
             if space_2d == space {

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -504,12 +504,14 @@ pub fn view_3d(
         space_cameras,
         state,
         ctx.selection_state().hovered_space_context(),
+        egui::Color32::WHITE,
     );
     show_projections_from_2d_space(
         &mut line_builder,
         space_cameras,
         state,
         ctx.selection_state().selected_space_context(),
+        ui.style().visuals.selection.bg_fill,
     );
 
     {
@@ -635,6 +637,7 @@ fn show_projections_from_2d_space(
     space_cameras: &[SpaceCamera3D],
     state: &SpatialSpaceViewState,
     space_context: &SelectedSpaceContext,
+    color: egui::Color32,
 ) {
     match space_context {
         SelectedSpaceContext::TwoD { space_2d, pos } => {
@@ -661,7 +664,13 @@ fn show_projections_from_2d_space(
                         macaw::Ray3::from_origin_dir(origin, (stop_in_world - origin).normalize());
 
                     let thick_ray_length = (stop_in_world - origin).length();
-                    add_picking_ray(line_builder, ray, &state.scene_bbox_accum, thick_ray_length);
+                    add_picking_ray(
+                        line_builder,
+                        ray,
+                        &state.scene_bbox_accum,
+                        thick_ray_length,
+                        color,
+                    );
                 }
             }
         }
@@ -679,7 +688,7 @@ fn show_projections_from_2d_space(
                     let cam_to_pos = *pos - cam.position();
                     let distance = cam_to_pos.length();
                     let ray = macaw::Ray3::from_origin_dir(cam.position(), cam_to_pos / distance);
-                    add_picking_ray(line_builder, ray, &state.scene_bbox_accum, distance);
+                    add_picking_ray(line_builder, ray, &state.scene_bbox_accum, distance, color);
                 }
             }
         }
@@ -692,6 +701,7 @@ fn add_picking_ray(
     ray: macaw::Ray3,
     scene_bbox_accum: &BoundingBox,
     thick_ray_length: f32,
+    color: egui::Color32,
 ) {
     let mut line_batch = line_builder.batch("picking ray");
 
@@ -702,11 +712,11 @@ fn add_picking_ray(
 
     line_batch
         .add_segment(origin, main_ray_end)
-        .color(egui::Color32::WHITE)
+        .color(color)
         .radius(Size::new_points(1.0));
     line_batch
         .add_segment(main_ray_end, fallback_ray_end)
-        .color(egui::Color32::DARK_GRAY)
+        .color(color.gamma_multiply(0.7))
         // TODO(andreas): Make this dashed.
         .radius(Size::new_points(0.5));
 }

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -503,15 +503,15 @@ pub fn view_3d(
         &mut line_builder,
         space_cameras,
         state,
-        ctx.selection_state().hovered_space_context(),
-        egui::Color32::WHITE,
+        ctx.selection_state().selected_space_context(),
+        ui.style().visuals.selection.bg_fill,
     );
     show_projections_from_2d_space(
         &mut line_builder,
         space_cameras,
         state,
-        ctx.selection_state().selected_space_context(),
-        ui.style().visuals.selection.bg_fill,
+        ctx.selection_state().hovered_space_context(),
+        egui::Color32::WHITE,
     );
 
     {

--- a/crates/re_time_panel/src/data_density_graph.rs
+++ b/crates/re_time_panel/src/data_density_graph.rs
@@ -481,12 +481,10 @@ pub fn data_density_graph_ui(
     );
 
     if 0 < num_hovered_messages {
-        ctx.rec_cfg
-            .selection_state
-            .set_hovered(std::iter::once(item.clone()));
+        ctx.selection_state().set_hovered(item.clone());
 
         if time_area_response.clicked_by(egui::PointerButton::Primary) {
-            ctx.set_single_selection(item);
+            ctx.selection_state().set_selection(item.clone());
             time_ctrl.set_time(hovered_time_range.min);
             time_ctrl.pause();
         } else if !ui.ctx().memory(|mem| mem.is_anything_being_dragged()) {
@@ -503,7 +501,7 @@ pub fn data_density_graph_ui(
 }
 
 fn graph_color(ctx: &ViewerContext<'_>, item: &Item, ui: &egui::Ui) -> Color32 {
-    let is_selected = ctx.selection().contains(item);
+    let is_selected = ctx.selection().contains_item(item);
     if is_selected {
         make_brighter(ui.visuals().widgets.active.fg_stroke.color)
     } else {

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -12,7 +12,6 @@ mod time_selection_ui;
 
 use egui::emath::Rangef;
 use egui::{pos2, Color32, CursorIcon, NumExt, Painter, PointerButton, Rect, Shape, Ui, Vec2};
-use std::slice;
 
 use re_data_store::{EntityTree, InstancePath, TimeHistogram};
 use re_data_ui::item_ui;
@@ -484,7 +483,7 @@ impl TimePanel {
         let default_open = tree.path.len() <= 1 && !tree.is_leaf();
 
         let item = Item::InstancePath(None, InstancePath::entity_splat(tree.path.clone()));
-        let is_selected = ctx.selection().contains(&item);
+        let is_selected = ctx.selection().contains_item(&item);
         let is_item_hovered =
             ctx.selection_state().highlight_for_ui_element(&item) == HoverHighlight::Hovered;
 
@@ -517,7 +516,7 @@ impl TimePanel {
         let response = response
             .on_hover_ui(|ui| re_data_ui::item_ui::entity_hover_card_ui(ui, ctx, &tree.path));
 
-        item_ui::select_hovered_on_click(ctx, &response, slice::from_ref(&item));
+        item_ui::select_hovered_on_click(ctx, &response, item.clone());
 
         let is_closed = body_response.is_none();
         let response_rect = response.rect;
@@ -611,7 +610,7 @@ impl TimePanel {
                 let response =
                     re_data_ui::temporary_style_ui_for_component(ui, component_name, |ui| {
                         ListItem::new(ctx.re_ui, short_component_name)
-                            .selected(ctx.selection().contains(&item))
+                            .selected(ctx.selection().contains_item(&item))
                             .width_allocation_mode(WidthAllocationMode::Compact)
                             .force_hovered(
                                 ctx.selection_state().highlight_for_ui_element(&item)
@@ -626,11 +625,7 @@ impl TimePanel {
 
                 ui.set_clip_rect(clip_rect_save);
 
-                re_data_ui::item_ui::select_hovered_on_click(
-                    ctx,
-                    &response,
-                    slice::from_ref(&item),
-                );
+                re_data_ui::item_ui::select_hovered_on_click(ctx, &response, item.clone());
 
                 let response_rect = response.rect;
 
@@ -751,7 +746,7 @@ fn highlight_timeline_row(
 ) {
     let item_hovered =
         ctx.selection_state().highlight_for_ui_element(item) == HoverHighlight::Hovered;
-    let item_selected = ctx.selection().contains(item);
+    let item_selected = ctx.selection().contains_item(item);
     let bg_color = if item_selected {
         Some(ui.visuals().selection.bg_fill.gamma_multiply(0.4))
     } else if item_hovered {

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -5,8 +5,8 @@ use re_log_types::{LogMsg, StoreId, TimeRangeF};
 use re_smart_channel::ReceiveSet;
 use re_space_view::DataQuery as _;
 use re_viewer_context::{
-    AppOptions, Caches, CommandSender, ComponentUiRegistry, PlayState, RecordingConfig,
-    SelectionState, SpaceViewClassRegistry, StoreContext, SystemCommandSender as _, ViewerContext,
+    AppOptions, ApplicationSelectionState, Caches, CommandSender, ComponentUiRegistry, PlayState,
+    RecordingConfig, SpaceViewClassRegistry, StoreContext, SystemCommandSender as _, ViewerContext,
 };
 use re_viewport::{
     identify_entities_per_system_per_class, SpaceInfoCollection, Viewport, ViewportBlueprint,
@@ -377,7 +377,10 @@ fn recording_config_entry<'cfgs>(
 /// Detect and handle that here.
 ///
 /// Must run after any ui code, or other code that tells egui to open an url.
-fn check_for_clicked_hyperlinks(egui_ctx: &egui::Context, selection_state: &SelectionState) {
+fn check_for_clicked_hyperlinks(
+    egui_ctx: &egui::Context,
+    selection_state: &ApplicationSelectionState,
+) {
     let recording_scheme = "recording://";
 
     let mut path = None;
@@ -392,9 +395,9 @@ fn check_for_clicked_hyperlinks(egui_ctx: &egui::Context, selection_state: &Sele
     });
 
     if let Some(path) = path {
-        match path.parse() {
+        match path.parse::<re_viewer_context::Item>() {
             Ok(item) => {
-                selection_state.set_single_selection(item);
+                selection_state.set_selection(item);
             }
             Err(err) => {
                 re_log::warn!("Failed to parse entity path {path:?}: {err}");

--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -158,13 +158,19 @@ fn item_kind_ui(ui: &mut egui::Ui, sel: &Item) {
 }
 
 fn selection_to_string(blueprint: &ViewportBlueprint, selection: &Selection) -> String {
-    debug_assert!(!selection.is_empty()); // history never contains empty selections.
+    debug_assert!(
+        !selection.is_empty(),
+        "History should never contain empty selections."
+    );
     if selection.len() == 1 {
         if let Some(item) = selection.iter_items().next() {
             item_to_string(blueprint, item)
         } else {
             // All items got removed or weren't there to begin with.
-            debug_assert!(selection.iter_space_context().next().is_some()); // Should never keep both empty item & context list.
+            debug_assert!(
+                selection.iter_space_context().next().is_some(),
+                "History should never keep selections that have both an empty item & context list."
+            );
             "<space context>".to_owned()
         }
     } else if let Some(kind) = selection.are_all_items_same_kind() {

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -113,13 +113,13 @@ impl SelectionPanel {
         // no gap before the first item title
         ui.add_space(-ui.spacing().item_spacing.y);
 
-        let selection = ctx.selection().to_vec();
+        let selection = ctx.selection();
         let multi_selection_verbosity = if selection.len() > 1 {
             UiVerbosity::LimitHeight
         } else {
             UiVerbosity::Full
         };
-        for (i, item) in selection.iter().enumerate() {
+        for (i, item) in selection.iter_items().enumerate() {
             ui.push_id(i, |ui| {
                 what_is_selected_ui(ui, ctx, viewport.blueprint, item);
 
@@ -171,7 +171,7 @@ fn space_view_button(
     space_view: &re_viewport::SpaceViewBlueprint,
 ) -> egui::Response {
     let item = Item::SpaceView(space_view.id);
-    let is_selected = ctx.selection().contains(&item);
+    let is_selected = ctx.selection().contains_item(&item);
 
     let response = ctx
         .re_ui

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -75,8 +75,7 @@ impl SelectionPanel {
                             viewport.blueprint,
                             &mut history,
                         ) {
-                            ctx.selection_state()
-                                .set_selection(selection.iter().cloned());
+                            ctx.selection_state().set_selection(selection);
                         }
                     });
             });

--- a/crates/re_viewer_context/src/item.rs
+++ b/crates/re_viewer_context/src/item.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools as _;
-
 use re_data_store::InstancePath;
 use re_log_types::{ComponentPath, DataPath, EntityPath};
 
@@ -115,78 +113,6 @@ impl Item {
             Item::DataBlueprintGroup(_, _, _) => "Group",
             Item::Container(_) => "Container",
         }
-    }
-}
-
-/// An ordered collection of [`Item`].
-///
-/// Used to store what is currently selected and/or hovered.
-///
-/// Immutable object, may pre-compute additional information about the selection on creation.
-#[derive(Default, Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-pub struct ItemCollection {
-    items: Vec<Item>,
-}
-
-impl ItemCollection {
-    pub fn new(items: impl Iterator<Item = Item>) -> Self {
-        let items = items.unique().collect();
-        Self { items }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.items.is_empty()
-    }
-
-    /// Number of elements in this multiselection
-    pub fn len(&self) -> usize {
-        self.items.len()
-    }
-
-    /// The first selected object if any.
-    pub fn first(&self) -> Option<&Item> {
-        self.items.first()
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &Item> {
-        self.items.iter()
-    }
-
-    pub fn to_vec(&self) -> Vec<Item> {
-        self.items.clone()
-    }
-
-    /// Returns true if the exact selection is part of the current selection.
-    pub fn contains(&self, item: &Item) -> bool {
-        self.items.contains(item)
-    }
-
-    pub fn are_all_same_kind(&self) -> Option<&'static str> {
-        if let Some(first_selection) = self.items.first() {
-            if self
-                .items
-                .iter()
-                .skip(1)
-                .all(|item| std::mem::discriminant(first_selection) == std::mem::discriminant(item))
-            {
-                return Some(first_selection.kind());
-            }
-        }
-        None
-    }
-
-    /// Retains elements that fulfill a certain condition.
-    pub fn retain(&mut self, f: impl Fn(&Item) -> bool) {
-        self.items.retain(|item| f(item));
-    }
-}
-
-impl std::iter::IntoIterator for ItemCollection {
-    type Item = Item;
-    type IntoIter = std::vec::IntoIter<Item>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.items.into_iter()
     }
 }
 

--- a/crates/re_viewer_context/src/item.rs
+++ b/crates/re_viewer_context/src/item.rs
@@ -8,8 +8,6 @@ use super::SpaceViewId;
 /// One "thing" in the UI.
 ///
 /// This is the granularity of what is selectable and hoverable.
-///
-/// A set of these is a an [`ItemCollection`].
 #[derive(Clone, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
 pub enum Item {
     ComponentPath(ComponentPath),

--- a/crates/re_viewer_context/src/item.rs
+++ b/crates/re_viewer_context/src/item.rs
@@ -181,6 +181,15 @@ impl ItemCollection {
     }
 }
 
+impl<T> From<T> for ItemCollection
+where
+    T: Iterator<Item = Item>,
+{
+    fn from(value: T) -> Self {
+        ItemCollection::new(value)
+    }
+}
+
 impl std::iter::IntoIterator for ItemCollection {
     type Item = Item;
     type IntoIter = std::vec::IntoIter<Item>;

--- a/crates/re_viewer_context/src/item.rs
+++ b/crates/re_viewer_context/src/item.rs
@@ -181,15 +181,6 @@ impl ItemCollection {
     }
 }
 
-impl<T> From<T> for ItemCollection
-where
-    T: Iterator<Item = Item>,
-{
-    fn from(value: T) -> Self {
-        ItemCollection::new(value)
-    }
-}
-
 impl std::iter::IntoIterator for ItemCollection {
     type Item = Item;
     type IntoIter = std::vec::IntoIter<Item>;

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -33,10 +33,8 @@ pub use command_sender::{
     command_channel, CommandReceiver, CommandSender, SystemCommand, SystemCommandSender,
 };
 pub use component_ui_registry::{ComponentUiRegistry, UiVerbosity};
-pub use item::{resolve_mono_instance_path, resolve_mono_instance_path_item, Item, ItemCollection};
-use nohash_hasher::{IntMap, IntSet};
+pub use item::Item;
 pub use query_context::{DataQueryResult, DataResultHandle, DataResultNode, DataResultTree};
-use re_log_types::EntityPath;
 pub use selection_history::SelectionHistory;
 pub use selection_state::{
     ApplicationSelectionState, HoverHighlight, InteractionHighlight, SelectedSpaceContext,
@@ -68,6 +66,9 @@ pub mod external {
 }
 
 // ---------------------------------------------------------------------------
+
+use nohash_hasher::{IntMap, IntSet};
+use re_log_types::EntityPath;
 
 pub type EntitiesPerSystem = IntMap<ViewSystemIdentifier, IntSet<EntityPath>>;
 

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -39,7 +39,8 @@ pub use query_context::{DataQueryResult, DataResultHandle, DataResultNode, DataR
 use re_log_types::EntityPath;
 pub use selection_history::SelectionHistory;
 pub use selection_state::{
-    HoverHighlight, InteractionHighlight, SelectedSpaceContext, SelectionHighlight, SelectionState,
+    ApplicationSelectionState, HoverHighlight, InteractionHighlight, SelectedSpaceContext,
+    Selection, SelectionHighlight,
 };
 pub use space_view::{
     default_heuristic_filter, AutoSpawnHeuristic, DataResult, DynSpaceViewClass,

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -39,7 +39,7 @@ pub use query_context::{DataQueryResult, DataResultHandle, DataResultNode, DataR
 use re_log_types::EntityPath;
 pub use selection_history::SelectionHistory;
 pub use selection_state::{
-    HoverHighlight, HoveredSpace, InteractionHighlight, SelectionHighlight, SelectionState,
+    HoverHighlight, InteractionHighlight, SelectedSpaceContext, SelectionHighlight, SelectionState,
 };
 pub use space_view::{
     default_heuristic_filter, AutoSpawnHeuristic, DataResult, DynSpaceViewClass,

--- a/crates/re_viewer_context/src/selection_history.rs
+++ b/crates/re_viewer_context/src/selection_history.rs
@@ -1,14 +1,16 @@
-use super::{Item, ItemCollection};
+use crate::selection_state::Selection;
+
+use super::Item;
 
 /// A `Selection` and its index into the historical stack.
 #[derive(Debug, Clone)]
 pub struct HistoricalSelection {
     pub index: usize,
-    pub selection: ItemCollection,
+    pub selection: Selection,
 }
 
-impl From<(usize, ItemCollection)> for HistoricalSelection {
-    fn from((index, selection): (usize, ItemCollection)) -> Self {
+impl From<(usize, Selection)> for HistoricalSelection {
+    fn from((index, selection): (usize, Selection)) -> Self {
         Self { index, selection }
     }
 }
@@ -24,7 +26,7 @@ pub struct SelectionHistory {
     pub current: usize,
 
     /// Oldest first.
-    pub stack: Vec<ItemCollection>,
+    pub stack: Vec<Selection>,
 }
 
 impl SelectionHistory {
@@ -34,7 +36,7 @@ impl SelectionHistory {
 
         let mut i = 0;
         self.stack.retain_mut(|selection| {
-            selection.retain(f);
+            selection.items.retain(f);
             let retain = !selection.is_empty();
             if !retain && i <= self.current {
                 self.current = self.current.saturating_sub(1);
@@ -67,7 +69,7 @@ impl SelectionHistory {
     }
 
     #[must_use]
-    pub fn select_previous(&mut self) -> Option<ItemCollection> {
+    pub fn select_previous(&mut self) -> Option<Selection> {
         if let Some(previous) = self.previous() {
             if previous.index != self.current {
                 self.current = previous.index;
@@ -78,7 +80,7 @@ impl SelectionHistory {
     }
 
     #[must_use]
-    pub fn select_next(&mut self) -> Option<ItemCollection> {
+    pub fn select_next(&mut self) -> Option<Selection> {
         if let Some(next) = self.next() {
             if next.index != self.current {
                 self.current = next.index;
@@ -88,15 +90,15 @@ impl SelectionHistory {
         None
     }
 
-    pub fn update_selection(&mut self, item_collection: &ItemCollection) {
+    pub fn update_selection(&mut self, selection: &Selection) {
         // Selecting nothing is irrelevant from a history standpoint.
-        if item_collection.is_empty() {
+        if selection.is_empty() {
             return;
         }
 
         // Do not grow the history if the thing being selected is equal to the value that the
         // current history cursor points to.
-        if self.current().as_ref().map(|c| &c.selection) == Some(item_collection) {
+        if self.current().as_ref().map(|c| &c.selection) == Some(selection) {
             return;
         }
 
@@ -104,7 +106,7 @@ impl SelectionHistory {
         // diverging timeline!
         self.stack.truncate(self.current + 1);
 
-        self.stack.push(item_collection.clone());
+        self.stack.push(selection.clone());
 
         // Keep size under a certain maximum.
         if self.stack.len() > MAX_SELECTION_HISTORY_LENGTH {

--- a/crates/re_viewer_context/src/selection_history.rs
+++ b/crates/re_viewer_context/src/selection_history.rs
@@ -36,7 +36,7 @@ impl SelectionHistory {
 
         let mut i = 0;
         self.stack.retain_mut(|selection| {
-            selection.items.retain(f);
+            selection.retain(f);
             let retain = !selection.is_empty();
             if !retain && i <= self.current {
                 self.current = self.current.saturating_sub(1);

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -258,15 +258,16 @@ impl ApplicationSelectionState {
     pub fn toggle_selection(&self, toggle_items: Selection) {
         re_tracing::profile_function!();
 
-        // Make sure we preserve the order - old items kept in same order, new items added to the end.
-
-        // All the items to toggle. If an was already selected with the same context, it will be removed from this.
         let mut toggle_items_set: HashMap<Item, Option<SelectedSpaceContext>> =
             toggle_items.iter().cloned().collect();
 
         let mut new_selection = self.selection_previous_frame.clone();
+
+        // If an item was already selected with the exact same context remove it.
+        // If an item was already selected and loses its context, remove it.
         new_selection.0.retain(|(item, ctx)| {
-            if toggle_items_set.get(item) == Some(ctx) {
+            let new_ctx = toggle_items_set.get(item);
+            if new_ctx == Some(ctx) || new_ctx == Some(&None) {
                 toggle_items_set.remove(item);
                 false
             } else {
@@ -282,6 +283,7 @@ impl ApplicationSelectionState {
             }
         }
 
+        // Make sure we preserve the order - old items kept in same order, new items added to the end.
         // Add the new items, unless they were toggling out existing items:
         new_selection.extend(
             toggle_items

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -136,22 +136,26 @@ impl SelectionState {
     }
 
     /// Selects the previous element in the history if any.
+    ///
+    /// Clears the selected space context.
     pub fn select_previous(&self) {
         if let Some(selection) = self.history.lock().select_previous() {
-            self.selection_this_frame.lock().items = selection;
+            self.set_selection(selection);
         }
     }
 
     /// Selections the next element in the history if any.
+    ///
+    /// Clears the selected space context.
     pub fn select_next(&self) {
         if let Some(selection) = self.history.lock().select_next() {
-            self.selection_this_frame.lock().items = selection;
+            self.set_selection(selection);
         }
     }
 
     /// Clears the current selection out.
     pub fn clear_current(&self) {
-        self.selection_this_frame.lock().items = ItemCollection::default();
+        self.set_selection(ItemCollection::default());
     }
 
     /// Sets a single selection, updating history as needed.
@@ -164,8 +168,8 @@ impl SelectionState {
     /// Sets several objects to be selected, updating history as needed.
     ///
     /// Clears the selected space context.
-    pub fn set_selection(&self, items: impl Iterator<Item = Item>) {
-        let new_selection = ItemCollection::new(items);
+    pub fn set_selection(&self, items: impl Into<ItemCollection>) {
+        let new_selection = items.into();
         let mut selection_state = self.selection_this_frame.lock();
         selection_state.items = new_selection;
         selection_state.space_context = SelectedSpaceContext::None;

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -266,10 +266,13 @@ impl ApplicationSelectionState {
         // If an item was already selected with the exact same context remove it.
         // If an item was already selected and loses its context, remove it.
         new_selection.0.retain(|(item, ctx)| {
-            let new_ctx = toggle_items_set.get(item);
-            if new_ctx == Some(ctx) || new_ctx == Some(&None) {
-                toggle_items_set.remove(item);
-                false
+            if let Some(new_ctx) = toggle_items_set.get(item) {
+                if new_ctx == ctx || new_ctx.is_none() {
+                    toggle_items_set.remove(item);
+                    false
+                } else {
+                    true
+                }
             } else {
                 true
             }

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -4,9 +4,10 @@ use parking_lot::RwLock;
 use re_data_store::{store_db::StoreDb, EntityTree, TimeHistogramPerTimeline};
 
 use crate::{
-    item::resolve_mono_instance_path_item, query_context::DataQueryResult, AppOptions, Caches,
-    CommandSender, ComponentUiRegistry, DataQueryId, EntitiesPerSystemPerClass, Item,
-    ItemCollection, SelectionState, SpaceViewClassRegistry, StoreContext, TimeControl,
+    item::resolve_mono_instance_path_item, query_context::DataQueryResult, AppOptions,
+    ApplicationSelectionState, Caches, CommandSender, ComponentUiRegistry, DataQueryId,
+    EntitiesPerSystemPerClass, Item, ItemCollection, SpaceViewClassRegistry, StoreContext,
+    TimeControl,
 };
 
 /// Common things needed by many parts of the viewer.
@@ -56,7 +57,7 @@ impl<'a> ViewerContext<'a> {
     pub fn set_single_selection(&self, item: &Item) {
         self.rec_cfg
             .selection_state
-            .set_single_selection(resolve_mono_instance_path_item(
+            .set_selection(resolve_mono_instance_path_item(
                 &self.rec_cfg.time_ctrl.read().current_query(),
                 self.store_db.store(),
                 item,
@@ -86,7 +87,7 @@ impl<'a> ViewerContext<'a> {
             }));
     }
 
-    pub fn selection_state(&self) -> &SelectionState {
+    pub fn selection_state(&self) -> &ApplicationSelectionState {
         &self.rec_cfg.selection_state
     }
 
@@ -123,5 +124,5 @@ pub struct RecordingConfig {
     pub time_ctrl: RwLock<TimeControl>,
 
     /// Selection & hovering state.
-    pub selection_state: SelectionState,
+    pub selection_state: ApplicationSelectionState,
 }

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -4,10 +4,9 @@ use parking_lot::RwLock;
 use re_data_store::{store_db::StoreDb, EntityTree, TimeHistogramPerTimeline};
 
 use crate::{
-    item::resolve_mono_instance_path_item, query_context::DataQueryResult, AppOptions,
-    ApplicationSelectionState, Caches, CommandSender, ComponentUiRegistry, DataQueryId,
-    EntitiesPerSystemPerClass, Item, ItemCollection, SpaceViewClassRegistry, StoreContext,
-    TimeControl,
+    query_context::DataQueryResult, AppOptions, ApplicationSelectionState, Caches, CommandSender,
+    ComponentUiRegistry, DataQueryId, EntitiesPerSystemPerClass, Selection, SpaceViewClassRegistry,
+    StoreContext, TimeControl,
 };
 
 /// Common things needed by many parts of the viewer.
@@ -53,38 +52,14 @@ pub struct ViewerContext<'a> {
 }
 
 impl<'a> ViewerContext<'a> {
-    /// Sets a single selection on the next frame, updating history as needed.
-    pub fn set_single_selection(&self, item: &Item) {
-        self.rec_cfg
-            .selection_state
-            .set_selection(resolve_mono_instance_path_item(
-                &self.rec_cfg.time_ctrl.read().current_query(),
-                self.store_db.store(),
-                item,
-            ));
-    }
-
     /// Returns the current selection.
-    pub fn selection(&self) -> &ItemCollection {
+    pub fn selection(&self) -> &Selection {
         self.rec_cfg.selection_state.current()
     }
 
     /// Returns the currently hovered objects.
-    pub fn hovered(&self) -> &ItemCollection {
+    pub fn hovered(&self) -> &Selection {
         self.rec_cfg.selection_state.hovered()
-    }
-
-    /// Set the hovered objects. Will be in [`Self::hovered`] on the next frame.
-    pub fn set_hovered<'b>(&self, hovered: impl Iterator<Item = &'b Item>) {
-        self.rec_cfg
-            .selection_state
-            .set_hovered(hovered.map(|item| {
-                resolve_mono_instance_path_item(
-                    &self.rec_cfg.time_ctrl.read().current_query(),
-                    self.store_db.store(),
-                    item,
-                )
-            }));
     }
 
     pub fn selection_state(&self) -> &ApplicationSelectionState {

--- a/crates/re_viewport/src/space_view_highlights.rs
+++ b/crates/re_viewport/src/space_view_highlights.rs
@@ -6,14 +6,14 @@ use nohash_hasher::IntMap;
 use re_log_types::EntityPathHash;
 use re_renderer::OutlineMaskPreference;
 use re_viewer_context::{
-    HoverHighlight, Item, SelectionHighlight, SelectionState, SpaceViewEntityHighlight,
+    ApplicationSelectionState, HoverHighlight, Item, SelectionHighlight, SpaceViewEntityHighlight,
     SpaceViewHighlights, SpaceViewId, SpaceViewOutlineMasks,
 };
 
 use crate::SpaceViewBlueprint;
 
 pub fn highlights_for_space_view(
-    selection_state: &SelectionState,
+    selection_state: &ApplicationSelectionState,
     space_view_id: SpaceViewId,
     _space_views: &BTreeMap<SpaceViewId, SpaceViewBlueprint>,
 ) -> SpaceViewHighlights {

--- a/crates/re_viewport/src/space_view_highlights.rs
+++ b/crates/re_viewport/src/space_view_highlights.rs
@@ -36,7 +36,7 @@ pub fn highlights_for_space_view(
         OutlineMaskPreference::some(hover_mask_index, 0)
     };
 
-    for current_selection in selection_state.current().iter() {
+    for current_selection in selection_state.current().iter_items() {
         match current_selection {
             Item::ComponentPath(_) | Item::SpaceView(_) | Item::Container(_) => {}
 
@@ -113,7 +113,7 @@ pub fn highlights_for_space_view(
         };
     }
 
-    for current_hover in selection_state.hovered().iter() {
+    for current_hover in selection_state.hovered().iter_items() {
         match current_hover {
             Item::ComponentPath(_) | Item::SpaceView(_) | Item::Container(_) => {}
 

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -499,11 +499,7 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
         }
 
         if let Some(egui_tiles::Tile::Pane(space_view_id)) = tiles.get(tile_id) {
-            item_ui::select_hovered_on_click(
-                self.ctx,
-                &response,
-                &[Item::SpaceView(*space_view_id)],
-            );
+            item_ui::select_hovered_on_click(self.ctx, &response, Item::SpaceView(*space_view_id));
         }
 
         response
@@ -664,14 +660,14 @@ impl TabWidget {
             tab_viewer
                 .ctx
                 .selection()
-                .contains(&Item::SpaceView(space_view.id))
+                .contains_item(&Item::SpaceView(space_view.id))
         });
 
         let hovered = space_view.map_or(false, |space_view| {
             tab_viewer
                 .ctx
                 .hovered()
-                .contains(&Item::SpaceView(space_view.id))
+                .contains_item(&Item::SpaceView(space_view.id))
         });
 
         // tab icon

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -85,7 +85,7 @@ impl Viewport<'_, '_> {
 
         let response = ListItem::new(ctx.re_ui, format!("{:?}", container.kind()))
             .subdued(true)
-            .selected(ctx.selection().contains(&item))
+            .selected(ctx.selection().contains_item(&item))
             .with_buttons(|re_ui, ui| {
                 let vis_response = visibility_button_ui(re_ui, ui, true, &mut visible);
                 visibility_changed = vis_response.changed();
@@ -102,7 +102,7 @@ impl Viewport<'_, '_> {
             })
             .item_response;
 
-        item_ui::select_hovered_on_click(ctx, &response, &[item]);
+        item_ui::select_hovered_on_click(ctx, &response, item);
 
         if remove {
             self.blueprint.mark_user_interaction(ctx);
@@ -155,7 +155,7 @@ impl Viewport<'_, '_> {
             ctx.selection_state().highlight_for_ui_element(&item) == HoverHighlight::Hovered;
 
         let response = ListItem::new(ctx.re_ui, space_view.display_name.clone())
-            .selected(ctx.selection().contains(&item))
+            .selected(ctx.selection().contains_item(&item))
             .subdued(!visible)
             .force_hovered(is_item_hovered)
             .with_icon(space_view.class(ctx.space_view_class_registry).icon())
@@ -194,7 +194,7 @@ impl Viewport<'_, '_> {
             self.deferred_tree_actions.focus_tab = Some(space_view.id);
         }
 
-        item_ui::select_hovered_on_click(ctx, &response, &[item]);
+        item_ui::select_hovered_on_click(ctx, &response, item);
 
         if visibility_changed {
             if self.blueprint.auto_layout {
@@ -259,7 +259,7 @@ impl Viewport<'_, '_> {
                 )
             };
 
-            let is_selected = ctx.selection().contains(&item);
+            let is_selected = ctx.selection().contains_item(&item);
 
             let is_item_hovered =
                 ctx.selection_state().highlight_for_ui_element(&item) == HoverHighlight::Hovered;
@@ -373,7 +373,7 @@ impl Viewport<'_, '_> {
             };
             data_result.save_override(Some(properties), ctx);
 
-            item_ui::select_hovered_on_click(ctx, &response, &[item]);
+            item_ui::select_hovered_on_click(ctx, &response, item);
         }
     }
 
@@ -407,7 +407,8 @@ impl Viewport<'_, '_> {
                             .clicked()
                         {
                             ui.close_menu();
-                            ctx.set_single_selection(&Item::SpaceView(space_view.id));
+                            ctx.selection_state()
+                                .set_selection(Item::SpaceView(space_view.id));
                             self.blueprint.add_space_views(
                                 std::iter::once(space_view),
                                 ctx,

--- a/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
@@ -248,7 +248,7 @@ fn color_space_ui(
             item_ui::select_hovered_on_click(
                 ctx,
                 &interact,
-                &[Item::InstancePath(Some(query.space_view_id), instance)],
+                Item::InstancePath(Some(query.space_view_id), instance),
             );
         }
     }


### PR DESCRIPTION
### What

* Fixes: #3047

Makes the 2D->3D and 3D->2D sticky upon selection!
Going the extra mile to make selection history be aware of this added a bit more stuff, but the code is better off overall I think :)


https://github.com/rerun-io/rerun/assets/1220815/b59f6f07-b7f4-4e62-b14e-2d8385f49fd5



**Update!** Now also works fine with multielection!
We now associate each item selection with an optional space context. Right now you can't space context without items, but this is not a structural limitation.
Toggle (ctrl+cmd select action) behavior has a few new special rules now: If you change the space view context on an already selected object its context is updated. If you add a new object, we add it to the list _with_ the context.
Overall this paves also the way to displaying the context together with the selected item in a more sane way. Should be easier to reason with in general I believe.



https://github.com/rerun-io/rerun/assets/1220815/728b569f-e527-4dcd-b346-1007dccea8c7



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4587/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4587/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4587/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4587)
- [Docs preview](https://rerun.io/preview/5d4f28365919b9ad57af36e5a7779ec8e9d156a8/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5d4f28365919b9ad57af36e5a7779ec8e9d156a8/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)