### PR TITLE
Fix rectangle that indicates the zoomed pixel area on hover being one  pixel to small

### DIFF
--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -503,7 +503,7 @@ pub fn show_zoomed_image_region_area_outline(
     let height = height as f32;
 
     // Show where on the original image the zoomed-in region is at:
-    // The aread shown is ZOOMED_IMAGE_TEXEL_RADIUS _surrounding_ the center.
+    // The area shown is ZOOMED_IMAGE_TEXEL_RADIUS _surrounding_ the center.
     // Since the center is the top-left/rounded-down, coordinate, we need to add 1 to right/bottom.
     let left = (center_x - ZOOMED_IMAGE_TEXEL_RADIUS) as f32;
     let right = (center_x + ZOOMED_IMAGE_TEXEL_RADIUS + 1) as f32;

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -503,10 +503,12 @@ pub fn show_zoomed_image_region_area_outline(
     let height = height as f32;
 
     // Show where on the original image the zoomed-in region is at:
+    // The aread shown is ZOOMED_IMAGE_TEXEL_RADIUS _surrounding_ the center.
+    // Since the center is the top-left/rounded-down, coordinate, we need to add 1 to right/bottom.
     let left = (center_x - ZOOMED_IMAGE_TEXEL_RADIUS) as f32;
-    let right = (center_x + ZOOMED_IMAGE_TEXEL_RADIUS) as f32;
+    let right = (center_x + ZOOMED_IMAGE_TEXEL_RADIUS + 1) as f32;
     let top = (center_y - ZOOMED_IMAGE_TEXEL_RADIUS) as f32;
-    let bottom = (center_y + ZOOMED_IMAGE_TEXEL_RADIUS) as f32;
+    let bottom = (center_y + ZOOMED_IMAGE_TEXEL_RADIUS + 1) as f32;
 
     let left = remap(left, 0.0..=width, image_rect.x_range());
     let right = remap(right, 0.0..=width, image_rect.x_range());


### PR DESCRIPTION
### What

* Fixes #3074

The outlines of the zoomed rectangle that we super-impose on the 2D space view were off by one pixel

Before:
![Screenshot 2023-12-19 174351](https://github.com/rerun-io/rerun/assets/1220815/c624c81a-cac9-4efc-a278-5b98847c9963)
Note how the rectangle on the picture is smaller than the zoomed-preview (zoomed out in this case)

After:
![Screenshot 2023-12-19 175201](https://github.com/rerun-io/rerun/assets/1220815/5b8e2132-7cf4-40b6-bc54-bdbd2cec39d0)
Note how the rectangle on the picture is identically to the zoomed-preview. The hover overlay hasn't changed, but a different pixel is hovered and the rect is correctly sized now


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4590/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4590/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4590/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4590)
- [Docs preview](https://rerun.io/preview/4b0954988c67c9227677ff8609dd231737bf929a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4b0954988c67c9227677ff8609dd231737bf929a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)