### PR TITLE
Add overview diagram of external data loaders

### DIFF
--- a/docs/content/howto/open-any-file.md
+++ b/docs/content/howto/open-any-file.md
@@ -48,6 +48,14 @@ From there, it can log data as usual, using the [`stdout` logging sink](../refer
 
 The Rerun Viewer will then automatically load the data streamed to the external loader's standard output.
 
+<picture>
+  <img src="https://static.rerun.io/external_data_loader/bb98877088a9169ee15fd862ad022f9d9fbd5e6f/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/external_data_loader/bb98877088a9169ee15fd862ad022f9d9fbd5e6f/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/external_data_loader/bb98877088a9169ee15fd862ad022f9d9fbd5e6f/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/external_data_loader/bb98877088a9169ee15fd862ad022f9d9fbd5e6f/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/external_data_loader/bb98877088a9169ee15fd862ad022f9d9fbd5e6f/1200w.png">
+</picture>
+
 Like any other `DataLoader`, an external loader will be notified of all file openings, unconditionally.
 To indicate that it does not support a given file, the loader has to exit with a [dedicated status code](https://docs.rs/rerun/latest/rerun/constant.EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE.html?speculative-link).
 


### PR DESCRIPTION

![Screenshot 2024-01-03 at 15 23 34](https://github.com/rerun-io/rerun/assets/2624717/ea1ccded-118d-4466-ae33-5d530388838c)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4657/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4657/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4657/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4657)
- [Docs preview](https://rerun.io/preview/2496f75bdd634bd9ab9c1d1430e0cd37ce8136eb/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2496f75bdd634bd9ab9c1d1430e0cd37ce8136eb/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)