### PR TITLE
`Once` semantics for `setup_{web|native}_logging`

### DIFF
--- a/crates/re_analytics/examples/end_to_end.rs
+++ b/crates/re_analytics/examples/end_to_end.rs
@@ -7,7 +7,7 @@ fn input_filled_event(body: String) -> Event {
 }
 
 fn main() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let mut analytics = Analytics::new(Duration::from_secs(3)).unwrap();
     analytics.register_append_property("application_id", "end_to_end_example");

--- a/crates/re_data_store/src/test_util.rs
+++ b/crates/re_data_store/src/test_util.rs
@@ -79,17 +79,3 @@ pub fn insert_table_with_retries(store: &mut DataStore, table: &DataTable) {
         }
     }
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-pub fn init_logs() {
-    use std::sync::atomic::{AtomicBool, Ordering};
-
-    static INIT: AtomicBool = AtomicBool::new(false);
-
-    if INIT
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_ok()
-    {
-        re_log::setup_native_logging();
-    }
-}

--- a/crates/re_data_store/tests/correctness.rs
+++ b/crates/re_data_store/tests/correctness.rs
@@ -2,8 +2,6 @@
 //!
 //! Bending and twisting the datastore APIs in all kinds of weird ways to try and break them.
 
-use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
-
 use rand::Rng;
 
 use re_data_store::{
@@ -194,7 +192,7 @@ fn row_id_ordering_semantics() -> anyhow::Result<()> {
 
 #[test]
 fn write_errors() {
-    init_logs();
+    re_log::setup_native_logging();
 
     let ent_path = EntityPath::from("this/that");
 
@@ -289,7 +287,7 @@ fn write_errors() {
 
 #[test]
 fn latest_at_emptiness_edge_cases() {
-    init_logs();
+    re_log::setup_native_logging();
 
     for config in re_data_store::test_util::all_configs() {
         let mut store = DataStore::new(
@@ -410,7 +408,7 @@ fn latest_at_emptiness_edge_cases_impl(store: &mut DataStore) {
 
 #[test]
 fn gc_correct() {
-    init_logs();
+    re_log::setup_native_logging();
 
     let mut store = DataStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
@@ -524,19 +522,9 @@ fn gc_metadata_size() -> anyhow::Result<()> {
 
 // ---
 
-pub fn init_logs() {
-    static INIT: AtomicBool = AtomicBool::new(false);
-
-    if INIT.compare_exchange(false, true, SeqCst, SeqCst).is_ok() {
-        re_log::setup_native_logging();
-    }
-}
-
-// ---
-
 #[test]
 fn entity_min_time_correct() -> anyhow::Result<()> {
-    init_logs();
+    re_log::setup_native_logging();
 
     for config in re_data_store::test_util::all_configs() {
         let mut store = DataStore::new(

--- a/crates/re_data_store/tests/correctness.rs
+++ b/crates/re_data_store/tests/correctness.rs
@@ -192,7 +192,7 @@ fn row_id_ordering_semantics() -> anyhow::Result<()> {
 
 #[test]
 fn write_errors() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let ent_path = EntityPath::from("this/that");
 
@@ -287,7 +287,7 @@ fn write_errors() {
 
 #[test]
 fn latest_at_emptiness_edge_cases() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     for config in re_data_store::test_util::all_configs() {
         let mut store = DataStore::new(
@@ -408,7 +408,7 @@ fn latest_at_emptiness_edge_cases_impl(store: &mut DataStore) {
 
 #[test]
 fn gc_correct() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let mut store = DataStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
@@ -524,7 +524,7 @@ fn gc_metadata_size() -> anyhow::Result<()> {
 
 #[test]
 fn entity_min_time_correct() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     for config in re_data_store::test_util::all_configs() {
         let mut store = DataStore::new(

--- a/crates/re_data_store/tests/data_store.rs
+++ b/crates/re_data_store/tests/data_store.rs
@@ -24,7 +24,7 @@ use re_types_core::{ComponentName, Loggable as _};
 
 #[test]
 fn all_components() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let ent_path = EntityPath::from("this/that");
 
@@ -254,7 +254,7 @@ fn all_components() {
 
 #[test]
 fn latest_at() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     for config in re_data_store::test_util::all_configs() {
         let mut store = DataStore::new(
@@ -267,7 +267,7 @@ fn latest_at() {
 }
 
 fn latest_at_impl(store: &mut DataStore) {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let ent_path = EntityPath::from("this/that");
 
@@ -380,7 +380,7 @@ fn latest_at_impl(store: &mut DataStore) {
 
 #[test]
 fn range() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     for config in re_data_store::test_util::all_configs() {
         let mut store = DataStore::new(
@@ -393,7 +393,7 @@ fn range() {
 }
 
 fn range_impl(store: &mut DataStore) {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let ent_path = EntityPath::from("this/that");
 
@@ -595,7 +595,7 @@ fn range_impl(store: &mut DataStore) {
 
 #[test]
 fn gc() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     for config in re_data_store::test_util::all_configs() {
         let mut store = DataStore::new(
@@ -666,7 +666,7 @@ fn gc_impl(store: &mut DataStore) {
 
 #[test]
 fn protected_gc() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     for config in re_data_store::test_util::all_configs() {
         let mut store = DataStore::new(
@@ -679,7 +679,7 @@ fn protected_gc() {
 }
 
 fn protected_gc_impl(store: &mut DataStore) {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let ent_path = EntityPath::from("this/that");
 
@@ -771,7 +771,7 @@ fn protected_gc_impl(store: &mut DataStore) {
 
 #[test]
 fn protected_gc_clear() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     for config in re_data_store::test_util::all_configs() {
         let mut store = DataStore::new(
@@ -784,7 +784,7 @@ fn protected_gc_clear() {
 }
 
 fn protected_gc_clear_impl(store: &mut DataStore) {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let ent_path = EntityPath::from("this/that");
 

--- a/crates/re_data_store/tests/data_store.rs
+++ b/crates/re_data_store/tests/data_store.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use rand::Rng;
 use re_data_store::{
     test_row,
-    test_util::{init_logs, insert_table_with_retries, sanity_unwrap},
+    test_util::{insert_table_with_retries, sanity_unwrap},
     DataStore, DataStoreConfig, DataStoreStats, GarbageCollectionOptions, GarbageCollectionTarget,
     LatestAtQuery, RangeQuery, TimeInt, TimeRange,
 };
@@ -24,7 +24,7 @@ use re_types_core::{ComponentName, Loggable as _};
 
 #[test]
 fn all_components() {
-    init_logs();
+    re_log::setup_native_logging();
 
     let ent_path = EntityPath::from("this/that");
 
@@ -254,7 +254,7 @@ fn all_components() {
 
 #[test]
 fn latest_at() {
-    init_logs();
+    re_log::setup_native_logging();
 
     for config in re_data_store::test_util::all_configs() {
         let mut store = DataStore::new(
@@ -267,7 +267,7 @@ fn latest_at() {
 }
 
 fn latest_at_impl(store: &mut DataStore) {
-    init_logs();
+    re_log::setup_native_logging();
 
     let ent_path = EntityPath::from("this/that");
 
@@ -380,7 +380,7 @@ fn latest_at_impl(store: &mut DataStore) {
 
 #[test]
 fn range() {
-    init_logs();
+    re_log::setup_native_logging();
 
     for config in re_data_store::test_util::all_configs() {
         let mut store = DataStore::new(
@@ -393,7 +393,7 @@ fn range() {
 }
 
 fn range_impl(store: &mut DataStore) {
-    init_logs();
+    re_log::setup_native_logging();
 
     let ent_path = EntityPath::from("this/that");
 
@@ -595,7 +595,7 @@ fn range_impl(store: &mut DataStore) {
 
 #[test]
 fn gc() {
-    init_logs();
+    re_log::setup_native_logging();
 
     for config in re_data_store::test_util::all_configs() {
         let mut store = DataStore::new(
@@ -666,7 +666,7 @@ fn gc_impl(store: &mut DataStore) {
 
 #[test]
 fn protected_gc() {
-    init_logs();
+    re_log::setup_native_logging();
 
     for config in re_data_store::test_util::all_configs() {
         let mut store = DataStore::new(
@@ -679,7 +679,7 @@ fn protected_gc() {
 }
 
 fn protected_gc_impl(store: &mut DataStore) {
-    init_logs();
+    re_log::setup_native_logging();
 
     let ent_path = EntityPath::from("this/that");
 
@@ -771,7 +771,7 @@ fn protected_gc_impl(store: &mut DataStore) {
 
 #[test]
 fn protected_gc_clear() {
-    init_logs();
+    re_log::setup_native_logging();
 
     for config in re_data_store::test_util::all_configs() {
         let mut store = DataStore::new(
@@ -784,7 +784,7 @@ fn protected_gc_clear() {
 }
 
 fn protected_gc_clear_impl(store: &mut DataStore) {
-    init_logs();
+    re_log::setup_native_logging();
 
     let ent_path = EntityPath::from("this/that");
 

--- a/crates/re_data_store/tests/dump.rs
+++ b/crates/re_data_store/tests/dump.rs
@@ -3,7 +3,7 @@
 use itertools::Itertools;
 use re_data_store::{
     test_row,
-    test_util::{init_logs, insert_table_with_retries, sanity_unwrap},
+    test_util::{insert_table_with_retries, sanity_unwrap},
     DataStore, DataStoreStats, GarbageCollectionOptions, TimeInt, TimeRange, Timeline,
 };
 use re_log_types::{
@@ -71,7 +71,7 @@ impl RowSet {
 
 #[test]
 fn data_store_dump() {
-    init_logs();
+    re_log::setup_native_logging();
 
     for mut config in re_data_store::test_util::all_configs() {
         // NOTE: insert IDs aren't serialized and can be different across runs.
@@ -176,7 +176,7 @@ fn data_store_dump_impl(store1: &mut DataStore, store2: &mut DataStore, store3: 
 
 #[test]
 fn data_store_dump_filtered() {
-    init_logs();
+    re_log::setup_native_logging();
 
     for mut config in re_data_store::test_util::all_configs() {
         // NOTE: insert IDs aren't serialized and can be different across runs.
@@ -310,7 +310,7 @@ fn create_insert_table(ent_path: impl Into<EntityPath>) -> DataTable {
 // See: https://github.com/rerun-io/rerun/pull/2007
 #[test]
 fn data_store_dump_empty_column() {
-    init_logs();
+    re_log::setup_native_logging();
 
     // Split tables on 1 row
     let mut config = re_data_store::DataStoreConfig {

--- a/crates/re_data_store/tests/dump.rs
+++ b/crates/re_data_store/tests/dump.rs
@@ -71,7 +71,7 @@ impl RowSet {
 
 #[test]
 fn data_store_dump() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     for mut config in re_data_store::test_util::all_configs() {
         // NOTE: insert IDs aren't serialized and can be different across runs.
@@ -176,7 +176,7 @@ fn data_store_dump_impl(store1: &mut DataStore, store2: &mut DataStore, store3: 
 
 #[test]
 fn data_store_dump_filtered() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     for mut config in re_data_store::test_util::all_configs() {
         // NOTE: insert IDs aren't serialized and can be different across runs.
@@ -310,7 +310,7 @@ fn create_insert_table(ent_path: impl Into<EntityPath>) -> DataTable {
 // See: https://github.com/rerun-io/rerun/pull/2007
 #[test]
 fn data_store_dump_empty_column() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     // Split tables on 1 row
     let mut config = re_data_store::DataStoreConfig {

--- a/crates/re_data_store/tests/internals.rs
+++ b/crates/re_data_store/tests/internals.rs
@@ -20,7 +20,7 @@ use re_types_core::Loggable as _;
 // make an exception, for now…
 #[test]
 fn pathological_bucket_topology() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let mut store_forward = DataStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),

--- a/crates/re_data_store/tests/internals.rs
+++ b/crates/re_data_store/tests/internals.rs
@@ -2,7 +2,7 @@
 //!
 //! They're awful, but sometimes you just have to…
 
-use re_data_store::{test_util::init_logs, DataStore, DataStoreConfig};
+use re_data_store::{DataStore, DataStoreConfig};
 use re_log_types::{build_frame_nr, DataRow, EntityPath, RowId, TimePoint};
 use re_types::{components::InstanceKey, datagen::build_some_instances};
 use re_types_core::Loggable as _;
@@ -20,7 +20,7 @@ use re_types_core::Loggable as _;
 // make an exception, for now…
 #[test]
 fn pathological_bucket_topology() {
-    init_logs();
+    re_log::setup_native_logging();
 
     let mut store_forward = DataStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),

--- a/crates/re_entity_db/tests/clear.rs
+++ b/crates/re_entity_db/tests/clear.rs
@@ -13,7 +13,7 @@ use re_types_core::{
 /// Complete test suite for the clear & pending clear paths.
 #[test]
 fn clears() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let mut db = EntityDb::new(StoreId::random(re_log_types::StoreKind::Recording));
 
@@ -437,7 +437,7 @@ fn clears() -> anyhow::Result<()> {
 /// Test for GC behavior following clear. This functionality is expected by blueprints.
 #[test]
 fn clear_and_gc() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let mut db = EntityDb::new(StoreId::random(re_log_types::StoreKind::Recording));
 

--- a/crates/re_entity_db/tests/clear.rs
+++ b/crates/re_entity_db/tests/clear.rs
@@ -13,7 +13,7 @@ use re_types_core::{
 /// Complete test suite for the clear & pending clear paths.
 #[test]
 fn clears() -> anyhow::Result<()> {
-    init_logs();
+    re_log::setup_native_logging();
 
     let mut db = EntityDb::new(StoreId::random(re_log_types::StoreKind::Recording));
 
@@ -437,7 +437,7 @@ fn clears() -> anyhow::Result<()> {
 /// Test for GC behavior following clear. This functionality is expected by blueprints.
 #[test]
 fn clear_and_gc() -> anyhow::Result<()> {
-    init_logs();
+    re_log::setup_native_logging();
 
     let mut db = EntityDb::new(StoreId::random(re_log_types::StoreKind::Recording));
 
@@ -488,17 +488,4 @@ fn clear_and_gc() -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-// ---
-
-pub fn init_logs() {
-    use std::sync::atomic::AtomicBool;
-    use std::sync::atomic::Ordering::SeqCst;
-
-    static INIT: AtomicBool = AtomicBool::new(false);
-
-    if INIT.compare_exchange(false, true, SeqCst, SeqCst).is_ok() {
-        re_log::setup_native_logging();
-    }
 }

--- a/crates/re_log/src/lib.rs
+++ b/crates/re_log/src/lib.rs
@@ -42,7 +42,7 @@ pub use channel_logger::*;
 pub use multi_logger::{add_boxed_logger, add_logger, MultiLoggerNotSetupError};
 
 #[cfg(feature = "setup")]
-pub use setup::*;
+pub use setup::setup_logging;
 
 /// Re-exports of other crates.
 pub mod external {

--- a/crates/re_log/src/multi_logger.rs
+++ b/crates/re_log/src/multi_logger.rs
@@ -6,7 +6,7 @@ static MULTI_LOGGER: MultiLogger = MultiLogger::new();
 
 static HAS_MULTI_LOGGER: AtomicBool = AtomicBool::new(false);
 
-/// Produced when trying to install additional loggers when [`crate::setup_native_logging`] has not been called.
+/// Produced when trying to install additional loggers when [`crate::setup_logging`] has not been called.
 ///
 /// This can happen for example when users of the `rerun` crate use the `spawn` method,
 /// and they aren't using `re_log`.

--- a/crates/re_log/src/setup.rs
+++ b/crates/re_log/src/setup.rs
@@ -1,8 +1,10 @@
 //! Function to setup logging in binaries and web apps.
 
-/// Directs [`log`] calls to stderr.
-#[cfg(not(target_arch = "wasm32"))]
-pub fn setup_native_logging() {
+/// Automatically does the right thing dependending on target environment (native vs. web).
+///
+/// Directs [`log`] calls to stderr on native.
+pub fn setup_logging() {
+    #[cfg(not(target_arch = "wasm32"))]
     fn setup() {
         if cfg!(debug_assertions) && std::env::var("RUST_BACKTRACE").is_err() {
             // In debug build, default `RUST_BACKTRACE` to `1` if it is not set.
@@ -39,13 +41,7 @@ pub fn setup_native_logging() {
         }
     }
 
-    use std::sync::Once;
-    static START: Once = Once::new();
-    START.call_once(setup);
-}
-
-#[cfg(target_arch = "wasm32")]
-pub fn setup_web_logging() {
+    #[cfg(target_arch = "wasm32")]
     fn setup() {
         crate::multi_logger::init().expect("Failed to set logger");
         log::set_max_level(log::LevelFilter::Debug);

--- a/crates/re_log/src/setup.rs
+++ b/crates/re_log/src/setup.rs
@@ -3,39 +3,45 @@
 /// Directs [`log`] calls to stderr.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn setup_native_logging() {
-    if cfg!(debug_assertions) && std::env::var("RUST_BACKTRACE").is_err() {
-        // In debug build, default `RUST_BACKTRACE` to `1` if it is not set.
-        // This ensures sure we produce backtraces if our examples (etc) panics.
+    fn setup() {
+        if cfg!(debug_assertions) && std::env::var("RUST_BACKTRACE").is_err() {
+            // In debug build, default `RUST_BACKTRACE` to `1` if it is not set.
+            // This ensures sure we produce backtraces if our examples (etc) panics.
 
-        // Our own crash handler (`re_crash_handler`) always prints a backtraces
-        // (currently ignoring `RUST_BACKTRACE`) but we only use that for `rerun-cli`, our main binary.
+            // Our own crash handler (`re_crash_handler`) always prints a backtraces
+            // (currently ignoring `RUST_BACKTRACE`) but we only use that for `rerun-cli`, our main binary.
 
-        // `RUST_BACKTRACE` also turns on printing backtraces for `anyhow::Error`s that
-        // are returned from `main` (i.e. if `main` returns `anyhow::Result`).
-        std::env::set_var("RUST_BACKTRACE", "1");
+            // `RUST_BACKTRACE` also turns on printing backtraces for `anyhow::Error`s that
+            // are returned from `main` (i.e. if `main` returns `anyhow::Result`).
+            std::env::set_var("RUST_BACKTRACE", "1");
+        }
+
+        crate::multi_logger::init().expect("Failed to set logger");
+
+        let log_filter = crate::default_log_filter();
+
+        if log_filter.contains("trace") {
+            log::set_max_level(log::LevelFilter::Trace);
+        } else if log_filter.contains("debug") {
+            log::set_max_level(log::LevelFilter::Debug);
+        } else {
+            log::set_max_level(log::LevelFilter::Info);
+        }
+
+        let mut stderr_logger = env_logger::Builder::new();
+        stderr_logger.parse_filters(&log_filter);
+        crate::add_boxed_logger(Box::new(stderr_logger.build())).expect("Failed to install logger");
+
+        if env_var_bool("RERUN_PANIC_ON_WARN") == Some(true) {
+            crate::add_boxed_logger(Box::new(PanicOnWarn {}))
+                .expect("Failed to enable RERUN_PANIC_ON_WARN");
+            crate::info!("RERUN_PANIC_ON_WARN: any warning or error will cause Rerun to panic.");
+        }
     }
 
-    crate::multi_logger::init().expect("Failed to set logger");
-
-    let log_filter = crate::default_log_filter();
-
-    if log_filter.contains("trace") {
-        log::set_max_level(log::LevelFilter::Trace);
-    } else if log_filter.contains("debug") {
-        log::set_max_level(log::LevelFilter::Debug);
-    } else {
-        log::set_max_level(log::LevelFilter::Info);
-    }
-
-    let mut stderr_logger = env_logger::Builder::new();
-    stderr_logger.parse_filters(&log_filter);
-    crate::add_boxed_logger(Box::new(stderr_logger.build())).expect("Failed to install logger");
-
-    if env_var_bool("RERUN_PANIC_ON_WARN") == Some(true) {
-        crate::add_boxed_logger(Box::new(PanicOnWarn {}))
-            .expect("Failed to enable RERUN_PANIC_ON_WARN");
-        crate::info!("RERUN_PANIC_ON_WARN: any warning or error will cause Rerun to panic.");
-    }
+    use std::sync::Once;
+    static START: Once = Once::new();
+    START.call_once(setup);
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/re_renderer_examples/framework.rs
+++ b/crates/re_renderer_examples/framework.rs
@@ -386,7 +386,7 @@ pub fn start<E: Example + 'static>() {
 
     #[cfg(not(target_arch = "wasm32"))]
     {
-        re_log::setup_native_logging();
+        re_log::setup_logging();
         pollster::block_on(run::<E>(event_loop, window));
     }
 
@@ -395,7 +395,7 @@ pub fn start<E: Example + 'static>() {
         // Make sure panics are logged using `console.error`.
         console_error_panic_hook::set_once();
 
-        re_log::setup_web_logging();
+        re_log::setup_logging();
 
         use winit::platform::web::WindowExtWebSys;
         let canvas = window.canvas().expect("Couldn't get canvas");

--- a/crates/re_types_builder/src/bin/build_re_types.rs
+++ b/crates/re_types_builder/src/bin/build_re_types.rs
@@ -32,7 +32,7 @@ macro_rules! join {
 }
 
 fn main() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let mut profiler = re_tracing::Profiler::default(); // must be started early and dropped late to catch everything
 

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -31,7 +31,7 @@ fn command_channel() -> (CommandSender, CommandReceiver) {
 }
 
 fn main() -> eframe::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -22,7 +22,7 @@ impl WebHandle {
     #[allow(clippy::new_without_default)]
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
-        re_log::setup_web_logging();
+        re_log::setup_logging();
 
         Self {
             runner: eframe::WebRunner::new(),

--- a/crates/re_web_viewer_server/src/main.rs
+++ b/crates/re_web_viewer_server/src/main.rs
@@ -24,7 +24,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/crates/rerun-cli/src/bin/rerun.rs
+++ b/crates/rerun-cli/src/bin/rerun.rs
@@ -18,7 +18,7 @@ static GLOBAL: AccountingAllocator<mimalloc::MiMalloc> =
 
 #[tokio::main]
 async fn main() -> std::process::ExitCode {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     // Name the rayon threads for the benefit of debuggers and profilers:
     rayon::ThreadPoolBuilder::new()

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -258,7 +258,7 @@ fn rr_recording_stream_new_impl(
     store_info: *const CStoreInfo,
     default_enabled: bool,
 ) -> Result<CRecordingStream, CError> {
-    initialize_logging();
+    re_log::setup_native_logging();
 
     let store_info = ptr::try_ptr_as_ref(store_info, "store_info")?;
 
@@ -734,15 +734,4 @@ pub unsafe extern "C" fn _rr_free_string(str: *mut c_char) {
         // SAFETY: `_rr_free_string` should only be called on strings allocated by `_rr_escape_entity_path_part`.
         let _ = CString::from_raw(str);
     }
-}
-
-// ----------------------------------------------------------------------------
-// Helper functions:
-
-fn initialize_logging() {
-    use std::sync::Once;
-    static START: Once = Once::new();
-    START.call_once(|| {
-        re_log::setup_native_logging();
-    });
 }

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -258,7 +258,7 @@ fn rr_recording_stream_new_impl(
     store_info: *const CStoreInfo,
     default_enabled: bool,
 ) -> Result<CRecordingStream, CError> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let store_info = ptr::try_ptr_as_ref(store_info, "store_info")?;
 

--- a/examples/rust/clock/src/main.rs
+++ b/examples/rust/clock/src/main.rs
@@ -22,7 +22,7 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/examples/rust/custom_data_loader/src/main.rs
+++ b/examples/rust/custom_data_loader/src/main.rs
@@ -14,7 +14,7 @@ use rerun::{
 
 #[tokio::main]
 async fn main() -> anyhow::Result<std::process::ExitCode> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     re_data_source::register_custom_data_loader(HashLoader);
 

--- a/examples/rust/custom_space_view/src/main.rs
+++ b/examples/rust/custom_space_view/src/main.rs
@@ -15,7 +15,7 @@ static GLOBAL: re_memory::AccountingAllocator<mimalloc::MiMalloc> =
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Direct calls using the `log` crate to stderr. Control with `RUST_LOG=debug` etc.
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     // Install handlers for panics and crashes that prints to stderr and send
     // them to Rerun analytics (if the `analytics` feature is on in `Cargo.toml`).

--- a/examples/rust/custom_store_subscriber/src/main.rs
+++ b/examples/rust/custom_store_subscriber/src/main.rs
@@ -20,7 +20,7 @@ use rerun::{
 
 #[tokio::main]
 async fn main() -> anyhow::Result<std::process::ExitCode> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     let _handle = re_data_store::DataStore::register_subscriber(Box::<Orchestrator>::default());
     // Could use the returned handle to get a reference to the view if needed.

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -15,7 +15,7 @@ static GLOBAL: re_memory::AccountingAllocator<mimalloc::MiMalloc> =
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Direct calls using the `log` crate to stderr. Control with `RUST_LOG=debug` etc.
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     // Install handlers for panics and crashes that prints to stderr and send
     // them to Rerun analytics (if the `analytics` feature is on in `Cargo.toml`).

--- a/examples/rust/minimal_options/src/main.rs
+++ b/examples/rust/minimal_options/src/main.rs
@@ -23,7 +23,7 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/examples/rust/objectron/src/main.rs
+++ b/examples/rust/objectron/src/main.rs
@@ -392,7 +392,7 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/examples/rust/raw_mesh/src/main.rs
+++ b/examples/rust/raw_mesh/src/main.rs
@@ -175,7 +175,7 @@ fn run(rec: &RecordingStream, args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -125,7 +125,7 @@ fn main(py: Python<'_>) -> PyResult<u8> {
 fn rerun_bindings(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     // NOTE: We do this here because some the inner init methods don't respond too kindly to being
     // called more than once.
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     // We always want main to be available
     m.add_function(wrap_pyfunction!(main, m)?)?;

--- a/tests/rust/plot_dashboard_stress/src/main.rs
+++ b/tests/rust/plot_dashboard_stress/src/main.rs
@@ -49,7 +49,7 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/annotation_context/src/main.rs
+++ b/tests/rust/roundtrips/annotation_context/src/main.rs
@@ -28,7 +28,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/arrows2d/src/main.rs
+++ b/tests/rust/roundtrips/arrows2d/src/main.rs
@@ -24,7 +24,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/arrows3d/src/main.rs
+++ b/tests/rust/roundtrips/arrows3d/src/main.rs
@@ -24,7 +24,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/boxes2d/src/main.rs
+++ b/tests/rust/roundtrips/boxes2d/src/main.rs
@@ -26,7 +26,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/boxes3d/src/main.rs
+++ b/tests/rust/roundtrips/boxes3d/src/main.rs
@@ -35,7 +35,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/depth_image/src/main.rs
+++ b/tests/rust/roundtrips/depth_image/src/main.rs
@@ -29,7 +29,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/disconnected_space/src/main.rs
+++ b/tests/rust/roundtrips/disconnected_space/src/main.rs
@@ -15,7 +15,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/image/src/main.rs
+++ b/tests/rust/roundtrips/image/src/main.rs
@@ -39,7 +39,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/line_strips2d/src/main.rs
+++ b/tests/rust/roundtrips/line_strips2d/src/main.rs
@@ -35,7 +35,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/line_strips3d/src/main.rs
+++ b/tests/rust/roundtrips/line_strips3d/src/main.rs
@@ -24,7 +24,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/pinhole/src/main.rs
+++ b/tests/rust/roundtrips/pinhole/src/main.rs
@@ -20,7 +20,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/points2d/src/main.rs
+++ b/tests/rust/roundtrips/points2d/src/main.rs
@@ -35,7 +35,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/points3d/src/main.rs
+++ b/tests/rust/roundtrips/points3d/src/main.rs
@@ -24,7 +24,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/segmentation_image/src/main.rs
+++ b/tests/rust/roundtrips/segmentation_image/src/main.rs
@@ -26,7 +26,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/tensor/src/main.rs
+++ b/tests/rust/roundtrips/tensor/src/main.rs
@@ -18,7 +18,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/text_document/src/main.rs
+++ b/tests/rust/roundtrips/text_document/src/main.rs
@@ -31,7 +31,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/text_log/src/main.rs
+++ b/tests/rust/roundtrips/text_log/src/main.rs
@@ -24,7 +24,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/transform3d/src/main.rs
+++ b/tests/rust/roundtrips/transform3d/src/main.rs
@@ -85,7 +85,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/roundtrips/view_coordinates/src/main.rs
+++ b/tests/rust/roundtrips/view_coordinates/src/main.rs
@@ -15,7 +15,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();

--- a/tests/rust/test_api/src/main.rs
+++ b/tests/rust/test_api/src/main.rs
@@ -587,7 +587,7 @@ fn run(rec: &RecordingStream, args: &Args) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
-    re_log::setup_native_logging();
+    re_log::setup_logging();
 
     use clap::Parser as _;
     let args = Args::parse();


### PR DESCRIPTION
- Fixes #4893 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4896/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4896/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4896/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4896)
- [Docs preview](https://rerun.io/preview/882cdd28a203faf740c68262522af73d16970804/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/882cdd28a203faf740c68262522af73d16970804/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)