### PR TITLE
Improve shading with two lights instead of one

### DIFF
--- a/crates/re_renderer/shader/instanced_mesh.wgsl
+++ b/crates/re_renderer/shader/instanced_mesh.wgsl
@@ -73,10 +73,15 @@ fn fs_main_shaded(in: VertexOut) -> @location(0) vec4f {
         // no normal, no shading
         return vec4f(albedo, 1.0);
     } else {
-        // Hardcoded lambert lighting. TODO(andreas): Some microfacet model.
-        let light_dir = normalize(vec3f(1.0, 2.0, 0.0)); // TODO(andreas): proper lighting
         let normal = normalize(in.normal_world_space);
-        let shading = clamp(dot(normal, light_dir), 0.0, 1.0) + 0.2;
+
+        var shading = 0.2;
+
+        // We use two lights so we get shading on all sides
+        shading += 1.0 * clamp(dot(normalize(vec3f(1.0, 2.0, 3.0)), normal), 0.0, 1.0);
+        shading += 0.5 * clamp(dot(normalize(vec3f(-1.0, -3.0, -5.0)), normal), 0.0, 1.0);
+
+        shading = clamp(shading, 0.0, 1.0);
 
         let radiance = albedo * shading;
 


### PR DESCRIPTION
## Before
The backside of meshes was a uniform gray
![shading-before](https://github.com/rerun-io/rerun/assets/1148717/32de891d-25d0-4a0c-9846-f28413fa0bc5)

## After
All sides have some shading
![shading-after](https://github.com/rerun-io/rerun/assets/1148717/bc0f5a19-198d-4f67-b057-0764d89ded25)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4648/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4648/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4648/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4648)
- [Docs preview](https://rerun.io/preview/589f6d567dd314ed718810fc4e00927cc77a42b4/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/589f6d567dd314ed718810fc4e00927cc77a42b4/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)