### PR TITLE
Primary caching 17: timeless range

### DIFF
--- a/crates/re_data_store/src/store_format.rs
+++ b/crates/re_data_store/src/store_format.rs
@@ -1,4 +1,5 @@
 use re_format::{format_bytes, format_number};
+use re_log_types::TimeInt;
 use re_types_core::SizeBytes as _;
 
 use crate::{DataStore, IndexedBucket, IndexedTable, PersistentIndexedTable};
@@ -129,7 +130,7 @@ impl std::fmt::Display for IndexedBucket {
 
         let time_range = {
             let time_range = &self.inner.read().time_range;
-            if time_range.min.as_i64() != i64::MAX && time_range.max.as_i64() != i64::MIN {
+            if time_range.min != TimeInt::MAX && time_range.max != TimeInt::MIN {
                 format!(
                     "    - {}: {}",
                     self.timeline.name(),

--- a/crates/re_data_store/src/store_read.rs
+++ b/crates/re_data_store/src/store_read.rs
@@ -65,7 +65,7 @@ impl std::fmt::Debug for RangeQuery {
             self.timeline.typ().format_utc(self.range.min),
             self.timeline.typ().format_utc(self.range.max),
             self.timeline.name(),
-            if self.range.min == TimeInt::MIN {
+            if self.range.min <= TimeInt::MIN {
                 "including"
             } else {
                 "excluding"
@@ -494,7 +494,7 @@ impl DataStore {
             .flatten()
             .map(|(time, row_id, cells)| (Some(time), row_id, cells));
 
-        if query.range.min == TimeInt::MIN {
+        if query.range.min <= TimeInt::MIN {
             let timeless = self
                 .timeless_tables
                 .get(&ent_path_hash)

--- a/crates/re_data_store/src/store_sanity.rs
+++ b/crates/re_data_store/src/store_sanity.rs
@@ -1,4 +1,6 @@
-use re_log_types::{DataCellColumn, NumInstances, RowId, TimeRange, VecDequeSortingExt as _};
+use re_log_types::{
+    DataCellColumn, NumInstances, RowId, TimeInt, TimeRange, VecDequeSortingExt as _,
+};
 use re_types_core::{ComponentName, Loggable, SizeBytes as _};
 
 use crate::{
@@ -179,8 +181,16 @@ impl IndexedBucket {
                 let mut times = col_time.clone();
                 times.sort();
 
-                let expected_min = times.front().copied().unwrap_or(i64::MAX).into();
-                let expected_max = times.back().copied().unwrap_or(i64::MIN).into();
+                let expected_min = times
+                    .front()
+                    .copied()
+                    .unwrap_or(TimeInt::MAX.as_i64())
+                    .into();
+                let expected_max = times
+                    .back()
+                    .copied()
+                    .unwrap_or(TimeInt::MIN.as_i64())
+                    .into();
                 let expected_time_range = TimeRange::new(expected_min, expected_max);
 
                 if expected_time_range != *time_range {

--- a/crates/re_data_store/tests/correctness.rs
+++ b/crates/re_data_store/tests/correctness.rs
@@ -451,7 +451,7 @@ fn range_join_across_single_row_impl(store: &mut DataStore) {
     let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
     let query = re_data_store::RangeQuery::new(
         timeline_frame_nr,
-        re_data_store::TimeRange::new(i64::MIN.into(), i64::MAX.into()),
+        re_data_store::TimeRange::new(TimeInt::MIN, TimeInt::MAX),
     );
     let components = [InstanceKey::name(), Position2D::name(), Color::name()];
     let dfs = re_data_store::polars_util::range_components(

--- a/crates/re_log_types/src/data_row.rs
+++ b/crates/re_log_types/src/data_row.rs
@@ -155,6 +155,7 @@ impl std::fmt::Display for RowId {
 
 impl RowId {
     pub const ZERO: Self = Self(re_tuid::Tuid::ZERO);
+    pub const MAX: Self = Self(re_tuid::Tuid::MAX);
 
     /// Create a new unique [`RowId`] based on the current time.
     #[allow(clippy::new_without_default)]

--- a/crates/re_log_types/src/time_point/time_int.rs
+++ b/crates/re_log_types/src/time_point/time_int.rs
@@ -29,6 +29,7 @@ impl TimeInt {
     // a bit of leeway.
     pub const BEGINNING: Self = Self(i64::MIN / 2);
 
+    // TODO(#4832): `TimeInt::BEGINNING` vs. `TimeInt::MIN` vs. `Option<TimeInt>`…
     pub const MIN: Self = Self(i64::MIN);
     pub const MAX: Self = Self(i64::MAX);
 

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, VecDeque},
+    ops::Range,
     sync::Arc,
 };
 
@@ -327,6 +328,8 @@ impl CachesPerArchetype {
 
         re_tracing::profile_function!();
 
+        // TODO(cmc): range invalidation
+
         for latest_at_cache in self.latest_at_per_archetype.read().values() {
             let mut latest_at_cache = latest_at_cache.write();
 
@@ -419,12 +422,6 @@ pub struct CacheBucket {
 }
 
 impl CacheBucket {
-    /// Iterate over the timestamps of the point-of-view components.
-    #[inline]
-    pub fn iter_data_times(&self) -> impl Iterator<Item = &(TimeInt, RowId)> {
-        self.data_times.iter()
-    }
-
     #[inline]
     pub fn time_range(&self) -> Option<TimeRange> {
         let first_time = self.data_times.front().map(|(t, _)| *t)?;
@@ -442,6 +439,25 @@ impl CacheBucket {
     #[inline]
     pub fn contains_data_row(&self, data_time: TimeInt, row_id: RowId) -> bool {
         self.data_times.binary_search(&(data_time, row_id)).is_ok()
+    }
+
+    /// How many timestamps' worth of data is stored in this bucket?
+    #[inline]
+    pub fn num_entries(&self) -> usize {
+        self.data_times.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.num_entries() == 0
+    }
+
+    // ---
+
+    /// Iterate over the timestamps of the point-of-view components.
+    #[inline]
+    pub fn iter_data_times(&self) -> impl Iterator<Item = &(TimeInt, RowId)> {
+        self.data_times.iter()
     }
 
     /// Iterate over the [`InstanceKey`] batches of the point-of-view components.
@@ -474,15 +490,73 @@ impl CacheBucket {
         Some(data.iter())
     }
 
-    /// How many timestamps' worth of data is stored in this bucket?
+    // ---
+
+    /// Returns the index range that corresponds to the specified `time_range`.
+    ///
+    /// Use the returned range with one of the range iteration methods:
+    /// - [`Self::range_data_times`]
+    /// - [`Self::range_pov_instance_keys`]
+    /// - [`Self::range_component`]
+    /// - [`Self::range_component_opt`]
+    ///
+    /// Make sure that the bucket hasn't been modified in-between!
+    ///
+    /// This is `O(2*log(n))`, so make sure to clone the returned range rather than calling this
+    /// multiple times.
     #[inline]
-    pub fn num_entries(&self) -> usize {
-        self.data_times.len()
+    pub fn entry_range(&self, time_range: TimeRange) -> Range<usize> {
+        let start_index = self
+            .data_times
+            .partition_point(|(data_time, _)| data_time < &time_range.min);
+        let end_index = self
+            .data_times
+            .partition_point(|(data_time, _)| data_time <= &time_range.max);
+        start_index..end_index
     }
 
+    /// Range over the timestamps of the point-of-view components.
     #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.num_entries() == 0
+    pub fn range_data_times(
+        &self,
+        entry_range: Range<usize>,
+    ) -> impl Iterator<Item = &(TimeInt, RowId)> {
+        self.data_times.range(entry_range)
+    }
+
+    /// Range over the [`InstanceKey`] batches of the point-of-view components.
+    #[inline]
+    pub fn range_pov_instance_keys(
+        &self,
+        entry_range: Range<usize>,
+    ) -> impl Iterator<Item = &[InstanceKey]> {
+        self.pov_instance_keys.range(entry_range)
+    }
+
+    /// Range over the batches of the specified non-optional component.
+    #[inline]
+    pub fn range_component<C: Component + Send + Sync + 'static>(
+        &self,
+        entry_range: Range<usize>,
+    ) -> Option<impl Iterator<Item = &[C]>> {
+        let data = self
+            .components
+            .get(&C::name())
+            .and_then(|data| data.as_any().downcast_ref::<FlatVecDeque<C>>())?;
+        Some(data.range(entry_range))
+    }
+
+    /// Range over the batches of the specified optional component.
+    #[inline]
+    pub fn range_component_opt<C: Component + Send + Sync + 'static>(
+        &self,
+        entry_range: Range<usize>,
+    ) -> Option<impl Iterator<Item = &[Option<C>]>> {
+        let data = self
+            .components
+            .get(&C::name())
+            .and_then(|data| data.as_any().downcast_ref::<FlatVecDeque<Option<C>>>())?;
+        Some(data.range(entry_range))
     }
 }
 

--- a/crates/re_query_cache/src/cache_stats.rs
+++ b/crates/re_query_cache/src/cache_stats.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use re_log_types::{EntityPath, TimeRange, Timeline};
 use re_types_core::ComponentName;
 
-use crate::{Caches, LatestAtCache, RangeCache};
+use crate::{cache::CacheBucket, Caches, LatestAtCache, RangeCache};
 
 // ---
 
@@ -71,6 +71,18 @@ impl Caches {
     pub fn stats(detailed_stats: bool) -> CachesStats {
         re_tracing::profile_function!();
 
+        fn upsert_bucket_stats(
+            per_component: &mut BTreeMap<ComponentName, CachedComponentStats>,
+            bucket: &CacheBucket,
+        ) {
+            for (component_name, data) in &bucket.components {
+                let stats: &mut CachedComponentStats =
+                    per_component.entry(*component_name).or_default();
+                stats.total_rows += data.dyn_num_entries() as u64;
+                stats.total_instances += data.dyn_num_values() as u64;
+            }
+        }
+
         Self::with(|caches| {
             let latest_at = caches
                 .0
@@ -98,22 +110,12 @@ impl Caches {
                             if let Some(per_component) = per_component.as_mut() {
                                 re_tracing::profile_scope!("detailed");
 
-                                for bucket in per_data_time.values() {
-                                    for (component_name, data) in &bucket.read().components {
-                                        let stats: &mut CachedComponentStats =
-                                            per_component.entry(*component_name).or_default();
-                                        stats.total_rows += data.dyn_num_entries() as u64;
-                                        stats.total_instances += data.dyn_num_values() as u64;
-                                    }
+                                if let Some(bucket) = &timeless {
+                                    upsert_bucket_stats(per_component, bucket);
                                 }
 
-                                if let Some(bucket) = &timeless {
-                                    for (component_name, data) in &bucket.components {
-                                        let stats: &mut CachedComponentStats =
-                                            per_component.entry(*component_name).or_default();
-                                        stats.total_rows += data.dyn_num_entries() as u64;
-                                        stats.total_instances += data.dyn_num_values() as u64;
-                                    }
+                                for bucket in per_data_time.values() {
+                                    upsert_bucket_stats(per_component, &bucket.read());
                                 }
                             }
                         }
@@ -141,6 +143,7 @@ impl Caches {
                             .map(|range_cache| {
                                 let RangeCache {
                                     per_data_time,
+                                    timeless,
                                     total_size_bytes,
                                 } = &*range_cache.read();
 
@@ -150,12 +153,8 @@ impl Caches {
                                 if let Some(per_component) = per_component.as_mut() {
                                     re_tracing::profile_scope!("detailed");
 
-                                    for (component_name, data) in &per_data_time.components {
-                                        let stats: &mut CachedComponentStats =
-                                            per_component.entry(*component_name).or_default();
-                                        stats.total_rows += data.dyn_num_entries() as u64;
-                                        stats.total_instances += data.dyn_num_values() as u64;
-                                    }
+                                    upsert_bucket_stats(per_component, timeless);
+                                    upsert_bucket_stats(per_component, per_data_time);
                                 }
 
                                 (

--- a/crates/re_query_cache/src/cache_stats.rs
+++ b/crates/re_query_cache/src/cache_stats.rs
@@ -140,17 +140,17 @@ impl Caches {
                             .values()
                             .map(|range_cache| {
                                 let RangeCache {
-                                    bucket,
+                                    per_data_time,
                                     total_size_bytes,
                                 } = &*range_cache.read();
 
-                                let total_rows = bucket.data_times.len() as u64;
+                                let total_rows = per_data_time.data_times.len() as u64;
 
                                 let mut per_component = detailed_stats.then(BTreeMap::default);
                                 if let Some(per_component) = per_component.as_mut() {
                                     re_tracing::profile_scope!("detailed");
 
-                                    for (component_name, data) in &bucket.components {
+                                    for (component_name, data) in &per_data_time.components {
                                         let stats: &mut CachedComponentStats =
                                             per_component.entry(*component_name).or_default();
                                         stats.total_rows += data.dyn_num_entries() as u64;
@@ -160,7 +160,7 @@ impl Caches {
 
                                 (
                                     key.timeline,
-                                    bucket.time_range().unwrap_or(TimeRange::EMPTY),
+                                    per_data_time.time_range().unwrap_or(TimeRange::EMPTY),
                                     CachedEntityStats {
                                         total_size_bytes: *total_size_bytes,
                                         total_rows,

--- a/crates/re_query_cache/src/latest_at.rs
+++ b/crates/re_query_cache/src/latest_at.rs
@@ -90,7 +90,6 @@ macro_rules! impl_query_archetype_latest_at {
                     f(data);
                 }
 
-
                 Ok(())
             };
 

--- a/crates/re_query_cache/src/range.rs
+++ b/crates/re_query_cache/src/range.rs
@@ -182,6 +182,8 @@ macro_rules! impl_query_archetype_range {
                 // NOTE: Same logic as what the store does.
                 if query.range.min <= TimeInt::MIN {
                     let mut reduced_query = query.clone();
+                    // This is the reduced query corresponding to the timeless part of the data.
+                    // It is inclusive and so it will yield `MIN..=MIN` = `[MIN]`.
                     reduced_query.range.max = TimeInt::MIN; // inclusive
 
                     // NOTE: `+ 2` because we always grab the indicator component as well as the

--- a/crates/re_query_cache/src/range.rs
+++ b/crates/re_query_cache/src/range.rs
@@ -114,7 +114,6 @@ macro_rules! impl_query_archetype_range {
                 re_tracing::profile_scope!("iter");
 
                 let entry_range = bucket.entry_range(time_range);
-        dbg!(&entry_range);
 
                 let it = itertools::izip!(
                     bucket.range_data_times(entry_range.clone()),
@@ -180,14 +179,10 @@ macro_rules! impl_query_archetype_range {
             let mut range_callback = |query: &RangeQuery, range_cache: &mut crate::RangeCache| {
                 re_tracing::profile_scope!("range", format!("{query:?}"));
 
-                eprintln!("query 1: {query:?}");
-
                 // NOTE: Same logic as what the store does.
                 if query.range.min <= TimeInt::MIN {
                     let mut reduced_query = query.clone();
                     reduced_query.range.max = TimeInt::MIN; // inclusive
-
-                    eprintln!("query timeless: {reduced_query:?}");
 
                     // NOTE: `+ 2` because we always grab the indicator component as well as the
                     // instance keys.
@@ -205,10 +200,7 @@ macro_rules! impl_query_archetype_range {
                 let mut query = query.clone();
                 query.range.min = TimeInt::max((TimeInt::MIN.as_i64() + 1).into(), query.range.min);
 
-                eprintln!("query 2: {query:?}");
-
                 for reduced_query in range_cache.compute_queries(&query) {
-                    eprintln!("query 2: {reduced_query:?}");
                     // NOTE: `+ 2` because we always grab the indicator component as well as the
                     // instance keys.
                     let arch_views =

--- a/crates/re_query_cache/src/range.rs
+++ b/crates/re_query_cache/src/range.rs
@@ -13,7 +13,7 @@ use crate::{CacheBucket, Caches, MaybeCachedComponentData};
 #[derive(Default)]
 pub struct RangeCache {
     // TODO(cmc): bucketize
-    pub bucket: CacheBucket,
+    pub per_data_time: CacheBucket,
 
     /// Total size of the data stored in this cache in bytes.
     pub total_size_bytes: u64,
@@ -35,11 +35,11 @@ impl RangeCache {
     pub fn compute_front_query(&self, query: &RangeQuery) -> Option<RangeQuery> {
         let mut reduced_query = query.clone();
 
-        if self.bucket.is_empty() {
+        if self.per_data_time.is_empty() {
             return Some(reduced_query);
         }
 
-        if let Some(bucket_time_range) = self.bucket.time_range() {
+        if let Some(bucket_time_range) = self.per_data_time.time_range() {
             reduced_query.range.max = TimeInt::min(
                 reduced_query.range.max,
                 bucket_time_range.min.as_i64().saturating_sub(1).into(),
@@ -61,7 +61,7 @@ impl RangeCache {
     pub fn compute_back_query(&self, query: &RangeQuery) -> Option<RangeQuery> {
         let mut reduced_query = query.clone();
 
-        if let Some(bucket_time_range) = self.bucket.time_range() {
+        if let Some(bucket_time_range) = self.per_data_time.time_range() {
             reduced_query.range.min = TimeInt::max(
                 reduced_query.range.min,
                 bucket_time_range.max.as_i64().saturating_add(1).into(),
@@ -177,10 +177,10 @@ macro_rules! impl_query_archetype_range {
                     let arch_views =
                         ::re_query::range_archetype::<A, { $N + $M + 2 }>(store, &reduced_query, entity_path);
                     range_cache.total_size_bytes +=
-                        upsert_results::<A, $($pov,)+ $($comp,)*>(arch_views, &mut range_cache.bucket)?;
+                        upsert_results::<A, $($pov,)+ $($comp,)*>(arch_views, &mut range_cache.per_data_time)?;
                 }
 
-                iter_results(&range_cache.bucket)
+                iter_results(&range_cache.per_data_time)
             };
 
 

--- a/crates/re_query_cache/tests/range.rs
+++ b/crates/re_query_cache/tests/range.rs
@@ -97,8 +97,6 @@ fn simple_range() {
 }
 
 #[test]
-// TODO(cmc): timeless support
-#[should_panic(expected = "assertion failed: `(left == right)`")]
 fn timeless_range() {
     let mut store = DataStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
@@ -211,6 +209,8 @@ fn timeless_range() {
     query_and_compare(&store, &query, &ent_path);
 
     // --- Third test: `[-inf, +inf]` ---
+
+    eprintln!("XXXXXXXXXXXXXXXXXXXXXXXX");
 
     let query =
         re_data_store::RangeQuery::new(timepoint1[0].0, TimeRange::new(TimeInt::MIN, TimeInt::MAX));
@@ -363,7 +363,7 @@ fn query_and_compare(store: &DataStore, query: &RangeQuery, ent_path: &EntityPat
         }
 
         // Keep this around for the next unlucky chap.
-        // eprintln!("(expected={expected_data_times:?}, uncached={uncached_data_times:?}, cached={cached_data_times:?})");
+        eprintln!("(expected={expected_data_times:?}, uncached={uncached_data_times:?}, cached={cached_data_times:?})");
         // eprintln!("{}", store.to_data_table().unwrap());
 
         similar_asserts::assert_eq!(expected_data_times, uncached_data_times);

--- a/crates/re_query_cache/tests/range.rs
+++ b/crates/re_query_cache/tests/range.rs
@@ -210,8 +210,6 @@ fn timeless_range() {
 
     // --- Third test: `[-inf, +inf]` ---
 
-    eprintln!("XXXXXXXXXXXXXXXXXXXXXXXX");
-
     let query =
         re_data_store::RangeQuery::new(timepoint1[0].0, TimeRange::new(TimeInt::MIN, TimeInt::MAX));
 
@@ -363,7 +361,7 @@ fn query_and_compare(store: &DataStore, query: &RangeQuery, ent_path: &EntityPat
         }
 
         // Keep this around for the next unlucky chap.
-        eprintln!("(expected={expected_data_times:?}, uncached={uncached_data_times:?}, cached={cached_data_times:?})");
+        // eprintln!("(expected={expected_data_times:?}, uncached={uncached_data_times:?}, cached={cached_data_times:?})");
         // eprintln!("{}", store.to_data_table().unwrap());
 
         similar_asserts::assert_eq!(expected_data_times, uncached_data_times);

--- a/crates/re_space_view_time_series/src/visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/visualizer_system.rs
@@ -1,4 +1,5 @@
 use re_data_store::TimeRange;
+use re_log_types::TimeInt;
 use re_query_cache::QueryError;
 use re_types::{
     archetypes::TimeSeriesScalar,
@@ -152,7 +153,7 @@ impl TimeSeriesSystem {
                         visible_history.to(query.latest_at),
                     )
                 } else {
-                    (i64::MIN.into(), i64::MAX.into())
+                    (TimeInt::MIN, TimeInt::MAX)
                 };
 
                 let query =


### PR DESCRIPTION
Simply add a timeless path for the range cache, and actually only iterate over the range the user asked for (we were still blindly iterating over everything until now).

Also some very minimal clean up related to #4832, but we have a long way to go...
- #4832

---

- Fixes #4821 

---

Part of the primary caching series of PR (index search, joins, deserialization):
- #4592
- #4593
- #4659
- #4680 
- #4681
- #4698
- #4711
- #4712
- #4721 
- #4726 
- #4773
- #4784
- #4785
- #4793
- #4800
- #4851
- #4852
- #4853
- #4856

---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4800/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4800/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4800/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4800)
- [Docs preview](https://rerun.io/preview/f9f71a7fabd3aa0c4d76d7425ac7dde76535bb31/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f9f71a7fabd3aa0c4d76d7425ac7dde76535bb31/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)