### PR TITLE
Primary cache: do not err on `PrimaryNotFound`

### DIFF
--- a/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
@@ -183,7 +183,7 @@ macro_rules! impl_process_archetype {
                     space_view_class_identifier: view_ctx.space_view_class_identifier(),
                 };
 
-                ctx.entity_db.query_caches().[<query_archetype_with_history_pov$N _comp$M>]::<A, $($pov,)+ $($comp,)* _>(
+                match ctx.entity_db.query_caches().[<query_archetype_with_history_pov$N _comp$M>]::<A, $($pov,)+ $($comp,)* _>(
                     ctx.app_options.experimental_primary_caching_latest_at,
                     ctx.app_options.experimental_primary_caching_range,
                     ctx.entity_db.store(),
@@ -212,7 +212,15 @@ macro_rules! impl_process_archetype {
                             );
                         }
                     }
-                )?;
+                ) {
+                    Ok(_) | Err(QueryError::PrimaryNotFound(_)) => {}
+                    Err(err) => {
+                        re_log::error_once!(
+                            "Unexpected error querying {:?}: {err}",
+                            &data_result.entity_path
+                        );
+                    }
+                }
             }
 
             Ok(())


### PR DESCRIPTION
Ignore `PrimaryNotFound` errors on the cached entity_iterator path, the same way the vanilla path does.

- Fixes #4858
- DNR: requires #4856

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4892/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4892/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4892/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4892)
- [Docs preview](https://rerun.io/preview/bebd894b2f4fc299c9882b9529d24c760b68e0bd/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bebd894b2f4fc299c9882b9529d24c760b68e0bd/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)