### PR TITLE
Primary cache: don't denormalize defaulted component values

### DIFF
--- a/crates/re_data_store/benches/data_store.rs
+++ b/crates/re_data_store/benches/data_store.rs
@@ -1,7 +1,7 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use arrow2::array::{Array as _, StructArray, UnionArray};
+use arrow2::array::{Array as _, StructArray};
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use re_data_store::{
@@ -312,7 +312,7 @@ fn range(c: &mut Criterion) {
                             .unwrap()
                             .as_arrow_ref()
                             .as_any()
-                            .downcast_ref::<UnionArray>()
+                            .downcast_ref::<StructArray>()
                             .unwrap();
                         assert_eq!(NUM_INSTANCES as usize, large_structs.len());
                     }

--- a/crates/re_query_cache/benches/latest_at.rs
+++ b/crates/re_query_cache/benches/latest_at.rs
@@ -292,12 +292,14 @@ fn query_and_visit_points(
                 &query.clone().into(),
                 path,
                 |(_, _, positions, colors)| {
-                    itertools::izip!(positions.iter(), colors.iter()).for_each(|(pos, color)| {
-                        points.push(SavePoint {
-                            _pos: *pos,
-                            _color: *color,
-                        });
-                    });
+                    itertools::izip!(positions.iter(), colors.unwrap().iter()).for_each(
+                        |(pos, color)| {
+                            points.push(SavePoint {
+                                _pos: *pos,
+                                _color: *color,
+                            });
+                        },
+                    );
                 },
             )
             .unwrap();
@@ -328,7 +330,7 @@ fn query_and_visit_strings(
                 &query.clone().into(),
                 path,
                 |(_, _, _, labels)| {
-                    for label in labels.iter() {
+                    for label in labels.unwrap().iter() {
                         strings.push(SaveString {
                             _label: label.clone(),
                         });

--- a/crates/re_query_cache/src/latest_at.rs
+++ b/crates/re_query_cache/src/latest_at.rs
@@ -125,7 +125,7 @@ macro_rules! impl_query_archetype_latest_at {
                     (Option<TimeInt>, RowId),
                     MaybeCachedComponentData<'_, InstanceKey>,
                     $(MaybeCachedComponentData<'_, $pov>,)+
-                    $(MaybeCachedComponentData<'_, Option<$comp>>,)*
+                    $(Option<MaybeCachedComponentData<'_, Option<$comp>>>,)*
                 ),
             ),
         {
@@ -144,7 +144,7 @@ macro_rules! impl_query_archetype_latest_at {
                         ((!timeless).then_some(*time), *row_id),
                         MaybeCachedComponentData::Cached(instance_keys),
                         $(MaybeCachedComponentData::Cached($pov),)+
-                        $(MaybeCachedComponentData::Cached($comp),)*
+                        $((!$comp.is_empty()).then_some(MaybeCachedComponentData::Cached($comp)),)*
                     )
                 });
 

--- a/crates/re_query_cache/src/range.rs
+++ b/crates/re_query_cache/src/range.rs
@@ -136,7 +136,7 @@ macro_rules! impl_query_archetype_range {
                     (Option<TimeInt>, RowId),
                     MaybeCachedComponentData<'_, InstanceKey>,
                     $(MaybeCachedComponentData<'_, $pov>,)+
-                    $(MaybeCachedComponentData<'_, Option<$comp>>,)*
+                    $(Option<MaybeCachedComponentData<'_, Option<$comp>>>,)*
                 ),
             ),
         {
@@ -158,7 +158,7 @@ macro_rules! impl_query_archetype_range {
                         ((!timeless).then_some(*time), *row_id),
                         MaybeCachedComponentData::Cached(instance_keys),
                         $(MaybeCachedComponentData::Cached($pov),)+
-                        $(MaybeCachedComponentData::Cached($comp),)*
+                        $((!$comp.is_empty()).then_some(MaybeCachedComponentData::Cached($comp)),)*
                     )
                 });
 

--- a/crates/re_query_cache/tests/latest_at.rs
+++ b/crates/re_query_cache/tests/latest_at.rs
@@ -10,7 +10,7 @@ use re_log_types::{
     example_components::{MyColor, MyPoint, MyPoints},
     DataRow, EntityPath, RowId, TimePoint,
 };
-use re_query_cache::Caches;
+use re_query_cache::{Caches, MaybeCachedComponentData};
 use re_types_core::{components::InstanceKey, Loggable as _};
 
 // ---
@@ -463,7 +463,10 @@ fn query_and_compare(
                     uncached_data_time = data_time;
                     uncached_instance_keys.extend(instance_keys.iter().copied());
                     uncached_positions.extend(positions.iter().copied());
-                    uncached_colors.extend(colors.iter().copied());
+                    uncached_colors.extend(MaybeCachedComponentData::iter_or_repeat_opt(
+                        &colors,
+                        positions.len(),
+                    ));
                 },
             )
             .unwrap();
@@ -482,7 +485,10 @@ fn query_and_compare(
                     cached_data_time = data_time;
                     cached_instance_keys.extend(instance_keys.iter().copied());
                     cached_positions.extend(positions.iter().copied());
-                    cached_colors.extend(colors.iter().copied());
+                    cached_colors.extend(MaybeCachedComponentData::iter_or_repeat_opt(
+                        &colors,
+                        positions.len(),
+                    ));
                 },
             )
             .unwrap();

--- a/crates/re_query_cache/tests/range.rs
+++ b/crates/re_query_cache/tests/range.rs
@@ -10,7 +10,7 @@ use re_log_types::{
     example_components::{MyColor, MyLabel, MyPoint, MyPoints},
     DataRow, EntityPath, RowId, TimeInt, TimePoint, TimeRange,
 };
-use re_query_cache::Caches;
+use re_query_cache::{Caches, MaybeCachedComponentData};
 use re_types::components::InstanceKey;
 use re_types_core::Loggable as _;
 
@@ -597,7 +597,11 @@ fn query_and_compare(
                     uncached_data_times.push(data_time);
                     uncached_instance_keys.push(instance_keys.to_vec());
                     uncached_positions.push(positions.to_vec());
-                    uncached_colors.push(colors.to_vec());
+                    uncached_colors.push(
+                        MaybeCachedComponentData::iter_or_repeat_opt(&colors, positions.len())
+                            .copied()
+                            .collect_vec(),
+                    );
                 },
             )
             .unwrap();
@@ -616,7 +620,11 @@ fn query_and_compare(
                     cached_data_times.push(data_time);
                     cached_instance_keys.push(instance_keys.to_vec());
                     cached_positions.push(positions.to_vec());
-                    cached_colors.push(colors.to_vec());
+                    cached_colors.push(
+                        MaybeCachedComponentData::iter_or_repeat_opt(&colors, positions.len())
+                            .copied()
+                            .collect_vec(),
+                    );
                 },
             )
             .unwrap();

--- a/crates/re_space_view_spatial/benches/bench_points.rs
+++ b/crates/re_space_view_spatial/benches/bench_points.rs
@@ -116,17 +116,11 @@ fn bench_points(c: &mut criterion::Criterion) {
                 let data = Points3DComponentData {
                     instance_keys: instance_keys.as_slice(),
                     positions: positions.as_slice(),
-                    colors: colors.as_slice(),
-                    radii: radii.as_slice(),
-                    labels: labels.as_slice(),
-                    keypoint_ids: keypoint_ids
-                        .iter()
-                        .any(Option::is_some)
-                        .then_some(keypoint_ids.as_slice()),
-                    class_ids: class_ids
-                        .iter()
-                        .any(Option::is_some)
-                        .then_some(class_ids.as_slice()),
+                    colors: colors.as_deref(),
+                    radii: radii.as_deref(),
+                    labels: labels.as_deref(),
+                    keypoint_ids: keypoint_ids.as_deref(),
+                    class_ids: class_ids.as_deref(),
                 };
                 assert_eq!(data.instance_keys.len(), NUM_POINTS);
 

--- a/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
@@ -139,7 +139,7 @@ macro_rules! impl_process_archetype {
                 (Option<TimeInt>, RowId),
                 &[InstanceKey],
                 $(&[$pov],)*
-                $(&[Option<$comp>],)*
+                $(Option<&[Option<$comp>]>,)*
             ) -> ::re_query::Result<()>,
         {
             // NOTE: not `profile_function!` because we want them merged together.
@@ -204,7 +204,7 @@ macro_rules! impl_process_archetype {
                             t,
                             keys.as_slice(),
                             $($pov.as_slice(),)+
-                            $($comp.as_slice(),)*
+                            $($comp.as_deref(),)*
                         ) {
                             re_log::error_once!(
                                 "Unexpected error querying {:?}: {err}",

--- a/crates/re_space_view_text_log/src/visualizer_system.rs
+++ b/crates/re_space_view_text_log/src/visualizer_system.rs
@@ -1,6 +1,7 @@
 use re_data_store::TimeRange;
 use re_entity_db::EntityPath;
 use re_log_types::RowId;
+use re_query_cache::MaybeCachedComponentData;
 use re_types::{
     archetypes::TextLog,
     components::{Color, Text, TextLogLevel},
@@ -74,9 +75,11 @@ impl VisualizerSystem for TextLogSystem {
                 &timeline_query.clone().into(),
                 &data_result.entity_path,
                 |((time, row_id), _, bodies, levels, colors)| {
-                    for (body, level, color) in
-                        itertools::izip!(bodies.iter(), levels.iter(), colors.iter())
-                    {
+                    for (body, level, color) in itertools::izip!(
+                        bodies.iter(),
+                        MaybeCachedComponentData::iter_or_repeat_opt(&levels, bodies.len()),
+                        MaybeCachedComponentData::iter_or_repeat_opt(&colors, bodies.len()),
+                    ) {
                         self.entries.push(Entry {
                             row_id,
                             entity_path: data_result.entity_path.clone(),

--- a/crates/re_space_view_time_series/src/visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/visualizer_system.rs
@@ -1,6 +1,6 @@
 use re_data_store::TimeRange;
 use re_log_types::TimeInt;
-use re_query_cache::QueryError;
+use re_query_cache::{MaybeCachedComponentData, QueryError};
 use re_types::{
     archetypes::TimeSeriesScalar,
     components::{Color, Radius, Scalar, ScalarScattering, Text},
@@ -180,10 +180,10 @@ impl TimeSeriesSystem {
 
                         for (scalar, scattered, color, radius, label) in itertools::izip!(
                             scalars.iter(),
-                            scatterings.iter(),
-                            colors.iter(),
-                            radii.iter(),
-                            labels.iter()
+                            MaybeCachedComponentData::iter_or_repeat_opt(&scatterings, scalars.len()),
+                            MaybeCachedComponentData::iter_or_repeat_opt(&colors, scalars.len()),
+                            MaybeCachedComponentData::iter_or_repeat_opt(&radii, scalars.len()),
+                            MaybeCachedComponentData::iter_or_repeat_opt(&labels, scalars.len()),
                         ) {
                             let color =
                                 annotation_info.color(color.map(|c| c.to_array()), default_color);


### PR DESCRIPTION
The cache will now keep track of missing optional components, and store an empty slice instead of a bunch of `None` values.
When queried, an empty shows up as a `None` option to the end-user, who can act appropriately.

SFM before:
![image](https://github.com/rerun-io/rerun/assets/2910679/34256f8b-3b4b-4d1a-b1ea-5f9e1fd7860b)

SFM after:
![image](https://github.com/rerun-io/rerun/assets/2910679/b676052a-b1fc-4840-bddf-67e5f490add2)


---

- Fixes #4779
- DNR: requires #4856

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4891/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4891/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4891/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4891)
- [Docs preview](https://rerun.io/preview/bf89c307dac5dc8fd8016dd985f8af30a6ee73a7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bf89c307dac5dc8fd8016dd985f8af30a6ee73a7/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)