### PR TITLE
Primary caching 13: stats & memory panel integration for range queries

### DIFF
--- a/crates/re_data_store/src/store_format.rs
+++ b/crates/re_data_store/src/store_format.rs
@@ -130,7 +130,11 @@ impl std::fmt::Display for IndexedBucket {
         let time_range = {
             let time_range = &self.inner.read().time_range;
             if time_range.min.as_i64() != i64::MAX && time_range.max.as_i64() != i64::MIN {
-                self.timeline.format_time_range_utc(time_range)
+                format!(
+                    "    - {}: {}",
+                    self.timeline.name(),
+                    self.timeline.format_time_range_utc(time_range)
+                )
             } else {
                 "time range: N/A\n".to_owned()
             }

--- a/crates/re_data_store/src/store_write.rs
+++ b/crates/re_data_store/src/store_write.rs
@@ -384,10 +384,7 @@ impl IndexedTable {
             if 0 < config.indexed_bucket_num_rows {
                 let bucket_time_range = bucket.inner.read().time_range;
 
-                re_log::debug_once!(
-                    "Failed to split bucket on timeline {}",
-                    bucket.timeline.format_time_range_utc(&bucket_time_range)
-                );
+                re_log::debug_once!("Failed to split bucket on timeline {}", timeline.name());
 
                 if 1 < config.indexed_bucket_num_rows
                     && bucket_time_range.min == bucket_time_range.max

--- a/crates/re_log_types/src/time_point/timeline.rs
+++ b/crates/re_log_types/src/time_point/timeline.rs
@@ -101,8 +101,7 @@ impl Timeline {
         time_zone_for_timestamps: TimeZone,
     ) -> String {
         format!(
-            "    - {}: from {} to {} (all inclusive)",
-            self.name,
+            "{}..={}",
             self.typ.format(time_range.min, time_zone_for_timestamps),
             self.typ.format(time_range.max, time_zone_for_timestamps),
         )

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -12,7 +12,7 @@ use seq_macro::seq;
 use re_data_store::{
     LatestAtQuery, RangeQuery, StoreDiff, StoreEvent, StoreSubscriber, StoreSubscriberHandle,
 };
-use re_log_types::{EntityPath, RowId, StoreId, TimeInt, Timeline};
+use re_log_types::{EntityPath, RowId, StoreId, TimeInt, TimeRange, Timeline};
 use re_query::ArchetypeView;
 use re_types_core::{
     components::InstanceKey, Archetype, ArchetypeName, Component, ComponentName, SizeBytes as _,
@@ -423,6 +423,13 @@ impl CacheBucket {
     #[inline]
     pub fn iter_data_times(&self) -> impl Iterator<Item = &(TimeInt, RowId)> {
         self.data_times.iter()
+    }
+
+    #[inline]
+    pub fn time_range(&self) -> Option<TimeRange> {
+        let first_time = self.data_times.front().map(|(t, _)| *t)?;
+        let last_time = self.data_times.back().map(|(t, _)| *t)?;
+        Some(TimeRange::new(first_time, last_time))
     }
 
     #[inline]

--- a/crates/re_query_cache/src/lib.rs
+++ b/crates/re_query_cache/src/lib.rs
@@ -9,7 +9,8 @@ mod range;
 
 pub use self::cache::{AnyQuery, Caches};
 pub use self::cache_stats::{
-    detailed_stats, set_detailed_stats, CachedComponentStats, CachedEntityStats, CachesStats,
+    detailed_stats, set_detailed_stats, set_show_empty_caches, show_empty_caches,
+    CachedComponentStats, CachedEntityStats, CachesStats,
 };
 pub use self::flat_vec_deque::{ErasedFlatVecDeque, FlatVecDeque};
 pub use self::query::{

--- a/crates/re_query_cache/src/lib.rs
+++ b/crates/re_query_cache/src/lib.rs
@@ -8,10 +8,7 @@ mod query;
 mod range;
 
 pub use self::cache::{AnyQuery, Caches};
-pub use self::cache_stats::{
-    detailed_stats, set_detailed_stats, set_show_empty_caches, show_empty_caches,
-    CachedComponentStats, CachedEntityStats, CachesStats,
-};
+pub use self::cache_stats::{CachedComponentStats, CachedEntityStats, CachesStats};
 pub use self::flat_vec_deque::{ErasedFlatVecDeque, FlatVecDeque};
 pub use self::query::{
     query_archetype_pov1, query_archetype_with_history_pov1, MaybeCachedComponentData,

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1128,7 +1128,8 @@ impl eframe::App for App {
         };
 
         let store_stats = store_hub.stats();
-        let caches_stats = re_query_cache::Caches::stats();
+        let caches_stats =
+            re_query_cache::Caches::stats(self.memory_panel.primary_cache_detailed_stats_enabled());
 
         // do early, before doing too many allocations
         self.memory_panel

--- a/crates/re_viewer/src/ui/memory_panel.rs
+++ b/crates/re_viewer/src/ui/memory_panel.rs
@@ -355,7 +355,11 @@ impl MemoryPanel {
                 for (entity_path, stats_per_range) in range {
                     for (timeline, time_range, stats) in stats_per_range {
                         let res = ui.label(entity_path.to_string());
-                        ui.label(timeline.format_time_range_utc(time_range));
+                        ui.label(format!(
+                            "{}({})",
+                            timeline.name(),
+                            timeline.format_time_range_utc(time_range)
+                        ));
                         entity_stats_ui(ui, res, stats);
                         ui.end_row();
                     }

--- a/crates/re_viewer/src/ui/memory_panel.rs
+++ b/crates/re_viewer/src/ui/memory_panel.rs
@@ -323,47 +323,57 @@ impl MemoryPanel {
         ui.separator();
 
         ui.strong("LatestAt");
-        egui::Grid::new("latest_at cache stats grid")
-            .num_columns(3)
+        egui::ScrollArea::vertical()
+            .max_height(200.0)
+            .id_source("latest_at")
             .show(ui, |ui| {
-                ui.label(egui::RichText::new("Entity").underline());
-                ui.label(egui::RichText::new("Rows").underline())
-                    .on_hover_text("How many distinct data timestamps have been cached?");
-                ui.label(egui::RichText::new("Size").underline());
-                ui.end_row();
+                egui::Grid::new("latest_at cache stats grid")
+                    .num_columns(3)
+                    .show(ui, |ui| {
+                        ui.label(egui::RichText::new("Entity").underline());
+                        ui.label(egui::RichText::new("Rows").underline())
+                            .on_hover_text("How many distinct data timestamps have been cached?");
+                        ui.label(egui::RichText::new("Size").underline());
+                        ui.end_row();
 
-                for (entity_path, stats) in latest_at {
-                    let res = ui.label(entity_path.to_string());
-                    entity_stats_ui(ui, res, stats);
-                    ui.end_row();
-                }
+                        for (entity_path, stats) in latest_at {
+                            let res = ui.label(entity_path.to_string());
+                            entity_stats_ui(ui, res, stats);
+                            ui.end_row();
+                        }
+                    });
             });
 
         ui.separator();
 
         ui.strong("Range");
-        egui::Grid::new("range cache stats grid")
-            .num_columns(4)
+        egui::ScrollArea::vertical()
+            .max_height(200.0)
+            .id_source("range")
             .show(ui, |ui| {
-                ui.label(egui::RichText::new("Entity").underline());
-                ui.label(egui::RichText::new("Time range").underline());
-                ui.label(egui::RichText::new("Rows").underline())
-                    .on_hover_text("How many distinct data timestamps have been cached?");
-                ui.label(egui::RichText::new("Size").underline());
-                ui.end_row();
-
-                for (entity_path, stats_per_range) in range {
-                    for (timeline, time_range, stats) in stats_per_range {
-                        let res = ui.label(entity_path.to_string());
-                        ui.label(format!(
-                            "{}({})",
-                            timeline.name(),
-                            timeline.format_time_range_utc(time_range)
-                        ));
-                        entity_stats_ui(ui, res, stats);
+                egui::Grid::new("range cache stats grid")
+                    .num_columns(4)
+                    .show(ui, |ui| {
+                        ui.label(egui::RichText::new("Entity").underline());
+                        ui.label(egui::RichText::new("Time range").underline());
+                        ui.label(egui::RichText::new("Rows").underline())
+                            .on_hover_text("How many distinct data timestamps have been cached?");
+                        ui.label(egui::RichText::new("Size").underline());
                         ui.end_row();
-                    }
-                }
+
+                        for (entity_path, stats_per_range) in range {
+                            for (timeline, time_range, stats) in stats_per_range {
+                                let res = ui.label(entity_path.to_string());
+                                ui.label(format!(
+                                    "{}({})",
+                                    timeline.name(),
+                                    timeline.format_time_range_utc(time_range)
+                                ));
+                                entity_stats_ui(ui, res, stats);
+                                ui.end_row();
+                            }
+                        }
+                    });
             });
 
         fn entity_stats_ui(

--- a/crates/re_viewer/src/ui/memory_panel.rs
+++ b/crates/re_viewer/src/ui/memory_panel.rs
@@ -316,7 +316,7 @@ impl MemoryPanel {
             .on_hover_text("Show detailed statistics when hovering entity paths below.\nThis will slow down the program.");
         re_query_cache::set_detailed_stats(detailed_stats);
 
-        let CachesStats { latest_at } = caches_stats;
+        let CachesStats { latest_at, range } = caches_stats;
 
         // NOTE: This is a debug tool: do _not_ hide empty things. Empty things are a bug.
 
@@ -336,6 +336,29 @@ impl MemoryPanel {
                     let res = ui.label(entity_path.to_string());
                     entity_stats_ui(ui, res, stats);
                     ui.end_row();
+                }
+            });
+
+        ui.separator();
+
+        ui.strong("Range");
+        egui::Grid::new("range cache stats grid")
+            .num_columns(4)
+            .show(ui, |ui| {
+                ui.label(egui::RichText::new("Entity").underline());
+                ui.label(egui::RichText::new("Time range").underline());
+                ui.label(egui::RichText::new("Rows").underline())
+                    .on_hover_text("How many distinct data timestamps have been cached?");
+                ui.label(egui::RichText::new("Size").underline());
+                ui.end_row();
+
+                for (entity_path, stats_per_range) in range {
+                    for (timeline, time_range, stats) in stats_per_range {
+                        let res = ui.label(entity_path.to_string());
+                        ui.label(timeline.format_time_range_utc(time_range));
+                        entity_stats_ui(ui, res, stats);
+                        ui.end_row();
+                    }
                 }
             });
 


### PR DESCRIPTION
Title.

https://github.com/rerun-io/rerun/assets/2910679/cf2c2748-a461-49fe-8124-c2a94164c956

---

Part of the primary caching series of PR (index search, joins, deserialization):
- #4592
- #4593
- #4659
- #4680 
- #4681
- #4698
- #4711
- #4712
- #4721 
- #4726 
- #4773
- #4784
- #4785
- #4793
- #4800

---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4592/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4592)
- [Docs preview](https://rerun.io/preview/9ef1839106ff77234ba8b465bd04d00b3f0b7857/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/9ef1839106ff77234ba8b465bd04d00b3f0b7857/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)