### PR TITLE
Add vertical guides in the blueprint tree

### DIFF
--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -111,6 +111,7 @@ impl Viewport<'_, '_> {
 
         let response = ListItem::new(ctx.re_ui, format!("{:?}", container.kind()))
             .subdued(!container_visible)
+            .vertical_line(true)
             .selected(ctx.selection().contains_item(&item))
             .with_icon(crate::icon_for_container_kind(&container.kind()))
             .with_buttons(|re_ui, ui| {
@@ -191,6 +192,7 @@ impl Viewport<'_, '_> {
             .with_icon(space_view.class(ctx.space_view_class_registry).icon())
             .selected(ctx.selection().contains_item(&item))
             .subdued(!space_view_visible)
+            .vertical_line(true)
             .force_hovered(is_item_hovered)
             .with_buttons(|re_ui, ui| {
                 let vis_response = visibility_button_ui(re_ui, ui, container_visible, &mut visible);


### PR DESCRIPTION
### What

Add vertical guides in the blueprint tree, for containers and space view but not below.

See #4868 for an alternative with line only for space views.

<img width="305" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/4b70ce65-c73b-4644-8e11-322e66aae696">

* Fixes https://github.com/rerun-io/rerun/issues/4743

cc @martenbjork 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4863/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4863/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4863/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4863)
- [Docs preview](https://rerun.io/preview/3fa037179390f3b1b412144236d9dddcac097c5a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3fa037179390f3b1b412144236d9dddcac097c5a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)