### PR TITLE
C++ & Python API: add helpers for constructing an entity path

### DIFF
--- a/crates/re_log_types/src/path/mod.rs
+++ b/crates/re_log_types/src/path/mod.rs
@@ -25,7 +25,7 @@ pub use parse_path::PathParseError;
 /// Build a `Vec<EntityPathPart>`:
 /// ```
 /// # use re_log_types::*;
-/// let parts: Vec<EntityPathPart> = entity_path_vec!("foo", "bar");
+/// let parts: Vec<EntityPathPart> = entity_path_vec!("foo", 42, "my image!");
 /// ```
 #[macro_export]
 macro_rules! entity_path_vec {
@@ -34,7 +34,10 @@ macro_rules! entity_path_vec {
         ::std::vec::Vec::<$crate::EntityPathPart>::new()
     };
     ($($part: expr),* $(,)?) => {
-        vec![ $($crate::EntityPathPart::from($part),)+ ]
+        vec![ $($crate::EntityPathPart::from(
+            #[allow(clippy::str_to_string, clippy::string_to_string)]
+            $part.to_string()
+        ),)+ ]
     };
 }
 
@@ -42,8 +45,8 @@ macro_rules! entity_path_vec {
 ///
 /// ```
 /// # use re_log_types::*;
-/// let path: EntityPath = entity_path!("world", "my image!");
-/// assert_eq!(path, EntityPath::parse_strict(r"world/my\ image\!").unwrap());
+/// let path: EntityPath = entity_path!("world", 42, "my image!");
+/// assert_eq!(path, EntityPath::parse_strict(r"world/42/my\ image\!").unwrap());
 /// ```
 #[macro_export]
 macro_rules! entity_path {

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -31,7 +31,9 @@ pub use self::recording_stream::{
 
 pub use re_sdk_comms::{default_flush_timeout, default_server_addr};
 
-pub use re_log_types::{entity_path, ApplicationId, EntityPath, StoreId, StoreKind};
+pub use re_log_types::{
+    entity_path, ApplicationId, EntityPath, EntityPathPart, StoreId, StoreKind,
+};
 
 pub use global::cleanup_if_forked_child;
 

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -719,15 +719,16 @@ impl RecordingStream {
     /// The data will be timestamped automatically based on the [`RecordingStream`]'s internal clock.
     /// See [`RecordingStream::set_time_sequence`] etc for more information.
     ///
+    /// The entity path can either be a string
+    /// (with special characters escaped, split on unescaped slashes)
+    /// or an [`EntityPath`] constructed with [`crate::entity_path`].
+    /// See <https://www.rerun.io/docs/concepts/entity-path> for more on entity paths.
+    ///
     /// See also: [`Self::log_timeless`] for logging timeless data.
     ///
     /// Internally, the stream will automatically micro-batch multiple log calls to optimize
     /// transport.
     /// See [SDK Micro Batching] for more information.
-    ///
-    /// The entity path can either be a string
-    /// (with special characters escaped, split on unescaped slashes)
-    /// or an [`EntityPath`] constructed with [`crate::entity_path`].
     ///
     /// # Example:
     /// ```ignore
@@ -791,6 +792,11 @@ impl RecordingStream {
     /// internal clock.
     /// See `RecordingStream::set_time_*` family of methods for more information.
     ///
+    /// The entity path can either be a string
+    /// (with special characters escaped, split on unescaped slashes)
+    /// or an [`EntityPath`] constructed with [`crate::entity_path`].
+    /// See <https://www.rerun.io/docs/concepts/entity-path> for more on entity paths.
+    ///
     /// Internally, the stream will automatically micro-batch multiple log calls to optimize
     /// transport.
     /// See [SDK Micro Batching] for more information.
@@ -829,6 +835,11 @@ impl RecordingStream {
     /// The number of instances will be determined by the longest batch in the bundle.
     /// All of the batches should have the same number of instances, or length 1 if the component is
     /// a splat, or 0 if the component is being cleared.
+    ///
+    /// The entity path can either be a string
+    /// (with special characters escaped, split on unescaped slashes)
+    /// or an [`EntityPath`] constructed with [`crate::entity_path`].
+    /// See <https://www.rerun.io/docs/concepts/entity-path> for more on entity paths.
     ///
     /// Internally, the stream will automatically micro-batch multiple log calls to optimize
     /// transport.

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -731,7 +731,7 @@ pub unsafe extern "C" fn _rr_free_string(str: *mut c_char) {
 
     // Free the string:
     unsafe {
-        // SAFETY: `_rr_free_string` should
+        // SAFETY: `_rr_free_string` should only be called on strings allocated by `_rr_escape_entity_path_part`.
         let _ = CString::from_raw(str);
     }
 }

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -704,6 +704,39 @@ pub unsafe extern "C" fn rr_recording_stream_log(
 }
 
 // ----------------------------------------------------------------------------
+// Private functions
+
+#[allow(unsafe_code)]
+#[no_mangle]
+pub unsafe extern "C" fn _rr_escape_entity_path_part(part: CStringView) -> *const c_char {
+    let Ok(part) = part.as_str("entity_path_part") else {
+        return std::ptr::null();
+    };
+
+    let part = re_sdk::EntityPathPart::from(part).to_string(); // escape the part
+
+    let Ok(part) = CString::new(part) else {
+        return std::ptr::null();
+    };
+
+    part.into_raw()
+}
+
+#[allow(unsafe_code)]
+#[no_mangle]
+pub unsafe extern "C" fn _rr_free_string(str: *mut c_char) {
+    if str.is_null() {
+        return;
+    }
+
+    // Free the string:
+    unsafe {
+        // SAFETY: `_rr_free_string` should
+        let _ = CString::from_raw(str);
+    }
+}
+
+// ----------------------------------------------------------------------------
 // Helper functions:
 
 fn initialize_logging() {

--- a/crates/rerun_c/src/rerun.h
+++ b/crates/rerun_c/src/rerun.h
@@ -413,6 +413,23 @@ extern void rr_recording_stream_log(
 );
 
 // ----------------------------------------------------------------------------
+// Private functions
+
+/// PRIVATE FUNCTION: do not use.
+///
+/// Escape a single part of an entity path, returning an new null-terminated string.
+///
+/// The returned string must be freed with `_rr_free_string`.
+///
+/// Returns `nullptr` on failure (e.g. invalid UTF8, ore null bytes in the string).
+extern char* _rr_escape_entity_path_part(rr_string part);
+
+/// PRIVATE FUNCTION: do not use.
+///
+/// Must only be called with the results from `_rr_escape_entity_path_part`.
+extern void _rr_free_string(char* string);
+
+// ----------------------------------------------------------------------------
 
 #ifdef __cplusplus
 }

--- a/docs/code-examples/Cargo.toml
+++ b/docs/code-examples/Cargo.toml
@@ -72,6 +72,10 @@ name = "disconnected_space"
 path = "disconnected_space.rs"
 
 [[bin]]
+name = "entity_path"
+path = "entity_path.rs"
+
+[[bin]]
 name = "image_simple"
 path = "image_simple.rs"
 

--- a/docs/code-examples/entity_path.cpp
+++ b/docs/code-examples/entity_path.cpp
@@ -14,4 +14,7 @@ int main() {
         rerun::new_entity_path({"world", std::to_string(42), "unescaped string!"}),
         rerun::TextDocument("This entity path was provided as a list of unescaped strings")
     );
+
+    assert(rerun::escape_entity_path_part("my string!") == R"(my\ string\!)");
+    assert(rerun::new_entity_path({"world", "42", "my string!"}) == R"(/world/42/my\ string\!)");
 }

--- a/docs/code-examples/entity_path.cpp
+++ b/docs/code-examples/entity_path.cpp
@@ -10,9 +10,8 @@ int main() {
         R"(world/42/escaped\ string\!)",
         rerun::TextDocument("This entity path was escaped manually")
     );
-    // TODO(emilk): implement entity path escaping in C++
-    // rec.log(
-    //     {"world", 42, "unescaped string!"},
-    //     rerun::TextDocument("This entity path was provided as a list of unescaped strings")
-    // );
+    rec.log(
+        rerun::escape_entity_path({"world", std::to_string(42), "unescaped string!"}),
+        rerun::TextDocument("This entity path was provided as a list of unescaped strings")
+    );
 }

--- a/docs/code-examples/entity_path.cpp
+++ b/docs/code-examples/entity_path.cpp
@@ -1,0 +1,18 @@
+// Log a `TextDocument`
+
+#include <rerun.hpp>
+
+int main() {
+    const auto rec = rerun::RecordingStream("rerun_example_text_document");
+    rec.spawn().exit_on_failure();
+
+    rec.log(
+        R"(world/escaped\ string\!)",
+        rerun::TextDocument("This entity path was escaped manually")
+    );
+    // TODO: figure this one out
+    // rec.log(
+    //     rerun::entity_path ![ "world", "unescaped string!" ],
+    //     rerun::TextDocument("This entity path was provided as a list of unescaped strings")
+    // );
+}

--- a/docs/code-examples/entity_path.cpp
+++ b/docs/code-examples/entity_path.cpp
@@ -11,7 +11,7 @@ int main() {
         rerun::TextDocument("This entity path was escaped manually")
     );
     rec.log(
-        rerun::escape_entity_path({"world", std::to_string(42), "unescaped string!"}),
+        rerun::new_entity_path({"world", std::to_string(42), "unescaped string!"}),
         rerun::TextDocument("This entity path was provided as a list of unescaped strings")
     );
 }

--- a/docs/code-examples/entity_path.cpp
+++ b/docs/code-examples/entity_path.cpp
@@ -10,7 +10,7 @@ int main() {
         R"(world/42/escaped\ string\!)",
         rerun::TextDocument("This entity path was escaped manually")
     );
-    // TODO: figure this one out
+    // TODO(emilk): implement entity path escaping in C++
     // rec.log(
     //     {"world", 42, "unescaped string!"},
     //     rerun::TextDocument("This entity path was provided as a list of unescaped strings")

--- a/docs/code-examples/entity_path.cpp
+++ b/docs/code-examples/entity_path.cpp
@@ -7,12 +7,12 @@ int main() {
     rec.spawn().exit_on_failure();
 
     rec.log(
-        R"(world/escaped\ string\!)",
+        R"(world/42/escaped\ string\!)",
         rerun::TextDocument("This entity path was escaped manually")
     );
     // TODO: figure this one out
     // rec.log(
-    //     rerun::entity_path ![ "world", "unescaped string!" ],
+    //     {"world", 42, "unescaped string!"},
     //     rerun::TextDocument("This entity path was provided as a list of unescaped strings")
     // );
 }

--- a/docs/code-examples/entity_path.py
+++ b/docs/code-examples/entity_path.py
@@ -2,5 +2,7 @@ import rerun as rr
 
 rr.init("rerun_example_entity_path", spawn=True)
 
-rr.log(r"world/escaped\ string\!", rr.TextDocument("This entity path was escaped manually"))
-rr.log(["world", "unescaped string!"], rr.TextDocument("This entity path was provided as a list of unescaped strings"))
+rr.log(r"world/42/escaped\ string\!", rr.TextDocument("This entity path was escaped manually"))
+rr.log(
+    ["world", 42, "unescaped string!"], rr.TextDocument("This entity path was provided as a list of unescaped strings")
+)

--- a/docs/code-examples/entity_path.py
+++ b/docs/code-examples/entity_path.py
@@ -1,0 +1,6 @@
+import rerun as rr
+
+rr.init("rerun_example_entity_path", spawn=True)
+
+rr.log(r"world/escaped\ string\!", rr.TextDocument("This entity path was escaped manually"))
+rr.log(["world", "unescaped string!"], rr.TextDocument("This entity path was provided as a list of unescaped strings"))

--- a/docs/code-examples/entity_path.py
+++ b/docs/code-examples/entity_path.py
@@ -6,3 +6,6 @@ rr.log(r"world/42/escaped\ string\!", rr.TextDocument("This entity path was esca
 rr.log(
     ["world", 42, "unescaped string!"], rr.TextDocument("This entity path was provided as a list of unescaped strings")
 )
+
+assert rr.escape_entity_path_part("my string!") == r"my\ string\!"
+assert rr.new_entity_path(["world", 42, "my string!"]) == r"/world/42/my\ string\!"

--- a/docs/code-examples/entity_path.rs
+++ b/docs/code-examples/entity_path.rs
@@ -1,5 +1,3 @@
-//! Log a `TextDocument`
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document").spawn()?;
 

--- a/docs/code-examples/entity_path.rs
+++ b/docs/code-examples/entity_path.rs
@@ -1,3 +1,5 @@
+//! Example of different ways of constructing an entity path.
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document").spawn()?;
 

--- a/docs/code-examples/entity_path.rs
+++ b/docs/code-examples/entity_path.rs
@@ -4,11 +4,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document").spawn()?;
 
     rec.log(
-        r"world/escaped\ string\!",
+        r"world/42/escaped\ string\!",
         &rerun::TextDocument::new("This entity path was escaped manually"),
     )?;
     rec.log(
-        rerun::entity_path!["world", "unescaped string!"],
+        rerun::entity_path!["world", 42, "unescaped string!"],
         &rerun::TextDocument::new("This entity path was provided as a list of unescaped strings"),
     )?;
 

--- a/docs/code-examples/entity_path.rs
+++ b/docs/code-examples/entity_path.rs
@@ -1,0 +1,16 @@
+//! Log a `TextDocument`
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_text_document").spawn()?;
+
+    rec.log(
+        r"world/escaped\ string\!",
+        &rerun::TextDocument::new("This entity path was escaped manually"),
+    )?;
+    rec.log(
+        rerun::entity_path!["world", "unescaped string!"],
+        &rerun::TextDocument::new("This entity path was provided as a list of unescaped strings"),
+    )?;
+
+    Ok(())
+}

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -41,7 +41,6 @@ opt_out_run = {
 opt_out_compare = {
     "arrow3d_simple": ["cpp", "py", "rust"], # TODO(#3206): examples use different RNGs
     "asset3d_out_of_tree": ["cpp", "py", "rust"], # float issues since calculation is done slightly differently (also, Python uses doubles)
-    "entity_path": ["cpp"], # C++ doesn't have helpers for escaping an entity path yet
     "mesh3d_partial_updates": ["cpp", "py", "rust"], # float precision issues
     "pinhole_simple": ["cpp", "py", "rust"], # TODO(#3206): examples use different RNGs
     "point2d_random": ["cpp", "py", "rust"], # TODO(#3206): examples use different RNGs

--- a/docs/code-examples/roundtrips.py
+++ b/docs/code-examples/roundtrips.py
@@ -41,6 +41,7 @@ opt_out_run = {
 opt_out_compare = {
     "arrow3d_simple": ["cpp", "py", "rust"], # TODO(#3206): examples use different RNGs
     "asset3d_out_of_tree": ["cpp", "py", "rust"], # float issues since calculation is done slightly differently (also, Python uses doubles)
+    "entity_path": ["cpp"], # C++ doesn't have helpers for escaping an entity path yet
     "mesh3d_partial_updates": ["cpp", "py", "rust"], # float precision issues
     "pinhole_simple": ["cpp", "py", "rust"], # TODO(#3206): examples use different RNGs
     "point2d_random": ["cpp", "py", "rust"], # TODO(#3206): examples use different RNGs

--- a/rerun_cpp/src/rerun.hpp
+++ b/rerun_cpp/src/rerun.hpp
@@ -10,6 +10,7 @@
 #include "rerun/collection_adapter.hpp"
 #include "rerun/collection_adapter_builtins.hpp"
 #include "rerun/config.hpp"
+#include "rerun/entity_path.hpp"
 #include "rerun/error.hpp"
 #include "rerun/recording_stream.hpp"
 #include "rerun/result.hpp"

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -413,6 +413,23 @@ extern void rr_recording_stream_log(
 );
 
 // ----------------------------------------------------------------------------
+// Private functions
+
+/// PRIVATE FUNCTION: do not use.
+///
+/// Escape a single part of an entity path, returning an new null-terminated string.
+///
+/// The returned string must be freed with `_rr_free_string`.
+///
+/// Returns `nullptr` on failure (e.g. invalid UTF8, ore null bytes in the string).
+extern char* _rr_escape_entity_path_part(rr_string part);
+
+/// PRIVATE FUNCTION: do not use.
+///
+/// Must only be called with the results from `_rr_escape_entity_path_part`.
+extern void _rr_free_string(char* string);
+
+// ----------------------------------------------------------------------------
 
 #ifdef __cplusplus
 }

--- a/rerun_cpp/src/rerun/entity_path.cpp
+++ b/rerun_cpp/src/rerun/entity_path.cpp
@@ -1,0 +1,34 @@
+#include "entity_path.hpp"
+
+#include "c/rerun.h"
+#include "error.hpp"
+#include "string_utils.hpp"
+
+namespace rerun {
+    std::string escape_entity_path(const std::vector<std::string_view>& path) {
+        if (path.empty()) {
+            return "/";
+        }
+
+        std::string result;
+
+        for (const auto& part : path) {
+            auto escaped_c_str = _rr_escape_entity_path_part(detail::to_rr_string(part));
+
+            if (escaped_c_str == nullptr) {
+                Error(ErrorCode::InvalidStringArgument, "Failed to escape entity path part")
+                    .handle();
+            } else {
+                if (!result.empty()) {
+                    result += "/"; // leading slash would also have be fine
+                }
+
+                result += escaped_c_str;
+                _rr_free_string(escaped_c_str);
+            }
+        }
+
+        return result;
+    }
+
+} // namespace rerun

--- a/rerun_cpp/src/rerun/entity_path.cpp
+++ b/rerun_cpp/src/rerun/entity_path.cpp
@@ -5,7 +5,7 @@
 #include "string_utils.hpp"
 
 namespace rerun {
-    std::string escape_entity_path(const std::vector<std::string_view>& path) {
+    std::string new_entity_path(const std::vector<std::string_view>& path) {
         if (path.empty()) {
             return "/";
         }
@@ -22,7 +22,6 @@ namespace rerun {
                 if (!result.empty()) {
                     result += "/"; // leading slash would also have be fine
                 }
-
                 result += escaped_c_str;
                 _rr_free_string(escaped_c_str);
             }

--- a/rerun_cpp/src/rerun/entity_path.cpp
+++ b/rerun_cpp/src/rerun/entity_path.cpp
@@ -5,6 +5,19 @@
 #include "string_utils.hpp"
 
 namespace rerun {
+    std::string escape_entity_path_part(std::string_view unescaped) {
+        auto escaped_c_str = _rr_escape_entity_path_part(detail::to_rr_string(unescaped));
+
+        if (escaped_c_str == nullptr) {
+            Error(ErrorCode::InvalidStringArgument, "Failed to escape entity path part").handle();
+            return std::string(unescaped);
+        } else {
+            std::string result = escaped_c_str;
+            _rr_free_string(escaped_c_str);
+            return result;
+        }
+    }
+
     std::string new_entity_path(const std::vector<std::string_view>& path) {
         if (path.empty()) {
             return "/";
@@ -13,18 +26,8 @@ namespace rerun {
         std::string result;
 
         for (const auto& part : path) {
-            auto escaped_c_str = _rr_escape_entity_path_part(detail::to_rr_string(part));
-
-            if (escaped_c_str == nullptr) {
-                Error(ErrorCode::InvalidStringArgument, "Failed to escape entity path part")
-                    .handle();
-            } else {
-                if (!result.empty()) {
-                    result += "/"; // leading slash would also have be fine
-                }
-                result += escaped_c_str;
-                _rr_free_string(escaped_c_str);
-            }
+            result += "/";
+            result += escape_entity_path_part(part);
         }
 
         return result;

--- a/rerun_cpp/src/rerun/entity_path.hpp
+++ b/rerun_cpp/src/rerun/entity_path.hpp
@@ -6,8 +6,8 @@
 namespace rerun {
     /// Construct an entity path by escaping each part of the path.
     ///
-    /// For instance, `rerun::escape_entity_path({"world", 42, "unescaped string!"})` will return
+    /// For instance, `rerun::new_entity_path({"world", 42, "unescaped string!"})` will return
     /// `"world/42/escaped\ string\!"`.
-    std::string escape_entity_path(const std::vector<std::string_view>& path);
+    std::string new_entity_path(const std::vector<std::string_view>& path);
 
 } // namespace rerun

--- a/rerun_cpp/src/rerun/entity_path.hpp
+++ b/rerun_cpp/src/rerun/entity_path.hpp
@@ -7,7 +7,7 @@ namespace rerun {
 
     /// Escape an individual part of an entity path.
     ///
-    /// For instance, `escape_entity_path_parth("my image!")` will return `"my\ image\!"`.
+    /// For instance, `escape_entity_path_path("my image!")` will return `"my\ image\!"`.
     std::string escape_entity_path_part(std::string_view str);
 
     /// Construct an entity path by escaping each part of the path.

--- a/rerun_cpp/src/rerun/entity_path.hpp
+++ b/rerun_cpp/src/rerun/entity_path.hpp
@@ -4,6 +4,12 @@
 #include <vector>
 
 namespace rerun {
+
+    /// Escape an individual part of an entity path.
+    ///
+    /// For instance, `escape_entity_path_parth("my image!")` will return `"my\ image\!"`.
+    std::string escape_entity_path_part(std::string_view str);
+
     /// Construct an entity path by escaping each part of the path.
     ///
     /// For instance, `rerun::new_entity_path({"world", 42, "unescaped string!"})` will return

--- a/rerun_cpp/src/rerun/entity_path.hpp
+++ b/rerun_cpp/src/rerun/entity_path.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string_view>
+#include <vector>
+
+namespace rerun {
+    /// Construct an entity path by escaping each part of the path.
+    ///
+    /// For instance, `rerun::escape_entity_path({"world", 42, "unescaped string!"})` will return
+    /// `"world/42/escaped\ string\!"`.
+    std::string escape_entity_path(const std::vector<std::string_view>& path);
+
+} // namespace rerun

--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -233,6 +233,8 @@ SECTION_TABLE: Final[list[Section]] = [
             "set_global_data_recording",
             "set_thread_local_data_recording",
             "start_web_viewer_server",
+            "escape_entity_path_part",
+            "new_entity_path",
         ],
         class_list=["RecordingStream", "LoggingHandler", "MemoryRecording"],
     ),

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -65,6 +65,7 @@ __all__ = [
     "datatypes",
     "disable_timeline",
     "disconnect",
+    "escape_entity_path_part",
     "experimental",
     "get_application_id",
     "get_data_recording",
@@ -72,9 +73,10 @@ __all__ = [
     "get_recording_id",
     "get_thread_local_data_recording",
     "is_enabled",
-    "log",
     "log_components",
+    "log",
     "memory_recording",
+    "new_entity_path",
     "reset_time",
     "save",
     "script_add_args",
@@ -92,7 +94,15 @@ __all__ = [
 import rerun_bindings as bindings  # type: ignore[attr-defined]
 
 from ._image import ImageEncoded, ImageFormat
-from ._log import AsComponents, ComponentBatchLike, IndicatorComponentBatch, log, log_components
+from ._log import (
+    AsComponents,
+    ComponentBatchLike,
+    IndicatorComponentBatch,
+    escape_entity_path_part,
+    log,
+    log_components,
+    new_entity_path,
+)
 from .any_value import AnyValues
 from .archetypes import (
     AnnotationContext,

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -283,7 +283,7 @@ def escape_entity_path_part(part: str) -> str:
     r"""
     Escape an individual part of an entity path.
 
-    For instance, `escape_entity_path_parth("my image!")` will return `"my\ image\!"`.
+    For instance, `escape_entity_path_path("my image!")` will return `"my\ image\!"`.
 
     See <https://www.rerun.io/docs/concepts/entity-path> for more on entity paths.
 

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -230,7 +230,7 @@ def log_components(
         num_instances = max(len(arr) for arr in arrow_arrays)
 
     if isinstance(entity_path, list):
-        entity_path = bindings.escape_entity_path([str(part) for part in entity_path])
+        entity_path = bindings.new_entity_path([str(part) for part in entity_path])
 
     added = set()
 
@@ -279,13 +279,13 @@ def log_components(
     )
 
 
-def escape_entity_path(entity_path: list[Any]) -> str:
+def new_entity_path(entity_path: list[Any]) -> str:
     r"""
     Construct an entity path, defined by a list of (unescaped) parts.
 
     If any part if not a string, it will be converted to a string using `str()`.
 
-    For instance, `escape_entity_path(["world", 42, "my image!"])` will return `"world/42/my\ image\!"`.
+    For instance, `new_entity_path(["world", 42, "my image!"])` will return `"world/42/my\ image\!"`.
 
     See <https://www.rerun.io/docs/concepts/entity-path> for more on entity paths.
 
@@ -299,4 +299,4 @@ def escape_entity_path(entity_path: list[Any]) -> str:
     str:
         The escaped entity path.
     """
-    return str(bindings.escape_entity_path([str(part) for part in entity_path]))
+    return str(bindings.new_entity_path([str(part) for part in entity_path]))

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Any, Iterable
 
 import pyarrow as pa
 import rerun_bindings as bindings
@@ -279,11 +279,13 @@ def log_components(
     )
 
 
-def escape_entity_path(entity_path: list[str]) -> str:
+def escape_entity_path(entity_path: list[Any]) -> str:
     r"""
     Construct an entity path, defined by a list of (unescaped) parts.
 
-    For instance, `escape_entity_path(["world", "my image!"])` will return `"world/my\ image\!"`.
+    If any part if not a string, it will be converted to a string using `str()`.
+
+    For instance, `escape_entity_path(["world", 42, "my image!"])` will return `"world/42/my\ image\!"`.
 
     See <https://www.rerun.io/docs/concepts/entity-path> for more on entity paths.
 
@@ -297,4 +299,4 @@ def escape_entity_path(entity_path: list[str]) -> str:
     str:
         The escaped entity path.
     """
-    return bindings.escape_entity_path([str(part) for part in entity_path])
+    return str(bindings.escape_entity_path([str(part) for part in entity_path]))

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -279,6 +279,27 @@ def log_components(
     )
 
 
+def escape_entity_path_part(part: str) -> str:
+    r"""
+    Escape an individual part of an entity path.
+
+    For instance, `escape_entity_path_parth("my image!")` will return `"my\ image\!"`.
+
+    See <https://www.rerun.io/docs/concepts/entity-path> for more on entity paths.
+
+    Parameters
+    ----------
+    part:
+        An unescaped string
+
+    Returns
+    -------
+    str:
+        The escaped entity path.
+    """
+    return str(bindings.escape_entity_path_part(part))
+
+
 def new_entity_path(entity_path: list[Any]) -> str:
     r"""
     Construct an entity path, defined by a list of (unescaped) parts.

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -15,7 +15,7 @@ use pyo3::{
 //use re_viewport::{SpaceViewBlueprint, VIEWPORT_PATH};
 use re_viewport::VIEWPORT_PATH;
 
-use re_log_types::{DataRow, StoreKind};
+use re_log_types::{DataRow, EntityPathPart, StoreKind};
 use rerun::{
     log::RowId, sink::MemorySinkStorage, time::TimePoint, EntityPath, RecordingStream,
     RecordingStreamBuilder, StoreId,
@@ -152,6 +152,7 @@ fn rerun_bindings(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(version, m)?)?;
     m.add_function(wrap_pyfunction!(get_app_url, m)?)?;
     m.add_function(wrap_pyfunction!(start_web_viewer_server, m)?)?;
+    m.add_function(wrap_pyfunction!(escape_entity_path, m)?)?;
 
     // blueprint
     m.add_function(wrap_pyfunction!(set_panels, m)?)?;
@@ -760,7 +761,7 @@ fn set_panel(entity_path: &str, is_expanded: bool, blueprint: Option<&PyRecordin
     use re_viewer::blueprint::components::PanelView;
 
     // TODO(jleibs): Validation this is a valid blueprint path?
-    let entity_path = parse_entity_path(entity_path);
+    let entity_path = EntityPath::parse_forgiving(entity_path);
 
     let panel_state = PanelView(is_expanded);
 
@@ -867,7 +868,7 @@ fn log_arrow_msg(
         return Ok(());
     };
 
-    let entity_path = parse_entity_path(entity_path);
+    let entity_path = EntityPath::parse_forgiving(entity_path);
 
     // It's important that we don't hold the session lock while building our arrow component.
     // the API we call to back through pyarrow temporarily releases the GIL, which can cause
@@ -936,6 +937,12 @@ fn start_web_viewer_server(port: u16) -> PyResult<()> {
             "The Rerun SDK was not compiled with the 'web_viewer' feature",
         ))
     }
+}
+
+#[pyfunction]
+fn escape_entity_path(parts: Vec<&str>) -> String {
+    let path = EntityPath::from(parts.into_iter().map(EntityPathPart::from).collect_vec());
+    path.to_string()
 }
 
 // --- Helpers ---
@@ -1012,9 +1019,4 @@ authkey = multiprocessing.current_process().authkey
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))
     })
     .map(|authkey: &PyBytes| authkey.as_bytes().to_vec())
-}
-
-fn parse_entity_path(entity_path: &str) -> EntityPath {
-    // We accept anything!
-    EntityPath::parse_forgiving(entity_path)
 }

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -152,6 +152,7 @@ fn rerun_bindings(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(version, m)?)?;
     m.add_function(wrap_pyfunction!(get_app_url, m)?)?;
     m.add_function(wrap_pyfunction!(start_web_viewer_server, m)?)?;
+    m.add_function(wrap_pyfunction!(escape_entity_path_part, m)?)?;
     m.add_function(wrap_pyfunction!(new_entity_path, m)?)?;
 
     // blueprint
@@ -937,6 +938,11 @@ fn start_web_viewer_server(port: u16) -> PyResult<()> {
             "The Rerun SDK was not compiled with the 'web_viewer' feature",
         ))
     }
+}
+
+#[pyfunction]
+fn escape_entity_path_part(part: &str) -> String {
+    EntityPathPart::from(part).to_string()
 }
 
 #[pyfunction]

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -152,7 +152,7 @@ fn rerun_bindings(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(version, m)?)?;
     m.add_function(wrap_pyfunction!(get_app_url, m)?)?;
     m.add_function(wrap_pyfunction!(start_web_viewer_server, m)?)?;
-    m.add_function(wrap_pyfunction!(escape_entity_path, m)?)?;
+    m.add_function(wrap_pyfunction!(new_entity_path, m)?)?;
 
     // blueprint
     m.add_function(wrap_pyfunction!(set_panels, m)?)?;
@@ -940,7 +940,7 @@ fn start_web_viewer_server(port: u16) -> PyResult<()> {
 }
 
 #[pyfunction]
-fn escape_entity_path(parts: Vec<&str>) -> String {
+fn new_entity_path(parts: Vec<&str>) -> String {
     let path = EntityPath::from(parts.into_iter().map(EntityPathPart::from).collect_vec());
     path.to_string()
 }


### PR DESCRIPTION
### What
Added `rr.new_entity_path`, which constructs an entity path from a list of strings.
`rr.log` also accepts such a list of unescaped strings directly.

In C++, `rerun::new_entity_path` has been added, e.g. `rerun::new_entity_path({"world", "unescaped string!"})`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4595/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4595/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4595/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4595)
- [Docs preview](https://rerun.io/preview/a5103b62304217c31d9c410aa435a54406e24161/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a5103b62304217c31d9c410aa435a54406e24161/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)