### PR TITLE
Update cfg_aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,6 +965,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f"
+
+[[package]]
 name = "chrono"
 version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4785,7 +4791,7 @@ dependencies = [
  "bitflags 2.4.1",
  "bytemuck",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.0",
  "clean-path",
  "crossbeam",
  "document-features",
@@ -7680,7 +7686,7 @@ checksum = "9596d90b45384f5281384ab204224876e8e8bf7d58366d9b795ad99aa9894b94"
 dependencies = [
  "android-activity",
  "bitflags 1.3.2",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "core-foundation",
  "core-graphics",
  "dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ bytemuck = { version = "1.11", features = ["extern_crate_alloc"] }
 camino = "1.1"
 cargo_metadata = "0.18"
 cargo-run-wasm = "0.3.2"
-cfg_aliases = "0.1"
+cfg_aliases = "0.2"
 cfg-if = "1.0"
 clang-format = "0.3"
 clap = "4.0"

--- a/crates/re_renderer/build.rs
+++ b/crates/re_renderer/build.rs
@@ -119,22 +119,11 @@ fn should_run() -> bool {
 }
 
 fn main() {
-    // TODO(andreas): Create an upstream PR `cfg_aliases` to fix this.
-    // Workaround for CARGO_CFG_DEBUG_ASSERTIONS not being set as expected.
-    // `cfg_aliases` relies on this.
-    if std::env::var("PROFILE") == Ok("debug".to_owned()) {
-        std::env::set_var("CARGO_CFG_DEBUG_ASSERTIONS", "1");
-    }
-
-    #[allow(clippy::str_to_string)]
-    // TODO(andreas): Create an upstream PR to `cfg_aliases` fix this.
-    {
-        cfg_aliases::cfg_aliases! {
-            native: { not(target_arch = "wasm32") },
-            webgl: { all(not(native), feature = "webgl") },
-            webgpu: { all(not(webgl), not(native)) },
-            load_shaders_from_disk: { all(native, debug_assertions) } // Shader reloading is only supported on native-debug currently.
-        }
+    cfg_aliases::cfg_aliases! {
+        native: { not(target_arch = "wasm32") },
+        webgl: { all(not(native), feature = "webgl") },
+        webgpu: { all(not(webgl), not(native)) },
+        load_shaders_from_disk: { all(native, debug_assertions) } // Shader reloading is only supported on native-debug currently.
     }
 
     if !should_run() {

--- a/deny.toml
+++ b/deny.toml
@@ -49,8 +49,9 @@ skip = [
   { name = "ahash" },                # Popular crate + fast release schedule = lots of crates still using old versions
   { name = "base64" },               # Too popular
   { name = "cargo_metadata" },       # Older version used by ply-rs. It's small, and it's build-time only!
-  { name = "foreign-types" },        # used for cocoa bindings. wgpu uses newer than eframe.
+  { name = "cfg_aliases" },          # Tiny macro-only crate. Winit and other use older version than us.
   { name = "foreign-types-shared" }, # used for cocoa bindings. wgpu uses newer than eframe.
+  { name = "foreign-types" },        # used for cocoa bindings. wgpu uses newer than eframe.
   { name = "hashbrown" },            # Old version used by polar-rs
   { name = "libloading" },           # Old version used by ash (vulkan binding), newer version used by khronos-egl
   { name = "memoffset" },            # Small crate


### PR DESCRIPTION
### What

@zicklag was super awesome and merged these two PRs + published a new version instantly <3

* https://github.com/katharostech/cfg_aliases/pull/5
* https://github.com/katharostech/cfg_aliases/pull/4

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4589/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4589/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4589/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4589)
- [Docs preview](https://rerun.io/preview/dc1a046880d479c82de3536ebb85e06645208401/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/dc1a046880d479c82de3536ebb85e06645208401/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)