### PR TITLE
Add Help and Discord to command palette

### DIFF
--- a/crates/re_types/src/tensor_data.rs
+++ b/crates/re_types/src/tensor_data.rs
@@ -551,9 +551,7 @@ impl DecodedTensor {
         jpeg_bytes: &::re_types_core::ArrowBuffer<u8>,
         [expected_height, expected_width, expected_channels]: [u64; 3],
     ) -> Result<DecodedTensor, TensorImageLoadError> {
-        re_tracing::profile_function!();
-
-        re_log::debug!("Decoding {expected_width}x{expected_height} JPEG");
+        re_tracing::profile_function!(format!("{expected_width}x{expected_height}"));
 
         use zune_core::colorspace::ColorSpace;
         use zune_core::options::DecoderOptions;

--- a/crates/re_ui/src/command_palette.rs
+++ b/crates/re_ui/src/command_palette.rs
@@ -30,11 +30,21 @@ impl CommandPalette {
         let max_height = 320.0.at_most(screen_rect.height());
 
         egui::Window::new("Command Palette")
-            .title_bar(false)
+            .fixed_pos(screen_rect.center() - 0.5 * max_height * egui::Vec2::Y)
             .fixed_size([width, max_height])
             .pivot(egui::Align2::CENTER_TOP)
-            .fixed_pos(screen_rect.center() - 0.5 * max_height * egui::Vec2::Y)
-            .show(egui_ctx, |ui| self.window_content_ui(ui))?
+            .resizable(false)
+            .scroll2(false)
+            .title_bar(false)
+            .show(egui_ctx, |ui| {
+                // We need an exatra frame here because we set clip_rect_margin to zero.
+                egui::Frame {
+                    inner_margin: 2.0.into(),
+                    ..Default::default()
+                }
+                .show(ui, |ui| self.window_content_ui(ui))
+                .inner
+            })?
             .inner?
     }
 
@@ -199,7 +209,7 @@ fn commands_that_match(query: &str) -> Vec<FuzzyMatch> {
                 })
             })
             .collect();
-        matches.sort_by_key(|m| -m.score);
+        matches.sort_by_key(|m| -m.score); // highest score first
         matches
     }
 }

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -405,7 +405,7 @@ impl App {
 
     fn run_ui_command(
         &mut self,
-        _egui_ctx: &egui::Context,
+        egui_ctx: &egui::Context,
         app_blueprint: &AppBlueprint<'_>,
         store_context: Option<&StoreContext<'_>>,
         cmd: UICommand,
@@ -435,7 +435,7 @@ impl App {
             }
             #[cfg(target_arch = "wasm32")]
             UICommand::Open => {
-                let egui_ctx = _egui_ctx.clone();
+                let egui_ctx = egui_ctx.clone();
                 self.open_files_promise = Some(poll_promise::Promise::spawn_local(async move {
                     let file = async_open_rrd_dialog().await;
                     egui_ctx.request_repaint(); // Wake ui thread
@@ -454,7 +454,21 @@ impl App {
 
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::Quit => {
-                _egui_ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                egui_ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+            }
+
+            UICommand::OpenWebHelp => {
+                egui_ctx.open_url(egui::output::OpenUrl {
+                    url: "https://www.rerun.io/docs/getting-started/viewer-walkthrough".to_owned(),
+                    new_tab: true,
+                });
+            }
+
+            UICommand::OpenRerunDiscord => {
+                egui_ctx.open_url(egui::output::OpenUrl {
+                    url: "https://discord.gg/PXtCgFBSmH".to_owned(),
+                    new_tab: true,
+                });
             }
 
             UICommand::ResetViewer => self.command_sender.send_system(SystemCommand::ResetViewer),
@@ -482,28 +496,28 @@ impl App {
 
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::ToggleFullscreen => {
-                let fullscreen = _egui_ctx.input(|i| i.viewport().fullscreen.unwrap_or(false));
-                _egui_ctx.send_viewport_cmd(egui::ViewportCommand::Fullscreen(!fullscreen));
+                let fullscreen = egui_ctx.input(|i| i.viewport().fullscreen.unwrap_or(false));
+                egui_ctx.send_viewport_cmd(egui::ViewportCommand::Fullscreen(!fullscreen));
             }
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::ZoomIn => {
-                let mut zoom_factor = _egui_ctx.zoom_factor();
+                let mut zoom_factor = egui_ctx.zoom_factor();
                 zoom_factor += 0.1;
                 zoom_factor = zoom_factor.clamp(MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR);
                 zoom_factor = (zoom_factor * 10.).round() / 10.;
-                _egui_ctx.set_zoom_factor(zoom_factor);
+                egui_ctx.set_zoom_factor(zoom_factor);
             }
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::ZoomOut => {
-                let mut zoom_factor = _egui_ctx.zoom_factor();
+                let mut zoom_factor = egui_ctx.zoom_factor();
                 zoom_factor -= 0.1;
                 zoom_factor = zoom_factor.clamp(MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR);
                 zoom_factor = (zoom_factor * 10.).round() / 10.;
-                _egui_ctx.set_zoom_factor(zoom_factor);
+                egui_ctx.set_zoom_factor(zoom_factor);
             }
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::ZoomReset => {
-                _egui_ctx.set_zoom_factor(1.0);
+                egui_ctx.set_zoom_factor(1.0);
             }
 
             UICommand::SelectionPrevious => {
@@ -548,7 +562,7 @@ impl App {
 
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::ScreenshotWholeApp => {
-                self.screenshotter.request_screenshot(_egui_ctx);
+                self.screenshotter.request_screenshot(egui_ctx);
             }
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::PrintDatastore => {

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -1,6 +1,6 @@
 //! The main Rerun drop-down menu found in the top panel.
 
-use egui::{NumExt as _, Widget};
+use egui::NumExt as _;
 
 use re_log_types::TimeZone;
 use re_ui::{ReUi, UICommand};
@@ -96,48 +96,8 @@ impl App {
 
             ui.add_space(SPACING);
 
-            // dont use `hyperlink_to` for styling reasons
-            const HELP_URL: &str = "https://www.rerun.io/docs/getting-started/viewer-walkthrough";
-
-            if egui::Button::image_and_text(
-                re_ui::icons::EXTERNAL_LINK
-                    .as_image()
-                    .fit_to_exact_size(ReUi::small_icon_size()),
-                "Help",
-            )
-            .ui(ui)
-            .on_hover_cursor(egui::CursorIcon::PointingHand)
-            .on_hover_text(HELP_URL)
-            .clicked()
-            {
-                ui.ctx().output_mut(|o| {
-                    o.open_url = Some(egui::output::OpenUrl {
-                        url: HELP_URL.to_owned(),
-                        new_tab: true,
-                    });
-                });
-            }
-
-            if egui::Button::image_and_text(
-                re_ui::icons::DISCORD
-                    .as_image()
-                    .fit_to_exact_size(ReUi::small_icon_size()),
-                "Rerun Discord",
-            )
-            .ui(ui)
-            .on_hover_cursor(egui::CursorIcon::PointingHand)
-            .on_hover_text(
-                "Join the ReRun Discord server, where you can ask questions and get help.",
-            )
-            .clicked()
-            {
-                ui.ctx().output_mut(|o| {
-                    o.open_url = Some(egui::output::OpenUrl {
-                        url: "https://discord.gg/PXtCgFBSmH".to_owned(),
-                        new_tab: true,
-                    });
-                });
-            }
+            UICommand::OpenWebHelp.menu_button_ui(ui, &self.command_sender);
+            UICommand::OpenRerunDiscord.menu_button_ui(ui, &self.command_sender);
 
             #[cfg(not(target_arch = "wasm32"))]
             {


### PR DESCRIPTION
### What
You can now open the help web site and visit the Rerun Discord from the command pallette.

* Closes https://github.com/rerun-io/rerun/issues/4436

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
