### PR TITLE
Fix incorrect bounding box calculation for camera view parts

### DIFF
--- a/crates/re_space_view_spatial/src/parts/cameras.rs
+++ b/crates/re_space_view_spatial/src/parts/cameras.rs
@@ -74,10 +74,11 @@ impl CamerasPart {
 
         // We need special handling to find the 3D transform for drawing the
         // frustum itself. The transform that would otherwise be in the
-        // transform context includes the pinhole.  This makes sense, since if
-        // there's an image logged here one would expect that the transform
-        // applies. We're however first interested in the rigid transform at this
-        // entity path, excluding the pinhole portion.
+        // transform context might include both a rigid transform and a pinhole. This
+        // makes sense, since if there's an image logged here one would expect
+        // both the rigid and the pinhole to apply, but here we're only interested
+        // in the rigid transform at this entity path, excluding the pinhole
+        // portion (we handle the pinhole separately later).
         let world_from_camera_rigid = {
             // Start with the transform to the entity parent, if it exists
             let world_from_parent = ent_path

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -380,6 +380,9 @@ pub fn view_3d(
             axis_length,
             re_renderer::OutlineMaskPreference::NONE,
         );
+
+        // If we are showing the axes for the space, then add the space origin to the bounding box.
+        state.scene_bbox.extend(glam::Vec3::ZERO);
     }
 
     // Determine view port resolution and position.


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/4452

The wrong transform was being used for the bounding box calculation.
Clarify the transform naming / construction.
Also include the origin when the origin axes are turned on.

![image](https://github.com/rerun-io/rerun/assets/3312232/c0076200-927c-404a-894a-34d9750d26bd)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4640/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4640/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4640/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4640)
- [Docs preview](https://rerun.io/preview/0faa6bf2ec93fdf2b93c71e6695a177fb0c6aa5f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0faa6bf2ec93fdf2b93c71e6695a177fb0c6aa5f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)