### PR TITLE
Fix code talking about "views" instead of subscribers

### DIFF
--- a/crates/re_arrow_store/src/store_event.rs
+++ b/crates/re_arrow_store/src/store_event.rs
@@ -498,7 +498,7 @@ mod tests {
             assert!(event.cells.contains_key(&store.cluster_key()));
 
             let (events, _) = store.gc(&GarbageCollectionOptions::gc_everything());
-            assert!(events.len() == 1);
+            assert_eq!(1, events.len());
             assert!(events[0].cells.contains_key(&store.cluster_key()));
         }
 
@@ -515,7 +515,7 @@ mod tests {
             assert!(!event.cells.contains_key(&store.cluster_key()));
 
             let (events, _) = store.gc(&GarbageCollectionOptions::gc_everything());
-            assert!(events.len() == 1);
+            assert_eq!(1, events.len());
             assert!(!events[0].cells.contains_key(&store.cluster_key()));
         }
 


### PR DESCRIPTION
_Starting to cherry-pick some of the stuff buried in my caching branch_

Trivial.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4591/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4591/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4591/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4591)
- [Docs preview](https://rerun.io/preview/9b28218be6a43aa9cddde6cba822abf050d47e46/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/9b28218be6a43aa9cddde6cba822abf050d47e46/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)