### PR TITLE
Benchmark data store insertion using same timepoint

### DIFF
--- a/crates/re_data_store/benches/arrow2.rs
+++ b/crates/re_data_store/benches/arrow2.rs
@@ -113,7 +113,8 @@ fn erased_clone(c: &mut Criterion) {
             .sum::<u64>();
         assert!(
             total_size_bytes as usize >= NUM_ROWS * NUM_INSTANCES * std::mem::size_of::<T>(),
-            "Size calculated to be {} bytes, but should be at least {} bytes",
+            "Size for {} calculated to be {} bytes, but should be at least {} bytes",
+            T::name(),
             total_size_bytes,
             NUM_ROWS * NUM_INSTANCES * std::mem::size_of::<T>()
         );

--- a/crates/re_data_store/benches/arrow2.rs
+++ b/crates/re_data_store/benches/arrow2.rs
@@ -111,7 +111,12 @@ fn erased_clone(c: &mut Criterion) {
             .iter()
             .map(|array| array.total_size_bytes())
             .sum::<u64>();
-        assert!(total_size_bytes as usize >= NUM_ROWS * NUM_INSTANCES * std::mem::size_of::<T>());
+        assert!(
+            total_size_bytes as usize >= NUM_ROWS * NUM_INSTANCES * std::mem::size_of::<T>(),
+            "Size calculated to be {} bytes, but should be at least {} bytes",
+            total_size_bytes,
+            NUM_ROWS * NUM_INSTANCES * std::mem::size_of::<T>()
+        );
 
         group.bench_function("array", |b| {
             b.iter(|| {

--- a/crates/re_data_store/benches/data_store.rs
+++ b/crates/re_data_store/benches/data_store.rs
@@ -102,7 +102,7 @@ fn insert_same_time_point(c: &mut Criterion) {
     #[cfg(debug_assertions)]
     let num_rows_list = [100];
     #[cfg(not(debug_assertions))]
-    let num_rows_list = [1000, 10_000, 100_000];
+    let num_rows_list = [1_000, 10_000, 50_000];
 
     for num_rows in num_rows_list {
         for shuffled in [false, true] {
@@ -111,6 +111,7 @@ fn insert_same_time_point(c: &mut Criterion) {
             let mut group = c.benchmark_group(format!(
                 "datastore/num_rows={num_rows}/num_instances={num_instances}/insert_same_time_point/shuffled={shuffled}"
             ));
+            group.sample_size(10); // it is so slow
             group.throughput(criterion::Throughput::Elements(num_rows * num_instances));
 
             let rows = build_rows_ex(num_rows as _, num_instances as _, shuffled, packed, |_| {

--- a/crates/re_data_store/benches/data_store.rs
+++ b/crates/re_data_store/benches/data_store.rs
@@ -98,7 +98,13 @@ fn insert_same_time_point(c: &mut Criterion) {
     // Benchmark a corner-case where all rows have the same time point, and arrive out-of-order.
     // See https://github.com/rerun-io/rerun/issues/4415
 
-    for num_rows in [1000, 10_000, 100_000] {
+    // `cargo test` also runs the benchmark setup code, so make sure they run quickly:
+    #[cfg(debug_assertions)]
+    let num_rows_list = [100];
+    #[cfg(not(debug_assertions))]
+    let num_rows_list = [1000, 10_000, 100_000];
+
+    for num_rows in num_rows_list {
         for shuffled in [false, true] {
             let num_instances = 1;
             let packed = false;

--- a/crates/re_data_store/benches/data_store.rs
+++ b/crates/re_data_store/benches/data_store.rs
@@ -109,7 +109,7 @@ fn insert_same_time_point(c: &mut Criterion) {
             let num_instances = 1;
             let packed = false;
             let mut group = c.benchmark_group(format!(
-                "datastore/num_rows={num_rows}/num_instances={num_instances}/shuffled={shuffled}/insert_same_time_point"
+                "datastore/num_rows={num_rows}/num_instances={num_instances}/insert_same_time_point/shuffled={shuffled}"
             ));
             group.throughput(criterion::Throughput::Elements(num_rows * num_instances));
 


### PR DESCRIPTION
### What
In order to investigate https://github.com/rerun-io/rerun/issues/4415 I wanted to reproduce it.

This PR adds a benchmark that inserts many rows using the same timepoint, either in-order or shuffled.

I also fixed a "bug" in the existing insertion benchmarks, which accidentally were _also_ measuring the time to call `DataTable::to_rows` (and collect the result), which was about 10% of the measured time.

---

5950X pinned to core #7 / Arch:
```
datastore/num_rows=1000/num_instances=1/shuffled=false/insert_same_time_point/insert      1.00  1641.2±28.89µs 595.0 KElem/sec
datastore/num_rows=1000/num_instances=1/shuffled=true/insert_same_time_point/insert       1.00      3.0±0.04ms 328.4 KElem/sec
datastore/num_rows=10000/num_instances=1/shuffled=false/insert_same_time_point/insert     1.00     27.1±1.59ms 361.0 KElem/sec
datastore/num_rows=10000/num_instances=1/shuffled=true/insert_same_time_point/insert      1.00    162.5±1.23ms 60.1 KElem/sec
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4676/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4676/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4676/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4676)
- [Docs preview](https://rerun.io/preview/75ba0c0685dbea827b473270b1b350e348e72974/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/75ba0c0685dbea827b473270b1b350e348e72974/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)