### PR TITLE
Show download sizes of in the example page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,7 +1720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "753c36d3e2f7a32425af5290af2e52efb3471ea3a263b87f003b5433351b0fd7"
 dependencies = [
  "egui",
- "ehttp",
+ "ehttp 0.3.1",
  "enum-map",
  "image",
  "log",
@@ -1773,6 +1773,20 @@ name = "ehttp"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88f45662356f96afc7d9e2bc9910ad8352ee01417f7c69b8b16a53c8767a75d"
+dependencies = [
+ "document-features",
+ "js-sys",
+ "ureq",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ehttp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e598cc2bfc28612f26426259ed99a978270e9433d63ae6d2843e30fb0974cd02"
 dependencies = [
  "document-features",
  "futures-util",
@@ -4469,7 +4483,7 @@ version = "0.13.0-alpha.2"
 dependencies = [
  "crossbeam",
  "directories-next",
- "ehttp",
+ "ehttp 0.4.0",
  "re_build_info",
  "re_build_tools",
  "re_log",
@@ -4697,7 +4711,7 @@ name = "re_log_encoding"
 version = "0.13.0-alpha.2"
 dependencies = [
  "criterion",
- "ehttp",
+ "ehttp 0.4.0",
  "js-sys",
  "lz4_flex",
  "mimalloc",
@@ -5298,7 +5312,7 @@ dependencies = [
  "egui-wgpu",
  "egui_plot",
  "egui_tiles",
- "ehttp",
+ "ehttp 0.4.0",
  "image",
  "itertools 0.12.0",
  "once_cell",
@@ -7065,9 +7079,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7158,9 +7172,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ criterion = "0.5"
 crossbeam = "0.8"
 directories-next = "2"
 document-features = "0.2"
-ehttp = "0.3.1"
+ehttp = "0.4.0"
 enumset = "1.0.12"
 env_logger = { version = "0.10", default-features = false }
 ewebsock = "0.4.0"

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -258,7 +258,8 @@ impl App {
     }
 
     pub fn set_examples_manifest_url(&mut self, url: String) {
-        self.state.set_examples_manifest_url(url);
+        self.state
+            .set_examples_manifest_url(&self.re_ui.egui_ctx, url);
     }
 
     pub fn build_info(&self) -> &re_build_info::BuildInfo {

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -51,8 +51,8 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn set_examples_manifest_url(&mut self, url: String) {
-        self.welcome_screen.set_examples_manifest_url(url);
+    pub fn set_examples_manifest_url(&mut self, egui_ctx: &egui::Context, url: String) {
+        self.welcome_screen.set_examples_manifest_url(egui_ctx, url);
     }
 
     pub fn app_options(&self) -> &AppOptions {

--- a/crates/re_viewer/src/ui/welcome_screen/example_page.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/example_page.rs
@@ -131,7 +131,7 @@ fn load_manifest(egui_ctx: &egui::Context, url: String) -> ManifestPromise {
 
 /// Do a HEAD request to get the size of a file.
 ///
-/// In case of an erorr, it is logged as DEBUG and
+/// In case of an error, it is logged as DEBUG and
 /// the promise is resolved to `None`.
 fn load_file_size(egui_ctx: &egui::Context, url: String) -> Promise<Option<u64>> {
     let (sender, promise) = Promise::new();

--- a/crates/re_viewer/src/ui/welcome_screen/example_page.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/example_page.rs
@@ -1,7 +1,7 @@
 use egui::{NumExt as _, Ui};
-
 use ehttp::{fetch, Request};
 use poll_promise::Promise;
+
 use re_log_types::LogMsg;
 use re_smart_channel::ReceiveSet;
 use re_viewer_context::SystemCommandSender;
@@ -46,13 +46,24 @@ const THUMBNAIL_RADIUS: f32 = 4.0;
 /// For layout purposes, each example spans multiple cells in the grid. This structure is used to
 /// track the rectangle that spans the block of cells used for the corresponding example, so hover/
 /// click can be detected.
-#[derive(Debug)]
 struct ExampleDescLayout {
     desc: ExampleDesc,
     rect: egui::Rect,
+
+    /// We do an async HEAD request to get the size of the RRD file
+    /// so we can show it to the user.
+    rrd_byte_size_promise: Promise<Option<u64>>,
 }
 
 impl ExampleDescLayout {
+    fn new(desc: ExampleDesc) -> Self {
+        ExampleDescLayout {
+            rrd_byte_size_promise: load_file_size(desc.rrd_url.clone()),
+            desc,
+            rect: egui::Rect::NOTHING,
+        }
+    }
+
     /// Saves the top left corner of the hover/click area for this example.
     fn set_top_left(&mut self, pos: egui::Pos2) {
         self.rect.min = pos;
@@ -71,15 +82,6 @@ impl ExampleDescLayout {
     fn hovered(&self, ui: &egui::Ui, id: egui::Id) -> bool {
         ui.interact(self.rect, id.with(&self.desc.name), egui::Sense::hover())
             .hovered()
-    }
-}
-
-impl From<ExampleDesc> for ExampleDescLayout {
-    fn from(desc: ExampleDesc) -> Self {
-        ExampleDescLayout {
-            desc,
-            rect: egui::Rect::NOTHING,
-        }
     }
 }
 
@@ -109,10 +111,48 @@ fn load_manifest(url: String) -> ManifestPromise {
     fetch(Request::get(url), move |response| match response {
         Ok(response) => sender.send(
             serde_json::from_slice::<ManifestJson>(&response.bytes)
-                .map(|examples| examples.into_iter().map(ExampleDescLayout::from).collect())
+                .map(|examples| examples.into_iter().map(ExampleDescLayout::new).collect())
                 .map_err(LoadError::Deserialize),
         ),
         Err(err) => sender.send(Err(LoadError::Fetch(err))),
+    });
+
+    promise
+}
+
+/// Do a HEAD request to get the size of a file.
+///
+/// In case of an erorr, it is logged as DEBUG and
+/// the promise is resolved to `None`.
+fn load_file_size(url: String) -> Promise<Option<u64>> {
+    let (sender, promise) = Promise::new();
+
+    let request = Request {
+        method: "HEAD".into(),
+        ..Request::get(url.clone())
+    };
+
+    fetch(request, move |response| match response {
+        Ok(response) => {
+            if response.ok {
+                let headers = &response.headers;
+                let content_length = headers
+                    .get("content-length")
+                    .or_else(|| headers.get("x-goog-stored-content-length"))
+                    .and_then(|s| s.parse::<u64>().ok());
+                sender.send(content_length);
+            } else {
+                re_log::debug!(
+                    "Failed to load file size of {url:?}: {} {}",
+                    response.status,
+                    response.status_text
+                );
+            }
+        }
+        Err(err) => {
+            re_log::debug!("Failed to load file size of {url:?}: {err}");
+            sender.send(None);
+        }
     });
 
     promise
@@ -278,7 +318,7 @@ impl ExamplePage {
                                     ui.vertical(|ui| {
                                         example_description(
                                             ui,
-                                            &example.desc,
+                                            example,
                                             example.hovered(ui, self.id),
                                         );
 
@@ -374,17 +414,27 @@ fn example_thumbnail(
     }
 }
 
-fn example_description(ui: &mut Ui, example: &ExampleDesc, hovered: bool) {
-    ui.label(
-        egui::RichText::new(example.title.clone())
-            .strong()
-            .line_height(Some(22.0))
-            .text_style(re_ui::ReUi::welcome_screen_body()),
-    );
+fn example_description(ui: &mut Ui, example: &ExampleDescLayout, hovered: bool) {
+    let desc = &example.desc;
+
+    let title = egui::RichText::new(desc.title.clone())
+        .strong()
+        .line_height(Some(22.0))
+        .text_style(re_ui::ReUi::welcome_screen_body());
+
+    ui.horizontal(|ui| {
+        ui.label(title);
+
+        if let Some(Some(size)) = example.rrd_byte_size_promise.ready().cloned() {
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                ui.label(re_format::format_bytes(size as f64));
+            });
+        }
+    });
 
     ui.add_space(4.0);
 
-    let mut desc_text = egui::RichText::new(example.description.clone()).line_height(Some(19.0));
+    let mut desc_text = egui::RichText::new(desc.description.clone()).line_height(Some(19.0));
     if hovered {
         desc_text = desc_text.strong();
     }

--- a/crates/re_viewer/src/ui/welcome_screen/mod.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/mod.rs
@@ -38,8 +38,8 @@ impl Default for WelcomeScreen {
 }
 
 impl WelcomeScreen {
-    pub fn set_examples_manifest_url(&mut self, url: String) {
-        self.example_page.set_manifest_url(url);
+    pub fn set_examples_manifest_url(&mut self, egui_ctx: &egui::Context, url: String) {
+        self.example_page.set_manifest_url(egui_ctx, url);
     }
 
     /// Welcome screen shown in place of the viewport when no data is loaded.

--- a/deny.toml
+++ b/deny.toml
@@ -52,6 +52,7 @@ skip = [
   { name = "cargo_metadata" },       # Older version used by ply-rs. It's small, and it's build-time only!
   { name = "cfg_aliases" },          # Tiny macro-only crate. Winit and other use older version than us.
   { name = "core-graphics" },        # old version via arboard
+  { name = "ehttp" },                # Will go away with next egui update
   { name = "foreign-types-shared" }, # used for cocoa bindings. wgpu uses newer than eframe.
   { name = "foreign-types" },        # used for cocoa bindings. wgpu uses newer than eframe.
   { name = "hashbrown" },            # Old version used by polar-rs


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/4724

![image](https://github.com/rerun-io/rerun/assets/1148717/623f1d47-5f5d-4597-b117-00763cdf151c)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4841/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4841/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4841/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4841)
- [Docs preview](https://rerun.io/preview/7bf9d8177bdcf7abf61948aa6e431254cccc613e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7bf9d8177bdcf7abf61948aa6e431254cccc613e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)