### PR TITLE
Allow TextLog body to display as immutable TextEdit rather than Label

### DIFF
--- a/crates/re_space_view_text_log/src/space_view_class.rs
+++ b/crates/re_space_view_text_log/src/space_view_class.rs
@@ -443,9 +443,9 @@ fn table_ui(
                         };
                         text = text.layouter(&mut layouter);
 
-                        let mut response = text.ui(ui);
+                        let response = text.ui(ui);
                         if response.hovered() {
-                            response = response.on_hover_text(entry.body.as_str());
+                            response.on_hover_text(entry.body.as_str());
                         }
                     } else {
                         let mut text = egui::RichText::new(entry.body.as_str());

--- a/crates/re_space_view_text_log/src/space_view_class.rs
+++ b/crates/re_space_view_text_log/src/space_view_class.rs
@@ -424,7 +424,7 @@ fn table_ui(
                         let text_color = if let Some(color) = entry.color {
                             color.into()
                         } else {
-                            // TODO(lupickup): Understand why TextEdit text color is white instead of grey like the RichText version.
+                            // TODO(lupickup): Understand why TextEdit text color is white instead of gray like the RichText version.
                             ui.visuals()
                                 .override_text_color
                                 .unwrap_or_else(|| ui.visuals().widgets.inactive.text_color())

--- a/crates/re_space_view_text_log/src/visualizer_system.rs
+++ b/crates/re_space_view_text_log/src/visualizer_system.rs
@@ -26,6 +26,8 @@ pub struct Entry {
 
     pub body: Text,
 
+    pub num_body_lines: usize,
+
     pub level: Option<TextLogLevel>,
 }
 
@@ -78,12 +80,15 @@ impl VisualizerSystem for TextLogSystem {
                 let colors = arch_view.iter_optional_component::<Color>()?;
 
                 for (body, level, color) in itertools::izip!(bodies, levels, colors) {
+                    // Simple, fast, ugly, and functional
+                    let num_body_lines = body.bytes().filter(|&c| c == b'\n').count() + 1;
                     self.entries.push(Entry {
                         row_id: arch_view.primary_row_id(),
                         entity_path: data_result.entity_path.clone(),
                         time: time.map(|time| time.as_i64()),
                         color,
                         body,
+                        num_body_lines,
                         level,
                     });
                 }


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What
Convert TextLog body to display as immutable TextEdit rather than Label.
This allows selecting and copying text from the log body.

Used discussion in https://github.com/emilk/egui/discussions/353#discussioncomment-7020619 as inspiration.

`selectable == false` (default):
<img width="1136" alt="image" src="https://github.com/rerun-io/rerun/assets/1692218/66581105-8685-4274-ac58-fa51eda34d76">

`selectable == true`:
<img width="1136" alt="image" src="https://github.com/rerun-io/rerun/assets/1692218/3dadddb4-d7fd-484e-aa90-2f3bc9cabab7">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4716/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4716/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4716/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4716)
- [Docs preview](https://rerun.io/preview/937db0e5dd98a082dd2656cd237417376f737803/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/937db0e5dd98a082dd2656cd237417376f737803/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)