### PR TITLE
Fix group selection/hover with data queries

### DIFF
--- a/crates/re_viewer_context/src/query_context.rs
+++ b/crates/re_viewer_context/src/query_context.rs
@@ -150,6 +150,17 @@ impl DataResultTree {
         }
     }
 
+    /// Depth-first traversal of a subtree, starting with the given group entity-path, calling `visitor` on each result.
+    pub fn visit_group(
+        &self,
+        entity_path: &EntityPath,
+        visitor: &mut impl FnMut(DataResultHandle),
+    ) {
+        if let Some(subtree_handle) = self.data_results_by_path.get(&(entity_path.clone(), true)) {
+            self.visit_recursive(*subtree_handle, visitor);
+        }
+    }
+
     /// Look up a [`DataResult`] in the tree based on its handle.
     pub fn lookup_result(&self, handle: DataResultHandle) -> Option<&DataResult> {
         self.data_results.get(handle).map(|node| &node.data_result)

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -251,7 +251,6 @@ impl SpaceViewBlueprint {
 
         let query_result = ctx.lookup_query_result(self.query_id()).clone();
 
-        // TODO(#4377): Use PerSystemDataResults
         let mut per_system_entities = PerSystemEntities::default();
         {
             re_tracing::profile_scope!("per_system_data_results");

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -80,8 +80,6 @@ pub fn all_possible_space_views(
                     let mut entity_path_filter = EntityPathFilter::default();
                     entity_path_filter.add_subtree(candidate_space_path.clone());
 
-                    // TODO(#4377): The need to run a query-per-candidate for all possible candidates
-                    // is way too expensive. This needs to be optimized significantly.
                     let candidate_query =
                         DataQueryBlueprint::new(class_identifier, entity_path_filter);
 
@@ -217,7 +215,6 @@ pub fn default_created_space_views(
     // Main pass through all candidates.
     // We first check if a candidate is "interesting" and then split it up/modify it further if required.
     for (candidate, query_result) in candidates {
-        // TODO(#4377): Can spawn heuristics consume the query_result directly?
         let mut per_system_entities = PerSystemEntities::default();
         {
             re_tracing::profile_scope!("per_system_data_results");

--- a/crates/re_viewport/src/system_execution.rs
+++ b/crates/re_viewport/src/system_execution.rs
@@ -73,8 +73,7 @@ pub fn execute_systems_for_space_views<'a>(
         .par_drain(..)
         .filter_map(|space_view_id| {
             let space_view_blueprint = space_views.get(&space_view_id)?;
-            let highlights =
-                highlights_for_space_view(ctx.selection_state(), space_view_id, space_views);
+            let highlights = highlights_for_space_view(ctx, space_view_id);
             let output = space_view_blueprint.execute_systems(ctx, time_int, highlights);
             Some((space_view_id, output))
         })

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -495,11 +495,7 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
             if let Some(result) = self.executed_systems_per_space_view.remove(space_view_id) {
                 result
             } else {
-                let highlights = highlights_for_space_view(
-                    self.ctx.selection_state(),
-                    *space_view_id,
-                    self.space_views,
-                );
+                let highlights = highlights_for_space_view(self.ctx, *space_view_id);
                 space_view_blueprint.execute_systems(self.ctx, latest_at, highlights)
             };
 


### PR DESCRIPTION
### What
 - Resolves: https://github.com/rerun-io/rerun/issues/4377

Restores the behavior of group hover/selection using the cached data query result.

Also removes some deprecated TODOs.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4643/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4643/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4643/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4643)
- [Docs preview](https://rerun.io/preview/cfc9311cc36a57c15ac46eede644d60e67b5d050/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/cfc9311cc36a57c15ac46eede644d60e67b5d050/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)