### PR TITLE
Improve documentation of re_memory crate

### DIFF
--- a/crates/re_memory/README.md
+++ b/crates/re_memory/README.md
@@ -7,7 +7,10 @@ Part of the [`rerun`](https://github.com/rerun-io/rerun) family of crates.
 ![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
 
-Includes an opt-in sampling profiler for allocation callstacks.
+This is a library for tracking memory use in a running application.
+This is useful for tracking leaks, and for figuring out what is using up memory.
+
+`re_memory` includes an opt-in sampling profiler for allocation callstacks.
 Each time memory is allocated there is a chance a callstack will be collected.
 This information is tracked until deallocation.
 You can thus get information about what callstacks lead to the most live allocations,

--- a/crates/re_memory/src/allocation_tracker.rs
+++ b/crates/re_memory/src/allocation_tracker.rs
@@ -22,7 +22,7 @@ impl PtrHash {
 
 // ----------------------------------------------------------------------------
 
-/// Formatted [`Backtrace`].
+/// Formatted backtrace.
 ///
 /// Clones without allocating.
 #[derive(Clone)]
@@ -54,6 +54,10 @@ pub struct CallstackStatistics {
     pub readable_backtrace: ReadableBacktrace,
 
     /// If this was stochastically sampled - at what rate?
+    ///
+    /// A `stochastic_rate` of `10` means that we only sampled 1 in 10 allocations.
+    ///
+    /// (so this is actually an interval rather than rate…).
     pub stochastic_rate: usize,
 
     /// Live allocations at this callstack.

--- a/crates/re_memory/src/lib.rs
+++ b/crates/re_memory/src/lib.rs
@@ -56,6 +56,7 @@ use backtrace_web::Backtrace;
 
 pub use {
     accounting_allocator::{AccountingAllocator, TrackingStatistics},
+    allocation_tracker::{CallstackStatistics, ReadableBacktrace},
     memory_history::MemoryHistory,
     memory_limit::MemoryLimit,
     memory_use::MemoryUse,

--- a/crates/re_memory/src/lib.rs
+++ b/crates/re_memory/src/lib.rs
@@ -1,6 +1,38 @@
 //! Run-time memory tracking and profiling.
 //!
-//! See [`AccountingAllocator`] and [`accounting_allocator`].
+//! ## First steps
+//!
+//! Add `re_memory` to your `Cargo.toml`:
+//!
+//! ```toml
+//! cargo add re_memory
+//! ```
+//!
+//! Install the [`AccountingAllocator`] in your `main.rs`:
+//! ```no_run
+//! use re_memory::AccountingAllocator;
+//!
+//! #[global_allocator]
+//! static GLOBAL: AccountingAllocator<std::alloc::System>
+//!     = AccountingAllocator::new(std::alloc::System);
+//! ```
+//!
+//! ### Checking memory use
+//! Use [`MemoryUse::capture`] to get the current memory use of your application.
+//!
+//! ### Finding meory leaks
+//! Turn on memory tracking at the top of your `main()` function:
+//!
+//! ```rs
+//! re_memory::accounting_allocator::set_tracking_callstacks(true);
+//! ```
+//!
+//! Now let your app run for a while, and then call [`accounting_allocator::tracking_stats`]
+//! to get the statistics. Any memory leak should show up in
+//! [`TrackingStatistics::top_callstacks`].
+//!
+//! ### More
+//! See also [`accounting_allocator`].
 
 pub mod accounting_allocator;
 mod allocation_tracker;
@@ -23,8 +55,11 @@ mod backtrace_web;
 use backtrace_web::Backtrace;
 
 pub use {
-    accounting_allocator::AccountingAllocator, memory_history::MemoryHistory,
-    memory_limit::MemoryLimit, memory_use::MemoryUse, ram_warner::*,
+    accounting_allocator::{AccountingAllocator, TrackingStatistics},
+    memory_history::MemoryHistory,
+    memory_limit::MemoryLimit,
+    memory_use::MemoryUse,
+    ram_warner::*,
 };
 
 /// Number of allocation and their total size.

--- a/crates/re_memory/src/lib.rs
+++ b/crates/re_memory/src/lib.rs
@@ -20,7 +20,7 @@
 //! ### Checking memory use
 //! Use [`MemoryUse::capture`] to get the current memory use of your application.
 //!
-//! ### Finding meory leaks
+//! ### Finding memory leaks
 //! Turn on memory tracking at the top of your `main()` function:
 //!
 //! ```rs

--- a/crates/re_memory/src/memory_use.rs
+++ b/crates/re_memory/src/memory_use.rs
@@ -1,3 +1,4 @@
+/// How much RAM is the application using?
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct MemoryUse {
     /// Bytes allocated by the application according to operating system.
@@ -18,6 +19,7 @@ pub struct MemoryUse {
 }
 
 impl MemoryUse {
+    /// Read the current memory of the running application.
     #[inline]
     pub fn capture() -> Self {
         Self {
@@ -50,6 +52,7 @@ impl std::ops::Mul<f32> for MemoryUse {
 impl std::ops::Sub for MemoryUse {
     type Output = Self;
 
+    #[inline]
     fn sub(self, rhs: Self) -> Self::Output {
         fn sub(a: Option<i64>, b: Option<i64>) -> Option<i64> {
             Some(a? - b?)

--- a/crates/re_memory/src/ram_warner.rs
+++ b/crates/re_memory/src/ram_warner.rs
@@ -23,6 +23,9 @@ pub fn total_ram_in_bytes() -> u64 {
 
 // ----------------------------------------------------------------------------
 
+/// Helper to warn if we are using too much RAM.
+///
+/// You need to call [`RamLimitWarner::update`] regularly.
 pub struct RamLimitWarner {
     total_ram_in_bytes: u64,
     warn_limit: u64,

--- a/crates/re_memory/src/util.rs
+++ b/crates/re_memory/src/util.rs
@@ -1,3 +1,5 @@
+//! Utitility functions
+
 /// Returns monotonically increasing time in seconds.
 #[inline]
 pub fn sec_since_start() -> f64 {


### PR DESCRIPTION
I keep referring people to re_memory to diagnose memory leaks, but our docs are lacking… until now.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4918/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4918/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4918/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4918)
- [Docs preview](https://rerun.io/preview/639ee6175884d4d80f333add07948dc51a1e3301/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/639ee6175884d4d80f333add07948dc51a1e3301/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)