### PR TITLE
Write-protect code-generated files

### DIFF
--- a/crates/re_types_builder/src/codegen/common.rs
+++ b/crates/re_types_builder/src/codegen/common.rs
@@ -383,17 +383,10 @@ pub fn remove_orphaned_files(reporter: &Reporter, files: &GeneratedFiles) {
 
 /// Write file if any changes were made and ensure folder hierarchy exists.
 pub fn write_file(filepath: &Utf8PathBuf, source: &str) {
-    if let Ok(existing) = std::fs::read_to_string(filepath) {
-        if existing == source {
-            // Don't touch the timestamp unnecessarily
-            return;
-        }
-    }
-
     let parent_dir = filepath.parent().unwrap();
     std::fs::create_dir_all(parent_dir)
         .unwrap_or_else(|err| panic!("Failed to create dir {parent_dir:?}: {err}"));
 
-    std::fs::write(filepath, source)
+    re_build_tools::write_file_if_necessary(filepath, source.as_bytes())
         .unwrap_or_else(|err| panic!("Failed to write file {filepath:?}: {err}"));
 }


### PR DESCRIPTION
Prevents users accidentally editing the wrong file

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4772/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4772/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4772/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4772)
- [Docs preview](https://rerun.io/preview/ca39eb0f50452f96123d92838abefe7ddf221c52/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ca39eb0f50452f96123d92838abefe7ddf221c52/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)