### PR TITLE
Fix support for compressing mono images by respecting mode to determine depth

### DIFF
--- a/rerun_py/rerun_sdk/rerun/_image.py
+++ b/rerun_py/rerun_sdk/rerun/_image.py
@@ -141,9 +141,9 @@ class ImageEncoded(AsComponents):
             tensor_buffer = TensorBuffer(np.frombuffer(np_buffer, dtype=np.uint8))
             tensor_buffer.kind = "jpeg"
 
-            if img_data.mode == 'L':
+            if img_data.mode == "L":
                 depth = 1
-            elif img_data.mode == 'RGB':
+            elif img_data.mode == "RGB":
                 depth = 3
             else:
                 raise ValueError(f"Unsupported JPEG mode: {img_data.mode}")

--- a/rerun_py/rerun_sdk/rerun/_image.py
+++ b/rerun_py/rerun_sdk/rerun/_image.py
@@ -141,10 +141,17 @@ class ImageEncoded(AsComponents):
             tensor_buffer = TensorBuffer(np.frombuffer(np_buffer, dtype=np.uint8))
             tensor_buffer.kind = "jpeg"
 
+            if img_data.mode == 'L':
+                depth = 1
+            elif img_data.mode == 'RGB':
+                depth = 3
+            else:
+                raise ValueError(f"Unsupported JPEG mode: {img_data.mode}")
+
             tensor_shape = (
                 TensorDimension(img_data.height, "height"),
                 TensorDimension(img_data.width, "width"),
-                TensorDimension(3, "depth"),
+                TensorDimension(depth, "depth"),
             )
             tensor_data = TensorData(buffer=tensor_buffer, shape=tensor_shape)
         else:

--- a/rerun_py/tests/unit/test_image_encoded.py
+++ b/rerun_py/tests/unit/test_image_encoded.py
@@ -36,6 +36,7 @@ def test_image_encoded_jpg() -> None:
 
     assert img.data.buffer.kind == "jpeg"
 
+
 def test_image_encoded_mono_jpg() -> None:
     _, file_path = tempfile.mkstemp(suffix=".jpg")
 
@@ -73,6 +74,7 @@ def test_image_encoded_jpg_from_bytes() -> None:
     assert img.data.shape[1].size == 300
     assert img.data.shape[2].size == 3
     assert img.data.buffer.kind == "jpeg"
+
 
 def test_image_encoded_mono_jpg_from_bytes() -> None:
     bin = io.BytesIO()

--- a/rerun_py/tests/unit/test_image_encoded.py
+++ b/rerun_py/tests/unit/test_image_encoded.py
@@ -17,6 +17,7 @@ def test_image_encoded_png() -> None:
 
     assert img.data.shape[0].size == 200
     assert img.data.shape[1].size == 300
+    assert img.data.shape[2].size == 4
     assert img.data.buffer.kind == "u8"
 
 
@@ -28,8 +29,25 @@ def test_image_encoded_jpg() -> None:
 
     img = rr.ImageEncoded(path=file_path)
 
+    assert len(img.data.shape) == 3
     assert img.data.shape[0].size == 200
     assert img.data.shape[1].size == 300
+    assert img.data.shape[2].size == 3
+
+    assert img.data.buffer.kind == "jpeg"
+
+def test_image_encoded_mono_jpg() -> None:
+    _, file_path = tempfile.mkstemp(suffix=".jpg")
+
+    image = Image.new("L", (300, 200), color=0)
+    image.save(file_path)
+
+    img = rr.ImageEncoded(path=file_path)
+
+    assert len(img.data.shape) == 3
+    assert img.data.shape[0].size == 200
+    assert img.data.shape[1].size == 300
+    assert img.data.shape[2].size == 1
     assert img.data.buffer.kind == "jpeg"
 
 
@@ -41,13 +59,40 @@ def test_image_encoded_jpg_from_bytes() -> None:
 
     img = rr.ImageEncoded(contents=bin)
 
+    assert len(img.data.shape) == 3
     assert img.data.shape[0].size == 200
     assert img.data.shape[1].size == 300
+    assert img.data.shape[2].size == 3
     assert img.data.buffer.kind == "jpeg"
 
     bin.seek(0)
     img = rr.ImageEncoded(contents=bin.read())
 
+    assert len(img.data.shape) == 3
     assert img.data.shape[0].size == 200
     assert img.data.shape[1].size == 300
+    assert img.data.shape[2].size == 3
+    assert img.data.buffer.kind == "jpeg"
+
+def test_image_encoded_mono_jpg_from_bytes() -> None:
+    bin = io.BytesIO()
+
+    image = Image.new("L", (300, 200), color=0)
+    image.save(bin, format="jpeg")
+
+    img = rr.ImageEncoded(contents=bin)
+
+    assert len(img.data.shape) == 3
+    assert img.data.shape[0].size == 200
+    assert img.data.shape[1].size == 300
+    assert img.data.shape[2].size == 1
+    assert img.data.buffer.kind == "jpeg"
+
+    bin.seek(0)
+    img = rr.ImageEncoded(contents=bin.read())
+
+    assert len(img.data.shape) == 3
+    assert img.data.shape[0].size == 200
+    assert img.data.shape[1].size == 300
+    assert img.data.shape[2].size == 1
     assert img.data.buffer.kind == "jpeg"


### PR DESCRIPTION
### What
 - Resolves: https://github.com/rerun-io/rerun/issues/4846

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4847/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4847/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4847/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4847)
- [Docs preview](https://rerun.io/preview/deef4d8eb0369c94bbc7d29b100e021802e29c9b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/deef4d8eb0369c94bbc7d29b100e021802e29c9b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)