### PR TITLE
pixi: make sure `py-plot-dashboard` depends on pixi's `py-build`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -51,7 +51,9 @@ py-build = "maturin develop --manifest-path rerun_py/Cargo.toml --extras=tests"
 py-test = { cmd = "python -m pytest -vv rerun_py/tests/unit", depends_on = [
   "py-build",
 ] }
-py-plot-dashboard = { cmd = "python tests/python/plot_dashboard_stress/main.py" }
+py-plot-dashboard = { cmd = "python tests/python/plot_dashboard_stress/main.py", depends_on =[
+  "py-build",
+] }
 
 rs-plot-dashboard = { cmd = "cargo r -p plot_dashboard_stress --release --" }
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -51,7 +51,7 @@ py-build = "maturin develop --manifest-path rerun_py/Cargo.toml --extras=tests"
 py-test = { cmd = "python -m pytest -vv rerun_py/tests/unit", depends_on = [
   "py-build",
 ] }
-py-plot-dashboard = { cmd = "python tests/python/plot_dashboard_stress/main.py", depends_on =[
+py-plot-dashboard = { cmd = "python tests/python/plot_dashboard_stress/main.py", depends_on = [
   "py-build",
 ] }
 


### PR DESCRIPTION

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4902/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4902/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4902/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4902)
- [Docs preview](https://rerun.io/preview/7a4c706e8decdf555ad4175453b80c2a2ff69ef5/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7a4c706e8decdf555ad4175453b80c2a2ff69ef5/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)