### PR TITLE
Introduce a new "release" channel for examples and use it on explicitly released versions

### DIFF
--- a/.github/workflows/reusable_publish_web.yml
+++ b/.github/workflows/reusable_publish_web.yml
@@ -114,18 +114,15 @@ jobs:
         shell: bash
         run: |
           pixi run build-examples rrd \
-            --channel "nightly" \
+            --channel "release" \
             web_viewer/examples
 
       - name: Build examples manifest
         shell: bash
         run: |
-          full_commit="${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}"
-          sha="$(echo $full_commit | cut -c1-7)"
-
           pixi run build-examples manifest \
-            --base-url "https://app.rerun.io/commit/$sha" \
-            --channel "nightly" \
+            --base-url "https://app.rerun.io/version/${{inputs.release-version}}" \
+            --channel "release" \
             web_viewer/examples_manifest.json
 
       - name: Upload app.rerun.io (versioned)

--- a/crates/re_build_examples/src/example.rs
+++ b/crates/re_build_examples/src/example.rs
@@ -22,6 +22,7 @@ pub enum Channel {
     #[default]
     Main,
     Nightly,
+    Release,
 }
 
 impl Channel {
@@ -31,6 +32,11 @@ impl Channel {
 
             // Include all `main` examples in `nightly`
             Channel::Nightly => matches!(other, Channel::Main | Channel::Nightly),
+
+            // Include all `main` and `nightly` examples in `release`
+            Channel::Release => {
+                matches!(other, Channel::Main | Channel::Nightly | Channel::Release)
+            }
         }
     }
 
@@ -101,6 +107,7 @@ impl Display for Channel {
         let s = match self {
             Channel::Main => "main",
             Channel::Nightly => "nightly",
+            Channel::Release => "release",
         };
         f.write_str(s)
     }
@@ -113,6 +120,7 @@ impl FromStr for Channel {
         match s {
             "main" => Ok(Self::Main),
             "nightly" => Ok(Self::Nightly),
+            "release" => Ok(Self::Release),
             _ => Err(InvalidChannelName),
         }
     }

--- a/crates/re_build_examples/src/example.rs
+++ b/crates/re_build_examples/src/example.rs
@@ -30,12 +30,14 @@ impl Channel {
         match self {
             Channel::Main => matches!(other, Channel::Main),
 
-            // Include all `main` examples in `nightly`
-            Channel::Nightly => matches!(other, Channel::Main | Channel::Nightly),
-
-            // Include all `main` and `nightly` examples in `release`
+            // Include all `main` examples in `release`
             Channel::Release => {
-                matches!(other, Channel::Main | Channel::Nightly | Channel::Release)
+                matches!(other, Channel::Main | Channel::Release)
+            }
+
+            // Include all `main` and `release` examples in `nightly`
+            Channel::Nightly => {
+                matches!(other, Channel::Main | Channel::Release | Channel::Nightly)
             }
         }
     }

--- a/examples/python/detect_and_track_objects/README.md
+++ b/examples/python/detect_and_track_objects/README.md
@@ -4,7 +4,7 @@ tags = ["2D", "huggingface", "object-detection", "object-tracking", "opencv"]
 description = "Visualize object detection and segmentation using the Huggingface `transformers` library."
 thumbnail = "https://static.rerun.io/detect_and_track_objects/59f5b97a8724f9037353409ab3d0b7cb47d1544b/480w.png"
 thumbnail_dimensions = [480, 279]
-channel = "nightly"
+channel = "release"
 -->
 
 

--- a/examples/python/nuscenes/README.md
+++ b/examples/python/nuscenes/README.md
@@ -4,7 +4,7 @@ tags = ["lidar", "3D", "2D", "object-detection", "pinhole-camera"]
 description = "Visualize the nuScenes dataset including lidar, radar, images, and bounding boxes."
 thumbnail = "https://static.rerun.io/nuscenes/64a50a9d67cbb69ae872551989ee807b195f6b5d/480w.png"
 thumbnail_dimensions = [480, 282]
-channel = "nightly"
+channel = "release"
 build_args = ["--seconds=5"]
 -->
 

--- a/examples/python/objectron/README.md
+++ b/examples/python/objectron/README.md
@@ -3,7 +3,7 @@ title = "Objectron"
 tags = ["2D", "3D", "object-detection", "pinhole-camera"]
 thumbnail = "https://static.rerun.io/objectron/8ea3a37e6b4af2e06f8e2ea5e70c1951af67fea8/480w.png"
 thumbnail_dimensions = [480, 268]
-channel = "nightly"
+channel = "release"
 build_args = ["--frames=150"]
 -->
 

--- a/examples/python/open_photogrammetry_format/README.md
+++ b/examples/python/open_photogrammetry_format/README.md
@@ -3,7 +3,7 @@ title = "Open Photogrammetry Format"
 tags = ["2d", "3d", "camera", "photogrammetry"]
 thumbnail = "https://static.rerun.io/open_photogrammetry_format/603d5605f9670889bc8bce3365f16b831fce1eb1/480w.png"
 thumbnail_dimensions = [480, 310]
-channel = "nightly"
+channel = "release"
 build_args = ["--jpeg-quality=50"]
 -->
 

--- a/examples/python/raw_mesh/README.md
+++ b/examples/python/raw_mesh/README.md
@@ -3,7 +3,7 @@ title = "Raw Mesh"
 tags = ["mesh"]
 thumbnail = "https://static.rerun.io/raw_mesh/64bec98280b07794f7c9617f30ba2c20278601c3/480w.png"
 thumbnail_dimensions = [480, 271]
-channel = "nightly"
+channel = "release"
 -->
 
 

--- a/examples/python/rgbd/README.md
+++ b/examples/python/rgbd/README.md
@@ -3,7 +3,7 @@ title = "RGBD"
 tags = ["2D", "3D", "depth", "nyud", "pinhole-camera"]
 thumbnail = "https://static.rerun.io/rgbd/4109d29ed52fa0a8f980fcdd0e9673360c76879f/480w.png"
 thumbnail_dimensions = [480, 254]
-channel = "nightly"
+channel = "release"
 build_args = ["--frames=300"]
 -->
 

--- a/examples/python/segment_anything_model/README.md
+++ b/examples/python/segment_anything_model/README.md
@@ -3,7 +3,7 @@ title = "Segment Anything Model"
 tags = ["2D", "sam", "segmentation"]
 thumbnail = "https://static.rerun.io/segment_anything_model/6aa2651907efbcf81be55b343caa76b9de5f2138/480w.png"
 thumbnail_dimensions = [480, 283]
-channel = "nightly"
+channel = "release"
 -->
 
 


### PR DESCRIPTION
### What

This now points to versioned example locations when the build is run from an RC or Release.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4735/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4735/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4735/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4735)
- [Docs preview](https://rerun.io/preview/8d875827449601c0498aaacab896055766e5b134/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8d875827449601c0498aaacab896055766e5b134/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)