### PR TITLE
Fix a bunch of clippy 1.75 lints

### DIFF
--- a/crates/re_arrow_store/src/arrow_util.rs
+++ b/crates/re_arrow_store/src/arrow_util.rs
@@ -228,7 +228,7 @@ fn test_clean_for_polars_nomodify() {
     use re_types::datagen::build_some_colors;
 
     // Colors don't need polars cleaning
-    let cell: DataCell = build_some_colors(5).try_into().unwrap();
+    let cell: DataCell = build_some_colors(5).into();
     let cleaned = cell.as_arrow_ref().clean_for_polars();
     assert_eq!(cell.as_arrow_ref(), &*cleaned);
 

--- a/crates/re_arrow_store/src/store_helpers.rs
+++ b/crates/re_arrow_store/src/store_helpers.rs
@@ -52,7 +52,7 @@ impl DataStore {
         re_tracing::profile_function!();
 
         let (row_id, cells) = self.latest_at(query, entity_path, C::name(), &[C::name()])?;
-        let cell = cells.get(0)?.as_ref()?;
+        let cell = cells.first()?.as_ref()?;
 
         cell.try_to_native_mono::<C>()
             .map_err(|err| {

--- a/crates/re_log_types/src/hash.rs
+++ b/crates/re_log_types/src/hash.rs
@@ -135,10 +135,6 @@ fn hash_with_seed(value: impl std::hash::Hash, seed: u128) -> u64 {
 /// Hash the given value.
 #[inline]
 fn hash(value: impl std::hash::Hash) -> u64 {
-    use std::hash::Hasher as _;
-
     // Don't use ahash::AHasher::default() since it uses a random number for seeding the hasher on every application start.
-    let mut hasher = HASH_RANDOM_STATE.build_hasher();
-    value.hash(&mut hasher);
-    hasher.finish()
+    HASH_RANDOM_STATE.hash_one(value)
 }

--- a/crates/re_log_types/src/vec_deque_ext.rs
+++ b/crates/re_log_types/src/vec_deque_ext.rs
@@ -180,7 +180,7 @@ impl<T: Clone> VecDequeRemovalExt<T> for VecDeque<T> {
         }
 
         if index == 0 {
-            let v = self.get(0).cloned();
+            let v = self.front().cloned();
             self.rotate_left(1);
             self.truncate(self.len() - 1);
             v

--- a/crates/re_query/src/query.rs
+++ b/crates/re_query/src/query.rs
@@ -124,10 +124,7 @@ pub fn query_archetype<A: Archetype>(
 
     let required_components: Vec<_> = A::required_components()
         .iter()
-        .map(|component| {
-            get_component_with_instances(store, query, ent_path, *component)
-                .map(|(row_id, component_result)| (row_id, component_result))
-        })
+        .map(|component| get_component_with_instances(store, query, ent_path, *component))
         .collect();
 
     // NOTE: It's important to use `PrimaryNotFound` here. Any other error will be

--- a/crates/re_types_builder/src/codegen/common.rs
+++ b/crates/re_types_builder/src/codegen/common.rs
@@ -336,7 +336,7 @@ pub fn remove_orphaned_files(reporter: &Reporter, files: &GeneratedFiles) {
             let filepath = Utf8PathBuf::try_from(entry.path()).unwrap();
 
             if let Some(stem) = filepath.as_str().strip_suffix("_ext.rs") {
-                let generated_path = Utf8PathBuf::try_from(format!("{stem}.rs")).unwrap();
+                let generated_path = Utf8PathBuf::from(format!("{stem}.rs"));
                 if !generated_path.exists() {
                     reporter.error(
                         filepath.as_str(),
@@ -348,7 +348,7 @@ pub fn remove_orphaned_files(reporter: &Reporter, files: &GeneratedFiles) {
             }
 
             if let Some(stem) = filepath.as_str().strip_suffix("_ext.py") {
-                let generated_path = Utf8PathBuf::try_from(format!("{stem}.py")).unwrap();
+                let generated_path = Utf8PathBuf::from(format!("{stem}.py"));
                 if !generated_path.exists() {
                     reporter.error(
                         filepath.as_str(),
@@ -360,7 +360,7 @@ pub fn remove_orphaned_files(reporter: &Reporter, files: &GeneratedFiles) {
             }
 
             if let Some(stem) = filepath.as_str().strip_suffix("_ext.cpp") {
-                let generated_hpp_path = Utf8PathBuf::try_from(format!("{stem}.hpp")).unwrap();
+                let generated_hpp_path = Utf8PathBuf::from(format!("{stem}.hpp"));
                 if !generated_hpp_path.exists() {
                     reporter.error(
                         filepath.as_str(),

--- a/crates/re_viewer/src/saving.rs
+++ b/crates/re_viewer/src/saving.rs
@@ -20,8 +20,6 @@ fn sanitize_app_id(app_id: &ApplicationId) -> String {
 /// This path should be deterministic and unique.
 // TODO(#2579): Implement equivalent for web
 pub fn default_blueprint_path(app_id: &ApplicationId) -> anyhow::Result<std::path::PathBuf> {
-    use std::hash::{BuildHasher, Hash as _, Hasher as _};
-
     use anyhow::Context;
 
     let Some(storage_dir) = eframe::storage_dir(crate::native::APP_ID) else {
@@ -58,11 +56,7 @@ pub fn default_blueprint_path(app_id: &ApplicationId) -> anyhow::Result<std::pat
     if sanitized_app_id != app_id.0 {
         // Hash the original app-id.
 
-        let hash = {
-            let mut hasher = ahash::RandomState::with_seeds(1, 2, 3, 4).build_hasher();
-            app_id.0.hash(&mut hasher);
-            hasher.finish()
-        };
+        let hash = ahash::RandomState::with_seeds(1, 2, 3, 4).hash_one(&app_id.0);
 
         sanitized_app_id = format!("{sanitized_app_id}-{hash:x}");
     }

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -21,15 +21,6 @@ use rerun::{
     RecordingStreamBuilder, StoreId,
 };
 
-pub use rerun::{
-    components::{
-        AnnotationContext, Blob, ClassId, Color, DisconnectedSpace, DrawOrder, InstanceKey,
-        KeypointId, LineStrip2D, LineStrip3D, OutOfTreeTransform3D, PinholeProjection, Position2D,
-        Position3D, Radius, Text, Transform3D, Vector3D, ViewCoordinates,
-    },
-    coordinates::{Axis3, Handedness, Sign, SignedAxis3},
-};
-
 #[cfg(feature = "web_viewer")]
 use re_web_viewer_server::WebViewerServerPort;
 #[cfg(feature = "web_viewer")]


### PR DESCRIPTION
Found with `cargo +1.75.0 cranky --all-targets --all-features`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4625/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4625/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4625/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4625)
- [Docs preview](https://rerun.io/preview/7dd05f0d3249a096487873ba8245fd7166cd83b3/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7dd05f0d3249a096487873ba8245fd7166cd83b3/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)