### PR TITLE
Workaround for objectron spatial heuristics sometimes failing on startup

### DIFF
--- a/examples/python/objectron/main.py
+++ b/examples/python/objectron/main.py
@@ -116,9 +116,9 @@ def log_ar_frames(samples: Iterable[SampleARFrame], seq: Sequence) -> None:
         rr.set_time_seconds("time", sample.timestamp)
         frame_times.append(sample.timestamp)
 
-        rr.log("world/camera", rr.ImageEncoded(path=sample.image_path))
         log_camera(sample.frame.camera)
         log_point_cloud(sample.frame.raw_feature_points)
+        rr.log("world/camera", rr.ImageEncoded(path=sample.image_path))
 
     log_frame_annotations(frame_times, seq.frame_annotations)
 

--- a/examples/python/objectron/main.py
+++ b/examples/python/objectron/main.py
@@ -116,6 +116,8 @@ def log_ar_frames(samples: Iterable[SampleARFrame], seq: Sequence) -> None:
         rr.set_time_seconds("time", sample.timestamp)
         frame_times.append(sample.timestamp)
 
+        # TODO(#4689): log the camera first, so that Rerun's space view generation heuristic won't
+        # accidentally create a 2D space view at `world/`
         log_camera(sample.frame.camera)
         log_point_cloud(sample.frame.raw_feature_points)
         rr.log("world/camera", rr.ImageEncoded(path=sample.image_path))


### PR DESCRIPTION
### What

Workaround for:
* #4689

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4707/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4707/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4707/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4707)
- [Docs preview](https://rerun.io/preview/7e5c1a8ac5d3ad4cb5c5209faf9fd98b05d48163/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7e5c1a8ac5d3ad4cb5c5209faf9fd98b05d48163/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)