### PR TITLE
Update docs: Input to external data-loaders is passed on argv

### DIFF
--- a/docs/content/howto/open-any-file.md
+++ b/docs/content/howto/open-any-file.md
@@ -42,18 +42,18 @@ In these instances of unsupported files, we expose two ways of implementing and 
 
 The easiest way to create your own `DataLoader` is by implementing what we call an "external loader": a stand alone executable written in any language that the Rerun SDK ships for. Any executable on your `$PATH` with a name that starts with `rerun-loader-` will be treated as a `DataLoader`.
 
-This executable takes a file path as input on `stdin` and outputs Rerun logs on `stdout`.
+This executable takes a file path as a command line argument and outputs Rerun logs on `stdout`.
 It will be called by the Rerun Viewer when the user opens a file, and be passed the path to that file.
 From there, it can log data as usual, using the [`stdout` logging sink](../reference/sdk-operating-modes?speculative-link#standard-inputoutput).
 
 The Rerun Viewer will then automatically load the data streamed to the external loader's standard output.
 
 <picture>
-  <img src="https://static.rerun.io/external_data_loader/bb98877088a9169ee15fd862ad022f9d9fbd5e6f/full.png" alt="">
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/external_data_loader/bb98877088a9169ee15fd862ad022f9d9fbd5e6f/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/external_data_loader/bb98877088a9169ee15fd862ad022f9d9fbd5e6f/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/external_data_loader/bb98877088a9169ee15fd862ad022f9d9fbd5e6f/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/external_data_loader/bb98877088a9169ee15fd862ad022f9d9fbd5e6f/1200w.png">
+  <img src="https://static.rerun.io/data-loader-external-overview/97e978000c709b78290f50d52c229a91f7543648/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/data-loader-external-overview/97e978000c709b78290f50d52c229a91f7543648/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/data-loader-external-overview/97e978000c709b78290f50d52c229a91f7543648/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/data-loader-external-overview/97e978000c709b78290f50d52c229a91f7543648/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/data-loader-external-overview/97e978000c709b78290f50d52c229a91f7543648/1200w.png">
 </picture>
 
 Like any other `DataLoader`, an external loader will be notified of all file openings, unconditionally.


### PR DESCRIPTION
### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
