### PR TITLE
Update `egui_plot` to fix auto-bounds bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "egui_plot"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37b2edcdd197db41825266ae7979bd7591fa2eb6b40152375ac05eb323eb9d2"
+checksum = "29b484821a5b336af40a34151a940f52bef0f1ab56ec0d8cf80f74783eaae412"
 dependencies = [
  "egui",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ egui = { version = "0.24.1", features = [
 ] }
 egui_commonmark = { version = "0.10", default-features = false }
 egui_extras = { version = "0.24.1", features = ["http", "image", "puffin"] }
-egui_plot = "0.24.1"
+egui_plot = "0.24.2"
 egui_tiles = "0.4"
 egui-wgpu = "0.24.1"
 emath = "0.24.1"


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/4635
* See also https://github.com/emilk/egui/pull/3763
* Includes this fix: https://github.com/emilk/egui/pull/3722

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4645/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4645/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4645/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4645)
- [Docs preview](https://rerun.io/preview/82415b7ed7cb1d02464d80766a7007a9ab8cca08/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/82415b7ed7cb1d02464d80766a7007a9ab8cca08/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)