### PR TITLE
Entity query editor: simplify button presentation logic

### DIFF
--- a/crates/re_viewport/src/space_view_entity_picker.rs
+++ b/crates/re_viewport/src/space_view_entity_picker.rs
@@ -205,27 +205,18 @@ fn add_entities_line_ui(
             } else if is_included {
                 // Remove-button
                 // Shows when an entity is already included (but not explicitly)
-                // Only enabled if the entity is compatible.
-                let enabled = add_info.can_add_self_or_descendant.is_compatible();
+                let response = ctx.re_ui.small_icon_button(ui, &re_ui::icons::REMOVE);
 
-                ui.add_enabled_ui(enabled, |ui| {
-                    let response = ctx.re_ui.small_icon_button(ui, &re_ui::icons::REMOVE);
+                if response.clicked() {
+                    space_view.add_entity_exclusion(
+                        ctx,
+                        EntityPathRule::including_subtree(entity_tree.path.clone()),
+                    );
+                }
 
-                    if response.clicked() {
-                        space_view.add_entity_exclusion(
-                            ctx,
-                            EntityPathRule::including_subtree(entity_tree.path.clone()),
-                        );
-                    }
-
-                    if enabled {
-                        response.on_hover_text(
-                            "Exclude this Entity and all its descendants from the Space View",
-                        );
-                    } else if let CanAddToSpaceView::No { reason } = &add_info.can_add {
-                        response.on_disabled_hover_text(reason);
-                    }
-                });
+                response.on_hover_text(
+                    "Exclude this Entity and all its descendants from the Space View",
+                );
             } else {
                 // Add-button:
                 // Shows when an entity is not included

--- a/crates/re_viewport/src/space_view_entity_picker.rs
+++ b/crates/re_viewport/src/space_view_entity_picker.rs
@@ -188,35 +188,25 @@ fn add_entities_line_ui(
         });
 
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-            // TODO(emilk): Show at most one button.
+            if entity_path_filter.contains_rule_for_exactly(entity_path) {
+                // Reset-button
+                // Shows when an entity is explicitly excluded or included
+                let response = ctx.re_ui.small_icon_button(ui, &re_ui::icons::RESET);
 
-            // Reset-button
-            {
-                let enabled = add_info.can_add_self_or_descendant.is_compatible()
-                    && entity_path_filter.contains_rule_for_exactly(entity_path);
+                if response.clicked() {
+                    space_view.remove_filter_rule_for(ctx, &entity_tree.path);
+                }
 
-                ui.add_enabled_ui(enabled, |ui| {
-                    let response = ctx.re_ui.small_icon_button(ui, &re_ui::icons::RESET);
-
-                    if response.clicked() {
-                        space_view.remove_filter_rule_for(ctx, &entity_tree.path);
-                    }
-
-                    if enabled {
-                        if is_explicitly_excluded {
-                            response.on_hover_text("Stop excluding this EntityPath.");
-                        } else if is_explicitly_included {
-                            response.on_hover_text("Stop including this EntityPath.");
-                        }
-                    }
-                });
-            }
-
-            // Remove-button
-            {
-                let enabled = is_included
-                    && add_info.can_add_self_or_descendant.is_compatible()
-                    && query_result.contains_any(&entity_tree.path);
+                if is_explicitly_excluded {
+                    response.on_hover_text("Stop excluding this EntityPath.");
+                } else if is_explicitly_included {
+                    response.on_hover_text("Stop including this EntityPath.");
+                }
+            } else if is_included {
+                // Remove-button
+                // Shows when an entity is already included (but not explicitly)
+                // Only enabled if the entity is compatible.
+                let enabled = add_info.can_add_self_or_descendant.is_compatible();
 
                 ui.add_enabled_ui(enabled, |ui| {
                     let response = ctx.re_ui.small_icon_button(ui, &re_ui::icons::REMOVE);
@@ -232,13 +222,15 @@ fn add_entities_line_ui(
                         response.on_hover_text(
                             "Exclude this Entity and all its descendants from the Space View",
                         );
+                    } else if let CanAddToSpaceView::No { reason } = &add_info.can_add {
+                        response.on_disabled_hover_text(reason);
                     }
                 });
-            }
-
-            // Add-button
-            {
-                let enabled = !is_included && add_info.can_add_self_or_descendant.is_compatible();
+            } else {
+                // Add-button:
+                // Shows when an entity is not included
+                // Only enabled if the entity is compatible.
+                let enabled = add_info.can_add_self_or_descendant.is_compatible();
 
                 ui.add_enabled_ui(enabled, |ui| {
                     let response = ctx.re_ui.small_icon_button(ui, &re_ui::icons::ADD);


### PR DESCRIPTION
### What
The buttons in almost all cases were mutually exclusive.

This simplifies the logic to show the most appropriate button given the state.
 - Added / removed explicitly: show reset
 - Already included (but not covered by above): show remove
 - Baseline: show add
 
This introduces one more click when transitioning from explicitly added to explicitly removed, which feels like a worthwhile tradeof for the simplicity.

Before:
![image](https://github.com/rerun-io/rerun/assets/3312232/96e8d2ca-3f7a-4922-a066-ca588f0e24f0)

After:
![image](https://github.com/rerun-io/rerun/assets/3312232/b72c7417-61a7-483f-892f-4bfd26b5272a)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4662/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4662/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4662/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4662)
- [Docs preview](https://rerun.io/preview/71c95097c4a403ebd8eb108edfd445bf43329be1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/71c95097c4a403ebd8eb108edfd445bf43329be1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)