### PR TITLE
Primary caching 1: more `VecDeque` extensions

### DIFF
--- a/crates/re_log_types/benches/vec_deque_ext.rs
+++ b/crates/re_log_types/benches/vec_deque_ext.rs
@@ -1,18 +1,26 @@
 //! Simple benchmark suite to keep track of how the different removal methods for [`VecDeque`]
 //! behave in practice.
 
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use std::collections::VecDeque;
 
 use criterion::{criterion_group, criterion_main, Criterion};
+use itertools::Itertools;
 
-use re_log_types::VecDequeRemovalExt as _;
+use re_log_types::{VecDequeInsertionExt as _, VecDequeRemovalExt as _};
 
 // ---
 
-criterion_group!(benches, remove, swap_remove, swap_remove_front);
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+criterion_group!(
+    benches,
+    insert_range,
+    remove_range,
+    remove,
+    swap_remove,
+    swap_remove_front,
+);
 criterion_main!(benches);
 
 // ---
@@ -21,11 +29,13 @@ criterion_main!(benches);
 #[cfg(debug_assertions)]
 mod constants {
     pub const INITIAL_NUM_ENTRIES: usize = 1;
+    pub const NUM_MODIFIED_ELEMENTS: usize = 1;
 }
 
 #[cfg(not(debug_assertions))]
 mod constants {
     pub const INITIAL_NUM_ENTRIES: usize = 20_000;
+    pub const NUM_MODIFIED_ELEMENTS: usize = 1_000;
 }
 
 #[allow(clippy::wildcard_imports)]
@@ -33,97 +43,189 @@ use self::constants::*;
 
 // ---
 
-fn remove(c: &mut Criterion) {
-    {
-        let mut group = c.benchmark_group("flat_vec_deque");
-        group.throughput(criterion::Throughput::Elements(1));
-        group.bench_function("remove/prefilled/front", |b| {
-            let base = create_prefilled();
-            b.iter(|| {
-                let mut v: VecDeque<i64> = base.clone();
-                v.remove(0);
-                v
-            });
-        });
-        group.bench_function("remove/prefilled/middle", |b| {
-            let base = create_prefilled();
-            b.iter(|| {
-                let mut v: VecDeque<i64> = base.clone();
-                v.remove(INITIAL_NUM_ENTRIES / 2);
-                v
-            });
-        });
-        group.bench_function("remove/prefilled/back", |b| {
-            let base = create_prefilled();
-            b.iter(|| {
-                let mut v: VecDeque<i64> = base.clone();
-                v.remove(INITIAL_NUM_ENTRIES - 1);
-                v
-            });
-        });
+fn insert_range(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
     }
+
+    let inserted = (0..NUM_MODIFIED_ELEMENTS as i64).collect_vec();
+
+    let mut group = c.benchmark_group("vec_deque");
+    group.throughput(criterion::Throughput::Elements(inserted.len() as _));
+
+    group.bench_function("insert_range/prefilled/front", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.insert_range(0, inserted.clone().into_iter());
+            v
+        });
+    });
+
+    group.bench_function("insert_range/prefilled/middle", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.insert_range(INITIAL_NUM_ENTRIES / 2, inserted.clone().into_iter());
+            v
+        });
+    });
+
+    group.bench_function("insert_range/prefilled/back", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.insert_range(INITIAL_NUM_ENTRIES, inserted.clone().into_iter());
+            v
+        });
+    });
+}
+
+fn remove_range(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
+    }
+
+    let mut group = c.benchmark_group("vec_deque");
+    group.throughput(criterion::Throughput::Elements(NUM_MODIFIED_ELEMENTS as _));
+
+    group.bench_function("remove_range/prefilled/front", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.remove_range(0..NUM_MODIFIED_ELEMENTS);
+            v
+        });
+    });
+
+    group.bench_function("remove_range/prefilled/middle", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.remove_range(
+                INITIAL_NUM_ENTRIES / 2 - NUM_MODIFIED_ELEMENTS / 2
+                    ..INITIAL_NUM_ENTRIES / 2 + NUM_MODIFIED_ELEMENTS / 2,
+            );
+            v
+        });
+    });
+
+    group.bench_function("remove_range/prefilled/back", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.remove_range(INITIAL_NUM_ENTRIES - NUM_MODIFIED_ELEMENTS..INITIAL_NUM_ENTRIES);
+            v
+        });
+    });
+}
+
+fn remove(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
+    }
+
+    let mut group = c.benchmark_group("vec_deque");
+    group.throughput(criterion::Throughput::Elements(1));
+
+    group.bench_function("remove/prefilled/front", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.remove(0);
+            v
+        });
+    });
+
+    group.bench_function("remove/prefilled/middle", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.remove(INITIAL_NUM_ENTRIES / 2);
+            v
+        });
+    });
+
+    group.bench_function("remove/prefilled/back", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.remove(INITIAL_NUM_ENTRIES - 1);
+            v
+        });
+    });
 }
 
 fn swap_remove(c: &mut Criterion) {
-    {
-        let mut group = c.benchmark_group("flat_vec_deque");
-        group.throughput(criterion::Throughput::Elements(1));
-        group.bench_function("swap_remove/prefilled/front", |b| {
-            let base = create_prefilled();
-            b.iter(|| {
-                let mut v: VecDeque<i64> = base.clone();
-                v.swap_remove(0);
-                v
-            });
-        });
-        group.bench_function("swap_remove/prefilled/middle", |b| {
-            let base = create_prefilled();
-            b.iter(|| {
-                let mut v: VecDeque<i64> = base.clone();
-                v.swap_remove(INITIAL_NUM_ENTRIES / 2);
-                v
-            });
-        });
-        group.bench_function("swap_remove/prefilled/back", |b| {
-            let base = create_prefilled();
-            b.iter(|| {
-                let mut v: VecDeque<i64> = base.clone();
-                v.swap_remove(INITIAL_NUM_ENTRIES - 1);
-                v
-            });
-        });
+    if std::env::var("CI").is_ok() {
+        return;
     }
+
+    let mut group = c.benchmark_group("vec_deque");
+    group.throughput(criterion::Throughput::Elements(1));
+
+    group.bench_function("swap_remove/prefilled/front", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.swap_remove(0);
+            v
+        });
+    });
+
+    group.bench_function("swap_remove/prefilled/middle", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.swap_remove(INITIAL_NUM_ENTRIES / 2);
+            v
+        });
+    });
+
+    group.bench_function("swap_remove/prefilled/back", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.swap_remove(INITIAL_NUM_ENTRIES - 1);
+            v
+        });
+    });
 }
 
 fn swap_remove_front(c: &mut Criterion) {
-    {
-        let mut group = c.benchmark_group("flat_vec_deque");
-        group.throughput(criterion::Throughput::Elements(1));
-        group.bench_function("swap_remove_front/prefilled/front", |b| {
-            let base = create_prefilled();
-            b.iter(|| {
-                let mut v: VecDeque<i64> = base.clone();
-                v.swap_remove_front(0);
-                v
-            });
-        });
-        group.bench_function("swap_remove_front/prefilled/middle", |b| {
-            let base = create_prefilled();
-            b.iter(|| {
-                let mut v: VecDeque<i64> = base.clone();
-                v.swap_remove_front(INITIAL_NUM_ENTRIES / 2);
-                v
-            });
-        });
-        group.bench_function("swap_remove_front/prefilled/back", |b| {
-            let base = create_prefilled();
-            b.iter(|| {
-                let mut v: VecDeque<i64> = base.clone();
-                v.swap_remove_front(INITIAL_NUM_ENTRIES - 1);
-                v
-            });
-        });
+    if std::env::var("CI").is_ok() {
+        return;
     }
+
+    let mut group = c.benchmark_group("vec_deque");
+    group.throughput(criterion::Throughput::Elements(1));
+
+    group.bench_function("swap_remove_front/prefilled/front", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.swap_remove_front(0);
+            v
+        });
+    });
+
+    group.bench_function("swap_remove_front/prefilled/middle", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.swap_remove_front(INITIAL_NUM_ENTRIES / 2);
+            v
+        });
+    });
+
+    group.bench_function("swap_remove_front/prefilled/back", |b| {
+        let base = create_prefilled();
+        b.iter(|| {
+            let mut v: VecDeque<i64> = base.clone();
+            v.swap_remove_front(INITIAL_NUM_ENTRIES - 1);
+            v
+        });
+    });
 }
 
 // ---

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -54,7 +54,7 @@ pub use self::time::{Duration, Time, TimeZone};
 pub use self::time_point::{TimeInt, TimePoint, TimeType, Timeline, TimelineName};
 pub use self::time_range::{TimeRange, TimeRangeF};
 pub use self::time_real::TimeReal;
-pub use self::vec_deque_ext::{VecDequeRemovalExt, VecDequeSortingExt};
+pub use self::vec_deque_ext::{VecDequeInsertionExt, VecDequeRemovalExt, VecDequeSortingExt};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use self::data_table_batcher::{

--- a/crates/re_log_types/src/vec_deque_ext.rs
+++ b/crates/re_log_types/src/vec_deque_ext.rs
@@ -155,12 +155,6 @@ pub trait VecDequeRemovalExt<T> {
     /// Note that the capacity of `self` does not change.
     fn split_off_or_default(&mut self, at: usize) -> Self;
 
-    /// Shortens the deque, keeping the first N elements up to `at` (excluded) and
-    /// dropping the rest.
-    ///
-    /// If at is greater or equal to the deque's current length, this has no effect.
-    fn truncate_at(&mut self, at: usize);
-
     /// Removes and returns the elements in the given `range` from the deque.
     ///
     /// This is O(1) if `range` either starts at the beginning of the deque, or ends at the end of
@@ -207,11 +201,6 @@ impl<T: Clone> VecDequeRemovalExt<T> for VecDeque<T> {
             return Default::default();
         }
         self.split_off(at)
-    }
-
-    #[inline]
-    fn truncate_at(&mut self, at: usize) {
-        self.truncate(self.len() - at);
     }
 
     #[inline]


### PR DESCRIPTION
Adding some more `VecDeque` extensions that are used by the upcoming cache implementation.

Also made sure to _not_ run these benchmarks on CI since they are only useful when iterating specifically on the implementation of these extensions and are not worth the CI compute time otherwise.

Some numbers for posterity / git log (5950X, Arch):
```
vec_deque/insert_range/prefilled/back           1.00      5.6±0.07µs 170.8 MElem/sec
vec_deque/insert_range/prefilled/front          1.00      5.5±0.12µs 172.4 MElem/sec
vec_deque/insert_range/prefilled/middle         1.00      7.2±0.28µs 131.7 MElem/sec
vec_deque/remove/prefilled/back                 1.00      2.5±0.04µs 384.2 KElem/sec
vec_deque/remove/prefilled/front                1.00      2.5±0.03µs 390.7 KElem/sec
vec_deque/remove/prefilled/middle               1.00      3.3±0.13µs 292.1 KElem/sec
vec_deque/remove_range/prefilled/back           1.00      2.5±0.12µs 375.8 MElem/sec
vec_deque/remove_range/prefilled/front          1.00      2.5±0.11µs 378.4 MElem/sec
vec_deque/remove_range/prefilled/middle         1.00      5.2±0.25µs 182.7 MElem/sec
vec_deque/swap_remove/prefilled/back            1.00      2.6±0.02µs 381.6 KElem/sec
vec_deque/swap_remove/prefilled/front           1.00      2.6±0.05µs 380.8 KElem/sec
vec_deque/swap_remove/prefilled/middle          1.00      2.5±0.08µs 383.3 KElem/sec
vec_deque/swap_remove_front/prefilled/back      1.00      2.5±0.05µs 392.0 KElem/sec
vec_deque/swap_remove_front/prefilled/front     1.00      2.5±0.10µs 394.2 KElem/sec
vec_deque/swap_remove_front/prefilled/middle    1.00      2.6±0.02µs 378.8 KElem/sec
```

---

Part of the primary caching series of PR (index search, joins, deserialization):
- #4592
- #4593

---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4592/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4592)
- [Docs preview](https://rerun.io/preview/55cce9569c90f7fa4ac1be468597510e9d37cf31/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/55cce9569c90f7fa4ac1be468597510e9d37cf31/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)