### PR TITLE
Fix panic when failing to load RRD size

### DIFF
--- a/crates/re_viewer/src/ui/welcome_screen/example_page.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/example_page.rs
@@ -158,6 +158,7 @@ fn load_file_size(egui_ctx: &egui::Context, url: String) -> Promise<Option<u64>>
                         response.status,
                         response.status_text
                     );
+                    sender.send(None);
                 }
             }
             Err(err) => {


### PR DESCRIPTION
### What
* Introduced in https://github.com/rerun-io/rerun/pull/4841

`poll-promise` has a gotcha: if you drop the `Sender` without sending a result,, the `Promise` will panic when polled.

I opened an issue about this: https://github.com/EmbarkStudios/poll-promise/issues/25

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4872/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4872/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4872/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4872)
- [Docs preview](https://rerun.io/preview/bdbdc1f71719e792869be347ebef16bcb318f2dd/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bdbdc1f71719e792869be347ebef16bcb318f2dd/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)