### PR TITLE
Lint all python code

### DIFF
--- a/justfile
+++ b/justfile
@@ -60,7 +60,7 @@ cpp-plot-dashboard *ARGS:
 
 ### Python
 
-py_folders := "docs/code-examples examples rerun_py scripts tests"
+py_folders := "."
 
 # Set up a Pythonvirtual environment for development
 py-dev-env:

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,5 @@
-"""Nox sessions.
+"""
+Nox sessions.
 
 This file is used by `nox` to run tests and examples against multiple Python versions.
 
@@ -9,13 +10,12 @@ from __future__ import annotations
 
 import nox  # type: ignore
 
-
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 
 @nox.session(python=PYTHON_VERSIONS)
 def tests(session: nox.Session) -> None:
-    """Run the Python test suite"""
+    """Run the Python test suite."""
     session.install("-r", "rerun_py/requirements-build.txt")
 
     # TODO(#4704): clean that up when torch is 3.12 compatible
@@ -30,7 +30,7 @@ def tests(session: nox.Session) -> None:
 
 @nox.session(python=PYTHON_VERSIONS)
 def run_all(session: nox.Session) -> None:
-    """Run all examples through the run_all.py script (pass args with: "-- <args>")"""
+    """Run all examples through the run_all.py script (pass args with: "-- <args>")."""
 
     # TODO(#4704): clean that up when torch is 3.12 compatible
     if session.python == "3.12":
@@ -48,7 +48,7 @@ roundtrip_cpp_built = False
 
 @nox.session(python=PYTHON_VERSIONS)
 def roundtrips(session: nox.Session) -> None:
-    """Run all roundtrip tests (C++ will be built only once / skip with: "-- --no-cpp-build")"""
+    """Run all roundtrip tests (C++ will be built only once / skip with: "-- --no-cpp-build")."""
 
     global roundtrip_cpp_built
 

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -108,7 +108,14 @@ select = [
 ]
 
 [tool.ruff.per-file-ignores]
-"docs/code-examples/*" = ["I002"]
+"docs/code-examples/*" = [
+  # Missing required import: `from __future__ import annotations`
+  "I002",
+]
+"crates/re_viewer/data/quick_start_guides/*" = [
+  # Missing required import: `from __future__ import annotations`
+  "I002",
+]
 "__init__.py" = ["F401", "F403"]
 
 [tool.ruff.isort]

--- a/scripts/fast_lint.py
+++ b/scripts/fast_lint.py
@@ -76,7 +76,7 @@ class LintJob:
         return proc.returncode == 0
 
 
-PY_FOLDERS = ["docs/code-examples", "examples", "rerun_py", "scripts", "tests"]
+PY_FOLDERS = ["."]
 
 
 def main() -> None:


### PR DESCRIPTION
### What
I don't know why we used to have a list of folders to run python linting on, but running it recursively on "." seems to work just as fine.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4768/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4768/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4768/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4768)
- [Docs preview](https://rerun.io/preview/c964b6f091bc745e90c46a5cb2e7efa3d9bc61b0/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c964b6f091bc745e90c46a5cb2e7efa3d9bc61b0/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)