### PR TITLE
Replace `atty` dependency with `std::io::IsTerminal`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,17 +633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2603,15 +2592,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -4924,7 +4904,6 @@ version = "0.13.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
- "atty",
  "crossbeam",
  "document-features",
  "itertools 0.12.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,6 @@ array-init = "2.1"
 arrow2 = "0.17"
 arrow2_convert = "0.5.0"
 async-executor = "1.0"
-atty = "0.2"
 backtrace = "0.3"
 bincode = "1.3"
 bitflags = { version = "2.4", features = ["bytemuck"] }

--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -52,7 +52,6 @@ re_sdk_comms = { workspace = true, features = ["client"] }
 re_types_core.workspace = true
 
 ahash.workspace = true
-atty.workspace = true
 crossbeam.workspace = true
 document-features.workspace = true
 once_cell.workspace = true


### PR DESCRIPTION
### What

The `atty` library has [a GitHub security advisory](https://github.com/advisories/GHSA-g98v-hv3f-hcfr) noting that it is unmaintained and can be unsound under some conditions. Its functionality can be replaced with `std::io::IsTerminal`; this PR does that.

I also added a helper function which replaces the two identical uses; this gives a single place to change the policy if desired, rather than perhaps accidentally editing only one site.

### Checklist
* [X] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [X] ~~I've included a screenshot or gif (if applicable)~~
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4790/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4790/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4790/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4790)
- [Docs preview](https://rerun.io/preview/454262478e4c3cef9c9bed509c20aeb1e0dc9f25/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/454262478e4c3cef9c9bed509c20aeb1e0dc9f25/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)