### PR TITLE
Document that in C++ PinholeProjection::from_mat3x3 is column major

### DIFF
--- a/rerun_cpp/src/rerun/components/pinhole_projection.hpp
+++ b/rerun_cpp/src/rerun/components/pinhole_projection.hpp
@@ -34,7 +34,7 @@ namespace rerun::components {
       public:
         // Extensions to generated type defined in 'pinhole_projection_ext.cpp'
 
-        /// Construct a new 3x3 pinhole matrix from a pointer to 9 floats (in row major order).
+        /// Construct a new 3x3 pinhole matrix from a pointer to 9 floats (in column major order).
         static PinholeProjection from_mat3x3(const float* elements) {
             return PinholeProjection(rerun::datatypes::Mat3x3(elements));
         }

--- a/rerun_cpp/src/rerun/components/pinhole_projection_ext.cpp
+++ b/rerun_cpp/src/rerun/components/pinhole_projection_ext.cpp
@@ -12,7 +12,7 @@ namespace rerun {
 
             // <CODEGEN_COPY_TO_HEADER>
 
-            /// Construct a new 3x3 pinhole matrix from a pointer to 9 floats (in row major order).
+            /// Construct a new 3x3 pinhole matrix from a pointer to 9 floats (in column major order).
             static PinholeProjection from_mat3x3(const float* elements) {
                 return PinholeProjection(rerun::datatypes::Mat3x3(elements));
             }


### PR DESCRIPTION
### What

Another incorrect docstring.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4843/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4843/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4843/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4843)
- [Docs preview](https://rerun.io/preview/228340f651711520dc1e0ea85e15cf5ce2a63ed3/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/228340f651711520dc1e0ea85e15cf5ce2a63ed3/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)