### PR TITLE
Get rid of `core_benchmarks_only`

### DIFF
--- a/crates/re_arrow_store/Cargo.toml
+++ b/crates/re_arrow_store/Cargo.toml
@@ -25,10 +25,6 @@ deadlock_detection = ["parking_lot/deadlock_detection"]
 ## Integration with `polars`, to efficiently use the datastore with dataframes.
 polars = ["dep:polars-core", "dep:polars-ops"]
 
-## When set, only run the core set of benchmark suites.
-## Commonly set implicitly by --all-features, e.g. on CI.
-core_benchmarks_only = []
-
 
 [dependencies]
 # Rerun dependencies:

--- a/crates/re_arrow_store/benches/arrow2.rs
+++ b/crates/re_arrow_store/benches/arrow2.rs
@@ -21,12 +21,7 @@ use re_types_core::{Component, SizeBytes as _};
 
 criterion::criterion_group!(benches, erased_clone, estimated_size_bytes);
 
-#[cfg(not(feature = "core_benchmarks_only"))]
 criterion::criterion_main!(benches);
-
-// Don't run these benchmarks on CI: they measure the performance of third-party libraries.
-#[cfg(feature = "core_benchmarks_only")]
-fn main() {}
 
 // ---
 
@@ -66,6 +61,10 @@ impl std::fmt::Display for ArrayKind {
 }
 
 fn erased_clone(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
+    }
+
     let kind = [
         ArrayKind::Primitive,
         ArrayKind::Struct,
@@ -179,6 +178,10 @@ fn erased_clone(c: &mut Criterion) {
 }
 
 fn estimated_size_bytes(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
+    }
+
     let kind = [
         ArrayKind::Primitive,
         ArrayKind::Struct,

--- a/crates/re_arrow_store/benches/data_store.rs
+++ b/crates/re_arrow_store/benches/data_store.rs
@@ -35,23 +35,17 @@ const NUM_ROWS: i64 = 1;
 const NUM_INSTANCES: i64 = 1;
 
 fn packed() -> &'static [bool] {
-    #[cfg(feature = "core_benchmarks_only")]
-    {
+    if std::env::var("CI").is_ok() {
         &[false]
-    }
-    #[cfg(not(feature = "core_benchmarks_only"))]
-    {
+    } else {
         &[false, true]
     }
 }
 
 fn num_rows_per_bucket() -> &'static [u64] {
-    #[cfg(feature = "core_benchmarks_only")]
-    {
+    if std::env::var("CI").is_ok() {
         &[]
-    }
-    #[cfg(not(feature = "core_benchmarks_only"))]
-    {
+    } else {
         &[0, 2, 32, 2048]
     }
 }

--- a/crates/re_arrow_store/benches/gc.rs
+++ b/crates/re_arrow_store/benches/gc.rs
@@ -34,23 +34,17 @@ mod constants {
 use constants::{NUM_ENTITY_PATHS, NUM_ROWS_PER_ENTITY_PATH};
 
 fn gc_batching() -> &'static [bool] {
-    #[cfg(feature = "core_benchmarks_only")]
-    {
+    if std::env::var("CI").is_ok() {
         &[false]
-    }
-    #[cfg(not(feature = "core_benchmarks_only"))]
-    {
+    } else {
         &[false, true]
     }
 }
 
 fn num_rows_per_bucket() -> &'static [u64] {
-    #[cfg(feature = "core_benchmarks_only")]
-    {
+    if std::env::var("CI").is_ok() {
         &[]
-    }
-    #[cfg(not(feature = "core_benchmarks_only"))]
-    {
+    } else {
         &[256, 512, 1024, 2048]
     }
 }

--- a/crates/re_arrow_store/benches/vectors.rs
+++ b/crates/re_arrow_store/benches/vectors.rs
@@ -12,12 +12,7 @@ use tinyvec::TinyVec;
 
 criterion_group!(benches, sort, split, swap, swap_opt);
 
-#[cfg(not(feature = "core_benchmarks_only"))]
 criterion::criterion_main!(benches);
-
-// Don't run these benchmarks on CI: they measure the performance of third-party libraries.
-#[cfg(feature = "core_benchmarks_only")]
-fn main() {}
 
 // ---
 
@@ -35,6 +30,10 @@ const SMALLVEC_SIZE: usize = 1;
 // --- Benchmarks ---
 
 fn split(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
+    }
+
     let mut group = c.benchmark_group(format!("vector_ops/split_off/instances={NUM_INSTANCES}"));
     group.throughput(criterion::Throughput::Elements(NUM_INSTANCES as _));
 
@@ -146,6 +145,10 @@ fn split(c: &mut Criterion) {
 }
 
 fn sort(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
+    }
+
     let mut group = c.benchmark_group(format!("vector_ops/sort/instances={NUM_INSTANCES}"));
     group.throughput(criterion::Throughput::Elements(NUM_INSTANCES as _));
 
@@ -193,6 +196,10 @@ fn sort(c: &mut Criterion) {
 }
 
 fn swap(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
+    }
+
     let mut group = c.benchmark_group(format!("vector_ops/swap/instances={NUM_INSTANCES}"));
     group.throughput(criterion::Throughput::Elements(NUM_INSTANCES as _));
 
@@ -264,6 +271,10 @@ fn swap(c: &mut Criterion) {
 }
 
 fn swap_opt(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
+    }
+
     let mut group = c.benchmark_group(format!("vector_ops/swap_opt/instances={NUM_INSTANCES}"));
     group.throughput(criterion::Throughput::Elements(NUM_INSTANCES as _));
 


### PR DESCRIPTION
Replace the `core_benchmarks_only` feature flag lunacy I introduced a while back with a much simpler env check.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4594/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4594/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4594/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4594)
- [Docs preview](https://rerun.io/preview/6d84be96db76fc8999fb7dd34333d1b36ca62ed6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/6d84be96db76fc8999fb7dd34333d1b36ca62ed6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)