### PR TITLE
Default to DEBUG log level in debug builds

### DIFF
--- a/crates/re_log/src/setup.rs
+++ b/crates/re_log/src/setup.rs
@@ -5,7 +5,13 @@
 /// Also sets some other log levels on crates that are too loud.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn default_log_filter() -> String {
-    let mut rust_log = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_owned());
+    let mut rust_log = std::env::var("RUST_LOG").unwrap_or_else(|_| {
+        if cfg!(debug_assertions) {
+            "debug".to_owned()
+        } else {
+            "info".to_owned()
+        }
+    });
 
     for crate_name in crate::CRATES_AT_ERROR_LEVEL {
         if !rust_log.contains(&format!("{crate_name}=")) {


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/4629

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4749/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4749/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4749/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4749)
- [Docs preview](https://rerun.io/preview/86cdb73e839f7f5301f94ccd7b59248b721a7a1e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/86cdb73e839f7f5301f94ccd7b59248b721a7a1e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)