### PR TITLE
Fix Rust examples and improve ci coverage

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,14 @@ on:
     - cron: "15 12 * * *"
 
 jobs:
+  checks:
+    name: Checks
+    uses: ./.github/workflows/reusable_checks.yml
+    with:
+      CONCURRENCY: nightly
+      ALL_CHECKS: true
+    secrets: inherit
+
   build-web:
     name: "Build Web"
     uses: ./.github/workflows/reusable_build_web.yml

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -173,12 +173,10 @@ jobs:
 
       - name: Rust checks & tests
         if: ${{ !inputs.ALL_CHECKS }}
-        shell: bash
         run: ./scripts/ci/rust_checks.py --skip-check-individual-crates
 
       - name: Rust all checks & tests
         if: inputs.ALL_CHECKS
-        shell: bash
         run: ./scripts/ci/rust_checks.py
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -167,6 +167,11 @@ jobs:
           workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
       - name: Rust checks & tests
         shell: bash
         run: python ./scripts/ci/rust_checks.py

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -171,20 +171,15 @@ jobs:
           workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.8"
-
       - name: Rust checks & tests
         if: ${{ !inputs.ALL_CHECKS }}
         shell: bash
-        run: python ./scripts/ci/rust_checks.py --skip-check-individual-crates
+        run: ./scripts/ci/rust_checks.py --skip-check-individual-crates
 
       - name: Rust all checks & tests
         if: inputs.ALL_CHECKS
         shell: bash
-        run: python ./scripts/ci/rust_checks.py
+        run: ./scripts/ci/rust_checks.py
 
   # ---------------------------------------------------------------------------
 

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -22,6 +22,10 @@ on:
         required: false
         type: string
         default: ""
+      ALL_CHECKS:
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ inputs.CONCURRENCY }}-checks
@@ -173,6 +177,12 @@ jobs:
           python-version: "3.11"
 
       - name: Rust checks & tests
+        if: ${{ !inputs.ALL_CHECKS }}
+        shell: bash
+        run: python ./scripts/ci/rust_checks.py --skip-check-individual-crates
+
+      - name: Rust all checks & tests
+        if: inputs.ALL_CHECKS
         shell: bash
         run: python ./scripts/ci/rust_checks.py
 

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -167,68 +167,9 @@ jobs:
           workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
-      # First do our check with --locked to make sure `Cargo.lock` is up to date
-      - name: Check all features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --locked --all-features
-
-      - name: Rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-      - name: Cranky
-        uses: actions-rs/cargo@v1
-        with:
-          command: cranky
-          args: --all-targets --all-features -- --deny warnings
-
-      # Check a few important permutations of the feature flags for our `rerun` library:
-      - name: Check rerun with `--no-default-features``
-        uses: actions-rs/cargo@v1
-        with:
-          command: cranky
-          args: --locked -p rerun --no-default-features
-
-      - name: Check rerun with `--features sdk`
-        uses: actions-rs/cargo@v1
-        with:
-          command: cranky
-          args: --locked -p rerun --no-default-features --features sdk
-
-      - name: Test doc-tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --doc --all-features
-
-      - name: cargo doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --no-deps --all-features --workspace
-
-      - name: cargo doc --document-private-items
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --document-private-items --no-deps --all-features --workspace
-
-      # Just a normal `cargo test` should always work:
-      - name: cargo test --all-targets
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-
-      # Full test of everything:
-      - name: cargo test --all-targets --all-features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-targets --all-features
+      - name: Rust checks & tests
+        shell: bash
+        run: python ./scripts/ci/rust_checks.py
 
   # ---------------------------------------------------------------------------
 

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.8"
 
       - name: Rust checks & tests
         if: ${{ !inputs.ALL_CHECKS }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2979,7 +2979,6 @@ dependencies = [
  "anyhow",
  "clap",
  "glam",
- "re_log",
  "re_tracing",
  "rerun",
 ]
@@ -4104,7 +4103,6 @@ dependencies = [
  "bytes",
  "clap",
  "gltf",
- "mimalloc",
  "rerun",
 ]
 
@@ -4490,7 +4488,6 @@ dependencies = [
  "re_tracing",
  "re_types",
  "re_types_core",
- "rmp-serde",
  "serde",
  "similar-asserts",
  "smallvec",
@@ -4502,19 +4499,13 @@ name = "re_query_cache"
 version = "0.13.0-alpha.2"
 dependencies = [
  "ahash",
- "backtrace",
  "criterion",
- "document-features",
  "itertools 0.12.0",
  "mimalloc",
- "nohash-hasher",
- "once_cell",
  "parking_lot",
  "paste",
  "rand",
- "re_arrow2",
  "re_data_store",
- "re_format",
  "re_log",
  "re_log_types",
  "re_query",
@@ -4523,7 +4514,6 @@ dependencies = [
  "re_types_core",
  "seq-macro",
  "similar-asserts",
- "thiserror",
  "web-time",
 ]
 
@@ -4584,7 +4574,6 @@ dependencies = [
  "glam",
  "image",
  "itertools 0.12.0",
- "log",
  "macaw",
  "pollster",
  "rand",
@@ -4662,13 +4651,11 @@ dependencies = [
  "egui",
  "itertools 0.12.0",
  "nohash-hasher",
- "once_cell",
  "re_entity_db",
  "re_log_types",
  "re_tracing",
  "re_types_core",
  "re_viewer_context",
- "serde",
  "slotmap",
  "smallvec",
 ]
@@ -4697,11 +4684,9 @@ version = "0.13.0-alpha.2"
 dependencies = [
  "egui",
  "egui_extras",
- "itertools 0.12.0",
  "re_data_store",
  "re_data_ui",
  "re_entity_db",
- "re_log",
  "re_log_types",
  "re_query",
  "re_renderer",
@@ -4803,7 +4788,6 @@ dependencies = [
  "re_entity_db",
  "re_log",
  "re_log_types",
- "re_query_cache",
  "re_renderer",
  "re_tracing",
  "re_types",
@@ -5116,7 +5100,6 @@ dependencies = [
  "re_ui",
  "re_viewer_context",
  "rmp-serde",
- "tinyvec",
 ]
 
 [[package]]
@@ -5265,7 +5248,6 @@ dependencies = [
 name = "rerun-cli"
 version = "0.13.0-alpha.2"
 dependencies = [
- "anyhow",
  "document-features",
  "mimalloc",
  "rayon",
@@ -6157,7 +6139,6 @@ version = "0.13.0-alpha.2"
 dependencies = [
  "mimalloc",
  "re_format",
- "re_log",
  "rerun",
 ]
 

--- a/crates/re_query/Cargo.toml
+++ b/crates/re_query/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 default = []
 
 ## Enable (de)serialization using serde.
-serde = ["dep:serde", "dep:rmp-serde"]
+serde = ["dep:serde"]
 
 
 [dependencies]
@@ -37,7 +37,6 @@ arrow2.workspace = true
 backtrace.workspace = true
 document-features.workspace = true
 itertools = { workspace = true }
-rmp-serde = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 smallvec.workspace = true
 thiserror.workspace = true

--- a/crates/re_query_cache/Cargo.toml
+++ b/crates/re_query_cache/Cargo.toml
@@ -22,7 +22,6 @@ default = []
 [dependencies]
 # Rerun dependencies:
 re_data_store.workspace = true
-re_format.workspace = true
 re_log.workspace = true
 re_log_types.workspace = true
 re_query.workspace = true
@@ -31,16 +30,10 @@ re_types_core.workspace = true
 
 # External dependencies:
 ahash.workspace = true
-arrow2.workspace = true
-backtrace.workspace = true
-document-features.workspace = true
 itertools.workspace = true
-nohash-hasher.workspace = true
-once_cell.workspace = true
 parking_lot.workspace = true
 paste.workspace = true
 seq-macro.workspace = true
-thiserror.workspace = true
 web-time.workspace = true
 
 

--- a/crates/re_renderer_examples/Cargo.toml
+++ b/crates/re_renderer_examples/Cargo.toml
@@ -44,7 +44,6 @@ bytemuck.workspace = true
 glam.workspace = true
 image = { workspace = true, default-features = false, features = ["png"] }
 itertools.workspace = true
-log.workspace = true
 macaw.workspace = true
 pollster.workspace = true
 rand = { workspace = true, features = ["std", "std_rng"] }

--- a/crates/re_space_view/Cargo.toml
+++ b/crates/re_space_view/Cargo.toml
@@ -28,7 +28,5 @@ re_viewer_context.workspace = true
 egui.workspace = true
 itertools.workspace = true
 nohash-hasher.workspace = true
-once_cell.workspace = true
-serde.workspace = true
 slotmap.workspace = true
 smallvec = { workspace = true, features = ["serde"] }

--- a/crates/re_space_view_dataframe/Cargo.toml
+++ b/crates/re_space_view_dataframe/Cargo.toml
@@ -19,7 +19,6 @@ all-features = true
 re_data_store.workspace = true
 re_data_ui.workspace = true
 re_entity_db.workspace = true
-re_log.workspace = true
 re_log_types.workspace = true
 re_query.workspace = true
 re_renderer.workspace = true
@@ -30,4 +29,3 @@ re_viewer_context.workspace = true
 
 egui_extras.workspace = true
 egui.workspace = true
-itertools.workspace = true

--- a/crates/re_space_view_text_log/Cargo.toml
+++ b/crates/re_space_view_text_log/Cargo.toml
@@ -21,7 +21,6 @@ re_data_ui.workspace = true
 re_entity_db.workspace = true
 re_log.workspace = true
 re_log_types.workspace = true
-re_query_cache.workspace = true
 re_renderer.workspace = true
 re_tracing.workspace = true
 re_types.workspace = true

--- a/crates/re_viewer/src/viewer_analytics.rs
+++ b/crates/re_viewer/src/viewer_analytics.rs
@@ -248,6 +248,7 @@ impl ViewerAnalytics {
         Self {}
     }
 
+    #[allow(clippy::unused_self)]
     pub fn on_viewer_started(
         &mut self,
         _build_info: &re_build_info::BuildInfo,
@@ -255,5 +256,6 @@ impl ViewerAnalytics {
     ) {
     }
 
+    #[allow(clippy::unused_self)]
     pub fn on_open_recording(&mut self, _entity_db: &re_entity_db::EntityDb) {}
 }

--- a/crates/re_viewport/Cargo.toml
+++ b/crates/re_viewport/Cargo.toml
@@ -47,4 +47,3 @@ nohash-hasher.workspace = true
 once_cell.workspace = true
 rayon.workspace = true
 rmp-serde.workspace = true
-tinyvec.workspace = true

--- a/crates/re_web_viewer_server/Cargo.toml
+++ b/crates/re_web_viewer_server/Cargo.toml
@@ -45,7 +45,7 @@ analytics = ["dep:re_analytics"]
 
 
 [dependencies]
-re_log.workspace = true
+re_log = { workspace = true, features = ["setup"] }
 
 document-features.workspace = true
 futures-util.workspace = true

--- a/crates/rerun-cli/Cargo.toml
+++ b/crates/rerun-cli/Cargo.toml
@@ -64,7 +64,6 @@ rerun = { workspace = true, features = [
   "server",
 ] }
 
-anyhow.workspace = true
 document-features.workspace = true
 mimalloc.workspace = true
 rayon.workspace = true

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -47,6 +47,9 @@ mint = ["re_types?/mint"]
 ## Integration with the [`image`](https://crates.io/crates/image/) crate, plus JPEG support.
 image = ["re_types?/image"]
 
+## Integration with the [`ecolor`](https://crates.io/crates/ecolor/) crate.
+ecolor = ["re_types?/ecolor"]
+
 ## Integration with the [`log`](https://crates.io/crates/log/) crate.
 log = ["dep:env_logger", "dep:log"]
 

--- a/examples/rust/clock/Cargo.toml
+++ b/examples/rust/clock/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = ["web_viewer", "clap"] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/external_data_loader/src/main.rs
+++ b/examples/rust/external_data_loader/src/main.rs
@@ -1,8 +1,6 @@
 //! Example of an external data-loader executable plugin for the Rerun Viewer.
 
-use rerun::{
-    external::re_data_source::extension, MediaType, EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE,
-};
+use rerun::{MediaType, EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE};
 
 // The Rerun Viewer will always pass these two pieces of information:
 // 1. The path to be loaded, as a positional arg.
@@ -31,6 +29,14 @@ struct Args {
     /// optional ID of the shared recording
     #[argh(option)]
     recording_id: Option<String>,
+}
+
+fn extension(path: &std::path::Path) -> String {
+    path.extension()
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .to_string_lossy()
+        .to_string()
 }
 
 fn main() -> anyhow::Result<()> {

--- a/examples/rust/minimal_options/Cargo.toml
+++ b/examples/rust/minimal_options/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = ["web_viewer", "clap"] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/objectron/Cargo.toml
+++ b/examples/rust/objectron/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = ["web_viewer", "clap"] }
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/rust/raw_mesh/Cargo.toml
+++ b/examples/rust/raw_mesh/Cargo.toml
@@ -7,7 +7,11 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer", "clap"] }
+rerun = { path = "../../../crates/rerun", features = [
+  "web_viewer",
+  "clap",
+  "ecolor",
+] }
 
 anyhow = "1.0"
 bytes = "1.3"

--- a/examples/rust/raw_mesh/Cargo.toml
+++ b/examples/rust/raw_mesh/Cargo.toml
@@ -13,4 +13,3 @@ anyhow = "1.0"
 bytes = "1.3"
 clap = { version = "4.0", features = ["derive"] }
 gltf = "1.1"
-mimalloc = "0.1"

--- a/examples/rust/raw_mesh/Cargo.toml
+++ b/examples/rust/raw_mesh/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = ["web_viewer", "clap"] }
 
 anyhow = "1.0"
 bytes = "1.3"

--- a/examples/rust/raw_mesh/src/main.rs
+++ b/examples/rust/raw_mesh/src/main.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use bytes::Bytes;
 use rerun::{
     components::{MeshProperties, Transform3D},
-    external::re_log,
+    external::{ecolor, re_log},
     Color, Mesh3D, RecordingStream,
 };
 
@@ -50,14 +50,8 @@ impl From<GltfPrimitive> for Mesh3D {
         }
         if albedo_factor.is_some() {
             mesh = mesh.with_mesh_material(rerun::datatypes::Material {
-                albedo_factor: albedo_factor.map(|[r, g, b, a]| {
-                    rerun::Rgba32::from_unmultiplied_rgba(
-                        (r * 255.0) as u8,
-                        (g * 255.0) as u8,
-                        (b * 255.0) as u8,
-                        (a * 255.0) as u8,
-                    )
-                }),
+                albedo_factor: albedo_factor
+                    .map(|[r, g, b, a]| ecolor::Rgba::from_rgba_unmultiplied(r, g, b, a).into()),
             });
         }
 

--- a/examples/rust/raw_mesh/src/main.rs
+++ b/examples/rust/raw_mesh/src/main.rs
@@ -52,10 +52,10 @@ impl From<GltfPrimitive> for Mesh3D {
             mesh = mesh.with_mesh_material(rerun::datatypes::Material {
                 albedo_factor: albedo_factor.map(|[r, g, b, a]| {
                     rerun::Rgba32::from_unmultiplied_rgba(
-                        (r / 255.0) as u8,
-                        (g / 255.0) as u8,
-                        (b / 255.0) as u8,
-                        (a / 255.0) as u8,
+                        (r * 255.0) as u8,
+                        (g * 255.0) as u8,
+                        (b * 255.0) as u8,
+                        (a * 255.0) as u8,
                     )
                 }),
             });

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+"""Run various rust checks for CI."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+
+
+def run_cargo(args: str) -> None:
+    print(f"Running `cargo {args}`")
+    result = subprocess.call(f"cargo {args}", shell=True)
+    if result != 0:
+        sys.exit(result)
+
+
+def main() -> None:
+    # First check with --locked to make sure Cargo.lock is up to date.
+    run_cargo("check --locked --all-features")
+
+    run_cargo("fmt --all -- --check")
+    run_cargo("cranky --all-targets --all-features -- --deny warnings")
+
+    # Since features are additive, check samples individually.
+    for path, dirnames, filenames in os.walk("examples/rust"):
+        if "Cargo.toml" in filenames:
+            # Read the package name from the Cargo.toml file. Crude but effective.
+            with open(f"{path}/Cargo.toml") as file:
+                cargo_toml_contents = file.read()
+            package_name_result = re.search(r'name\s+=\s"([\w\-_]+)"', cargo_toml_contents)
+            if package_name_result is None:
+                raise Exception(f"Failed to find package name in {path}/Cargo.toml")
+            package_name = package_name_result.group(1)
+
+            run_cargo(f"check --no-default-features -p {package_name}")
+            run_cargo(f"check --all-features -p {package_name}")
+
+    # Check a few important permutations of the feature flags for our `rerun` library:
+    run_cargo("cranky -p rerun --no-default-features")
+    run_cargo("cranky -p rerun --no-default-features --features sdk")
+
+    # Doc tests
+    run_cargo("doc --all-features")
+    run_cargo("doc --no-deps --all-features --workspace")
+    run_cargo("doc --document-private-items --no-deps --all-features --workspace")
+
+    # Just a normal `cargo test` should always work:
+    run_cargo("test --all-targets")
+
+    # Full test of everything:
+    run_cargo("test --all-targets --all-features")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -85,7 +85,8 @@ def main() -> None:
 
     # Doc tests
     if args.skip_docs is not True:
-        timings.append(run_cargo("doc", "--all-features"))
+        # Full doc build takes prohibitively long (over 17min as of writing), so we skip it:
+        # timings.append(run_cargo("doc", "--all-features"))
         timings.append(run_cargo("doc", "--no-deps --all-features --workspace"))
         timings.append(run_cargo("doc", "--document-private-items --no-deps --all-features --workspace"))
 

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -8,21 +8,35 @@ import os
 import re
 import subprocess
 import sys
+import time
 
 
-def run_cargo(args: str) -> None:
-    print(f"Running `cargo {args}`")
-    result = subprocess.call(f"cargo {args}", shell=True)
+class Timing:
+    def __init__(self, command: str, start_time: float) -> None:
+        self.command = command
+        self.duration = time.time() - start_time
+
+
+def run_cargo(args: str) -> Timing:
+    command = f"cargo {args}"
+    print(f"Running '{command}'")
+    start = time.time()
+    result = subprocess.call(command, shell=True)
+
     if result != 0:
         sys.exit(result)
 
+    return Timing(command, start)
+
 
 def main() -> None:
-    # First check with --locked to make sure Cargo.lock is up to date.
-    run_cargo("check --locked --all-features")
+    timings = []
 
-    run_cargo("fmt --all -- --check")
-    run_cargo("cranky --all-targets --all-features -- --deny warnings")
+    # First check with --locked to make sure Cargo.lock is up to date.
+    timings.append(run_cargo("check --locked --all-features"))
+
+    timings.append(run_cargo("fmt --all -- --check"))
+    timings.append(run_cargo("cranky --all-targets --all-features -- --deny warnings"))
 
     # Since features are additive, check samples individually.
     for path, dirnames, filenames in os.walk("examples/rust"):
@@ -35,23 +49,29 @@ def main() -> None:
                 raise Exception(f"Failed to find package name in {path}/Cargo.toml")
             package_name = package_name_result.group(1)
 
-            run_cargo(f"check --no-default-features -p {package_name}")
-            run_cargo(f"check --all-features -p {package_name}")
+            timings.append(run_cargo(f"check --no-default-features -p {package_name}"))
+            timings.append(run_cargo(f"check --all-features -p {package_name}"))
 
     # Check a few important permutations of the feature flags for our `rerun` library:
-    run_cargo("cranky -p rerun --no-default-features")
-    run_cargo("cranky -p rerun --no-default-features --features sdk")
+    timings.append(run_cargo("cranky -p rerun --no-default-features"))
+    timings.append(run_cargo("cranky -p rerun --no-default-features --features sdk"))
 
     # Doc tests
-    run_cargo("doc --all-features")
-    run_cargo("doc --no-deps --all-features --workspace")
-    run_cargo("doc --document-private-items --no-deps --all-features --workspace")
+    timings.append(run_cargo("doc --all-features"))
+    timings.append(run_cargo("doc --no-deps --all-features --workspace"))
+    timings.append(run_cargo("doc --document-private-items --no-deps --all-features --workspace"))
 
     # Just a normal `cargo test` should always work:
-    run_cargo("test --all-targets")
+    timings.append(run_cargo("test --all-targets"))
 
     # Full test of everything:
-    run_cargo("test --all-targets --all-features")
+    timings.append(run_cargo("test --all-targets --all-features"))
+
+    # Print timings overview
+    print("-----------------")
+    print("Timings:")
+    for timing in timings:
+        print(f"{timing.duration:.2f}s \t {timing.command}")
 
 
 if __name__ == "__main__":

--- a/tests/rust/log_benchmark/Cargo.toml
+++ b/tests/rust/log_benchmark/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 publish = false
 
 [dependencies]
-re_log = { workspace = true, features = ["setup"] }
 re_tracing = { path = "../../../crates/re_tracing", features = ["server"] }
 rerun = { path = "../../../crates/rerun" }
 

--- a/tests/rust/test_image_memory/Cargo.toml
+++ b/tests/rust/test_image_memory/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 
 [dependencies]
 re_format.workspace = true
-re_log = { workspace = true, features = ["setup"] }
 rerun = { workspace = true, features = ["sdk", "image"] }
 
 mimalloc.workspace = true


### PR DESCRIPTION
### What

Other things that sneaked into here by now:
* cargo machete pass deleting unnecessary dependencies
* expose `ecolor` feature on `rerun`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4904/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4904/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4904/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4904)
- [Docs preview](https://rerun.io/preview/76bed735a2ed9c3f4cd6a0e757e799f00a261960/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/76bed735a2ed9c3f4cd6a0e757e799f00a261960/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)