### PR TITLE
Primary caching 10: latest-at cache invalidation

### DIFF
--- a/crates/re_data_store/src/store_subscriber.rs
+++ b/crates/re_data_store/src/store_subscriber.rs
@@ -98,7 +98,7 @@ impl DataStore {
         StoreSubscriberHandle(subscribers.len() as u32 - 1)
     }
 
-    /// Passes a reference to the downcasted subscriber to the given callback.
+    /// Passes a reference to the downcasted subscriber to the given `FnMut` callback.
     ///
     /// Returns `None` if the subscriber doesn't exist or downcasting failed.
     pub fn with_subscriber<V: StoreSubscriber, T, F: FnMut(&V) -> T>(
@@ -109,6 +109,20 @@ impl DataStore {
         subscribers.get(handle as usize).and_then(|subscriber| {
             let subscriber = subscriber.read();
             subscriber.as_any().downcast_ref::<V>().map(&mut f)
+        })
+    }
+
+    /// Passes a reference to the downcasted subscriber to the given `FnOnce` callback.
+    ///
+    /// Returns `None` if the subscriber doesn't exist or downcasting failed.
+    pub fn with_subscriber_once<V: StoreSubscriber, T, F: FnOnce(&V) -> T>(
+        StoreSubscriberHandle(handle): StoreSubscriberHandle,
+        f: F,
+    ) -> Option<T> {
+        let subscribers = SUBSCRIBERS.read();
+        subscribers.get(handle as usize).and_then(|subscriber| {
+            let subscriber = subscriber.read();
+            subscriber.as_any().downcast_ref::<V>().map(f)
         })
     }
 

--- a/crates/re_query/src/query.rs
+++ b/crates/re_query/src/query.rs
@@ -90,7 +90,7 @@ pub fn get_component_with_instances(
 /// # let store = re_query::__populate_example_store();
 ///
 /// let ent_path = "point";
-/// let query = LatestAtQuery::n ew(Timeline::new_sequence("frame_nr"), 123.into());
+/// let query = LatestAtQuery::new(Timeline::new_sequence("frame_nr"), 123.into());
 ///
 /// let arch_view = re_query::query_archetype::<MyPoints>(
 ///   &store,

--- a/crates/re_query/src/query.rs
+++ b/crates/re_query/src/query.rs
@@ -90,7 +90,7 @@ pub fn get_component_with_instances(
 /// # let store = re_query::__populate_example_store();
 ///
 /// let ent_path = "point";
-/// let query = LatestAtQuery::new(Timeline::new_sequence("frame_nr"), 123.into());
+/// let query = LatestAtQuery::n ew(Timeline::new_sequence("frame_nr"), 123.into());
 ///
 /// let arch_view = re_query::query_archetype::<MyPoints>(
 ///   &store,

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -279,7 +279,6 @@ impl CachesPerArchetype {
 
             if pending_timeless_invalidation {
                 latest_at_cache.timeless = None;
-                self.pending_timeless_invalidation = false;
             }
 
             if let Some(min_time) = self.pending_timeful_invalidation {
@@ -290,10 +289,11 @@ impl CachesPerArchetype {
                 latest_at_cache
                     .per_data_time
                     .retain(|&data_time, _| data_time < min_time);
-
-                self.pending_timeful_invalidation = None;
             }
         }
+
+        self.pending_timeful_invalidation = None;
+        self.pending_timeless_invalidation = false;
     }
 }
 

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -76,9 +76,9 @@ pub struct CachesPerArchetype {
     /// time effectively behaves as a natural micro-batching mechanism.
     pending_timeful_invalidation: Option<TimeInt>,
 
-    /// If `true`, the timeless data associated with this case has been asynchronously invalidated.
+    /// If `true`, the timeless data associated with this cache has been asynchronously invalidated.
     ///
-    /// The next time this cache gets queried, it must remove any entry matching this criteria.
+    /// If `true`, this cache must remove all of its timeless entries the next time it gets queried.
     /// `false` indicates that there's no pending invalidation.
     ///
     /// Invalidation is deferred to query time because it is far more efficient that way: the frame
@@ -194,7 +194,7 @@ impl StoreSubscriber for Caches {
             } = event;
 
             let StoreDiff {
-                kind: _, // Don't care: both additions and deletions invalid query results.
+                kind: _, // Don't care: both additions and deletions invalidate query results.
                 row_id: _,
                 times,
                 entity_path,

--- a/crates/re_query_cache/src/query.rs
+++ b/crates/re_query_cache/src/query.rs
@@ -111,7 +111,7 @@ macro_rules! impl_query_archetype {
                 re_tracing::profile_scope!("iter");
 
                 let it = itertools::izip!(
-                    bucket.iter_pov_data_times(),
+                    bucket.iter_data_times(),
                     bucket.iter_pov_instance_keys(),
                     $(bucket.iter_component::<$pov>()
                         .ok_or_else(|| re_query::ComponentNotFoundError(<$pov>::name()))?,)+
@@ -132,7 +132,6 @@ macro_rules! impl_query_archetype {
 
                 Ok(())
             };
-
 
             let upsert_results = |
                     data_time: TimeInt,

--- a/crates/re_query_cache/tests/latest_at.rs
+++ b/crates/re_query_cache/tests/latest_at.rs
@@ -5,7 +5,7 @@
 use itertools::Itertools as _;
 
 use re_data_store::{DataStore, LatestAtQuery};
-use re_log_types::{build_frame_nr, DataRow, EntityPath, RowId};
+use re_log_types::{build_frame_nr, DataRow, EntityPath, RowId, TimePoint};
 use re_query_cache::query_archetype_pov1_comp1;
 use re_types::{
     archetypes::Points2D,
@@ -159,79 +159,170 @@ fn splatted_query() {
 }
 
 #[test]
-// TODO(cmc): implement invalidation + in-depth invalidation tests + in-depth OOO tests
-#[should_panic(expected = "assertion failed: `(left == right)`")]
 fn invalidation() {
-    let mut store = DataStore::new(
-        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
-        InstanceKey::name(),
-        Default::default(),
+    let ent_path = "point";
+
+    let test_invalidation = |query: LatestAtQuery,
+                             present_data_timepoint: TimePoint,
+                             past_data_timepoint: TimePoint,
+                             future_data_timepoint: TimePoint| {
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            Default::default(),
+        );
+
+        // Create some positions with implicit instances
+        let positions = vec![Position2D::new(1.0, 2.0), Position2D::new(3.0, 4.0)];
+        let row = DataRow::from_cells1_sized(
+            RowId::new(),
+            ent_path,
+            present_data_timepoint.clone(),
+            2,
+            positions,
+        )
+        .unwrap();
+        store.insert_row(&row).unwrap();
+
+        // Assign one of them a color with an explicit instance
+        let color_instances = vec![InstanceKey(1)];
+        let colors = vec![Color::from_rgb(1, 2, 3)];
+        let row = DataRow::from_cells2_sized(
+            RowId::new(),
+            ent_path,
+            present_data_timepoint.clone(),
+            1,
+            (color_instances, colors),
+        )
+        .unwrap();
+        store.insert_row(&row).unwrap();
+
+        query_and_compare(&store, &query, &ent_path.into());
+
+        // --- Modify present ---
+
+        // Modify the PoV component
+        let positions = vec![Position2D::new(10.0, 20.0), Position2D::new(30.0, 40.0)];
+        let row = DataRow::from_cells1_sized(
+            RowId::new(),
+            ent_path,
+            present_data_timepoint.clone(),
+            2,
+            positions,
+        )
+        .unwrap();
+        store.insert_row(&row).unwrap();
+
+        query_and_compare(&store, &query, &ent_path.into());
+
+        // Modify the optional component
+        let colors = vec![Color::from_rgb(4, 5, 6), Color::from_rgb(7, 8, 9)];
+        let row =
+            DataRow::from_cells1_sized(RowId::new(), ent_path, present_data_timepoint, 2, colors)
+                .unwrap();
+        store.insert_row(&row).unwrap();
+
+        query_and_compare(&store, &query, &ent_path.into());
+
+        // --- Modify past ---
+
+        // Modify the PoV component
+        let positions = vec![Position2D::new(100.0, 200.0), Position2D::new(300.0, 400.0)];
+        let row = DataRow::from_cells1_sized(
+            RowId::new(),
+            ent_path,
+            past_data_timepoint.clone(),
+            2,
+            positions,
+        )
+        .unwrap();
+        store.insert_row(&row).unwrap();
+
+        query_and_compare(&store, &query, &ent_path.into());
+
+        // Modify the optional component
+        let colors = vec![Color::from_rgb(10, 11, 12), Color::from_rgb(13, 14, 15)];
+        let row =
+            DataRow::from_cells1_sized(RowId::new(), ent_path, past_data_timepoint, 2, colors)
+                .unwrap();
+        store.insert_row(&row).unwrap();
+
+        query_and_compare(&store, &query, &ent_path.into());
+
+        // --- Modify future ---
+
+        // Modify the PoV component
+        let positions = vec![
+            Position2D::new(1000.0, 2000.0),
+            Position2D::new(3000.0, 4000.0),
+        ];
+        let row = DataRow::from_cells1_sized(
+            RowId::new(),
+            ent_path,
+            future_data_timepoint.clone(),
+            2,
+            positions,
+        )
+        .unwrap();
+        store.insert_row(&row).unwrap();
+
+        query_and_compare(&store, &query, &ent_path.into());
+
+        // Modify the optional component
+        let colors = vec![Color::from_rgb(16, 17, 18)];
+        let row =
+            DataRow::from_cells1_sized(RowId::new(), ent_path, future_data_timepoint, 1, colors)
+                .unwrap();
+        store.insert_row(&row).unwrap();
+
+        query_and_compare(&store, &query, &ent_path.into());
+    };
+
+    let timeless = TimePoint::timeless();
+    let frame_122 = build_frame_nr(123.into());
+    let frame_123 = build_frame_nr(123.into());
+    let frame_124 = build_frame_nr(123.into());
+
+    test_invalidation(
+        LatestAtQuery {
+            timeline: frame_123.0,
+            at: frame_123.1,
+        },
+        [frame_123].into(),
+        [frame_122].into(),
+        [frame_124].into(),
     );
 
-    let ent_path = "point";
-    let timepoint = [build_frame_nr(123.into())];
-
-    // Create some positions with implicit instances
-    let positions = vec![Position2D::new(1.0, 2.0), Position2D::new(3.0, 4.0)];
-    let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timepoint, 2, positions).unwrap();
-    store.insert_row(&row).unwrap();
-
-    // Assign one of them a color with an explicit instance
-    let color_instances = vec![InstanceKey(1)];
-    let colors = vec![Color::from_rgb(255, 0, 0)];
-    let row = DataRow::from_cells2_sized(
-        RowId::new(),
-        ent_path,
-        timepoint,
-        1,
-        (color_instances, colors),
-    )
-    .unwrap();
-    store.insert_row(&row).unwrap();
-
-    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
-    query_and_compare(&store, &query, &ent_path.into());
-
-    // Invalidate the PoV component
-    let positions = vec![Position2D::new(10.0, 20.0), Position2D::new(30.0, 40.0)];
-    let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timepoint, 2, positions).unwrap();
-    store.insert_row(&row).unwrap();
-
-    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
-    query_and_compare(&store, &query, &ent_path.into());
-
-    // Invalidate the optional component
-    let colors = vec![Color::from_rgb(255, 0, 0), Color::from_rgb(0, 255, 0)];
-    let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timepoint, 2, colors).unwrap();
-    store.insert_row(&row).unwrap();
-
-    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
-    query_and_compare(&store, &query, &ent_path.into());
+    test_invalidation(
+        LatestAtQuery {
+            timeline: frame_123.0,
+            at: frame_123.1,
+        },
+        [frame_123].into(),
+        timeless,
+        [frame_124].into(),
+    );
 }
 
 // Test the following scenario:
 // ```py
-// rr.set_time(0)
-// rr.log("points", rr.Points3D([1, 2, 3]))
+// rr.log("points", rr.Points3D([1, 2, 3]), timeless=True)
 //
 // # Do first query here: LatestAt(+inf)
 // # Expected: points=[[1,2,3]] colors=[]
 //
-// rr.set_time(1)
+// rr.set_time(2)
 // rr.log_components("points", rr.components.Color(0xFF0000))
 //
 // # Do second query here: LatestAt(+inf)
 // # Expected: points=[[1,2,3]] colors=[0xFF0000]
 //
-// rr.set_time(2)
+// rr.set_time(3)
 // rr.log_components("points", rr.components.Color(0x0000FF))
 //
 // # Do third query here: LatestAt(+inf)
 // # Expected: points=[[1,2,3]] colors=[0x0000FF]
 // ```
-//
-// TODO(cmc): this needs proper invalidation to pass
-#[should_panic(expected = "assertion failed: `(left == right)`")]
 #[test]
 fn invalidation_of_future_optionals() {
     let mut store = DataStore::new(
@@ -242,14 +333,14 @@ fn invalidation_of_future_optionals() {
 
     let ent_path = "points";
 
-    let frame1 = [build_frame_nr(1.into())];
+    let timeless = TimePoint::timeless();
     let frame2 = [build_frame_nr(2.into())];
     let frame3 = [build_frame_nr(3.into())];
 
     let query_time = [build_frame_nr(9999.into())];
 
     let positions = vec![Position2D::new(1.0, 2.0), Position2D::new(3.0, 4.0)];
-    let row = DataRow::from_cells1_sized(RowId::new(), ent_path, frame1, 2, positions).unwrap();
+    let row = DataRow::from_cells1_sized(RowId::new(), ent_path, timeless, 2, positions).unwrap();
     store.insert_row(&row).unwrap();
 
     let query = re_data_store::LatestAtQuery::new(query_time[0].0, query_time[0].1);
@@ -280,24 +371,44 @@ fn invalidation_of_future_optionals() {
 
 fn query_and_compare(store: &DataStore, query: &LatestAtQuery, ent_path: &EntityPath) {
     for _ in 0..3 {
-        let mut got_instance_keys = Vec::new();
-        let mut got_positions = Vec::new();
-        let mut got_colors = Vec::new();
+        let mut uncached_data_time = None;
+        let mut uncached_instance_keys = Vec::new();
+        let mut uncached_positions = Vec::new();
+        let mut uncached_colors = Vec::new();
+        query_archetype_pov1_comp1::<Points2D, Position2D, Color, _>(
+            false, // cached?
+            store,
+            &query.clone().into(),
+            ent_path,
+            |((data_time, _), instance_keys, positions, colors)| {
+                uncached_data_time = data_time;
+                uncached_instance_keys.extend(instance_keys.iter().copied());
+                uncached_positions.extend(positions.iter().copied());
+                uncached_colors.extend(colors.iter().copied());
+            },
+        )
+        .unwrap();
 
+        let mut cached_data_time = None;
+        let mut cached_instance_keys = Vec::new();
+        let mut cached_positions = Vec::new();
+        let mut cached_colors = Vec::new();
         query_archetype_pov1_comp1::<Points2D, Position2D, Color, _>(
             true, // cached?
             store,
             &query.clone().into(),
             ent_path,
-            |(_, instance_keys, positions, colors)| {
-                got_instance_keys.extend(instance_keys.iter().copied());
-                got_positions.extend(positions.iter().copied());
-                got_colors.extend(colors.iter().copied());
+            |((data_time, _), instance_keys, positions, colors)| {
+                cached_data_time = data_time;
+                cached_instance_keys.extend(instance_keys.iter().copied());
+                cached_positions.extend(positions.iter().copied());
+                cached_colors.extend(colors.iter().copied());
             },
         )
         .unwrap();
 
         let expected = re_query::query_archetype::<Points2D>(store, query, ent_path).unwrap();
+        let expected_data_time = expected.data_time();
 
         let expected_instance_keys = expected.iter_instance_keys().collect_vec();
         let expected_positions = expected
@@ -309,8 +420,17 @@ fn query_and_compare(store: &DataStore, query: &LatestAtQuery, ent_path: &Entity
             .unwrap()
             .collect_vec();
 
-        similar_asserts::assert_eq!(expected_instance_keys, got_instance_keys);
-        similar_asserts::assert_eq!(expected_positions, got_positions);
-        similar_asserts::assert_eq!(expected_colors, got_colors);
+        // Keep this around for the next unlucky chap.
+        // eprintln!("(expected={expected_data_time:?}, uncached={uncached_data_time:?}, cached={cached_data_time:?})");
+
+        similar_asserts::assert_eq!(expected_data_time, uncached_data_time);
+        similar_asserts::assert_eq!(expected_instance_keys, uncached_instance_keys);
+        similar_asserts::assert_eq!(expected_positions, uncached_positions);
+        similar_asserts::assert_eq!(expected_colors, uncached_colors);
+
+        similar_asserts::assert_eq!(expected_data_time, cached_data_time);
+        similar_asserts::assert_eq!(expected_instance_keys, cached_instance_keys);
+        similar_asserts::assert_eq!(expected_positions, cached_positions);
+        similar_asserts::assert_eq!(expected_colors, cached_colors);
     }
 }

--- a/crates/re_viewer_context/src/app_options.rs
+++ b/crates/re_viewer_context/src/app_options.rs
@@ -60,13 +60,8 @@ impl Default for AppOptions {
 
             experimental_additive_workflow: cfg!(debug_assertions),
 
-            // TODO(cmc): default to true for debug/rerun-workspace once minimal features have been
-            // merged in.
-            experimental_primary_caching_point_clouds: false,
-
-            // TODO(cmc): default to true for debug/rerun-workspace once minimal features have been
-            // merged in.
-            experimental_primary_caching_series: false,
+            experimental_primary_caching_point_clouds: true,
+            experimental_primary_caching_series: true,
 
             show_picking_debug_overlay: false,
 


### PR DESCRIPTION
This implements cache invalidation via a `StoreSubscriber`.

We keep track of the timestamps to invalidate in the `StoreSubscriber`, but we only do the actual removal of components at query time.
This is similar to how we handle bucket sorting in the main store: doing it at query time has the benefit that the frame time effectively behaves as natural micro-batching mechanism that vastly improves performance.

---

Part of the primary caching series of PR (index search, joins, deserialization):
- #4592
- #4593
- #4659
- #4680 
- #4681
- #4698
- #4711
- #4712
- #4721 
- #4726 
- #4773
- #4784
- #4785
- #4793
- #4800

---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4592/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4592)
- [Docs preview](https://rerun.io/preview/78a8668f2d9900029b0de633f71274dfe5649b0d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/78a8668f2d9900029b0de633f71274dfe5649b0d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)