### PR TITLE
Always point to versioned manifest when building a versioned binary

### DIFF
--- a/crates/re_viewer/src/ui/welcome_screen/example_page.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/example_page.rs
@@ -133,16 +133,17 @@ fn default_manifest_url() -> String {
     let build_info = re_build_info::build_info!();
     let short_sha = build_info.short_git_hash();
 
-    if build_info.is_in_rerun_workspace {
-        // Always point to `version/main` for rerun devs,
-        // because the current commit's manifest is unlikely to be uploaded to GCS.
-        "https://app.rerun.io/version/main/examples_manifest.json".into()
-    } else if build_info.version.is_rc() || build_info.version.is_release() {
-        // Point to the current version's manifest
+    if build_info.version.is_rc() || build_info.version.is_release() {
+        // If this is versioned as a release or rc, always point to the versioned
+        // example manifest. This applies even if doing a local source build.
         format!(
             "https://app.rerun.io/version/{version}/examples_manifest.json",
             version = build_info.version,
         )
+    } else if build_info.is_in_rerun_workspace {
+        // Otherwise, always point to `version/main` for rerun devs,
+        // because the current commit's manifest is unlikely to be uploaded to GCS.
+        "https://app.rerun.io/version/main/examples_manifest.json".into()
     } else if !short_sha.is_empty() {
         // If we have a sha, try to point at it.
         format!("https://app.rerun.io/commit/{short_sha}/examples_manifest.json")


### PR DESCRIPTION
### What
 - Resolves: https://github.com/rerun-io/rerun/issues/4778

The logic here is that if you check out 0.12.0 and do a source build you probably want the 0.12.0 examples, not the example from main. This is generally what folks will want if integrating a rerun-build into a third-party system, and similarly applies to conda.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4781/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4781/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4781/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4781)
- [Docs preview](https://rerun.io/preview/937bfc1a07fb179f66fa487768a0f5067c15398f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/937bfc1a07fb179f66fa487768a0f5067c15398f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)