### PR TITLE
Optimize point clouds

### DIFF
--- a/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
+++ b/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
@@ -119,21 +119,30 @@ where
         elements: impl Iterator<Item = T>,
     ) -> Result<usize, CpuWriteGpuReadError> {
         re_tracing::profile_function!();
-        let num_written_before = self.num_written();
 
-        for element in elements {
-            if self.unwritten_element_range.start >= self.unwritten_element_range.end {
-                return Err(CpuWriteGpuReadError::BufferFull {
-                    buffer_element_capacity: self.capacity(),
-                });
+        // TODO(emilk): optimize the extend function.
+        // Right now it is 3-4x faster to collect to a vec first, which is crazy.
+        if true {
+            let vec = elements.collect::<Vec<_>>();
+            self.extend_from_slice(&vec)?;
+            Ok(vec.len())
+        } else {
+            let num_written_before = self.num_written();
+
+            for element in elements {
+                if self.unwritten_element_range.start >= self.unwritten_element_range.end {
+                    return Err(CpuWriteGpuReadError::BufferFull {
+                        buffer_element_capacity: self.capacity(),
+                    });
+                }
+
+                self.as_mut_byte_slice()[..std::mem::size_of::<T>()]
+                    .copy_from_slice(bytemuck::bytes_of(&element));
+                self.unwritten_element_range.start += 1;
             }
 
-            self.as_mut_byte_slice()[..std::mem::size_of::<T>()]
-                .copy_from_slice(bytemuck::bytes_of(&element));
-            self.unwritten_element_range.start += 1;
+            Ok(self.num_written() - num_written_before)
         }
-
-        Ok(self.num_written() - num_written_before)
     }
 
     /// Fills the buffer with n instances of an element.

--- a/crates/re_space_view_spatial/src/visualizers/mod.rs
+++ b/crates/re_space_view_spatial/src/visualizers/mod.rs
@@ -130,7 +130,7 @@ pub fn process_color_slice<'a>(
     default_len: usize,
     ent_path: &'a EntityPath,
     annotation_infos: &'a ResolvedAnnotationInfos,
-) -> impl Iterator<Item = egui::Color32> + 'a {
+) -> Vec<egui::Color32> {
     re_tracing::profile_function!();
     let default_color = DefaultColor::EntityPath(ent_path);
 
@@ -139,9 +139,11 @@ pub fn process_color_slice<'a>(
         |data| itertools::Either::Right(data.iter()),
     );
 
-    itertools::izip!(annotation_infos.iter(), colors).map(move |(annotation_info, color)| {
-        annotation_info.color(color.map(|c| c.to_array()), default_color)
-    })
+    itertools::izip!(annotation_infos.iter(), colors)
+        .map(move |(annotation_info, color)| {
+            annotation_info.color(color.map(|c| c.to_array()), default_color)
+        })
+        .collect()
 }
 
 /// Process [`Text`] components using annotations.

--- a/crates/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points2d.rs
@@ -143,12 +143,7 @@ impl Points2DVisualizer {
             re_tracing::profile_scope!("labels");
 
             // Max labels is small enough that we can afford iterating on the colors again.
-            let colors = process_color_slice(
-                data.colors,
-                data.positions.len(),
-                ent_path,
-                &annotation_infos,
-            );
+            let colors = process_color_slice(data.colors, ent_path, &annotation_infos);
 
             let instance_path_hashes_for_picking = {
                 re_tracing::profile_scope!("instance_hashes");
@@ -199,13 +194,11 @@ impl Points2DVisualizer {
 
     #[inline]
     pub fn load_colors(
-        &Points2DComponentData {
-            positions, colors, ..
-        }: &Points2DComponentData<'_>,
+        &Points2DComponentData { colors, .. }: &Points2DComponentData<'_>,
         ent_path: &EntityPath,
         annotation_infos: &ResolvedAnnotationInfos,
     ) -> Vec<re_renderer::Color32> {
-        crate::visualizers::process_color_slice(colors, positions.len(), ent_path, annotation_infos)
+        crate::visualizers::process_color_slice(colors, ent_path, annotation_infos)
     }
 
     #[inline]

--- a/crates/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points2d.rs
@@ -184,12 +184,7 @@ impl Points2DVisualizer {
         }: &Points2DComponentData<'_>,
         ent_path: &EntityPath,
     ) -> Vec<re_renderer::Size> {
-        re_tracing::profile_function!();
-        let radii = crate::visualizers::process_radius_slice(radii, positions.len(), ent_path);
-        {
-            re_tracing::profile_scope!("collect");
-            radii.collect()
-        }
+        crate::visualizers::process_radius_slice(radii, positions.len(), ent_path)
     }
 
     #[inline]

--- a/crates/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points2d.rs
@@ -148,8 +148,7 @@ impl Points2DVisualizer {
                 data.positions.len(),
                 ent_path,
                 &annotation_infos,
-            )
-            .collect::<Vec<_>>();
+            );
 
             let instance_path_hashes_for_picking = {
                 re_tracing::profile_scope!("instance_hashes");
@@ -206,17 +205,7 @@ impl Points2DVisualizer {
         ent_path: &EntityPath,
         annotation_infos: &ResolvedAnnotationInfos,
     ) -> Vec<re_renderer::Color32> {
-        re_tracing::profile_function!();
-        let colors = crate::visualizers::process_color_slice(
-            colors,
-            positions.len(),
-            ent_path,
-            annotation_infos,
-        );
-        {
-            re_tracing::profile_scope!("collect");
-            colors.collect()
-        }
+        crate::visualizers::process_color_slice(colors, positions.len(), ent_path, annotation_infos)
     }
 
     #[inline]

--- a/crates/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points3d.rs
@@ -139,8 +139,7 @@ impl Points3DVisualizer {
                 data.positions.len(),
                 ent_path,
                 &annotation_infos,
-            )
-            .collect::<Vec<_>>();
+            );
 
             let instance_path_hashes_for_picking = {
                 re_tracing::profile_scope!("instance_hashes");
@@ -341,17 +340,7 @@ impl LoadedPoints {
         ent_path: &EntityPath,
         annotation_infos: &ResolvedAnnotationInfos,
     ) -> Vec<re_renderer::Color32> {
-        re_tracing::profile_function!();
-        let colors = crate::visualizers::process_color_slice(
-            colors,
-            positions.len(),
-            ent_path,
-            annotation_infos,
-        );
-        {
-            re_tracing::profile_scope!("collect");
-            colors.collect()
-        }
+        crate::visualizers::process_color_slice(colors, positions.len(), ent_path, annotation_infos)
     }
 
     #[inline]

--- a/crates/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points3d.rs
@@ -319,12 +319,7 @@ impl LoadedPoints {
         }: &Points3DComponentData<'_>,
         ent_path: &EntityPath,
     ) -> Vec<re_renderer::Size> {
-        re_tracing::profile_function!();
-        let radii = crate::visualizers::process_radius_slice(radii, positions.len(), ent_path);
-        {
-            re_tracing::profile_scope!("collect");
-            radii.collect()
-        }
+        crate::visualizers::process_radius_slice(radii, positions.len(), ent_path)
     }
 
     #[inline]

--- a/crates/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points3d.rs
@@ -134,12 +134,7 @@ impl Points3DVisualizer {
             re_tracing::profile_scope!("labels");
 
             // Max labels is small enough that we can afford iterating on the colors again.
-            let colors = process_color_slice(
-                data.colors,
-                data.positions.len(),
-                ent_path,
-                &annotation_infos,
-            );
+            let colors = process_color_slice(data.colors, ent_path, &annotation_infos);
 
             let instance_path_hashes_for_picking = {
                 re_tracing::profile_scope!("instance_hashes");
@@ -334,13 +329,11 @@ impl LoadedPoints {
 
     #[inline]
     pub fn load_colors(
-        &Points3DComponentData {
-            positions, colors, ..
-        }: &Points3DComponentData<'_>,
+        &Points3DComponentData { colors, .. }: &Points3DComponentData<'_>,
         ent_path: &EntityPath,
         annotation_infos: &ResolvedAnnotationInfos,
     ) -> Vec<re_renderer::Color32> {
-        crate::visualizers::process_color_slice(colors, positions.len(), ent_path, annotation_infos)
+        crate::visualizers::process_color_slice(colors, ent_path, annotation_infos)
     }
 
     #[inline]


### PR DESCRIPTION
### What
Some optimizations I found while playing around with large point clouds.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4932/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4932/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4932/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4932)
- [Docs preview](https://rerun.io/preview/772cd4195531d6731463ca5b74e3f61eddb38600/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/772cd4195531d6731463ca5b74e3f61eddb38600/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)