### PR TITLE
Improve error handling in codegen

### DIFF
--- a/crates/re_types_builder/src/codegen/common.rs
+++ b/crates/re_types_builder/src/codegen/common.rs
@@ -321,7 +321,7 @@ pub fn remove_orphaned_files(reporter: &Reporter, files: &GeneratedFiles) {
         .collect();
 
     for folder_path in folder_paths {
-        re_log::debug!("Checking for orphaned files in {folder_path}");
+        re_log::trace!("Checking for orphaned files in {folder_path}");
 
         let iter = std::fs::read_dir(folder_path).ok();
         if iter.is_none() {

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -13,7 +13,9 @@ use rayon::prelude::*;
 
 use crate::{
     codegen::{autogen_warning, common::collect_examples_for_api_docs},
-    format_path, ArrowRegistry, Docs, ElementType, GeneratedFiles, Object, ObjectField, ObjectKind,
+    format_path,
+    objects::ObjectType,
+    ArrowRegistry, Docs, ElementType, GeneratedFiles, Object, ObjectField, ObjectKind,
     ObjectSpecifics, Objects, Reporter, Type, ATTR_CPP_NO_FIELD_CTORS,
 };
 
@@ -360,8 +362,8 @@ impl QuotedObject {
         hpp_includes: Includes,
         hpp_type_extensions: &TokenStream,
     ) -> Self {
-        match obj.specifics {
-            crate::ObjectSpecifics::Struct => match obj.kind {
+        match obj.typ() {
+            ObjectType::Struct => match obj.kind {
                 ObjectKind::Datatype | ObjectKind::Component => {
                     Self::from_struct(objects, obj, hpp_includes, hpp_type_extensions)
                 }
@@ -369,8 +371,9 @@ impl QuotedObject {
                     Self::from_archetype(obj, hpp_includes, hpp_type_extensions)
                 }
             },
-            crate::ObjectSpecifics::Union { .. } => {
-                Self::from_union(objects, obj, hpp_includes, hpp_type_extensions)
+            ObjectType::Union => Self::from_union(objects, obj, hpp_includes, hpp_type_extensions),
+            ObjectType::Enum => {
+                unimplemented!("enum")
             }
         }
     }

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -433,7 +433,14 @@ impl PythonCodeGenerator {
                 crate::objects::ObjectType::Union => {
                     code_for_union(arrow_registry, &ext_class, objects, obj)
                 }
-                crate::objects::ObjectType::Enum => unimplemented!("enums"),
+                crate::objects::ObjectType::Enum => {
+                    reporter.error(
+                        &obj.virtpath,
+                        &obj.fqname,
+                        "Enums are not implemented in Python",
+                    );
+                    continue;
+                }
             };
 
             code.push_text(&obj_code, 1, 0);

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -198,13 +198,15 @@ impl ObjectKind {
     pub const ALL: [Self; 3] = [Self::Datatype, Self::Component, Self::Archetype];
 
     // TODO(#2364): use an attr instead of the path
-    pub fn from_pkg_name(pkg_name: impl AsRef<str>, attrs: &Attributes) -> Self {
-        let scope = match attrs.try_get::<String>(pkg_name.as_ref(), crate::ATTR_RERUN_SCOPE) {
+    pub fn from_pkg_name(pkg_name: &str, attrs: &Attributes) -> Self {
+        assert!(!pkg_name.is_empty(), "Missing package name");
+
+        let scope = match attrs.try_get::<String>(pkg_name, crate::ATTR_RERUN_SCOPE) {
             Some(scope) => format!(".{scope}"),
             None => String::new(),
         };
 
-        let pkg_name = pkg_name.as_ref().replace(".testing", "");
+        let pkg_name = pkg_name.replace(".testing", "");
         if pkg_name.starts_with(format!("rerun{scope}.datatypes").as_str()) {
             ObjectKind::Datatype
         } else if pkg_name.starts_with(format!("rerun{scope}.components").as_str()) {
@@ -440,11 +442,10 @@ impl Object {
         let include_dir_path = include_dir_path.as_ref();
 
         let fqname = obj.name().to_owned();
-        let (pkg_name, name) = fqname
-            .rsplit_once('.')
-            .map_or((String::new(), fqname.clone()), |(pkg_name, name)| {
-                (pkg_name.to_owned(), name.to_owned())
-            });
+        let (pkg_name, name) = fqname.rsplit_once('.').map_or_else(
+            || panic!("Missing '.' separator in fqname: {fqname:?} - Did you forget to put it in a `namespace`?"),
+            |(pkg_name, name)| (pkg_name.to_owned(), name.to_owned()),
+        );
 
         let virtpath = obj
             .declaration_file()
@@ -523,11 +524,10 @@ impl Object {
         let include_dir_path = include_dir_path.as_ref();
 
         let fqname = enm.name().to_owned();
-        let (pkg_name, name) = fqname
-            .rsplit_once('.')
-            .map_or((String::new(), fqname.clone()), |(pkg_name, name)| {
-                (pkg_name.to_owned(), name.to_owned())
-            });
+        let (pkg_name, name) = fqname.rsplit_once('.').map_or_else(
+            || panic!("Missing '.' separator in fqname: {fqname:?} - Did you forget to put it in a `namespace`?"),
+            |(pkg_name, name)| (pkg_name.to_owned(), name.to_owned()),
+        );
 
         let virtpath = enm
             .declaration_file()

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -610,6 +610,10 @@ impl Object {
         self.attrs.has(name)
     }
 
+    pub fn typ(&self) -> ObjectType {
+        self.specifics.typ()
+    }
+
     pub fn is_struct(&self) -> bool {
         match &self.specifics {
             ObjectSpecifics::Struct {} => true,
@@ -699,6 +703,27 @@ pub enum ObjectSpecifics {
         /// `None` if this is a union, some value if this is an enum.
         utype: Option<ElementType>,
     },
+}
+
+impl ObjectSpecifics {
+    pub fn typ(&self) -> ObjectType {
+        match self {
+            ObjectSpecifics::Struct => ObjectType::Struct,
+            ObjectSpecifics::Union { utype: None } => ObjectType::Union,
+            ObjectSpecifics::Union { utype: Some(_) } => ObjectType::Enum,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ObjectType {
+    Struct,
+
+    /// A proper union sum type
+    Union,
+
+    /// An enumeration of alternatives
+    Enum,
 }
 
 /// A high-level representation of a flatbuffers field, which can be either a struct member or a


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/3384

Small restructure and refactor to improve error reporting in the codegen, especially when it comes to `enum` being unimplemented.

See commit messages.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4786/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4786/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4786/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4786)
- [Docs preview](https://rerun.io/preview/3e8e9722b7d64b28ca55453152ab80d259600cfe/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3e8e9722b7d64b28ca55453152ab80d259600cfe/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)