### PR TITLE
Replace `warn` logging with `debug` logging for dangerous looking {under|over}flows

### DIFF
--- a/crates/re_data_store/src/store_gc.rs
+++ b/crates/re_data_store/src/store_gc.rs
@@ -282,10 +282,13 @@ impl DataStore {
                     .heap_size_bytes
                     .checked_sub(metadata_dropped_size_bytes)
                     .unwrap_or_else(|| {
-                        re_log::warn_once!(
-                            "GC metadata_registry size tracker underflowed, this is a bug!"
+                        re_log::debug!(
+                            entity_path = %dropped.entity_path,
+                            current = metadata_registry.heap_size_bytes,
+                            removed = metadata_dropped_size_bytes,
+                            "book keeping underflowed"
                         );
-                        0
+                        u64::MIN
                     });
                 num_bytes_to_drop -= metadata_dropped_size_bytes as f64;
 
@@ -323,10 +326,13 @@ impl DataStore {
                     .heap_size_bytes
                     .checked_sub(metadata_dropped_size_bytes)
                     .unwrap_or_else(|| {
-                        re_log::warn_once!(
-                            "GC metadata_registry size tracker underflowed, this is a bug!"
+                        re_log::debug!(
+                            entity_path = %dropped.entity_path,
+                            current = metadata_registry.heap_size_bytes,
+                            removed = metadata_dropped_size_bytes,
+                            "book keeping underflowed"
                         );
-                        0
+                        u64::MIN
                     });
                 num_bytes_to_drop -= metadata_dropped_size_bytes as f64;
 

--- a/crates/re_entity_db/src/time_histogram_per_timeline.rs
+++ b/crates/re_entity_db/src/time_histogram_per_timeline.rs
@@ -57,7 +57,11 @@ impl TimeHistogramPerTimeline {
                 .num_timeless_messages
                 .checked_add(n as u64)
                 .unwrap_or_else(|| {
-                    re_log::warn_once!("Timeless counter overflowed, store events are bugged!");
+                    re_log::debug!(
+                        current = self.num_timeless_messages,
+                        added = n,
+                        "book keeping overflowed"
+                    );
                     u64::MAX
                 });
         } else {
@@ -76,8 +80,13 @@ impl TimeHistogramPerTimeline {
                 .num_timeless_messages
                 .checked_sub(n as u64)
                 .unwrap_or_else(|| {
-                    re_log::debug_once!("Timeless counter underflowed, store events are bugged!"); // TODO(#4355): hitting this on plots demo
-                    0
+                    // TODO(#4355): hitting this on plots demo
+                    re_log::debug!(
+                        current = self.num_timeless_messages,
+                        removed = n,
+                        "book keeping underflowed"
+                    );
+                    u64::MIN
                 });
         } else {
             for (timeline, time_value) in timepoint.iter() {

--- a/crates/re_entity_db/src/times_per_timeline.rs
+++ b/crates/re_entity_db/src/times_per_timeline.rs
@@ -62,12 +62,24 @@ impl StoreSubscriber for TimesPerTimeline {
 
                 if delta < 0 {
                     *count = count.checked_sub(delta.unsigned_abs()).unwrap_or_else(|| {
-                        re_log::warn_once!("Time counter underflowed, store events are bugged!");
-                        0
+                        re_log::debug!(
+                            store_id = %event.store_id,
+                            entity_path = %event.diff.entity_path,
+                            current = count,
+                            removed = delta.unsigned_abs(),
+                            "book keeping underflowed"
+                        );
+                        u64::MIN
                     });
                 } else {
                     *count = count.checked_add(delta.unsigned_abs()).unwrap_or_else(|| {
-                        re_log::warn_once!("Time counter overflowed, store events are bugged!");
+                        re_log::debug!(
+                            store_id = %event.store_id,
+                            entity_path = %event.diff.entity_path,
+                            current = count,
+                            removed = delta.unsigned_abs(),
+                            "book keeping overflowed"
+                        );
                         u64::MAX
                     });
                 }


### PR DESCRIPTION
A quick pass over all dangerous looking `{checked|saturating}_{sub|add}`s I could find.

They will now all log in DEBUG (reminder: we now show DEBUG logs by default in debug builds) and print as many information as possible.
They will also all behave as a saturating operation in case of failure.

I've also removed the `_once`: whether this repeats or not might actually help us track the root cause.

I couldn't reproduce the issue in #4355, so don't know about that.

- Part of #4355 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4771/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4771/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4771/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4771)
- [Docs preview](https://rerun.io/preview/7d32a731897ed06d93e7be16434e915cb59d9a34/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7d32a731897ed06d93e7be16434e915cb59d9a34/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)