### PR TITLE
Remove backtraces on error when running `rerun` binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5562,6 +5562,7 @@ dependencies = [
  "rayon",
  "re_build_info",
  "re_build_tools",
+ "re_error",
  "re_log",
  "re_memory",
  "rerun",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "arboard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ emath = "0.24.1"
 
 # All of our direct external dependencies should be found here:
 ahash = "0.8"
-anyhow = "1.0"
+anyhow = { version = "1.0", default-features = false }
 arboard = { version = "3.2", default-features = false }
 argh = "0.1.12"
 array-init = "2.1"

--- a/crates/rerun-cli/Cargo.toml
+++ b/crates/rerun-cli/Cargo.toml
@@ -47,6 +47,7 @@ web_viewer = ["rerun/web_viewer", "rerun/sdk"]
 
 [dependencies]
 re_build_info.workspace = true
+re_error.workspace = true
 re_log.workspace = true
 re_memory.workspace = true
 rerun = { workspace = true, features = [

--- a/crates/rerun-cli/src/bin/rerun.rs
+++ b/crates/rerun-cli/src/bin/rerun.rs
@@ -17,7 +17,7 @@ static GLOBAL: AccountingAllocator<mimalloc::MiMalloc> =
     AccountingAllocator::new(mimalloc::MiMalloc);
 
 #[tokio::main]
-async fn main() -> anyhow::Result<std::process::ExitCode> {
+async fn main() -> std::process::ExitCode {
     re_log::setup_native_logging();
 
     // Name the rayon threads for the benefit of debuggers and profilers:
@@ -27,7 +27,14 @@ async fn main() -> anyhow::Result<std::process::ExitCode> {
         .unwrap();
 
     let build_info = re_build_info::build_info!();
-    rerun::run(build_info, rerun::CallSource::Cli, std::env::args())
-        .await
-        .map(std::process::ExitCode::from)
+
+    let result = rerun::run(build_info, rerun::CallSource::Cli, std::env::args()).await;
+
+    match result {
+        Ok(exit_code) => std::process::ExitCode::from(exit_code),
+        Err(err) => {
+            eprintln!("Error: {}", re_error::format(err));
+            std::process::ExitCode::FAILURE
+        }
+    }
 }


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/4738

Starting in [`anyhow 1.0.77`](https://github.com/dtolnay/anyhow/releases/tag/1.0.77), a backtrace will be printed on error if `RUST_BACKTRACE` is set, and we set `RUST_BACKTRACE=1` in:

https://github.com/rerun-io/rerun/blob/d204936e4a186b6f264425f7a3d3849f94b7b86f/crates/re_log/src/setup.rs#L32-L35

We do this because we want to print stack traces on panics.

However, for `anyhow::Error` our error messages _should_ be good enough to not require a stack trace,
so with this PR we now explicitly print out the error instead of relying in the formatting that happens when returning `anyhow::Result` from `main`.

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
