### PR TITLE
Migrate from `egui_Tile::TileId` to proper blueprint IDs in `ViewportBlueprint` API

### DIFF
--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -143,12 +143,8 @@ impl AppState {
         // this, which gives us interior mutability (only a shared reference of `ViewportBlueprint`
         // is available to the UI code) and, if needed in the future, concurrency.
         let (sender, receiver) = std::sync::mpsc::channel();
-        let viewport_blueprint = ViewportBlueprint::try_from_db(
-            store_context.blueprint,
-            &blueprint_query,
-            app_options,
-            sender,
-        );
+        let viewport_blueprint =
+            ViewportBlueprint::try_from_db(store_context.blueprint, &blueprint_query, sender);
         let mut viewport = Viewport::new(
             &viewport_blueprint,
             viewport_state,

--- a/crates/re_viewer/src/ui/add_space_view_or_container_modal.rs
+++ b/crates/re_viewer/src/ui/add_space_view_or_container_modal.rs
@@ -5,17 +5,17 @@ use itertools::Itertools;
 use re_log_types::{EntityPath, EntityPathFilter};
 use re_space_view::DataQueryBlueprint;
 use re_ui::ReUi;
-use re_viewer_context::ViewerContext;
+use re_viewer_context::{ContainerId, ViewerContext};
 use re_viewport::{icon_for_container_kind, SpaceViewBlueprint, Viewport};
 
 #[derive(Default)]
 pub struct AddSpaceViewOrContainerModal {
-    target_container: Option<egui_tiles::TileId>,
+    target_container: Option<ContainerId>,
     modal_handler: re_ui::modal::ModalHandler,
 }
 
 impl AddSpaceViewOrContainerModal {
-    pub fn open(&mut self, target_container: egui_tiles::TileId) {
+    pub fn open(&mut self, target_container: ContainerId) {
         self.target_container = Some(target_container);
         self.modal_handler.open();
     }
@@ -38,7 +38,7 @@ fn modal_ui(
     ui: &mut egui::Ui,
     ctx: &ViewerContext<'_>,
     viewport: &Viewport<'_, '_>,
-    target_container: Option<egui_tiles::TileId>,
+    target_container: Option<ContainerId>,
 ) {
     let container_data = [
         (

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -401,14 +401,6 @@ fn experimental_feature_ui(
             "Primary caching: range queries",
         )
         .on_hover_text("Toggle primary caching for range queries.\nApplies to the 2D/3D point cloud, text log and time series space views.");
-
-    re_ui
-        .checkbox(
-            ui,
-            &mut app_options.legacy_container_blueprint,
-            "Use the legacy container blueprint storage for the viewport",
-        )
-        .on_hover_text("The legacy container blueprint storage is deprecated, but may be helpful if unexpected regressions are found in the new container blueprints.");
 }
 
 #[cfg(debug_assertions)]

--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -1,5 +1,4 @@
 use egui::RichText;
-use egui_tiles::Tile;
 use re_ui::UICommand;
 use re_viewer_context::{Item, Selection, SelectionHistory};
 use re_viewport::ViewportBlueprint;
@@ -196,25 +195,9 @@ fn item_to_string(blueprint: &ViewportBlueprint, item: &Item) -> String {
         Item::ComponentPath(path) => {
             format!("{}:{}", path.entity_path, path.component_name.short_name(),)
         }
-        Item::Container(tile_id) => {
-            if let Some(tile) = blueprint.tree.tiles.get(*tile_id) {
-                match tile {
-                    Tile::Pane(sid) => {
-                        // This case shouldn't happen really.
-                        if let Some(space_view) = blueprint.space_view(sid) {
-                            format!(
-                                "Tile showing {}",
-                                space_view
-                                    .display_name
-                                    .as_ref()
-                                    .unwrap_or(&space_view.missing_name_placeholder())
-                            )
-                        } else {
-                            "Tile containing unknown Space View".to_owned()
-                        }
-                    }
-                    Tile::Container(container) => format!("{:?}", container.kind()),
-                }
+        Item::Container(container_id) => {
+            if let Some(container) = blueprint.container(container_id) {
+                format!("{:?}", container.container_kind)
             } else {
                 "<removed Container>".to_owned()
             }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -1,5 +1,4 @@
 use egui::NumExt as _;
-use egui_tiles::{GridLayout, Tile};
 
 use re_data_ui::{image_meaning_for_entity, item_ui, DataUi};
 use re_entity_db::{
@@ -15,13 +14,13 @@ use re_ui::list_item::ListItem;
 use re_ui::ReUi;
 use re_ui::SyntaxHighlighting as _;
 use re_viewer_context::{
-    blueprint_timepoint_for_writes, gpu_bridge::colormap_dropdown_button_ui, HoverHighlight, Item,
-    SpaceViewClass, SpaceViewClassIdentifier, SpaceViewId, SystemCommand, SystemCommandSender as _,
-    UiVerbosity, ViewerContext,
+    blueprint_timepoint_for_writes, gpu_bridge::colormap_dropdown_button_ui, ContainerId,
+    HoverHighlight, Item, SpaceViewClass, SpaceViewClassIdentifier, SpaceViewId, SystemCommand,
+    SystemCommandSender as _, UiVerbosity, ViewerContext,
 };
 use re_viewport::{
     external::re_space_view::blueprint::components::QueryExpressions, icon_for_container_kind,
-    Viewport, ViewportBlueprint,
+    Contents, Viewport, ViewportBlueprint,
 };
 
 use crate::ui::add_space_view_or_container_modal::AddSpaceViewOrContainerModal;
@@ -154,14 +153,14 @@ impl SelectionPanel {
                 what_is_selected_ui(ui, ctx, viewport.blueprint, item);
 
                 match item {
-                    Item::Container(tile_id) => {
-                        container_top_level_properties(ui, ctx, viewport, tile_id);
+                    Item::Container(container_id) => {
+                        container_top_level_properties(ui, ctx, viewport, container_id);
 
                         // the container children and related additive workflow is only available with the new container
                         // blueprints feature
                         if ctx.app_options.experimental_additive_workflow {
                             ui.add_space(12.0);
-                            self.container_children(ui, ctx, viewport, tile_id);
+                            self.container_children(ui, ctx, viewport, container_id);
                         }
                     }
 
@@ -203,9 +202,9 @@ impl SelectionPanel {
         ui: &mut egui::Ui,
         ctx: &ViewerContext<'_>,
         viewport: &Viewport<'_, '_>,
-        tile_id: &egui_tiles::TileId,
+        container_id: &ContainerId,
     ) {
-        let Some(Tile::Container(container)) = viewport.tree.tiles.get(*tile_id) else {
+        let Some(container) = viewport.blueprint.container(container_id) else {
             return;
         };
 
@@ -218,7 +217,7 @@ impl SelectionPanel {
                     .small_icon_button(ui, &re_ui::icons::ADD)
                     .clicked()
                 {
-                    self.add_space_view_or_container_modal.open(*tile_id);
+                    self.add_space_view_or_container_modal.open(*container_id);
                 }
             });
         });
@@ -227,8 +226,8 @@ impl SelectionPanel {
 
         let show_content = |ui: &mut egui::Ui| {
             let mut has_child = false;
-            for &child_tile_id in container.children() {
-                has_child |= show_list_item_for_container_child(ui, ctx, viewport, child_tile_id);
+            for child_contents in &container.contents {
+                has_child |= show_list_item_for_container_child(ui, ctx, viewport, child_contents);
             }
 
             if !has_child {
@@ -327,14 +326,16 @@ fn what_is_selected_ui(
 
             item_title_ui(ctx.re_ui, ui, &title, Some(&re_ui::icons::STORE), &id_str);
         }
-        Item::Container(tile_id) => {
-            if let Some(Tile::Container(container)) = viewport.tree.tiles.get(*tile_id) {
+        Item::Container(container_id) => {
+            if let Some(container_blueprint) = viewport.container(container_id) {
                 item_title_ui(
                     ctx.re_ui,
                     ui,
-                    &format!("{:?}", container.kind()),
-                    Some(re_viewport::icon_for_container_kind(&container.kind())),
-                    &format!("{:?} container", container.kind()),
+                    &format!("{:?}", container_blueprint.container_kind),
+                    Some(re_viewport::icon_for_container_kind(
+                        &container_blueprint.container_kind,
+                    )),
+                    &format!("{:?} container", container_blueprint.container_kind),
                 );
             }
         }
@@ -561,115 +562,111 @@ fn space_view_top_level_properties(
 fn container_top_level_properties(
     ui: &mut egui::Ui,
     ctx: &ViewerContext<'_>,
-    viewport: &mut Viewport<'_, '_>,
-    tile_id: &egui_tiles::TileId,
+    viewport: &Viewport<'_, '_>,
+    container_id: &ContainerId,
 ) {
-    if let Some(Tile::Container(container)) = viewport.tree.tiles.get_mut(*tile_id) {
-        egui::Grid::new("container_top_level_properties")
-            .num_columns(2)
-            .show(ui, |ui| {
-                ui.label("Kind");
+    let Some(container) = viewport.blueprint.container(container_id) else {
+        return;
+    };
 
-                let mut container_kind = container.kind();
-                egui::ComboBox::from_id_source("container_kind")
-                    .selected_text(format!("{container_kind:?}"))
+    egui::Grid::new("container_top_level_properties")
+        .num_columns(2)
+        .show(ui, |ui| {
+            ui.label("Kind");
+
+            let mut container_kind = container.container_kind;
+            egui::ComboBox::from_id_source("container_kind")
+                .selected_text(format!("{container_kind:?}"))
+                .show_ui(ui, |ui| {
+                    ui.style_mut().wrap = Some(false);
+                    ui.set_min_width(64.0);
+
+                    ui.selectable_value(
+                        &mut container_kind,
+                        egui_tiles::ContainerKind::Tabs,
+                        format!("{:?}", egui_tiles::ContainerKind::Tabs),
+                    );
+                    ui.selectable_value(
+                        &mut container_kind,
+                        egui_tiles::ContainerKind::Horizontal,
+                        format!("{:?}", egui_tiles::ContainerKind::Horizontal),
+                    );
+                    ui.selectable_value(
+                        &mut container_kind,
+                        egui_tiles::ContainerKind::Vertical,
+                        format!("{:?}", egui_tiles::ContainerKind::Vertical),
+                    );
+                    ui.selectable_value(
+                        &mut container_kind,
+                        egui_tiles::ContainerKind::Grid,
+                        format!("{:?}", egui_tiles::ContainerKind::Grid),
+                    );
+                });
+
+            viewport
+                .blueprint
+                .set_container_kind(*container_id, container_kind);
+
+            ui.end_row();
+
+            if container.container_kind == egui_tiles::ContainerKind::Grid {
+                ui.label("Columns");
+
+                fn columns_to_string(columns: &Option<u32>) -> String {
+                    match columns {
+                        None => "Auto".to_owned(),
+                        Some(cols) => cols.to_string(),
+                    }
+                }
+
+                let mut new_columns = container.grid_columns;
+
+                egui::ComboBox::from_id_source("container_grid_columns")
+                    .selected_text(columns_to_string(&new_columns))
                     .show_ui(ui, |ui| {
                         ui.style_mut().wrap = Some(false);
                         ui.set_min_width(64.0);
 
-                        ui.selectable_value(
-                            &mut container_kind,
-                            egui_tiles::ContainerKind::Tabs,
-                            format!("{:?}", egui_tiles::ContainerKind::Tabs),
-                        );
-                        ui.selectable_value(
-                            &mut container_kind,
-                            egui_tiles::ContainerKind::Horizontal,
-                            format!("{:?}", egui_tiles::ContainerKind::Horizontal),
-                        );
-                        ui.selectable_value(
-                            &mut container_kind,
-                            egui_tiles::ContainerKind::Vertical,
-                            format!("{:?}", egui_tiles::ContainerKind::Vertical),
-                        );
-                        ui.selectable_value(
-                            &mut container_kind,
-                            egui_tiles::ContainerKind::Grid,
-                            format!("{:?}", egui_tiles::ContainerKind::Grid),
-                        );
+                        ui.selectable_value(&mut new_columns, None, columns_to_string(&None));
+
+                        ui.separator();
+
+                        for columns in 1..=container.contents.len() as u32 {
+                            ui.selectable_value(
+                                &mut new_columns,
+                                Some(columns),
+                                columns_to_string(&Some(columns)),
+                            );
+                        }
                     });
 
-                viewport
-                    .blueprint
-                    .set_container_kind(*tile_id, container_kind);
+                container.set_grid_columns(ctx, new_columns);
 
                 ui.end_row();
+            }
 
-                if let egui_tiles::Container::Grid(grid) = container {
-                    ui.label("Columns");
-
-                    fn grid_layout_to_string(layout: &egui_tiles::GridLayout) -> String {
-                        match layout {
-                            GridLayout::Auto => "Auto".to_owned(),
-                            GridLayout::Columns(cols) => cols.to_string(),
-                        }
-                    }
-
-                    let original_layout = grid.layout;
-
-                    egui::ComboBox::from_id_source("container_grid_columns")
-                        .selected_text(grid_layout_to_string(&grid.layout))
-                        .show_ui(ui, |ui| {
-                            ui.style_mut().wrap = Some(false);
-                            ui.set_min_width(64.0);
-
-                            ui.selectable_value(
-                                &mut grid.layout,
-                                GridLayout::Auto,
-                                grid_layout_to_string(&GridLayout::Auto),
-                            );
-
-                            ui.separator();
-
-                            for columns in 1..=grid.num_children() {
-                                ui.selectable_value(
-                                    &mut grid.layout,
-                                    GridLayout::Columns(columns),
-                                    grid_layout_to_string(&GridLayout::Columns(columns)),
-                                );
-                            }
-                        });
-
-                    // TODO(jleibs): Manually marking edited like this is way too error prone.
-                    // Need to detect this in a better way.
-                    viewport.edited |= original_layout != grid.layout;
-
-                    ui.end_row();
+            // this feature is only available with the new container blueprints feature
+            #[allow(clippy::collapsible_if)]
+            if ctx.app_options.experimental_additive_workflow {
+                if ui
+                    .button("Simplify hierarchy")
+                    .on_hover_text("Simplify this container and its children")
+                    .clicked()
+                {
+                    viewport.blueprint.simplify_container(
+                        container_id,
+                        egui_tiles::SimplificationOptions {
+                            prune_empty_tabs: true,
+                            prune_empty_containers: true,
+                            prune_single_child_tabs: false,
+                            prune_single_child_containers: false,
+                            all_panes_must_have_tabs: true,
+                            join_nested_linear_containers: true,
+                        },
+                    );
                 }
-
-                // this feature is only available with the new container blueprints feature
-                #[allow(clippy::collapsible_if)]
-                if ctx.app_options.experimental_additive_workflow {
-                    if ui
-                        .button("Simplify hierarchy")
-                        .on_hover_text("Simplify this container and its children")
-                        .clicked()
-                    {
-                        viewport.blueprint.simplify_container(
-                            *tile_id,
-                            egui_tiles::SimplificationOptions {
-                                prune_empty_tabs: true,
-                                prune_empty_containers: true,
-                                prune_single_child_tabs: false,
-                                prune_single_child_containers: false,
-                                all_panes_must_have_tabs: true,
-                                join_nested_linear_containers: true,
-                            },
-                        );
-                    }
-                }
-            });
-    }
+            }
+        });
 }
 
 // TODO(#4560): this code should be generic and part of re_data_ui
@@ -680,16 +677,11 @@ fn show_list_item_for_container_child(
     ui: &mut egui::Ui,
     ctx: &ViewerContext<'_>,
     viewport: &Viewport<'_, '_>,
-    child_tile_id: egui_tiles::TileId,
+    child_contents: &Contents,
 ) -> bool {
-    let Some(child_tile) = viewport.tree.tiles.get(child_tile_id) else {
-        re_log::warn_once!("Could not find child tile with ID {child_tile_id:?}",);
-        return false;
-    };
-
-    let (item, mut list_item) = match child_tile {
-        Tile::Pane(space_view_id) => {
-            let Some(space_view) = viewport.blueprint.space_views.get(space_view_id) else {
+    let (item, mut list_item) = match child_contents {
+        Contents::SpaceView(space_view_id) => {
+            let Some(space_view) = viewport.blueprint.space_view(space_view_id) else {
                 re_log::warn_once!("Could not find space view with ID {space_view_id:?}",);
                 return false;
             };
@@ -702,18 +694,16 @@ fn show_list_item_for_container_child(
                     .with_icon(space_view.class(ctx.space_view_class_registry).icon()),
             )
         }
-        Tile::Container(container) => {
-            // TODO(#4285): this hack should be cleaned with "blueprintified" containers
-            if let (egui_tiles::Container::Tabs(_), Some(child_id)) =
-                (container, container.only_child())
-            {
-                return show_list_item_for_container_child(ui, ctx, viewport, child_id);
-            }
+        Contents::Container(container_id) => {
+            let Some(container) = viewport.blueprint.container(container_id) else {
+                re_log::warn_once!("Could not find container with ID {container_id:?}",);
+                return false;
+            };
 
             (
-                Item::Container(child_tile_id),
-                ListItem::new(ctx.re_ui, format!("{:?}", container.kind()))
-                    .with_icon(icon_for_container_kind(&container.kind())),
+                Item::Container(*container_id),
+                ListItem::new(ctx.re_ui, format!("{:?}", container.container_kind))
+                    .with_icon(icon_for_container_kind(&container.container_kind)),
             )
         }
     };

--- a/crates/re_viewer_context/src/app_options.rs
+++ b/crates/re_viewer_context/src/app_options.rs
@@ -17,9 +17,6 @@ pub struct AppOptions {
     /// Enable experimental dataframe space views.
     pub experimental_dataframe_space_view: bool,
 
-    /// Use the legacy container blueprint storage for the space view.
-    pub legacy_container_blueprint: bool,
-
     pub experimental_entity_filter_editor: bool,
 
     /// Enable the experimental support for the container addition workflow.
@@ -60,8 +57,6 @@ impl Default for AppOptions {
             experimental_space_view_screenshots: false,
 
             experimental_dataframe_space_view: false,
-
-            legacy_container_blueprint: false,
 
             experimental_entity_filter_editor: false,
 

--- a/crates/re_viewer_context/src/item.rs
+++ b/crates/re_viewer_context/src/item.rs
@@ -1,9 +1,7 @@
 use re_entity_db::InstancePath;
 use re_log_types::{ComponentPath, DataPath, EntityPath};
 
-use crate::DataQueryId;
-
-use super::SpaceViewId;
+use crate::{ContainerId, DataQueryId, SpaceViewId};
 
 /// One "thing" in the UI.
 ///
@@ -16,7 +14,7 @@ pub enum Item {
     SpaceView(SpaceViewId),
     InstancePath(Option<SpaceViewId>, InstancePath),
     DataBlueprintGroup(SpaceViewId, DataQueryId, EntityPath),
-    Container(egui_tiles::TileId),
+    Container(ContainerId),
 }
 
 impl Item {

--- a/crates/re_viewport/src/container.rs
+++ b/crates/re_viewport/src/container.rs
@@ -5,6 +5,7 @@ use re_entity_db::EntityDb;
 use re_log::ResultExt;
 use re_log_types::{DataRow, EntityPath, RowId};
 use re_query::query_archetype;
+use re_types::blueprint::components::Visible;
 use re_types_core::{archetypes::Clear, ArrowBuffer};
 use re_viewer_context::{
     blueprint_timepoint_for_writes, BlueprintId, BlueprintIdRegistry, ContainerId, SpaceViewId,
@@ -39,7 +40,7 @@ impl Contents {
     }
 
     #[inline]
-    fn to_tile_id(&self) -> TileId {
+    pub fn to_tile_id(&self) -> TileId {
         match self {
             Self::Container(id) => blueprint_id_to_tile_id(id),
             Self::SpaceView(id) => blueprint_id_to_tile_id(id),
@@ -324,6 +325,26 @@ impl ContainerBlueprint {
                     egui_tiles::GridLayout::Auto => None,
                 },
             },
+        }
+    }
+
+    #[inline]
+    pub fn set_visible(&self, ctx: &ViewerContext<'_>, visible: bool) {
+        if visible != self.visible {
+            let component = Visible(visible);
+            ctx.save_blueprint_component(&self.entity_path(), component);
+        }
+    }
+
+    #[inline]
+    pub fn set_grid_columns(&self, ctx: &ViewerContext<'_>, grid_columns: Option<u32>) {
+        if grid_columns != self.grid_columns {
+            if let Some(grid_columns) = grid_columns {
+                let component = GridColumns(grid_columns);
+                ctx.save_blueprint_component(&self.entity_path(), component);
+            } else {
+                ctx.save_empty_blueprint_component::<GridColumns>(&self.entity_path());
+            }
         }
     }
 

--- a/crates/re_viewport/src/lib.rs
+++ b/crates/re_viewport/src/lib.rs
@@ -23,6 +23,7 @@ mod viewport_blueprint_ui;
 /// Unstable. Used for the ongoing blueprint experimentations.
 pub mod blueprint;
 
+pub use container::{ContainerBlueprint, Contents};
 pub use space_info::SpaceInfoCollection;
 pub use space_view::{SpaceViewBlueprint, SpaceViewName};
 pub use viewport::{Viewport, ViewportState};

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -13,12 +13,13 @@ use re_entity_db::EntityPropertyMap;
 
 use re_ui::{Icon, ReUi};
 use re_viewer_context::{
-    AppOptions, Item, SpaceViewClassIdentifier, SpaceViewClassRegistry, SpaceViewId,
+    AppOptions, ContainerId, Item, SpaceViewClassIdentifier, SpaceViewClassRegistry, SpaceViewId,
     SpaceViewState, SystemExecutionOutput, ViewQuery, ViewerContext,
 };
 
+use crate::container::blueprint_id_to_tile_id;
 use crate::{
-    space_view_entity_picker::SpaceViewEntityPicker,
+    container::Contents, space_view_entity_picker::SpaceViewEntityPicker,
     space_view_heuristics::default_created_space_views,
     system_execution::execute_systems_for_space_views, SpaceInfoCollection, SpaceViewBlueprint,
     ViewportBlueprint,
@@ -71,22 +72,22 @@ impl ViewportState {
 #[derive(Clone)]
 pub enum TreeAction {
     /// Add a new space view to the provided container (or the root if `None`).
-    AddSpaceView(SpaceViewId, Option<egui_tiles::TileId>),
+    AddSpaceView(SpaceViewId, Option<ContainerId>),
 
     /// Add a new container of the provided kind to the provided container (or the root if `None`).
-    AddContainer(egui_tiles::ContainerKind, Option<egui_tiles::TileId>),
+    AddContainer(egui_tiles::ContainerKind, Option<ContainerId>),
 
     /// Change the kind of a container.
-    SetContainerKind(egui_tiles::TileId, egui_tiles::ContainerKind),
+    SetContainerKind(ContainerId, egui_tiles::ContainerKind),
 
     /// Ensure the tab for the provided space view is focused (see [`egui_tiles::Tree::make_active`]).
     FocusTab(SpaceViewId),
 
-    /// Remove a tile and all its children.
-    Remove(egui_tiles::TileId),
+    /// Remove a container (recursively) or a space view
+    RemoveContents(Contents),
 
     /// Simplify the container with the provided options
-    SimplifyContainer(egui_tiles::TileId, egui_tiles::SimplificationOptions),
+    SimplifyContainer(ContainerId, egui_tiles::SimplificationOptions),
 }
 
 fn tree_simplification_option_for_app_options(
@@ -126,7 +127,10 @@ pub struct Viewport<'a, 'b> {
     /// to be mutable for things like drag-and-drop and is ultimately saved back to the store.
     /// at the end of the frame if edited.
     pub tree: egui_tiles::Tree<SpaceViewId>,
-    pub edited: bool,
+
+    /// Should be set to `true` whenever a tree modification should be back-ported to the blueprint
+    /// store. That should _only_ happen as a result of a user action.
+    pub tree_edited: bool,
 
     /// Actions to perform at the end of the frame.
     ///
@@ -161,7 +165,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
             blueprint,
             state,
             tree,
-            edited,
+            tree_edited: edited,
             tree_action_receiver,
         }
     }
@@ -240,7 +244,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
             }
 
             // TODO(#4687): Be extra careful here. If we mark edited inappropriately we can create an infinite edit loop.
-            self.edited |= tab_viewer.edited;
+            self.tree_edited |= tab_viewer.edited;
         });
 
         self.blueprint.set_maximized(maximized, ctx);
@@ -326,10 +330,12 @@ impl<'a, 'b> Viewport<'a, 'b> {
                         );
 
                         reset = true;
-                    } else if let Some(parent_id) = parent_container.or(self.tree.root) {
+                    } else if let Some(parent_id) =
+                        parent_container.or(self.blueprint.root_container)
+                    {
                         let tile_id = self.tree.tiles.insert_pane(space_view_id);
                         if let Some(egui_tiles::Tile::Container(container)) =
-                            self.tree.tiles.get_mut(parent_id)
+                            self.tree.tiles.get_mut(blueprint_id_to_tile_id(&parent_id))
                         {
                             re_log::trace!("Inserting new space view into root container");
                             container.add_child(tile_id);
@@ -341,16 +347,16 @@ impl<'a, 'b> Viewport<'a, 'b> {
                         re_log::trace!("No root found - will re-run auto-layout");
                     }
 
-                    self.edited = true;
+                    self.tree_edited = true;
                 }
                 TreeAction::AddContainer(container_kind, parent_container) => {
-                    if let Some(parent_id) = parent_container.or(self.tree.root) {
+                    if let Some(parent_id) = parent_container.or(self.blueprint.root_container) {
                         let tile_id = self
                             .tree
                             .tiles
                             .insert_container(egui_tiles::Container::new(container_kind, vec![]));
                         if let Some(egui_tiles::Tile::Container(container)) =
-                            self.tree.tiles.get_mut(parent_id)
+                            self.tree.tiles.get_mut(blueprint_id_to_tile_id(&parent_id))
                         {
                             re_log::trace!("Inserting new space view into container {parent_id:?}");
                             container.add_child(tile_id);
@@ -364,11 +370,13 @@ impl<'a, 'b> Viewport<'a, 'b> {
                         re_log::trace!("No root found - will re-run auto-layout");
                     }
 
-                    self.edited = true;
+                    self.tree_edited = true;
                 }
                 TreeAction::SetContainerKind(container_id, container_kind) => {
-                    if let Some(egui_tiles::Tile::Container(container)) =
-                        self.tree.tiles.get_mut(container_id)
+                    if let Some(egui_tiles::Tile::Container(container)) = self
+                        .tree
+                        .tiles
+                        .get_mut(blueprint_id_to_tile_id(&container_id))
                     {
                         re_log::trace!("Mutating container {container_id:?} to {container_kind:?}");
                         container.set_kind(container_kind);
@@ -376,7 +384,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
                         re_log::trace!("No root found - will re-run auto-layout");
                     }
 
-                    self.edited = true;
+                    self.tree_edited = true;
                 }
                 TreeAction::FocusTab(space_view_id) => {
                     let found = self.tree.make_active(|_, tile| match tile {
@@ -388,9 +396,11 @@ impl<'a, 'b> Viewport<'a, 'b> {
                     re_log::trace!(
                         "Found tab to focus on for space view ID {space_view_id}: {found}"
                     );
-                    self.edited = true;
+                    self.tree_edited = true;
                 }
-                TreeAction::Remove(tile_id) => {
+                TreeAction::RemoveContents(contents) => {
+                    let tile_id = contents.to_tile_id();
+
                     for tile in self.tree.remove_recursively(tile_id) {
                         re_log::trace!("Removing tile {tile_id:?}");
                         if let egui_tiles::Tile::Pane(space_view_id) = tile {
@@ -403,12 +413,13 @@ impl<'a, 'b> Viewport<'a, 'b> {
                     if Some(tile_id) == self.tree.root {
                         self.tree.root = None;
                     }
-                    self.edited = true;
+                    self.tree_edited = true;
                 }
-                TreeAction::SimplifyContainer(tile_id, options) => {
+                TreeAction::SimplifyContainer(container_id, options) => {
                     re_log::trace!("Simplifying tree with options: {options:?}");
+                    let tile_id = blueprint_id_to_tile_id(&container_id);
                     self.tree.simplify_children_of_tile(tile_id, &options);
-                    self.edited = true;
+                    self.tree_edited = true;
                 }
             }
         }
@@ -418,14 +429,12 @@ impl<'a, 'b> Viewport<'a, 'b> {
             // written to the store yet.
             re_log::trace!("Clearing the blueprint tree to force reset on the next frame");
             self.tree = egui_tiles::Tree::empty("viewport_tree");
-            self.edited = true;
+            self.tree_edited = true;
         }
 
         // Finally, save any edits to the blueprint tree
         // This is a no-op if the tree hasn't changed.
-        if ctx.app_options.legacy_container_blueprint {
-            self.blueprint.set_tree(&self.tree, ctx);
-        } else if self.edited {
+        if self.tree_edited {
             // TODO(#4687): Be extra careful here. If we mark edited inappropriately we can create an infinite edit loop.
 
             // Simplify before we save the tree. Normally additional simplification will


### PR DESCRIPTION
### What

The PR removes many instances of `egui_tiles::TileId` in the `Viewport`/`ViewportBlueprint`/`SpaceViewBlueprint`/`ContainerBlueprint` APIs, replacing them by `SpaceViewId` and `ContainerId` as appropriate. It also adds some new APIs to support operations previously performed via the tile tree.

This PR _also_ removes the `legacy_container_blueprint` feature flag (was added for 0.12 and has been defaulting to `false` for a while).

Note that much of the actual data mutation is still done via tile tree and synchronised back to the blueprint store. This should be further improved in the future.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4900/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4900/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4900/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4900)
- [Docs preview](https://rerun.io/preview/8921f6893384f4b8d094b91f7d4c82c577d8aada/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8921f6893384f4b8d094b91f7d4c82c577d8aada/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)