### PR TITLE
Click a spatial space view background to select the space view

### DIFF
--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -629,6 +629,11 @@ pub fn picking(
         };
     }
 
+    if hovered_items.is_empty() {
+        // If we hover nothing, we are hovering the space-view itself.
+        hovered_items.push(Item::SpaceView(query.space_view_id));
+    }
+
     // Associate the hovered space with the first item in the hovered item list.
     // If we were to add several, space views might render unnecessary additional hints.
     // TODO(andreas): Should there be context if no item is hovered at all? There's no usecase for that today it seems.


### PR DESCRIPTION
### What
![click-spaceview](https://github.com/rerun-io/rerun/assets/1148717/ab71048d-1605-4696-97d8-da3fc02a749a)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4796/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4796/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4796/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4796)
- [Docs preview](https://rerun.io/preview/a2cfacc9ff862a1f3aba32a5019cbc271023fb66/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a2cfacc9ff862a1f3aba32a5019cbc271023fb66/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)