### PR TITLE
Fix 2D images showing up in 3D space views again

### DIFF
--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -4,6 +4,7 @@ use re_types::{components::PinholeProjection, Loggable as _};
 use re_viewer_context::{
     AutoSpawnHeuristic, PerSystemEntities, SpaceViewClass, SpaceViewClassRegistryError,
     SpaceViewId, SpaceViewSystemExecutionError, ViewQuery, ViewerContext,
+    VisualizableFilterContext,
 };
 
 use crate::{
@@ -18,6 +19,12 @@ use crate::{
 
 pub struct VisualizableFilterContext2D {
     pub has_pinhole_at_root: bool,
+}
+
+impl VisualizableFilterContext for VisualizableFilterContext2D {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 #[derive(Default)]
@@ -60,7 +67,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
         &self,
         space_origin: &EntityPath,
         entity_db: &re_entity_db::EntityDb,
-    ) -> Box<dyn std::any::Any> {
+    ) -> Box<dyn VisualizableFilterContext> {
         re_tracing::profile_function!();
 
         let has_pinhole_at_root = entity_db

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 pub struct VisualizableFilterContext2D {
-    pub has_pinhole_at_root: bool,
+    pub has_pinhole_at_origin: bool,
 }
 
 impl VisualizableFilterContext for VisualizableFilterContext2D {
@@ -70,7 +70,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
     ) -> Box<dyn VisualizableFilterContext> {
         re_tracing::profile_function!();
 
-        let has_pinhole_at_root = entity_db
+        let has_pinhole_at_origin = entity_db
             .tree()
             .subtree(space_origin)
             .map_or(false, |tree| {
@@ -80,7 +80,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
             });
 
         Box::new(VisualizableFilterContext2D {
-            has_pinhole_at_root,
+            has_pinhole_at_origin,
         })
     }
 

--- a/crates/re_space_view_spatial/src/space_view_3d.rs
+++ b/crates/re_space_view_spatial/src/space_view_3d.rs
@@ -5,7 +5,7 @@ use re_types::{components::PinholeProjection, Loggable as _};
 use re_viewer_context::{
     AutoSpawnHeuristic, IdentifiedViewSystem as _, PerSystemEntities, SpaceViewClass,
     SpaceViewClassRegistryError, SpaceViewId, SpaceViewSystemExecutionError, ViewQuery,
-    ViewerContext,
+    ViewerContext, VisualizableFilterContext,
 };
 
 use crate::{
@@ -21,6 +21,12 @@ use crate::{
 pub struct VisualizableFilterContext3D {
     /// Set of all entities that are under a pinhole camera.
     pub entities_under_pinhole: IntSet<EntityPathHash>,
+}
+
+impl VisualizableFilterContext for VisualizableFilterContext3D {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 #[derive(Default)]
@@ -62,7 +68,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
         &self,
         space_origin: &EntityPath,
         entity_db: &re_entity_db::EntityDb,
-    ) -> Box<dyn std::any::Any> {
+    ) -> Box<dyn VisualizableFilterContext> {
         re_tracing::profile_function!();
 
         // TODO(andreas): Potential optimization:

--- a/crates/re_space_view_spatial/src/space_view_3d.rs
+++ b/crates/re_space_view_spatial/src/space_view_3d.rs
@@ -96,10 +96,11 @@ impl SpaceViewClass for SpatialSpaceView3D {
         let entity_tree = &entity_db.tree();
 
         // Walk down the tree from the space_origin.
-        let Some(current_tree) = &entity_tree.subtree(space_origin) else {
-            return Box::new(());
+        // Note that if there's no subtree, we still have to return a `VisualizerFilterContext3D` to
+        // indicate to all visualizable-filters that we're in a 3D space view.
+        if let Some(current_tree) = &entity_tree.subtree(space_origin) {
+            visit_children_recursively(current_tree, &mut entities_under_pinhole);
         };
-        visit_children_recursively(current_tree, &mut entities_under_pinhole);
 
         Box::new(VisualizableFilterContext3D {
             entities_under_pinhole,

--- a/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -7,8 +7,9 @@ use re_types::{
     Archetype as _, ComponentNameSet,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewQuery, ViewerContext, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
+    SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
+    VisualizableEntities, VisualizerSystem,
 };
 
 use super::{picking_id_from_instance_key, process_annotations, SpatialViewVisualizerData};
@@ -16,8 +17,8 @@ use crate::{
     contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
     view_kind::SpatialSpaceViewKind,
     visualizers::{
-        entity_iterator::process_archetype_views, process_colors, process_radii, UiLabel,
-        UiLabelTarget,
+        entity_iterator::process_archetype_views, filter_visualizable_3d_entities, process_colors,
+        process_radii, UiLabel, UiLabelTarget,
     },
 };
 
@@ -178,6 +179,14 @@ impl VisualizerSystem for Arrows3DVisualizer {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(Arrows3D::indicator().name()).collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -9,7 +9,7 @@ use re_types::{
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
-    VisualizableEntities, VisualizerSystem,
+    VisualizableEntities, VisualizerSystem, VisualizableFilterContext
 };
 
 use super::{picking_id_from_instance_key, process_annotations, SpatialViewVisualizerData};
@@ -184,7 +184,7 @@ impl VisualizerSystem for Arrows3DVisualizer {
     fn filter_visualizable_entities(
         &self,
         entities: ApplicableEntities,
-        context: &dyn std::any::Any,
+        context: &dyn VisualizableFilterContext,
     ) -> VisualizableEntities {
         filter_visualizable_3d_entities(entities, context)
     }

--- a/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -9,7 +9,7 @@ use re_types::{
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
-    VisualizableEntities, VisualizerSystem, VisualizableFilterContext
+    VisualizableEntities, VisualizableFilterContext, VisualizerSystem,
 };
 
 use super::{picking_id_from_instance_key, process_annotations, SpatialViewVisualizerData};

--- a/crates/re_space_view_spatial/src/visualizers/assets3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/assets3d.rs
@@ -8,7 +8,7 @@ use re_types::{
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,VisualizableFilterContext
 };
 
 use super::{
@@ -119,7 +119,7 @@ impl VisualizerSystem for Asset3DVisualizer {
     fn filter_visualizable_entities(
         &self,
         entities: ApplicableEntities,
-        context: &dyn std::any::Any,
+        context: &dyn VisualizableFilterContext,
     ) -> VisualizableEntities {
         filter_visualizable_3d_entities(entities, context)
     }

--- a/crates/re_space_view_spatial/src/visualizers/assets3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/assets3d.rs
@@ -7,11 +7,14 @@ use re_types::{
     Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery,
-    ViewerContext, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
 };
 
-use super::{entity_iterator::process_archetype_views, SpatialViewVisualizerData};
+use super::{
+    entity_iterator::process_archetype_views, filter_visualizable_3d_entities,
+    SpatialViewVisualizerData,
+};
 use crate::{
     contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
     instance_hash_conversions::picking_layer_id_from_instance_path_hash,
@@ -111,6 +114,14 @@ impl VisualizerSystem for Asset3DVisualizer {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(Asset3D::indicator().name()).collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/assets3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/assets3d.rs
@@ -8,7 +8,7 @@ use re_types::{
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,VisualizableFilterContext
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizableFilterContext, VisualizerSystem,
 };
 
 use super::{

--- a/crates/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -8,7 +8,7 @@ use re_types::{
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
-    VisualizableEntities, VisualizerSystem,
+    VisualizableEntities, VisualizableFilterContext, VisualizerSystem,
 };
 
 use crate::{
@@ -182,7 +182,7 @@ impl VisualizerSystem for Boxes2DVisualizer {
     fn filter_visualizable_entities(
         &self,
         entities: ApplicableEntities,
-        context: &dyn std::any::Any,
+        context: &dyn VisualizableFilterContext,
     ) -> VisualizableEntities {
         re_tracing::profile_function!();
         filter_visualizable_2d_entities(entities, context)

--- a/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -7,7 +7,7 @@ use re_types::{
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,VisualizableFilterContext
 };
 
 use crate::{
@@ -141,7 +141,7 @@ impl VisualizerSystem for Boxes3DVisualizer {
     fn filter_visualizable_entities(
         &self,
         entities: ApplicableEntities,
-        context: &dyn std::any::Any,
+        context: &dyn VisualizableFilterContext,
     ) -> VisualizableEntities {
         filter_visualizable_3d_entities(entities, context)
     }

--- a/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -6,8 +6,8 @@ use re_types::{
     Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery,
-    ViewerContext, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
 };
 
 use crate::{
@@ -17,8 +17,9 @@ use crate::{
 };
 
 use super::{
-    entity_iterator::process_archetype_views, picking_id_from_instance_key, process_annotations,
-    process_colors, process_labels, process_radii, SpatialViewVisualizerData,
+    entity_iterator::process_archetype_views, filter_visualizable_3d_entities,
+    picking_id_from_instance_key, process_annotations, process_colors, process_labels,
+    process_radii, SpatialViewVisualizerData,
 };
 
 pub struct Boxes3DVisualizer(SpatialViewVisualizerData);
@@ -135,6 +136,14 @@ impl VisualizerSystem for Boxes3DVisualizer {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(Boxes3D::indicator().as_ref().name()).collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -7,7 +7,7 @@ use re_types::{
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,VisualizableFilterContext
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizableFilterContext, VisualizerSystem,
 };
 
 use crate::{

--- a/crates/re_space_view_spatial/src/visualizers/cameras.rs
+++ b/crates/re_space_view_spatial/src/visualizers/cameras.rs
@@ -8,7 +8,7 @@ use re_types::{
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, SpaceViewOutlineMasks, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
+    ViewContextCollection, ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,VisualizableFilterContext
 };
 
 use super::{filter_visualizable_3d_entities, SpatialViewVisualizerData};
@@ -201,7 +201,7 @@ impl VisualizerSystem for CamerasVisualizer {
     fn filter_visualizable_entities(
         &self,
         entities: ApplicableEntities,
-        context: &dyn std::any::Any,
+        context: &dyn VisualizableFilterContext,
     ) -> VisualizableEntities {
         filter_visualizable_3d_entities(entities, context)
     }

--- a/crates/re_space_view_spatial/src/visualizers/cameras.rs
+++ b/crates/re_space_view_spatial/src/visualizers/cameras.rs
@@ -8,7 +8,8 @@ use re_types::{
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, SpaceViewOutlineMasks, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,VisualizableFilterContext
+    ViewContextCollection, ViewQuery, ViewerContext, VisualizableEntities,
+    VisualizableFilterContext, VisualizerSystem,
 };
 
 use super::{filter_visualizable_3d_entities, SpatialViewVisualizerData};

--- a/crates/re_space_view_spatial/src/visualizers/cameras.rs
+++ b/crates/re_space_view_spatial/src/visualizers/cameras.rs
@@ -7,11 +7,11 @@ use re_types::{
     Archetype as _, ComponentNameSet,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, SpaceViewOutlineMasks, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewQuery, ViewerContext, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, SpaceViewOutlineMasks, SpaceViewSystemExecutionError,
+    ViewContextCollection, ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
 };
 
-use super::SpatialViewVisualizerData;
+use super::{filter_visualizable_3d_entities, SpatialViewVisualizerData};
 use crate::{
     contexts::{SharedRenderBuilders, TransformContext},
     instance_hash_conversions::picking_layer_id_from_instance_path_hash,
@@ -196,6 +196,14 @@ impl VisualizerSystem for CamerasVisualizer {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(re_types::archetypes::Pinhole::indicator().name()).collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/images.rs
+++ b/crates/re_space_view_spatial/src/visualizers/images.rs
@@ -21,8 +21,8 @@ use re_types::{
 use re_viewer_context::{
     gpu_bridge, ApplicableEntities, DefaultColor, IdentifiedViewSystem, SpaceViewClass,
     SpaceViewSystemExecutionError, TensorDecodeCache, TensorStatsCache, ViewContextCollection,
-    ViewQuery, ViewerContext, VisualizableEntities, VisualizerAdditionalApplicabilityFilter,
-    VisualizerSystem,
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizableFilterContext,
+    VisualizerAdditionalApplicabilityFilter, VisualizerSystem,
 };
 
 use crate::{
@@ -694,7 +694,7 @@ impl VisualizerSystem for ImageVisualizer {
     fn filter_visualizable_entities(
         &self,
         entities: ApplicableEntities,
-        context: &dyn std::any::Any,
+        context: &dyn VisualizableFilterContext,
     ) -> VisualizableEntities {
         re_tracing::profile_function!();
         filter_visualizable_2d_entities(entities, context)

--- a/crates/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -8,7 +8,7 @@ use re_types::{
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
-    VisualizableEntities, VisualizerSystem,
+    VisualizableEntities, VisualizerSystem,VisualizableFilterContext
 };
 
 use crate::{
@@ -179,7 +179,7 @@ impl VisualizerSystem for Lines2DVisualizer {
     fn filter_visualizable_entities(
         &self,
         entities: ApplicableEntities,
-        context: &dyn std::any::Any,
+        context: &dyn VisualizableFilterContext,
     ) -> VisualizableEntities {
         re_tracing::profile_function!();
         filter_visualizable_2d_entities(entities, context)

--- a/crates/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -8,7 +8,7 @@ use re_types::{
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
-    VisualizableEntities, VisualizerSystem,VisualizableFilterContext
+    VisualizableEntities, VisualizableFilterContext, VisualizerSystem,
 };
 
 use crate::{

--- a/crates/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -6,8 +6,9 @@ use re_types::{
     Archetype as _, ComponentNameSet,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewQuery, ViewerContext, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
+    SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
+    VisualizableEntities, VisualizerSystem,
 };
 
 use crate::{
@@ -19,7 +20,9 @@ use crate::{
     },
 };
 
-use super::{picking_id_from_instance_key, SpatialViewVisualizerData};
+use super::{
+    filter_visualizable_3d_entities, picking_id_from_instance_key, SpatialViewVisualizerData,
+};
 
 pub struct Lines3DVisualizer {
     /// If the number of arrows in the batch is > max_labels, don't render point labels.
@@ -178,6 +181,14 @@ impl VisualizerSystem for Lines3DVisualizer {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(LineStrips3D::indicator().name()).collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -8,7 +8,7 @@ use re_types::{
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
-    VisualizableEntities, VisualizerSystem,
+    VisualizableEntities, VisualizableFilterContext, VisualizerSystem,
 };
 
 use crate::{
@@ -186,7 +186,7 @@ impl VisualizerSystem for Lines3DVisualizer {
     fn filter_visualizable_entities(
         &self,
         entities: ApplicableEntities,
-        context: &dyn std::any::Any,
+        context: &dyn VisualizableFilterContext,
     ) -> VisualizableEntities {
         filter_visualizable_3d_entities(entities, context)
     }

--- a/crates/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/re_space_view_spatial/src/visualizers/meshes.rs
@@ -8,7 +8,7 @@ use re_types::{
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizableFilterContext, VisualizerSystem,
 };
 
 use super::{
@@ -151,7 +151,7 @@ impl VisualizerSystem for Mesh3DVisualizer {
     fn filter_visualizable_entities(
         &self,
         entities: ApplicableEntities,
-        context: &dyn std::any::Any,
+        context: &dyn VisualizableFilterContext,
     ) -> VisualizableEntities {
         filter_visualizable_3d_entities(entities, context)
     }

--- a/crates/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/re_space_view_spatial/src/visualizers/meshes.rs
@@ -7,11 +7,14 @@ use re_types::{
     Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery,
-    ViewerContext, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
 };
 
-use super::{entity_iterator::process_archetype_views, SpatialViewVisualizerData};
+use super::{
+    entity_iterator::process_archetype_views, filter_visualizable_3d_entities,
+    SpatialViewVisualizerData,
+};
 use crate::{
     contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
     instance_hash_conversions::picking_layer_id_from_instance_path_hash,
@@ -143,6 +146,14 @@ impl VisualizerSystem for Mesh3DVisualizer {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(Mesh3D::indicator().name()).collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/mod.rs
+++ b/crates/re_space_view_spatial/src/visualizers/mod.rs
@@ -36,6 +36,7 @@ use re_viewer_context::{
     SpaceViewSystemRegistrator, ViewQuery, VisualizableEntities, VisualizerCollection,
 };
 
+use crate::space_view_2d::VisualizableFilterContext2D;
 use crate::space_view_3d::VisualizableFilterContext3D;
 
 use super::contexts::SpatialSceneEntityContext;
@@ -359,5 +360,21 @@ fn filter_visualizable_2d_entities(
         )
     } else {
         VisualizableEntities(entities.0)
+    }
+}
+
+/// If 3d object is shown in a 2d space view, it is only then visualizable, if it only visualizable if the root of the space view has a pinhole camera.
+fn filter_visualizable_3d_entities(
+    entities: ApplicableEntities,
+    context: &dyn std::any::Any,
+) -> VisualizableEntities {
+    // `VisualizableFilterContext2D` will only be available if we're in a 2D space view.
+    if context
+        .downcast_ref::<VisualizableFilterContext2D>()
+        .map_or(true, |c| c.has_pinhole_at_root)
+    {
+        VisualizableEntities(entities.0)
+    } else {
+        VisualizableEntities::default()
     }
 }

--- a/crates/re_space_view_spatial/src/visualizers/mod.rs
+++ b/crates/re_space_view_spatial/src/visualizers/mod.rs
@@ -366,7 +366,7 @@ fn filter_visualizable_2d_entities(
     }
 }
 
-/// If 3d object is shown in a 2d space view, it is only then visualizable, if it only visualizable if the root of the space view has a pinhole camera.
+/// If 3d object is shown in a 2d space view, it is only visualizable, if the origin of the space view has a pinhole camera.
 fn filter_visualizable_3d_entities(
     entities: ApplicableEntities,
     context: &dyn VisualizableFilterContext,
@@ -375,7 +375,7 @@ fn filter_visualizable_3d_entities(
     if context
         .as_any()
         .downcast_ref::<VisualizableFilterContext2D>()
-        .map_or(true, |c| c.has_pinhole_at_root)
+        .map_or(true, |c| c.has_pinhole_at_origin)
     {
         VisualizableEntities(entities.0)
     } else {

--- a/crates/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points2d.rs
@@ -8,7 +8,7 @@ use re_types::{
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
-    VisualizableEntities, VisualizerSystem,
+    VisualizableEntities, VisualizableFilterContext, VisualizerSystem,
 };
 
 use crate::{
@@ -205,7 +205,7 @@ impl VisualizerSystem for Points2DVisualizer {
     fn filter_visualizable_entities(
         &self,
         entities: ApplicableEntities,
-        context: &dyn std::any::Any,
+        context: &dyn VisualizableFilterContext,
     ) -> VisualizableEntities {
         re_tracing::profile_function!();
         filter_visualizable_2d_entities(entities, context)

--- a/crates/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points3d.rs
@@ -10,7 +10,7 @@ use re_types::{
 use re_viewer_context::{
     Annotations, ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
-    VisualizableEntities, VisualizerSystem,
+    VisualizableEntities, VisualizableFilterContext, VisualizerSystem,
 };
 
 use crate::{
@@ -188,7 +188,7 @@ impl VisualizerSystem for Points3DVisualizer {
     fn filter_visualizable_entities(
         &self,
         entities: ApplicableEntities,
-        context: &dyn std::any::Any,
+        context: &dyn VisualizableFilterContext,
     ) -> VisualizableEntities {
         filter_visualizable_3d_entities(entities, context)
     }

--- a/crates/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points3d.rs
@@ -8,8 +8,9 @@ use re_types::{
     Archetype as _, ComponentNameSet, DeserializationResult,
 };
 use re_viewer_context::{
-    Annotations, IdentifiedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewQuery, ViewerContext, VisualizerSystem,
+    Annotations, ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
+    SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
+    VisualizableEntities, VisualizerSystem,
 };
 
 use crate::{
@@ -21,7 +22,10 @@ use crate::{
     },
 };
 
-use super::{picking_id_from_instance_key, Keypoints, SpatialViewVisualizerData};
+use super::{
+    filter_visualizable_3d_entities, picking_id_from_instance_key, Keypoints,
+    SpatialViewVisualizerData,
+};
 
 pub struct Points3DVisualizer {
     /// If the number of points in the batch is > max_labels, don't render point labels.
@@ -179,6 +183,14 @@ impl VisualizerSystem for Points3DVisualizer {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(Points3D::indicator().name()).collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -7,7 +7,7 @@ use re_types::{
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,VisualizableFilterContext
 };
 
 use crate::{
@@ -53,7 +53,7 @@ impl VisualizerSystem for Transform3DArrowsVisualizer {
     fn filter_visualizable_entities(
         &self,
         entities: ApplicableEntities,
-        context: &dyn std::any::Any,
+        context: &dyn VisualizableFilterContext,
     ) -> VisualizableEntities {
         filter_visualizable_3d_entities(entities, context)
     }

--- a/crates/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -6,8 +6,8 @@ use re_types::{
     Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery,
-    ViewerContext, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
 };
 
 use crate::{
@@ -15,7 +15,7 @@ use crate::{
     view_kind::SpatialSpaceViewKind,
 };
 
-use super::SpatialViewVisualizerData;
+use super::{filter_visualizable_3d_entities, SpatialViewVisualizerData};
 
 pub struct Transform3DArrowsVisualizer(SpatialViewVisualizerData);
 
@@ -48,6 +48,14 @@ impl VisualizerSystem for Transform3DArrowsVisualizer {
                 .name(),
         )
         .collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -7,7 +7,7 @@ use re_types::{
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,VisualizableFilterContext
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizableFilterContext, VisualizerSystem,
 };
 
 use crate::{

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -48,7 +48,8 @@ pub use space_view::{
     SpaceViewEntityHighlight, SpaceViewHighlights, SpaceViewOutlineMasks, SpaceViewState,
     SpaceViewSystemExecutionError, SpaceViewSystemRegistrator, SystemExecutionOutput,
     ViewContextCollection, ViewContextSystem, ViewQuery, ViewSystemIdentifier,
-    VisualizerAdditionalApplicabilityFilter, VisualizerCollection, VisualizerSystem,
+    VisualizableFilterContext, VisualizerAdditionalApplicabilityFilter, VisualizerCollection,
+    VisualizerSystem,
 };
 pub use store_context::StoreContext;
 pub use tensor::{TensorDecodeCache, TensorStats, TensorStatsCache};

--- a/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
@@ -34,6 +34,17 @@ pub enum SpaceViewClassLayoutPriority {
     High,
 }
 
+/// Context object returned by [`crate::SpaceViewClass::visualizable_filter_context`].
+pub trait VisualizableFilterContext {
+    fn as_any(&self) -> &dyn std::any::Any;
+}
+
+impl VisualizableFilterContext for () {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 /// Defines a class of space view without any concrete types making it suitable for storage and interfacing.
 ///
 /// Implemented by [`crate::SpaceViewClass`].
@@ -101,7 +112,7 @@ pub trait DynSpaceViewClass: Send + Sync {
         &self,
         space_origin: &EntityPath,
         entity_db: &re_entity_db::EntityDb,
-    ) -> Box<dyn std::any::Any>;
+    ) -> Box<dyn VisualizableFilterContext>;
 
     /// Heuristic used to determine which space view is the best fit for a set of paths.
     fn auto_spawn_heuristic(

--- a/crates/re_viewer_context/src/space_view/mod.rs
+++ b/crates/re_viewer_context/src/space_view/mod.rs
@@ -20,6 +20,7 @@ mod visualizer_system;
 pub use auto_spawn_heuristic::AutoSpawnHeuristic;
 pub use dyn_space_view_class::{
     DynSpaceViewClass, SpaceViewClassIdentifier, SpaceViewClassLayoutPriority, SpaceViewState,
+    VisualizableFilterContext,
 };
 pub use highlights::{SpaceViewEntityHighlight, SpaceViewHighlights, SpaceViewOutlineMasks};
 pub use named_system::{IdentifiedViewSystem, PerSystemEntities, ViewSystemIdentifier};

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -6,6 +6,7 @@ use crate::{
     AutoSpawnHeuristic, DynSpaceViewClass, PerSystemEntities, SpaceViewClassIdentifier,
     SpaceViewClassRegistryError, SpaceViewId, SpaceViewState, SpaceViewSystemExecutionError,
     SpaceViewSystemRegistrator, SystemExecutionOutput, ViewQuery, ViewerContext,
+    VisualizableFilterContext,
 };
 
 /// Defines a class of space view.
@@ -71,7 +72,7 @@ pub trait SpaceViewClass: std::marker::Sized + Send + Sync {
         &self,
         _space_origin: &EntityPath,
         _entity_db: &re_entity_db::EntityDb,
-    ) -> Box<dyn std::any::Any> {
+    ) -> Box<dyn VisualizableFilterContext> {
         Box::new(())
     }
 
@@ -189,7 +190,7 @@ impl<T: SpaceViewClass + 'static> DynSpaceViewClass for T {
         &self,
         space_origin: &EntityPath,
         entity_db: &re_entity_db::EntityDb,
-    ) -> Box<dyn std::any::Any> {
+    ) -> Box<dyn VisualizableFilterContext> {
         self.visualizable_filter_context(space_origin, entity_db)
     }
 

--- a/crates/re_viewer_context/src/space_view/visualizer_system.rs
+++ b/crates/re_viewer_context/src/space_view/visualizer_system.rs
@@ -5,7 +5,7 @@ use re_types::ComponentNameSet;
 use crate::{
     ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
     ViewQuery, ViewSystemIdentifier, ViewerContext, VisualizableEntities,
-    VisualizerAdditionalApplicabilityFilter,
+    VisualizableFilterContext, VisualizerAdditionalApplicabilityFilter,
 };
 
 /// Element of a scene derived from a single archetype query.
@@ -34,7 +34,7 @@ pub trait VisualizerSystem: Send + Sync + 'static {
     fn filter_visualizable_entities(
         &self,
         entities: ApplicableEntities,
-        _context: &dyn std::any::Any,
+        _context: &dyn VisualizableFilterContext,
     ) -> VisualizableEntities {
         VisualizableEntities(entities.0)
     }

--- a/crates/re_viewport/src/lib.rs
+++ b/crates/re_viewport/src/lib.rs
@@ -83,8 +83,10 @@ pub fn determine_visualizable_entities(
                 let entities = if let Some(applicable_entities) =
                     applicable_entities_per_visualizer.get(&visualizer_identifier)
                 {
-                    visualizer_system
-                        .filter_visualizable_entities(applicable_entities.clone(), &filter_ctx)
+                    visualizer_system.filter_visualizable_entities(
+                        applicable_entities.clone(),
+                        filter_ctx.as_ref(),
+                    )
                 } else {
                     VisualizableEntities::default()
                 };


### PR DESCRIPTION
### What

Before: `cargo rerun ./examples/assets` would show 2D images since the new filter system was actually not fed correctly with `VisualizableFilterContext3D`

<img width="960" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/9fc4d19d-a8cd-45f0-a121-bd1aac8fe1b8">



Furthermore, we now also mark all 3D objects in 2D space views that don't have their origin at the pinhole as non-visualizable



Does NOT fix
* #4689


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4696/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4696/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4696/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4696)
- [Docs preview](https://rerun.io/preview/ca71c481dd8a9261bd51dbc0e79b609fd4d61635/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ca71c481dd8a9261bd51dbc0e79b609fd4d61635/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)