### PR TITLE
Fix CMake trying to pick up test folders outside of the Rerun project/zip

### DIFF
--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -186,6 +186,6 @@ install(FILES
 # -----------------------------------------------------------------------------
 # Add tests if they exist (they are not part of the distribution zip).
 # Has direct dependency to arrow, so needs to happen last.
-if(EXISTS tests)
-    add_subdirectory(tests)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tests)
 endif()


### PR DESCRIPTION
### What

This PR changes the `CMakeLists.txt` of `rerun_cpp` to test for the full path of the `tests` directory to avoid false positives.

Closes #4769 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4770/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4770/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4770/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4770)
- [Docs preview](https://rerun.io/preview/ebe1d4ba438ffd72329b1b50052bc797917208db/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ebe1d4ba438ffd72329b1b50052bc797917208db/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)