### PR TITLE
Allow systems to specify custom filter for the applicable set beyond required_components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5036,6 +5036,7 @@ dependencies = [
  "re_log",
  "re_log_types",
  "re_renderer",
+ "re_space_view",
  "re_tracing",
  "re_types",
  "re_ui",

--- a/crates/re_space_view/src/lib.rs
+++ b/crates/re_space_view/src/lib.rs
@@ -13,3 +13,22 @@ pub use data_query::{DataQuery, EntityOverrideContext, PropertyResolver};
 pub use data_query_blueprint::DataQueryBlueprint;
 pub use screenshot::ScreenshotMode;
 pub use unreachable_transform_reason::UnreachableTransformReason;
+
+// -----------
+
+use re_data_store::external::re_arrow_store;
+
+/// Utility for implementing [`VisualizerAdditionalApplicabilityFilter`] using on the properties of a concrete component.
+#[inline]
+pub fn diff_component_filter<T: re_types_core::Component>(
+    event: &re_arrow_store::StoreEvent,
+    filter: impl Fn(&T) -> bool,
+) -> bool {
+    let filter = &filter;
+    event.diff.cells.iter().any(|(component_name, cell)| {
+        component_name == &T::name()
+            && T::from_arrow(cell.as_arrow_ref())
+                .map(|components| components.iter().any(filter))
+                .unwrap_or(false)
+    })
+}

--- a/crates/re_space_view/src/lib.rs
+++ b/crates/re_space_view/src/lib.rs
@@ -18,7 +18,7 @@ pub use unreachable_transform_reason::UnreachableTransformReason;
 
 use re_data_store::external::re_arrow_store;
 
-/// Utility for implementing [`VisualizerAdditionalApplicabilityFilter`] using on the properties of a concrete component.
+/// Utility for implementing [`re_viewer_context::VisualizerAdditionalApplicabilityFilter`] using on the properties of a concrete component.
 #[inline]
 pub fn diff_component_filter<T: re_types_core::Component>(
     event: &re_arrow_store::StoreEvent,

--- a/crates/re_space_view_bar_chart/src/view_part_system.rs
+++ b/crates/re_space_view_bar_chart/src/view_part_system.rs
@@ -2,11 +2,12 @@ use std::collections::BTreeMap;
 
 use re_arrow_store::LatestAtQuery;
 use re_data_store::EntityPath;
+use re_space_view::diff_component_filter;
 use re_types::{
     archetypes::{BarChart, Tensor},
     components::Color,
     datatypes::TensorData,
-    Archetype, ComponentNameSet, Loggable,
+    Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
     IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewPartSystem,
@@ -29,11 +30,8 @@ struct BarChartVisualizerEntityFilter;
 
 impl VisualizerAdditionalApplicabilityFilter for BarChartVisualizerEntityFilter {
     fn update_applicability(&mut self, event: &re_arrow_store::StoreEvent) -> bool {
-        event.diff.cells.iter().any(|(component_name, cell)| {
-            component_name == &re_types::components::TensorData::name()
-                && re_types::components::TensorData::from_arrow(cell.as_arrow_ref())
-                    .map(|tensors| tensors.iter().any(|tensor| tensor.is_vector()))
-                    .unwrap_or(false)
+        diff_component_filter(event, |tensor: &re_types::components::TensorData| {
+            tensor.is_vector()
         })
     }
 }

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -16,12 +16,12 @@ use re_types::{
     archetypes::{DepthImage, Image, SegmentationImage},
     components::{Color, DrawOrder, TensorData, ViewCoordinates},
     tensor_data::{DecodedTensor, TensorDataMeaning},
-    Archetype as _, ComponentNameSet,
+    Archetype as _, ComponentNameSet, Loggable as _,
 };
 use re_viewer_context::{
     default_heuristic_filter, gpu_bridge, DefaultColor, HeuristicFilterContext, SpaceViewClass,
     SpaceViewSystemExecutionError, TensorDecodeCache, TensorStatsCache, ViewPartSystem, ViewQuery,
-    ViewerContext,
+    ViewerContext, VisualizerAdditionalApplicabilityFilter,
 };
 use re_viewer_context::{IdentifiedViewSystem, ViewContextCollection};
 
@@ -643,6 +643,23 @@ impl IdentifiedViewSystem for ImagesPart {
     }
 }
 
+struct ImageVisualizerEntityFilter;
+
+impl VisualizerAdditionalApplicabilityFilter for ImageVisualizerEntityFilter {
+    fn update_applicability(&mut self, event: &re_arrow_store::StoreEvent) -> bool {
+        event.diff.cells.iter().any(|(component_name, cell)| {
+            component_name == &re_types::components::TensorData::name()
+                && re_types::components::TensorData::from_arrow(cell.as_arrow_ref())
+                    .map(|tensors| {
+                        tensors
+                            .iter()
+                            .any(|tensor| tensor.is_shaped_like_an_image())
+                    })
+                    .unwrap_or(false)
+        })
+    }
+}
+
 impl ViewPartSystem for ImagesPart {
     fn required_components(&self) -> ComponentNameSet {
         let image: ComponentNameSet = Image::required_components()
@@ -677,12 +694,16 @@ impl ViewPartSystem for ImagesPart {
         .collect()
     }
 
+    fn applicability_filter(&self) -> Option<Box<dyn VisualizerAdditionalApplicabilityFilter>> {
+        Some(Box::new(ImageVisualizerEntityFilter))
+    }
+
     fn heuristic_filter(
         &self,
-        store: &re_arrow_store::DataStore,
-        ent_path: &EntityPath,
+        _store: &re_arrow_store::DataStore,
+        _ent_path: &EntityPath,
         ctx: HeuristicFilterContext,
-        query: &LatestAtQuery,
+        _query: &LatestAtQuery,
         entity_components: &ComponentNameSet,
     ) -> bool {
         if !default_heuristic_filter(entity_components, &self.indicator_components()) {
@@ -697,14 +718,7 @@ impl ViewPartSystem for ImagesPart {
             return false;
         }
 
-        // NOTE: We want to make sure we query at the right time, otherwise we might take into
-        // account a `Clear()` that actually only applies into the future, and then
-        // `is_shaped_like_an_image` will righfully fail because of the empty tensor.
-        if let Some(tensor) = store.query_latest_component::<TensorData>(ent_path, query) {
-            tensor.is_shaped_like_an_image()
-        } else {
-            false
-        }
+        true
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/parts/images.rs
+++ b/crates/re_space_view_spatial/src/parts/images.rs
@@ -12,11 +12,12 @@ use re_renderer::{
     renderer::{DepthCloud, DepthClouds, RectangleOptions, TexturedRect},
     Colormap,
 };
+use re_space_view::diff_component_filter;
 use re_types::{
     archetypes::{DepthImage, Image, SegmentationImage},
     components::{Color, DrawOrder, TensorData, ViewCoordinates},
     tensor_data::{DecodedTensor, TensorDataMeaning},
-    Archetype as _, ComponentNameSet, Loggable as _,
+    Archetype as _, ComponentNameSet,
 };
 use re_viewer_context::{
     default_heuristic_filter, gpu_bridge, DefaultColor, HeuristicFilterContext, SpaceViewClass,
@@ -647,15 +648,8 @@ struct ImageVisualizerEntityFilter;
 
 impl VisualizerAdditionalApplicabilityFilter for ImageVisualizerEntityFilter {
     fn update_applicability(&mut self, event: &re_arrow_store::StoreEvent) -> bool {
-        event.diff.cells.iter().any(|(component_name, cell)| {
-            component_name == &re_types::components::TensorData::name()
-                && re_types::components::TensorData::from_arrow(cell.as_arrow_ref())
-                    .map(|tensors| {
-                        tensors
-                            .iter()
-                            .any(|tensor| tensor.is_shaped_like_an_image())
-                    })
-                    .unwrap_or(false)
+        diff_component_filter(event, |tensor: &re_types::components::TensorData| {
+            tensor.is_shaped_like_an_image()
         })
     }
 }

--- a/crates/re_space_view_tensor/Cargo.toml
+++ b/crates/re_space_view_tensor/Cargo.toml
@@ -22,6 +22,7 @@ re_data_ui.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
 re_renderer.workspace = true
+re_space_view.workspace = true
 re_tracing.workspace = true
 re_types.workspace = true
 re_ui.workspace = true

--- a/crates/re_space_view_tensor/src/view_part_system.rs
+++ b/crates/re_space_view_tensor/src/view_part_system.rs
@@ -1,9 +1,10 @@
 use re_arrow_store::{LatestAtQuery, VersionedComponent};
 use re_data_store::EntityPath;
 use re_log_types::RowId;
+use re_space_view::diff_component_filter;
 use re_types::{
     archetypes::Tensor, components::TensorData, tensor_data::DecodedTensor, Archetype,
-    ComponentNameSet, Loggable as _,
+    ComponentNameSet,
 };
 use re_viewer_context::{
     IdentifiedViewSystem, SpaceViewSystemExecutionError, TensorDecodeCache, ViewContextCollection,
@@ -25,11 +26,8 @@ struct TensorVisualizerEntityFilter;
 
 impl VisualizerAdditionalApplicabilityFilter for TensorVisualizerEntityFilter {
     fn update_applicability(&mut self, event: &re_arrow_store::StoreEvent) -> bool {
-        event.diff.cells.iter().any(|(component_name, cell)| {
-            component_name == &re_types::components::TensorData::name()
-                && re_types::components::TensorData::from_arrow(cell.as_arrow_ref())
-                    .map(|tensors| tensors.iter().any(|tensor| !tensor.is_vector()))
-                    .unwrap_or(false)
+        diff_component_filter(event, |tensor: &re_types::components::TensorData| {
+            !tensor.is_vector()
         })
     }
 }

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -49,6 +49,7 @@ pub use space_view::{
     SpaceViewOutlineMasks, SpaceViewState, SpaceViewSystemExecutionError,
     SpaceViewSystemRegistrator, SystemExecutionOutput, ViewContextCollection, ViewContextSystem,
     ViewPartCollection, ViewPartSystem, ViewQuery, ViewSystemIdentifier,
+    VisualizerAdditionalApplicabilityFilter,
 };
 pub use store_context::StoreContext;
 pub use tensor::{TensorDecodeCache, TensorStats, TensorStatsCache};

--- a/crates/re_viewer_context/src/space_view/mod.rs
+++ b/crates/re_viewer_context/src/space_view/mod.rs
@@ -33,6 +33,7 @@ pub use view_part_system::{
     default_heuristic_filter, HeuristicFilterContext, ViewPartCollection, ViewPartSystem,
 };
 pub use view_query::{DataResult, PerSystemDataResults, ViewQuery};
+pub use visualizer_entity_subscriber::VisualizerAdditionalApplicabilityFilter;
 
 // ---------------------------------------------------------------------------
 

--- a/crates/re_viewer_context/src/space_view/view_part_system.rs
+++ b/crates/re_viewer_context/src/space_view/view_part_system.rs
@@ -7,6 +7,7 @@ use re_types::ComponentNameSet;
 use crate::{
     IdentifiedViewSystem, SpaceViewClassIdentifier, SpaceViewSystemExecutionError,
     ViewContextCollection, ViewQuery, ViewSystemIdentifier, ViewerContext,
+    VisualizerAdditionalApplicabilityFilter,
 };
 
 /// This is additional context made available to the `heuristic_filter`.
@@ -79,6 +80,13 @@ pub trait ViewPartSystem: Send + Sync + 'static {
         entity_components: &ComponentNameSet,
     ) -> bool {
         default_heuristic_filter(entity_components, &self.indicator_components())
+    }
+
+    /// Additional filter for applicability.
+    ///
+    /// If none is specified, applicability is solely determined by required components.
+    fn applicability_filter(&self) -> Option<Box<dyn VisualizerAdditionalApplicabilityFilter>> {
+        None
     }
 
     /// Queries the data store and performs data conversions to make it ready for display.

--- a/crates/re_viewer_context/src/space_view/visualizer_entity_subscriber.rs
+++ b/crates/re_viewer_context/src/space_view/visualizer_entity_subscriber.rs
@@ -39,7 +39,7 @@ pub trait VisualizerAdditionalApplicabilityFilter: Send + Sync {
     ///
     /// Called for every update no matter whether the entity is already has all required components or not.
     ///
-    /// Returns true if the entity is now applicable to the visualizer, false otherwise.
+    /// Returns true if the entity changed in the event is now applicable to the visualizer, false otherwise.
     /// Once a entity passes this filter, it can never go back to being filtered out.
     /// **This implies that the filter does not _need_ to be stateful.**
     /// It is perfectly fine to return `true` only if something in the diff is regarded as applicable and false otherwise.


### PR DESCRIPTION
### What

Part of general query effort, mostly
* [#4388](https://github.com/rerun-io/rerun/issues/4388)

Allows visualizers to specify `VisualizerAdditionalApplicabilityFilter` which can be used to answer global visualizer applicability questions like "is this an image tensor". Therefore moving these kind of checks out of the `heuristic_filter`.

Right now this has a negligible (presumed positive) impact on performance. However, there's two strong motivating factors here:
* `heuristic_filter` is right now incorrectly applied on a per space view _class_ bases. It currently is used to extract the "visualizable set" which actually **has** to be determined per space view _instance_ since it is dependent on things like the space's origin. Once `heuristic_filter` runs per instance (or much much worse, per instance candidate during heuristic!) the now moved checks become a huge burden. This is about to happen in a follow-up PR!
* previously, we did a latest-at-query for things that should be resolved with a store diff. Therefore, this change makes the entity->visualizer mapping more correct & deterministic since missing an update because of rendering pacing is no longer possible!

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4604/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4604/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4604/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4604)
- [Docs preview](https://rerun.io/preview/a5b72a18a7c05938ec66e510aea455fc42b3608b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a5b72a18a7c05938ec66e510aea455fc42b3608b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)