### PR TITLE
Subdue container labels to distinguish them from space views

### DIFF
--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -57,6 +57,9 @@ pub enum LabelStyle {
 
     /// Label displaying the placeholder text for a yet unnamed item (e.g. an unnamed space view).
     Unnamed,
+
+    /// Label for containers, which are subdued compared to space views to make them distinctive
+    Container,
 }
 
 // ----------------------------------------------------------------------------
@@ -925,7 +928,7 @@ impl ReUi {
 
         let mut text: egui::WidgetText = text.into();
         match style {
-            LabelStyle::Normal => {}
+            LabelStyle::Normal | LabelStyle::Container => {}
             LabelStyle::Unnamed => {
                 // TODO(ab): use design tokens
                 text = text.italics();
@@ -990,6 +993,10 @@ impl ReUi {
                 LabelStyle::Unnamed => {
                     // TODO(ab): use design tokens
                     text_color = text_color.gamma_multiply(0.5);
+                }
+                LabelStyle::Container => {
+                    // TODO(ab): use design tokens
+                    text_color = ui.visuals().widgets.noninteractive.text_color();
                 }
             }
             ui.painter()

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -325,6 +325,11 @@ impl<'a> ListItem<'a> {
             LabelStyle::Unnamed => {
                 self.italics = true;
             }
+            LabelStyle::Container => {
+                self.text = self
+                    .text
+                    .color(ui.visuals().widgets.noninteractive.text_color());
+            }
         }
 
         if self.italics {
@@ -455,7 +460,7 @@ impl<'a> ListItem<'a> {
             }
 
             match self.label_style {
-                LabelStyle::Normal => {}
+                LabelStyle::Normal | LabelStyle::Container => {}
                 LabelStyle::Unnamed => {
                     self.text = self.text.color(visuals.fg_stroke.color.gamma_multiply(0.5));
                 }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -675,6 +675,7 @@ fn show_list_item_for_container_child(
             (
                 Item::Container(child_tile_id),
                 ListItem::new(ctx.re_ui, format!("{:?}", container.kind()))
+                    .label_style(re_ui::LabelStyle::Container)
                     .with_icon(icon_for_container_kind(&container.kind())),
             )
         }

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -112,6 +112,7 @@ impl Viewport<'_, '_> {
         let response = ListItem::new(ctx.re_ui, format!("{:?}", container.kind()))
             .subdued(!container_visible)
             .selected(ctx.selection().contains_item(&item))
+            .label_style(re_ui::LabelStyle::Container)
             .with_icon(crate::icon_for_container_kind(&container.kind()))
             .with_buttons(|re_ui, ui| {
                 let vis_response = visibility_button_ui(re_ui, ui, parent_visible, &mut visible);


### PR DESCRIPTION
### What

As the title says ☝🏻. Note that the icon still reflects visibility.

Here, the tab widget is visible but not the vertical one:

<img width="303" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/3214b284-f7dd-492a-b9a5-4c6b8c5f6536">

<br/>
<br/>

Selection panel (which currently doesn't reflect visibility state https://github.com/rerun-io/rerun/issues/4854):

<img width="335" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/3aaeb038-0a88-41d5-a673-afc893371f58">

<br/>
<br/>


Relates to:
- https://github.com/rerun-io/rerun/issues/4743

Note: this PR piles on debt to be paid off with:
- https://github.com/rerun-io/rerun/issues/4802

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
