### PR TITLE
Fix `entity_path_vec!` and `entity_path!` depending on `ToString` being in scope.

### DIFF
--- a/crates/re_log_types/src/path/mod.rs
+++ b/crates/re_log_types/src/path/mod.rs
@@ -20,21 +20,32 @@ pub use parse_path::PathParseError;
 
 // ----------------------------------------------------------------------------
 
+/// Reexports for use by macros to avoid depending on the caller's namespacing.
+#[doc(hidden)]
+pub mod __private {
+    pub use ::std::{string, vec};
+}
+
 /// Build a `Vec<EntityPathPart>`:
 /// ```
+/// # #![no_std] // test that the macro does not depend on the std *prelude*
+/// # extern crate std;
+/// # fn main() {
+/// # use std::vec::Vec;
 /// # use re_log_types::*;
 /// let parts: Vec<EntityPathPart> = entity_path_vec!("foo", 42, "my image!");
+/// # }
 /// ```
 #[macro_export]
 macro_rules! entity_path_vec {
     () => {
         // A vector of no elements that nevertheless has the expected concrete type.
-        ::std::vec::Vec::<$crate::EntityPathPart>::new()
+       $crate::path::__private::vec::Vec::<$crate::EntityPathPart>::new()
     };
     ($($part: expr),* $(,)?) => {
-        vec![ $($crate::EntityPathPart::from(
+        $crate::path::__private::vec![ $($crate::EntityPathPart::from(
             #[allow(clippy::str_to_string, clippy::string_to_string)]
-            $part.to_string()
+            $crate::path::__private::string::ToString::to_string(&$part)
         ),)+ ]
     };
 }


### PR DESCRIPTION
### What

The macros used to work in `no_std`+`alloc` conditions, but that was broken in 0.12 by the addition of the `.to_string()` call. This change fixes it by making all items used by the macro use fully qualified, reexported paths; this way, the macro does not depend on the calling module and crate's imports at all.

This change would ideally be released as a 0.12.1 bugfix.

### Checklist
* [X] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [X] ~~I've included a screenshot or gif (if applicable)~~
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4766/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4766/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4766/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [X] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4766)
- [Docs preview](https://rerun.io/preview/8d39d674d8a6a26a3e9586553a2eab3264152240/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8d39d674d8a6a26a3e9586553a2eab3264152240/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)