### PR TITLE
Primary caching 11: cache stats and integration with memory panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5312,6 +5312,7 @@ dependencies = [
  "re_log_encoding",
  "re_log_types",
  "re_memory",
+ "re_query_cache",
  "re_renderer",
  "re_smart_channel",
  "re_space_view",

--- a/crates/re_log_types/src/time_point/time_int.rs
+++ b/crates/re_log_types/src/time_point/time_int.rs
@@ -11,6 +11,13 @@ pub struct TimeInt(pub(crate) i64);
 
 impl nohash_hasher::IsEnabled for TimeInt {}
 
+impl re_types_core::SizeBytes for TimeInt {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+}
+
 impl TimeInt {
     /// The beginning of time.
     ///

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -51,8 +51,6 @@ static CACHES: Lazy<StoreSubscriberHandle> =
     Lazy::new(|| re_data_store::DataStore::register_subscriber(Box::<Caches>::default()));
 
 /// Maintains the top-level cache mappings.
-//
-// TODO(#4730): SizeBytes support + size stats + mem panel
 #[derive(Default)]
 pub struct Caches(pub(crate) RwLock<HashMap<CacheKey, CachesPerArchetype>>);
 
@@ -368,7 +366,6 @@ pub struct CacheBucket {
     pub(crate) total_size_bytes: u64,
     //
     // TODO(cmc): secondary cache
-    // TODO(#4730): size stats: this requires codegen'ing SizeBytes for all components!
 }
 
 impl CacheBucket {

--- a/crates/re_query_cache/src/cache_stats.rs
+++ b/crates/re_query_cache/src/cache_stats.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, sync::atomic::AtomicBool};
 use re_log_types::EntityPath;
 use re_types_core::ComponentName;
 
-use crate::{cache::LatestAtCache, Caches};
+use crate::{Caches, LatestAtCache};
 
 // ---
 
@@ -36,14 +36,18 @@ impl CachesStats {
         re_tracing::profile_function!();
 
         let Self { latest_at } = self;
-        latest_at.values().map(|stats| stats.total_size_bytes).sum()
+
+        let latest_at_size_bytes: u64 =
+            latest_at.values().map(|stats| stats.total_size_bytes).sum();
+
+        latest_at_size_bytes
     }
 }
 
 /// Stats for a cached entity.
 #[derive(Debug, Clone)]
 pub struct CachedEntityStats {
-    pub total_times: u64,
+    pub total_rows: u64,
     pub total_size_bytes: u64,
 
     /// Only if [`detailed_stats`] returns `true` (see [`set_detailed_stats`]).
@@ -53,8 +57,8 @@ pub struct CachedEntityStats {
 /// Stats for a cached component.
 #[derive(Default, Debug, Clone)]
 pub struct CachedComponentStats {
-    pub total_times: u64,
-    pub total_values: u64,
+    pub total_rows: u64,
+    pub total_instances: u64,
 }
 
 impl Caches {
@@ -72,7 +76,7 @@ impl Caches {
                 .map(|(key, caches_per_arch)| {
                     (key.entity_path.clone(), {
                         let mut total_size_bytes = 0u64;
-                        let mut total_times = 0u64;
+                        let mut total_rows = 0u64;
                         let mut per_component = detailed_stats().then(BTreeMap::default);
 
                         for latest_at_cache in
@@ -86,15 +90,15 @@ impl Caches {
                             } = &*latest_at_cache.read();
 
                             total_size_bytes += latest_at_cache.total_size_bytes;
-                            total_times = per_data_time.len() as u64 + timeless.is_some() as u64;
+                            total_rows = per_data_time.len() as u64 + timeless.is_some() as u64;
 
                             if let Some(per_component) = per_component.as_mut() {
                                 for bucket in per_data_time.values() {
                                     for (component_name, data) in &bucket.read().components {
                                         let stats: &mut CachedComponentStats =
                                             per_component.entry(*component_name).or_default();
-                                        stats.total_times += data.dyn_num_entries() as u64;
-                                        stats.total_values += data.dyn_num_values() as u64;
+                                        stats.total_rows += data.dyn_num_entries() as u64;
+                                        stats.total_instances += data.dyn_num_values() as u64;
                                     }
                                 }
 
@@ -102,8 +106,8 @@ impl Caches {
                                     for (component_name, data) in &bucket.components {
                                         let stats: &mut CachedComponentStats =
                                             per_component.entry(*component_name).or_default();
-                                        stats.total_times += data.dyn_num_entries() as u64;
-                                        stats.total_values += data.dyn_num_values() as u64;
+                                        stats.total_rows += data.dyn_num_entries() as u64;
+                                        stats.total_instances += data.dyn_num_values() as u64;
                                     }
                                 }
                             }
@@ -111,7 +115,7 @@ impl Caches {
 
                         CachedEntityStats {
                             total_size_bytes,
-                            total_times,
+                            total_rows,
 
                             per_component,
                         }

--- a/crates/re_query_cache/src/cache_stats.rs
+++ b/crates/re_query_cache/src/cache_stats.rs
@@ -1,0 +1,68 @@
+use std::collections::BTreeMap;
+
+use re_log_types::EntityPath;
+
+use crate::Caches;
+
+// ---
+
+/// Stats for all primary caches.
+///
+/// Fetch them via [`Caches::stats`].
+#[derive(Default, Debug, Clone)]
+pub struct CachesStats {
+    pub latest_at: BTreeMap<EntityPath, CachedEntityStats>,
+}
+
+impl CachesStats {
+    #[inline]
+    pub fn total_size_bytes(&self) -> u64 {
+        re_tracing::profile_function!();
+
+        let Self { latest_at } = self;
+        latest_at.values().map(|stats| stats.total_size_bytes).sum()
+    }
+}
+
+/// Stats for a cached entity.
+#[derive(Debug, Clone)]
+pub struct CachedEntityStats {
+    pub total_size_bytes: u64,
+    pub num_cached_timestamps: u64,
+}
+
+impl Caches {
+    /// Computes the stats for all primary caches.
+    pub fn stats() -> CachesStats {
+        re_tracing::profile_function!();
+
+        Self::with(|caches| {
+            let latest_at = caches
+                .0
+                .read()
+                .iter()
+                .map(|(key, caches_per_arch)| {
+                    (key.entity_path.clone(), {
+                        let mut total_size_bytes = 0u64;
+                        let mut num_cached_timestamps = 0u64;
+
+                        for latest_at_cache in
+                            caches_per_arch.latest_at_per_archetype.read().values()
+                        {
+                            let latest_at_cache = latest_at_cache.read();
+                            total_size_bytes += latest_at_cache.total_size_bytes;
+                            num_cached_timestamps = latest_at_cache.per_data_time.len() as _;
+                        }
+
+                        CachedEntityStats {
+                            total_size_bytes,
+                            num_cached_timestamps,
+                        }
+                    })
+                })
+                .collect();
+
+            CachesStats { latest_at }
+        })
+    }
+}

--- a/crates/re_query_cache/src/cache_stats.rs
+++ b/crates/re_query_cache/src/cache_stats.rs
@@ -20,6 +20,8 @@ pub fn set_detailed_stats(b: bool) {
     ENABLE_DETAILED_STATS.store(b, std::sync::atomic::Ordering::Relaxed);
 }
 
+// ---
+
 /// Stats for all primary caches.
 ///
 /// Fetch them via [`Caches::stats`].

--- a/crates/re_query_cache/src/cache_stats.rs
+++ b/crates/re_query_cache/src/cache_stats.rs
@@ -1,10 +1,24 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::atomic::AtomicBool};
 
 use re_log_types::EntityPath;
+use re_types_core::ComponentName;
 
 use crate::Caches;
 
 // ---
+
+/// If `true`, enables the much-more-costly-to-compute per-component stats.
+static ENABLE_DETAILED_STATS: AtomicBool = AtomicBool::new(false);
+
+#[inline]
+pub fn detailed_stats() -> bool {
+    ENABLE_DETAILED_STATS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+#[inline]
+pub fn set_detailed_stats(b: bool) {
+    ENABLE_DETAILED_STATS.store(b, std::sync::atomic::Ordering::Relaxed);
+}
 
 /// Stats for all primary caches.
 ///
@@ -27,12 +41,24 @@ impl CachesStats {
 /// Stats for a cached entity.
 #[derive(Debug, Clone)]
 pub struct CachedEntityStats {
+    pub total_times: u64,
     pub total_size_bytes: u64,
-    pub num_cached_timestamps: u64,
+
+    /// Only if [`detailed_stats`] returns `true` (see [`set_detailed_stats`]).
+    pub per_component: Option<BTreeMap<ComponentName, CachedComponentStats>>,
+}
+
+/// Stats for a cached component.
+#[derive(Default, Debug, Clone)]
+pub struct CachedComponentStats {
+    pub total_times: u64,
+    pub total_values: u64,
 }
 
 impl Caches {
     /// Computes the stats for all primary caches.
+    ///
+    /// `per_component` toggles per-component stats.
     pub fn stats() -> CachesStats {
         re_tracing::profile_function!();
 
@@ -44,19 +70,33 @@ impl Caches {
                 .map(|(key, caches_per_arch)| {
                     (key.entity_path.clone(), {
                         let mut total_size_bytes = 0u64;
-                        let mut num_cached_timestamps = 0u64;
+                        let mut total_times = 0u64;
+                        let mut per_component = detailed_stats().then(BTreeMap::default);
 
                         for latest_at_cache in
                             caches_per_arch.latest_at_per_archetype.read().values()
                         {
                             let latest_at_cache = latest_at_cache.read();
                             total_size_bytes += latest_at_cache.total_size_bytes;
-                            num_cached_timestamps = latest_at_cache.per_data_time.len() as _;
+                            total_times = latest_at_cache.per_data_time.len() as _;
+
+                            if let Some(per_component) = per_component.as_mut() {
+                                for bucket in latest_at_cache.per_data_time.values() {
+                                    for (component_name, data) in &bucket.read().components {
+                                        let stats: &mut CachedComponentStats =
+                                            per_component.entry(*component_name).or_default();
+                                        stats.total_times += data.dyn_num_entries() as u64;
+                                        stats.total_values += data.dyn_num_values() as u64;
+                                    }
+                                }
+                            }
                         }
 
                         CachedEntityStats {
                             total_size_bytes,
-                            num_cached_timestamps,
+                            total_times,
+
+                            per_component,
                         }
                     })
                 })

--- a/crates/re_query_cache/src/flat_vec_deque.rs
+++ b/crates/re_query_cache/src/flat_vec_deque.rs
@@ -122,6 +122,17 @@ impl<T: SizeBytes> SizeBytes for FlatVecDeque<T> {
     }
 }
 
+impl<T> From<VecDeque<T>> for FlatVecDeque<T> {
+    #[inline]
+    fn from(values: VecDeque<T>) -> Self {
+        let num_values = values.len();
+        Self {
+            values,
+            offsets: std::iter::once(num_values).collect(),
+        }
+    }
+}
+
 impl<T> Default for FlatVecDeque<T> {
     #[inline]
     fn default() -> Self {
@@ -284,11 +295,7 @@ impl<T> FlatVecDeque<T> {
     #[inline]
     pub fn insert(&mut self, entry_index: usize, values: impl IntoIterator<Item = T>) {
         let values: VecDeque<T> = values.into_iter().collect();
-        let num_values = values.len();
-        let deque = Self {
-            values,
-            offsets: std::iter::once(num_values).collect(),
-        };
+        let deque = values.into();
         self.insert_deque(entry_index, deque);
     }
 

--- a/crates/re_query_cache/src/flat_vec_deque.rs
+++ b/crates/re_query_cache/src/flat_vec_deque.rs
@@ -16,6 +16,18 @@ pub trait ErasedFlatVecDeque: std::any::Any {
 
     fn into_any(self: Box<Self>) -> Box<dyn std::any::Any>;
 
+    /// Dynamically dispatches to [`FlatVecDeque::num_entries`].
+    ///
+    /// This is prefixed with `dyn_` to avoid method dispatch ambiguities that are very hard to
+    /// avoid even with explicit syntax and that silently lead to infinite recursions.
+    fn dyn_num_entries(&self) -> usize;
+
+    /// Dynamically dispatches to [`FlatVecDeque::num_values`].
+    ///
+    /// This is prefixed with `dyn_` to avoid method dispatch ambiguities that are very hard to
+    /// avoid even with explicit syntax and that silently lead to infinite recursions.
+    fn dyn_num_values(&self) -> usize;
+
     /// Dynamically dispatches to [`FlatVecDeque::remove`].
     ///
     /// This is prefixed with `dyn_` to avoid method dispatch ambiguities that are very hard to
@@ -49,6 +61,16 @@ impl<T: 'static> ErasedFlatVecDeque for FlatVecDeque<T> {
     #[inline]
     fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
         self
+    }
+
+    #[inline]
+    fn dyn_num_entries(&self) -> usize {
+        self.num_entries()
+    }
+
+    #[inline]
+    fn dyn_num_values(&self) -> usize {
+        self.num_values()
     }
 
     #[inline]

--- a/crates/re_query_cache/src/lib.rs
+++ b/crates/re_query_cache/src/lib.rs
@@ -6,7 +6,9 @@ mod flat_vec_deque;
 mod query;
 
 pub use self::cache::{AnyQuery, Caches};
-pub use self::cache_stats::{CachedEntityStats, CachesStats};
+pub use self::cache_stats::{
+    detailed_stats, set_detailed_stats, CachedComponentStats, CachedEntityStats, CachesStats,
+};
 pub use self::flat_vec_deque::{ErasedFlatVecDeque, FlatVecDeque};
 pub use self::query::{
     query_archetype_pov1, query_archetype_with_history_pov1, MaybeCachedComponentData,

--- a/crates/re_query_cache/src/lib.rs
+++ b/crates/re_query_cache/src/lib.rs
@@ -1,10 +1,12 @@
 //! Caching datastructures for `re_query`.
 
 mod cache;
+mod cache_stats;
 mod flat_vec_deque;
 mod query;
 
 pub use self::cache::{AnyQuery, Caches};
+pub use self::cache_stats::{CachedEntityStats, CachesStats};
 pub use self::flat_vec_deque::{ErasedFlatVecDeque, FlatVecDeque};
 pub use self::query::{
     query_archetype_pov1, query_archetype_with_history_pov1, MaybeCachedComponentData,

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -45,12 +45,14 @@ re_data_ui.workspace = true
 re_entity_db = { workspace = true, features = ["serde"] }
 re_error.workspace = true
 re_format.workspace = true
+re_log.workspace = true
 re_log_encoding = { workspace = true, features = ["decoder", "encoder"] }
 re_log_types.workspace = true
-re_log.workspace = true
 re_memory.workspace = true
+re_query_cache.workspace = true
 re_renderer = { workspace = true, default-features = false }
 re_smart_channel.workspace = true
+re_space_view.workspace = true
 re_space_view_bar_chart.workspace = true
 re_space_view_dataframe.workspace = true
 re_space_view_spatial.workspace = true
@@ -58,11 +60,10 @@ re_space_view_tensor.workspace = true
 re_space_view_text_document = { workspace = true, features = ["markdown"] }
 re_space_view_text_log.workspace = true
 re_space_view_time_series.workspace = true
-re_space_view.workspace = true
 re_time_panel.workspace = true
 re_tracing = { workspace = true, features = ["server"] }
-re_types_core.workspace = true
 re_types.workspace = true
+re_types_core.workspace = true
 re_ui.workspace = true
 re_viewer_context.workspace = true
 re_viewport.workspace = true

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -667,6 +667,7 @@ impl App {
         ui: &mut egui::Ui,
         gpu_resource_stats: &WgpuResourcePoolStatistics,
         store_stats: &StoreHubStats,
+        caches_stats: &re_query_cache::CachesStats,
     ) {
         let frame = egui::Frame {
             fill: ui.visuals().panel_fill,
@@ -684,6 +685,7 @@ impl App {
                     &self.startup_options.memory_limit,
                     gpu_resource_stats,
                     store_stats,
+                    caches_stats,
                 );
             });
     }
@@ -703,6 +705,7 @@ impl App {
     /// Top-level ui function.
     ///
     /// Shows the viewer ui.
+    #[allow(clippy::too_many_arguments)]
     fn ui(
         &mut self,
         egui_ctx: &egui::Context,
@@ -711,6 +714,7 @@ impl App {
         gpu_resource_stats: &WgpuResourcePoolStatistics,
         store_context: Option<&StoreContext<'_>>,
         store_stats: &StoreHubStats,
+        caches_stats: &re_query_cache::CachesStats,
     ) {
         let mut main_panel_frame = egui::Frame::default();
         if re_ui::CUSTOM_WINDOW_DECORATIONS {
@@ -727,7 +731,7 @@ impl App {
 
                 crate::ui::top_panel(self, app_blueprint, store_context, gpu_resource_stats, ui);
 
-                self.memory_panel_ui(ui, gpu_resource_stats, store_stats);
+                self.memory_panel_ui(ui, gpu_resource_stats, store_stats, caches_stats);
 
                 self.style_panel_ui(egui_ctx, ui);
 
@@ -1124,9 +1128,11 @@ impl eframe::App for App {
         };
 
         let store_stats = store_hub.stats();
+        let caches_stats = re_query_cache::Caches::stats();
 
         // do early, before doing too many allocations
-        self.memory_panel.update(&gpu_resource_stats, &store_stats);
+        self.memory_panel
+            .update(&gpu_resource_stats, &store_stats, &caches_stats);
 
         self.check_keyboard_shortcuts(egui_ctx);
 
@@ -1159,6 +1165,7 @@ impl eframe::App for App {
             &gpu_resource_stats,
             store_context.as_ref(),
             &store_stats,
+            &caches_stats,
         );
 
         if re_ui::CUSTOM_WINDOW_DECORATIONS {

--- a/crates/re_viewer/src/ui/memory_panel.rs
+++ b/crates/re_viewer/src/ui/memory_panel.rs
@@ -1,6 +1,7 @@
 use re_data_store::{DataStoreConfig, DataStoreRowStats, DataStoreStats};
 use re_format::{format_bytes, format_number};
 use re_memory::{util::sec_since_start, MemoryHistory, MemoryLimit, MemoryUse};
+use re_query_cache::{CachedEntityStats, CachesStats};
 use re_renderer::WgpuResourcePoolStatistics;
 
 use crate::{env_vars::RERUN_TRACK_ALLOCATIONS, store_hub::StoreHubStats};
@@ -19,6 +20,7 @@ impl MemoryPanel {
         &mut self,
         gpu_resource_stats: &WgpuResourcePoolStatistics,
         store_stats: &StoreHubStats,
+        caches_stats: &CachesStats,
     ) {
         re_tracing::profile_function!();
         self.history.capture(
@@ -27,6 +29,7 @@ impl MemoryPanel {
                     + gpu_resource_stats.total_texture_size_in_bytes) as _,
             ),
             Some(store_stats.recording_stats.total.num_bytes as _),
+            Some(caches_stats.total_size_bytes() as _),
             Some(store_stats.blueprint_stats.total.num_bytes as _),
         );
     }
@@ -44,6 +47,7 @@ impl MemoryPanel {
         limit: &MemoryLimit,
         gpu_resource_stats: &WgpuResourcePoolStatistics,
         store_stats: &StoreHubStats,
+        caches_stats: &CachesStats,
     ) {
         re_tracing::profile_function!();
 
@@ -55,7 +59,14 @@ impl MemoryPanel {
             .min_width(250.0)
             .default_width(300.0)
             .show_inside(ui, |ui| {
-                Self::left_side(ui, re_ui, limit, gpu_resource_stats, store_stats);
+                Self::left_side(
+                    ui,
+                    re_ui,
+                    limit,
+                    gpu_resource_stats,
+                    store_stats,
+                    caches_stats,
+                );
             });
 
         egui::CentralPanel::default().show_inside(ui, |ui| {
@@ -70,6 +81,7 @@ impl MemoryPanel {
         limit: &MemoryLimit,
         gpu_resource_stats: &WgpuResourcePoolStatistics,
         store_stats: &StoreHubStats,
+        caches_stats: &CachesStats,
     ) {
         ui.strong("Rerun Viewer resource usage");
 
@@ -90,6 +102,11 @@ impl MemoryPanel {
                 &store_stats.recording_config,
                 &store_stats.recording_stats,
             );
+        });
+
+        ui.separator();
+        ui.collapsing("Primary Cache Resources", |ui| {
+            Self::caches_stats(ui, caches_stats);
         });
 
         ui.separator();
@@ -292,6 +309,39 @@ impl MemoryPanel {
             });
     }
 
+    fn caches_stats(ui: &mut egui::Ui, caches_stats: &CachesStats) {
+        egui::Grid::new("cache stats grid")
+            .num_columns(3)
+            .show(ui, |ui| {
+                let CachesStats { latest_at } = caches_stats;
+
+                ui.label(egui::RichText::new("Stats").italics());
+                ui.label("Entity");
+                ui.label("Entries").on_hover_text(
+                    "How many timestamps distinct data timestamps have been cached?",
+                );
+                ui.label("Size");
+                ui.end_row();
+
+                fn label_entity_stats(ui: &mut egui::Ui, cache_stats: &CachedEntityStats) {
+                    let &CachedEntityStats {
+                        total_size_bytes,
+                        num_cached_timestamps,
+                    } = cache_stats;
+
+                    ui.label(re_format::format_number(num_cached_timestamps as _));
+                    ui.label(re_format::format_bytes(total_size_bytes as _));
+                }
+
+                for (entity_path, stats) in latest_at {
+                    ui.label(entity_path.to_string());
+                    ui.label("");
+                    label_entity_stats(ui, stats);
+                    ui.end_row();
+                }
+            });
+    }
+
     fn tracking_stats(
         ui: &mut egui::Ui,
         tracking_stats: re_memory::accounting_allocator::TrackingStatistics,
@@ -411,6 +461,7 @@ impl MemoryPanel {
                     counted,
                     counted_gpu,
                     counted_store,
+                    counted_primary_caches,
                     counted_blueprint,
                 } = &self.history;
 
@@ -418,6 +469,11 @@ impl MemoryPanel {
                 plot_ui.line(to_line(counted).name("Counted").width(1.5));
                 plot_ui.line(to_line(counted_gpu).name("Counted GPU").width(1.5));
                 plot_ui.line(to_line(counted_store).name("Counted Store").width(1.5));
+                plot_ui.line(
+                    to_line(counted_primary_caches)
+                        .name("Counted Primary Caches")
+                        .width(1.5),
+                );
                 plot_ui.line(
                     to_line(counted_blueprint)
                         .name("Counted Blueprint")

--- a/crates/re_viewer/src/ui/memory_panel.rs
+++ b/crates/re_viewer/src/ui/memory_panel.rs
@@ -323,9 +323,8 @@ impl MemoryPanel {
                 let CachesStats { latest_at } = caches_stats;
 
                 ui.label("Entity");
-                ui.label("Entries").on_hover_text(
-                    "How many timestamps distinct data timestamps have been cached?",
-                );
+                ui.label("Timestamps")
+                    .on_hover_text("How many distinct data timestamps have been cached?");
                 ui.label("Size");
                 ui.end_row();
 
@@ -347,7 +346,7 @@ impl MemoryPanel {
                                 .num_columns(3)
                                 .show(ui, |ui| {
                                     ui.label("Component");
-                                    ui.label("Entries");
+                                    ui.label("Timestamps");
                                     ui.label("Count");
                                     ui.end_row();
 


### PR DESCRIPTION
The primary cache now tracks memory statistics and display them in the memory panel.

This immediately highlights a very stupid thing that the cache does: missing optional components that have been turned into streams of default values by the `ArchetypeView` are materialized as such :man_facepalming: 
- #4779

https://github.com/rerun-io/rerun/assets/2910679/876b264a-3f77-4d91-934e-aa8897bb32fe



- Fixes #4730 


---

Part of the primary caching series of PR (index search, joins, deserialization):
- #4592
- #4593
- #4659
- #4680 
- #4681
- #4698
- #4711
- #4712
- #4721 
- #4726 
- #4773
- #4784
- #4785
- #4793
- #4800

---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4592/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4592)
- [Docs preview](https://rerun.io/preview/b0015f3b9decbb89ce5743dd482f1a785f1f2278/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b0015f3b9decbb89ce5743dd482f1a785f1f2278/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)