### PR TITLE
Use thiserror in re_renderer everywhere except shader file reloading

### DIFF
--- a/crates/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/re_renderer/src/renderer/mesh_renderer.rs
@@ -12,7 +12,7 @@ use crate::{
     draw_phases::{DrawPhase, OutlineMaskProcessor},
     include_shader_module,
     mesh::{gpu_data::MaterialUniformBuffer, mesh_vertices, GpuMesh, Mesh},
-    resource_managers::{GpuMeshHandle, ResourceHandle},
+    resource_managers::{GpuMeshHandle, ResourceHandle, ResourceManagerError},
     view_builder::ViewBuilder,
     wgpu_resources::{
         BindGroupLayoutDesc, BufferDesc, GpuBindGroupLayoutHandle, GpuBuffer,
@@ -151,7 +151,10 @@ impl MeshDrawData {
     /// Try bundling all mesh instances into a single draw data instance whenever possible.
     /// If you pass zero mesh instances, subsequent drawing will do nothing.
     /// Mesh data itself is gpu uploaded if not already present.
-    pub fn new(ctx: &RenderContext, instances: &[MeshInstance]) -> anyhow::Result<Self> {
+    pub fn new(
+        ctx: &RenderContext,
+        instances: &[MeshInstance],
+    ) -> Result<MeshDrawData, ResourceManagerError> {
         re_tracing::profile_function!();
 
         let _mesh_renderer = ctx.renderer::<MeshRenderer>();

--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -517,8 +516,7 @@ impl ViewBuilder {
                     phase,
                     pass,
                     queued_draw.draw_data.as_ref(),
-                )
-                .with_context(|| format!("draw call during phase {phase:?}"));
+                );
                 if let Err(err) = res {
                     re_log::error!(renderer=%queued_draw.renderer_name, %err,
                         "renderer failed to draw");


### PR DESCRIPTION
### What

* part of #1845 

Started also removing it the file resolver/reloader but it's super tedious and makes errors worse since during include resolve we often want to stack errors. We can revisit that if we ever move out the shader reloading or when we tackle

* #2664 

but otherwise I don't think it's worth it.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4759/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4759/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4759/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4759)
- [Docs preview](https://rerun.io/preview/79d6075baae6651555be0431005e07817440c3b5/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/79d6075baae6651555be0431005e07817440c3b5/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)