### PR TITLE
Fix showing 3D objects in 2D space views without pinhole camera at root

### DIFF
--- a/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -7,8 +7,9 @@ use re_types::{
     Archetype as _, ComponentNameSet,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewQuery, ViewerContext, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
+    SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
+    VisualizableEntities, VisualizerSystem,
 };
 
 use super::{picking_id_from_instance_key, process_annotations, SpatialViewVisualizerData};
@@ -16,8 +17,8 @@ use crate::{
     contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
     view_kind::SpatialSpaceViewKind,
     visualizers::{
-        entity_iterator::process_archetype_views, process_colors, process_radii, UiLabel,
-        UiLabelTarget,
+        entity_iterator::process_archetype_views, filter_visualizable_3d_entities, process_colors,
+        process_radii, UiLabel, UiLabelTarget,
     },
 };
 
@@ -178,6 +179,14 @@ impl VisualizerSystem for Arrows3DVisualizer {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(Arrows3D::indicator().name()).collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/assets3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/assets3d.rs
@@ -7,11 +7,14 @@ use re_types::{
     Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery,
-    ViewerContext, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
 };
 
-use super::{entity_iterator::process_archetype_views, SpatialViewVisualizerData};
+use super::{
+    entity_iterator::process_archetype_views, filter_visualizable_3d_entities,
+    SpatialViewVisualizerData,
+};
 use crate::{
     contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
     instance_hash_conversions::picking_layer_id_from_instance_path_hash,
@@ -111,6 +114,14 @@ impl VisualizerSystem for Asset3DVisualizer {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(Asset3D::indicator().name()).collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -6,8 +6,8 @@ use re_types::{
     Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery,
-    ViewerContext, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
 };
 
 use crate::{
@@ -17,8 +17,9 @@ use crate::{
 };
 
 use super::{
-    entity_iterator::process_archetype_views, picking_id_from_instance_key, process_annotations,
-    process_colors, process_labels, process_radii, SpatialViewVisualizerData,
+    entity_iterator::process_archetype_views, filter_visualizable_3d_entities,
+    picking_id_from_instance_key, process_annotations, process_colors, process_labels,
+    process_radii, SpatialViewVisualizerData,
 };
 
 pub struct Boxes3DVisualizer(SpatialViewVisualizerData);
@@ -135,6 +136,14 @@ impl VisualizerSystem for Boxes3DVisualizer {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(Boxes3D::indicator().as_ref().name()).collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/cameras.rs
+++ b/crates/re_space_view_spatial/src/visualizers/cameras.rs
@@ -7,11 +7,11 @@ use re_types::{
     Archetype as _, ComponentNameSet,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, SpaceViewOutlineMasks, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewQuery, ViewerContext, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, SpaceViewOutlineMasks, SpaceViewSystemExecutionError,
+    ViewContextCollection, ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
 };
 
-use super::SpatialViewVisualizerData;
+use super::{filter_visualizable_3d_entities, SpatialViewVisualizerData};
 use crate::{
     contexts::{SharedRenderBuilders, TransformContext},
     instance_hash_conversions::picking_layer_id_from_instance_path_hash,
@@ -196,6 +196,14 @@ impl VisualizerSystem for CamerasVisualizer {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(re_types::archetypes::Pinhole::indicator().name()).collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -6,8 +6,9 @@ use re_types::{
     Archetype as _, ComponentNameSet,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewQuery, ViewerContext, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
+    SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
+    VisualizableEntities, VisualizerSystem,
 };
 
 use crate::{
@@ -19,7 +20,9 @@ use crate::{
     },
 };
 
-use super::{picking_id_from_instance_key, SpatialViewVisualizerData};
+use super::{
+    filter_visualizable_3d_entities, picking_id_from_instance_key, SpatialViewVisualizerData,
+};
 
 pub struct Lines3DVisualizer {
     /// If the number of arrows in the batch is > max_labels, don't render point labels.
@@ -178,6 +181,14 @@ impl VisualizerSystem for Lines3DVisualizer {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(LineStrips3D::indicator().name()).collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/re_space_view_spatial/src/visualizers/meshes.rs
@@ -7,11 +7,14 @@ use re_types::{
     Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery,
-    ViewerContext, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
 };
 
-use super::{entity_iterator::process_archetype_views, SpatialViewVisualizerData};
+use super::{
+    entity_iterator::process_archetype_views, filter_visualizable_3d_entities,
+    SpatialViewVisualizerData,
+};
 use crate::{
     contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
     instance_hash_conversions::picking_layer_id_from_instance_path_hash,
@@ -143,6 +146,14 @@ impl VisualizerSystem for Mesh3DVisualizer {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(Mesh3D::indicator().name()).collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/mod.rs
+++ b/crates/re_space_view_spatial/src/visualizers/mod.rs
@@ -36,6 +36,7 @@ use re_viewer_context::{
     SpaceViewSystemRegistrator, ViewQuery, VisualizableEntities, VisualizerCollection,
 };
 
+use crate::space_view_2d::VisualizableFilterContext2D;
 use crate::space_view_3d::VisualizableFilterContext3D;
 
 use super::contexts::SpatialSceneEntityContext;
@@ -359,5 +360,21 @@ fn filter_visualizable_2d_entities(
         )
     } else {
         VisualizableEntities(entities.0)
+    }
+}
+
+/// If 3d object is shown in a 2d space view, it is only then visualizable, if it only visualizable if the root of the space view has a pinhole camera.
+fn filter_visualizable_3d_entities(
+    entities: ApplicableEntities,
+    context: &dyn std::any::Any,
+) -> VisualizableEntities {
+    // `VisualizableFilterContext2D` will only be available if we're in a 2D space view.
+    if context
+        .downcast_ref::<VisualizableFilterContext2D>()
+        .map_or(true, |c| c.has_pinhole_at_root)
+    {
+        VisualizableEntities(entities.0)
+    } else {
+        VisualizableEntities::default()
     }
 }

--- a/crates/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points3d.rs
@@ -8,8 +8,9 @@ use re_types::{
     Archetype as _, ComponentNameSet, DeserializationResult,
 };
 use re_viewer_context::{
-    Annotations, IdentifiedViewSystem, ResolvedAnnotationInfos, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewQuery, ViewerContext, VisualizerSystem,
+    Annotations, ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
+    SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
+    VisualizableEntities, VisualizerSystem,
 };
 
 use crate::{
@@ -21,7 +22,10 @@ use crate::{
     },
 };
 
-use super::{picking_id_from_instance_key, Keypoints, SpatialViewVisualizerData};
+use super::{
+    filter_visualizable_3d_entities, picking_id_from_instance_key, Keypoints,
+    SpatialViewVisualizerData,
+};
 
 pub struct Points3DVisualizer {
     /// If the number of points in the batch is > max_labels, don't render point labels.
@@ -179,6 +183,14 @@ impl VisualizerSystem for Points3DVisualizer {
 
     fn indicator_components(&self) -> ComponentNameSet {
         std::iter::once(Points3D::indicator().name()).collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(

--- a/crates/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -6,8 +6,8 @@ use re_types::{
     Archetype, ComponentNameSet,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery,
-    ViewerContext, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewQuery, ViewerContext, VisualizableEntities, VisualizerSystem,
 };
 
 use crate::{
@@ -15,7 +15,7 @@ use crate::{
     view_kind::SpatialSpaceViewKind,
 };
 
-use super::SpatialViewVisualizerData;
+use super::{filter_visualizable_3d_entities, SpatialViewVisualizerData};
 
 pub struct Transform3DArrowsVisualizer(SpatialViewVisualizerData);
 
@@ -48,6 +48,14 @@ impl VisualizerSystem for Transform3DArrowsVisualizer {
                 .name(),
         )
         .collect()
+    }
+
+    fn filter_visualizable_entities(
+        &self,
+        entities: ApplicableEntities,
+        context: &dyn std::any::Any,
+    ) -> VisualizableEntities {
+        filter_visualizable_3d_entities(entities, context)
     }
 
     fn execute(


### PR DESCRIPTION
### What

With the new system for filtering applicable entitites this is actually super easy!
I believe we didn't do this filter before at all, so likely this goes beyond fixing a regression.

* Fixes #4689

DRAFT:
~Confirm this. Only reproed on the Ci's web build for me!~
Doesn't actually work. The problem here is that we try to display something that is _under_ a pinhole _inside_ a 2D spaceview. Almost feels like we want the full space partition here...


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4701/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4701/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4701/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4701)
- [Docs preview](https://rerun.io/preview/41edd05394cd2c4414f3d9439c7e4f00a300002d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/41edd05394cd2c4414f3d9439c7e4f00a300002d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)