### PR TITLE
Fix heuristic object properties being broken in some cases / fix DepthMeter being ignored sometimes

### DIFF
--- a/crates/re_entity_db/src/entity_properties.rs
+++ b/crates/re_entity_db/src/entity_properties.rs
@@ -50,6 +50,17 @@ impl EntityPropertyMap {
         }
     }
 
+    /// Overrides the properties for a given entity path.
+    ///
+    /// Like `update`, but auto properties are always updated.
+    pub fn overwrite_properties(&mut self, entity_path: EntityPath, prop: EntityProperties) {
+        if prop == EntityProperties::default() {
+            self.props.remove(&entity_path); // save space
+        } else {
+            self.props.insert(entity_path, prop);
+        }
+    }
+
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = (&EntityPath, &EntityProperties)> {
         self.props.iter()
@@ -136,7 +147,7 @@ impl Default for EntityProperties {
             color_mapper: EditableAutoValue::default(),
             pinhole_image_plane_distance: EditableAutoValue::default(),
             backproject_depth: EditableAutoValue::Auto(true),
-            depth_from_world_scale: EditableAutoValue::default(),
+            depth_from_world_scale: EditableAutoValue::Auto(1.0),
             backproject_radius_scale: EditableAutoValue::Auto(1.0),
             transform_3d_visible: EditableAutoValue::Auto(false),
             transform_3d_size: EditableAutoValue::Auto(1.0),

--- a/crates/re_space_view_spatial/src/heuristics.rs
+++ b/crates/re_space_view_spatial/src/heuristics.rs
@@ -134,7 +134,7 @@ fn update_pinhole_property_heuristics(
             };
             properties.pinhole_image_plane_distance =
                 EditableAutoValue::Auto(default_image_plane_distance);
-            entity_properties.update(ent_path.clone(), properties);
+            entity_properties.overwrite_properties(ent_path.clone(), properties);
         }
     }
 }
@@ -186,7 +186,7 @@ fn update_depth_cloud_property_heuristics(
                 properties.backproject_radius_scale = EditableAutoValue::Auto(1.0);
             }
 
-            entity_properties.update(ent_path.clone(), properties);
+            entity_properties.overwrite_properties(ent_path.clone(), properties);
         }
     }
 }
@@ -256,6 +256,6 @@ fn update_transform3d_lines_heuristics(
             }
         }
 
-        entity_properties.update(ent_path.clone(), properties);
+        entity_properties.overwrite_properties(ent_path.clone(), properties);
     }
 }


### PR DESCRIPTION
### What

* Fixes #4644 

The way we updated properties for auto-property values made it pretty much random (not literally, but feels as-if) when and when not we'd see updated `EditableAutoValue::Auto` values!

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4679/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4679/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4679/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4679)
- [Docs preview](https://rerun.io/preview/7f911b822059b82883b2e8d1a909819ab618ff46/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7f911b822059b82883b2e8d1a909819ab618ff46/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)