### PR TITLE
Reflect visibillity in the container tree and fix blueprint-edit-loop

### DIFF
--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -249,6 +249,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
                 blueprint.set_auto_layout(false, ctx);
             }
 
+            // TODO(#4687): We must be share not to mark edited if not edit has occurred
             self.edited |= tab_viewer.edited;
 
             state.space_views_displayed_last_frame = tab_viewer.space_views_displayed_current_frame;
@@ -326,6 +327,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
 
         let mut reset = false;
 
+        // TODO(#4687): We must be share not to mark edited if not edit has occurred
         for tree_action in self.tree_action_receiver.try_iter() {
             match tree_action {
                 TreeAction::AddSpaceView(space_view_id, parent_container) => {
@@ -436,6 +438,8 @@ impl<'a, 'b> Viewport<'a, 'b> {
         if ctx.app_options.legacy_container_blueprint {
             self.blueprint.set_tree(&self.tree, ctx);
         } else if self.edited {
+            // TODO(#4687): We must be share not to mark edited if not edit has occurred
+
             // Simplify before we save the tree. Normally additional simplification will
             // happen on the next render loop, but that's too late -- unsimplified
             // changes will be baked into the tree.

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -249,7 +249,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
                 blueprint.set_auto_layout(false, ctx);
             }
 
-            // TODO(#4687): We must be share not to mark edited if not edit has occurred
+            // TODO(#4687): Be extra careful here. If we mark edited inappropriately we can create an infinite edit loop.
             self.edited |= tab_viewer.edited;
 
             state.space_views_displayed_last_frame = tab_viewer.space_views_displayed_current_frame;
@@ -327,7 +327,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
 
         let mut reset = false;
 
-        // TODO(#4687): We must be share not to mark edited if not edit has occurred
+        // TODO(#4687): Be extra careful here. If we mark edited inappropriately we can create an infinite edit loop.
         for tree_action in self.tree_action_receiver.try_iter() {
             match tree_action {
                 TreeAction::AddSpaceView(space_view_id, parent_container) => {
@@ -438,7 +438,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
         if ctx.app_options.legacy_container_blueprint {
             self.blueprint.set_tree(&self.tree, ctx);
         } else if self.edited {
-            // TODO(#4687): We must be share not to mark edited if not edit has occurred
+            // TODO(#4687): Be extra careful here. If we mark edited inappropriately we can create an infinite edit loop.
 
             // Simplify before we save the tree. Normally additional simplification will
             // happen on the next render loop, but that's too late -- unsimplified

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -85,7 +85,7 @@ impl Viewport<'_, '_> {
 
             if visible != child_is_visible {
                 self.tree.set_visible(tile_id, child_is_visible);
-                // TODO(#4687): We must be share not to mark edited if not edit has occurred
+                // TODO(#4687): Be extra careful here. If we mark edited inappropriately we can create an infinite edit loop.
                 self.edited = true;
             }
 
@@ -137,7 +137,7 @@ impl Viewport<'_, '_> {
             self.blueprint.set_auto_layout(false, ctx);
 
             self.tree.set_visible(tile_id, visible);
-            // TODO(#4687): We must be share not to mark edited if not edit has occurred
+            // TODO(#4687): Be extra careful here. If we mark edited inappropriately we can create an infinite edit loop.
             self.edited = true;
         }
     }

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -85,6 +85,7 @@ impl Viewport<'_, '_> {
 
             if visible != child_is_visible {
                 self.tree.set_visible(tile_id, child_is_visible);
+                // TODO(#4687): We must be share not to mark edited if not edit has occurred
                 self.edited = true;
             }
 
@@ -136,6 +137,7 @@ impl Viewport<'_, '_> {
             self.blueprint.set_auto_layout(false, ctx);
 
             self.tree.set_visible(tile_id, visible);
+            // TODO(#4687): We must be share not to mark edited if not edit has occurred
             self.edited = true;
         }
     }

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -27,7 +27,7 @@ impl Viewport<'_, '_> {
             .show(ui, |ui| {
                 ctx.re_ui.panel_content(ui, |_, ui| {
                     if let Some(root) = self.tree.root() {
-                        self.tile_ui(ctx, ui, root);
+                        self.tile_ui(ctx, ui, root, true);
                     }
                 });
             });
@@ -39,7 +39,13 @@ impl Viewport<'_, '_> {
         2 <= num_children && num_children <= 3
     }
 
-    fn tile_ui(&mut self, ctx: &ViewerContext<'_>, ui: &mut egui::Ui, tile_id: egui_tiles::TileId) {
+    fn tile_ui(
+        &mut self,
+        ctx: &ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        tile_id: egui_tiles::TileId,
+        parent_visible: bool,
+    ) {
         // Temporarily remove the tile so we don't get borrow-checker fights:
         let Some(mut tile) = self.tree.tiles.remove(tile_id) else {
             return;
@@ -47,11 +53,11 @@ impl Viewport<'_, '_> {
 
         match &mut tile {
             egui_tiles::Tile::Container(container) => {
-                self.container_tree_ui(ctx, ui, tile_id, container);
+                self.container_tree_ui(ctx, ui, tile_id, container, parent_visible);
             }
             egui_tiles::Tile::Pane(space_view_id) => {
                 // A space view
-                self.space_view_entry_ui(ctx, ui, tile_id, space_view_id);
+                self.space_view_entry_ui(ctx, ui, tile_id, space_view_id, parent_visible);
             }
         };
 
@@ -64,6 +70,7 @@ impl Viewport<'_, '_> {
         ui: &mut egui::Ui,
         tile_id: egui_tiles::TileId,
         container: &egui_tiles::Container,
+        parent_visible: bool,
     ) {
         // TODO(#4285): this will disappear once we walk the container blueprint tree instead of `egui_tiles::Tree`
         if let (egui_tiles::Container::Tabs(_), Some(child_id)) =
@@ -73,24 +80,32 @@ impl Viewport<'_, '_> {
             // This means we won't be showing the visibility button of the parent container,
             // so if the child is made invisible, we should do the same for the parent.
             let child_is_visible = self.tree.is_visible(child_id);
-            self.tree.set_visible(tile_id, child_is_visible);
-            self.edited = true;
-            return self.tile_ui(ctx, ui, child_id);
+
+            let visible = self.tree.is_visible(tile_id);
+
+            if visible != child_is_visible {
+                self.tree.set_visible(tile_id, child_is_visible);
+                self.edited = true;
+            }
+
+            return self.tile_ui(ctx, ui, child_id, parent_visible);
         }
 
         let item = Item::Container(tile_id);
 
         let mut visibility_changed = false;
         let mut visible = self.tree.is_visible(tile_id);
+        let container_visible = visible && parent_visible;
         let mut remove = false;
 
         let default_open = true;
 
         let response = ListItem::new(ctx.re_ui, format!("{:?}", container.kind()))
+            .subdued(!container_visible)
             .selected(ctx.selection().contains_item(&item))
             .with_icon(crate::icon_for_container_kind(&container.kind()))
             .with_buttons(|re_ui, ui| {
-                let vis_response = visibility_button_ui(re_ui, ui, true, &mut visible);
+                let vis_response = visibility_button_ui(re_ui, ui, parent_visible, &mut visible);
                 visibility_changed = vis_response.changed();
 
                 let remove_response = remove_button_ui(re_ui, ui, "Remove container");
@@ -100,7 +115,7 @@ impl Viewport<'_, '_> {
             })
             .show_collapsing(ui, ui.id().with(tile_id), default_open, |_, ui| {
                 for &child in container.children() {
-                    self.tile_ui(ctx, ui, child);
+                    self.tile_ui(ctx, ui, child, container_visible);
                 }
             })
             .item_response;
@@ -131,6 +146,7 @@ impl Viewport<'_, '_> {
         ui: &mut egui::Ui,
         tile_id: egui_tiles::TileId,
         space_view_id: &SpaceViewId,
+        container_visible: bool,
     ) {
         let Some(space_view) = self.blueprint.space_views.get(space_view_id) else {
             re_log::warn_once!("Bug: asked to show a ui for a Space View that doesn't exist");
@@ -147,7 +163,7 @@ impl Viewport<'_, '_> {
 
         let mut visibility_changed = false;
         let mut visible = self.tree.is_visible(tile_id);
-        let visible_child = visible;
+        let space_view_visible = visible && container_visible;
         let item = Item::SpaceView(space_view.id);
 
         let root_node = result_tree.first_interesting_root();
@@ -160,11 +176,11 @@ impl Viewport<'_, '_> {
 
         let response = ListItem::new(ctx.re_ui, space_view.display_name.clone())
             .selected(ctx.selection().contains_item(&item))
-            .subdued(!visible)
+            .subdued(!space_view_visible)
             .force_hovered(is_item_hovered)
             .with_icon(space_view.class(ctx.space_view_class_registry).icon())
             .with_buttons(|re_ui, ui| {
-                let vis_response = visibility_button_ui(re_ui, ui, true, &mut visible);
+                let vis_response = visibility_button_ui(re_ui, ui, container_visible, &mut visible);
                 visibility_changed = vis_response.changed();
 
                 let response = remove_button_ui(re_ui, ui, "Remove Space View from the Viewport");
@@ -185,7 +201,7 @@ impl Viewport<'_, '_> {
                         &query_result,
                         result_node,
                         space_view,
-                        visible_child,
+                        space_view_visible,
                     );
                 } else {
                     ui.label("No results");


### PR DESCRIPTION
### What
 - Resolves: https://github.com/rerun-io/rerun/issues/4684
 - Resolves: https://github.com/rerun-io/rerun/issues/4692
 - Resolves: https://github.com/rerun-io/rerun/issues/4693

Also fixes a bug where rare edge-cases of the blueprint would get into an infinite edit loop.
Added an issue and TODOs to avoid this issue:
 - https://github.com/rerun-io/rerun/issues/4687

![image](https://github.com/rerun-io/rerun/assets/3312232/2e329288-81a9-4ed4-b423-d4fa1dcd07cf)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4688/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4688/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4688/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4688)
- [Docs preview](https://rerun.io/preview/38c5dd05c23a3ee65e80f2704ec08841c77bd0ef/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/38c5dd05c23a3ee65e80f2704ec08841c77bd0ef/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)