### PR TITLE
Primary caching 9: timeless latest-at support

### DIFF
--- a/crates/re_log_types/src/time_point/time_int.rs
+++ b/crates/re_log_types/src/time_point/time_int.rs
@@ -68,11 +68,6 @@ impl TimeInt {
     pub fn abs(&self) -> Self {
         Self(self.0.saturating_abs())
     }
-
-    #[inline]
-    pub fn is_timeless(&self) -> bool {
-        self == &Self::BEGINNING
-    }
 }
 
 impl From<i64> for TimeInt {

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -49,7 +49,6 @@ static CACHES: Lazy<Caches> = Lazy::new(Caches::default);
 //
 // TODO(cmc): Store subscriber and cache invalidation.
 // TODO(#4730): SizeBytes support + size stats + mem panel
-// TODO(cmc): timeless caching support
 #[derive(Default)]
 pub struct Caches {
     latest_at: RwLock<HashMap<CacheKey, Arc<RwLock<LatestAtCache>>>>,
@@ -351,4 +350,13 @@ pub struct LatestAtCache {
     /// Due to how our latest-at semantics work, any number of queries at time `T+n` where `n >= 0`
     /// can result in a data time of `T`.
     pub per_data_time: BTreeMap<TimeInt, Arc<RwLock<CacheBucket>>>,
+
+    /// Dedicated bucket for timeless data, if any.
+    ///
+    /// Query time and data time are one and the same in the timeless case, therefore we only need
+    /// this one bucket.
+    //
+    // NOTE: Lives separately so we don't pay the extra `Option` cost in the much more common
+    // timeful case.
+    pub timeless: Option<CacheBucket>,
 }

--- a/crates/re_query_cache/src/query.rs
+++ b/crates/re_query_cache/src/query.rs
@@ -177,7 +177,7 @@ macro_rules! impl_query_archetype {
                     entry @ std::collections::btree_map::Entry::Vacant(_) => entry,
                 };
 
-                let  arch_view = query_archetype::<A>(store, &query, entity_path)?;
+                let arch_view = query_archetype::<A>(store, &query, entity_path)?;
                 let data_time = arch_view.data_time();
 
                 // Fast path: we've run the query and realized that we already have the data for the resulting

--- a/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
@@ -137,7 +137,7 @@ macro_rules! impl_process_archetype {
                 &EntityPath,
                 &EntityProperties,
                 &SpatialSceneEntityContext<'_>,
-                (TimeInt, RowId),
+                (Option<TimeInt>, RowId),
                 &[InstanceKey],
                 $(&[$pov],)*
                 $(&[Option<$comp>],)*

--- a/crates/re_space_view_text_log/src/visualizer_system.rs
+++ b/crates/re_space_view_text_log/src/visualizer_system.rs
@@ -1,6 +1,6 @@
 use re_data_store::TimeRange;
 use re_entity_db::EntityPath;
-use re_log_types::{RowId, TimeInt};
+use re_log_types::RowId;
 use re_types::{
     archetypes::TextLog,
     components::{Color, Text, TextLogLevel},
@@ -61,6 +61,8 @@ impl VisualizerSystem for TextLogSystem {
         let store = ctx.entity_db.store();
 
         for data_result in query.iter_visible_data_results(Self::identifier()) {
+            re_tracing::profile_scope!("primary", &data_result.entity_path.to_string());
+
             // We want everything, for all times:
             let timeline_query =
                 re_data_store::RangeQuery::new(query.timeline, TimeRange::EVERYTHING);
@@ -77,8 +79,7 @@ impl VisualizerSystem for TextLogSystem {
                         self.entries.push(Entry {
                             row_id,
                             entity_path: data_result.entity_path.clone(),
-                            // TODO(cmc): real support for timeless data in caches.
-                            time: (time != TimeInt::MIN).then(|| time.as_i64()),
+                            time: time.map(|time| time.as_i64()),
                             color: *color,
                             body: body.clone(),
                             level: level.clone(),
@@ -86,11 +87,6 @@ impl VisualizerSystem for TextLogSystem {
                     }
                 },
             )?;
-        }
-
-        {
-            re_tracing::profile_scope!("sort");
-            self.entries.sort_by_key(|entry| entry.time);
         }
 
         Ok(Vec::new())


### PR DESCRIPTION
Introduces a dedicated cache bucket for timeless data and properly forwards the information through all APIs downstream.

---

Part of the primary caching series of PR (index search, joins, deserialization):
- #4592
- #4593
- #4659
- #4680 
- #4681
- #4698
- #4711
- #4712
- #4721 
- #4726 
- #4773
- #4784
- #4785
- #4793
- #4800

---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4592/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4592)
- [Docs preview](https://rerun.io/preview/f83b05a3e32aa7d270a41aedeb9a80532d98fb07/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f83b05a3e32aa7d270a41aedeb9a80532d98fb07/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)