### PR TITLE
Remove `cache/` from gitignore + fix resulting lints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,3 @@ wheels
 
 .nox/
 *.rrd
-
-# Python example dataset caches:
-cache/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,11 +88,11 @@ Of course, this will only take us so far. In the future we plan on caching queri
 Here is an overview of the crates included in the project:
 
 <picture>
-  <img src="https://static.rerun.io/crates/21c577a05570720e96b850e8da21b5aa1fcd6c93/full.png" alt="">
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/crates/21c577a05570720e96b850e8da21b5aa1fcd6c93/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/crates/21c577a05570720e96b850e8da21b5aa1fcd6c93/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/crates/21c577a05570720e96b850e8da21b5aa1fcd6c93/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/crates/21c577a05570720e96b850e8da21b5aa1fcd6c93/1200w.png">
+  <img src="https://static.rerun.io/crates/1a5eff8b1577097cab249a751b658ba79c34396c/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/crates/1a5eff8b1577097cab249a751b658ba79c34396c/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/crates/1a5eff8b1577097cab249a751b658ba79c34396c/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/crates/1a5eff8b1577097cab249a751b658ba79c34396c/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/crates/1a5eff8b1577097cab249a751b658ba79c34396c/1200w.png">
 </picture>
 
 <!-- !!! IMPORTANT!!!
@@ -149,6 +149,7 @@ Update instructions:
 |-----------------|-----------------------------------------------------------------|
 | re_data_store   | In-memory storage of Rerun log data, indexed for fast queries.  |
 | re_query        | Querying data in the re_arrow_store                             |
+| re_query_cache  | Caching datastructures for re_query                             |
 | re_types        | The built-in Rerun data types, component types, and archetypes. |
 | re_log_encoding | Helpers for encoding and transporting Rerun log messages        |
 

--- a/crates/re_query_cache/README.md
+++ b/crates/re_query_cache/README.md
@@ -1,0 +1,10 @@
+# re_query_cache
+
+Part of the [`rerun`](https://github.com/rerun-io/rerun) family of crates.
+
+[![Latest version](https://img.shields.io/crates/v/re_query_cache.svg)](https://crates.io/crates/re_query_cache)
+[![Documentation](https://docs.rs/re_query/badge.svg)](https://docs.rs/re_query)
+![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
+![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
+
+Caching datastructures for `re_query`.


### PR DESCRIPTION
`scripts/lints.py` parses the gitignore file but apparently it does not do so in a git compliant way, resulting in `re_query_cache` being ignored by that script but not by git :unamused: 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4641/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4641/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4641/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4641)
- [Docs preview](https://rerun.io/preview/bcb83a238cfb4a46721833f29785b534a819829b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bcb83a238cfb4a46721833f29785b534a819829b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)