### PR TITLE
Primary caching 8: implement latest-at data-time cache entry deduplication 

### DIFF
--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -332,13 +332,18 @@ impl CacheBucket {
 // which is notoriously painful in Rust (i.e., macros).
 // For this reason we move as much of the code as possible into the already existing macros in `query.rs`.
 
-/// Caches the results of `LatestAt` queries.
+/// Caches the results of `LatestAt` archetype queries (`ArchetypeView`).
+///
+/// There is one `LatestAtCache` for each unique [`CacheKey`].
+///
+/// All query steps are cached: index search, cluster key joins and deserialization.
 #[derive(Default)]
 pub struct LatestAtCache {
     /// Organized by _query_ time.
     ///
-    /// If the data you're looking for isn't in here, try partially running the query and check
-    /// if there is any data available for the resulting _data_ time in [`Self::per_data_time`].
+    /// If the data you're looking for isn't in here, try partially running the query (i.e. run the
+    /// index search in order to find a data time, but don't actually deserialize and join the data)
+    /// and check if there is any data available for the resulting _data_ time in [`Self::per_data_time`].
     pub per_query_time: BTreeMap<TimeInt, Arc<RwLock<CacheBucket>>>,
 
     /// Organized by _data_ time.

--- a/crates/re_query_cache/src/lib.rs
+++ b/crates/re_query_cache/src/lib.rs
@@ -10,7 +10,7 @@ pub use self::query::{
     query_archetype_pov1, query_archetype_with_history_pov1, MaybeCachedComponentData,
 };
 
-pub(crate) use self::cache::LatestAtCache;
+pub(crate) use self::cache::{CacheBucket, LatestAtCache};
 
 pub use re_query::{QueryError, Result}; // convenience
 


### PR DESCRIPTION
Introduces the notion of cache deduplication: given a query at time `4` and a query at time `8` that both returns data at time `2`, they must share a single cache entry.

I.e. starting with this PR, scrubbing through the OPF example will not result if more cache memory being used.

---

Part of the primary caching series of PR (index search, joins, deserialization):
- #4592
- #4593
- #4659
- #4680 
- #4681
- #4698
- #4711
- #4712
- #4721 
- #4726 
- #4773
- #4784
- #4785
- #4793
- #4800

---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4592/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4592)
- [Docs preview](https://rerun.io/preview/95fdb2edd4494ea82d330e0efc8462b66a763e43/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/95fdb2edd4494ea82d330e0efc8462b66a763e43/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)