### PR TITLE
Improve documentation of the `Clear` archetype

### DIFF
--- a/crates/re_types/definitions/rerun/archetypes/clear.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/clear.fbs
@@ -9,6 +9,14 @@ namespace rerun.archetypes;
 
 /// Empties all the components of an entity.
 ///
+/// The presence of a clear means that a latest-at query of components at a given path(s)
+/// will not return any components that were logged at those paths before the clear.
+/// Any logged components after the clear are unaffected by the clear.
+///
+/// This implies that a range query that includes time points that are before the clear,
+/// still returns all components at the given path(s), except those logged directly before the clear.
+/// Meaning that in practice clears are ineffective for time series plots and other usages of visible time ranges.
+///
 /// \example clear_simple title="Flat" image="https://static.rerun.io/clear_simple/2f5df95fcc53e9f0552f65670aef7f94830c5c1a/1200w.png"
 /// \example clear_recursive !api "Recursive"
 table Clear (

--- a/crates/re_types_core/src/archetypes/clear.rs
+++ b/crates/re_types_core/src/archetypes/clear.rs
@@ -23,6 +23,14 @@ use crate::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Empties all the components of an entity.
 ///
+/// The presence of a clear means that a latest-at query of components at a given path(s)
+/// will not return any components that were logged at those paths before the clear.
+/// Any logged components after the clear are unaffected by the clear.
+///
+/// This implies that a range query that includes time points that are before the clear,
+/// still returns all components at the given path(s), except those logged directly before the clear.
+/// Meaning that in practice clears are ineffective for time series plots and other usages of visible time ranges.
+///
 /// ## Example
 ///
 /// ### Flat

--- a/docs/content/reference/types/archetypes/clear.md
+++ b/docs/content/reference/types/archetypes/clear.md
@@ -4,6 +4,14 @@ title: "Clear"
 
 Empties all the components of an entity.
 
+The presence of a clear means that a latest-at query of components at a given path(s)
+will not return any components that were logged at those paths before the clear.
+Any logged components after the clear are unaffected by the clear.
+
+This implies that a range query that includes time points that are before the clear,
+still returns all components at the given path(s), except those logged directly before the clear.
+Meaning that in practice clears are ineffective for time series plots and other usages of visible time ranges.
+
 ## Components
 
 **Required**: [`ClearIsRecursive`](../components/clear_is_recursive.md)

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -16,6 +16,14 @@
 namespace rerun::archetypes {
     /// **Archetype**: Empties all the components of an entity.
     ///
+    /// The presence of a clear means that a latest-at query of components at a given path(s)
+    /// will not return any components that were logged at those paths before the clear.
+    /// Any logged components after the clear are unaffected by the clear.
+    ///
+    /// This implies that a range query that includes time points that are before the clear,
+    /// still returns all components at the given path(s), except those logged directly before the clear.
+    /// Meaning that in practice clears are ineffective for time series plots and other usages of visible time ranges.
+    ///
     /// ## Example
     ///
     /// ### Flat

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -19,6 +19,14 @@ class Clear(ClearExt, Archetype):
     """
     **Archetype**: Empties all the components of an entity.
 
+    The presence of a clear means that a latest-at query of components at a given path(s)
+    will not return any components that were logged at those paths before the clear.
+    Any logged components after the clear are unaffected by the clear.
+
+    This implies that a range query that includes time points that are before the clear,
+    still returns all components at the given path(s), except those logged directly before the clear.
+    Meaning that in practice clears are ineffective for time series plots and other usages of visible time ranges.
+
     Example
     -------
     ### Flat:


### PR DESCRIPTION
### What

* Fixes #4143

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4760/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4760/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4760/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4760)
- [Docs preview](https://rerun.io/preview/a9424c7a3a0c8d23c003598b5aae9c9db2e18603/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a9424c7a3a0c8d23c003598b5aae9c9db2e18603/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)