### PR TITLE
Properly clear containers that have been removed from the tile tree

### DIFF
--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -527,7 +527,7 @@ impl ViewportBlueprint {
         // by any tiles.
         for (container_id, container) in &self.containers {
             let tile_id = blueprint_id_to_tile_id(container_id);
-            if !contents_from_tile_id.contains_key(&tile_id) {
+            if tree.tiles.get(tile_id).is_none() {
                 container.clear(ctx);
             }
         }


### PR DESCRIPTION
### What
Bug that was introduced in the container blueprint refactor.

Gets rid of egui_tiles spam about GC collecting tiles.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4617/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4617/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4617/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4617)
- [Docs preview](https://rerun.io/preview/b15496c2abf0b59d23a2ac8abf8c3d6d327babe7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b15496c2abf0b59d23a2ac8abf8c3d6d327babe7/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)