### PR TITLE
Declare that the Python package doesn't support Python 3.12

### DIFF
--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 description = "The Rerun Logging SDK"
 keywords = ["computer-vision", "logging", "rerun"]
 name = "rerun-sdk"
-requires-python = ">=3.8, <3.12"
+requires-python = ">=3.8, <3.12" # TODO(#3699): Support Python 3.12
 
 [[project.authors]]
 email = "opensource@rerun.io"

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 description = "The Rerun Logging SDK"
 keywords = ["computer-vision", "logging", "rerun"]
 name = "rerun-sdk"
-requires-python = ">=3.8"
+requires-python = ">=3.8, <3.12"
 
 [[project.authors]]
 email = "opensource@rerun.io"


### PR DESCRIPTION
What the title says

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4697/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4697/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4697/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4697)
- [Docs preview](https://rerun.io/preview/0f87096e6ec0b9601bdfcd46ffa8891070e79d84/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0f87096e6ec0b9601bdfcd46ffa8891070e79d84/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)