### PR TITLE
Diagram in docs/index has full color for C++

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -24,11 +24,11 @@ For a list of built-in data types, see the [Types](reference/types.md) section.
 
 ## How do you use it?
 <picture>
-  <img src="https://static.rerun.io/how-to-use-rerun/9de74809cf7b27be995af8cba614809257cd544f/full.png" alt="">
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/how-to-use-rerun/9de74809cf7b27be995af8cba614809257cd544f/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/how-to-use-rerun/9de74809cf7b27be995af8cba614809257cd544f/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/how-to-use-rerun/9de74809cf7b27be995af8cba614809257cd544f/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/how-to-use-rerun/9de74809cf7b27be995af8cba614809257cd544f/1200w.png">
+  <img src="https://static.rerun.io/how-to-use-rerun/225d92a2aa2fba442a15310420f45343f6da4ae1/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/how-to-use-rerun/225d92a2aa2fba442a15310420f45343f6da4ae1/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/how-to-use-rerun/225d92a2aa2fba442a15310420f45343f6da4ae1/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/how-to-use-rerun/225d92a2aa2fba442a15310420f45343f6da4ae1/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/how-to-use-rerun/225d92a2aa2fba442a15310420f45343f6da4ae1/1200w.png">
 </picture>
 
 1. Stream multimodal data from your code by logging it with the Rerun SDK


### PR DESCRIPTION
Before:
![Screenshot 2024-01-03 at 11 53 06](https://github.com/rerun-io/rerun/assets/2624717/1f645c30-9ec5-4490-b125-c3558cc8c496)

After:
![Screenshot 2024-01-03 at 11 52 30](https://github.com/rerun-io/rerun/assets/2624717/a380928a-35bb-4d8f-ae65-79df15933398)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4653/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4653/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4653/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4653)
- [Docs preview](https://rerun.io/preview/6dc869c5764cb5037cead8aa458e5ec9a71442ab/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/6dc869c5764cb5037cead8aa458e5ec9a71442ab/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)