### PR TITLE
Random walk series for plot benchmark in python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3689,6 +3689,7 @@ dependencies = [
  "anyhow",
  "clap",
  "rand",
+ "rand_distr",
  "re_log",
  "rerun",
 ]
@@ -6088,9 +6089,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.7"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
+checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,7 @@ pyo3 = "0.20.2"
 pyo3-build-config = "0.20.2"
 quote = "1.0"
 rand = { version = "0.8", default-features = false }
+rand_distr = { version = "0.4", default-features = false }
 rayon = "1.7"
 rfd = { version = "0.12", default_features = false, features = ["xdg-portal"] }
 rmp-serde = "1"

--- a/tests/python/plot_dashboard_stress/main.py
+++ b/tests/python/plot_dashboard_stress/main.py
@@ -86,7 +86,7 @@ def main() -> None:
     )
     if args.series_type == "gaussian_random_walk":
         values = np.cumsum(np.random.normal(size=values_shape), axis=0)
-    elif args.series_type == "sin_normal":
+    elif args.series_type == "sin_uniform":
         values = np.sin(np.random.uniform(0, math.pi, size=values_shape))
     else:
         # Just generate random numbers rather than crash

--- a/tests/python/plot_dashboard_stress/main.py
+++ b/tests/python/plot_dashboard_stress/main.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import argparse
 import math
-import random
 import time
 
 import numpy as np

--- a/tests/python/plot_dashboard_stress/main.py
+++ b/tests/python/plot_dashboard_stress/main.py
@@ -38,13 +38,18 @@ order = [
     "random",
 ]
 parser.add_argument(
-    "--order", type=str, default="forwards", help="What order to log the data in (applies to all series)", choices=order
+    "--order", type=str, default=order[0], help="What order to log the data in (applies to all series)", choices=order
 )
+
+series_type = [
+    "gaussian-random-walk",
+    "sin-uniform",
+]
 parser.add_argument(
-    "--series_type",
+    "--series-type",
     type=str,
-    default="gaussian_random_walk",
-    choices=("gaussian_random_walk", "sin_uniform"),
+    default=series_type[0],
+    choices=series_type,
     help="The method used to generate time series",
 )
 
@@ -84,9 +89,9 @@ def main() -> None:
         len(plot_paths),
         len(series_paths),
     )
-    if args.series_type == "gaussian_random_walk":
+    if args.series_type == "gaussian-random-walk":
         values = np.cumsum(np.random.normal(size=values_shape), axis=0)
-    elif args.series_type == "sin_uniform":
+    elif args.series_type == "sin-uniform":
         values = np.sin(np.random.uniform(0, math.pi, size=values_shape))
     else:
         # Just generate random numbers rather than crash
@@ -94,7 +99,9 @@ def main() -> None:
 
     for time_step, sim_time in enumerate(sim_times):
         rr.set_time_seconds("sim_time", sim_time)
+
         # Log
+
         for plot_idx, plot_path in enumerate(plot_paths):
             for series_idx, series_path in enumerate(series_paths):
                 value = values[time_step, plot_idx, series_idx]

--- a/tests/python/plot_dashboard_stress/main.py
+++ b/tests/python/plot_dashboard_stress/main.py
@@ -65,11 +65,12 @@ def main() -> None:
     num_series = len(plot_paths) * len(series_paths)
     time_per_tick = 1.0 / args.freq
     expected_total_freq = args.freq * num_series
+    stop_time = args.num_points_per_series * time_per_tick
 
     if args.order == "forwards":
-        sim_times = np.arange(args.num_points_per_series)
+        sim_times = np.arange(0, stop_time, time_per_tick)
     elif args.order == "backwards":
-        sim_times = np.arange(args.num_points_per_series)[::-1]
+        sim_times = np.arange(0, stop_time, time_per_tick)[::-1]
     else:
         sim_times = np.random.randint(0, args.num_points_per_series)
 

--- a/tests/rust/plot_dashboard_stress/Cargo.toml
+++ b/tests/rust/plot_dashboard_stress/Cargo.toml
@@ -13,3 +13,4 @@ rerun = { path = "../../../crates/rerun", features = ["clap"] }
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 rand = "0.8"
+rand_distr = "0.4"

--- a/tests/rust/plot_dashboard_stress/src/main.rs
+++ b/tests/rust/plot_dashboard_stress/src/main.rs
@@ -19,6 +19,12 @@ enum Order {
     Random,
 }
 
+#[derive(Debug, clap::ValueEnum, Clone)]
+enum SeriesType {
+    SinUniform,
+    GaussianRandomWalk,
+}
+
 // TODO(cmc): could have flags to add attributes (color, radius...) to put some more stress
 // on the line fragmenter.
 #[derive(Debug, clap::Parser)]
@@ -43,9 +49,13 @@ struct Args {
     #[clap(long, default_value = "1000.0")]
     freq: f64,
 
-    /// What order to log the data in (applies to all series)
+    /// What order to log the data in (applies to all series).
     #[clap(long, value_enum, default_value = "forwards")]
     order: Order,
+
+    /// The method used to generate time series.
+    #[clap(long, value_enum, default_value = "gaussian-random-walk")]
+    series_type: SeriesType,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -70,18 +80,38 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
 
     use rand::Rng as _;
     let mut rng = rand::thread_rng();
-    let uniform_pi = rand::distributions::Uniform::new(0f64, std::f64::consts::PI);
+    let distr_uniform_pi = rand::distributions::Uniform::new(0f64, std::f64::consts::PI);
+    let distr_std_normal = rand_distr::StandardNormal;
 
-    let sim_times: Vec<i64> = match args.order {
-        Order::Forwards => (0..args.num_points_per_series as i64).collect(),
-        Order::Backwards => (0..args.num_points_per_series as i64).rev().collect(),
+    let mut sim_times: Vec<f64> = (0..args.num_points_per_series as i64)
+        .map(|i| time_per_tick * i as f64)
+        .collect();
+    match args.order {
+        Order::Forwards => {}
+        Order::Backwards => sim_times.reverse(),
         Order::Random => {
             use rand::seq::SliceRandom as _;
-            let mut sim_times: Vec<i64> = (0..args.num_points_per_series as i64).collect();
             sim_times.shuffle(&mut rng);
-            sim_times
         }
     };
+
+    let values_per_series: Vec<Vec<f64>> = std::iter::from_fn(|| {
+        let mut value = 0.0;
+        let values = (0..args.num_points_per_series)
+            .map(|_| {
+                match args.series_type {
+                    SeriesType::SinUniform => value = rng.sample(distr_uniform_pi).sin(),
+                    SeriesType::GaussianRandomWalk => {
+                        value += rng.sample::<f64, _>(distr_std_normal);
+                    }
+                }
+                value
+            })
+            .collect();
+        Some(values)
+    })
+    .take(num_series as _)
+    .collect();
 
     let mut total_num_scalars = 0;
     let mut total_start_time = std::time::Instant::now();
@@ -90,14 +120,15 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
     let mut tick_start_time = std::time::Instant::now();
 
     #[allow(clippy::unchecked_duration_subtraction)]
-    for sim_time in sim_times {
-        rec.set_time_sequence("sim_time", sim_time);
+    for (time_step, sim_time) in sim_times.into_iter().enumerate() {
+        rec.set_time_seconds("sim_time", sim_time);
 
         // Log
 
-        for plot_path in &plot_paths {
-            for series_path in &series_paths {
-                let value = rng.sample(uniform_pi).sin();
+        for (plot_idx, plot_path) in plot_paths.iter().enumerate() {
+            let plot_idx = plot_idx * args.num_series_per_plot as usize;
+            for (series_idx, series_path) in series_paths.iter().enumerate() {
+                let value = values_per_series[plot_idx + series_idx][time_step];
                 rec.log(
                     format!("{plot_path}/{series_path}"),
                     &rerun::TimeSeriesScalar::new(value),


### PR DESCRIPTION
Adds a "Gaussian Random Walk" method to the plot dashboard benchmark.

Also fixes "sim_time" to be in seconds and be consistent with the frequency argument.

- Python:
  - [x] `just py-plot-dashboard --num-plots 10 --num-series-per-plot 5 --num-points-per-series 5000 --freq 1000 --series-type gaussian-random-walk --save plot_gauss_py.rrd`
  - [x] `just py-plot-dashboard --num-plots 10 --num-series-per-plot 5 --num-points-per-series 5000 --freq 1000 --series-type sin-uniform --save plot_uniform_py.rrd`
- Rust:
  - [x] `just rs-plot-dashboard --num-plots 10 --num-series-per-plot 5 --num-points-per-series 5000 --freq 1000 --series-type gaussian-random-walk --save plot_gauss_rs.rrd`
  - [x] `just rs-plot-dashboard --num-plots 10 --num-series-per-plot 5 --num-points-per-series 5000 --freq 1000 --series-type sin-uniform --save plot_uniform_rs.rrd`
- C++:
  - [x] `just cpp-plot-dashboard --num-plots 10 --num-series-per-plot 5 --num-points-per-series 5000 --freq 1000 --series-type gaussian-random-walk --save plot_gauss_cpp.rrd`
  - [x] `just cpp-plot-dashboard --num-plots 10 --num-series-per-plot 5 --num-points-per-series 5000 --freq 1000 --series-type sin-uniform --save plot_uniform_cpp.rrd`



![image](https://github.com/rerun-io/rerun/assets/2624717/4341bcc8-c8c9-4536-90b6-aa1d78a755f0)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4903/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4903/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4903/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4903)
- [Docs preview](https://rerun.io/preview/a1ac3e16b5b6fda1da8de5ecd8b866be7b6f1c78/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a1ac3e16b5b6fda1da8de5ecd8b866be7b6f1c78/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)