### PR TITLE
Fix the material templates which were broken by auto-formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,7 @@
 rerun_cpp/docs/**/*
 
+rerun_py/docs/templates/**
+
 rerun_js/web-viewer/re_viewer_bg.js
 rerun_js/web-viewer/re_viewer.js
 web_viewer/re_viewer.js

--- a/rerun_py/docs/templates/python/material/class.html
+++ b/rerun_py/docs/templates/python/material/class.html
@@ -1,81 +1,126 @@
 {# Very minimally patched from:
 https://github.com/mkdocstrings/python/blob/master/src/mkdocstrings_handlers/python/templates/material/_base/class.html
-See: CHANGE comments below #} {{ log.debug("Rendering " + class.path) }}
+
+See: CHANGE comments below
+#}
+
+{{ log.debug("Rendering " + class.path) }}
 
 <div class="doc doc-object doc-class">
-  {% with html_id = class.path %} {% if root %} {% set show_full_path =
-  config.show_root_full_path %} {% set root_members = True %} {% elif
-  root_members %} {% set show_full_path = config.show_root_members_full_path or
-  config.show_object_full_path %} {% set root_members = False %} {% else %} {%
-  set show_full_path = config.show_object_full_path %} {% endif %} {% if not
-  root or config.show_root_heading %} {% filter heading(heading_level,
-  role="class", id=html_id, class="doc doc-heading", toc_label=class.name) %} {%
-  if config.separate_signature %}
-  <span class="doc doc-object-name doc-class-name"
-    >{% if show_full_path %}{{ class.path }}{% else %}{{ class.name }}{% endif
-    %}</span
-  >
-  {% elif config.merge_init_into_class and "__init__" in class.members -%} {%-
-  with function = class.members["__init__"] -%} {%- filter
-  highlight(language="python", inline=True) -%} {# CHANGE: Insert class before
-  class for better highlighting #} class {% if show_full_path %}{{ class.path
-  }}{% else %}{{ class.name }}{% endif %} {%- include "signature.html" with
-  context -%} {%- endfilter -%} {%- endwith -%} {% else %} {# CHANGE: Insert
-  class before class for better highlighting #} {%- filter
-  highlight(language="python", inline=True) -%} class {% if show_full_path %}{{
-  class.path }}{% else %}{{ class.name }}{% endif %} {%- endfilter -%} {% endif
-  %} {% with labels = class.labels %} {% include "labels.html" with context %}
-  {% endwith %} {% endfilter %} {% if config.separate_signature and
-  config.merge_init_into_class %} {% if "__init__" in class.members %} {% with
-  function = class.members["__init__"] %} {% filter highlight(language="python",
-  inline=False) %} {% filter format_signature(config.line_length) %} {% if
-  show_full_path %}{{ class.path }}{% else %}{{ class.name }}{% endif %} {%
-  include "signature.html" with context %} {% endfilter %} {% endfilter %} {%
-  endwith %} {% endif %} {% endif %} {% else %} {% if config.show_root_toc_entry
-  %} {% filter heading(heading_level, role="class", id=html_id,
-  toc_label=class.path if config.show_root_full_path else class.name,
-  hidden=True) %} {% endfilter %} {% endif %} {% set heading_level =
-  heading_level - 1 %} {% endif %} {# CHANGE Relative to Upstream: don't apply
-  the 'first' class since it causes worse CSS formatting for our #} {# generated
-  common API index since we inline bare functions that become root-level rather
-  than modules. #} {#
-  <div class="doc doc-contents {% if root %}first{% endif %}">
-    #}
-    <div class="doc doc-contents">
-      {% if config.show_bases and class.bases %}
+{% with html_id = class.path %}
+
+  {% if root %}
+    {% set show_full_path = config.show_root_full_path %}
+    {% set root_members = True %}
+  {% elif root_members %}
+    {% set show_full_path = config.show_root_members_full_path or config.show_object_full_path %}
+    {% set root_members = False %}
+  {% else %}
+    {% set show_full_path = config.show_object_full_path %}
+  {% endif %}
+
+  {% if not root or config.show_root_heading %}
+
+    {% filter heading(heading_level,
+        role="class",
+        id=html_id,
+        class="doc doc-heading",
+        toc_label=class.name) %}
+
+      {% if config.separate_signature %}
+        <span class="doc doc-object-name doc-class-name">{% if show_full_path %}{{ class.path }}{% else %}{{ class.name }}{% endif %}</span>
+      {% elif config.merge_init_into_class and "__init__" in class.members -%}
+        {%- with function = class.members["__init__"] -%}
+          {%- filter highlight(language="python", inline=True) -%}
+            {# CHANGE: Insert class before class for better highlighting #}
+            class {% if show_full_path %}{{ class.path }}{% else %}{{ class.name }}{% endif %}
+            {%- include "signature.html" with context -%}
+          {%- endfilter -%}
+        {%- endwith -%}
+      {% else %}
+        {# CHANGE: Insert class before class for better highlighting #}
+          {%- filter highlight(language="python", inline=True) -%}
+            class {% if show_full_path %}{{ class.path }}{% else %}{{ class.name }}{% endif %}
+          {%- endfilter -%}
+      {% endif %}
+
+      {% with labels = class.labels %}
+        {% include "labels.html" with context %}
+      {% endwith %}
+
+    {% endfilter %}
+
+    {% if config.separate_signature and config.merge_init_into_class %}
+      {% if "__init__" in class.members %}
+        {% with function = class.members["__init__"] %}
+          {% filter highlight(language="python", inline=False) %}
+            {% filter format_signature(config.line_length) %}
+              {% if show_full_path %}{{ class.path }}{% else %}{{ class.name }}{% endif %}
+              {% include "signature.html" with context %}
+            {% endfilter %}
+          {% endfilter %}
+        {% endwith %}
+      {% endif %}
+    {% endif %}
+
+  {% else %}
+    {% if config.show_root_toc_entry %}
+      {% filter heading(heading_level,
+          role="class",
+          id=html_id,
+          toc_label=class.path if config.show_root_full_path else class.name,
+          hidden=True) %}
+      {% endfilter %}
+    {% endif %}
+    {% set heading_level = heading_level - 1 %}
+  {% endif %}
+
+  {# CHANGE Relative to Upstream: don't apply the 'first' class since it causes worse CSS formatting for our #}
+  {# generated common API index since we inline bare functions that become root-level rather than modules. #}
+  {#<div class="doc doc-contents {% if root %}first{% endif %}">#}
+  <div class="doc doc-contents">
+    {% if config.show_bases and class.bases %}
       <p class="doc doc-class-bases">
         Bases: {% for expression in class.bases -%}
-        <code>{% include "expression.html" with context %}</code>{% if not
-        loop.last %}, {% endif %} {% endfor -%}
+          <code>{% include "expression.html" with context %}</code>{% if not loop.last %}, {% endif %}
+        {% endfor -%}
       </p>
-      {% endif %} {% with docstring_sections = class.docstring.parsed %} {%
-      include "docstring.html" with context %} {% endwith %} {% if
-      config.merge_init_into_class %} {% if "__init__" in class.members and
-      class.members["__init__"].has_docstring %} {% with docstring_sections =
-      class.members["__init__"].docstring.parsed %} {% include "docstring.html"
-      with context %} {% endwith %} {% endif %} {% endif %} {% if
-      config.show_source %} {% if config.merge_init_into_class %} {% if
-      "__init__" in class.members and class.members["__init__"].source %}
-      <details class="quote">
-        <summary>
-          Source code in <code>{{ class.relative_filepath }}</code>
-        </summary>
-        {{ class.members["__init__"].source|highlight(language="python",
-        linestart=class.members["__init__"].lineno, linenums=True) }}
-      </details>
-      {% endif %} {% elif class.source %}
-      <details class="quote">
-        <summary>
-          Source code in <code>{{ class.relative_filepath }}</code>
-        </summary>
-        {{ class.source|highlight(language="python", linestart=class.lineno,
-        linenums=True) }}
-      </details>
-      {% endif %} {% endif %} {% with obj = class %} {% set root = False %} {%
-      set heading_level = heading_level + 1 %} {% include "children.html" with
-      context %} {% endwith %}
-    </div>
+    {% endif %}
 
+    {% with docstring_sections = class.docstring.parsed %}
+      {% include "docstring.html" with context %}
+    {% endwith %}
+
+    {% if config.merge_init_into_class %}
+      {% if "__init__" in class.members and class.members["__init__"].has_docstring %}
+        {% with docstring_sections = class.members["__init__"].docstring.parsed %}
+          {% include "docstring.html" with context %}
+        {% endwith %}
+      {% endif %}
+    {% endif %}
+
+    {% if config.show_source %}
+      {% if config.merge_init_into_class %}
+        {% if "__init__" in class.members and class.members["__init__"].source %}
+          <details class="quote">
+            <summary>Source code in <code>{{ class.relative_filepath }}</code></summary>
+            {{ class.members["__init__"].source|highlight(language="python", linestart=class.members["__init__"].lineno, linenums=True) }}
+          </details>
+        {% endif %}
+      {% elif class.source %}
+        <details class="quote">
+          <summary>Source code in <code>{{ class.relative_filepath }}</code></summary>
+          {{ class.source|highlight(language="python", linestart=class.lineno, linenums=True) }}
+        </details>
+      {% endif %}
+    {% endif %}
+
+    {% with obj = class %}
+      {% set root = False %}
+      {% set heading_level = heading_level + 1 %}
+      {% include "children.html" with context %}
     {% endwith %}
   </div>
+
+{% endwith %}
 </div>

--- a/rerun_py/docs/templates/python/material/function.html
+++ b/rerun_py/docs/templates/python/material/function.html
@@ -1,54 +1,84 @@
 {# Very minimally patched from:
 https://github.com/mkdocstrings/python/blob/master/src/mkdocstrings_handlers/python/templates/material/_base/function.html
-See: CHANGE comments below #} {{ log.debug("Rendering " + function.path) }}
+
+See: CHANGE comments below
+#}
+{{ log.debug("Rendering " + function.path) }}
 
 <div class="doc doc-object doc-function">
-  {% with html_id = function.path %} {% if root %} {% set show_full_path =
-  config.show_root_full_path %} {% set root_members = True %} {% elif
-  root_members %} {% set show_full_path = config.show_root_members_full_path or
-  config.show_object_full_path %} {% set root_members = False %} {% else %} {%
-  set show_full_path = config.show_object_full_path %} {% endif %} {% if not
-  root or config.show_root_heading %} {% filter heading(heading_level,
-  role="function", id=html_id, class="doc doc-heading", toc_label=function.name
-  ~ "()") %} {% if config.separate_signature %}
-  <span class="doc doc-object-name doc-function-name"
-    >{% if show_full_path %}{{ function.path }}{% else %}{{ function.name }}{%
-    endif %}</span
-  >
-  {% else %} {% filter highlight(language="python", inline=True) %} {# CHANGE:
-  Insert def before function for better highlighting #} def {% if show_full_path
-  %}{{ function.path }}{% else %}{{ function.name }}{% endif %} {% include
-  "signature.html" with context %} {% endfilter %} {% endif %} {% with labels =
-  function.labels %} {% include "labels.html" with context %} {% endwith %} {%
-  endfilter %} {% if config.separate_signature %} {% filter
-  highlight(language="python", inline=False) %} {# CHANGE: Insert def before
-  function for better highlighting #} def {% filter
-  format_signature(config.line_length) %} {% if show_full_path %}{{
-  function.path }}{% else %}{{ function.name }}{% endif %} {% include
-  "signature.html" with context %} {% endfilter %} {% endfilter %} {% endif %}
-  {% else %} {% if config.show_root_toc_entry %} {% filter
-  heading(heading_level, role="function", id=html_id, toc_label=function.path if
-  config.show_root_full_path else function.name, hidden=True) %} {% endfilter %}
-  {% endif %} {% set heading_level = heading_level - 1 %} {% endif %} {# CHANGE
-  Relative to Upstream: don't apply the 'first' class since it causes worse CSS
-  formatting for our #} {# generated common API index since we inline bare
-  functions that become root-level rather than modules. #} {#
-  <div class="doc doc-contents {% if root %}first{% endif %}">
-    #}
-    <div class="doc doc-contents">
-      {% with docstring_sections = function.docstring.parsed %} {% include
-      "docstring.html" with context %} {% endwith %} {% if config.show_source
-      and function.source %}
-      <details class="quote">
-        <summary>
-          Source code in <code>{{ function.relative_filepath }}</code>
-        </summary>
-        {{ function.source|highlight(language="python",
-        linestart=function.lineno, linenums=True) }}
-      </details>
-      {% endif %}
-    </div>
+{% with html_id = function.path %}
 
+  {% if root %}
+    {% set show_full_path = config.show_root_full_path %}
+    {% set root_members = True %}
+  {% elif root_members %}
+    {% set show_full_path = config.show_root_members_full_path or config.show_object_full_path %}
+    {% set root_members = False %}
+  {% else %}
+    {% set show_full_path = config.show_object_full_path %}
+  {% endif %}
+
+  {% if not root or config.show_root_heading %}
+
+    {% filter heading(heading_level,
+        role="function",
+        id=html_id,
+        class="doc doc-heading",
+        toc_label=function.name ~ "()") %}
+
+      {% if config.separate_signature %}
+        <span class="doc doc-object-name doc-function-name">{% if show_full_path %}{{ function.path }}{% else %}{{ function.name }}{% endif %}</span>
+      {% else %}
+        {% filter highlight(language="python", inline=True) %}
+          {# CHANGE: Insert def before function for better highlighting #}
+          def {% if show_full_path %}{{ function.path }}{% else %}{{ function.name }}{% endif %}
+          {% include "signature.html" with context %}
+        {% endfilter %}
+      {% endif %}
+
+      {% with labels = function.labels %}
+        {% include "labels.html" with context %}
+      {% endwith %}
+
+    {% endfilter %}
+
+    {% if config.separate_signature %}
+      {% filter highlight(language="python", inline=False) %}
+        {# CHANGE: Insert def before function for better highlighting #}
+        def {% filter format_signature(config.line_length) %}
+          {% if show_full_path %}{{ function.path }}{% else %}{{ function.name }}{% endif %}
+          {% include "signature.html" with context %}
+        {% endfilter %}
+      {% endfilter %}
+    {% endif %}
+
+  {% else %}
+    {% if config.show_root_toc_entry %}
+      {% filter heading(heading_level,
+          role="function",
+          id=html_id,
+          toc_label=function.path if config.show_root_full_path else function.name,
+          hidden=True) %}
+      {% endfilter %}
+    {% endif %}
+    {% set heading_level = heading_level - 1 %}
+  {% endif %}
+
+  {# CHANGE Relative to Upstream: don't apply the 'first' class since it causes worse CSS formatting for our #}
+  {# generated common API index since we inline bare functions that become root-level rather than modules. #}
+  {#<div class="doc doc-contents {% if root %}first{% endif %}">#}
+  <div class="doc doc-contents">
+    {% with docstring_sections = function.docstring.parsed %}
+      {% include "docstring.html" with context %}
     {% endwith %}
+
+    {% if config.show_source and function.source %}
+      <details class="quote">
+        <summary>Source code in <code>{{ function.relative_filepath }}</code></summary>
+        {{ function.source|highlight(language="python", linestart=function.lineno, linenums=True) }}
+      </details>
+    {% endif %}
   </div>
+
+{% endwith %}
 </div>


### PR DESCRIPTION
### What
These seem to have been mangled by the auto-formatting rules applied in: https://github.com/rerun-io/rerun/pull/4373/files#diff-53c95a7b38f4e261d062f1a13563b81da95ce01db4807a30663bebd6b673c9cf

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4757/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4757/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4757/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4757)
- [Docs preview](https://rerun.io/preview/f6cc83cd7319981976b8743b1ff3c52a4a75bc8d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f6cc83cd7319981976b8743b1ff3c52a4a75bc8d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)