### PR TITLE
Datatype deduplication 2: switch to `re_arrow2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,28 +313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow2"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0f73029049896b3d70ba17756afef171ceef3569016cfa9dbca58d29e0e16f9"
-dependencies = [
- "ahash",
- "arrow-format",
- "bytemuck",
- "chrono",
- "comfy-table",
- "dyn-clone",
- "either",
- "ethnum",
- "foreign_vec",
- "getrandom",
- "hash_hasher",
- "num-traits",
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
 name = "as-raw-xcb-connection"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,11 +938,10 @@ checksum = "77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
- "num-integer",
  "num-traits",
 ]
 
@@ -1183,8 +1160,19 @@ version = "6.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e7b787b0dc42e8111badfdbe4c3059158ccb2db8780352fa1b01e8ccf45cc4d"
 dependencies = [
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+ "unicode-width",
+]
+
+[[package]]
+name = "comfy-table"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
+dependencies = [
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "unicode-width",
 ]
 
@@ -1764,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "emath"
@@ -4196,6 +4184,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "re_arrow2"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1285f33f03e2faf9f77b06c19f32f8c54792a4cbb19df762b9ea70b79e0773d"
+dependencies = [
+ "ahash",
+ "arrow-format",
+ "bytemuck",
+ "chrono",
+ "comfy-table 7.1.0",
+ "dyn-clone",
+ "either",
+ "ethnum",
+ "foreign_vec",
+ "getrandom",
+ "hash_hasher",
+ "hashbrown 0.14.2",
+ "num-traits",
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "re_build_examples"
 version = "0.13.0-alpha.2"
 dependencies = [
@@ -4278,7 +4289,6 @@ version = "0.13.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
- "arrow2",
  "criterion",
  "document-features",
  "indent",
@@ -4288,6 +4298,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rand",
+ "re_arrow2",
  "re_error",
  "re_format",
  "re_log",
@@ -4375,8 +4386,8 @@ dependencies = [
 name = "re_format"
 version = "0.13.0-alpha.2"
 dependencies = [
- "arrow2",
- "comfy-table",
+ "comfy-table 6.1.4",
+ "re_arrow2",
  "re_tuid",
  "re_types_core",
 ]
@@ -4436,7 +4447,6 @@ version = "0.13.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
- "arrow2",
  "backtrace",
  "bytemuck",
  "clean-path",
@@ -4451,6 +4461,7 @@ dependencies = [
  "nohash-hasher",
  "num-derive",
  "num-traits",
+ "re_arrow2",
  "re_format",
  "re_log",
  "re_string_interner",
@@ -4493,13 +4504,13 @@ dependencies = [
 name = "re_query"
 version = "0.13.0-alpha.2"
 dependencies = [
- "arrow2",
  "backtrace",
  "criterion",
  "document-features",
  "itertools 0.12.0",
  "mimalloc",
  "rand",
+ "re_arrow2",
  "re_data_store",
  "re_format",
  "re_log",
@@ -4519,7 +4530,6 @@ name = "re_query_cache"
 version = "0.13.0-alpha.2"
 dependencies = [
  "ahash",
- "arrow2",
  "backtrace",
  "criterion",
  "document-features",
@@ -4530,6 +4540,7 @@ dependencies = [
  "parking_lot",
  "paste",
  "rand",
+ "re_arrow2",
  "re_data_store",
  "re_format",
  "re_log",
@@ -4550,7 +4561,6 @@ version = "0.13.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
- "arrow2",
  "bitflags 2.4.1",
  "bytemuck",
  "cfg-if",
@@ -4572,6 +4582,7 @@ dependencies = [
  "parking_lot",
  "pathdiff",
  "profiling",
+ "re_arrow2",
  "re_build_tools",
  "re_error",
  "re_log",
@@ -4905,7 +4916,6 @@ version = "0.13.0-alpha.2"
 dependencies = [
  "anyhow",
  "array-init",
- "arrow2",
  "bytemuck",
  "document-features",
  "ecolor",
@@ -4923,6 +4933,7 @@ dependencies = [
  "ply-rs",
  "rand",
  "rayon",
+ "re_arrow2",
  "re_build_tools",
  "re_log",
  "re_tracing",
@@ -4942,7 +4953,6 @@ name = "re_types_builder"
 version = "0.13.0-alpha.2"
 dependencies = [
  "anyhow",
- "arrow2",
  "camino",
  "clang-format",
  "convert_case",
@@ -4953,6 +4963,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rayon",
+ "re_arrow2",
  "re_build_tools",
  "re_log",
  "re_tracing",
@@ -4968,12 +4979,12 @@ name = "re_types_core"
 version = "0.13.0-alpha.2"
 dependencies = [
  "anyhow",
- "arrow2",
  "backtrace",
  "bytemuck",
  "criterion",
  "document-features",
  "once_cell",
+ "re_arrow2",
  "re_error",
  "re_string_interner",
  "re_tracing",
@@ -4998,8 +5009,8 @@ dependencies = [
  "re_log_types",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "sublime_fuzzy",
 ]
 
@@ -5108,7 +5119,6 @@ name = "re_viewport"
 version = "0.13.0-alpha.2"
 dependencies = [
  "ahash",
- "arrow2",
  "egui",
  "egui_tiles",
  "glam",
@@ -5117,6 +5127,7 @@ dependencies = [
  "nohash-hasher",
  "once_cell",
  "rayon",
+ "re_arrow2",
  "re_data_store",
  "re_data_ui",
  "re_entity_db",
@@ -5308,9 +5319,9 @@ name = "rerun_c"
 version = "0.13.0-alpha.2"
 dependencies = [
  "ahash",
- "arrow2",
  "once_cell",
  "parking_lot",
+ "re_arrow2",
  "re_log",
  "re_sdk",
 ]
@@ -5319,7 +5330,6 @@ dependencies = [
 name = "rerun_py"
 version = "0.13.0-alpha.2"
 dependencies = [
- "arrow2",
  "crossbeam",
  "document-features",
  "itertools 0.12.0",
@@ -5329,6 +5339,7 @@ dependencies = [
  "pyo3",
  "pyo3-build-config",
  "rand",
+ "re_arrow2",
  "re_build_info",
  "re_build_tools",
  "re_error",
@@ -6059,8 +6070,14 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
 ]
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"
@@ -6073,6 +6090,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.32",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6102,7 +6102,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.32",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,23 +1156,12 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7b787b0dc42e8111badfdbe4c3059158ccb2db8780352fa1b01e8ccf45cc4d"
-dependencies = [
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "unicode-width",
-]
-
-[[package]]
-name = "comfy-table"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
 dependencies = [
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum",
+ "strum_macros",
  "unicode-width",
 ]
 
@@ -4193,7 +4182,7 @@ dependencies = [
  "arrow-format",
  "bytemuck",
  "chrono",
- "comfy-table 7.1.0",
+ "comfy-table",
  "dyn-clone",
  "either",
  "ethnum",
@@ -4386,7 +4375,7 @@ dependencies = [
 name = "re_format"
 version = "0.13.0-alpha.2"
 dependencies = [
- "comfy-table 6.1.4",
+ "comfy-table",
  "re_arrow2",
  "re_tuid",
  "re_types_core",
@@ -5009,8 +4998,8 @@ dependencies = [
  "re_log_types",
  "serde",
  "serde_json",
- "strum 0.24.1",
- "strum_macros 0.24.3",
+ "strum",
+ "strum_macros",
  "sublime_fuzzy",
 ]
 
@@ -6066,30 +6055,11 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros 0.24.3",
-]
-
-[[package]]
-name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
+ "strum_macros",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ cfg-if = "1.0"
 clang-format = "0.3"
 clap = "4.0"
 clean-path = "0.2"
-comfy-table = { version = "6.1", default-features = false }        # update of comfy-table blocked on old version used by arrow2
+comfy-table = { version = "7.0", default-features = false }
 console_error_panic_hook = "0.1.6"
 convert_case = "0.6"
 criterion = "0.5"
@@ -198,9 +198,8 @@ similar-asserts = "1.4.2"
 slotmap = { version = "1.0.6", features = ["serde"] }
 smallvec = { version = "1.0", features = ["const_generics", "union"] }
 static_assertions = "1.1"
-# update of strum blocked by arrow2/comfytable
-strum = { version = "0.24", features = ["derive"] }
-strum_macros = "0.24"
+strum = { version = "0.25", features = ["derive"] }
+strum_macros = "0.25"
 sublime_fuzzy = "0.7"
 syn = "2.0"
 sysinfo = { version = "0.30.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,8 +101,7 @@ anyhow = { version = "1.0", default-features = false }
 arboard = { version = "3.2", default-features = false }
 argh = "0.1.12"
 array-init = "2.1"
-arrow2 = "0.17"
-arrow2_convert = "0.5.0"
+arrow2 = { package = "re_arrow2", version = "0.17" }
 async-executor = "1.0"
 backtrace = "0.3"
 bincode = "1.3"

--- a/crates/re_entity_db/src/blueprint/components/entity_properties_component.rs
+++ b/crates/re_entity_db/src/blueprint/components/entity_properties_component.rs
@@ -55,7 +55,7 @@ impl ::re_types_core::Loggable for EntityPropertiesComponent {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: DataType::UInt8,
             is_nullable: false,
@@ -146,7 +146,7 @@ impl ::re_types_core::Loggable for EntityPropertiesComponent {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: DataType::UInt8,
                             is_nullable: false,

--- a/crates/re_format/src/arrow.rs
+++ b/crates/re_format/src/arrow.rs
@@ -180,7 +180,10 @@ impl std::fmt::Display for DisplayDataType {
             DataType::Decimal(_, _) => "decimal",
             DataType::Decimal256(_, _) => "decimal256",
             DataType::Extension(name, data_type, _) => {
-                let s = format!("extension<{name}>[{}]", DisplayDataType(*data_type.clone()));
+                let s = format!(
+                    "extension<{name}>[{}]",
+                    DisplayDataType((**data_type).clone())
+                );
                 return f.write_str(&s);
             }
         };

--- a/crates/re_log_types/src/data_cell.rs
+++ b/crates/re_log_types/src/data_cell.rs
@@ -686,8 +686,8 @@ fn data_cell_sizes() {
             DataCell::from_arrow(InstanceKey::name(), UInt64Array::from_vec(vec![]).boxed());
         cell.compute_size_bytes();
 
-        assert_eq!(216, cell.heap_size_bytes());
-        assert_eq!(216, cell.heap_size_bytes());
+        assert_eq!(184, cell.heap_size_bytes());
+        assert_eq!(184, cell.heap_size_bytes());
     }
 
     // anything else
@@ -699,7 +699,7 @@ fn data_cell_sizes() {
         cell.compute_size_bytes();
 
         // zero-sized + 3x u64s
-        assert_eq!(240, cell.heap_size_bytes());
-        assert_eq!(240, cell.heap_size_bytes());
+        assert_eq!(208, cell.heap_size_bytes());
+        assert_eq!(208, cell.heap_size_bytes());
     }
 }

--- a/crates/re_log_types/src/data_table.rs
+++ b/crates/re_log_types/src/data_table.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, VecDeque};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    sync::Arc,
+};
 
 use ahash::HashMap;
 use itertools::{izip, Itertools as _};
@@ -810,7 +813,7 @@ impl DataTable {
                 field
             };
 
-            let datatype = DataType::List(Box::new(field));
+            let datatype = DataType::List(Arc::new(field));
             let offsets = Offsets::try_from_lengths(column.iter().map(|cell| {
                 cell.as_ref()
                     .map_or(0, |cell| cell.num_instances() as usize)

--- a/crates/re_log_types/src/example_components.rs
+++ b/crates/re_log_types/src/example_components.rs
@@ -1,5 +1,7 @@
 //! Example components to be used for tests and docs
 
+use std::sync::Arc;
+
 use re_types_core::{components::InstanceKey, Loggable, SizeBytes};
 
 // ----------------------------------------------------------------------------
@@ -67,10 +69,10 @@ impl Loggable for MyPoint {
 
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::DataType::Float32;
-        arrow2::datatypes::DataType::Struct(vec![
+        arrow2::datatypes::DataType::Struct(Arc::new(vec![
             arrow2::datatypes::Field::new("x", Float32, false),
             arrow2::datatypes::Field::new("y", Float32, false),
-        ])
+        ]))
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/blueprint/components/column_shares.rs
+++ b/crates/re_types/src/blueprint/components/column_shares.rs
@@ -68,7 +68,7 @@ impl ::re_types_core::Loggable for ColumnShares {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: DataType::Float32,
             is_nullable: false,
@@ -146,7 +146,7 @@ impl ::re_types_core::Loggable for ColumnShares {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: DataType::Float32,
                             is_nullable: false,

--- a/crates/re_types/src/blueprint/components/included_contents.rs
+++ b/crates/re_types/src/blueprint/components/included_contents.rs
@@ -65,7 +65,7 @@ impl ::re_types_core::Loggable for IncludedContents {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: <crate::datatypes::EntityPath>::arrow_datatype(),
             is_nullable: false,
@@ -173,7 +173,7 @@ impl ::re_types_core::Loggable for IncludedContents {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: <crate::datatypes::EntityPath>::arrow_datatype(),
                             is_nullable: false,

--- a/crates/re_types/src/blueprint/components/included_queries.rs
+++ b/crates/re_types/src/blueprint/components/included_queries.rs
@@ -60,7 +60,7 @@ impl ::re_types_core::Loggable for IncludedQueries {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: <crate::datatypes::Uuid>::arrow_datatype(),
             is_nullable: false,
@@ -139,7 +139,7 @@ impl ::re_types_core::Loggable for IncludedQueries {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: <crate::datatypes::Uuid>::arrow_datatype(),
                             is_nullable: false,

--- a/crates/re_types/src/blueprint/components/legend.rs
+++ b/crates/re_types/src/blueprint/components/legend.rs
@@ -73,7 +73,7 @@ impl ::re_types_core::Loggable for Legend {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "visible".to_owned(),
                 data_type: DataType::Boolean,
@@ -86,7 +86,7 @@ impl ::re_types_core::Loggable for Legend {
                 is_nullable: true,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/blueprint/components/row_shares.rs
+++ b/crates/re_types/src/blueprint/components/row_shares.rs
@@ -68,7 +68,7 @@ impl ::re_types_core::Loggable for RowShares {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: DataType::Float32,
             is_nullable: false,
@@ -146,7 +146,7 @@ impl ::re_types_core::Loggable for RowShares {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: DataType::Float32,
                             is_nullable: false,

--- a/crates/re_types/src/blueprint/datatypes/legend.rs
+++ b/crates/re_types/src/blueprint/datatypes/legend.rs
@@ -63,7 +63,7 @@ impl ::re_types_core::Loggable for Legend {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "visible".to_owned(),
                 data_type: DataType::Boolean,
@@ -76,7 +76,7 @@ impl ::re_types_core::Loggable for Legend {
                 is_nullable: true,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -175,7 +175,7 @@ impl ::re_types_core::Loggable for Legend {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![
+                        DataType::Struct(std::sync::Arc::new(vec![
                             Field {
                                 name: "visible".to_owned(),
                                 data_type: DataType::Boolean,
@@ -188,7 +188,7 @@ impl ::re_types_core::Loggable for Legend {
                                 is_nullable: true,
                                 metadata: [].into(),
                             },
-                        ]),
+                        ])),
                         arrow_data.data_type().clone(),
                     )
                 })

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -68,7 +68,7 @@ impl ::re_types_core::Loggable for AnnotationContext {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: <crate::datatypes::ClassDescriptionMapElem>::arrow_datatype(),
             is_nullable: false,
@@ -147,7 +147,7 @@ impl ::re_types_core::Loggable for AnnotationContext {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: <crate::datatypes::ClassDescriptionMapElem>::arrow_datatype(
                             ),

--- a/crates/re_types/src/components/blob.rs
+++ b/crates/re_types/src/components/blob.rs
@@ -66,7 +66,7 @@ impl ::re_types_core::Loggable for Blob {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: DataType::UInt8,
             is_nullable: false,
@@ -144,7 +144,7 @@ impl ::re_types_core::Loggable for Blob {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: DataType::UInt8,
                             is_nullable: false,

--- a/crates/re_types/src/components/half_sizes2d.rs
+++ b/crates/re_types/src/components/half_sizes2d.rs
@@ -77,7 +77,7 @@ impl ::re_types_core::Loggable for HalfSizes2D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::Float32,
                 is_nullable: false,
@@ -170,7 +170,7 @@ impl ::re_types_core::Loggable for HalfSizes2D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::Float32,
                                 is_nullable: false,
@@ -262,7 +262,7 @@ impl ::re_types_core::Loggable for HalfSizes2D {
                     .ok_or_else(|| {
                         DeserializationError::datatype_mismatch(
                             DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: false,

--- a/crates/re_types/src/components/half_sizes3d.rs
+++ b/crates/re_types/src/components/half_sizes3d.rs
@@ -77,7 +77,7 @@ impl ::re_types_core::Loggable for HalfSizes3D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::Float32,
                 is_nullable: false,
@@ -170,7 +170,7 @@ impl ::re_types_core::Loggable for HalfSizes3D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::Float32,
                                 is_nullable: false,
@@ -262,7 +262,7 @@ impl ::re_types_core::Loggable for HalfSizes3D {
                     .ok_or_else(|| {
                         DeserializationError::datatype_mismatch(
                             DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: false,

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -68,7 +68,7 @@ impl ::re_types_core::Loggable for LineStrip2D {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: <crate::datatypes::Vec2D>::arrow_datatype(),
             is_nullable: false,
@@ -147,7 +147,7 @@ impl ::re_types_core::Loggable for LineStrip2D {
                             });
                         FixedSizeListArray::new(
                             DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: false,
@@ -190,7 +190,7 @@ impl ::re_types_core::Loggable for LineStrip2D {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: <crate::datatypes::Vec2D>::arrow_datatype(),
                             is_nullable: false,
@@ -212,7 +212,7 @@ impl ::re_types_core::Loggable for LineStrip2D {
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
                                     DataType::FixedSizeList(
-                                        Box::new(Field {
+                                        std::sync::Arc::new(Field {
                                             name: "item".to_owned(),
                                             data_type: DataType::Float32,
                                             is_nullable: false,

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -68,7 +68,7 @@ impl ::re_types_core::Loggable for LineStrip3D {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: <crate::datatypes::Vec3D>::arrow_datatype(),
             is_nullable: false,
@@ -147,7 +147,7 @@ impl ::re_types_core::Loggable for LineStrip3D {
                             });
                         FixedSizeListArray::new(
                             DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: false,
@@ -190,7 +190,7 @@ impl ::re_types_core::Loggable for LineStrip3D {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: <crate::datatypes::Vec3D>::arrow_datatype(),
                             is_nullable: false,
@@ -212,7 +212,7 @@ impl ::re_types_core::Loggable for LineStrip3D {
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
                                     DataType::FixedSizeList(
-                                        Box::new(Field {
+                                        std::sync::Arc::new(Field {
                                             name: "item".to_owned(),
                                             data_type: DataType::Float32,
                                             is_nullable: false,

--- a/crates/re_types/src/components/material.rs
+++ b/crates/re_types/src/components/material.rs
@@ -73,12 +73,12 @@ impl ::re_types_core::Loggable for Material {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![Field {
+        DataType::Struct(std::sync::Arc::new(vec![Field {
             name: "albedo_factor".to_owned(),
             data_type: <crate::datatypes::Rgba32>::arrow_datatype(),
             is_nullable: true,
             metadata: [].into(),
-        }])
+        }]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/mesh_properties.rs
+++ b/crates/re_types/src/components/mesh_properties.rs
@@ -73,9 +73,9 @@ impl ::re_types_core::Loggable for MeshProperties {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![Field {
+        DataType::Struct(std::sync::Arc::new(vec![Field {
             name: "indices".to_owned(),
-            data_type: DataType::List(Box::new(Field {
+            data_type: DataType::List(std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::UInt32,
                 is_nullable: false,
@@ -83,7 +83,7 @@ impl ::re_types_core::Loggable for MeshProperties {
             })),
             is_nullable: true,
             metadata: [].into(),
-        }])
+        }]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/out_of_tree_transform3d.rs
+++ b/crates/re_types/src/components/out_of_tree_transform3d.rs
@@ -79,7 +79,7 @@ impl ::re_types_core::Loggable for OutOfTreeTransform3D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::Union(
-            vec![
+            std::sync::Arc::new(vec![
                 Field {
                     name: "_null_markers".to_owned(),
                     data_type: DataType::Null,
@@ -98,8 +98,8 @@ impl ::re_types_core::Loggable for OutOfTreeTransform3D {
                     is_nullable: false,
                     metadata: [].into(),
                 },
-            ],
-            Some(vec![0i32, 1i32, 2i32]),
+            ]),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
             UnionMode::Dense,
         )
     }

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -84,7 +84,7 @@ impl ::re_types_core::Loggable for PinholeProjection {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::Float32,
                 is_nullable: false,
@@ -177,7 +177,7 @@ impl ::re_types_core::Loggable for PinholeProjection {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::Float32,
                                 is_nullable: false,
@@ -269,7 +269,7 @@ impl ::re_types_core::Loggable for PinholeProjection {
                     .ok_or_else(|| {
                         DeserializationError::datatype_mismatch(
                             DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: false,

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -75,7 +75,7 @@ impl ::re_types_core::Loggable for Position2D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::Float32,
                 is_nullable: false,
@@ -168,7 +168,7 @@ impl ::re_types_core::Loggable for Position2D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::Float32,
                                 is_nullable: false,
@@ -260,7 +260,7 @@ impl ::re_types_core::Loggable for Position2D {
                     .ok_or_else(|| {
                         DeserializationError::datatype_mismatch(
                             DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: false,

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -75,7 +75,7 @@ impl ::re_types_core::Loggable for Position3D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::Float32,
                 is_nullable: false,
@@ -168,7 +168,7 @@ impl ::re_types_core::Loggable for Position3D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::Float32,
                                 is_nullable: false,
@@ -260,7 +260,7 @@ impl ::re_types_core::Loggable for Position3D {
                     .ok_or_else(|| {
                         DeserializationError::datatype_mismatch(
                             DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: false,

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -76,7 +76,7 @@ impl ::re_types_core::Loggable for Resolution {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::Float32,
                 is_nullable: false,
@@ -169,7 +169,7 @@ impl ::re_types_core::Loggable for Resolution {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::Float32,
                                 is_nullable: false,
@@ -261,7 +261,7 @@ impl ::re_types_core::Loggable for Resolution {
                     .ok_or_else(|| {
                         DeserializationError::datatype_mismatch(
                             DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: false,

--- a/crates/re_types/src/components/rotation3d.rs
+++ b/crates/re_types/src/components/rotation3d.rs
@@ -77,7 +77,7 @@ impl ::re_types_core::Loggable for Rotation3D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::Union(
-            vec![
+            std::sync::Arc::new(vec![
                 Field {
                     name: "_null_markers".to_owned(),
                     data_type: DataType::Null,
@@ -96,8 +96,8 @@ impl ::re_types_core::Loggable for Rotation3D {
                     is_nullable: false,
                     metadata: [].into(),
                 },
-            ],
-            Some(vec![0i32, 1i32, 2i32]),
+            ]),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
             UnionMode::Dense,
         )
     }

--- a/crates/re_types/src/components/tensor_data.rs
+++ b/crates/re_types/src/components/tensor_data.rs
@@ -74,10 +74,10 @@ impl ::re_types_core::Loggable for TensorData {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "shape".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: <crate::datatypes::TensorDimension>::arrow_datatype(),
                     is_nullable: false,
@@ -92,7 +92,7 @@ impl ::re_types_core::Loggable for TensorData {
                 is_nullable: false,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -77,7 +77,7 @@ impl ::re_types_core::Loggable for Transform3D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::Union(
-            vec![
+            std::sync::Arc::new(vec![
                 Field {
                     name: "_null_markers".to_owned(),
                     data_type: DataType::Null,
@@ -96,8 +96,8 @@ impl ::re_types_core::Loggable for Transform3D {
                     is_nullable: false,
                     metadata: [].into(),
                 },
-            ],
-            Some(vec![0i32, 1i32, 2i32]),
+            ]),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
             UnionMode::Dense,
         )
     }

--- a/crates/re_types/src/components/vector2d.rs
+++ b/crates/re_types/src/components/vector2d.rs
@@ -75,7 +75,7 @@ impl ::re_types_core::Loggable for Vector2D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::Float32,
                 is_nullable: false,
@@ -168,7 +168,7 @@ impl ::re_types_core::Loggable for Vector2D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::Float32,
                                 is_nullable: false,
@@ -260,7 +260,7 @@ impl ::re_types_core::Loggable for Vector2D {
                     .ok_or_else(|| {
                         DeserializationError::datatype_mismatch(
                             DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: false,

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -75,7 +75,7 @@ impl ::re_types_core::Loggable for Vector3D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::Float32,
                 is_nullable: false,
@@ -168,7 +168,7 @@ impl ::re_types_core::Loggable for Vector3D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::Float32,
                                 is_nullable: false,
@@ -260,7 +260,7 @@ impl ::re_types_core::Loggable for Vector3D {
                     .ok_or_else(|| {
                         DeserializationError::datatype_mismatch(
                             DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: false,

--- a/crates/re_types/src/components/view_coordinates.rs
+++ b/crates/re_types/src/components/view_coordinates.rs
@@ -85,7 +85,7 @@ impl ::re_types_core::Loggable for ViewCoordinates {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::UInt8,
                 is_nullable: false,
@@ -175,7 +175,7 @@ impl ::re_types_core::Loggable for ViewCoordinates {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::UInt8,
                                 is_nullable: false,
@@ -264,7 +264,7 @@ impl ::re_types_core::Loggable for ViewCoordinates {
                     .ok_or_else(|| {
                         DeserializationError::datatype_mismatch(
                             DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::UInt8,
                                     is_nullable: false,

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -59,7 +59,7 @@ impl ::re_types_core::Loggable for Angle {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::Union(
-            vec![
+            std::sync::Arc::new(vec![
                 Field {
                     name: "_null_markers".to_owned(),
                     data_type: DataType::Null,
@@ -78,8 +78,8 @@ impl ::re_types_core::Loggable for Angle {
                     is_nullable: false,
                     metadata: [].into(),
                 },
-            ],
-            Some(vec![0i32, 1i32, 2i32]),
+            ]),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
             UnionMode::Dense,
         )
     }
@@ -205,7 +205,7 @@ impl ::re_types_core::Loggable for Angle {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::Union(
-                            vec![
+                            std::sync::Arc::new(vec![
                                 Field {
                                     name: "_null_markers".to_owned(),
                                     data_type: DataType::Null,
@@ -224,8 +224,8 @@ impl ::re_types_core::Loggable for Angle {
                                     is_nullable: false,
                                     metadata: [].into(),
                                 },
-                            ],
-                            Some(vec![0i32, 1i32, 2i32]),
+                            ]),
+                            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
                             UnionMode::Dense,
                         ),
                         arrow_data.data_type().clone(),

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -65,7 +65,7 @@ impl ::re_types_core::Loggable for AnnotationInfo {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "id".to_owned(),
                 data_type: DataType::UInt16,
@@ -84,7 +84,7 @@ impl ::re_types_core::Loggable for AnnotationInfo {
                 is_nullable: true,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -242,7 +242,7 @@ impl ::re_types_core::Loggable for AnnotationInfo {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![
+                        DataType::Struct(std::sync::Arc::new(vec![
                             Field {
                                 name: "id".to_owned(),
                                 data_type: DataType::UInt16,
@@ -261,7 +261,7 @@ impl ::re_types_core::Loggable for AnnotationInfo {
                                 is_nullable: true,
                                 metadata: [].into(),
                             },
-                        ]),
+                        ])),
                         arrow_data.data_type().clone(),
                     )
                 })

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -77,7 +77,7 @@ impl ::re_types_core::Loggable for ClassDescription {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "info".to_owned(),
                 data_type: <crate::datatypes::AnnotationInfo>::arrow_datatype(),
@@ -86,7 +86,7 @@ impl ::re_types_core::Loggable for ClassDescription {
             },
             Field {
                 name: "keypoint_annotations".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: <crate::datatypes::AnnotationInfo>::arrow_datatype(),
                     is_nullable: false,
@@ -97,7 +97,7 @@ impl ::re_types_core::Loggable for ClassDescription {
             },
             Field {
                 name: "keypoint_connections".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: <crate::datatypes::KeypointPair>::arrow_datatype(),
                     is_nullable: false,
@@ -106,7 +106,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                 is_nullable: false,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -190,7 +190,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: <crate::datatypes::AnnotationInfo>::arrow_datatype(),
                                     is_nullable: false,
@@ -245,7 +245,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: <crate::datatypes::KeypointPair>::arrow_datatype(),
                                     is_nullable: false,
@@ -285,7 +285,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![
+                        DataType::Struct(std::sync::Arc::new(vec![
                             Field {
                                 name: "info".to_owned(),
                                 data_type: <crate::datatypes::AnnotationInfo>::arrow_datatype(),
@@ -294,7 +294,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                             },
                             Field {
                                 name: "keypoint_annotations".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
+                                data_type: DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: <crate::datatypes::AnnotationInfo>::arrow_datatype(),
                                     is_nullable: false,
@@ -305,7 +305,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                             },
                             Field {
                                 name: "keypoint_connections".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
+                                data_type: DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: <crate::datatypes::KeypointPair>::arrow_datatype(),
                                     is_nullable: false,
@@ -314,7 +314,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                                 is_nullable: false,
                                 metadata: [].into(),
                             },
-                        ]),
+                        ])),
                         arrow_data.data_type().clone(),
                     )
                 })
@@ -357,7 +357,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type:
                                             <crate::datatypes::AnnotationInfo>::arrow_datatype(),
@@ -431,7 +431,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: <crate::datatypes::KeypointPair>::arrow_datatype(
                                         ),

--- a/crates/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/re_types/src/datatypes/class_description_map_elem.rs
@@ -59,7 +59,7 @@ impl ::re_types_core::Loggable for ClassDescriptionMapElem {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "class_id".to_owned(),
                 data_type: <crate::datatypes::ClassId>::arrow_datatype(),
@@ -72,7 +72,7 @@ impl ::re_types_core::Loggable for ClassDescriptionMapElem {
                 is_nullable: false,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -175,7 +175,7 @@ impl ::re_types_core::Loggable for ClassDescriptionMapElem {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![
+                        DataType::Struct(std::sync::Arc::new(vec![
                             Field {
                                 name: "class_id".to_owned(),
                                 data_type: <crate::datatypes::ClassId>::arrow_datatype(),
@@ -188,7 +188,7 @@ impl ::re_types_core::Loggable for ClassDescriptionMapElem {
                                 is_nullable: false,
                                 metadata: [].into(),
                             },
-                        ]),
+                        ])),
                         arrow_data.data_type().clone(),
                     )
                 })

--- a/crates/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/re_types/src/datatypes/keypoint_pair.rs
@@ -57,7 +57,7 @@ impl ::re_types_core::Loggable for KeypointPair {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "keypoint0".to_owned(),
                 data_type: <crate::datatypes::KeypointId>::arrow_datatype(),
@@ -70,7 +70,7 @@ impl ::re_types_core::Loggable for KeypointPair {
                 is_nullable: false,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -183,7 +183,7 @@ impl ::re_types_core::Loggable for KeypointPair {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![
+                        DataType::Struct(std::sync::Arc::new(vec![
                             Field {
                                 name: "keypoint0".to_owned(),
                                 data_type: <crate::datatypes::KeypointId>::arrow_datatype(),
@@ -196,7 +196,7 @@ impl ::re_types_core::Loggable for KeypointPair {
                                 is_nullable: false,
                                 metadata: [].into(),
                             },
-                        ]),
+                        ])),
                         arrow_data.data_type().clone(),
                     )
                 })

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -78,7 +78,7 @@ impl ::re_types_core::Loggable for Mat3x3 {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::Float32,
                 is_nullable: false,
@@ -168,7 +168,7 @@ impl ::re_types_core::Loggable for Mat3x3 {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::Float32,
                                 is_nullable: false,

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -79,7 +79,7 @@ impl ::re_types_core::Loggable for Mat4x4 {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::Float32,
                 is_nullable: false,
@@ -169,7 +169,7 @@ impl ::re_types_core::Loggable for Mat4x4 {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::Float32,
                                 is_nullable: false,

--- a/crates/re_types/src/datatypes/material.rs
+++ b/crates/re_types/src/datatypes/material.rs
@@ -78,12 +78,12 @@ impl ::re_types_core::Loggable for Material {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![Field {
+        DataType::Struct(std::sync::Arc::new(vec![Field {
             name: "albedo_factor".to_owned(),
             data_type: <crate::datatypes::Rgba32>::arrow_datatype(),
             is_nullable: true,
             metadata: [].into(),
-        }])
+        }]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -165,12 +165,12 @@ impl ::re_types_core::Loggable for Material {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![Field {
+                        DataType::Struct(std::sync::Arc::new(vec![Field {
                             name: "albedo_factor".to_owned(),
                             data_type: <crate::datatypes::Rgba32>::arrow_datatype(),
                             is_nullable: true,
                             metadata: [].into(),
-                        }]),
+                        }])),
                         arrow_data.data_type().clone(),
                     )
                 })

--- a/crates/re_types/src/datatypes/mesh_properties.rs
+++ b/crates/re_types/src/datatypes/mesh_properties.rs
@@ -70,9 +70,9 @@ impl ::re_types_core::Loggable for MeshProperties {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![Field {
+        DataType::Struct(std::sync::Arc::new(vec![Field {
             name: "indices".to_owned(),
-            data_type: DataType::List(Box::new(Field {
+            data_type: DataType::List(std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::UInt32,
                 is_nullable: false,
@@ -80,7 +80,7 @@ impl ::re_types_core::Loggable for MeshProperties {
             })),
             is_nullable: true,
             metadata: [].into(),
-        }])
+        }]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -144,7 +144,7 @@ impl ::re_types_core::Loggable for MeshProperties {
                         .unwrap()
                         .into();
                         ListArray::new(
-                            DataType::List(Box::new(Field {
+                            DataType::List(std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::UInt32,
                                 is_nullable: false,
@@ -183,9 +183,9 @@ impl ::re_types_core::Loggable for MeshProperties {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![Field {
+                        DataType::Struct(std::sync::Arc::new(vec![Field {
                             name: "indices".to_owned(),
-                            data_type: DataType::List(Box::new(Field {
+                            data_type: DataType::List(std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::UInt32,
                                 is_nullable: false,
@@ -193,7 +193,7 @@ impl ::re_types_core::Loggable for MeshProperties {
                             })),
                             is_nullable: true,
                             metadata: [].into(),
-                        }]),
+                        }])),
                         arrow_data.data_type().clone(),
                     )
                 })
@@ -223,7 +223,7 @@ impl ::re_types_core::Loggable for MeshProperties {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::UInt32,
                                         is_nullable: false,

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -69,7 +69,7 @@ impl ::re_types_core::Loggable for Quaternion {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::Float32,
                 is_nullable: false,
@@ -159,7 +159,7 @@ impl ::re_types_core::Loggable for Quaternion {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::Float32,
                                 is_nullable: false,

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -62,7 +62,7 @@ impl ::re_types_core::Loggable for Rotation3D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::Union(
-            vec![
+            std::sync::Arc::new(vec![
                 Field {
                     name: "_null_markers".to_owned(),
                     data_type: DataType::Null,
@@ -81,8 +81,8 @@ impl ::re_types_core::Loggable for Rotation3D {
                     is_nullable: false,
                     metadata: [].into(),
                 },
-            ],
-            Some(vec![0i32, 1i32, 2i32]),
+            ]),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
             UnionMode::Dense,
         )
     }
@@ -160,7 +160,7 @@ impl ::re_types_core::Loggable for Rotation3D {
                                 });
                             FixedSizeListArray::new(
                                 DataType::FixedSizeList(
-                                    Box::new(Field {
+                                    std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float32,
                                         is_nullable: false,
@@ -251,7 +251,7 @@ impl ::re_types_core::Loggable for Rotation3D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::Union(
-                            vec![
+                            std::sync::Arc::new(vec![
                                 Field {
                                     name: "_null_markers".to_owned(),
                                     data_type: DataType::Null,
@@ -271,8 +271,8 @@ impl ::re_types_core::Loggable for Rotation3D {
                                     is_nullable: false,
                                     metadata: [].into(),
                                 },
-                            ],
-                            Some(vec![0i32, 1i32, 2i32]),
+                            ]),
+                            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
                             UnionMode::Dense,
                         ),
                         arrow_data.data_type().clone(),
@@ -312,7 +312,7 @@ impl ::re_types_core::Loggable for Rotation3D {
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
                                     DataType::FixedSizeList(
-                                        Box::new(Field {
+                                        std::sync::Arc::new(Field {
                                             name: "item".to_owned(),
                                             data_type: DataType::Float32,
                                             is_nullable: false,

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -61,7 +61,7 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "axis".to_owned(),
                 data_type: <crate::datatypes::Vec3D>::arrow_datatype(),
@@ -74,7 +74,7 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
                 is_nullable: false,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -142,7 +142,7 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
                                 });
                             FixedSizeListArray::new(
                                 DataType::FixedSizeList(
-                                    Box::new(Field {
+                                    std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float32,
                                         is_nullable: false,
@@ -206,7 +206,7 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![
+                        DataType::Struct(std::sync::Arc::new(vec![
                             Field {
                                 name: "axis".to_owned(),
                                 data_type: <crate::datatypes::Vec3D>::arrow_datatype(),
@@ -219,7 +219,7 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
                                 is_nullable: false,
                                 metadata: [].into(),
                             },
-                        ]),
+                        ])),
                         arrow_data.data_type().clone(),
                     )
                 })
@@ -250,7 +250,7 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
                                     DataType::FixedSizeList(
-                                        Box::new(Field {
+                                        std::sync::Arc::new(Field {
                                             name: "item".to_owned(),
                                             data_type: DataType::Float32,
                                             is_nullable: false,

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -62,7 +62,7 @@ impl ::re_types_core::Loggable for Scale3D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::Union(
-            vec![
+            std::sync::Arc::new(vec![
                 Field {
                     name: "_null_markers".to_owned(),
                     data_type: DataType::Null,
@@ -81,8 +81,8 @@ impl ::re_types_core::Loggable for Scale3D {
                     is_nullable: false,
                     metadata: [].into(),
                 },
-            ],
-            Some(vec![0i32, 1i32, 2i32]),
+            ]),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
             UnionMode::Dense,
         )
     }
@@ -158,7 +158,7 @@ impl ::re_types_core::Loggable for Scale3D {
                                 });
                             FixedSizeListArray::new(
                                 DataType::FixedSizeList(
-                                    Box::new(Field {
+                                    std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float32,
                                         is_nullable: false,
@@ -249,7 +249,7 @@ impl ::re_types_core::Loggable for Scale3D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::Union(
-                            vec![
+                            std::sync::Arc::new(vec![
                                 Field {
                                     name: "_null_markers".to_owned(),
                                     data_type: DataType::Null,
@@ -268,8 +268,8 @@ impl ::re_types_core::Loggable for Scale3D {
                                     is_nullable: false,
                                     metadata: [].into(),
                                 },
-                            ],
-                            Some(vec![0i32, 1i32, 2i32]),
+                            ]),
+                            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
                             UnionMode::Dense,
                         ),
                         arrow_data.data_type().clone(),
@@ -309,7 +309,7 @@ impl ::re_types_core::Loggable for Scale3D {
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
                                     DataType::FixedSizeList(
-                                        Box::new(Field {
+                                        std::sync::Arc::new(Field {
                                             name: "item".to_owned(),
                                             data_type: DataType::Float32,
                                             is_nullable: false,

--- a/crates/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/re_types/src/datatypes/tensor_buffer.rs
@@ -95,7 +95,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::Union(
-            vec![
+            std::sync::Arc::new(vec![
                 Field {
                     name: "_null_markers".to_owned(),
                     data_type: DataType::Null,
@@ -104,7 +104,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                 },
                 Field {
                     name: "U8".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: DataType::UInt8,
                         is_nullable: false,
@@ -115,7 +115,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                 },
                 Field {
                     name: "U16".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: DataType::UInt16,
                         is_nullable: false,
@@ -126,7 +126,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                 },
                 Field {
                     name: "U32".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: DataType::UInt32,
                         is_nullable: false,
@@ -137,7 +137,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                 },
                 Field {
                     name: "U64".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: DataType::UInt64,
                         is_nullable: false,
@@ -148,7 +148,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                 },
                 Field {
                     name: "I8".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: DataType::Int8,
                         is_nullable: false,
@@ -159,7 +159,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                 },
                 Field {
                     name: "I16".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: DataType::Int16,
                         is_nullable: false,
@@ -170,7 +170,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                 },
                 Field {
                     name: "I32".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: DataType::Int32,
                         is_nullable: false,
@@ -181,7 +181,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                 },
                 Field {
                     name: "I64".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: DataType::Int64,
                         is_nullable: false,
@@ -192,7 +192,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                 },
                 Field {
                     name: "F16".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: DataType::Float16,
                         is_nullable: false,
@@ -203,7 +203,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                 },
                 Field {
                     name: "F32".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: DataType::Float32,
                         is_nullable: false,
@@ -214,7 +214,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                 },
                 Field {
                     name: "F64".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: DataType::Float64,
                         is_nullable: false,
@@ -225,7 +225,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                 },
                 Field {
                     name: "JPEG".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: DataType::UInt8,
                         is_nullable: false,
@@ -236,7 +236,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                 },
                 Field {
                     name: "NV12".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: DataType::UInt8,
                         is_nullable: false,
@@ -245,11 +245,11 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     is_nullable: false,
                     metadata: [].into(),
                 },
-            ],
-            Some(vec![
+            ]),
+            Some(std::sync::Arc::new(vec![
                 0i32, 1i32, 2i32, 3i32, 4i32, 5i32, 6i32, 7i32, 8i32, 9i32, 10i32, 11i32, 12i32,
                 13i32,
-            ]),
+            ])),
             UnionMode::Dense,
         )
     }
@@ -330,7 +330,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::UInt8,
                                     is_nullable: false,
@@ -384,7 +384,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::UInt16,
                                     is_nullable: false,
@@ -438,7 +438,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::UInt32,
                                     is_nullable: false,
@@ -492,7 +492,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::UInt64,
                                     is_nullable: false,
@@ -546,7 +546,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Int8,
                                     is_nullable: false,
@@ -596,7 +596,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Int16,
                                     is_nullable: false,
@@ -650,7 +650,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Int32,
                                     is_nullable: false,
@@ -704,7 +704,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Int64,
                                     is_nullable: false,
@@ -758,7 +758,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float16,
                                     is_nullable: false,
@@ -812,7 +812,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: false,
@@ -866,7 +866,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float64,
                                     is_nullable: false,
@@ -920,7 +920,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::UInt8,
                                     is_nullable: false,
@@ -974,7 +974,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::UInt8,
                                     is_nullable: false,
@@ -1104,7 +1104,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::Union(
-                            vec![
+                            std::sync::Arc::new(vec![
                                 Field {
                                     name: "_null_markers".to_owned(),
                                     data_type: DataType::Null,
@@ -1113,7 +1113,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 },
                                 Field {
                                     name: "U8".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
+                                    data_type: DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::UInt8,
                                         is_nullable: false,
@@ -1124,7 +1124,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 },
                                 Field {
                                     name: "U16".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
+                                    data_type: DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::UInt16,
                                         is_nullable: false,
@@ -1135,7 +1135,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 },
                                 Field {
                                     name: "U32".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
+                                    data_type: DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::UInt32,
                                         is_nullable: false,
@@ -1146,7 +1146,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 },
                                 Field {
                                     name: "U64".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
+                                    data_type: DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::UInt64,
                                         is_nullable: false,
@@ -1157,7 +1157,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 },
                                 Field {
                                     name: "I8".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
+                                    data_type: DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Int8,
                                         is_nullable: false,
@@ -1168,7 +1168,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 },
                                 Field {
                                     name: "I16".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
+                                    data_type: DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Int16,
                                         is_nullable: false,
@@ -1179,7 +1179,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 },
                                 Field {
                                     name: "I32".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
+                                    data_type: DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Int32,
                                         is_nullable: false,
@@ -1190,7 +1190,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 },
                                 Field {
                                     name: "I64".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
+                                    data_type: DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Int64,
                                         is_nullable: false,
@@ -1201,7 +1201,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 },
                                 Field {
                                     name: "F16".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
+                                    data_type: DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float16,
                                         is_nullable: false,
@@ -1212,7 +1212,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 },
                                 Field {
                                     name: "F32".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
+                                    data_type: DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float32,
                                         is_nullable: false,
@@ -1223,7 +1223,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 },
                                 Field {
                                     name: "F64".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
+                                    data_type: DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float64,
                                         is_nullable: false,
@@ -1234,7 +1234,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 },
                                 Field {
                                     name: "JPEG".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
+                                    data_type: DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::UInt8,
                                         is_nullable: false,
@@ -1245,7 +1245,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 },
                                 Field {
                                     name: "NV12".to_owned(),
-                                    data_type: DataType::List(Box::new(Field {
+                                    data_type: DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::UInt8,
                                         is_nullable: false,
@@ -1254,11 +1254,11 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                     is_nullable: false,
                                     metadata: [].into(),
                                 },
-                            ],
-                            Some(vec![
+                            ]),
+                            Some(std::sync::Arc::new(vec![
                                 0i32, 1i32, 2i32, 3i32, 4i32, 5i32, 6i32, 7i32, 8i32, 9i32, 10i32,
                                 11i32, 12i32, 13i32,
-                            ]),
+                            ])),
                             UnionMode::Dense,
                         ),
                         arrow_data.data_type().clone(),
@@ -1297,7 +1297,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::UInt8,
                                         is_nullable: false,
@@ -1368,7 +1368,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::UInt16,
                                         is_nullable: false,
@@ -1439,7 +1439,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::UInt32,
                                         is_nullable: false,
@@ -1510,7 +1510,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::UInt64,
                                         is_nullable: false,
@@ -1581,7 +1581,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Int8,
                                         is_nullable: false,
@@ -1652,7 +1652,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Int16,
                                         is_nullable: false,
@@ -1723,7 +1723,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Int32,
                                         is_nullable: false,
@@ -1794,7 +1794,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Int64,
                                         is_nullable: false,
@@ -1865,7 +1865,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float16,
                                         is_nullable: false,
@@ -1936,7 +1936,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float32,
                                         is_nullable: false,
@@ -2007,7 +2007,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float64,
                                         is_nullable: false,
@@ -2078,7 +2078,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::UInt8,
                                         is_nullable: false,
@@ -2149,7 +2149,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::UInt8,
                                         is_nullable: false,

--- a/crates/re_types/src/datatypes/tensor_data.rs
+++ b/crates/re_types/src/datatypes/tensor_data.rs
@@ -62,10 +62,10 @@ impl ::re_types_core::Loggable for TensorData {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "shape".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: <crate::datatypes::TensorDimension>::arrow_datatype(),
                     is_nullable: false,
@@ -80,7 +80,7 @@ impl ::re_types_core::Loggable for TensorData {
                 is_nullable: false,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -139,7 +139,7 @@ impl ::re_types_core::Loggable for TensorData {
                                 .unwrap()
                                 .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: <crate::datatypes::TensorDimension>::arrow_datatype(
                                     ),
@@ -200,10 +200,10 @@ impl ::re_types_core::Loggable for TensorData {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![
+                        DataType::Struct(std::sync::Arc::new(vec![
                             Field {
                                 name: "shape".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
+                                data_type: DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: <crate::datatypes::TensorDimension>::arrow_datatype(
                                     ),
@@ -219,7 +219,7 @@ impl ::re_types_core::Loggable for TensorData {
                                 is_nullable: false,
                                 metadata: [].into(),
                             },
-                        ]),
+                        ])),
                         arrow_data.data_type().clone(),
                     )
                 })
@@ -249,7 +249,7 @@ impl ::re_types_core::Loggable for TensorData {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type:
                                             <crate::datatypes::TensorDimension>::arrow_datatype(),

--- a/crates/re_types/src/datatypes/tensor_dimension.rs
+++ b/crates/re_types/src/datatypes/tensor_dimension.rs
@@ -57,7 +57,7 @@ impl ::re_types_core::Loggable for TensorDimension {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "size".to_owned(),
                 data_type: DataType::UInt64,
@@ -70,7 +70,7 @@ impl ::re_types_core::Loggable for TensorDimension {
                 is_nullable: true,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -181,7 +181,7 @@ impl ::re_types_core::Loggable for TensorDimension {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![
+                        DataType::Struct(std::sync::Arc::new(vec![
                             Field {
                                 name: "size".to_owned(),
                                 data_type: DataType::UInt64,
@@ -194,7 +194,7 @@ impl ::re_types_core::Loggable for TensorDimension {
                                 is_nullable: true,
                                 metadata: [].into(),
                             },
-                        ]),
+                        ])),
                         arrow_data.data_type().clone(),
                     )
                 })

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -63,7 +63,7 @@ impl ::re_types_core::Loggable for Transform3D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::Union(
-            vec![
+            std::sync::Arc::new(vec![
                 Field {
                     name: "_null_markers".to_owned(),
                     data_type: DataType::Null,
@@ -82,8 +82,8 @@ impl ::re_types_core::Loggable for Transform3D {
                     is_nullable: false,
                     metadata: [].into(),
                 },
-            ],
-            Some(vec![0i32, 1i32, 2i32]),
+            ]),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
             UnionMode::Dense,
         )
     }
@@ -221,18 +221,19 @@ impl ::re_types_core::Loggable for Transform3D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::Union(
-                            vec![
-                            Field { name : "_null_markers".to_owned(), data_type :
-                            DataType::Null, is_nullable : true, metadata : [].into(), },
-                            Field { name : "TranslationAndMat3x3".to_owned(), data_type :
-                            < crate ::datatypes::TranslationAndMat3x3 >
-                            ::arrow_datatype(), is_nullable : false, metadata : []
-                            .into(), }, Field { name : "TranslationRotationScale"
-                            .to_owned(), data_type : < crate
-                            ::datatypes::TranslationRotationScale3D > ::arrow_datatype(),
-                            is_nullable : false, metadata : [].into(), },
-                        ],
-                            Some(vec![0i32, 1i32, 2i32]),
+                            std::sync::Arc::new(vec![
+                                Field { name : "_null_markers".to_owned(), data_type :
+                                DataType::Null, is_nullable : true, metadata : [].into(), },
+                                Field { name : "TranslationAndMat3x3".to_owned(), data_type
+                                : < crate ::datatypes::TranslationAndMat3x3 >
+                                ::arrow_datatype(), is_nullable : false, metadata : []
+                                .into(), }, Field { name : "TranslationRotationScale"
+                                .to_owned(), data_type : < crate
+                                ::datatypes::TranslationRotationScale3D >
+                                ::arrow_datatype(), is_nullable : false, metadata : []
+                                .into(), },
+                            ]),
+                            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
                             UnionMode::Dense,
                         ),
                         arrow_data.data_type().clone(),

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -69,7 +69,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "translation".to_owned(),
                 data_type: <crate::datatypes::Vec3D>::arrow_datatype(),
@@ -88,7 +88,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                 is_nullable: false,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -159,7 +159,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                                 });
                             FixedSizeListArray::new(
                                 DataType::FixedSizeList(
-                                    Box::new(Field {
+                                    std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float32,
                                         is_nullable: false,
@@ -225,7 +225,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                                 });
                             FixedSizeListArray::new(
                                 DataType::FixedSizeList(
-                                    Box::new(Field {
+                                    std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float32,
                                         is_nullable: false,
@@ -294,7 +294,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![
+                        DataType::Struct(std::sync::Arc::new(vec![
                             Field {
                                 name: "translation".to_owned(),
                                 data_type: <crate::datatypes::Vec3D>::arrow_datatype(),
@@ -313,7 +313,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                                 is_nullable: false,
                                 metadata: [].into(),
                             },
-                        ]),
+                        ])),
                         arrow_data.data_type().clone(),
                     )
                 })
@@ -344,7 +344,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
                                     DataType::FixedSizeList(
-                                        Box::new(Field {
+                                        std::sync::Arc::new(Field {
                                             name: "item".to_owned(),
                                             data_type: DataType::Float32,
                                             is_nullable: false,
@@ -430,7 +430,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
                                     DataType::FixedSizeList(
-                                        Box::new(Field {
+                                        std::sync::Arc::new(Field {
                                             name: "item".to_owned(),
                                             data_type: DataType::Float32,
                                             is_nullable: false,

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -72,7 +72,7 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "translation".to_owned(),
                 data_type: <crate::datatypes::Vec3D>::arrow_datatype(),
@@ -97,7 +97,7 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                 is_nullable: false,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -168,7 +168,7 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                                 });
                             FixedSizeListArray::new(
                                 DataType::FixedSizeList(
-                                    Box::new(Field {
+                                    std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float32,
                                         is_nullable: false,
@@ -283,7 +283,7 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![
+                        DataType::Struct(std::sync::Arc::new(vec![
                             Field {
                                 name: "translation".to_owned(),
                                 data_type: <crate::datatypes::Vec3D>::arrow_datatype(),
@@ -308,7 +308,7 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                                 is_nullable: false,
                                 metadata: [].into(),
                             },
-                        ]),
+                        ])),
                         arrow_data.data_type().clone(),
                     )
                 })
@@ -339,7 +339,7 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
                                     DataType::FixedSizeList(
-                                        Box::new(Field {
+                                        std::sync::Arc::new(Field {
                                             name: "item".to_owned(),
                                             data_type: DataType::Float32,
                                             is_nullable: false,

--- a/crates/re_types/src/datatypes/uuid.rs
+++ b/crates/re_types/src/datatypes/uuid.rs
@@ -68,10 +68,10 @@ impl ::re_types_core::Loggable for Uuid {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![Field {
+        DataType::Struct(std::sync::Arc::new(vec![Field {
             name: "bytes".to_owned(),
             data_type: DataType::FixedSizeList(
-                Box::new(Field {
+                std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::UInt8,
                     is_nullable: false,
@@ -81,7 +81,7 @@ impl ::re_types_core::Loggable for Uuid {
             ),
             is_nullable: false,
             metadata: [].into(),
-        }])
+        }]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -145,7 +145,7 @@ impl ::re_types_core::Loggable for Uuid {
                             });
                         FixedSizeListArray::new(
                             DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::UInt8,
                                     is_nullable: false,
@@ -188,10 +188,10 @@ impl ::re_types_core::Loggable for Uuid {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![Field {
+                        DataType::Struct(std::sync::Arc::new(vec![Field {
                             name: "bytes".to_owned(),
                             data_type: DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::UInt8,
                                     is_nullable: false,
@@ -201,7 +201,7 @@ impl ::re_types_core::Loggable for Uuid {
                             ),
                             is_nullable: false,
                             metadata: [].into(),
-                        }]),
+                        }])),
                         arrow_data.data_type().clone(),
                     )
                 })
@@ -232,7 +232,7 @@ impl ::re_types_core::Loggable for Uuid {
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
                                     DataType::FixedSizeList(
-                                        Box::new(Field {
+                                        std::sync::Arc::new(Field {
                                             name: "item".to_owned(),
                                             data_type: DataType::UInt8,
                                             is_nullable: false,

--- a/crates/re_types/src/datatypes/uvec2d.rs
+++ b/crates/re_types/src/datatypes/uvec2d.rs
@@ -67,7 +67,7 @@ impl ::re_types_core::Loggable for UVec2D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::UInt32,
                 is_nullable: false,
@@ -157,7 +157,7 @@ impl ::re_types_core::Loggable for UVec2D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::UInt32,
                                 is_nullable: false,

--- a/crates/re_types/src/datatypes/uvec3d.rs
+++ b/crates/re_types/src/datatypes/uvec3d.rs
@@ -67,7 +67,7 @@ impl ::re_types_core::Loggable for UVec3D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::UInt32,
                 is_nullable: false,
@@ -157,7 +157,7 @@ impl ::re_types_core::Loggable for UVec3D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::UInt32,
                                 is_nullable: false,

--- a/crates/re_types/src/datatypes/uvec4d.rs
+++ b/crates/re_types/src/datatypes/uvec4d.rs
@@ -67,7 +67,7 @@ impl ::re_types_core::Loggable for UVec4D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::UInt32,
                 is_nullable: false,
@@ -157,7 +157,7 @@ impl ::re_types_core::Loggable for UVec4D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::UInt32,
                                 is_nullable: false,

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -67,7 +67,7 @@ impl ::re_types_core::Loggable for Vec2D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::Float32,
                 is_nullable: false,
@@ -157,7 +157,7 @@ impl ::re_types_core::Loggable for Vec2D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::Float32,
                                 is_nullable: false,

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -67,7 +67,7 @@ impl ::re_types_core::Loggable for Vec3D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::Float32,
                 is_nullable: false,
@@ -157,7 +157,7 @@ impl ::re_types_core::Loggable for Vec3D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::Float32,
                                 is_nullable: false,

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -67,7 +67,7 @@ impl ::re_types_core::Loggable for Vec4D {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::FixedSizeList(
-            Box::new(Field {
+            std::sync::Arc::new(Field {
                 name: "item".to_owned(),
                 data_type: DataType::Float32,
                 is_nullable: false,
@@ -157,7 +157,7 @@ impl ::re_types_core::Loggable for Vec4D {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::FixedSizeList(
-                            Box::new(Field {
+                            std::sync::Arc::new(Field {
                                 name: "item".to_owned(),
                                 data_type: DataType::Float32,
                                 is_nullable: false,

--- a/crates/re_types/src/testing/components/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer1.rs
@@ -72,7 +72,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "single_float_optional".to_owned(),
                 data_type: DataType::Float32,
@@ -93,7 +93,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
             },
             Field {
                 name: "many_floats_optional".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float32,
                     is_nullable: false,
@@ -104,7 +104,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
             },
             Field {
                 name: "many_strings_required".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
@@ -115,7 +115,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
             },
             Field {
                 name: "many_strings_optional".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
@@ -142,7 +142,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                 is_nullable: true,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer11.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer11.rs
@@ -64,7 +64,7 @@ impl ::re_types_core::Loggable for AffixFuzzer11 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: DataType::Float32,
             is_nullable: false,
@@ -144,7 +144,7 @@ impl ::re_types_core::Loggable for AffixFuzzer11 {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: DataType::Float32,
                             is_nullable: false,

--- a/crates/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer12.rs
@@ -64,7 +64,7 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: DataType::Utf8,
             is_nullable: false,
@@ -164,7 +164,7 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: DataType::Utf8,
                             is_nullable: false,

--- a/crates/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer13.rs
@@ -64,7 +64,7 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: DataType::Utf8,
             is_nullable: false,
@@ -166,7 +166,7 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: DataType::Utf8,
                             is_nullable: false,

--- a/crates/re_types/src/testing/components/affix_fuzzer14.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer14.rs
@@ -73,7 +73,7 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::Union(
-            vec![
+            std::sync::Arc::new(vec![
                 Field {
                     name: "_null_markers".to_owned(),
                     data_type: DataType::Null,
@@ -94,7 +94,7 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
                 },
                 Field {
                     name: "craziness".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: <crate::testing::datatypes::AffixFuzzer1>::arrow_datatype(),
                         is_nullable: false,
@@ -106,7 +106,7 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
                 Field {
                     name: "fixed_size_shenanigans".to_owned(),
                     data_type: DataType::FixedSizeList(
-                        Box::new(Field {
+                        std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: DataType::Float32,
                             is_nullable: false,
@@ -117,8 +117,8 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
                     is_nullable: false,
                     metadata: [].into(),
                 },
-            ],
-            Some(vec![0i32, 1i32, 2i32, 3i32, 4i32]),
+            ]),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32, 3i32, 4i32])),
             UnionMode::Dense,
         )
     }

--- a/crates/re_types/src/testing/components/affix_fuzzer15.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer15.rs
@@ -73,7 +73,7 @@ impl ::re_types_core::Loggable for AffixFuzzer15 {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::Union(
-            vec![
+            std::sync::Arc::new(vec![
                 Field {
                     name: "_null_markers".to_owned(),
                     data_type: DataType::Null,
@@ -94,7 +94,7 @@ impl ::re_types_core::Loggable for AffixFuzzer15 {
                 },
                 Field {
                     name: "craziness".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: <crate::testing::datatypes::AffixFuzzer1>::arrow_datatype(),
                         is_nullable: false,
@@ -106,7 +106,7 @@ impl ::re_types_core::Loggable for AffixFuzzer15 {
                 Field {
                     name: "fixed_size_shenanigans".to_owned(),
                     data_type: DataType::FixedSizeList(
-                        Box::new(Field {
+                        std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: DataType::Float32,
                             is_nullable: false,
@@ -117,8 +117,8 @@ impl ::re_types_core::Loggable for AffixFuzzer15 {
                     is_nullable: false,
                     metadata: [].into(),
                 },
-            ],
-            Some(vec![0i32, 1i32, 2i32, 3i32, 4i32]),
+            ]),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32, 3i32, 4i32])),
             UnionMode::Dense,
         )
     }

--- a/crates/re_types/src/testing/components/affix_fuzzer16.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer16.rs
@@ -58,7 +58,7 @@ impl ::re_types_core::Loggable for AffixFuzzer16 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
             is_nullable: false,
@@ -137,7 +137,7 @@ impl ::re_types_core::Loggable for AffixFuzzer16 {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
                             is_nullable: false,

--- a/crates/re_types/src/testing/components/affix_fuzzer17.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer17.rs
@@ -58,7 +58,7 @@ impl ::re_types_core::Loggable for AffixFuzzer17 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
             is_nullable: false,
@@ -139,7 +139,7 @@ impl ::re_types_core::Loggable for AffixFuzzer17 {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
                             is_nullable: false,

--- a/crates/re_types/src/testing/components/affix_fuzzer18.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer18.rs
@@ -58,7 +58,7 @@ impl ::re_types_core::Loggable for AffixFuzzer18 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: <crate::testing::datatypes::AffixFuzzer4>::arrow_datatype(),
             is_nullable: false,
@@ -139,7 +139,7 @@ impl ::re_types_core::Loggable for AffixFuzzer18 {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: <crate::testing::datatypes::AffixFuzzer4>::arrow_datatype(),
                             is_nullable: false,

--- a/crates/re_types/src/testing/components/affix_fuzzer19.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer19.rs
@@ -72,12 +72,12 @@ impl ::re_types_core::Loggable for AffixFuzzer19 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![Field {
+        DataType::Struct(std::sync::Arc::new(vec![Field {
             name: "single_optional_union".to_owned(),
             data_type: <crate::testing::datatypes::AffixFuzzer4>::arrow_datatype(),
             is_nullable: true,
             metadata: [].into(),
-        }])
+        }]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer2.rs
@@ -72,7 +72,7 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "single_float_optional".to_owned(),
                 data_type: DataType::Float32,
@@ -93,7 +93,7 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
             },
             Field {
                 name: "many_floats_optional".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float32,
                     is_nullable: false,
@@ -104,7 +104,7 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
             },
             Field {
                 name: "many_strings_required".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
@@ -115,7 +115,7 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
             },
             Field {
                 name: "many_strings_optional".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
@@ -142,7 +142,7 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
                 is_nullable: true,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer20.rs
@@ -72,7 +72,7 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "p".to_owned(),
                 data_type: <crate::testing::datatypes::PrimitiveComponent>::arrow_datatype(),
@@ -85,7 +85,7 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
                 is_nullable: false,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer21.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer21.rs
@@ -72,7 +72,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "single_half".to_owned(),
                 data_type: DataType::Float16,
@@ -81,7 +81,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
             },
             Field {
                 name: "many_halves".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float16,
                     is_nullable: false,
@@ -90,7 +90,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                 is_nullable: false,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer22.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer22.rs
@@ -72,10 +72,10 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![Field {
+        DataType::Struct(std::sync::Arc::new(vec![Field {
             name: "fixed_sized_native".to_owned(),
             data_type: DataType::FixedSizeList(
-                Box::new(Field {
+                std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::UInt8,
                     is_nullable: false,
@@ -85,7 +85,7 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
             ),
             is_nullable: false,
             metadata: [].into(),
-        }])
+        }]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer3.rs
@@ -72,7 +72,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "single_float_optional".to_owned(),
                 data_type: DataType::Float32,
@@ -93,7 +93,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
             },
             Field {
                 name: "many_floats_optional".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float32,
                     is_nullable: false,
@@ -104,7 +104,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
             },
             Field {
                 name: "many_strings_required".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
@@ -115,7 +115,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
             },
             Field {
                 name: "many_strings_optional".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
@@ -142,7 +142,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                 is_nullable: true,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer4.rs
@@ -72,7 +72,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "single_float_optional".to_owned(),
                 data_type: DataType::Float32,
@@ -93,7 +93,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
             },
             Field {
                 name: "many_floats_optional".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float32,
                     is_nullable: false,
@@ -104,7 +104,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
             },
             Field {
                 name: "many_strings_required".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
@@ -115,7 +115,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
             },
             Field {
                 name: "many_strings_optional".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
@@ -142,7 +142,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                 is_nullable: true,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer5.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer5.rs
@@ -72,7 +72,7 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "single_float_optional".to_owned(),
                 data_type: DataType::Float32,
@@ -93,7 +93,7 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
             },
             Field {
                 name: "many_floats_optional".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float32,
                     is_nullable: false,
@@ -104,7 +104,7 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
             },
             Field {
                 name: "many_strings_required".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
@@ -115,7 +115,7 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
             },
             Field {
                 name: "many_strings_optional".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
@@ -142,7 +142,7 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
                 is_nullable: true,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer6.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer6.rs
@@ -72,7 +72,7 @@ impl ::re_types_core::Loggable for AffixFuzzer6 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "single_float_optional".to_owned(),
                 data_type: DataType::Float32,
@@ -93,7 +93,7 @@ impl ::re_types_core::Loggable for AffixFuzzer6 {
             },
             Field {
                 name: "many_floats_optional".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float32,
                     is_nullable: false,
@@ -104,7 +104,7 @@ impl ::re_types_core::Loggable for AffixFuzzer6 {
             },
             Field {
                 name: "many_strings_required".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
@@ -115,7 +115,7 @@ impl ::re_types_core::Loggable for AffixFuzzer6 {
             },
             Field {
                 name: "many_strings_optional".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
@@ -142,7 +142,7 @@ impl ::re_types_core::Loggable for AffixFuzzer6 {
                 is_nullable: true,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer7.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer7.rs
@@ -58,7 +58,7 @@ impl ::re_types_core::Loggable for AffixFuzzer7 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: <crate::testing::datatypes::AffixFuzzer1>::arrow_datatype(),
             is_nullable: false,
@@ -139,7 +139,7 @@ impl ::re_types_core::Loggable for AffixFuzzer7 {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: <crate::testing::datatypes::AffixFuzzer1>::arrow_datatype(),
                             is_nullable: false,

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -76,7 +76,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "single_float_optional".to_owned(),
                 data_type: DataType::Float32,
@@ -97,7 +97,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
             },
             Field {
                 name: "many_floats_optional".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float32,
                     is_nullable: false,
@@ -108,7 +108,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
             },
             Field {
                 name: "many_strings_required".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
@@ -119,7 +119,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
             },
             Field {
                 name: "many_strings_optional".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Utf8,
                     is_nullable: false,
@@ -146,7 +146,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                 is_nullable: true,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -335,7 +335,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: false,
@@ -390,7 +390,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Utf8,
                                     is_nullable: false,
@@ -469,7 +469,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Utf8,
                                     is_nullable: false,
@@ -610,7 +610,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![
+                        DataType::Struct(std::sync::Arc::new(vec![
                             Field {
                                 name: "single_float_optional".to_owned(),
                                 data_type: DataType::Float32,
@@ -631,7 +631,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             },
                             Field {
                                 name: "many_floats_optional".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
+                                data_type: DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float32,
                                     is_nullable: false,
@@ -642,7 +642,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             },
                             Field {
                                 name: "many_strings_required".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
+                                data_type: DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Utf8,
                                     is_nullable: false,
@@ -653,7 +653,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             },
                             Field {
                                 name: "many_strings_optional".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
+                                data_type: DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Utf8,
                                     is_nullable: false,
@@ -681,7 +681,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 is_nullable: true,
                                 metadata: [].into(),
                             },
-                        ]),
+                        ])),
                         arrow_data.data_type().clone(),
                     )
                 })
@@ -849,7 +849,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float32,
                                         is_nullable: false,
@@ -926,7 +926,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Utf8,
                                         is_nullable: false,
@@ -1048,7 +1048,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Utf8,
                                         is_nullable: false,

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
@@ -54,7 +54,7 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "p".to_owned(),
                 data_type: <crate::testing::datatypes::PrimitiveComponent>::arrow_datatype(),
@@ -67,7 +67,7 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
                 is_nullable: false,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -200,15 +200,15 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
                     .downcast_ref::<arrow2::array::StructArray>()
                     .ok_or_else(|| {
                         DeserializationError::datatype_mismatch(
-                            DataType::Struct(vec![
-                            Field { name : "p".to_owned(), data_type : < crate
-                            ::testing::datatypes::PrimitiveComponent >
-                            ::arrow_datatype(), is_nullable : false, metadata : []
-                            .into(), }, Field { name : "s".to_owned(), data_type : <
-                            crate ::testing::datatypes::StringComponent >
-                            ::arrow_datatype(), is_nullable : false, metadata : []
-                            .into(), },
-                        ]),
+                            DataType::Struct(std::sync::Arc::new(vec![
+                                Field { name : "p".to_owned(), data_type : < crate
+                                ::testing::datatypes::PrimitiveComponent >
+                                ::arrow_datatype(), is_nullable : false, metadata : []
+                                .into(), }, Field { name : "s".to_owned(), data_type : <
+                                crate ::testing::datatypes::StringComponent >
+                                ::arrow_datatype(), is_nullable : false, metadata : []
+                                .into(), },
+                            ])),
                             arrow_data.data_type().clone(),
                         )
                     })

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer21.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer21.rs
@@ -54,7 +54,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![
+        DataType::Struct(std::sync::Arc::new(vec![
             Field {
                 name: "single_half".to_owned(),
                 data_type: DataType::Float16,
@@ -63,7 +63,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
             },
             Field {
                 name: "many_halves".to_owned(),
-                data_type: DataType::List(Box::new(Field {
+                data_type: DataType::List(std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::Float16,
                     is_nullable: false,
@@ -72,7 +72,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                 is_nullable: false,
                 metadata: [].into(),
             },
-        ])
+        ]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -159,7 +159,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float16,
                                     is_nullable: false,
@@ -199,7 +199,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![
+                        DataType::Struct(std::sync::Arc::new(vec![
                             Field {
                                 name: "single_half".to_owned(),
                                 data_type: DataType::Float16,
@@ -208,7 +208,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                             },
                             Field {
                                 name: "many_halves".to_owned(),
-                                data_type: DataType::List(Box::new(Field {
+                                data_type: DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::Float16,
                                     is_nullable: false,
@@ -217,7 +217,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                                 is_nullable: false,
                                 metadata: [].into(),
                             },
-                        ]),
+                        ])),
                         arrow_data.data_type().clone(),
                     )
                 })
@@ -269,7 +269,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
-                                    DataType::List(Box::new(Field {
+                                    DataType::List(std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float16,
                                         is_nullable: false,

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer22.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer22.rs
@@ -66,10 +66,10 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![Field {
+        DataType::Struct(std::sync::Arc::new(vec![Field {
             name: "fixed_sized_native".to_owned(),
             data_type: DataType::FixedSizeList(
-                Box::new(Field {
+                std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::UInt8,
                     is_nullable: false,
@@ -79,7 +79,7 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
             ),
             is_nullable: false,
             metadata: [].into(),
-        }])
+        }]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -145,7 +145,7 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
                             });
                         FixedSizeListArray::new(
                             DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::UInt8,
                                     is_nullable: false,
@@ -188,10 +188,10 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![Field {
+                        DataType::Struct(std::sync::Arc::new(vec![Field {
                             name: "fixed_sized_native".to_owned(),
                             data_type: DataType::FixedSizeList(
-                                Box::new(Field {
+                                std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type: DataType::UInt8,
                                     is_nullable: false,
@@ -201,7 +201,7 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
                             ),
                             is_nullable: false,
                             metadata: [].into(),
-                        }]),
+                        }])),
                         arrow_data.data_type().clone(),
                     )
                 })
@@ -232,7 +232,7 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
                             .ok_or_else(|| {
                                 DeserializationError::datatype_mismatch(
                                     DataType::FixedSizeList(
-                                        Box::new(Field {
+                                        std::sync::Arc::new(Field {
                                             name: "item".to_owned(),
                                             data_type: DataType::UInt8,
                                             is_nullable: false,

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -65,7 +65,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::Union(
-            vec![
+            std::sync::Arc::new(vec![
                 Field {
                     name: "_null_markers".to_owned(),
                     data_type: DataType::Null,
@@ -86,7 +86,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                 },
                 Field {
                     name: "craziness".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: <crate::testing::datatypes::AffixFuzzer1>::arrow_datatype(),
                         is_nullable: false,
@@ -98,7 +98,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                 Field {
                     name: "fixed_size_shenanigans".to_owned(),
                     data_type: DataType::FixedSizeList(
-                        Box::new(Field {
+                        std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: DataType::Float32,
                             is_nullable: false,
@@ -109,8 +109,8 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                     is_nullable: false,
                     metadata: [].into(),
                 },
-            ],
-            Some(vec![0i32, 1i32, 2i32, 3i32, 4i32]),
+            ]),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32, 3i32, 4i32])),
             UnionMode::Dense,
         )
     }
@@ -233,7 +233,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type:
                                         <crate::testing::datatypes::AffixFuzzer1>::arrow_datatype(),
@@ -297,7 +297,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                             });
                             FixedSizeListArray::new(
                                 DataType::FixedSizeList(
-                                    Box::new(Field {
+                                    std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float32,
                                         is_nullable: false,
@@ -377,25 +377,26 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::Union(
-                            vec![
-                            Field { name : "_null_markers".to_owned(), data_type :
-                            DataType::Null, is_nullable : true, metadata : [].into(), },
-                            Field { name : "degrees".to_owned(), data_type :
-                            DataType::Float32, is_nullable : false, metadata : [].into(),
-                            }, Field { name : "radians".to_owned(), data_type :
-                            DataType::Float32, is_nullable : false, metadata : [].into(),
-                            }, Field { name : "craziness".to_owned(), data_type :
-                            DataType::List(Box::new(Field { name : "item".to_owned(),
-                            data_type : < crate ::testing::datatypes::AffixFuzzer1 >
-                            ::arrow_datatype(), is_nullable : false, metadata : []
-                            .into(), })), is_nullable : false, metadata : [].into(), },
-                            Field { name : "fixed_size_shenanigans".to_owned(), data_type
-                            : DataType::FixedSizeList(Box::new(Field { name : "item"
-                            .to_owned(), data_type : DataType::Float32, is_nullable :
-                            false, metadata : [].into(), }), 3usize), is_nullable :
-                            false, metadata : [].into(), },
-                        ],
-                            Some(vec![0i32, 1i32, 2i32, 3i32, 4i32]),
+                            std::sync::Arc::new(vec![
+                                Field { name : "_null_markers".to_owned(), data_type :
+                                DataType::Null, is_nullable : true, metadata : [].into(), },
+                                Field { name : "degrees".to_owned(), data_type :
+                                DataType::Float32, is_nullable : false, metadata : []
+                                .into(), }, Field { name : "radians".to_owned(), data_type :
+                                DataType::Float32, is_nullable : false, metadata : []
+                                .into(), }, Field { name : "craziness".to_owned(), data_type
+                                : DataType::List(std::sync::Arc::new(Field { name : "item"
+                                .to_owned(), data_type : < crate
+                                ::testing::datatypes::AffixFuzzer1 > ::arrow_datatype(),
+                                is_nullable : false, metadata : [].into(), })), is_nullable
+                                : false, metadata : [].into(), }, Field { name :
+                                "fixed_size_shenanigans".to_owned(), data_type :
+                                DataType::FixedSizeList(std::sync::Arc::new(Field { name :
+                                "item".to_owned(), data_type : DataType::Float32,
+                                is_nullable : false, metadata : [].into(), }), 3usize),
+                                is_nullable : false, metadata : [].into(), },
+                            ]),
+                            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32, 3i32, 4i32])),
                             UnionMode::Dense,
                         ),
                         arrow_data.data_type().clone(),
@@ -472,7 +473,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| DeserializationError::datatype_mismatch(
                                 DataType::List(
-                                    Box::new(Field {
+                                    std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: <crate::testing::datatypes::AffixFuzzer1>::arrow_datatype(),
                                         is_nullable: false,
@@ -547,7 +548,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                             .downcast_ref::<arrow2::array::FixedSizeListArray>()
                             .ok_or_else(|| DeserializationError::datatype_mismatch(
                                 DataType::FixedSizeList(
-                                    Box::new(Field {
+                                    std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: DataType::Float32,
                                         is_nullable: false,

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer4.rs
@@ -62,7 +62,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
         DataType::Union(
-            vec![
+            std::sync::Arc::new(vec![
                 Field {
                     name: "_null_markers".to_owned(),
                     data_type: DataType::Null,
@@ -77,7 +77,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                 },
                 Field {
                     name: "many_required".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
                         is_nullable: false,
@@ -88,7 +88,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                 },
                 Field {
                     name: "many_optional".to_owned(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: "item".to_owned(),
                         data_type: <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
                         is_nullable: false,
@@ -97,8 +97,8 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                     is_nullable: false,
                     metadata: [].into(),
                 },
-            ],
-            Some(vec![0i32, 1i32, 2i32, 3i32]),
+            ]),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32, 3i32])),
             UnionMode::Dense,
         )
     }
@@ -192,7 +192,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type:
                                         <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
@@ -248,7 +248,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                             .unwrap()
                             .into();
                             ListArray::new(
-                                DataType::List(Box::new(Field {
+                                DataType::List(std::sync::Arc::new(Field {
                                     name: "item".to_owned(),
                                     data_type:
                                         <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
@@ -319,25 +319,26 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
                         DataType::Union(
-                            vec![
-                            Field { name : "_null_markers".to_owned(), data_type :
-                            DataType::Null, is_nullable : true, metadata : [].into(), },
-                            Field { name : "single_required".to_owned(), data_type : <
-                            crate ::testing::datatypes::AffixFuzzer3 >
-                            ::arrow_datatype(), is_nullable : false, metadata : []
-                            .into(), }, Field { name : "many_required".to_owned(),
-                            data_type : DataType::List(Box::new(Field { name : "item"
-                            .to_owned(), data_type : < crate
-                            ::testing::datatypes::AffixFuzzer3 > ::arrow_datatype(),
-                            is_nullable : false, metadata : [].into(), })), is_nullable :
-                            false, metadata : [].into(), }, Field { name :
-                            "many_optional".to_owned(), data_type :
-                            DataType::List(Box::new(Field { name : "item".to_owned(),
-                            data_type : < crate ::testing::datatypes::AffixFuzzer3 >
-                            ::arrow_datatype(), is_nullable : false, metadata : []
-                            .into(), })), is_nullable : false, metadata : [].into(), },
-                        ],
-                            Some(vec![0i32, 1i32, 2i32, 3i32]),
+                            std::sync::Arc::new(vec![
+                                Field { name : "_null_markers".to_owned(), data_type :
+                                DataType::Null, is_nullable : true, metadata : [].into(), },
+                                Field { name : "single_required".to_owned(), data_type : <
+                                crate ::testing::datatypes::AffixFuzzer3 >
+                                ::arrow_datatype(), is_nullable : false, metadata : []
+                                .into(), }, Field { name : "many_required".to_owned(),
+                                data_type : DataType::List(std::sync::Arc::new(Field { name
+                                : "item".to_owned(), data_type : < crate
+                                ::testing::datatypes::AffixFuzzer3 > ::arrow_datatype(),
+                                is_nullable : false, metadata : [].into(), })), is_nullable
+                                : false, metadata : [].into(), }, Field { name :
+                                "many_optional".to_owned(), data_type :
+                                DataType::List(std::sync::Arc::new(Field { name : "item"
+                                .to_owned(), data_type : < crate
+                                ::testing::datatypes::AffixFuzzer3 > ::arrow_datatype(),
+                                is_nullable : false, metadata : [].into(), })), is_nullable
+                                : false, metadata : [].into(), },
+                            ]),
+                            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32, 3i32])),
                             UnionMode::Dense,
                         ),
                         arrow_data.data_type().clone(),
@@ -386,7 +387,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| DeserializationError::datatype_mismatch(
                                 DataType::List(
-                                    Box::new(Field {
+                                    std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
                                         is_nullable: false,
@@ -461,7 +462,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                             .downcast_ref::<arrow2::array::ListArray<i32>>()
                             .ok_or_else(|| DeserializationError::datatype_mismatch(
                                 DataType::List(
-                                    Box::new(Field {
+                                    std::sync::Arc::new(Field {
                                         name: "item".to_owned(),
                                         data_type: <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
                                         is_nullable: false,

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer5.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer5.rs
@@ -76,12 +76,12 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![Field {
+        DataType::Struct(std::sync::Arc::new(vec![Field {
             name: "single_optional_union".to_owned(),
             data_type: <crate::testing::datatypes::AffixFuzzer4>::arrow_datatype(),
             is_nullable: true,
             metadata: [].into(),
-        }])
+        }]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -156,12 +156,12 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![Field {
+                        DataType::Struct(std::sync::Arc::new(vec![Field {
                             name: "single_optional_union".to_owned(),
                             data_type: <crate::testing::datatypes::AffixFuzzer4>::arrow_datatype(),
                             is_nullable: true,
                             metadata: [].into(),
-                        }]),
+                        }])),
                         arrow_data.data_type().clone(),
                     )
                 })

--- a/crates/re_types/src/testing/datatypes/flattened_scalar.rs
+++ b/crates/re_types/src/testing/datatypes/flattened_scalar.rs
@@ -66,12 +66,12 @@ impl ::re_types_core::Loggable for FlattenedScalar {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![Field {
+        DataType::Struct(std::sync::Arc::new(vec![Field {
             name: "value".to_owned(),
             data_type: DataType::Float32,
             is_nullable: false,
             metadata: [].into(),
-        }])
+        }]))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -140,12 +140,12 @@ impl ::re_types_core::Loggable for FlattenedScalar {
                 .downcast_ref::<arrow2::array::StructArray>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::Struct(vec![Field {
+                        DataType::Struct(std::sync::Arc::new(vec![Field {
                             name: "value".to_owned(),
                             data_type: DataType::Float32,
                             is_nullable: false,
                             metadata: [].into(),
-                        }]),
+                        }])),
                         arrow_data.data_type().clone(),
                     )
                 })

--- a/crates/re_types/tests/util.rs
+++ b/crates/re_types/tests/util.rs
@@ -14,7 +14,7 @@ pub fn extract_extensions(datatype: &::arrow2::datatypes::DataType, acc: &mut Ve
             extract_extensions(field.data_type(), acc);
         }
         arrow2::datatypes::DataType::Struct(fields) => {
-            for field in fields {
+            for field in fields.iter() {
                 extract_extensions(field.data_type(), acc);
             }
         }

--- a/crates/re_types_builder/src/codegen/rust/arrow.rs
+++ b/crates/re_types_builder/src/codegen/rust/arrow.rs
@@ -32,12 +32,12 @@ impl quote::ToTokens for ArrowDataTypeTokenizer<'_> {
 
             DataType::List(field) => {
                 let field = ArrowFieldTokenizer(field);
-                quote!(DataType::List(Box::new(#field)))
+                quote!(DataType::List(std::sync::Arc::new(#field)))
             }
 
             DataType::FixedSizeList(field, length) => {
                 let field = ArrowFieldTokenizer(field);
-                quote!(DataType::FixedSizeList(Box::new(#field), #length))
+                quote!(DataType::FixedSizeList(std::sync::Arc::new(#field), #length))
             }
 
             DataType::Union(fields, types, mode) => {
@@ -47,15 +47,19 @@ impl quote::ToTokens for ArrowDataTypeTokenizer<'_> {
                     UnionMode::Sparse => quote!(UnionMode::Sparse),
                 };
                 if let Some(types) = types {
-                    quote!(DataType::Union(vec![ #(#fields,)* ], Some(vec![ #(#types,)* ]), #mode))
+                    quote!(DataType::Union(
+                        std::sync::Arc::new(vec![ #(#fields,)* ]),
+                        Some(std::sync::Arc::new(vec![ #(#types,)* ])),
+                        #mode,
+                    ))
                 } else {
-                    quote!(DataType::Union(vec![ #(#fields,)* ], None, #mode))
+                    quote!(DataType::Union(std::sync::Arc::new(vec![ #(#fields,)* ]), None, #mode))
                 }
             }
 
             DataType::Struct(fields) => {
                 let fields = fields.iter().map(ArrowFieldTokenizer);
-                quote!(DataType::Struct(vec![ #(#fields,)* ]))
+                quote!(DataType::Struct(std::sync::Arc::new(vec![ #(#fields,)* ])))
             }
 
             DataType::Extension(fqname, datatype, _metadata) => {

--- a/crates/re_types_core/src/archetype.rs
+++ b/crates/re_types_core/src/archetype.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     ComponentBatch, ComponentName, DeserializationResult, MaybeOwnedComponentBatch,
     SerializationResult, _Backtrace,
@@ -216,7 +218,7 @@ impl<A: Archetype> crate::LoggableBatch for GenericIndicatorComponent<A> {
             name.clone(),
             arrow2::datatypes::DataType::Extension(
                 name,
-                Box::new(arrow2::datatypes::DataType::Null),
+                Arc::new(arrow2::datatypes::DataType::Null),
                 None,
             ),
             false,
@@ -274,7 +276,7 @@ impl crate::LoggableBatch for NamedIndicatorComponent {
             name.clone(),
             arrow2::datatypes::DataType::Extension(
                 name,
-                Box::new(arrow2::datatypes::DataType::Null),
+                Arc::new(arrow2::datatypes::DataType::Null),
                 None,
             ),
             false,

--- a/crates/re_types_core/src/loggable.rs
+++ b/crates/re_types_core/src/loggable.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     result::_Backtrace, DeserializationResult, ResultExt as _, SerializationResult, SizeBytes,
 };
@@ -51,7 +53,7 @@ pub trait Loggable: Clone + Sized + SizeBytes {
     fn extended_arrow_datatype() -> arrow2::datatypes::DataType {
         arrow2::datatypes::DataType::Extension(
             Self::name().to_string(),
-            Box::new(Self::arrow_datatype()),
+            Arc::new(Self::arrow_datatype()),
             None,
         )
     }

--- a/crates/re_types_core/src/tuid.rs
+++ b/crates/re_types_core/src/tuid.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{DeserializationError, Loggable, SizeBytes};
 use arrow2::{
     array::{StructArray, UInt64Array},
@@ -25,10 +27,10 @@ impl Loggable for Tuid {
 
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        DataType::Struct(vec![
+        DataType::Struct(Arc::new(vec![
             Field::new("time_ns", DataType::UInt64, false),
             Field::new("inc", DataType::UInt64, false),
-        ])
+        ]))
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_viewport/src/blueprint/components/included_space_views.rs
+++ b/crates/re_viewport/src/blueprint/components/included_space_views.rs
@@ -60,7 +60,7 @@ impl ::re_types_core::Loggable for IncludedSpaceViews {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: <crate::datatypes::Uuid>::arrow_datatype(),
             is_nullable: false,
@@ -139,7 +139,7 @@ impl ::re_types_core::Loggable for IncludedSpaceViews {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: <crate::datatypes::Uuid>::arrow_datatype(),
                             is_nullable: false,

--- a/crates/re_viewport/src/blueprint/components/root_container.rs
+++ b/crates/re_viewport/src/blueprint/components/root_container.rs
@@ -76,10 +76,10 @@ impl ::re_types_core::Loggable for RootContainer {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![Field {
+        DataType::Struct(std::sync::Arc::new(vec![Field {
             name: "bytes".to_owned(),
             data_type: DataType::FixedSizeList(
-                Box::new(Field {
+                std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::UInt8,
                     is_nullable: false,
@@ -89,7 +89,7 @@ impl ::re_types_core::Loggable for RootContainer {
             ),
             is_nullable: false,
             metadata: [].into(),
-        }])
+        }]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_viewport/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_viewport/src/blueprint/components/space_view_maximized.rs
@@ -76,10 +76,10 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::Struct(vec![Field {
+        DataType::Struct(std::sync::Arc::new(vec![Field {
             name: "bytes".to_owned(),
             data_type: DataType::FixedSizeList(
-                Box::new(Field {
+                std::sync::Arc::new(Field {
                     name: "item".to_owned(),
                     data_type: DataType::UInt8,
                     is_nullable: false,
@@ -89,7 +89,7 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
             ),
             is_nullable: false,
             metadata: [].into(),
-        }])
+        }]))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_viewport/src/blueprint/components/viewport_layout.rs
+++ b/crates/re_viewport/src/blueprint/components/viewport_layout.rs
@@ -55,7 +55,7 @@ impl ::re_types_core::Loggable for ViewportLayout {
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::*;
-        DataType::List(Box::new(Field {
+        DataType::List(std::sync::Arc::new(Field {
             name: "item".to_owned(),
             data_type: DataType::UInt8,
             is_nullable: false,
@@ -146,7 +146,7 @@ impl ::re_types_core::Loggable for ViewportLayout {
                 .downcast_ref::<arrow2::array::ListArray<i32>>()
                 .ok_or_else(|| {
                     DeserializationError::datatype_mismatch(
-                        DataType::List(Box::new(Field {
+                        DataType::List(std::sync::Arc::new(Field {
                             name: "item".to_owned(),
                             data_type: DataType::UInt8,
                             is_nullable: false,


### PR DESCRIPTION
Grunt work to switch to `re_arrow2` and all the breaking changes that come with it.

- Fixes #4789

---

Part of the tiny datatype deduplication PR series:
- #4880
- #4883 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4883/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4883/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4883/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4883)
- [Docs preview](https://rerun.io/preview/83b8817bf331740f17cb1f0bcf4308d25cb2f05b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/83b8817bf331740f17cb1f0bcf4308d25cb2f05b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)