### PR TITLE
Indicate Mat3x3 and Mat4x4 constructors are column major

### DIFF
--- a/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
@@ -50,7 +50,7 @@ namespace rerun::datatypes {
                   columns[2].z(),
               } {}
 
-        /// Construct a new 3x3 matrix from a pointer to 9 floats (in row major order).
+        /// Construct a new 3x3 matrix from a pointer to 9 floats (in column major order).
         explicit Mat3x3(const float* elements)
             : flat_columns{
                   elements[0],

--- a/rerun_cpp/src/rerun/datatypes/mat3x3_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3_ext.cpp
@@ -27,7 +27,7 @@ namespace rerun {
                   columns[2].z(),
               } {}
 
-        /// Construct a new 3x3 matrix from a pointer to 9 floats (in row major order).
+        /// Construct a new 3x3 matrix from a pointer to 9 floats (in column major order).
         explicit Mat3x3(const float* elements)
             : flat_columns{
                   elements[0],

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
@@ -58,7 +58,7 @@ namespace rerun::datatypes {
                   columns[3].w(),
               } {}
 
-        /// Construct a new 4x4 matrix from a pointer to 16 floats (in row major order).
+        /// Construct a new 4x4 matrix from a pointer to 16 floats (in column major order).
         explicit Mat4x4(const float* elements)
             : flat_columns{
                   elements[0],

--- a/rerun_cpp/src/rerun/datatypes/mat4x4_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4_ext.cpp
@@ -34,7 +34,7 @@ namespace rerun {
                   columns[3].w(),
               } {}
 
-        /// Construct a new 4x4 matrix from a pointer to 16 floats (in row major order).
+        /// Construct a new 4x4 matrix from a pointer to 16 floats (in column major order).
         explicit Mat4x4(const float* elements)
             : flat_columns{
                   elements[0],


### PR DESCRIPTION
### What

The comments were incorrect.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4842/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4842/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4842/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4842)
- [Docs preview](https://rerun.io/preview/c5fdfbb020e4024ba8b3cb27a20bc8f20f4b4cf1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c5fdfbb020e4024ba8b3cb27a20bc8f20f4b4cf1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)