### PR TITLE
Fix not allowing to add any entitites to data table view

### DIFF
--- a/crates/re_space_view/src/data_query.rs
+++ b/crates/re_space_view/src/data_query.rs
@@ -1,6 +1,6 @@
 use re_entity_db::{external::re_data_store::LatestAtQuery, EntityProperties, EntityPropertyMap};
 use re_viewer_context::{
-    DataQueryResult, IndicatorMatchingEntities, PerVisualizer, StoreContext, VisualizableEntities,
+    DataQueryResult, IndicatedEntities, PerVisualizer, StoreContext, VisualizableEntities,
 };
 
 pub struct EntityOverrideContext {
@@ -36,6 +36,6 @@ pub trait DataQuery {
         &self,
         ctx: &StoreContext<'_>,
         visualizable_entities_for_visualizer_systems: &PerVisualizer<VisualizableEntities>,
-        indicated_entities_per_visualizer: &PerVisualizer<IndicatorMatchingEntities>,
+        indicated_entities_per_visualizer: &PerVisualizer<IndicatedEntities>,
     ) -> DataQueryResult;
 }

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -12,7 +12,7 @@ use re_log_types::{
 use re_types_core::archetypes::Clear;
 use re_viewer_context::{
     blueprint_timepoint_for_writes, DataQueryId, DataQueryResult, DataResult, DataResultHandle,
-    DataResultNode, DataResultTree, IndicatorMatchingEntities, PerVisualizer, PropertyOverrides,
+    DataResultNode, DataResultTree, IndicatedEntities, PerVisualizer, PropertyOverrides,
     SpaceViewClassIdentifier, SpaceViewId, StoreContext, SystemCommand, SystemCommandSender as _,
     ViewSystemIdentifier, ViewerContext, VisualizableEntities,
 };
@@ -181,7 +181,7 @@ impl DataQuery for DataQueryBlueprint {
         &self,
         ctx: &re_viewer_context::StoreContext<'_>,
         visualizable_entities_for_visualizer_systems: &PerVisualizer<VisualizableEntities>,
-        indicated_entities_per_visualizer: &PerVisualizer<IndicatorMatchingEntities>,
+        indicated_entities_per_visualizer: &PerVisualizer<IndicatedEntities>,
     ) -> DataQueryResult {
         re_tracing::profile_function!();
 
@@ -212,7 +212,7 @@ impl DataQuery for DataQueryBlueprint {
 /// to a pure recursive evaluation.
 struct QueryExpressionEvaluator<'a> {
     visualizable_entities_for_visualizer_systems: &'a PerVisualizer<VisualizableEntities>,
-    indicated_entities_per_visualizer: &'a IntMap<ViewSystemIdentifier, IndicatorMatchingEntities>,
+    indicated_entities_per_visualizer: &'a IntMap<ViewSystemIdentifier, IndicatedEntities>,
     entity_path_filter: EntityPathFilter,
 }
 
@@ -220,10 +220,7 @@ impl<'a> QueryExpressionEvaluator<'a> {
     fn new(
         blueprint: &'a DataQueryBlueprint,
         visualizable_entities_for_visualizer_systems: &'a PerVisualizer<VisualizableEntities>,
-        indicated_entities_per_visualizer: &'a IntMap<
-            ViewSystemIdentifier,
-            IndicatorMatchingEntities,
-        >,
+        indicated_entities_per_visualizer: &'a IntMap<ViewSystemIdentifier, IndicatedEntities>,
     ) -> Self {
         re_tracing::profile_function!();
 
@@ -657,14 +654,11 @@ mod tests {
                 entity_path_filter: EntityPathFilter::parse_forgiving(filter),
             };
 
-            let indicated_entities_per_visualizer = PerVisualizer::<IndicatorMatchingEntities>(
+            let indicated_entities_per_visualizer = PerVisualizer::<IndicatedEntities>(
                 visualizable_entities_for_visualizer_systems
                     .iter()
                     .map(|(id, entities)| {
-                        (
-                            *id,
-                            IndicatorMatchingEntities(entities.0.iter().cloned().collect()),
-                        )
+                        (*id, IndicatedEntities(entities.0.iter().cloned().collect()))
                     })
                     .collect(),
             );

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -56,7 +56,7 @@ pub use store_context::StoreContext;
 pub use tensor::{TensorDecodeCache, TensorStats, TensorStatsCache};
 pub use time_control::{Looping, PlayState, TimeControl, TimeView};
 pub use typed_entity_collections::{
-    ApplicableEntities, IndicatorMatchingEntities, PerVisualizer, VisualizableEntities,
+    ApplicableEntities, IndicatedEntities, PerVisualizer, VisualizableEntities,
 };
 pub use utils::{auto_color, level_to_rich_text, DefaultColor};
 pub use viewer_context::{RecordingConfig, ViewerContext};

--- a/crates/re_viewer_context/src/space_view/space_view_class_registry.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class_registry.rs
@@ -2,9 +2,9 @@ use ahash::{HashMap, HashSet};
 use re_data_store::DataStore;
 
 use crate::{
-    ApplicableEntities, DynSpaceViewClass, IdentifiedViewSystem, IndicatorMatchingEntities,
-    PerVisualizer, SpaceViewClassIdentifier, ViewContextCollection, ViewContextSystem,
-    ViewSystemIdentifier, VisualizerCollection, VisualizerSystem,
+    ApplicableEntities, DynSpaceViewClass, IdentifiedViewSystem, IndicatedEntities, PerVisualizer,
+    SpaceViewClassIdentifier, ViewContextCollection, ViewContextSystem, ViewSystemIdentifier,
+    VisualizerCollection, VisualizerSystem,
 };
 
 use super::{
@@ -308,10 +308,10 @@ impl SpaceViewClassRegistry {
     pub fn indicated_entities_per_visualizer(
         &self,
         store_id: &re_log_types::StoreId,
-    ) -> PerVisualizer<IndicatorMatchingEntities> {
+    ) -> PerVisualizer<IndicatedEntities> {
         re_tracing::profile_function!();
 
-        PerVisualizer::<IndicatorMatchingEntities>(
+        PerVisualizer::<IndicatedEntities>(
             self.visualizers
                 .iter()
                 .map(|(id, entry)| {

--- a/crates/re_viewer_context/src/space_view/space_view_class_registry.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class_registry.rs
@@ -319,7 +319,7 @@ impl SpaceViewClassRegistry {
                         *id,
                         DataStore::with_subscriber::<VisualizerEntitySubscriber, _, _>(
                             entry.entity_subscriber_handle,
-                            |subscriber| subscriber.indicator_matching_entities(store_id).cloned(),
+                            |subscriber| subscriber.indicated_entities(store_id).cloned(),
                         )
                         .flatten()
                         .unwrap_or_default(),

--- a/crates/re_viewer_context/src/space_view/visualizer_entity_subscriber.rs
+++ b/crates/re_viewer_context/src/space_view/visualizer_entity_subscriber.rs
@@ -8,7 +8,7 @@ use re_log_types::{EntityPathHash, StoreId};
 use re_types::{ComponentName, ComponentNameSet};
 
 use crate::{
-    ApplicableEntities, IdentifiedViewSystem, IndicatorMatchingEntities, ViewSystemIdentifier,
+    ApplicableEntities, IdentifiedViewSystem, IndicatedEntities, ViewSystemIdentifier,
     VisualizerSystem,
 };
 
@@ -82,7 +82,7 @@ struct VisualizerEntityMapping {
     ///
     /// Special case:
     /// If the visualizer has no indicator components, this list will contain all entities in the store.
-    indicated_entities: IndicatorMatchingEntities,
+    indicated_entities: IndicatedEntities,
 }
 
 impl VisualizerEntitySubscriber {
@@ -117,7 +117,7 @@ impl VisualizerEntitySubscriber {
     /// Does *not* imply that any of the given entities is also in the applicable-set!
     ///
     /// If the visualizer has no indicator components, this list will contain all entities in the store.
-    pub fn indicated_entities(&self, store: &StoreId) -> Option<&IndicatorMatchingEntities> {
+    pub fn indicated_entities(&self, store: &StoreId) -> Option<&IndicatedEntities> {
         self.per_store_mapping
             .get(store)
             .map(|mapping| &mapping.indicated_entities)

--- a/crates/re_viewer_context/src/typed_entity_collections.rs
+++ b/crates/re_viewer_context/src/typed_entity_collections.rs
@@ -25,9 +25,9 @@ impl std::ops::Deref for ApplicableEntities {
 /// In order to be a match the entity must have at some point in time on any timeline had any of
 /// the indicator components specified by the respective visualizer system.
 #[derive(Default, Clone)]
-pub struct IndicatorMatchingEntities(pub IntSet<EntityPath>);
+pub struct IndicatedEntities(pub IntSet<EntityPath>);
 
-impl std::ops::Deref for IndicatorMatchingEntities {
+impl std::ops::Deref for IndicatedEntities {
     type Target = IntSet<EntityPath>;
 
     #[inline]

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -6,8 +6,8 @@ use re_entity_db::entity_db::EntityDb;
 
 use crate::{
     query_context::DataQueryResult, AppOptions, ApplicableEntities, ApplicationSelectionState,
-    Caches, CommandSender, ComponentUiRegistry, DataQueryId, IndicatorMatchingEntities,
-    PerVisualizer, Selection, SpaceViewClassRegistry, StoreContext, TimeControl,
+    Caches, CommandSender, ComponentUiRegistry, DataQueryId, IndicatedEntities, PerVisualizer,
+    Selection, SpaceViewClassRegistry, StoreContext, TimeControl,
 };
 
 /// Common things needed by many parts of the viewer.
@@ -42,7 +42,7 @@ pub struct ViewerContext<'a> {
     ///
     /// TODO(andreas): Should we always do the intersection with `applicable_entities_per_visualizer`
     ///                 or are we ever interested in a non-applicable but indicator-matching entity?
-    pub indicated_entities_per_visualizer: &'a PerVisualizer<IndicatorMatchingEntities>,
+    pub indicated_entities_per_visualizer: &'a PerVisualizer<IndicatedEntities>,
 
     /// All the query results for this frame
     pub query_results: &'a HashMap<DataQueryId, DataQueryResult>,

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -561,8 +561,7 @@ mod tests {
     use re_space_view::{DataQuery as _, PropertyResolver as _};
     use re_types::archetypes::Points3D;
     use re_viewer_context::{
-        blueprint_timeline, IndicatorMatchingEntities, PerVisualizer, StoreContext,
-        VisualizableEntities,
+        blueprint_timeline, IndicatedEntities, PerVisualizer, StoreContext, VisualizableEntities,
     };
 
     use super::*;
@@ -629,16 +628,11 @@ mod tests {
                     .collect(),
                 )
             });
-        let indicated_entities_per_visualizer = PerVisualizer::<IndicatorMatchingEntities>(
+        let indicated_entities_per_visualizer = PerVisualizer::<IndicatedEntities>(
             visualizable_entities
                 .0
                 .iter()
-                .map(|(id, entities)| {
-                    (
-                        *id,
-                        IndicatorMatchingEntities(entities.iter().cloned().collect()),
-                    )
-                })
+                .map(|(id, entities)| (*id, IndicatedEntities(entities.iter().cloned().collect())))
                 .collect(),
         );
 


### PR DESCRIPTION
### What

* Fixes #4923

Special-case not requiring any indicator component to cause every entity to be "indicated" for visualizers.
Also, used the opportunity to infect more places with the idea of calling it "indicated entities" as recently landed to `main` in other parts of the code.

<img width="2485" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/2e48020f-0331-4c25-9287-3f2ead34ba25">



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4933/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4933/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4933/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4933)
- [Docs preview](https://rerun.io/preview/fd28112437d77b512f1dce85346a71821b9a7808/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/fd28112437d77b512f1dce85346a71821b9a7808/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)