### PR TITLE
Remove spammy debug message in space_view_heuristics

### DIFF
--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -58,18 +58,6 @@ pub fn all_possible_space_views(
 ) -> Vec<(SpaceViewBlueprint, DataQueryResult)> {
     re_tracing::profile_function!();
 
-    for (class_identifier, entities_per_system) in entities_per_system_per_class {
-        for (system_name, entities) in entities_per_system {
-            if entities.is_empty() {
-                re_log::debug!(
-                    "SpaceViewClassRegistry: No entities for system {:?} of class {:?}",
-                    system_name,
-                    class_identifier
-                );
-            }
-        }
-    }
-
     // For each candidate, create space views for all possible classes.
     candidate_space_view_paths(ctx, spaces_info)
         .flat_map(|candidate_space_path| {


### PR DESCRIPTION
### What
There shouldn't be any reason it's any issue that we have empty lists here. No reason to print something every frame.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4605/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4605/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4605/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4605)
- [Docs preview](https://rerun.io/preview/7c88b9c78058f68f8fd7a6ead90a6e2ac86a81a9/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7c88b9c78058f68f8fd7a6ead90a6e2ac86a81a9/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)