### PR TITLE
Update raw_mesh example screenshot

### DIFF
--- a/examples/python/raw_mesh/README.md
+++ b/examples/python/raw_mesh/README.md
@@ -8,11 +8,11 @@ channel = "nightly"
 
 
 <picture>
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/raw_mesh/64bec98280b07794f7c9617f30ba2c20278601c3/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/raw_mesh/64bec98280b07794f7c9617f30ba2c20278601c3/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/raw_mesh/64bec98280b07794f7c9617f30ba2c20278601c3/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/raw_mesh/64bec98280b07794f7c9617f30ba2c20278601c3/1200w.png">
-  <img src="https://static.rerun.io/raw_mesh/64bec98280b07794f7c9617f30ba2c20278601c3/full.png" alt="Raw Mesh example screenshot">
+  <img src="https://static.rerun.io/raw_mesh/18d4f1e460eb1f1bde4fa530019fbf314d567b37/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/raw_mesh/18d4f1e460eb1f1bde4fa530019fbf314d567b37/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/raw_mesh/18d4f1e460eb1f1bde4fa530019fbf314d567b37/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/raw_mesh/18d4f1e460eb1f1bde4fa530019fbf314d567b37/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/raw_mesh/18d4f1e460eb1f1bde4fa530019fbf314d567b37/1200w.png">
 </picture>
 
 This example demonstrates how to use the Rerun SDK to log raw 3D meshes (so-called "triangle soups") and their transform hierarchy. Simple material properties are supported.

--- a/examples/rust/raw_mesh/README.md
+++ b/examples/rust/raw_mesh/README.md
@@ -5,11 +5,11 @@ thumbnail = "https://static.rerun.io/raw_mesh/64bec98280b07794f7c9617f30ba2c2027
 
 
 <picture>
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/raw_mesh/64bec98280b07794f7c9617f30ba2c20278601c3/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/raw_mesh/64bec98280b07794f7c9617f30ba2c20278601c3/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/raw_mesh/64bec98280b07794f7c9617f30ba2c20278601c3/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/raw_mesh/64bec98280b07794f7c9617f30ba2c20278601c3/1200w.png">
-  <img src="https://static.rerun.io/raw_mesh/64bec98280b07794f7c9617f30ba2c20278601c3/full.png" alt="Raw Mesh example screenshot">
+  <img src="https://static.rerun.io/raw_mesh/18d4f1e460eb1f1bde4fa530019fbf314d567b37/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/raw_mesh/18d4f1e460eb1f1bde4fa530019fbf314d567b37/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/raw_mesh/18d4f1e460eb1f1bde4fa530019fbf314d567b37/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/raw_mesh/18d4f1e460eb1f1bde4fa530019fbf314d567b37/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/raw_mesh/18d4f1e460eb1f1bde4fa530019fbf314d567b37/1200w.png">
 </picture>
 
 This example demonstrates how to use the Rerun SDK to log raw 3D meshes (so-called "triangle soups") and their transform hierarchy. Simple material properties are supported.


### PR DESCRIPTION
### What

it has color by now, showed without in the preview

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
