### PR TITLE
Add tree mutation APIs to `ViewportBlueprint`

### DIFF
--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -444,7 +444,11 @@ fn container_top_level_properties(
                         );
                     });
 
-                container.set_kind(container_kind);
+                if container.kind() != container_kind {
+                    viewport
+                        .blueprint
+                        .set_container_kind(*tile_id, container_kind);
+                }
 
                 ui.end_row();
 
@@ -521,7 +525,7 @@ fn blueprint_ui(
                 {
                     if let Some(space_view) = viewport.blueprint.space_view(space_view_id) {
                         let new_space_view = space_view.duplicate();
-                        viewport.blueprint.add_space_views(std::iter::once(new_space_view), ctx, &mut viewport.deferred_tree_actions);
+                        viewport.blueprint.add_space_views(std::iter::once(new_space_view), ctx, None, true);
                         viewport.blueprint.mark_user_interaction(ctx);
                     }
                 }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -444,11 +444,9 @@ fn container_top_level_properties(
                         );
                     });
 
-                if container.kind() != container_kind {
-                    viewport
-                        .blueprint
-                        .set_container_kind(*tile_id, container_kind);
-                }
+                viewport
+                    .blueprint
+                    .set_container_kind(*tile_id, container_kind);
 
                 ui.end_row();
 
@@ -525,7 +523,10 @@ fn blueprint_ui(
                 {
                     if let Some(space_view) = viewport.blueprint.space_view(space_view_id) {
                         let new_space_view = space_view.duplicate();
-                        viewport.blueprint.add_space_views(std::iter::once(new_space_view), ctx, None, true);
+                        let new_ids = viewport.blueprint.add_space_views(std::iter::once(new_space_view), ctx, None);
+                        if let Some(new_id) = new_ids.first() {
+                            ctx.selection_state().set_selection(Item::SpaceView(*new_id));
+                        }
                         viewport.blueprint.mark_user_interaction(ctx);
                     }
                 }

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -263,7 +263,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
             }
 
             self.blueprint
-                .add_space_views(new_space_views.into_iter(), ctx, None, false);
+                .add_space_views(new_space_views.into_iter(), ctx, None);
         }
     }
 

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -72,13 +72,24 @@ impl ViewportState {
     }
 }
 
-// We delay any modifications to the tree until the end of the frame,
-// so that we don't iterate over something while modifying it.
-#[derive(Clone, Default)]
-pub struct TreeActions {
-    pub create: Vec<SpaceViewId>,
-    pub focus_tab: Option<SpaceViewId>,
-    pub remove: Vec<egui_tiles::TileId>,
+/// Mutation actions to perform on the tree at the end of the frame. These messages are sent by the mutation APIs from
+/// [`crate::ViewportBlueprint`].
+#[derive(Clone)]
+pub enum TreeAction {
+    /// Add a new space view to the provided container (or the root if `None`).
+    AddSpaceView(SpaceViewId, Option<egui_tiles::TileId>),
+
+    /// Add a new container of the provided kind to the provided container (or the root if `None`).
+    AddContainer(egui_tiles::ContainerKind, Option<egui_tiles::TileId>),
+
+    /// Change the kind of a container.
+    SetContainerKind(egui_tiles::TileId, egui_tiles::ContainerKind),
+
+    /// Ensure the tab for the provided space view is focused (see [`egui_tiles::Tree::make_active`]).
+    FocusTab(SpaceViewId),
+
+    /// Remove a tile and all its children.
+    Remove(egui_tiles::TileId),
 }
 
 // ----------------------------------------------------------------------------
@@ -102,9 +113,8 @@ pub struct Viewport<'a, 'b> {
     /// Actions to perform at the end of the frame.
     ///
     /// We delay any modifications to the tree until the end of the frame,
-    /// so that we don't mutate something while inspecitng it.
-    //TODO(jleibs): Can we use the SystemCommandSender for this, too?
-    pub deferred_tree_actions: TreeActions,
+    /// so that we don't mutate something while inspecting it.
+    tree_action_receiver: std::sync::mpsc::Receiver<TreeAction>,
 }
 
 impl<'a, 'b> Viewport<'a, 'b> {
@@ -112,6 +122,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
         blueprint: &'a ViewportBlueprint,
         state: &'b mut ViewportState,
         space_view_class_registry: &SpaceViewClassRegistry,
+        tree_action_receiver: std::sync::mpsc::Receiver<TreeAction>,
     ) -> Self {
         re_tracing::profile_function!();
 
@@ -133,7 +144,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
             state,
             tree,
             edited,
-            deferred_tree_actions: Default::default(),
+            tree_action_receiver,
         }
     }
 
@@ -248,11 +259,8 @@ impl<'a, 'b> Viewport<'a, 'b> {
                 }
             }
 
-            self.blueprint.add_space_views(
-                new_space_views.into_iter(),
-                ctx,
-                &mut self.deferred_tree_actions,
-            );
+            self.blueprint
+                .add_space_views(new_space_views.into_iter(), ctx, None, false);
         }
     }
 
@@ -296,62 +304,96 @@ impl<'a, 'b> Viewport<'a, 'b> {
 
         let mut reset = false;
 
-        let TreeActions {
-            create,
-            mut focus_tab,
-            remove,
-        } = std::mem::take(&mut self.deferred_tree_actions);
+        for tree_action in self.tree_action_receiver.try_iter() {
+            match tree_action {
+                TreeAction::AddSpaceView(space_view_id, parent_container) => {
+                    if self.blueprint.auto_layout {
+                        // Re-run the auto-layout next frame:
+                        re_log::trace!(
+                            "Added a space view with no user edits yet - will re-run auto-layout"
+                        );
 
-        for space_view in &create {
-            if self.blueprint.auto_layout {
-                // Re-run the auto-layout next frame:
-                re_log::trace!(
-                    "Added a space view with no user edits yet - will re-run auto-layout"
-                );
+                        reset = true;
+                    } else if let Some(parent_id) = parent_container.or(self.tree.root) {
+                        let tile_id = self.tree.tiles.insert_pane(space_view_id);
+                        if let Some(egui_tiles::Tile::Container(container)) =
+                            self.tree.tiles.get_mut(parent_id)
+                        {
+                            re_log::trace!("Inserting new space view into root container");
+                            container.add_child(tile_id);
+                        } else {
+                            re_log::trace!("Root was not a container - will re-run auto-layout");
+                            reset = true;
+                        }
+                    } else {
+                        re_log::trace!("No root found - will re-run auto-layout");
+                    }
 
-                reset = true;
-            } else if let Some(root_id) = self.tree.root {
-                let tile_id = self.tree.tiles.insert_pane(*space_view);
-                if let Some(egui_tiles::Tile::Container(container)) =
-                    self.tree.tiles.get_mut(root_id)
-                {
-                    re_log::trace!("Inserting new space view into root container");
-                    container.add_child(tile_id);
-                } else {
-                    re_log::trace!("Root was not a container - will re-run auto-layout");
-                    reset = true;
+                    self.edited = true;
                 }
-            } else {
-                re_log::trace!("No root found - will re-run auto-layout");
-            }
+                TreeAction::AddContainer(container_kind, parent_container) => {
+                    if let Some(parent_id) = parent_container.or(self.tree.root) {
+                        let tile_id = self
+                            .tree
+                            .tiles
+                            .insert_container(egui_tiles::Container::new(container_kind, vec![]));
+                        if let Some(egui_tiles::Tile::Container(container)) =
+                            self.tree.tiles.get_mut(parent_id)
+                        {
+                            re_log::trace!("Inserting new space view into container {parent_id:?}");
+                            container.add_child(tile_id);
+                        } else {
+                            re_log::trace!(
+                                "Parent or root was not a container - will re-run auto-layout"
+                            );
+                            reset = true;
+                        }
+                    } else {
+                        re_log::trace!("No root found - will re-run auto-layout");
+                    }
 
-            focus_tab = Some(*space_view);
-            self.edited = true;
-        }
+                    self.edited = true;
+                }
+                TreeAction::SetContainerKind(container_id, container_kind) => {
+                    if let Some(egui_tiles::Tile::Container(container)) =
+                        self.tree.tiles.get_mut(container_id)
+                    {
+                        re_log::trace!("Mutating container {container_id:?} to {container_kind:?}");
+                        container.set_kind(container_kind);
+                    } else {
+                        re_log::trace!("No root found - will re-run auto-layout");
+                    }
 
-        if let Some(focus_tab) = &focus_tab {
-            let found = self.tree.make_active(|_, tile| match tile {
-                egui_tiles::Tile::Pane(space_view_id) => space_view_id == focus_tab,
-                egui_tiles::Tile::Container(_) => false,
-            });
-            re_log::trace!("Found tab {focus_tab}: {found}");
-            self.edited = true;
-        }
+                    self.edited = true;
+                }
+                TreeAction::FocusTab(space_view_id) => {
+                    let found = self.tree.make_active(|_, tile| match tile {
+                        egui_tiles::Tile::Pane(this_space_view_id) => {
+                            *this_space_view_id == space_view_id
+                        }
+                        egui_tiles::Tile::Container(_) => false,
+                    });
+                    re_log::trace!(
+                        "Found tab to focus on for space view ID {space_view_id}: {found}"
+                    );
+                    self.edited = true;
+                }
+                TreeAction::Remove(tile_id) => {
+                    for tile in self.tree.tiles.remove_recursively(tile_id) {
+                        re_log::trace!("Removing tile {tile_id:?}");
+                        if let egui_tiles::Tile::Pane(space_view_id) = tile {
+                            re_log::trace!("Removing space view {space_view_id}");
+                            self.tree.tiles.remove(tile_id);
+                            self.blueprint.remove_space_view(&space_view_id, ctx);
+                        }
+                    }
 
-        for tile_id in remove {
-            for tile in self.tree.tiles.remove_recursively(tile_id) {
-                re_log::trace!("Removing tile {tile_id:?}");
-                if let egui_tiles::Tile::Pane(space_view_id) = tile {
-                    re_log::trace!("Removing space-view {space_view_id}");
-                    self.tree.tiles.remove(tile_id);
-                    self.blueprint.remove_space_view(&space_view_id, ctx);
+                    if Some(tile_id) == self.tree.root {
+                        self.tree.root = None;
+                    }
+                    self.edited = true;
                 }
             }
-
-            if Some(tile_id) == self.tree.root {
-                self.tree.root = None;
-            }
-            self.edited = true;
         }
 
         if reset {

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -90,6 +90,9 @@ pub enum TreeAction {
 
     /// Remove a tile and all its children.
     Remove(egui_tiles::TileId),
+
+    /// Simplify the specified subtree with the provided options
+    SimplifyTree(egui_tiles::TileId, egui_tiles::SimplificationOptions),
 }
 
 // ----------------------------------------------------------------------------
@@ -391,6 +394,11 @@ impl<'a, 'b> Viewport<'a, 'b> {
                     if Some(tile_id) == self.tree.root {
                         self.tree.root = None;
                     }
+                    self.edited = true;
+                }
+                TreeAction::SimplifyTree(tile_id, options) => {
+                    re_log::trace!("Simplifying tree with options: {options:?}");
+                    self.tree.simplify_tile(tile_id, &options);
                     self.edited = true;
                 }
             }

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use ahash::HashMap;
-use egui_tiles::TileId;
+use egui_tiles::{SimplificationOptions, TileId};
 use re_arrow_store::LatestAtQuery;
 use re_data_store::EntityPath;
 use re_log_types::Timeline;
@@ -391,6 +391,15 @@ impl ViewportBlueprint {
         kind: egui_tiles::ContainerKind,
     ) {
         self.send_tree_action(TreeAction::SetContainerKind(container_id, kind));
+    }
+
+    /// Simplify the container subtree with the provided options.
+    pub fn simplify_tree(
+        &self,
+        tile_id: egui_tiles::TileId,
+        simplification_options: SimplificationOptions,
+    ) {
+        self.send_tree_action(TreeAction::SimplifyTree(tile_id, simplification_options));
     }
 
     #[allow(clippy::unused_self)]

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -411,12 +411,14 @@ impl Viewport<'_, '_> {
                         ctx.selection_state()
                             .set_selection(Item::SpaceView(space_view.id));
 
-                        self.blueprint.add_space_views(
+                        let new_ids = self.blueprint.add_space_views(
                             std::iter::once(space_view),
                             ctx,
                             None, //TODO(ab): maybe add to the currently selected container instead?
-                            true,
                         );
+                        if let Some(new_id) = new_ids.first() {
+                            self.blueprint.focus_tab(*new_id);
+                        }
                     }
                 };
 

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -106,7 +106,7 @@ impl Viewport<'_, '_> {
 
         if remove {
             self.blueprint.mark_user_interaction(ctx);
-            self.deferred_tree_actions.remove.push(tile_id);
+            self.blueprint.remove(tile_id);
         }
 
         if visibility_changed {
@@ -130,7 +130,7 @@ impl Viewport<'_, '_> {
     ) {
         let Some(space_view) = self.blueprint.space_views.get(space_view_id) else {
             re_log::warn_once!("Bug: asked to show a ui for a Space View that doesn't exist");
-            self.deferred_tree_actions.remove.push(tile_id);
+            self.blueprint.remove(tile_id);
             return;
         };
         debug_assert_eq!(space_view.id, *space_view_id);
@@ -165,7 +165,7 @@ impl Viewport<'_, '_> {
 
                 let response = remove_button_ui(re_ui, ui, "Remove Space View from the Viewport");
                 if response.clicked() {
-                    self.deferred_tree_actions.remove.push(tile_id);
+                    self.blueprint.remove(tile_id);
                 }
 
                 response | vis_response
@@ -191,7 +191,7 @@ impl Viewport<'_, '_> {
             .on_hover_text("Space View");
 
         if response.clicked() {
-            self.deferred_tree_actions.focus_tab = Some(space_view.id);
+            self.blueprint.focus_tab(space_view.id);
         }
 
         item_ui::select_hovered_on_click(ctx, &response, item);
@@ -392,32 +392,33 @@ impl Viewport<'_, '_> {
             |ui| {
                 ui.style_mut().wrap = Some(false);
 
-                let mut add_space_view_item =
-                    |ui: &mut egui::Ui, space_view: SpaceViewBlueprint| {
-                        if ctx
-                            .re_ui
-                            .selectable_label_with_icon(
-                                ui,
-                                space_view.class(ctx.space_view_class_registry).icon(),
-                                if space_view.space_origin.is_root() {
-                                    space_view.display_name.clone()
-                                } else {
-                                    space_view.space_origin.to_string()
-                                },
-                                false,
-                            )
-                            .clicked()
-                        {
-                            ui.close_menu();
-                            ctx.selection_state()
-                                .set_selection(Item::SpaceView(space_view.id));
-                            self.blueprint.add_space_views(
-                                std::iter::once(space_view),
-                                ctx,
-                                &mut self.deferred_tree_actions,
-                            );
-                        }
-                    };
+                let add_space_view_item = |ui: &mut egui::Ui, space_view: SpaceViewBlueprint| {
+                    if ctx
+                        .re_ui
+                        .selectable_label_with_icon(
+                            ui,
+                            space_view.class(ctx.space_view_class_registry).icon(),
+                            if space_view.space_origin.is_root() {
+                                space_view.display_name.clone()
+                            } else {
+                                space_view.space_origin.to_string()
+                            },
+                            false,
+                        )
+                        .clicked()
+                    {
+                        ui.close_menu();
+                        ctx.selection_state()
+                            .set_selection(Item::SpaceView(space_view.id));
+
+                        self.blueprint.add_space_views(
+                            std::iter::once(space_view),
+                            ctx,
+                            None, //TODO(ab): maybe add to the currently selected container instead?
+                            true,
+                        );
+                    }
+                };
 
                 // Space view options proposed by heuristics
                 let mut possible_space_views =


### PR DESCRIPTION
### What

This PR adds tree mutation APIs to `ViewportBlueprint`, including adding container, changing container kind, removing tiles, etc. It also refactor the "deferred tree actions" mechanism used to implement them. A `std::sync::mpsc` channel is now used to pass `TreeAction` message from `ViewportBlueprint`'s new API to `Viewport`, which process them at the end of the frame. Using a channel is nice as it gives us interior mutability, which is we need for `ViewportBlueprint` (only a shared ref is provided to the UI code).

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4611/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4611/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4611/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4611)
- [Docs preview](https://rerun.io/preview/87371fc967336cc2b6460d87251e27a5be676441/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/87371fc967336cc2b6460d87251e27a5be676441/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)