### PR TITLE
Hide entity filter DSL behind a feature flag

### DIFF
--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -196,32 +196,46 @@ impl App {
             }
         });
 
-        #[cfg(not(target_arch = "wasm32"))]
         {
-            if self.re_ui
-                .checkbox(ui, &mut self.state.app_options.experimental_space_view_screenshots, "(experimental) Space View screenshots")
-                .on_hover_text("Allow taking screenshots of 2D and 3D Space Views via their context menu. Does not contain labels.")
+            ui.separator();
+            ui.label("Experimental features:");
+
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                if self.re_ui
+                    .checkbox(ui, &mut self.state.app_options.experimental_space_view_screenshots, "Space View screenshots")
+                    .on_hover_text("Allow taking screenshots of 2D and 3D Space Views via their context menu. Does not contain labels.")
+                    .clicked()
+                {
+                    ui.close_menu();
+                }
+            }
+
+            if self
+                .re_ui
+                .checkbox(
+                    ui,
+                    &mut self.state.app_options.experimental_dataframe_space_view,
+                    "Dataframe Space View",
+                )
+                .on_hover_text("Enable the experimental dataframe space view.")
                 .clicked()
             {
+                self.command_sender.send_system(
+                    SystemCommand::EnableExperimentalDataframeSpaceView(
+                        self.state.app_options.experimental_dataframe_space_view,
+                    ),
+                );
                 ui.close_menu();
             }
-        }
 
-        if self
-            .re_ui
-            .checkbox(
-                ui,
-                &mut self.state.app_options.experimental_dataframe_space_view,
-                "(experimental) Dataframe Space View",
-            )
-            .on_hover_text("Enable the experimental dataframe space view.")
-            .clicked()
-        {
-            self.command_sender
-                .send_system(SystemCommand::EnableExperimentalDataframeSpaceView(
-                    self.state.app_options.experimental_dataframe_space_view,
-                ));
-            ui.close_menu();
+            self.re_ui
+                .checkbox(
+                    ui,
+                    &mut self.state.app_options.experimental_entity_filter_editor,
+                    "Show entity filter DSL",
+                )
+                .on_hover_text("Show an entity filter DSL when selecting a space-view.");
         }
 
         #[cfg(debug_assertions)]
@@ -352,16 +366,14 @@ impl App {
         }
 
         self.re_ui.checkbox(ui,
-                       &mut self.state.app_options.show_picking_debug_overlay,
-                       "Picking Debug Overlay",
-        )
-            .on_hover_text("Show a debug overlay that renders the picking layer information using the `debug_overlay.wgsl` shader.");
+            &mut self.state.app_options.show_picking_debug_overlay,
+            "Picking Debug Overlay",
+        ).on_hover_text("Show a debug overlay that renders the picking layer information using the `debug_overlay.wgsl` shader.");
 
         self.re_ui.checkbox(ui,
-                       &mut self.state.app_options.show_blueprint_in_timeline,
-                       "Show Blueprint in the Time Panel",
-        )
-            .on_hover_text("Show the Blueprint data in the Time Panel tree view. This is useful for debugging the internal blueprint state.");
+            &mut self.state.app_options.show_blueprint_in_timeline,
+            "Show Blueprint in the Time Panel",
+        ).on_hover_text("Show the Blueprint data in the Time Panel tree view. This is useful for debugging the internal blueprint state.");
 
         self.re_ui
             .checkbox(

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -532,30 +532,33 @@ fn blueprint_ui(
                 }
             });
 
-            if let Some(space_view) = viewport.blueprint.space_view(space_view_id) {
-                if let Some(query) = space_view.queries.first() {
-                    if let Some(new_entity_path_filter) =
-                        entity_path_filter_ui(ui, &query.entity_path_filter)
-                    {
-                        let timepoint = TimePoint::timeless();
-                        let expressions_component = QueryExpressions::from(&new_entity_path_filter);
+            if ctx.app_options.experimental_entity_filter_editor {
+                if let Some(space_view) = viewport.blueprint.space_view(space_view_id) {
+                    if let Some(query) = space_view.queries.first() {
+                        if let Some(new_entity_path_filter) =
+                            entity_path_filter_ui(ui, &query.entity_path_filter)
+                        {
+                            let timepoint = TimePoint::timeless();
+                            let expressions_component =
+                                QueryExpressions::from(&new_entity_path_filter);
 
-                        let row = DataRow::from_cells1_sized(
-                            RowId::new(),
-                            query.id.as_entity_path(),
-                            timepoint,
-                            1,
-                            [expressions_component],
-                        )
-                        .unwrap();
+                            let row = DataRow::from_cells1_sized(
+                                RowId::new(),
+                                query.id.as_entity_path(),
+                                timepoint,
+                                1,
+                                [expressions_component],
+                            )
+                            .unwrap();
 
-                        ctx.command_sender
-                            .send_system(SystemCommand::UpdateBlueprint(
-                                ctx.store_context.blueprint.store_id().clone(),
-                                vec![row],
-                            ));
+                            ctx.command_sender
+                                .send_system(SystemCommand::UpdateBlueprint(
+                                    ctx.store_context.blueprint.store_id().clone(),
+                                    vec![row],
+                                ));
 
-                        space_view.set_entity_determined_by_user(ctx);
+                            space_view.set_entity_determined_by_user(ctx);
+                        }
                     }
                 }
             }

--- a/crates/re_viewer_context/src/app_options.rs
+++ b/crates/re_viewer_context/src/app_options.rs
@@ -20,6 +20,8 @@ pub struct AppOptions {
     /// Enable experimental support for new container blueprints
     pub experimental_container_blueprints: bool,
 
+    pub experimental_entity_filter_editor: bool,
+
     /// Displays an overlay for debugging picking.
     pub show_picking_debug_overlay: bool,
 
@@ -44,6 +46,8 @@ impl Default for AppOptions {
             experimental_dataframe_space_view: false,
 
             experimental_container_blueprints: cfg!(debug_assertions),
+
+            experimental_entity_filter_editor: false,
 
             show_picking_debug_overlay: false,
 


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/4634 

I'm gonna clean up the Rerun menu in a follow-up PR

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4660/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4660/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4660/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4660)
- [Docs preview](https://rerun.io/preview/27f0173a7b3115df2d0944d6e47b92b58722b494/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/27f0173a7b3115df2d0944d6e47b92b58722b494/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)