### PR TITLE
Clear selection when clicking blank space in the Blueprint View

### DIFF
--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -29,6 +29,14 @@ impl Viewport<'_, '_> {
                     if let Some(root) = self.tree.root() {
                         self.tile_ui(ctx, ui, root, true);
                     }
+
+                    // clear selection upon clicking on empty space
+                    if ui
+                        .allocate_response(ui.available_size(), egui::Sense::click())
+                        .clicked()
+                    {
+                        ctx.selection_state().clear_current();
+                    }
                 });
             });
     }


### PR DESCRIPTION
### What

As the title says.

- Fixes #2709

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4831/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4831/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4831/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4831)
- [Docs preview](https://rerun.io/preview/7c58c5ed42c20134bf28d110d28a313f3d378be8/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7c58c5ed42c20134bf28d110d28a313f3d378be8/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)