### PR TITLE
Primary caching 3: barebone latest-at caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4821,15 +4821,30 @@ name = "re_query_cache"
 version = "0.13.0-alpha.1+dev"
 dependencies = [
  "ahash",
+ "arrow2",
+ "backtrace",
  "criterion",
  "document-features",
  "itertools 0.12.0",
  "mimalloc",
+ "nohash-hasher",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "paste",
+ "rand",
+ "re_data_store",
+ "re_entity_db",
+ "re_format",
+ "re_log",
  "re_log_types",
  "re_query",
+ "re_tracing",
+ "re_types",
  "re_types_core",
+ "seq-macro",
  "similar-asserts",
  "thiserror",
+ "web-time",
 ]
 
 [[package]]
@@ -6005,6 +6020,12 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "seq-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ num-traits = "0.2"
 once_cell = "1.17"
 ordered-float = "4.2"
 parking_lot = "0.12"
+paste = "1.0"
 pathdiff = "0.2"
 pico-args = "0.5"
 ply-rs = { version = "0.1", default-features = false }
@@ -192,6 +193,7 @@ rfd = { version = "0.12", default_features = false, features = ["xdg-portal"] }
 rmp-serde = "1"
 ron = "0.8.0"
 rust-format = "0.3"
+seq-macro = "0.3"
 serde = "1"
 serde_bytes = "0.11"
 serde_json = { version = "1", default-features = false, features = ["std"] }

--- a/crates/re_data_store/src/store_read.rs
+++ b/crates/re_data_store/src/store_read.rs
@@ -17,7 +17,7 @@ use crate::{
 /// A query at a given time, for a given timeline.
 ///
 /// Get the latest version of the data available at this time.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct LatestAtQuery {
     pub timeline: Timeline,
     pub at: TimeInt,

--- a/crates/re_data_ui/src/component_ui_registry.rs
+++ b/crates/re_data_ui/src/component_ui_registry.rs
@@ -43,7 +43,7 @@ pub fn add_to_registry<C: EntityDataUi + re_types::Component>(registry: &mut Com
                 Ok(component) => {
                     component.entity_data_ui(ctx, ui, verbosity, entity_path, query);
                 }
-                Err(re_query::QueryError::ComponentNotFound) => {
+                Err(re_query::QueryError::ComponentNotFound(_)) => {
                     ui.weak("(not found)");
                 }
                 Err(err) => {

--- a/crates/re_log_types/benches/vec_deque_ext.rs
+++ b/crates/re_log_types/benches/vec_deque_ext.rs
@@ -15,7 +15,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 criterion_group!(
     benches,
-    insert_range,
+    insert_many,
     remove_range,
     remove,
     swap_remove,
@@ -43,7 +43,7 @@ use self::constants::*;
 
 // ---
 
-fn insert_range(c: &mut Criterion) {
+fn insert_many(c: &mut Criterion) {
     if std::env::var("CI").is_ok() {
         return;
     }
@@ -53,29 +53,29 @@ fn insert_range(c: &mut Criterion) {
     let mut group = c.benchmark_group("vec_deque");
     group.throughput(criterion::Throughput::Elements(inserted.len() as _));
 
-    group.bench_function("insert_range/prefilled/front", |b| {
+    group.bench_function("insert_many/prefilled/front", |b| {
         let base = create_prefilled();
         b.iter(|| {
             let mut v: VecDeque<i64> = base.clone();
-            v.insert_range(0, inserted.clone().into_iter());
+            v.insert_many(0, inserted.clone().into_iter());
             v
         });
     });
 
-    group.bench_function("insert_range/prefilled/middle", |b| {
+    group.bench_function("insert_many/prefilled/middle", |b| {
         let base = create_prefilled();
         b.iter(|| {
             let mut v: VecDeque<i64> = base.clone();
-            v.insert_range(INITIAL_NUM_ENTRIES / 2, inserted.clone().into_iter());
+            v.insert_many(INITIAL_NUM_ENTRIES / 2, inserted.clone().into_iter());
             v
         });
     });
 
-    group.bench_function("insert_range/prefilled/back", |b| {
+    group.bench_function("insert_many/prefilled/back", |b| {
         let base = create_prefilled();
         b.iter(|| {
             let mut v: VecDeque<i64> = base.clone();
-            v.insert_range(INITIAL_NUM_ENTRIES, inserted.clone().into_iter());
+            v.insert_many(INITIAL_NUM_ENTRIES, inserted.clone().into_iter());
             v
         });
     });

--- a/crates/re_log_types/src/time_range.rs
+++ b/crates/re_log_types/src/time_range.rs
@@ -4,7 +4,7 @@ use crate::{TimeInt, TimeReal};
 
 // ----------------------------------------------------------------------------
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct TimeRange {
     pub min: TimeInt,

--- a/crates/re_log_types/src/vec_deque_ext.rs
+++ b/crates/re_log_types/src/vec_deque_ext.rs
@@ -82,11 +82,11 @@ pub trait VecDequeInsertionExt<T> {
     /// at both ends of the added data.
     ///
     /// Panics if `index` is out of bounds.
-    fn insert_range(&mut self, index: usize, values: impl ExactSizeIterator<Item = T>);
+    fn insert_many(&mut self, index: usize, values: impl ExactSizeIterator<Item = T>);
 }
 
 impl<T> VecDequeInsertionExt<T> for VecDeque<T> {
-    fn insert_range(&mut self, index: usize, values: impl ExactSizeIterator<Item = T>) {
+    fn insert_many(&mut self, index: usize, values: impl ExactSizeIterator<Item = T>) {
         if index == self.len() {
             self.extend(values); // has a specialization fast-path builtin
         } else if index == 0 {
@@ -110,24 +110,24 @@ impl<T> VecDequeInsertionExt<T> for VecDeque<T> {
 }
 
 #[test]
-fn insert_range() {
+fn insert_many() {
     let mut v: VecDeque<i64> = vec![].into();
 
     assert!(v.is_empty());
 
-    v.insert_range(0, [1, 2, 3].into_iter());
+    v.insert_many(0, [1, 2, 3].into_iter());
     assert_deque_eq([1, 2, 3], v.clone());
 
-    v.insert_range(0, [4, 5].into_iter());
+    v.insert_many(0, [4, 5].into_iter());
     assert_deque_eq([4, 5, 1, 2, 3], v.clone());
 
-    v.insert_range(2, std::iter::once(6));
+    v.insert_many(2, std::iter::once(6));
     assert_deque_eq([4, 5, 6, 1, 2, 3], v.clone());
 
-    v.insert_range(v.len(), [7, 8, 9, 10].into_iter());
+    v.insert_many(v.len(), [7, 8, 9, 10].into_iter());
     assert_deque_eq([4, 5, 6, 1, 2, 3, 7, 8, 9, 10], v.clone());
 
-    v.insert_range(5, [11, 12].into_iter());
+    v.insert_many(5, [11, 12].into_iter());
     assert_deque_eq([4, 5, 6, 1, 2, 11, 12, 3, 7, 8, 9, 10], v.clone());
 }
 
@@ -262,7 +262,7 @@ fn remove_range() {
     assert!(v.is_empty());
     assert!(v.is_sorted());
 
-    v.insert_range(0, [1, 2, 3, 4, 5, 6, 7, 8, 9].into_iter());
+    v.insert_many(0, [1, 2, 3, 4, 5, 6, 7, 8, 9].into_iter());
     assert_deque_eq([1, 2, 3, 4, 5, 6, 7, 8, 9], v.clone());
     assert!(v.is_sorted());
 

--- a/crates/re_query/src/archetype_view.rs
+++ b/crates/re_query/src/archetype_view.rs
@@ -68,13 +68,13 @@ impl ComponentWithInstances {
         }
         let arr = self
             .lookup_arrow(instance_key)
-            .map_or_else(|| Err(QueryError::ComponentNotFound), Ok)?;
+            .map_or_else(|| Err(QueryError::ComponentNotFound(C::name())), Ok)?;
 
         let mut iter = C::from_arrow(arr.as_ref())?.into_iter();
 
         let val = iter
             .next()
-            .map_or_else(|| Err(QueryError::ComponentNotFound), Ok)?;
+            .map_or_else(|| Err(QueryError::ComponentNotFound(C::name())), Ok)?;
         Ok(val)
     }
 
@@ -575,7 +575,7 @@ fn lookup_value() {
     let missing_value = component.lookup::<Position2D>(&InstanceKey(46));
     assert!(matches!(
         missing_value.err().unwrap(),
-        QueryError::ComponentNotFound
+        QueryError::ComponentNotFound(_)
     ));
 
     let missing_value = component.lookup::<Color>(&InstanceKey(99));

--- a/crates/re_query/src/archetype_view.rs
+++ b/crates/re_query/src/archetype_view.rs
@@ -68,13 +68,13 @@ impl ComponentWithInstances {
         }
         let arr = self
             .lookup_arrow(instance_key)
-            .map_or_else(|| Err(QueryError::ComponentNotFound(C::name())), Ok)?;
+            .map_or_else(|| Err(crate::ComponentNotFoundError(C::name())), Ok)?;
 
         let mut iter = C::from_arrow(arr.as_ref())?.into_iter();
 
         let val = iter
             .next()
-            .map_or_else(|| Err(QueryError::ComponentNotFound(C::name())), Ok)?;
+            .map_or_else(|| Err(crate::ComponentNotFoundError(C::name())), Ok)?;
         Ok(val)
     }
 

--- a/crates/re_query/src/lib.rs
+++ b/crates/re_query/src/lib.rs
@@ -34,8 +34,8 @@ pub enum QueryError {
     #[error("Could not find required component: {0}")]
     RequiredComponentNotFound(re_types_core::ComponentName),
 
-    #[error("Could not find component")]
-    ComponentNotFound,
+    #[error("Could not find component: {0}")]
+    ComponentNotFound(re_types_core::ComponentName),
 
     #[error("Tried to access component of type '{actual:?}' using component '{requested:?}'")]
     TypeMismatch {

--- a/crates/re_query/src/lib.rs
+++ b/crates/re_query/src/lib.rs
@@ -23,6 +23,17 @@ pub use self::util::query_archetype_with_history;
 #[cfg(feature = "testing")]
 pub use self::query::__populate_example_store;
 
+#[derive(Debug, Clone, Copy)]
+pub struct ComponentNotFoundError(pub re_types_core::ComponentName);
+
+impl std::fmt::Display for ComponentNotFoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("Could not find component: {}", self.0))
+    }
+}
+
+impl std::error::Error for ComponentNotFoundError {}
+
 #[derive(thiserror::Error, Debug)]
 pub enum QueryError {
     #[error("Tried to access a column that doesn't exist")]
@@ -31,11 +42,8 @@ pub enum QueryError {
     #[error("Could not find primary component: {0}")]
     PrimaryNotFound(re_types_core::ComponentName),
 
-    #[error("Could not find required component: {0}")]
-    RequiredComponentNotFound(re_types_core::ComponentName),
-
-    #[error("Could not find component: {0}")]
-    ComponentNotFound(re_types_core::ComponentName),
+    #[error(transparent)]
+    ComponentNotFound(#[from] ComponentNotFoundError),
 
     #[error("Tried to access component of type '{actual:?}' using component '{requested:?}'")]
     TypeMismatch {

--- a/crates/re_query_cache/Cargo.toml
+++ b/crates/re_query_cache/Cargo.toml
@@ -21,22 +21,37 @@ default = []
 
 [dependencies]
 # Rerun dependencies:
+re_arrow_store.workspace = true
+re_data_store.workspace = true
+re_format.workspace = true
+re_log.workspace = true
 re_log_types.workspace = true
 re_query.workspace = true
+re_tracing.workspace = true
 re_types_core.workspace = true
 
 # External dependencies:
 ahash.workspace = true
+arrow2.workspace = true
+backtrace.workspace = true
 document-features.workspace = true
 itertools.workspace = true
+nohash-hasher.workspace = true
+once_cell.workspace = true
+parking_lot.workspace = true
+paste.workspace = true
+seq-macro.workspace = true
 thiserror.workspace = true
+web-time.workspace = true
 
 
 [dev-dependencies]
 re_log_types = { workspace = true, features = ["testing"] }
+re_types = { workspace = true, features = ["datagen"] }
 
 criterion.workspace = true
 mimalloc.workspace = true
+rand = { workspace = true, features = ["std", "std_rng"] }
 similar-asserts.workspace = true
 
 
@@ -46,4 +61,9 @@ bench = false
 
 [[bench]]
 name = "flat_vec_deque"
+harness = false
+
+
+[[bench]]
+name = "latest_at"
 harness = false

--- a/crates/re_query_cache/Cargo.toml
+++ b/crates/re_query_cache/Cargo.toml
@@ -21,8 +21,8 @@ default = []
 
 [dependencies]
 # Rerun dependencies:
-re_arrow_store.workspace = true
 re_data_store.workspace = true
+re_entity_db.workspace = true
 re_format.workspace = true
 re_log.workspace = true
 re_log_types.workspace = true

--- a/crates/re_query_cache/benches/latest_at.rs
+++ b/crates/re_query_cache/benches/latest_at.rs
@@ -6,7 +6,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use itertools::Itertools;
 use re_data_store::{DataStore, LatestAtQuery};
 use re_log_types::{entity_path, DataRow, EntityPath, RowId, TimeInt, TimeType, Timeline};
-use re_query_cache::query_cached_archetype_pov1_comp1;
+use re_query_cache::query_archetype_pov1_comp1;
 use re_types::{
     archetypes::Points2D,
     components::{Color, InstanceKey, Position2D, Text},
@@ -278,15 +278,12 @@ fn query_and_visit_points(store: &DataStore, paths: &[EntityPath]) -> Vec<SavePo
 
     // TODO(jleibs): Add Radius once we have support for it in field_types
     for path in paths {
-        query_cached_archetype_pov1_comp1::<Points2D, Position2D, Color, _>(
+        query_archetype_pov1_comp1::<Points2D, Position2D, Color, _>(
             store,
             &query.clone().into(),
             path,
-            |it| {
-                let (_, _, positions, colors) = it.next().unwrap();
-                assert!(it.next().is_none());
-
-                itertools::izip!(positions, colors).for_each(|(pos, color)| {
+            |(_, _, positions, colors)| {
+                itertools::izip!(positions.iter(), colors.iter()).for_each(|(pos, color)| {
                     points.push(SavePoint {
                         _pos: *pos,
                         _color: *color,
@@ -311,15 +308,12 @@ fn query_and_visit_strings(store: &DataStore, paths: &[EntityPath]) -> Vec<SaveS
     let mut strings = Vec::with_capacity(NUM_STRINGS as _);
 
     for path in paths {
-        query_cached_archetype_pov1_comp1::<Points2D, Position2D, Text, _>(
+        query_archetype_pov1_comp1::<Points2D, Position2D, Text, _>(
             store,
             &query.clone().into(),
             path,
-            |it| {
-                let (_, _, _, labels) = it.next().unwrap();
-                assert!(it.next().is_none());
-
-                for label in labels {
+            |(_, _, _, labels)| {
+                for label in labels.iter() {
                     strings.push(SaveString {
                         _label: label.clone(),
                     });

--- a/crates/re_query_cache/benches/latest_at.rs
+++ b/crates/re_query_cache/benches/latest_at.rs
@@ -1,0 +1,334 @@
+//! Contains:
+//! - A 1:1 port of the benchmarks in `crates/re_query/benches/query_benchmarks.rs`, with caching enabled.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use itertools::Itertools;
+use re_arrow_store::{DataStore, LatestAtQuery};
+use re_log_types::{entity_path, DataRow, EntityPath, RowId, TimeInt, TimeType, Timeline};
+use re_query_cache::query_cached_archetype_pov1_comp1;
+use re_types::{
+    archetypes::Points2D,
+    components::{Color, InstanceKey, Position2D, Text},
+};
+use re_types_core::Loggable as _;
+
+// ---
+
+// `cargo test` also runs the benchmark setup code, so make sure they run quickly:
+#[cfg(debug_assertions)]
+mod constants {
+    pub const NUM_FRAMES_POINTS: u32 = 1;
+    pub const NUM_POINTS: u32 = 1;
+    pub const NUM_FRAMES_STRINGS: u32 = 1;
+    pub const NUM_STRINGS: u32 = 1;
+}
+
+#[cfg(not(debug_assertions))]
+mod constants {
+    pub const NUM_FRAMES_POINTS: u32 = 1_000;
+    pub const NUM_POINTS: u32 = 1_000;
+    pub const NUM_FRAMES_STRINGS: u32 = 1_000;
+    pub const NUM_STRINGS: u32 = 1_000;
+}
+
+#[allow(clippy::wildcard_imports)]
+use self::constants::*;
+
+// ---
+
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+criterion_group!(
+    benches,
+    mono_points,
+    mono_strings,
+    batch_points,
+    batch_strings
+);
+criterion_main!(benches);
+
+// ---
+
+fn mono_points(c: &mut Criterion) {
+    // Each mono point gets logged at a different path
+    let paths = (0..NUM_POINTS)
+        .map(move |point_idx| entity_path!("points", point_idx.to_string()))
+        .collect_vec();
+    let msgs = build_points_rows(&paths, 1);
+
+    {
+        let mut group = c.benchmark_group("arrow_mono_points2");
+        // Mono-insert is slow -- decrease the sample size
+        group.sample_size(10);
+        group.throughput(criterion::Throughput::Elements(
+            (NUM_POINTS * NUM_FRAMES_POINTS) as _,
+        ));
+        group.bench_function("insert", |b| {
+            b.iter(|| insert_rows(msgs.iter()));
+        });
+    }
+
+    {
+        let mut group = c.benchmark_group("arrow_mono_points2");
+        group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
+        let store = insert_rows(msgs.iter());
+        group.bench_function("query", |b| {
+            b.iter(|| query_and_visit_points(&store, &paths));
+        });
+    }
+}
+
+fn mono_strings(c: &mut Criterion) {
+    // Each mono string gets logged at a different path
+    let paths = (0..NUM_STRINGS)
+        .map(move |string_idx| entity_path!("strings", string_idx.to_string()))
+        .collect_vec();
+    let msgs = build_strings_rows(&paths, 1);
+
+    {
+        let mut group = c.benchmark_group("arrow_mono_strings2");
+        group.sample_size(10);
+        group.throughput(criterion::Throughput::Elements(
+            (NUM_STRINGS * NUM_FRAMES_STRINGS) as _,
+        ));
+        group.bench_function("insert", |b| {
+            b.iter(|| insert_rows(msgs.iter()));
+        });
+    }
+
+    {
+        let mut group = c.benchmark_group("arrow_mono_strings2");
+        group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
+        let store = insert_rows(msgs.iter());
+        group.bench_function("query", |b| {
+            b.iter(|| query_and_visit_strings(&store, &paths));
+        });
+    }
+}
+
+fn batch_points(c: &mut Criterion) {
+    // Batch points are logged together at a single path
+    let paths = [EntityPath::from("points")];
+    let msgs = build_points_rows(&paths, NUM_POINTS as _);
+
+    {
+        let mut group = c.benchmark_group("arrow_batch_points2");
+        group.throughput(criterion::Throughput::Elements(
+            (NUM_POINTS * NUM_FRAMES_POINTS) as _,
+        ));
+        group.bench_function("insert", |b| {
+            b.iter(|| insert_rows(msgs.iter()));
+        });
+    }
+
+    {
+        let mut group = c.benchmark_group("arrow_batch_points2");
+        group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
+        let store = insert_rows(msgs.iter());
+        group.bench_function("query", |b| {
+            b.iter(|| query_and_visit_points(&store, &paths));
+        });
+    }
+}
+
+fn batch_strings(c: &mut Criterion) {
+    // Batch strings are logged together at a single path
+    let paths = [EntityPath::from("points")];
+    let msgs = build_strings_rows(&paths, NUM_STRINGS as _);
+
+    {
+        let mut group = c.benchmark_group("arrow_batch_strings2");
+        group.throughput(criterion::Throughput::Elements(
+            (NUM_STRINGS * NUM_FRAMES_STRINGS) as _,
+        ));
+        group.bench_function("insert", |b| {
+            b.iter(|| insert_rows(msgs.iter()));
+        });
+    }
+
+    {
+        let mut group = c.benchmark_group("arrow_batch_strings2");
+        group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
+        let store = insert_rows(msgs.iter());
+        group.bench_function("query", |b| {
+            b.iter(|| query_and_visit_strings(&store, &paths));
+        });
+    }
+}
+
+// --- Helpers ---
+
+pub fn build_some_point2d(len: usize) -> Vec<Position2D> {
+    use rand::Rng as _;
+    let mut rng = rand::thread_rng();
+
+    (0..len)
+        .map(|_| Position2D::new(rng.gen_range(0.0..10.0), rng.gen_range(0.0..10.0)))
+        .collect()
+}
+
+/// Create `len` dummy colors
+pub fn build_some_colors(len: usize) -> Vec<Color> {
+    (0..len).map(|i| Color::from(i as u32)).collect()
+}
+
+/// Build a ([`Timeline`], [`TimeInt`]) tuple from `frame_nr` suitable for inserting in a [`re_log_types::TimePoint`].
+pub fn build_frame_nr(frame_nr: TimeInt) -> (Timeline, TimeInt) {
+    (Timeline::new("frame_nr", TimeType::Sequence), frame_nr)
+}
+
+pub fn build_some_strings(len: usize) -> Vec<Text> {
+    use rand::Rng as _;
+    let mut rng = rand::thread_rng();
+
+    (0..len)
+        .map(|_| {
+            let ilen: usize = rng.gen_range(0..10000);
+            let s: String = rand::thread_rng()
+                .sample_iter(&rand::distributions::Alphanumeric)
+                .take(ilen)
+                .map(char::from)
+                .collect();
+            Text::from(s)
+        })
+        .collect()
+}
+
+fn build_points_rows(paths: &[EntityPath], num_points: usize) -> Vec<DataRow> {
+    (0..NUM_FRAMES_POINTS)
+        .flat_map(move |frame_idx| {
+            paths.iter().map(move |path| {
+                let mut row = DataRow::from_cells2(
+                    RowId::new(),
+                    path.clone(),
+                    [build_frame_nr((frame_idx as i64).into())],
+                    num_points as _,
+                    (
+                        build_some_point2d(num_points),
+                        build_some_colors(num_points),
+                    ),
+                )
+                .unwrap();
+                // NOTE: Using unsized cells will crash in debug mode, and benchmarks are run for 1 iteration,
+                // in debug mode, by the standard test harness.
+                if cfg!(debug_assertions) {
+                    row.compute_all_size_bytes();
+                }
+                row
+            })
+        })
+        .collect()
+}
+
+fn build_strings_rows(paths: &[EntityPath], num_strings: usize) -> Vec<DataRow> {
+    (0..NUM_FRAMES_STRINGS)
+        .flat_map(move |frame_idx| {
+            paths.iter().map(move |path| {
+                let mut row = DataRow::from_cells2(
+                    RowId::new(),
+                    path.clone(),
+                    [build_frame_nr((frame_idx as i64).into())],
+                    num_strings as _,
+                    // We still need to create points because they are the primary for the
+                    // archetype query we want to do. We won't actually deserialize the points
+                    // during the query -- we just need it for the primary keys.
+                    // TODO(jleibs): switch this to use `TextEntry` once the new type has
+                    // landed.
+                    (
+                        build_some_point2d(num_strings),
+                        build_some_strings(num_strings),
+                    ),
+                )
+                .unwrap();
+                // NOTE: Using unsized cells will crash in debug mode, and benchmarks are run for 1 iteration,
+                // in debug mode, by the standard test harness.
+                if cfg!(debug_assertions) {
+                    row.compute_all_size_bytes();
+                }
+                row
+            })
+        })
+        .collect()
+}
+
+fn insert_rows<'a>(msgs: impl Iterator<Item = &'a DataRow>) -> DataStore {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+    msgs.for_each(|row| {
+        store.insert_row(row).unwrap();
+    });
+    store
+}
+
+struct SavePoint {
+    _pos: Position2D,
+    _color: Option<Color>,
+}
+
+fn query_and_visit_points(store: &DataStore, paths: &[EntityPath]) -> Vec<SavePoint> {
+    let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
+    let query = LatestAtQuery::new(timeline_frame_nr, (NUM_FRAMES_POINTS as i64 / 2).into());
+
+    let mut points = Vec::with_capacity(NUM_POINTS as _);
+
+    // TODO(jleibs): Add Radius once we have support for it in field_types
+    for path in paths {
+        query_cached_archetype_pov1_comp1::<Points2D, Position2D, Color, _>(
+            store,
+            &query.clone().into(),
+            path,
+            |it| {
+                let (_, _, positions, colors) = it.next().unwrap();
+                assert!(it.next().is_none());
+
+                itertools::izip!(positions, colors).for_each(|(pos, color)| {
+                    points.push(SavePoint {
+                        _pos: *pos,
+                        _color: *color,
+                    });
+                });
+            },
+        )
+        .unwrap();
+    }
+    assert_eq!(NUM_POINTS as usize, points.len());
+    points
+}
+
+struct SaveString {
+    _label: Option<Text>,
+}
+
+fn query_and_visit_strings(store: &DataStore, paths: &[EntityPath]) -> Vec<SaveString> {
+    let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
+    let query = LatestAtQuery::new(timeline_frame_nr, (NUM_FRAMES_STRINGS as i64 / 2).into());
+
+    let mut strings = Vec::with_capacity(NUM_STRINGS as _);
+
+    for path in paths {
+        query_cached_archetype_pov1_comp1::<Points2D, Position2D, Text, _>(
+            store,
+            &query.clone().into(),
+            path,
+            |it| {
+                let (_, _, _, labels) = it.next().unwrap();
+                assert!(it.next().is_none());
+
+                for label in labels {
+                    strings.push(SaveString {
+                        _label: label.clone(),
+                    });
+                }
+            },
+        )
+        .unwrap();
+    }
+    assert_eq!(NUM_STRINGS as usize, strings.len());
+
+    criterion::black_box(strings)
+}

--- a/crates/re_query_cache/benches/latest_at.rs
+++ b/crates/re_query_cache/benches/latest_at.rs
@@ -54,7 +54,7 @@ criterion_main!(benches);
 fn mono_points(c: &mut Criterion) {
     // Each mono point gets logged at a different path
     let paths = (0..NUM_POINTS)
-        .map(move |point_idx| entity_path!("points", point_idx.to_string()))
+        .map(move |point_idx| entity_path!("points", point_idx))
         .collect_vec();
     let msgs = build_points_rows(&paths, 1);
 
@@ -83,7 +83,7 @@ fn mono_points(c: &mut Criterion) {
 fn mono_strings(c: &mut Criterion) {
     // Each mono string gets logged at a different path
     let paths = (0..NUM_STRINGS)
-        .map(move |string_idx| entity_path!("strings", string_idx.to_string()))
+        .map(move |string_idx| entity_path!("strings", string_idx))
         .collect_vec();
     let msgs = build_strings_rows(&paths, 1);
 

--- a/crates/re_query_cache/benches/latest_at.rs
+++ b/crates/re_query_cache/benches/latest_at.rs
@@ -4,7 +4,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use itertools::Itertools;
-use re_arrow_store::{DataStore, LatestAtQuery};
+use re_data_store::{DataStore, LatestAtQuery};
 use re_log_types::{entity_path, DataRow, EntityPath, RowId, TimeInt, TimeType, Timeline};
 use re_query_cache::query_cached_archetype_pov1_comp1;
 use re_types::{

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -1,0 +1,364 @@
+use std::{
+    collections::{BTreeMap, VecDeque},
+    sync::Arc,
+};
+
+use ahash::HashMap;
+use itertools::Either;
+use once_cell::sync::Lazy;
+use parking_lot::RwLock;
+use paste::paste;
+use seq_macro::seq;
+
+use re_arrow_store::LatestAtQuery;
+use re_log_types::{EntityPath, RowId, StoreId, TimeInt, Timeline};
+use re_query::ArchetypeView;
+use re_types_core::{components::InstanceKey, Archetype, ArchetypeName, Component, ComponentName};
+
+use crate::{ErasedFlatVecDeque, FlatVecDeque};
+
+// ---
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AnyQuery {
+    LatestAtQuery(LatestAtQuery),
+    // TODO(cmc): range queries support.
+}
+
+impl From<LatestAtQuery> for AnyQuery {
+    fn from(query: LatestAtQuery) -> Self {
+        Self::LatestAtQuery(query)
+    }
+}
+
+// ---
+
+// TODO(cmc): Centralize and harmonize all caches (query, jpeg, mesh).
+static CACHES: Lazy<Caches> = Lazy::new(Caches::default);
+
+/// Maintains the top-level cache mappings.
+//
+// TODO(cmc): Store subscriber and cache invalidation.
+// TODO(cmc): SizeBytes support + size stats + mem panel
+// TODO(cmc): timeless caching support
+#[derive(Default)]
+pub struct Caches {
+    latest_at: RwLock<HashMap<CacheKey, Arc<RwLock<LatestAtCache>>>>,
+}
+
+impl Caches {
+    /// Clears all caches.
+    //
+    // TODO(cmc): expose palette command.
+    #[inline]
+    pub fn clear() {
+        let Caches { latest_at } = &*CACHES;
+        latest_at.write().clear();
+    }
+
+    /// Gives write access to the appropriate [`LatestAtCache`] according to the specified
+    /// query parameters.
+    #[inline]
+    pub fn with_latest_at<A, F, R>(
+        store_id: StoreId,
+        entity_path: EntityPath,
+        query: &LatestAtQuery,
+        mut f: F,
+    ) -> R
+    where
+        A: Archetype,
+        F: FnMut(&mut LatestAtCache) -> R,
+    {
+        let key = CacheKey::new(store_id, entity_path, query.timeline, A::name());
+
+        // We want to make sure we release the lock on the top-level cache map ASAP.
+        let cache = {
+            let mut caches = CACHES.latest_at.write();
+            let latest_at_cache = caches.entry(key).or_default();
+            Arc::clone(latest_at_cache)
+        };
+
+        let mut cache = cache.write();
+        f(&mut cache)
+    }
+}
+
+/// Uniquely identifies cached query results in the [`Caches`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CacheKey {
+    /// Which [`re_arrow_store::DataStore`] is the query targeting?
+    pub store_id: StoreId,
+
+    /// Which [`EntityPath`] is the query targeting?
+    pub entity_path: EntityPath,
+
+    /// Which [`Timeline`] is the query targeting?
+    pub timeline: Timeline,
+
+    /// Which [`Archetype`] are we querying for?
+    ///
+    /// This is very important because of our data model: we not only query for components, but we
+    /// query for components from a specific point-of-view (the so-called primary component).
+    /// Different archetypes have different point-of-views, and therefore can end up with different
+    /// results, even from the same raw data.
+    //
+    // TODO(cmc): At some point we should probably just store the PoV and optional components rather
+    // than an `ArchetypeName`: the query system doesn't care about archetypes.
+    pub archetype_name: ArchetypeName,
+}
+
+impl CacheKey {
+    #[inline]
+    pub fn new(
+        store_id: impl Into<StoreId>,
+        entity_path: impl Into<EntityPath>,
+        timeline: impl Into<Timeline>,
+        archetype_name: impl Into<ArchetypeName>,
+    ) -> Self {
+        Self {
+            store_id: store_id.into(),
+            entity_path: entity_path.into(),
+            timeline: timeline.into(),
+            archetype_name: archetype_name.into(),
+        }
+    }
+}
+
+// ---
+
+/// Caches the results of any query for an arbitrary range of time.
+///
+/// This caches all the steps involved in getting data ready for space views:
+/// - index search,
+/// - instance key joining,
+/// - deserialization.
+///
+/// We share the `CacheBucket` implementation between all types of queries to avoid duplication of
+/// logic, especially for things that require metaprogramming, to keep the macro madness to a
+/// minimum.
+/// In the case of `LatestAt` queries, a `CacheBucket` will always contain a single timestamp worth
+/// of data.
+#[derive(Default)]
+pub struct CacheBucket {
+    /// The timestamps and [`RowId`]s of all cached rows.
+    ///
+    /// Reminder: within a single timestamp, rows are sorted according to their [`RowId`]s.
+    pub(crate) pov_times: VecDeque<(TimeInt, RowId)>,
+
+    /// The [`InstanceKey`]s of the point-of-view components.
+    pub(crate) pov_instance_keys: FlatVecDeque<InstanceKey>,
+
+    /// The resulting component data, pre-deserialized, pre-joined.
+    //
+    // TODO(cmc): Don't denormalize auto-generated instance keys.
+    // TODO(cmc): Don't denormalize splatted values.
+    pub(crate) components: BTreeMap<ComponentName, Box<dyn ErasedFlatVecDeque + Send + Sync>>,
+    //
+    // TODO(cmc): secondary cache
+    // TODO(cmc): size stats: this requires codegen'ing SizeBytes for all components!
+}
+
+impl CacheBucket {
+    /// Iterate over the timestamps of the point-of-view components.
+    #[inline]
+    pub fn iter_pov_times(&self) -> impl Iterator<Item = &(TimeInt, RowId)> {
+        self.pov_times.iter()
+    }
+
+    /// Iterate over the [`InstanceKey`] batches of the point-of-view components.
+    #[inline]
+    pub fn iter_pov_instance_keys(&self) -> impl Iterator<Item = &[InstanceKey]> {
+        self.pov_instance_keys.iter()
+    }
+
+    /// Iterate over the batches of the specified non-optional component.
+    #[inline]
+    pub fn iter_component<C: Component + Send + Sync + 'static>(
+        &self,
+    ) -> re_query::Result<impl Iterator<Item = &[C]>> {
+        let data = self
+            .components
+            .get(&C::name())
+            .map(|data| data.as_any().downcast_ref::<FlatVecDeque<C>>())
+            .ok_or_else(|| re_query::QueryError::RequiredComponentNotFound(C::name()))?;
+
+        let Some(data) = data else {
+            return Ok(Either::Left(std::iter::empty()));
+        };
+
+        Ok(Either::Right(data.iter()))
+    }
+
+    /// Iterate over the batches of the specified optional component.
+    #[inline]
+    pub fn iter_component_opt<C: Component + Send + Sync + 'static>(
+        &self,
+    ) -> re_query::Result<impl Iterator<Item = &[Option<C>]>> {
+        let data = self
+            .components
+            .get(&C::name())
+            .map(|data| data.as_any().downcast_ref::<FlatVecDeque<Option<C>>>())
+            .ok_or_else(|| re_query::QueryError::ComponentNotFound(C::name()))?;
+
+        let Some(data) = data else {
+            return Ok(Either::Left(std::iter::empty()));
+        };
+
+        Ok(Either::Right(data.iter()))
+    }
+
+    /// How many timestamps' worth of data is stored in this bucket?
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.pov_times.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+macro_rules! impl_insert {
+    (for N=$N:expr, M=$M:expr => povs=[$($pov:ident)+] comps=[$($comp:ident)*]) => { paste! {
+        #[doc = "Inserts the contents of the given [`ArchetypeView`], which are made of the specified"]
+        #[doc = "`" $N "` point-of-view components and `" $M "` optional components, to the cache."]
+        #[doc = ""]
+        #[doc = "`query_time` must be the time of query, _not_ of the resulting data."]
+        pub fn [<insert_pov$N _comp$M>]<A, $($pov,)+ $($comp),*>(
+            &mut self,
+            query_time: TimeInt,
+            arch_view: &ArchetypeView<A>,
+        ) -> ::re_query::Result<()>
+        where
+            A: Archetype,
+            $($pov: Component + Send + Sync + 'static,)+
+            $($comp: Component + Send + Sync + 'static,)*
+        {
+            // NOTE: not `profile_function!` because we want them merged together.
+            re_tracing::profile_scope!("CacheBucket::insert_povN_compM", format!("arch={} pov={} comp={}", A::name(), $N, $M));
+
+            let Self {
+                pov_times,
+                pov_instance_keys,
+                components: _,
+            } = self;
+
+            let pov_row_id = arch_view.primary_row_id();
+            let index = pov_times.partition_point(|t| t < &(query_time, pov_row_id));
+
+            pov_times.insert(index, (query_time, pov_row_id));
+            pov_instance_keys.insert(index, arch_view.iter_instance_keys());
+            $(self.insert_component::<A, $pov>(index, arch_view)?;)+
+            $(self.insert_component_opt::<A, $comp>(index, arch_view)?;)*
+
+            Ok(())
+        } }
+    };
+
+    // TODO(cmc): Supporting N>1 generically is quite painful due to limitations in declarative macros,
+    // not that we care at the moment.
+    (for N=1, M=$M:expr) => {
+        seq!(COMP in 1..=$M {
+            impl_insert!(for N=1, M=$M => povs=[R1] comps=[#(C~COMP)*]);
+        });
+    };
+}
+
+impl CacheBucket {
+    /// Alias for [`Self::insert_pov1_comp0`].
+    #[inline]
+    #[allow(dead_code)]
+    fn insert_pov1<A, R1>(
+        &mut self,
+        query_time: TimeInt,
+        arch_view: &ArchetypeView<A>,
+    ) -> ::re_query::Result<()>
+    where
+        A: Archetype,
+        R1: Component + Send + Sync + 'static,
+    {
+        self.insert_pov1_comp0::<A, R1>(query_time, arch_view)
+    }
+
+    seq!(NUM_COMP in 0..10 {
+        impl_insert!(for N=1, M=NUM_COMP);
+    });
+
+    #[inline]
+    fn insert_component<A: Archetype, C: Component + Send + Sync + 'static>(
+        &mut self,
+        at: usize,
+        arch_view: &ArchetypeView<A>,
+    ) -> re_query::Result<()> {
+        re_tracing::profile_function!(C::name());
+
+        let data = self
+            .components
+            .entry(C::name())
+            .or_insert_with(|| Box::new(FlatVecDeque::<C>::new()));
+
+        // NOTE: downcast cannot fail, we create it just above.
+        let data = data.as_any_mut().downcast_mut::<FlatVecDeque<C>>().unwrap();
+        data.insert(at, arch_view.iter_required_component::<C>()?);
+
+        Ok(())
+    }
+
+    #[inline]
+    fn insert_component_opt<A: Archetype, C: Component + Send + Sync + 'static>(
+        &mut self,
+        at: usize,
+        arch_view: &ArchetypeView<A>,
+    ) -> re_query::Result<()> {
+        re_tracing::profile_function!(C::name());
+
+        let data = self
+            .components
+            .entry(C::name())
+            .or_insert_with(|| Box::new(FlatVecDeque::<Option<C>>::new()));
+
+        // NOTE: downcast cannot fail, we create it just above.
+        let data = data
+            .as_any_mut()
+            .downcast_mut::<FlatVecDeque<Option<C>>>()
+            .unwrap();
+        data.insert(at, arch_view.iter_optional_component::<C>()?);
+
+        Ok(())
+    }
+}
+
+// ---
+
+// NOTE: Because we're working with deserialized data, everything has to be done with metaprogramming,
+// which is notoriously painful in Rust (i.e., macros).
+// For this reason we move as much of the code as possible into the already existing macros in `query.rs`.
+
+/// Caches the results of `LatestAt` queries.
+///
+/// The `TimeInt` in the index corresponds to the timestamp of the query, _not_ the timestamp of
+/// the resulting data!
+//
+// TODO(cmc): we need an extra indirection layer so that cached entries can be shared across
+// queries with different query timestamps but identical data timestamps.
+// This requires keeping track of all `RowId`s in `ArchetypeView`, not just the `RowId` of the
+// point-of-view component.
+#[derive(Default)]
+pub struct LatestAtCache(BTreeMap<TimeInt, CacheBucket>);
+
+impl std::ops::Deref for LatestAtCache {
+    type Target = BTreeMap<TimeInt, CacheBucket>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for LatestAtCache {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -10,7 +10,7 @@ use parking_lot::RwLock;
 use paste::paste;
 use seq_macro::seq;
 
-use re_arrow_store::LatestAtQuery;
+use re_data_store::LatestAtQuery;
 use re_log_types::{EntityPath, RowId, StoreId, TimeInt, Timeline};
 use re_query::ArchetypeView;
 use re_types_core::{components::InstanceKey, Archetype, ArchetypeName, Component, ComponentName};
@@ -86,7 +86,7 @@ impl Caches {
 /// Uniquely identifies cached query results in the [`Caches`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CacheKey {
-    /// Which [`re_arrow_store::DataStore`] is the query targeting?
+    /// Which [`re_data_store::DataStore`] is the query targeting?
     pub store_id: StoreId,
 
     /// Which [`EntityPath`] is the query targeting?

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -39,7 +39,7 @@ static CACHES: Lazy<Caches> = Lazy::new(Caches::default);
 /// Maintains the top-level cache mappings.
 //
 // TODO(cmc): Store subscriber and cache invalidation.
-// TODO(cmc): SizeBytes support + size stats + mem panel
+// TODO(#4730): SizeBytes support + size stats + mem panel
 // TODO(cmc): timeless caching support
 #[derive(Default)]
 pub struct Caches {
@@ -49,7 +49,7 @@ pub struct Caches {
 impl Caches {
     /// Clears all caches.
     //
-    // TODO(cmc): expose palette command.
+    // TODO(#4731): expose palette command.
     #[inline]
     pub fn clear() {
         let Caches { latest_at } = &*CACHES;
@@ -150,12 +150,12 @@ pub struct CacheBucket {
 
     /// The resulting component data, pre-deserialized, pre-joined.
     //
-    // TODO(cmc): Don't denormalize auto-generated instance keys.
-    // TODO(cmc): Don't denormalize splatted values.
+    // TODO(#4733): Don't denormalize auto-generated instance keys.
+    // TODO(#4734): Don't denormalize splatted values.
     pub(crate) components: BTreeMap<ComponentName, Box<dyn ErasedFlatVecDeque + Send + Sync>>,
     //
     // TODO(cmc): secondary cache
-    // TODO(cmc): size stats: this requires codegen'ing SizeBytes for all components!
+    // TODO(#4730): size stats: this requires codegen'ing SizeBytes for all components!
 }
 
 impl CacheBucket {
@@ -209,13 +209,13 @@ impl CacheBucket {
 
     /// How many timestamps' worth of data is stored in this bucket?
     #[inline]
-    pub fn len(&self) -> usize {
+    pub fn num_entries(&self) -> usize {
         self.pov_times.len()
     }
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.num_entries() == 0
     }
 }
 

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -21,13 +21,13 @@ use crate::{ErasedFlatVecDeque, FlatVecDeque};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AnyQuery {
-    LatestAtQuery(LatestAtQuery),
+    LatestAt(LatestAtQuery),
     // TODO(cmc): range queries support.
 }
 
 impl From<LatestAtQuery> for AnyQuery {
     fn from(query: LatestAtQuery) -> Self {
-        Self::LatestAtQuery(query)
+        Self::LatestAt(query)
     }
 }
 
@@ -236,7 +236,7 @@ macro_rules! impl_insert {
             $($comp: Component + Send + Sync + 'static,)*
         {
             // NOTE: not `profile_function!` because we want them merged together.
-            re_tracing::profile_scope!("CacheBucket::insert_povN_compM", format!("arch={} pov={} comp={}", A::name(), $N, $M));
+            re_tracing::profile_scope!("CacheBucket::insert", format!("arch={} pov={} comp={}", A::name(), $N, $M));
 
             let Self {
                 pov_times,

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -56,7 +56,7 @@ impl Caches {
         latest_at.write().clear();
     }
 
-    /// Gives write access to the appropriate [`LatestAtCache`] according to the specified
+    /// Gives write access to the appropriate `LatestAtCache` according to the specified
     /// query parameters.
     #[inline]
     pub fn with_latest_at<A, F, R>(

--- a/crates/re_query_cache/src/lib.rs
+++ b/crates/re_query_cache/src/lib.rs
@@ -2,9 +2,20 @@
 
 mod cache;
 mod flat_vec_deque;
+mod query;
 
 pub use self::cache::{AnyQuery, Caches};
 pub use self::flat_vec_deque::{ErasedFlatVecDeque, FlatVecDeque};
+pub use self::query::{query_cached_archetype_pov1, query_cached_archetype_with_history_pov1};
+
+// TODO(cmc): Supporting N>1 generically is quite painful due to limitations in declarative macros,
+// not that we care at the moment.
+seq_macro::seq!(NUM_COMP in 0..10 { paste::paste! {
+    pub use self::query::{#(
+        query_cached_archetype_pov1_comp~NUM_COMP,
+        query_cached_archetype_with_history_pov1_comp~NUM_COMP,
+    )*};
+}});
 
 pub mod external {
     pub use re_query;

--- a/crates/re_query_cache/src/lib.rs
+++ b/crates/re_query_cache/src/lib.rs
@@ -1,7 +1,9 @@
 //! Caching datastructures for `re_query`.
 
+mod cache;
 mod flat_vec_deque;
 
+pub use self::cache::{AnyQuery, Caches};
 pub use self::flat_vec_deque::{ErasedFlatVecDeque, FlatVecDeque};
 
 pub mod external {

--- a/crates/re_query_cache/src/lib.rs
+++ b/crates/re_query_cache/src/lib.rs
@@ -6,17 +6,22 @@ mod query;
 
 pub use self::cache::{AnyQuery, Caches};
 pub use self::flat_vec_deque::{ErasedFlatVecDeque, FlatVecDeque};
-pub use self::query::{query_cached_archetype_pov1, query_cached_archetype_with_history_pov1};
+pub use self::query::{
+    query_archetype_pov1, query_archetype_with_history_pov1, MaybeCachedComponentData,
+};
 
 // TODO(cmc): Supporting N>1 generically is quite painful due to limitations in declarative macros,
 // not that we care at the moment.
 seq_macro::seq!(NUM_COMP in 0..10 { paste::paste! {
     pub use self::query::{#(
-        query_cached_archetype_pov1_comp~NUM_COMP,
-        query_cached_archetype_with_history_pov1_comp~NUM_COMP,
+        query_archetype_pov1_comp~NUM_COMP,
+        query_archetype_with_history_pov1_comp~NUM_COMP,
     )*};
 }});
 
 pub mod external {
     pub use re_query;
+
+    pub use paste;
+    pub use seq_macro;
 }

--- a/crates/re_query_cache/src/lib.rs
+++ b/crates/re_query_cache/src/lib.rs
@@ -10,6 +10,8 @@ pub use self::query::{
     query_archetype_pov1, query_archetype_with_history_pov1, MaybeCachedComponentData,
 };
 
+pub(crate) use self::cache::LatestAtCache;
+
 // TODO(cmc): Supporting N>1 generically is quite painful due to limitations in declarative macros,
 // not that we care at the moment.
 seq_macro::seq!(NUM_COMP in 0..10 { paste::paste! {

--- a/crates/re_query_cache/src/query.rs
+++ b/crates/re_query_cache/src/query.rs
@@ -1,8 +1,8 @@
 use paste::paste;
 use seq_macro::seq;
 
-use re_arrow_store::{DataStore, LatestAtQuery, TimeInt, Timeline};
-use re_data_store::{ExtraQueryHistory, VisibleHistory};
+use re_data_store::{DataStore, LatestAtQuery, TimeInt, Timeline};
+use re_entity_db::{ExtraQueryHistory, VisibleHistory};
 use re_log_types::{EntityPath, RowId};
 use re_query::query_archetype;
 use re_types_core::{components::InstanceKey, Archetype, Component};

--- a/crates/re_query_cache/src/query.rs
+++ b/crates/re_query_cache/src/query.rs
@@ -11,12 +11,43 @@ use crate::{AnyQuery, Caches};
 
 // ---
 
+/// Either a reference to a slice of data residing in the cache, or some data being deserialized
+/// just-in-time from an [`re_query::ArchetypeView`].
+#[derive(Debug, Clone)]
+pub enum MaybeCachedComponentData<'a, C> {
+    Cached(&'a [C]),
+    // TODO(cmc): Ideally, this would be a reference to a `dyn Iterator` that is the result of
+    // calling `ArchetypeView::iter_{required|optional}_component`.
+    // In practice this enters lifetime invariance hell for, from what I can see, no particular gains.
+    Raw(Vec<C>),
+}
+
+impl<'a, C: Clone> MaybeCachedComponentData<'a, C> {
+    #[inline]
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &C> + '_ {
+        match self {
+            MaybeCachedComponentData::Cached(data) => itertools::Either::Left(data.iter()),
+            MaybeCachedComponentData::Raw(data) => itertools::Either::Right(data.iter()),
+        }
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[C] {
+        match self {
+            MaybeCachedComponentData::Cached(data) => data,
+            MaybeCachedComponentData::Raw(data) => data.as_slice(),
+        }
+    }
+}
+
+// ---
+
 /// Cached implementation of [`re_query::query_archetype`] and [`re_query::range_archetype`]
 /// (combined) for 1 point-of-view component and no optional components.
 ///
-/// Alias for [`query_cached_archetype_pov1_comp0`].
+/// Alias for [`query_archetype_pov1_comp0`].
 #[inline]
-pub fn query_cached_archetype_pov1<'a, A, R1, F>(
+pub fn query_archetype_pov1<'a, A, R1, F>(
     store: &'a DataStore,
     query: &AnyQuery,
     entity_path: &'a EntityPath,
@@ -25,16 +56,23 @@ pub fn query_cached_archetype_pov1<'a, A, R1, F>(
 where
     A: Archetype + 'a,
     R1: Component + Send + Sync + 'static,
-    F: FnMut(&mut dyn Iterator<Item = (&(TimeInt, RowId), &[InstanceKey], &[R1])>),
+    F: FnMut(
+        (
+            (TimeInt, RowId),
+            MaybeCachedComponentData<'_, InstanceKey>,
+            MaybeCachedComponentData<'_, R1>,
+        ),
+    ),
 {
-    query_cached_archetype_pov1_comp0::<A, R1, F>(store, query, entity_path, f)
+    query_archetype_pov1_comp0::<A, R1, F>(store, query, entity_path, f)
 }
 
-macro_rules! impl_query_cached_archetype {
+macro_rules! impl_query_archetype {
     (for N=$N:expr, M=$M:expr => povs=[$($pov:ident)+] comps=[$($comp:ident)*]) => { paste! {
         #[doc = "Cached implementation of [`re_query::query_archetype`] and [`re_query::range_archetype`]"]
-        #[doc = "(combined) `" $N "` point-of-view components and `" $M "` optional components."]
-        pub fn [<query_cached_archetype_pov$N _comp$M>]<'a, A, $($pov,)+ $($comp,)* F>(
+        #[doc = "(combined) for `" $N "` point-of-view components and `" $M "` optional components."]
+        #[allow(non_snake_case)]
+        pub fn [<query_archetype_pov$N _comp$M>]<'a, A, $($pov,)+ $($comp,)* F>(
             store: &'a DataStore,
             query: &AnyQuery,
             entity_path: &'a EntityPath,
@@ -45,24 +83,22 @@ macro_rules! impl_query_cached_archetype {
             $($pov: Component + Send + Sync + 'static,)+
             $($comp: Component + Send + Sync + 'static,)*
             F: FnMut(
-                &mut dyn Iterator<
-                    Item = (
-                        &(TimeInt, RowId),
-                        &[InstanceKey],
-                        $(&[$pov],)+
-                        $(&[Option<$comp>],)*
-                    ),
-                >,
+                (
+                    (TimeInt, RowId),
+                    MaybeCachedComponentData<'_, InstanceKey>,
+                    $(MaybeCachedComponentData<'_, $pov>,)+
+                    $(MaybeCachedComponentData<'_, Option<$comp>>,)*
+                ),
             ),
         {
             // NOTE: not `profile_function!` because we want them merged together.
             re_tracing::profile_scope!(
-                "query_cached_archetype_povN_compM",
+                "query_archetype",
                 format!("arch={} pov={} comp={}", A::name(), $N, $M)
             );
 
             match &query {
-                AnyQuery::LatestAtQuery(query) => {
+                AnyQuery::LatestAt(query) => {
                     Caches::with_latest_at::<A, _, _>(
                         store.id().clone(),
                         entity_path.clone(),
@@ -89,14 +125,23 @@ macro_rules! impl_query_cached_archetype {
                                 );
                             }
 
-                            let mut it = itertools::izip!(
+                            let it = itertools::izip!(
                                 bucket.iter_pov_times(),
                                 bucket.iter_pov_instance_keys(),
                                 $(bucket.iter_component::<$pov>()?,)+
                                 $(bucket.iter_component_opt::<$comp>()?,)*
-                            );
+                            ).map(|(time, instance_keys, $($pov,)+ $($comp,)*)| {
+                                (
+                                    *time,
+                                    MaybeCachedComponentData::Cached(instance_keys),
+                                    $(MaybeCachedComponentData::Cached($pov),)+
+                                    $(MaybeCachedComponentData::Cached($comp),)*
+                                )
+                            });
 
-                            f(&mut it);
+                            for data in it {
+                                f(data);
+                            }
 
                             Ok(())
                         }
@@ -110,13 +155,13 @@ macro_rules! impl_query_cached_archetype {
     // not that we care at the moment.
     (for N=1, M=$M:expr) => {
         seq!(COMP in 1..=$M {
-            impl_query_cached_archetype!(for N=1, M=$M => povs=[R1] comps=[#(C~COMP)*]);
+            impl_query_archetype!(for N=1, M=$M => povs=[R1] comps=[#(C~COMP)*]);
         });
     };
 }
 
 seq!(NUM_COMP in 0..10 {
-    impl_query_cached_archetype!(for N=1, M=NUM_COMP);
+    impl_query_archetype!(for N=1, M=NUM_COMP);
 });
 
 // ---
@@ -124,9 +169,9 @@ seq!(NUM_COMP in 0..10 {
 /// Cached implementation of [`re_query::query_archetype_with_history`] for 1 point-of-view component
 /// and no optional components.
 ///
-/// Alias for [`query_cached_archetype_with_history_pov1_comp0`].
+/// Alias for [`query_archetype_with_history_pov1_comp0`].
 #[inline]
-pub fn query_cached_archetype_with_history_pov1<'a, A, R1, F>(
+pub fn query_archetype_with_history_pov1<'a, A, R1, F>(
     store: &'a DataStore,
     timeline: &'a Timeline,
     time: &'a TimeInt,
@@ -137,20 +182,24 @@ pub fn query_cached_archetype_with_history_pov1<'a, A, R1, F>(
 where
     A: Archetype + 'a,
     R1: Component + Send + Sync + 'static,
-    F: FnMut(&mut dyn Iterator<Item = (&(TimeInt, RowId), &[InstanceKey], &[R1])>),
+    F: FnMut(
+        (
+            (TimeInt, RowId),
+            MaybeCachedComponentData<'_, InstanceKey>,
+            MaybeCachedComponentData<'_, R1>,
+        ),
+    ),
 {
-    query_cached_archetype_with_history_pov1_comp0::<A, R1, F>(
-        store, timeline, time, history, ent_path, f,
-    )
+    query_archetype_with_history_pov1_comp0::<A, R1, F>(store, timeline, time, history, ent_path, f)
 }
 
 /// Generates a function to cache a (potentially historical) query with N point-of-view components and M
 /// other components.
-macro_rules! impl_query_cached_archetype_with_history {
+macro_rules! impl_query_archetype_with_history {
     (for N=$N:expr, M=$M:expr => povs=[$($pov:ident)+] comps=[$($comp:ident)*]) => { paste! {
         #[doc = "Cached implementation of [`re_query::query_archetype_with_history`] for `" $N "` point-of-view"]
         #[doc = "components and `" $M "` optional components."]
-        pub fn [<query_cached_archetype_with_history_pov$N _comp$M>]<'a, A, $($pov,)+ $($comp,)* F>(
+        pub fn [<query_archetype_with_history_pov$N _comp$M>]<'a, A, $($pov,)+ $($comp,)* F>(
             store: &'a DataStore,
             timeline: &'a Timeline,
             time: &'a TimeInt,
@@ -163,19 +212,17 @@ macro_rules! impl_query_cached_archetype_with_history {
             $($pov: Component + Send + Sync + 'static,)+
             $($comp: Component + Send + Sync + 'static,)*
             F: FnMut(
-                &mut dyn Iterator<
-                    Item = (
-                        &(TimeInt, RowId),
-                        &[InstanceKey],
-                        $(&[$pov],)+
-                        $(&[Option<$comp>],)*
-                    ),
-                >,
+                (
+                    (TimeInt, RowId),
+                    MaybeCachedComponentData<'_, InstanceKey>,
+                    $(MaybeCachedComponentData<'_, $pov>,)+
+                    $(MaybeCachedComponentData<'_, Option<$comp>>,)*
+                ),
             ),
         {
             // NOTE: not `profile_function!` because we want them merged together.
             re_tracing::profile_scope!(
-                "query_cached_archetype_with_history_povN_compM",
+                "query_archetype_with_history",
                 format!("arch={} pov={} comp={}", A::name(), $N, $M)
             );
 
@@ -186,7 +233,7 @@ macro_rules! impl_query_cached_archetype_with_history {
 
             if !history.enabled || visible_history == VisibleHistory::OFF {
                 let query = LatestAtQuery::new(*timeline, *time);
-                $crate::[<query_cached_archetype_pov$N _comp$M>]::<A, $($pov,)+ $($comp,)* _>(
+                $crate::[<query_archetype_pov$N _comp$M>]::<A, $($pov,)+ $($comp,)* _>(
                     store,
                     &query.clone().into(),
                     ent_path,
@@ -202,11 +249,11 @@ macro_rules! impl_query_cached_archetype_with_history {
     // not that we care at the moment.
     (for N=1, M=$M:expr) => {
         seq!(COMP in 1..=$M {
-            impl_query_cached_archetype_with_history!(for N=1, M=$M => povs=[R1] comps=[#(C~COMP)*]);
+            impl_query_archetype_with_history!(for N=1, M=$M => povs=[R1] comps=[#(C~COMP)*]);
         });
     };
 }
 
 seq!(NUM_COMP in 0..10 {
-    impl_query_cached_archetype_with_history!(for N=1, M=NUM_COMP);
+    impl_query_archetype_with_history!(for N=1, M=NUM_COMP);
 });

--- a/crates/re_query_cache/src/query.rs
+++ b/crates/re_query_cache/src/query.rs
@@ -1,0 +1,212 @@
+use paste::paste;
+use seq_macro::seq;
+
+use re_arrow_store::{DataStore, LatestAtQuery, TimeInt, Timeline};
+use re_data_store::{ExtraQueryHistory, VisibleHistory};
+use re_log_types::{EntityPath, RowId};
+use re_query::query_archetype;
+use re_types_core::{components::InstanceKey, Archetype, Component};
+
+use crate::{AnyQuery, Caches};
+
+// ---
+
+/// Cached implementation of [`re_query::query_archetype`] and [`re_query::range_archetype`]
+/// (combined) for 1 point-of-view component and no optional components.
+///
+/// Alias for [`query_cached_archetype_pov1_comp0`].
+#[inline]
+pub fn query_cached_archetype_pov1<'a, A, R1, F>(
+    store: &'a DataStore,
+    query: &AnyQuery,
+    entity_path: &'a EntityPath,
+    f: F,
+) -> ::re_query::Result<()>
+where
+    A: Archetype + 'a,
+    R1: Component + Send + Sync + 'static,
+    F: FnMut(&mut dyn Iterator<Item = (&(TimeInt, RowId), &[InstanceKey], &[R1])>),
+{
+    query_cached_archetype_pov1_comp0::<A, R1, F>(store, query, entity_path, f)
+}
+
+macro_rules! impl_query_cached_archetype {
+    (for N=$N:expr, M=$M:expr => povs=[$($pov:ident)+] comps=[$($comp:ident)*]) => { paste! {
+        #[doc = "Cached implementation of [`re_query::query_archetype`] and [`re_query::range_archetype`]"]
+        #[doc = "(combined) `" $N "` point-of-view components and `" $M "` optional components."]
+        pub fn [<query_cached_archetype_pov$N _comp$M>]<'a, A, $($pov,)+ $($comp,)* F>(
+            store: &'a DataStore,
+            query: &AnyQuery,
+            entity_path: &'a EntityPath,
+            mut f: F,
+        ) -> ::re_query::Result<()>
+        where
+            A: Archetype + 'a,
+            $($pov: Component + Send + Sync + 'static,)+
+            $($comp: Component + Send + Sync + 'static,)*
+            F: FnMut(
+                &mut dyn Iterator<
+                    Item = (
+                        &(TimeInt, RowId),
+                        &[InstanceKey],
+                        $(&[$pov],)+
+                        $(&[Option<$comp>],)*
+                    ),
+                >,
+            ),
+        {
+            // NOTE: not `profile_function!` because we want them merged together.
+            re_tracing::profile_scope!(
+                "query_cached_archetype_povN_compM",
+                format!("arch={} pov={} comp={}", A::name(), $N, $M)
+            );
+
+            match &query {
+                AnyQuery::LatestAtQuery(query) => {
+                    Caches::with_latest_at::<A, _, _>(
+                        store.id().clone(),
+                        entity_path.clone(),
+                        query,
+                        |cache| {
+                            re_tracing::profile_scope!("latest_at");
+
+                             let bucket = cache.entry(query.at).or_default();
+                            // NOTE: Implicitly dropping the write guard here: the LatestAtCache is
+                            // free once again!
+
+                            if bucket.is_empty() {
+                                let now = web_time::Instant::now();
+                                let arch_view = query_archetype::<A>(store, &query, entity_path)?;
+
+                                bucket.[<insert_pov $N _comp$M>]::<A, $($pov,)+ $($comp,)*>(query.at, &arch_view)?;
+
+                                // TODO(cmc): I'd love a way of putting this information into
+                                // the `puffin` span directly.
+                                let elapsed = now.elapsed();
+                                ::re_log::trace!(
+                                    "cached new entry in {elapsed:?} ({:0.3} entries/s)",
+                                    1f64 / elapsed.as_secs_f64()
+                                );
+                            }
+
+                            let mut it = itertools::izip!(
+                                bucket.iter_pov_times(),
+                                bucket.iter_pov_instance_keys(),
+                                $(bucket.iter_component::<$pov>()?,)+
+                                $(bucket.iter_component_opt::<$comp>()?,)*
+                            );
+
+                            f(&mut it);
+
+                            Ok(())
+                        }
+                    )
+                },
+            }
+        } }
+    };
+
+    // TODO(cmc): Supporting N>1 generically is quite painful due to limitations in declarative macros,
+    // not that we care at the moment.
+    (for N=1, M=$M:expr) => {
+        seq!(COMP in 1..=$M {
+            impl_query_cached_archetype!(for N=1, M=$M => povs=[R1] comps=[#(C~COMP)*]);
+        });
+    };
+}
+
+seq!(NUM_COMP in 0..10 {
+    impl_query_cached_archetype!(for N=1, M=NUM_COMP);
+});
+
+// ---
+
+/// Cached implementation of [`re_query::query_archetype_with_history`] for 1 point-of-view component
+/// and no optional components.
+///
+/// Alias for [`query_cached_archetype_with_history_pov1_comp0`].
+#[inline]
+pub fn query_cached_archetype_with_history_pov1<'a, A, R1, F>(
+    store: &'a DataStore,
+    timeline: &'a Timeline,
+    time: &'a TimeInt,
+    history: &ExtraQueryHistory,
+    ent_path: &'a EntityPath,
+    f: F,
+) -> ::re_query::Result<()>
+where
+    A: Archetype + 'a,
+    R1: Component + Send + Sync + 'static,
+    F: FnMut(&mut dyn Iterator<Item = (&(TimeInt, RowId), &[InstanceKey], &[R1])>),
+{
+    query_cached_archetype_with_history_pov1_comp0::<A, R1, F>(
+        store, timeline, time, history, ent_path, f,
+    )
+}
+
+/// Generates a function to cache a (potentially historical) query with N point-of-view components and M
+/// other components.
+macro_rules! impl_query_cached_archetype_with_history {
+    (for N=$N:expr, M=$M:expr => povs=[$($pov:ident)+] comps=[$($comp:ident)*]) => { paste! {
+        #[doc = "Cached implementation of [`re_query::query_archetype_with_history`] for `" $N "` point-of-view"]
+        #[doc = "components and `" $M "` optional components."]
+        pub fn [<query_cached_archetype_with_history_pov$N _comp$M>]<'a, A, $($pov,)+ $($comp,)* F>(
+            store: &'a DataStore,
+            timeline: &'a Timeline,
+            time: &'a TimeInt,
+            history: &ExtraQueryHistory,
+            ent_path: &'a EntityPath,
+            f: F,
+        ) -> ::re_query::Result<()>
+        where
+            A: Archetype + 'a,
+            $($pov: Component + Send + Sync + 'static,)+
+            $($comp: Component + Send + Sync + 'static,)*
+            F: FnMut(
+                &mut dyn Iterator<
+                    Item = (
+                        &(TimeInt, RowId),
+                        &[InstanceKey],
+                        $(&[$pov],)+
+                        $(&[Option<$comp>],)*
+                    ),
+                >,
+            ),
+        {
+            // NOTE: not `profile_function!` because we want them merged together.
+            re_tracing::profile_scope!(
+                "query_cached_archetype_with_history_povN_compM",
+                format!("arch={} pov={} comp={}", A::name(), $N, $M)
+            );
+
+            let visible_history = match timeline.typ() {
+                re_log_types::TimeType::Time => history.nanos,
+                re_log_types::TimeType::Sequence => history.sequences,
+            };
+
+            if !history.enabled || visible_history == VisibleHistory::OFF {
+                let query = LatestAtQuery::new(*timeline, *time);
+                $crate::[<query_cached_archetype_pov$N _comp$M>]::<A, $($pov,)+ $($comp,)* _>(
+                    store,
+                    &query.clone().into(),
+                    ent_path,
+                    f,
+                )
+            } else {
+                unimplemented!("TODO(cmc): range support");
+            }
+        } }
+    };
+
+    // TODO(cmc): Supporting N>1 generically is quite painful due to limitations in declarative macros,
+    // not that we care at the moment.
+    (for N=1, M=$M:expr) => {
+        seq!(COMP in 1..=$M {
+            impl_query_cached_archetype_with_history!(for N=1, M=$M => povs=[R1] comps=[#(C~COMP)*]);
+        });
+    };
+}
+
+seq!(NUM_COMP in 0..10 {
+    impl_query_cached_archetype_with_history!(for N=1, M=NUM_COMP);
+});

--- a/crates/re_query_cache/tests/latest_at.rs
+++ b/crates/re_query_cache/tests/latest_at.rs
@@ -6,7 +6,7 @@ use itertools::Itertools as _;
 
 use re_data_store::{DataStore, LatestAtQuery};
 use re_log_types::{build_frame_nr, DataRow, EntityPath, RowId};
-use re_query_cache::query_cached_archetype_pov1_comp1;
+use re_query_cache::query_archetype_pov1_comp1;
 use re_types::{
     archetypes::Points2D,
     components::{Color, InstanceKey, Position2D},
@@ -217,17 +217,14 @@ fn query_and_compare(store: &DataStore, query: &LatestAtQuery, ent_path: &Entity
         let mut got_positions = Vec::new();
         let mut got_colors = Vec::new();
 
-        query_cached_archetype_pov1_comp1::<Points2D, Position2D, Color, _>(
+        query_archetype_pov1_comp1::<Points2D, Position2D, Color, _>(
             store,
             &query.clone().into(),
             ent_path,
-            |it| {
-                let (_, instance_keys, positions, colors) = it.next().unwrap();
-                assert!(it.next().is_none());
-
-                got_instance_keys = instance_keys.to_vec();
-                got_positions = positions.to_vec();
-                got_colors = colors.to_vec();
+            |(_, instance_keys, positions, colors)| {
+                got_instance_keys.extend(instance_keys.iter().copied());
+                got_positions.extend(positions.iter().copied());
+                got_colors.extend(colors.iter().copied());
             },
         )
         .unwrap();

--- a/crates/re_query_cache/tests/latest_at.rs
+++ b/crates/re_query_cache/tests/latest_at.rs
@@ -1,0 +1,251 @@
+//! Contains:
+//! - A 1:1 port of the tests in `crates/re_query/tests/archetype_query_tests.rs`, with caching enabled.
+//! - Invalidation tests.
+
+use itertools::Itertools as _;
+
+use re_arrow_store::{DataStore, LatestAtQuery};
+use re_log_types::{build_frame_nr, DataRow, EntityPath, RowId};
+use re_query_cache::query_cached_archetype_pov1_comp1;
+use re_types::{
+    archetypes::Points2D,
+    components::{Color, InstanceKey, Position2D},
+};
+use re_types_core::Loggable as _;
+
+// ---
+
+#[test]
+fn simple_query() {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+
+    let ent_path = "point";
+    let timepoint = [build_frame_nr(123.into())];
+
+    // Create some positions with implicit instances
+    let positions = vec![Position2D::new(1.0, 2.0), Position2D::new(3.0, 4.0)];
+    let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timepoint, 2, positions).unwrap();
+    store.insert_row(&row).unwrap();
+
+    // Assign one of them a color with an explicit instance
+    let color_instances = vec![InstanceKey(1)];
+    let colors = vec![Color::from_rgb(255, 0, 0)];
+    let row = DataRow::from_cells2_sized(
+        RowId::new(),
+        ent_path,
+        timepoint,
+        1,
+        (color_instances, colors),
+    )
+    .unwrap();
+    store.insert_row(&row).unwrap();
+
+    // Retrieve the view
+    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    query_and_compare(&store, &query, &ent_path.into());
+}
+
+#[test]
+fn timeless_query() {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+
+    let ent_path = "point";
+    let timepoint = [build_frame_nr(123.into())];
+
+    // Create some positions with implicit instances
+    let positions = vec![Position2D::new(1.0, 2.0), Position2D::new(3.0, 4.0)];
+    let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timepoint, 2, positions).unwrap();
+    store.insert_row(&row).unwrap();
+
+    // Assign one of them a color with an explicit instance.. timelessly!
+    let color_instances = vec![InstanceKey(1)];
+    let colors = vec![Color::from_rgb(255, 0, 0)];
+    let row = DataRow::from_cells2_sized(RowId::new(), ent_path, [], 1, (color_instances, colors))
+        .unwrap();
+    store.insert_row(&row).unwrap();
+
+    // Retrieve the view
+    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    query_and_compare(&store, &query, &ent_path.into());
+}
+
+#[test]
+fn no_instance_join_query() {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+
+    let ent_path = "point";
+    let timepoint = [build_frame_nr(123.into())];
+
+    // Create some positions with an implicit instance
+    let positions = vec![Position2D::new(1.0, 2.0), Position2D::new(3.0, 4.0)];
+    let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timepoint, 2, positions).unwrap();
+    store.insert_row(&row).unwrap();
+
+    // Assign them colors with explicit instances
+    let colors = vec![Color::from_rgb(255, 0, 0), Color::from_rgb(0, 255, 0)];
+    let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timepoint, 2, colors).unwrap();
+    store.insert_row(&row).unwrap();
+
+    // Retrieve the view
+    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    query_and_compare(&store, &query, &ent_path.into());
+}
+
+#[test]
+fn missing_column_join_query() {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+
+    let ent_path = "point";
+    let timepoint = [build_frame_nr(123.into())];
+
+    // Create some positions with an implicit instance
+    let positions = vec![Position2D::new(1.0, 2.0), Position2D::new(3.0, 4.0)];
+    let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timepoint, 2, positions).unwrap();
+    store.insert_row(&row).unwrap();
+
+    // Retrieve the view
+    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    query_and_compare(&store, &query, &ent_path.into());
+}
+
+#[test]
+fn splatted_query() {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+
+    let ent_path = "point";
+    let timepoint = [build_frame_nr(123.into())];
+
+    // Create some positions with implicit instances
+    let positions = vec![Position2D::new(1.0, 2.0), Position2D::new(3.0, 4.0)];
+    let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timepoint, 2, positions).unwrap();
+    store.insert_row(&row).unwrap();
+
+    // Assign all of them a color via splat
+    let color_instances = vec![InstanceKey::SPLAT];
+    let colors = vec![Color::from_rgb(255, 0, 0)];
+    let row = DataRow::from_cells2_sized(
+        RowId::new(),
+        ent_path,
+        timepoint,
+        1,
+        (color_instances, colors),
+    )
+    .unwrap();
+    store.insert_row(&row).unwrap();
+
+    // Retrieve the view
+    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    query_and_compare(&store, &query, &ent_path.into());
+}
+
+#[test]
+// TODO(cmc): implement invalidation + in-depth invalidation tests + in-depth OOO tests
+#[should_panic(expected = "assertion failed: `(left == right)`")]
+fn invalidation() {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+
+    let ent_path = "point";
+    let timepoint = [build_frame_nr(123.into())];
+
+    // Create some positions with implicit instances
+    let positions = vec![Position2D::new(1.0, 2.0), Position2D::new(3.0, 4.0)];
+    let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timepoint, 2, positions).unwrap();
+    store.insert_row(&row).unwrap();
+
+    // Assign one of them a color with an explicit instance
+    let color_instances = vec![InstanceKey(1)];
+    let colors = vec![Color::from_rgb(255, 0, 0)];
+    let row = DataRow::from_cells2_sized(
+        RowId::new(),
+        ent_path,
+        timepoint,
+        1,
+        (color_instances, colors),
+    )
+    .unwrap();
+    store.insert_row(&row).unwrap();
+
+    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    query_and_compare(&store, &query, &ent_path.into());
+
+    // Invalidate the PoV component
+    let positions = vec![Position2D::new(10.0, 20.0), Position2D::new(30.0, 40.0)];
+    let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timepoint, 2, positions).unwrap();
+    store.insert_row(&row).unwrap();
+
+    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    query_and_compare(&store, &query, &ent_path.into());
+
+    // Invalidate the optional component
+    let colors = vec![Color::from_rgb(255, 0, 0), Color::from_rgb(0, 255, 0)];
+    let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timepoint, 2, colors).unwrap();
+    store.insert_row(&row).unwrap();
+
+    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    query_and_compare(&store, &query, &ent_path.into());
+}
+
+// ---
+
+fn query_and_compare(store: &DataStore, query: &LatestAtQuery, ent_path: &EntityPath) {
+    for _ in 0..3 {
+        let mut got_instance_keys = Vec::new();
+        let mut got_positions = Vec::new();
+        let mut got_colors = Vec::new();
+
+        query_cached_archetype_pov1_comp1::<Points2D, Position2D, Color, _>(
+            store,
+            &query.clone().into(),
+            ent_path,
+            |it| {
+                let (_, instance_keys, positions, colors) = it.next().unwrap();
+                assert!(it.next().is_none());
+
+                got_instance_keys = instance_keys.to_vec();
+                got_positions = positions.to_vec();
+                got_colors = colors.to_vec();
+            },
+        )
+        .unwrap();
+
+        let expected = re_query::query_archetype::<Points2D>(store, query, ent_path).unwrap();
+
+        let expected_instance_keys = expected.iter_instance_keys().collect_vec();
+        let expected_positions = expected
+            .iter_required_component::<Position2D>()
+            .unwrap()
+            .collect_vec();
+        let expected_colors = expected
+            .iter_optional_component::<Color>()
+            .unwrap()
+            .collect_vec();
+
+        similar_asserts::assert_eq!(expected_instance_keys, got_instance_keys);
+        similar_asserts::assert_eq!(expected_positions, got_positions);
+        similar_asserts::assert_eq!(expected_colors, got_colors);
+    }
+}

--- a/crates/re_query_cache/tests/latest_at.rs
+++ b/crates/re_query_cache/tests/latest_at.rs
@@ -4,7 +4,7 @@
 
 use itertools::Itertools as _;
 
-use re_arrow_store::{DataStore, LatestAtQuery};
+use re_data_store::{DataStore, LatestAtQuery};
 use re_log_types::{build_frame_nr, DataRow, EntityPath, RowId};
 use re_query_cache::query_cached_archetype_pov1_comp1;
 use re_types::{
@@ -45,7 +45,7 @@ fn simple_query() {
     store.insert_row(&row).unwrap();
 
     // Retrieve the view
-    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
     query_and_compare(&store, &query, &ent_path.into());
 }
 
@@ -73,7 +73,7 @@ fn timeless_query() {
     store.insert_row(&row).unwrap();
 
     // Retrieve the view
-    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
     query_and_compare(&store, &query, &ent_path.into());
 }
 
@@ -99,7 +99,7 @@ fn no_instance_join_query() {
     store.insert_row(&row).unwrap();
 
     // Retrieve the view
-    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
     query_and_compare(&store, &query, &ent_path.into());
 }
 
@@ -120,7 +120,7 @@ fn missing_column_join_query() {
     store.insert_row(&row).unwrap();
 
     // Retrieve the view
-    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
     query_and_compare(&store, &query, &ent_path.into());
 }
 
@@ -154,7 +154,7 @@ fn splatted_query() {
     store.insert_row(&row).unwrap();
 
     // Retrieve the view
-    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
     query_and_compare(&store, &query, &ent_path.into());
 }
 
@@ -189,7 +189,7 @@ fn invalidation() {
     .unwrap();
     store.insert_row(&row).unwrap();
 
-    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
     query_and_compare(&store, &query, &ent_path.into());
 
     // Invalidate the PoV component
@@ -197,7 +197,7 @@ fn invalidation() {
     let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timepoint, 2, positions).unwrap();
     store.insert_row(&row).unwrap();
 
-    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
     query_and_compare(&store, &query, &ent_path.into());
 
     // Invalidate the optional component
@@ -205,7 +205,7 @@ fn invalidation() {
     let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timepoint, 2, colors).unwrap();
     store.insert_row(&row).unwrap();
 
-    let query = re_arrow_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
     query_and_compare(&store, &query, &ent_path.into());
 }
 


### PR DESCRIPTION
This implements the most barebone latest-at caching support.

The goal is merely to introduce all the machinery and boilerplate required to get the primary cache running, actual caching features will be implemented on top of this foundation in follow up PRs. 

The [existing benchmark suite](https://github.com/rerun-io/rerun/blob/790f391/crates/re_query/benches/query_benchmark.rs) has been ported as-is to the cached APIs (5950X, Arch):
```
group                           primcache_3_vanilla                         primcache_3_cached                  
-----                           -------------------                         ------------------                  
arrow_batch_points2/insert      1.02  1015.0±11.07µs 939.6 MElem/sec      1.00   1000.0±7.37µs 953.7 MElem/sec
arrow_batch_points2/query       2.90      3.4±0.02µs 276.5 MElem/sec      1.00  1190.5±41.55ns 801.0 MElem/sec
arrow_batch_strings2/insert     1.00   1045.7±7.85µs 912.0 MElem/sec      1.00  1042.1±14.01µs 915.1 MElem/sec
arrow_batch_strings2/query      1.91     21.3±0.17µs  44.7 MElem/sec      1.00     11.2±0.04µs  85.2 MElem/sec 
arrow_mono_points2/insert       1.01   1789.2±3.40ms 545.8 KElem/sec      1.00  1773.6±23.00ms 550.6 KElem/sec
arrow_mono_points2/query        6.78  1102.4±18.79µs 885.9 KElem/sec      1.00    162.6±3.39µs   5.9 MElem/sec 
arrow_mono_strings2/insert      1.00   1777.3±5.89ms 549.5 KElem/sec      1.00   1777.3±7.53ms 549.5 KElem/sec
arrow_mono_strings2/query       6.30  1149.9±15.36µs 849.3 KElem/sec      1.00    182.5±0.41µs   5.2 MElem/sec 
```

---

Part of the primary caching series of PR (index search, joins, deserialization):
- #4592
- #4593
- #4659
- #4680 
- #4681
- #4698
- #4711
- #4712
- #4721 
- #4726 

---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4592/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4592)
- [Docs preview](https://rerun.io/preview/bee3f9a64f1b6446e97bbcd63a650c639df0dc15/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bee3f9a64f1b6446e97bbcd63a650c639df0dc15/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)