### PR TITLE
Show entity path parts (entity "folder" names) unescaped in UI

### DIFF
--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -427,7 +427,7 @@ impl std::fmt::Display for EntityPath {
             // We always lead with a slash
             for comp in self.iter() {
                 f.write_char('/')?;
-                comp.fmt(f)?;
+                comp.escaped_string().fmt(f)?;
             }
             Ok(())
         }

--- a/crates/re_log_types/src/path/entity_path_part.rs
+++ b/crates/re_log_types/src/path/entity_path_part.rs
@@ -8,9 +8,11 @@ use crate::PathParseError;
 ///
 /// Note that the contents of the string is NOT escaped,
 /// so escaping needs to be done when printing this
-/// (done by the `Display` impl).
+/// using [`Self::escaped_string`].
 ///
-/// Because of this, `EntityPathPart` does NOT implement `AsRef<str>` etc.
+/// Because of this, `EntityPathPart` does NOT implement `AsRef<str>` etc,
+/// nor does it implement `Display`: you must explicitly chose
+/// either the escaped or the unescaped version of it.
 ///
 /// In the file system analogy, this is the name of a folder.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -144,14 +146,23 @@ impl EntityPathPart {
         Ok(Self::from(output))
     }
 
+    /// The style of string to use in a UI
+    #[inline]
+    pub fn ui_string(&self) -> String {
+        self.unescaped_str().to_owned() // Make it pretty. We only _need_ escaping for full entity paths, and really only then in the contexts of a query language or similar.
+    }
+
     /// The unescaped string.
     ///
-    /// Use [`Self::escaped_string`] or `to_string` to escape it.
+    /// Use [`Self::escaped_string`] to escape it.
+    ///
+    /// Use this when it is standalone in a ui somewhere.
     #[inline]
     pub fn unescaped_str(&self) -> &str {
         &self.0
     }
 
+    /// Use this when it is part of a fulle entity path.
     #[inline]
     pub fn escaped_string(&self) -> String {
         let mut s = String::with_capacity(self.0.len());
@@ -217,12 +228,6 @@ fn parse_unicode_escape(input: &mut impl Iterator<Item = char>) -> Result<char, 
     };
 
     char::from_u32(num).ok_or(all_chars)
-}
-
-impl std::fmt::Display for EntityPathPart {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.escaped_string().fmt(f)
-    }
 }
 
 impl From<InternedString> for EntityPathPart {

--- a/crates/re_log_types/src/path/entity_path_part.rs
+++ b/crates/re_log_types/src/path/entity_path_part.rs
@@ -162,7 +162,7 @@ impl EntityPathPart {
         &self.0
     }
 
-    /// Use this when it is part of a fulle entity path.
+    /// Use this when it is part of a full entity path.
     #[inline]
     pub fn escaped_string(&self) -> String {
         let mut s = String::with_capacity(self.0.len());

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -471,10 +471,11 @@ impl TimePanel {
 
         // The last part of the path component
         let text = if let Some(last_path_part) = last_path_part {
+            let stem = last_path_part.ui_string();
             if tree.is_leaf() {
-                last_path_part.to_string()
+                stem
             } else {
-                format!("{last_path_part}/") // show we have children with a /
+                format!("{stem}/") // show we have children with a /
             }
         } else {
             show_root_as.to_owned()

--- a/crates/re_viewer_context/src/blueprint_id.rs
+++ b/crates/re_viewer_context/src/blueprint_id.rs
@@ -40,7 +40,7 @@ impl<T: BlueprintIdRegistry> BlueprintId<T> {
         }
 
         path.last()
-            .and_then(|last| uuid::Uuid::parse_str(last.to_string().as_str()).ok())
+            .and_then(|last| uuid::Uuid::parse_str(last.unescaped_str()).ok())
             .map_or(Self::invalid(), |id| Self {
                 id,
                 _registry: std::marker::PhantomData,

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -62,7 +62,7 @@ impl SpaceViewBlueprint {
         // Spaces are now always named after the final element of the space-path (or the root), independent of the
         // query entities.
         let display_name = if let Some(name) = space_path.iter().last() {
-            name.to_string()
+            name.ui_string()
         } else {
             // Include class name in the display for root paths because they look a tad bit too short otherwise.
             format!("/ ({space_view_class_display_name})")
@@ -111,7 +111,7 @@ impl SpaceViewBlueprint {
         let display_name = display_name.map_or_else(
             || {
                 if let Some(name) = space_origin.iter().last() {
-                    name.to_string()
+                    name.ui_string()
                 } else {
                     // Include class name in the display for root paths because they look a tad bit too short otherwise.
                     format!("/ ({})", class_identifier.as_str())

--- a/crates/re_viewport/src/space_view_entity_picker.rs
+++ b/crates/re_viewport/src/space_view_entity_picker.rs
@@ -147,7 +147,7 @@ fn add_entities_tree_ui(
                 add_entities_tree_ui(
                     ctx,
                     ui,
-                    &path_comp.to_string(),
+                    &path_comp.ui_string(),
                     child_tree,
                     space_view,
                     query_result,

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -272,7 +272,7 @@ impl Viewport<'_, '_> {
             let name = entity_path
                 .iter()
                 .last()
-                .map_or("unknown".to_owned(), |e| e.to_string());
+                .map_or("unknown".to_owned(), |e| e.ui_string());
 
             let response = if child_node.children.is_empty() {
                 let label = format!("🔹 {name}");

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -713,7 +713,7 @@ pub unsafe extern "C" fn _rr_escape_entity_path_part(part: CStringView) -> *cons
         return std::ptr::null();
     };
 
-    let part = re_sdk::EntityPathPart::from(part).to_string(); // escape the part
+    let part = re_sdk::EntityPathPart::from(part).escaped_string();
 
     let Ok(part) = CString::new(part) else {
         return std::ptr::null();

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -942,7 +942,7 @@ fn start_web_viewer_server(port: u16) -> PyResult<()> {
 
 #[pyfunction]
 fn escape_entity_path_part(part: &str) -> String {
-    EntityPathPart::from(part).to_string()
+    EntityPathPart::from(part).escaped_string()
 }
 
 #[pyfunction]


### PR DESCRIPTION
### What

Remove `Display` implementation for `EntityPathPart`, forcing users to explicitly chose between three members:

* `escaped_string`
* `unescaped_str`
* `ui_string`

`ui_string` is only there so we can change this again in the future.

NOTE: this PR still escapes full entity paths everywhere

![image](https://github.com/rerun-io/rerun/assets/1148717/6022c7aa-d1ca-447d-9b55-a9bac159e55d)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4603/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4603/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4603/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4603)
- [Docs preview](https://rerun.io/preview/c9e67e773477bd6102316fcea1bde8ef5d1d56a2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c9e67e773477bd6102316fcea1bde8ef5d1d56a2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)