### PR TITLE
In the blueprint tree only show data results starting with the first interesting node

### DIFF
--- a/crates/re_viewer_context/src/query_context.rs
+++ b/crates/re_viewer_context/src/query_context.rs
@@ -119,12 +119,10 @@ impl DataResultTree {
             .and_then(|handle| self.data_results.get(handle))
     }
 
-    pub fn first_interesting_root(&self) -> Option<DataResultHandle> {
-        let mut next_handle = self.root_handle();
+    pub fn first_interesting_root(&self) -> Option<&DataResultNode> {
+        let mut next_node = self.root_node();
 
-        while let Some(handle) = next_handle {
-            let node = self.data_results.get(handle).unwrap();
-
+        while let Some(node) = next_node {
             // If both this node is trivial we can skip it.
             // A trivial node is a node which is a group, with a single child,
             // where that child still has children.
@@ -132,7 +130,7 @@ impl DataResultTree {
                 if let Some(child_handle) = node.children.first() {
                     if let Some(child) = self.data_results.get(*child_handle) {
                         if !child.children.is_empty() {
-                            next_handle = Some(*child_handle);
+                            next_node = Some(child);
                             continue;
                         }
                     }
@@ -142,7 +140,7 @@ impl DataResultTree {
             break;
         }
 
-        next_handle
+        next_node
     }
 
     /// Depth-first traversal of the tree, calling `visitor` on each result.

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -146,8 +146,10 @@ impl Viewport<'_, '_> {
         let visible_child = visible;
         let item = Item::SpaceView(space_view.id);
 
-        let default_open = result_tree
-            .root_node()
+        let root_handle = result_tree.first_interesting_root();
+
+        let default_open = root_handle
+            .and_then(|handle| result_tree.lookup_node(handle))
             .map_or(false, Self::default_open_for_data_result);
 
         let collapsing_header_id = ui.id().with(space_view.id);
@@ -171,7 +173,7 @@ impl Viewport<'_, '_> {
                 response | vis_response
             })
             .show_collapsing(ui, collapsing_header_id, default_open, |_, ui| {
-                if let Some(result_handle) = result_tree.root_handle() {
+                if let Some(result_handle) = root_handle {
                     // TODO(jleibs): handle the case where the only result
                     // in the tree is a single path (no groups). This should never
                     // happen for a SpaceViewContents.

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -8,8 +8,7 @@ use re_space_view::DataQueryBlueprint;
 use re_ui::list_item::ListItem;
 use re_ui::ReUi;
 use re_viewer_context::{
-    DataQueryResult, DataResultHandle, DataResultNode, HoverHighlight, Item, SpaceViewId,
-    ViewerContext,
+    DataQueryResult, DataResultNode, HoverHighlight, Item, SpaceViewId, ViewerContext,
 };
 
 use crate::{
@@ -146,11 +145,9 @@ impl Viewport<'_, '_> {
         let visible_child = visible;
         let item = Item::SpaceView(space_view.id);
 
-        let root_handle = result_tree.first_interesting_root();
+        let root_node = result_tree.first_interesting_root();
 
-        let default_open = root_handle
-            .and_then(|handle| result_tree.lookup_node(handle))
-            .map_or(false, Self::default_open_for_data_result);
+        let default_open = root_node.map_or(false, Self::default_open_for_data_result);
 
         let collapsing_header_id = ui.id().with(space_view.id);
         let is_item_hovered =
@@ -173,7 +170,7 @@ impl Viewport<'_, '_> {
                 response | vis_response
             })
             .show_collapsing(ui, collapsing_header_id, default_open, |_, ui| {
-                if let Some(result_handle) = root_handle {
+                if let Some(result_node) = root_node {
                     // TODO(jleibs): handle the case where the only result
                     // in the tree is a single path (no groups). This should never
                     // happen for a SpaceViewContents.
@@ -181,7 +178,7 @@ impl Viewport<'_, '_> {
                         ctx,
                         ui,
                         &query_result,
-                        result_handle,
+                        result_node,
                         space_view,
                         visible_child,
                     );
@@ -214,15 +211,10 @@ impl Viewport<'_, '_> {
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         query_result: &DataQueryResult,
-        result_handle: DataResultHandle,
+        top_node: &DataResultNode,
         space_view: &SpaceViewBlueprint,
         space_view_visible: bool,
     ) {
-        let Some(top_node) = query_result.tree.lookup_node(result_handle) else {
-            debug_assert!(false, "Invalid data result handle in data result tree");
-            return;
-        };
-
         let group_is_visible =
             top_node.data_result.accumulated_properties().visible && space_view_visible;
 
@@ -351,7 +343,7 @@ impl Viewport<'_, '_> {
                                 ctx,
                                 ui,
                                 query_result,
-                                *child,
+                                child_node,
                                 space_view,
                                 space_view_visible,
                             );


### PR DESCRIPTION
### What
Any node in the tree which is a group with a single child can be collapsed out.

Before:
![image](https://github.com/rerun-io/rerun/assets/3312232/28ec41fb-d8d9-471e-9a67-05cf82c09aab)

After:
![image](https://github.com/rerun-io/rerun/assets/3312232/5a63c534-81e4-4a76-9b7a-b2e5e9927143)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4618/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4618/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4618/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4618)
- [Docs preview](https://rerun.io/preview/40e82298958f9b66b24ad0d3dd7c3c4b54ab724a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/40e82298958f9b66b24ad0d3dd7c3c4b54ab724a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)