### PR TITLE
Fill in missing example description test snippets

### DIFF
--- a/examples/python/objectron/README.md
+++ b/examples/python/objectron/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "Objectron"
 tags = ["2D", "3D", "object-detection", "pinhole-camera"]
+description = "Example of using the Rerun SDK to log the Google Research Objectron dataset."
 thumbnail = "https://static.rerun.io/objectron/8ea3a37e6b4af2e06f8e2ea5e70c1951af67fea8/480w.png"
 thumbnail_dimensions = [480, 268]
 channel = "release"

--- a/examples/python/open_photogrammetry_format/README.md
+++ b/examples/python/open_photogrammetry_format/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "Open Photogrammetry Format"
 tags = ["2d", "3d", "camera", "photogrammetry"]
+description = "Displays a photogrammetrically reconstructed 3D point cloud loaded from an Open Photogrammetry Format (OPF) file."
 thumbnail = "https://static.rerun.io/open_photogrammetry_format/603d5605f9670889bc8bce3365f16b831fce1eb1/480w.png"
 thumbnail_dimensions = [480, 310]
 channel = "release"

--- a/examples/python/raw_mesh/README.md
+++ b/examples/python/raw_mesh/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "Raw Mesh"
 tags = ["mesh"]
+description = "Demonstrates logging of raw 3D mesh data with simple material properties."
 thumbnail = "https://static.rerun.io/raw_mesh/64bec98280b07794f7c9617f30ba2c20278601c3/480w.png"
 thumbnail_dimensions = [480, 271]
 channel = "release"

--- a/examples/python/rgbd/README.md
+++ b/examples/python/rgbd/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "RGBD"
 tags = ["2D", "3D", "depth", "nyud", "pinhole-camera"]
+description = "Shows an example dataset from New York University with RGB and Depth channels."
 thumbnail = "https://static.rerun.io/rgbd/4109d29ed52fa0a8f980fcdd0e9673360c76879f/480w.png"
 thumbnail_dimensions = [480, 254]
 channel = "release"

--- a/examples/python/segment_anything_model/README.md
+++ b/examples/python/segment_anything_model/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "Segment Anything Model"
 tags = ["2D", "sam", "segmentation"]
+description = "Example of using Rerun to log and visualize the output of Meta AI's Segment Anything model."
 thumbnail = "https://static.rerun.io/segment_anything_model/6aa2651907efbcf81be55b343caa76b9de5f2138/480w.png"
 thumbnail_dimensions = [480, 283]
 channel = "release"

--- a/examples/rust/objectron/README.md
+++ b/examples/rust/objectron/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "Objectron"
 tags = ["2D", "3D", "object-detection", "pinhole-camera"]
+description = "Example of using the Rerun SDK to log the Google Research Objectron dataset."
 thumbnail = "https://static.rerun.io/objectron/8ea3a37e6b4af2e06f8e2ea5e70c1951af67fea8/480w.png"
 build_args = ["--frames=100"]
 -->

--- a/examples/rust/raw_mesh/README.md
+++ b/examples/rust/raw_mesh/README.md
@@ -1,5 +1,6 @@
 <!--[metadata]
 title = "Raw Mesh"
+description = "Demonstrates logging of raw 3D mesh data with simple material properties."
 thumbnail = "https://static.rerun.io/raw_mesh/64bec98280b07794f7c9617f30ba2c20278601c3/480w.png"
 -->
 


### PR DESCRIPTION
### What

in the front-matter so that they show up in the example manifest

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4745/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4745/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4745/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4745)
- [Docs preview](https://rerun.io/preview/ae470e1efaefe6d1633d21ac92bc1a29e174cad3/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ae470e1efaefe6d1633d21ac92bc1a29e174cad3/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)