### PR TITLE
Include `Cargo.lock` in `rerun-cli` crate

### DIFF
--- a/crates/rerun-cli/Cargo.toml
+++ b/crates/rerun-cli/Cargo.toml
@@ -5,7 +5,13 @@ categories = ["visualization", "computer-vision"]
 description = "Log images, point clouds, etc, and visualize them effortlessly"
 edition.workspace = true
 homepage.workspace = true
-include.workspace = true
+include = [
+  "../../Cargo.lock",     # So that users can pass `--locked` to `cargo install`
+  "../../LICENSE-APACHE",
+  "../../LICENSE-MIT",
+  "**/*.rs",
+  "Cargo.toml",
+]
 keywords = ["mesh", "plotting", "point-cloud", "robotics", "visualization"]
 license.workspace = true
 publish = true


### PR DESCRIPTION
This allows users to pass in `--locked` when installing `rerun-cli` with `cargo-install`.

See https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
