### PR TITLE
2D visualizers are no longer applicable to paths that are behind a pinhole camera other than the space's origin

### DIFF
--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -1,4 +1,4 @@
-use re_entity_db::EntityProperties;
+use re_entity_db::{EntityProperties, EntityTree};
 use re_log_types::EntityPath;
 use re_types::{components::PinholeProjection, Loggable as _};
 use re_viewer_context::{
@@ -17,8 +17,13 @@ use crate::{
     },
 };
 
+// TODO(#4388): 2D/3D relationships should be solved via a "SpatialTopology" construct.
 pub struct VisualizableFilterContext2D {
+    /// True if there's a pinhole camera at the origin, meaning we can display 3d content.
     pub has_pinhole_at_origin: bool,
+
+    /// All subtrees that are invalid since they're behind a pinhole that's not at the origin.
+    pub invalid_subtrees: Vec<EntityPath>,
 }
 
 impl VisualizableFilterContext for VisualizableFilterContext2D {
@@ -70,17 +75,40 @@ impl SpaceViewClass for SpatialSpaceView2D {
     ) -> Box<dyn VisualizableFilterContext> {
         re_tracing::profile_function!();
 
-        let has_pinhole_at_origin = entity_db
-            .tree()
-            .subtree(space_origin)
-            .map_or(false, |tree| {
-                tree.entity
-                    .components
-                    .contains_key(&PinholeProjection::name())
-            });
+        // See also `SpatialSpaceView3D::visualizable_filter_context`
+
+        let origin_tree = entity_db.tree().subtree(space_origin);
+
+        let has_pinhole_at_origin = origin_tree.map_or(false, |tree| {
+            tree.entity
+                .components
+                .contains_key(&PinholeProjection::name())
+        });
+
+        fn visit_children_recursively(tree: &EntityTree, invalid_subtrees: &mut Vec<EntityPath>) {
+            if tree
+                .entity
+                .components
+                .contains_key(&PinholeProjection::name())
+            {
+                invalid_subtrees.push(tree.path.clone());
+            } else {
+                for child in tree.children.values() {
+                    visit_children_recursively(child, invalid_subtrees);
+                }
+            }
+        }
+
+        let mut invalid_subtrees = Vec::new();
+        if let Some(origin_tree) = origin_tree {
+            for child_tree in origin_tree.children.values() {
+                visit_children_recursively(child_tree, &mut invalid_subtrees);
+            }
+        };
 
         Box::new(VisualizableFilterContext2D {
             has_pinhole_at_origin,
+            invalid_subtrees,
         })
     }
 

--- a/crates/re_space_view_spatial/src/visualizers/mod.rs
+++ b/crates/re_space_view_spatial/src/visualizers/mod.rs
@@ -364,6 +364,26 @@ fn filter_visualizable_2d_entities(
                 .filter(|ent_path| context.entities_under_pinhole.contains(&ent_path.hash()))
                 .collect(),
         )
+    } else if let Some(context) = context
+        .as_any()
+        .downcast_ref::<VisualizableFilterContext2D>()
+    {
+        if !context.invalid_subtrees.is_empty() {
+            VisualizableEntities(
+                entities
+                    .0
+                    .into_iter()
+                    .filter(|ent_path| {
+                        !context
+                            .invalid_subtrees
+                            .iter()
+                            .any(|invalid_subtree| ent_path.starts_with(invalid_subtree))
+                    })
+                    .collect(),
+            )
+        } else {
+            VisualizableEntities(entities.0)
+        }
     } else {
         VisualizableEntities(entities.0)
     }


### PR DESCRIPTION
### What

Fixes broken heuristics for structure_from_motion.

This is a bit of a hacky addition. We need to solve this with a proper `SpatialTopology` data structure that can tell us efficiently if we're inside a 2d/3d space and how far it reaches. 

See also
* #4388


<img width="446" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/08f3dee5-1823-4055-a339-95cb778e4f01">

picture showing that a 2D space at `camera` is no longer suggested since it wouldn't be able to show anything: `camera/image` has a pinhole projection, therefore `camera` -> `camera/pinhole` is a 3D->2D projection but by having a 2D space at `camera` we implied `camera` to have an eye pinhole.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4728/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4728/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4728/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4728)
- [Docs preview](https://rerun.io/preview/74a06017c2380916ec46cf5639a82e4a3bf4189a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/74a06017c2380916ec46cf5639a82e4a3bf4189a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)