### PR TITLE
Primary caching 14: don't bake `LatestAt(T-1)` results into low-level range queries

### DIFF
--- a/crates/re_data_store/examples/range_components.rs
+++ b/crates/re_data_store/examples/range_components.rs
@@ -1,7 +1,7 @@
 //! Demonstrates usage of [`re_data_store::polars_util::range_components`].
 //!
 //! ```text
-//! POLARS_FMT_MAX_ROWS=100 cargo r -p re_data_store --example range_components
+//! POLARS_FMT_MAX_ROWS=100 cargo r -p re_data_store --all-features --example range_components
 //! ```
 
 use polars_core::prelude::JoinType;

--- a/crates/re_data_store/tests/data_store.rs
+++ b/crates/re_data_store/tests/data_store.rs
@@ -419,7 +419,6 @@ fn range_impl(store: &mut DataStore) {
 
     let ent_path = EntityPath::from("this/that");
 
-    let frame0 = TimeInt::from(0);
     let frame1 = TimeInt::from(1);
     let frame2 = TimeInt::from(2);
     let frame3 = TimeInt::from(3);
@@ -554,61 +553,43 @@ fn range_impl(store: &mut DataStore) {
 
     // Unit ranges (Color's PoV)
 
+    // NOTE: Check out [1] to see what the results would've looked like with latest-at semantics at
+    // T-1 baked in (like we used to do).
+    //
+    // [1]: <https://github.com/rerun-io/rerun/blob/790f391/crates/re_data_store/tests/data_store.rs#L555-L837>
+
     assert_range_components(
         TimeRange::new(frame1, frame1),
         [Color::name(), Position2D::name()],
-        &[
-            (
-                Some(frame0),
-                &[(Color::name(), &row4_3), (Position2D::name(), &row4_4)],
-            ), // timeless
-            (
-                Some(frame1),
-                &[
-                    (Color::name(), &row1),
-                    (Position2D::name(), &row4_4), // timeless
-                ],
-            ),
-        ],
+        &[(
+            Some(frame1),
+            &[
+                (Color::name(), &row1),
+                // (Position2D::name(), &row4_4), // timeless
+            ],
+        )],
     );
     assert_range_components(
         TimeRange::new(frame2, frame2),
         [Color::name(), Position2D::name()],
-        &[
-            (
-                Some(frame1),
-                &[
-                    (Color::name(), &row1),
-                    (Position2D::name(), &row4_4), // timeless
-                ],
-            ), //
-        ],
+        &[],
     );
     assert_range_components(
         TimeRange::new(frame3, frame3),
         [Color::name(), Position2D::name()],
-        &[
-            (
-                Some(frame2),
-                &[(Color::name(), &row1), (Position2D::name(), &row2)],
-            ), //
-        ],
+        &[],
     );
     assert_range_components(
         TimeRange::new(frame4, frame4),
         [Color::name(), Position2D::name()],
         &[
             (
-                Some(frame3),
-                &[(Color::name(), &row1), (Position2D::name(), &row3)],
+                Some(frame4),
+                &[(Color::name(), &row4_1)], //
             ),
             (
                 Some(frame4),
-                &[(Color::name(), &row4_1), (Position2D::name(), &row3)],
-            ),
-            (
-                Some(frame4),
-                &[(Color::name(), &row4_2), (Position2D::name(), &row3)],
+                &[(Color::name(), &row4_2)], //
             ),
             (
                 Some(frame4),
@@ -619,12 +600,7 @@ fn range_impl(store: &mut DataStore) {
     assert_range_components(
         TimeRange::new(frame5, frame5),
         [Color::name(), Position2D::name()],
-        &[
-            (
-                Some(frame4),
-                &[(Color::name(), &row4_3), (Position2D::name(), &row4_4)], // !!!
-            ), //
-        ],
+        &[],
     );
 
     // Unit ranges (Position2D's PoV)
@@ -632,52 +608,30 @@ fn range_impl(store: &mut DataStore) {
     assert_range_components(
         TimeRange::new(frame1, frame1),
         [Position2D::name(), Color::name()],
-        &[
-            (
-                Some(frame0),
-                &[(Position2D::name(), &row4_4), (Color::name(), &row4_3)],
-            ), // timeless
-        ],
+        &[],
     );
     assert_range_components(
         TimeRange::new(frame2, frame2),
         [Position2D::name(), Color::name()],
         &[
             (
-                Some(frame1),
-                &[
-                    (Position2D::name(), &row4_4), // timeless
-                    (Color::name(), &row1),
-                ],
-            ),
-            (
                 Some(frame2),
-                &[(Position2D::name(), &row2), (Color::name(), &row1)],
+                &[(Position2D::name(), &row2)], //
             ), //
         ],
     );
     assert_range_components(
         TimeRange::new(frame3, frame3),
         [Position2D::name(), Color::name()],
-        &[
-            (
-                Some(frame2),
-                &[(Position2D::name(), &row2), (Color::name(), &row1)],
-            ),
-            (
-                Some(frame3),
-                &[(Position2D::name(), &row3), (Color::name(), &row1)],
-            ),
-        ],
+        &[(
+            Some(frame3),
+            &[(Position2D::name(), &row3)], //
+        )],
     );
     assert_range_components(
         TimeRange::new(frame4, frame4),
         [Position2D::name(), Color::name()],
         &[
-            (
-                Some(frame3),
-                &[(Position2D::name(), &row3), (Color::name(), &row1)],
-            ),
             (
                 Some(frame4),
                 &[(Position2D::name(), &row4_25), (Color::name(), &row4_2)],
@@ -691,12 +645,7 @@ fn range_impl(store: &mut DataStore) {
     assert_range_components(
         TimeRange::new(frame5, frame5),
         [Position2D::name(), Color::name()],
-        &[
-            (
-                Some(frame4),
-                &[(Position2D::name(), &row4_4), (Color::name(), &row4_3)],
-            ), //
-        ],
+        &[],
     );
 
     // Full range (Color's PoV)
@@ -706,15 +655,8 @@ fn range_impl(store: &mut DataStore) {
         [Color::name(), Position2D::name()],
         &[
             (
-                Some(frame0),
-                &[(Color::name(), &row4_3), (Position2D::name(), &row4_4)],
-            ), // timeless
-            (
                 Some(frame1),
-                &[
-                    (Color::name(), &row1),
-                    (Position2D::name(), &row4_4), // timeless
-                ],
+                &[(Color::name(), &row1)], //
             ),
             (
                 Some(frame4),
@@ -737,10 +679,6 @@ fn range_impl(store: &mut DataStore) {
         TimeRange::new(frame1, frame5),
         [Position2D::name(), Color::name()],
         &[
-            (
-                Some(frame0),
-                &[(Position2D::name(), &row4_4), (Color::name(), &row4_3)],
-            ), // timeless
             (
                 Some(frame2),
                 &[(Position2D::name(), &row2), (Color::name(), &row1)],

--- a/crates/re_data_store/tests/data_store.rs
+++ b/crates/re_data_store/tests/data_store.rs
@@ -563,10 +563,7 @@ fn range_impl(store: &mut DataStore) {
         [Color::name(), Position2D::name()],
         &[(
             Some(frame1),
-            &[
-                (Color::name(), &row1),
-                // (Position2D::name(), &row4_4), // timeless
-            ],
+            &[(Color::name(), &row1)], //
         )],
     );
     assert_range_components(

--- a/crates/re_query/src/range.rs
+++ b/crates/re_query/src/range.rs
@@ -1,9 +1,9 @@
 use itertools::Itertools as _;
-use re_data_store::{DataStore, LatestAtQuery, RangeQuery};
+use re_data_store::{DataStore, RangeQuery};
 use re_log_types::EntityPath;
 use re_types_core::{Archetype, ComponentName};
 
-use crate::{get_component_with_instances, ArchetypeView, ComponentWithInstances};
+use crate::{ArchetypeView, ComponentWithInstances};
 
 // ---
 
@@ -61,61 +61,29 @@ pub fn range_archetype<'a, A: Archetype + 'a, const N: usize>(
         .take(components.len())
         .collect();
 
-    // NOTE: This will return none for `TimeInt::Min`, i.e. range queries that start infinitely far
-    // into the past don't have a latest-at state!
-    let query_time = query.range.min.as_i64().checked_sub(1).map(Into::into);
-
-    let mut cwis_latest = None;
-    if let Some(query_time) = query_time {
-        let mut cwis_latest_raw: Vec<_> = std::iter::repeat_with(|| None)
-            .take(components.len())
-            .collect();
-
-        // Fetch the latest data for every single component from their respective point-of-views,
-        // this will allow us to build up the initial state and send an initial latest-at
-        // entity-view if needed.
-        for (i, primary) in components.iter().enumerate() {
-            cwis_latest_raw[i] = get_component_with_instances(
-                store,
-                &LatestAtQuery::new(query.timeline, query_time),
-                ent_path,
-                *primary,
-            )
-            .map(|(_, row_id, cwi)| (row_id, cwi));
-        }
-
-        if cwis_latest_raw[primary_col].is_some() {
-            cwis_latest = Some(cwis_latest_raw);
-        }
-    }
-
-    // send the latest-at state before anything else
-    cwis_latest
-        .into_iter()
-        .map(move |cwis| (query_time, true, cwis))
-        .chain(store.range(query, ent_path, components).map(
-            move |(data_time, row_id, mut cells)| {
-                // NOTE: The unwrap cannot fail, the cluster key's presence is guaranteed
-                // by the store.
-                let instance_keys = cells[cluster_col].take().unwrap();
-                let is_primary = cells[primary_col].is_some();
-                let cwis = cells
-                    .into_iter()
-                    .map(|cell| {
-                        cell.map(|cell| {
-                            (
-                                row_id,
-                                ComponentWithInstances {
-                                    instance_keys: instance_keys.clone(), /* shallow */
-                                    values: cell,
-                                },
-                            )
-                        })
+    store
+        .range(query, ent_path, components)
+        .map(move |(data_time, row_id, mut cells)| {
+            // NOTE: The unwrap cannot fail, the cluster key's presence is guaranteed
+            // by the store.
+            let instance_keys = cells[cluster_col].take().unwrap();
+            let is_primary = cells[primary_col].is_some();
+            let cwis = cells
+                .into_iter()
+                .map(|cell| {
+                    cell.map(|cell| {
+                        (
+                            row_id,
+                            ComponentWithInstances {
+                                instance_keys: instance_keys.clone(), /* shallow */
+                                values: cell,
+                            },
+                        )
                     })
-                    .collect::<Vec<_>>();
-                (data_time, is_primary, cwis)
-            },
-        ))
+                })
+                .collect::<Vec<_>>();
+            (data_time, is_primary, cwis)
+        })
         .filter_map(move |(data_time, is_primary, cwis)| {
             for (i, cwi) in cwis
                 .into_iter()

--- a/crates/re_query/tests/archetype_range_tests.rs
+++ b/crates/re_query/tests/archetype_range_tests.rs
@@ -70,8 +70,6 @@ fn simple_range() {
 
     // --- First test: `(timepoint1, timepoint3]` ---
 
-    // The exclusion of `timepoint1` means latest-at semantics will kick in!
-
     let query = re_data_store::RangeQuery::new(
         timepoint1[0].0,
         TimeRange::new((timepoint1[0].1.as_i64() + 1).into(), timepoint3[0].1),
@@ -103,37 +101,9 @@ fn simple_range() {
     // └─────────────┴──────────────┴─────────────────┘
 
     {
-        // Frame #123
-
-        let arch_view = &results[0];
-        let time = arch_view.data_time().unwrap();
-
-        // Build expected df manually
-        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
-        let positions = vec![
-            Some(Position2D::new(1.0, 2.0)),
-            Some(Position2D::new(3.0, 4.0)),
-        ];
-        let colors = vec![None, Some(Color::from_rgb(255, 0, 0))];
-        let expected = DataCellRow(smallvec![
-            DataCell::from_native_sparse(instances),
-            DataCell::from_native_sparse(positions),
-            DataCell::from_native_sparse(colors)
-        ]);
-
-        //eprintln!("{df:?}");
-        //eprintln!("{expected:?}");
-
-        assert_eq!(TimeInt::from(123), time);
-        assert_eq!(
-            &expected,
-            &arch_view.to_data_cell_row_2::<Position2D, Color>().unwrap(),
-        );
-    }
-    {
         // Frame #323
 
-        let arch_view = &results[1];
+        let arch_view = &results[0];
         let time = arch_view.data_time().unwrap();
 
         // Build expected df manually
@@ -160,8 +130,6 @@ fn simple_range() {
     }
 
     // --- Second test: `[timepoint1, timepoint3]` ---
-
-    // The inclusion of `timepoint1` means latest-at semantics will _not_ kick in!
 
     let query = re_data_store::RangeQuery::new(
         timepoint1[0].0,
@@ -379,15 +347,6 @@ fn timeless_range() {
 
     // We expect this to generate the following `DataFrame`s:
     //
-    // Frame #123:
-    // ┌────────────────────┬───────────────┬─────────────────┐
-    // │ InstanceKey ┆ Point2D ┆ Color │
-    // ╞════════════════════╪═══════════════╪═════════════════╡
-    // │ 0                  ┆ {1.0,2.0}     ┆ null            │
-    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-    // │ 1                  ┆ {3.0,4.0}     ┆ 4278190080      │
-    // └────────────────────┴───────────────┴─────────────────┘
-    //
     // Frame #323:
     // ┌────────────────────┬───────────────┬─────────────────┐
     // │ InstanceKey ┆ Point2D ┆ Color │
@@ -398,37 +357,9 @@ fn timeless_range() {
     // └────────────────────┴───────────────┴─────────────────┘
 
     {
-        // Frame #123
-
-        let arch_view = &results[0];
-        let time = arch_view.data_time().unwrap();
-
-        // Build expected df manually
-        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
-        let positions = vec![
-            Some(Position2D::new(1.0, 2.0)),
-            Some(Position2D::new(3.0, 4.0)),
-        ];
-        let colors = vec![None, Some(Color::from_rgb(255, 0, 0))];
-        let expected = DataCellRow(smallvec![
-            DataCell::from_native_sparse(instances),
-            DataCell::from_native_sparse(positions),
-            DataCell::from_native_sparse(colors)
-        ]);
-
-        //eprintln!("{df:?}");
-        //eprintln!("{expected:?}");
-
-        assert_eq!(TimeInt::from(123), time);
-        assert_eq!(
-            &expected,
-            &arch_view.to_data_cell_row_2::<Position2D, Color>().unwrap(),
-        );
-    }
-    {
         // Frame #323
 
-        let arch_view = &results[1];
+        let arch_view = &results[0];
         let time = arch_view.data_time().unwrap();
 
         // Build expected df manually
@@ -456,8 +387,6 @@ fn timeless_range() {
 
     // --- Second test: `[timepoint1, timepoint3]` ---
 
-    // The inclusion of `timepoint1` means latest-at semantics will fall back to timeless data!
-
     let query = re_data_store::RangeQuery::new(
         timepoint1[0].0,
         TimeRange::new(timepoint1[0].1, timepoint3[0].1),
@@ -469,15 +398,6 @@ fn timeless_range() {
     let results = arch_views.collect::<Vec<_>>();
 
     // We expect this to generate the following `DataFrame`s:
-    //
-    // Frame #122:
-    // ┌────────────────────┬───────────────┬─────────────────┐
-    // │ InstanceKey ┆ Point2D ┆ Color │
-    // ╞════════════════════╪═══════════════╪═════════════════╡
-    // │ 0                  ┆ {10.0,20.0}   ┆ null            │
-    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-    // │ 1                  ┆ {30.0,40.0}   ┆ 4278190080      │
-    // └────────────────────┴───────────────┴─────────────────┘
     //
     // Frame #123:
     // ┌────────────────────┬───────────────┬─────────────────┐
@@ -498,36 +418,9 @@ fn timeless_range() {
     // └────────────────────┴───────────────┴─────────────────┘
 
     {
-        // Frame #122 (all timeless)
-
-        let arch_view = &results[0];
-        let time = arch_view.data_time().unwrap();
-
-        // Build expected df manually
-        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
-        let positions = vec![
-            Some(Position2D::new(10.0, 20.0)),
-            Some(Position2D::new(30.0, 40.0)),
-        ];
-        let colors = vec![None, Some(Color::from_rgb(255, 0, 0))];
-        let expected = DataCellRow(smallvec![
-            DataCell::from_native_sparse(instances),
-            DataCell::from_native_sparse(positions),
-            DataCell::from_native_sparse(colors)
-        ]);
-
-        //eprintln!("{df:?}");
-        //eprintln!("{expected:?}");
-
-        assert_eq!(TimeInt::from(122), time);
-        assert_eq!(
-            &expected,
-            &arch_view.to_data_cell_row_2::<Position2D, Color>().unwrap(),
-        );
-
         // Frame #123 (partially timeless)
 
-        let arch_view = &results[1];
+        let arch_view = &results[0];
         let time = arch_view.data_time().unwrap();
 
         // Build expected df manually
@@ -536,7 +429,7 @@ fn timeless_range() {
             Some(Position2D::new(1.0, 2.0)),
             Some(Position2D::new(3.0, 4.0)),
         ];
-        let colors = vec![None, Some(Color::from_rgb(255, 0, 0))];
+        let colors: Vec<Option<Color>> = vec![None, None];
         let expected = DataCellRow(smallvec![
             DataCell::from_native_sparse(instances),
             DataCell::from_native_sparse(positions),
@@ -555,7 +448,7 @@ fn timeless_range() {
     {
         // Frame #323
 
-        let arch_view = &results[2];
+        let arch_view = &results[1];
         let time = arch_view.data_time().unwrap();
 
         // Build expected df manually
@@ -802,8 +695,6 @@ fn simple_splatted_range() {
 
     // --- First test: `(timepoint1, timepoint3]` ---
 
-    // The exclusion of `timepoint1` means latest-at semantics will kick in!
-
     let query = re_data_store::RangeQuery::new(
         timepoint1[0].0,
         TimeRange::new((timepoint1[0].1.as_i64() + 1).into(), timepoint3[0].1),
@@ -816,15 +707,6 @@ fn simple_splatted_range() {
 
     // We expect this to generate the following `DataFrame`s:
     //
-    // Frame #123:
-    // ┌────────────────────┬───────────────┬─────────────────┐
-    // │ InstanceKey ┆ Point2D ┆ Color │
-    // ╞════════════════════╪═══════════════╪═════════════════╡
-    // │ 0                  ┆ {1.0,2.0}     ┆ null            │
-    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-    // │ 1                  ┆ {3.0,4.0}     ┆ 4278190080      │
-    // └────────────────────┴───────────────┴─────────────────┘
-    //
     // Frame #323:
     // ┌────────────────────┬───────────────┬─────────────────┐
     // │ InstanceKey ┆ Point2D ┆ Color │
@@ -834,41 +716,12 @@ fn simple_splatted_range() {
     // │ 1                  ┆ {30.0,40.0}   ┆ 16711680        │
     // └────────────────────┴───────────────┴─────────────────┘
 
-    assert_eq!(results.len(), 2);
-
-    {
-        // Frame #123
-
-        let arch_view = &results[0];
-        let time = arch_view.data_time().unwrap();
-
-        // Build expected df manually
-        let instances = vec![Some(InstanceKey(0)), Some(InstanceKey(1))];
-        let positions = vec![
-            Some(Position2D::new(1.0, 2.0)),
-            Some(Position2D::new(3.0, 4.0)),
-        ];
-        let colors = vec![None, Some(Color::from_rgb(255, 0, 0))];
-        let expected = DataCellRow(smallvec![
-            DataCell::from_native_sparse(instances),
-            DataCell::from_native_sparse(positions),
-            DataCell::from_native_sparse(colors)
-        ]);
-
-        //eprintln!("{df:?}");
-        //eprintln!("{expected:?}");
-
-        assert_eq!(TimeInt::from(123), time);
-        assert_eq!(
-            &expected,
-            &arch_view.to_data_cell_row_2::<Position2D, Color>().unwrap(),
-        );
-    }
+    assert_eq!(results.len(), 1);
 
     {
         // Frame #323
 
-        let arch_view = &results[1];
+        let arch_view = &results[0];
         let time = arch_view.data_time().unwrap();
 
         // Build expected df manually

--- a/crates/re_query/tests/archetype_range_tests.rs
+++ b/crates/re_query/tests/archetype_range_tests.rs
@@ -82,15 +82,6 @@ fn simple_range() {
 
     // We expect this to generate the following `DataFrame`s:
     //
-    // Frame #123:
-    // ┌─────────────┬───────────┬──────────────┐
-    // │ InstanceKey ┆ Point2D   ┆ Color        │
-    // ╞═════════════╪═══════════╪══════════════╡
-    // │ 0           ┆ {1.0,2.0} ┆ null         │
-    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-    // │ 1           ┆ {3.0,4.0} ┆ 4278190080   │
-    // └─────────────┴───────────┴──────────────┘
-    //
     // Frame #323:
     // ┌─────────────┬──────────────┬─────────────────┐
     // │ InstanceKey ┆ Point2D      ┆ Color           │
@@ -119,7 +110,6 @@ fn simple_range() {
             DataCell::from_native_sparse(colors)
         ]);
 
-        //eprintln!("{df:?}");
         //eprintln!("{expected:?}");
 
         assert_eq!(TimeInt::from(323), time);
@@ -180,7 +170,6 @@ fn simple_range() {
             DataCell::from_native_sparse(colors)
         ]);
 
-        //eprintln!("{df:?}");
         //eprintln!("{expected:?}");
 
         assert_eq!(TimeInt::from(123), time);
@@ -208,7 +197,6 @@ fn simple_range() {
             DataCell::from_native_sparse(colors)
         ]);
 
-        //eprintln!("{df:?}");
         //eprintln!("{expected:?}");
 
         assert_eq!(TimeInt::from(323), time);
@@ -375,7 +363,6 @@ fn timeless_range() {
             DataCell::from_native_sparse(colors)
         ]);
 
-        //eprintln!("{df:?}");
         //eprintln!("{expected:?}");
 
         assert_eq!(TimeInt::from(323), time);
@@ -436,7 +423,6 @@ fn timeless_range() {
             DataCell::from_native_sparse(colors)
         ]);
 
-        //eprintln!("{df:?}");
         //eprintln!("{expected:?}");
 
         assert_eq!(TimeInt::from(123), time);
@@ -464,7 +450,6 @@ fn timeless_range() {
             DataCell::from_native_sparse(colors)
         ]);
 
-        //eprintln!("{df:?}");
         //eprintln!("{expected:?}");
 
         assert_eq!(TimeInt::from(323), time);
@@ -541,7 +526,6 @@ fn timeless_range() {
             DataCell::from_native_sparse(colors)
         ]);
 
-        //eprintln!("{df:?}");
         //eprintln!("{expected:?}");
 
         assert_eq!(None, time);
@@ -568,7 +552,6 @@ fn timeless_range() {
             DataCell::from_native_sparse(colors)
         ]);
 
-        //eprintln!("{df:?}");
         //eprintln!("{expected:?}");
 
         assert_eq!(None, time);
@@ -595,7 +578,6 @@ fn timeless_range() {
             DataCell::from_native_sparse(colors)
         ]);
 
-        //eprintln!("{df:?}");
         //eprintln!("{expected:?}");
 
         assert_eq!(TimeInt::from(123), time);
@@ -623,7 +605,6 @@ fn timeless_range() {
             DataCell::from_native_sparse(colors)
         ]);
 
-        //eprintln!("{df:?}");
         //eprintln!("{expected:?}");
 
         assert_eq!(TimeInt::from(323), time);
@@ -742,7 +723,6 @@ fn simple_splatted_range() {
             DataCell::from_native_sparse(colors)
         ]);
 
-        //eprintln!("{df:?}");
         //eprintln!("{expected:?}");
 
         assert_eq!(TimeInt::from(323), time);
@@ -802,7 +782,6 @@ fn simple_splatted_range() {
             DataCell::from_native_sparse(colors)
         ]);
 
-        //eprintln!("{df:?}");
         //eprintln!("{expected:?}");
 
         assert_eq!(TimeInt::from(123), time);
@@ -833,7 +812,6 @@ fn simple_splatted_range() {
             DataCell::from_native_sparse(colors)
         ]);
 
-        //eprintln!("{df:?}");
         //eprintln!("{expected:?}");
 
         assert_eq!(TimeInt::from(323), time);

--- a/crates/re_query_cache/tests/range.rs
+++ b/crates/re_query_cache/tests/range.rs
@@ -17,8 +17,6 @@ use re_types_core::Loggable as _;
 // ---
 
 #[test]
-// TODO(cmc): actually make cached range queries correct
-#[should_panic(expected = "assertion failed: `(left == right)`")]
 fn simple_range() {
     let mut store = DataStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
@@ -79,8 +77,6 @@ fn simple_range() {
 
     // --- First test: `(timepoint1, timepoint3]` ---
 
-    // The exclusion of `timepoint1` means latest-at semantics will kick in!
-
     let query = re_data_store::RangeQuery::new(
         timepoint1[0].0,
         TimeRange::new((timepoint1[0].1.as_i64() + 1).into(), timepoint3[0].1),
@@ -101,7 +97,7 @@ fn simple_range() {
 }
 
 #[test]
-// TODO(cmc): cached range timeless support
+// TODO(cmc): timeless support
 #[should_panic(expected = "assertion failed: `(left == right)`")]
 fn timeless_range() {
     let mut store = DataStore::new(
@@ -196,8 +192,6 @@ fn timeless_range() {
 
     // --- First test: `(timepoint1, timepoint3]` ---
 
-    // The exclusion of `timepoint1` means latest-at semantics will kick in!
-
     let query = re_data_store::RangeQuery::new(
         timepoint1[0].0,
         TimeRange::new((timepoint1[0].1.as_i64() + 1).into(), timepoint3[0].1),
@@ -225,8 +219,6 @@ fn timeless_range() {
 }
 
 #[test]
-// TODO(cmc): actually make cached range queries correct
-#[should_panic(expected = "assertion failed: `(left == right)`")]
 fn simple_splatted_range() {
     let mut store = DataStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
@@ -286,8 +278,6 @@ fn simple_splatted_range() {
     }
 
     // --- First test: `(timepoint1, timepoint3]` ---
-
-    // The exclusion of `timepoint1` means latest-at semantics will kick in!
 
     let query = re_data_store::RangeQuery::new(
         timepoint1[0].0,
@@ -374,6 +364,7 @@ fn query_and_compare(store: &DataStore, query: &RangeQuery, ent_path: &EntityPat
 
         // Keep this around for the next unlucky chap.
         // eprintln!("(expected={expected_data_times:?}, uncached={uncached_data_times:?}, cached={cached_data_times:?})");
+        // eprintln!("{}", store.to_data_table().unwrap());
 
         similar_asserts::assert_eq!(expected_data_times, uncached_data_times);
         similar_asserts::assert_eq!(expected_instance_keys, uncached_instance_keys);

--- a/crates/re_space_view_time_series/src/visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/visualizer_system.rs
@@ -227,7 +227,17 @@ impl TimeSeriesSystem {
             let line_label =
                 same_label(&points).unwrap_or_else(|| data_result.entity_path.to_string());
 
-            self.add_line_segments(&line_label, points);
+            if points.len() == 1 {
+                self.lines.push(PlotSeries {
+                    label: line_label,
+                    color: points[0].attrs.color,
+                    width: 2.0 * points[0].attrs.radius,
+                    kind: PlotSeriesKind::Scatter,
+                    points: vec![(points[0].time, points[0].value)],
+                });
+            } else {
+                self.add_line_segments(&line_label, points);
+            }
         }
 
         Ok(())

--- a/crates/re_viewer/src/ui/visible_history.rs
+++ b/crates/re_viewer/src/ui/visible_history.rs
@@ -246,9 +246,6 @@ fn current_range_ui(
     is_sequence_timeline: bool,
     visible_history: &VisibleHistory,
 ) {
-    let from = visible_history.from(current_time.into());
-    let to = visible_history.to(current_time.into());
-
     let (time_type, quantity_name) = if is_sequence_timeline {
         (TimeType::Sequence, "frame")
     } else {
@@ -260,22 +257,13 @@ fn current_range_ui(
         ctx.app_options.time_zone_for_timestamps,
     );
 
-    if from == to {
-        ui.label(format!(
-            "Showing last data logged on or before {quantity_name} {from_formatted}"
-        ));
-    } else {
-        ui.label(format!(
-            "Showing data between {quantity_name}s {from_formatted} and {}.",
-            time_type.format(
-                visible_history.to(current_time.into()),
-                ctx.app_options.time_zone_for_timestamps
-            )
-        ))
-        .on_hover_text(format!(
-            "This includes the data current as of the starting {quantity_name}."
-        ));
-    };
+    ui.label(format!(
+        "Showing data between {quantity_name}s {from_formatted} and {} (included).",
+        time_type.format(
+            visible_history.to(current_time.into()),
+            ctx.app_options.time_zone_for_timestamps
+        )
+    ));
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Our low-level range APIs used to bake the latest-at results at `range.min - 1` into the range results, which is a big problem in a multi tenant setting because `range(1, 10)` vs. `latestat(1) + range(2, 10)` are two completely different things.

Side-effect: a plot with a window of len 1 now behaves as expected:


https://github.com/rerun-io/rerun/assets/2910679/957ac367-35a6-4bea-9f40-59d51c556639

---

Part of the primary caching series of PR (index search, joins, deserialization):
- #4592
- #4593
- #4659
- #4680 
- #4681
- #4698
- #4711
- #4712
- #4721 
- #4726 
- #4773
- #4784
- #4785
- #4793
- #4800

---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4592/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4592/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4592)
- [Docs preview](https://rerun.io/preview/07bdde90062d9f78539baeb6ebfb982251d904c4/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/07bdde90062d9f78539baeb6ebfb982251d904c4/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)