### PR TITLE
Remove redundant wheels folder from upload script

### DIFF
--- a/scripts/ci/build_and_upload_wheels.py
+++ b/scripts/ci/build_and_upload_wheels.py
@@ -97,7 +97,7 @@ def build_and_upload(bucket: Bucket, mode: BuildMode, gcs_dir: str, target: str,
 
     # Upload to GCS
     print("Uploading to GCS…")
-    bucket.blob(f"{gcs_dir}/wheels/{pkg}").upload_from_filename(f"{dist}/{pkg}")
+    bucket.blob(f"{gcs_dir}/{pkg}").upload_from_filename(f"{dist}/{pkg}")
 
 
 def main() -> None:


### PR DESCRIPTION
### What

The wheels folder is specified as part of the invocation and doesn't need to be appended by the script as well.  I made the change here rather than at the call-site because that invocation includes additional path components and it makes more sense to have the file end up at the specified path.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4632/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4632/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4632/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4632)
- [Docs preview](https://rerun.io/preview/f35e993d13178546c50ec408e05fd42141632db1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f35e993d13178546c50ec408e05fd42141632db1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)