### PR TITLE
Configurable dynamic plot aggregation based on zoom-level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4806,6 +4806,7 @@ dependencies = [
  "parking_lot",
  "re_data_store",
  "re_format",
+ "re_log",
  "re_log_types",
  "re_query",
  "re_query_cache",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4803,6 +4803,7 @@ dependencies = [
  "egui",
  "egui_plot",
  "itertools 0.12.0",
+ "parking_lot 0.12.1",
  "re_data_store",
  "re_format",
  "re_log_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4803,7 +4803,7 @@ dependencies = [
  "egui",
  "egui_plot",
  "itertools 0.12.0",
- "parking_lot 0.12.1",
+ "parking_lot",
  "re_data_store",
  "re_format",
  "re_log_types",

--- a/crates/re_entity_db/src/entity_properties.rs
+++ b/crates/re_entity_db/src/entity_properties.rs
@@ -372,49 +372,80 @@ impl From<LegendCorner> for egui_plot::Corner {
 
 // ----------------------------------------------------------------------------
 
-/// What kind of aggregation should we perform when the zoom-level on the X axis goes below 1.0?
+/// What kind of aggregation should be performed when the zoom-level on the X axis goes below 1.0?
+///
+/// Aggregation affects the points' values and radii.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum TimeSeriesAggregator {
+    /// No aggregation.
+    Off,
+
+    /// Average all points in the range together.
+    Average,
+
+    /// Keep only the maximum values in the range.
+    Max,
+
+    /// Keep only the minimum values in the range.
+    Min,
+
+    /// Keep both the minimum and maximum values in the range.
+    ///
+    /// This will yield two aggregated points instead of one, effectively creating a vertical line.
     #[default]
     MinMax,
-    Max,
-    Min,
-    Average,
-    None,
+
+    /// Find both the minimum and maximum values in the range, then use the average of those.
+    MinMaxAverage,
 }
 
 impl std::fmt::Display for TimeSeriesAggregator {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            TimeSeriesAggregator::MinMax => write!(f, "MinMax"),
+            TimeSeriesAggregator::Off => write!(f, "Off"),
+            TimeSeriesAggregator::Average => write!(f, "Average"),
             TimeSeriesAggregator::Max => write!(f, "Max"),
             TimeSeriesAggregator::Min => write!(f, "Min"),
-            TimeSeriesAggregator::Average => write!(f, "Average"),
-            TimeSeriesAggregator::None => write!(f, "None"),
+            TimeSeriesAggregator::MinMax => write!(f, "MinMax"),
+            TimeSeriesAggregator::MinMaxAverage => write!(f, "MinMaxAverage"),
         }
     }
 }
 
 impl TimeSeriesAggregator {
     #[inline]
-    pub fn variants() -> [TimeSeriesAggregator; 5] {
+    pub fn variants() -> [TimeSeriesAggregator; 6] {
         // Just making sure this method won't compile if the enum gets modified.
         #[allow(clippy::match_same_arms)]
         match Self::default() {
-            TimeSeriesAggregator::MinMax => {}
+            TimeSeriesAggregator::Off => {}
+            TimeSeriesAggregator::Average => {}
             TimeSeriesAggregator::Max => {}
             TimeSeriesAggregator::Min => {}
-            TimeSeriesAggregator::Average => {}
-            TimeSeriesAggregator::None => {}
+            TimeSeriesAggregator::MinMax => {}
+            TimeSeriesAggregator::MinMaxAverage => {}
         }
 
         [
-            TimeSeriesAggregator::MinMax,
+            TimeSeriesAggregator::Off,
+            TimeSeriesAggregator::Average,
             TimeSeriesAggregator::Max,
             TimeSeriesAggregator::Min,
-            TimeSeriesAggregator::Average,
-            TimeSeriesAggregator::None,
+            TimeSeriesAggregator::MinMax,
+            TimeSeriesAggregator::MinMaxAverage,
         ]
+    }
+
+    #[inline]
+    pub fn description(&self) -> &'static str {
+        match self {
+            TimeSeriesAggregator::Off => "No aggregation.",
+            TimeSeriesAggregator::Average => "Average all points in the range together.",
+            TimeSeriesAggregator::Max => "Keep only the maximum values in the range.",
+            TimeSeriesAggregator::Min => "Keep only the minimum values in the range.",
+            TimeSeriesAggregator::MinMax => "Keep both the minimum and maximum values in the range.\nThis will yield two aggregated points instead of one, effectively creating a vertical line.",
+            TimeSeriesAggregator::MinMaxAverage => "Find both the minimum and maximum values in the range, then use the average of those",
+        }
     }
 }

--- a/crates/re_space_view_time_series/Cargo.toml
+++ b/crates/re_space_view_time_series/Cargo.toml
@@ -28,6 +28,7 @@ re_types = { workspace = true, features = ["egui_plot"] }
 re_ui.workspace = true
 re_viewer_context.workspace = true
 
-egui_plot.workspace = true
 egui.workspace = true
+egui_plot.workspace = true
 itertools.workspace = true
+parking_lot.workspace = true

--- a/crates/re_space_view_time_series/Cargo.toml
+++ b/crates/re_space_view_time_series/Cargo.toml
@@ -18,6 +18,7 @@ all-features = true
 [dependencies]
 re_data_store.workspace = true
 re_format.workspace = true
+re_log.workspace = true
 re_log_types.workspace = true
 re_query.workspace = true
 re_query_cache.workspace = true

--- a/crates/re_space_view_time_series/src/lib.rs
+++ b/crates/re_space_view_time_series/src/lib.rs
@@ -16,5 +16,5 @@ pub use space_view_class::TimeSeriesSpaceView;
 /// ```
 #[inline]
 pub(crate) fn plot_id(space_view_id: re_viewer_context::SpaceViewId) -> egui::Id {
-    egui::Id::new(format!("plot_{space_view_id}"))
+    egui::Id::new(("plot", space_view_id))
 }

--- a/crates/re_space_view_time_series/src/lib.rs
+++ b/crates/re_space_view_time_series/src/lib.rs
@@ -6,3 +6,15 @@ mod space_view_class;
 mod visualizer_system;
 
 pub use space_view_class::TimeSeriesSpaceView;
+
+/// Computes a deterministic, globally unique ID for the plot based on the ID of the space view
+/// itself.
+///
+/// Use it to access the plot's state from anywhere, e.g.:
+/// ```ignore
+/// let plot_mem = egui_plot::PlotMemory::load(egui_ctx, crate::plot_id(query.space_view_id));
+/// ```
+#[inline]
+pub(crate) fn plot_id(space_view_id: re_viewer_context::SpaceViewId) -> egui::Id {
+    egui::Id::new(format!("plot_{space_view_id}"))
+}

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -112,7 +112,31 @@ impl SpaceViewClass for TimeSeriesSpaceView {
         .unwrap_or_default();
 
         ctx.re_ui
-            .selection_grid(ui, "time_series_selection_ui")
+            .selection_grid(ui, "time_series_selection_ui_aggregation")
+            .show(ui, |ui| {
+                ctx.re_ui
+                    .grid_left_hand_label(ui, "Aggregation")
+                    .on_hover_text("Configures the aggregation behavior of the plot when the zoom-level on the X axis goes below 1.0, i.e. a single pixel covers more than one tick worth of data.\nThis can greatly improve performance (and readability) in such situations as it prevents overdraw.");
+
+                let mut agg_mode = *root_entity_properties.time_series_aggregator.get();
+
+                egui::ComboBox::from_id_source("aggregation_mode")
+                    .selected_text(agg_mode.to_string())
+                    .show_ui(ui, |ui| {
+                        ui.style_mut().wrap = Some(false);
+                        ui.set_min_width(64.0);
+
+                        for variant in TimeSeriesAggregator::variants() {
+                            ui.selectable_value(&mut agg_mode, variant, variant.to_string());
+                        }
+                    });
+
+                root_entity_properties.time_series_aggregator =
+                    EditableAutoValue::UserEdited(agg_mode);
+            });
+
+        ctx.re_ui
+            .selection_grid(ui, "time_series_selection_ui_legend")
             .show(ui, |ui| {
                 ctx.re_ui.grid_left_hand_label(ui, "Legend");
 
@@ -166,6 +190,7 @@ impl SpaceViewClass for TimeSeriesSpaceView {
                         ctx.save_blueprint_component(&space_view_id.as_entity_path(), edit_legend);
                     }
                 });
+
                 ui.end_row();
             });
     }

--- a/crates/re_space_view_time_series/src/visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/visualizer_system.rs
@@ -601,7 +601,7 @@ fn are_aggregatable(point1: &PlotPoint, point2: &PlotPoint, window_size: usize) 
         scattered,
     } = attrs;
 
-    // We cannot aggregate two points that doesn't live in the same aggregation window to start with.
+    // We cannot aggregate two points that don't live in the same aggregation window to start with.
     // This is very common with e.g. sparse datasets.
     time.abs_diff(point2.time) <= window_size as u64
         && *label == point2.attrs.label

--- a/crates/re_space_view_time_series/src/visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/visualizer_system.rs
@@ -71,6 +71,12 @@ pub struct TimeSeriesSystem {
 
     /// Earliest time an entity was recorded at on the current timeline.
     pub min_time: Option<i64>,
+
+    /// What kind of aggregation was used to compute the graph?
+    pub agg_mode: TimeSeriesAggregator,
+
+    /// How many X ticks does each final value represent?
+    pub agg_range: f64,
 }
 
 impl IdentifiedViewSystem for TimeSeriesSystem {
@@ -228,6 +234,8 @@ impl TimeSeriesSystem {
                     .time_series_aggregator
                     .get();
 
+                self.agg_mode = *agg_mode;
+
                 re_tracing::profile_scope!("aggregate", agg_mode.to_string());
 
                 match agg_mode {
@@ -246,6 +254,8 @@ impl TimeSeriesSystem {
                     }
                 }
             };
+            self.agg_range = agg_range;
+
             re_tracing::profile_scope!("secondary", &data_result.entity_path.to_string());
 
             let min_time = store
@@ -351,6 +361,7 @@ impl TimeSeriesSystem {
         }
     }
 }
+
 // ---
 
 trait Aggregator {

--- a/crates/re_space_view_time_series/src/visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/visualizer_system.rs
@@ -469,16 +469,16 @@ impl Aggregator for MinMaxAggregator {
                     MinMaxAggregator::MinMax => {
                         acc_min.value = f64::min(acc_min.value, point.value);
                         acc_min.attrs.radius = f32::min(acc_min.attrs.radius, point.attrs.radius);
-                        acc_max.value = f64::max(acc_min.value, point.value);
-                        acc_max.attrs.radius = f32::max(acc_min.attrs.radius, point.attrs.radius);
+                        acc_max.value = f64::max(acc_max.value, point.value);
+                        acc_max.attrs.radius = f32::max(acc_max.attrs.radius, point.attrs.radius);
                     }
                     MinMaxAggregator::Min => {
                         acc_min.value = f64::min(acc_min.value, point.value);
                         acc_min.attrs.radius = f32::min(acc_min.attrs.radius, point.attrs.radius);
                     }
                     MinMaxAggregator::Max => {
-                        acc_max.value = f64::max(acc_min.value, point.value);
-                        acc_max.attrs.radius = f32::max(acc_min.attrs.radius, point.attrs.radius);
+                        acc_max.value = f64::max(acc_max.value, point.value);
+                        acc_max.attrs.radius = f32::max(acc_max.attrs.radius, point.attrs.radius);
                     }
                 }
 


### PR DESCRIPTION
:warning: [Try it live!](https://app.rerun.io/pr/4865/index.html?url=https://storage.googleapis.com/rerun-builds/pull_request/4865/plot_gauss2.rrd) :warning: 

Make it so users can configure an aggregation strategy in the rare case where they either have so much data or are so zoomed out that most of their plot results in an overdraw blurb.

Because this builds on top of the range cache, the data is neatly laid out in a memory slice already so this is very cheap to compute.

In my tests, the `MinMax` strategy has worked so well that I've decided to make it the default in the end... That might be controversial :no_mouth:.

`Off` vs. `MinMax`, using the [new gaussian walk benchmark](https://github.com/rerun-io/rerun/pull/4903):
![image (26)](https://github.com/rerun-io/rerun/assets/2910679/1811becb-d213-44bb-87ea-0e4a7fa058ad)
![image (27)](https://github.com/rerun-io/rerun/assets/2910679/b8d66c92-8719-4de5-a3cb-72c2ea4b1e96)
 


- Fixes #4271 
- DNR: requires #4856 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4865/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4865/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4865/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4865)
- [Docs preview](https://rerun.io/preview/3f868a4bfc7806bb0b2f5f45f899532c9d829d6f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3f868a4bfc7806bb0b2f5f45f899532c9d829d6f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)