### PR TITLE
Version lock griffe to 0.39 and fix some doc errors

### DIFF
--- a/rerun_py/requirements-doc.txt
+++ b/rerun_py/requirements-doc.txt
@@ -1,4 +1,4 @@
-griffe==0.38.1
+griffe==0.39.0
 mkdocs==1.5.3
 mkdocs-gen-files==0.5.0
 mkdocs-literate-nav==0.6.1

--- a/rerun_py/requirements-doc.txt
+++ b/rerun_py/requirements-doc.txt
@@ -1,3 +1,4 @@
+griffe==0.38.1
 mkdocs==1.5.3
 mkdocs-gen-files==0.5.0
 mkdocs-literate-nav==0.6.1

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -94,6 +94,8 @@ def log(
     )
     ```
 
+    See also: [`rerun.log_components`][].
+
     Parameters
     ----------
     entity_path:
@@ -125,8 +127,6 @@ def log(
         If True, raise exceptions on non-loggable data.
         If False, warn on non-loggable data.
         if None, use the global default from `rerun.strict_mode()`
-
-    See also: [`rerun.log_components`][].
     """
     # TODO(jleibs): Profile is_instance with runtime_checkable vs has_attr
     # Note from: https://docs.python.org/3/library/typing.html#typing.runtime_checkable
@@ -187,6 +187,8 @@ def log_components(
     `num_instances`, or length 1 if the component is a splat., or 0 if the
     component is being cleared.
 
+    See also: [`rerun.log`][].
+
     Parameters
     ----------
     entity_path:
@@ -215,8 +217,6 @@ def log_components(
         If True, raise exceptions on non-loggable data.
         If False, warn on non-loggable data.
         if None, use the global default from `rerun.strict_mode()`
-
-    See also: [`rerun.log`][].
     """
     instanced: dict[str, pa.Array] = {}
     splats: dict[str, pa.Array] = {}


### PR DESCRIPTION
### What

PRs for our doc tests started failing spuriously as griffe 0.39 was rolled out to github runners. A non-expected spontaneous upgrade to griffe is bad in general, so I added it to the requirements-doc.

However, the failure is actually a valid warning about a non-conformant docstring so I fixed the error and kept us on 0.39 since the validation it does is actually useful and would be more obvious if you were introducing a new docstring.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4835/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4835/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4835/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4835)
- [Docs preview](https://rerun.io/preview/5e5cf8def0e884dd743718ce76b01e8d16a489b2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5e5cf8def0e884dd743718ce76b01e8d16a489b2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)