### PR TITLE
`DisconnectedSpace` now only applies to spatial space views

### DIFF
--- a/crates/re_types/definitions/rerun/archetypes/disconnected_space.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/disconnected_space.fbs
@@ -5,8 +5,10 @@ include "rerun/components.fbs";
 
 namespace rerun.archetypes;
 
-/// Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
+/// Spatially disconnect this entity from its parent.
 ///
+/// Specifies that the entity path at which this is logged is spatially disconnected from its parent,
+/// making it impossible to transform the entity path into its parent's space and vice versa.
 /// It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 /// This is useful for specifying that a subgraph is independent of the rest of the scene.
 ///

--- a/crates/re_types/definitions/rerun/archetypes/disconnected_space.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/disconnected_space.fbs
@@ -5,12 +5,10 @@ include "rerun/components.fbs";
 
 namespace rerun.archetypes;
 
-/// Specifies that the entity path at which this is logged is disconnected from its parent.
+/// Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
 ///
+/// It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 /// This is useful for specifying that a subgraph is independent of the rest of the scene.
-///
-/// If a transform or pinhole is logged on the same path, this archetype's components
-/// will be ignored.
 ///
 /// \example disconnected_space title="Disconnected Space" image="https://static.rerun.io/disconnected_space/b8f95b0e32359de625a765247c84935146c1fba9/1200w.png"
 table DisconnectedSpace (

--- a/crates/re_types/definitions/rerun/components/disconnected_space.fbs
+++ b/crates/re_types/definitions/rerun/components/disconnected_space.fbs
@@ -9,8 +9,10 @@ namespace rerun.components;
 
 // ---
 
-/// Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
+/// Spatially disconnect this entity from its parent.
 ///
+/// Specifies that the entity path at which this is logged is spatially disconnected from its parent,
+/// making it impossible to transform the entity path into its parent's space and vice versa.
 /// It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 /// This is useful for specifying that a subgraph is independent of the rest of the scene.
 struct DisconnectedSpace (

--- a/crates/re_types/definitions/rerun/components/disconnected_space.fbs
+++ b/crates/re_types/definitions/rerun/components/disconnected_space.fbs
@@ -9,11 +9,10 @@ namespace rerun.components;
 
 // ---
 
-/// Specifies that the entity path at which this is logged is disconnected from its parent.
+/// Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
 ///
+/// It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 /// This is useful for specifying that a subgraph is independent of the rest of the scene.
-///
-/// If a transform or pinhole is logged on the same path, this component will be ignored.
 struct DisconnectedSpace (
   "attr.python.aliases": "bool",
   "attr.python.array_aliases": "bool, npt.NDArray[np.bool_]",

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -21,12 +21,10 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Archetype**: Specifies that the entity path at which this is logged is disconnected from its parent.
+/// **Archetype**: Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
 ///
+/// It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 /// This is useful for specifying that a subgraph is independent of the rest of the scene.
-///
-/// If a transform or pinhole is logged on the same path, this archetype's components
-/// will be ignored.
 ///
 /// ## Example
 ///

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -21,8 +21,10 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Archetype**: Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
+/// **Archetype**: Spatially disconnect this entity from its parent.
 ///
+/// Specifies that the entity path at which this is logged is spatially disconnected from its parent,
+/// making it impossible to transform the entity path into its parent's space and vice versa.
 /// It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 /// This is useful for specifying that a subgraph is independent of the rest of the scene.
 ///

--- a/crates/re_types/src/components/disconnected_space.rs
+++ b/crates/re_types/src/components/disconnected_space.rs
@@ -21,8 +21,10 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Component**: Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
+/// **Component**: Spatially disconnect this entity from its parent.
 ///
+/// Specifies that the entity path at which this is logged is spatially disconnected from its parent,
+/// making it impossible to transform the entity path into its parent's space and vice versa.
 /// It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 /// This is useful for specifying that a subgraph is independent of the rest of the scene.
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]

--- a/crates/re_types/src/components/disconnected_space.rs
+++ b/crates/re_types/src/components/disconnected_space.rs
@@ -21,11 +21,10 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Component**: Specifies that the entity path at which this is logged is disconnected from its parent.
+/// **Component**: Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
 ///
+/// It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 /// This is useful for specifying that a subgraph is independent of the rest of the scene.
-///
-/// If a transform or pinhole is logged on the same path, this component will be ignored.
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub struct DisconnectedSpace(
     /// Whether the entity path at which this is logged is disconnected from its parent.

--- a/docs/content/reference/types/archetypes/disconnected_space.md
+++ b/docs/content/reference/types/archetypes/disconnected_space.md
@@ -2,12 +2,10 @@
 title: "DisconnectedSpace"
 ---
 
-Specifies that the entity path at which this is logged is disconnected from its parent.
+Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
 
+It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 This is useful for specifying that a subgraph is independent of the rest of the scene.
-
-If a transform or pinhole is logged on the same path, this archetype's components
-will be ignored.
 
 ## Components
 

--- a/docs/content/reference/types/archetypes/disconnected_space.md
+++ b/docs/content/reference/types/archetypes/disconnected_space.md
@@ -2,8 +2,10 @@
 title: "DisconnectedSpace"
 ---
 
-Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
+Spatially disconnect this entity from its parent.
 
+Specifies that the entity path at which this is logged is spatially disconnected from its parent,
+making it impossible to transform the entity path into its parent's space and vice versa.
 It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 This is useful for specifying that a subgraph is independent of the rest of the scene.
 

--- a/docs/content/reference/types/components/disconnected_space.md
+++ b/docs/content/reference/types/components/disconnected_space.md
@@ -2,8 +2,10 @@
 title: "DisconnectedSpace"
 ---
 
-Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
+Spatially disconnect this entity from its parent.
 
+Specifies that the entity path at which this is logged is spatially disconnected from its parent,
+making it impossible to transform the entity path into its parent's space and vice versa.
 It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 This is useful for specifying that a subgraph is independent of the rest of the scene.
 

--- a/docs/content/reference/types/components/disconnected_space.md
+++ b/docs/content/reference/types/components/disconnected_space.md
@@ -2,11 +2,10 @@
 title: "DisconnectedSpace"
 ---
 
-Specifies that the entity path at which this is logged is disconnected from its parent.
+Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
 
+It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 This is useful for specifying that a subgraph is independent of the rest of the scene.
-
-If a transform or pinhole is logged on the same path, this component will be ignored.
 
 
 ## Links

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -14,12 +14,10 @@
 #include <vector>
 
 namespace rerun::archetypes {
-    /// **Archetype**: Specifies that the entity path at which this is logged is disconnected from its parent.
+    /// **Archetype**: Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
     ///
+    /// It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
     /// This is useful for specifying that a subgraph is independent of the rest of the scene.
-    ///
-    /// If a transform or pinhole is logged on the same path, this archetype's components
-    /// will be ignored.
     ///
     /// ## Example
     ///

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -14,8 +14,10 @@
 #include <vector>
 
 namespace rerun::archetypes {
-    /// **Archetype**: Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
+    /// **Archetype**: Spatially disconnect this entity from its parent.
     ///
+    /// Specifies that the entity path at which this is logged is spatially disconnected from its parent,
+    /// making it impossible to transform the entity path into its parent's space and vice versa.
     /// It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
     /// This is useful for specifying that a subgraph is independent of the rest of the scene.
     ///

--- a/rerun_cpp/src/rerun/components/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.hpp
@@ -15,8 +15,10 @@ namespace arrow {
 } // namespace arrow
 
 namespace rerun::components {
-    /// **Component**: Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
+    /// **Component**: Spatially disconnect this entity from its parent.
     ///
+    /// Specifies that the entity path at which this is logged is spatially disconnected from its parent,
+    /// making it impossible to transform the entity path into its parent's space and vice versa.
     /// It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
     /// This is useful for specifying that a subgraph is independent of the rest of the scene.
     struct DisconnectedSpace {

--- a/rerun_cpp/src/rerun/components/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.hpp
@@ -15,11 +15,10 @@ namespace arrow {
 } // namespace arrow
 
 namespace rerun::components {
-    /// **Component**: Specifies that the entity path at which this is logged is disconnected from its parent.
+    /// **Component**: Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
     ///
+    /// It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
     /// This is useful for specifying that a subgraph is independent of the rest of the scene.
-    ///
-    /// If a transform or pinhole is logged on the same path, this component will be ignored.
     struct DisconnectedSpace {
         /// Whether the entity path at which this is logged is disconnected from its parent.
         bool is_disconnected;

--- a/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
@@ -17,8 +17,10 @@ __all__ = ["DisconnectedSpace"]
 @define(str=False, repr=False, init=False)
 class DisconnectedSpace(DisconnectedSpaceExt, Archetype):
     """
-    **Archetype**: Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
+    **Archetype**: Spatially disconnect this entity from its parent.
 
+    Specifies that the entity path at which this is logged is spatially disconnected from its parent,
+    making it impossible to transform the entity path into its parent's space and vice versa.
     It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
     This is useful for specifying that a subgraph is independent of the rest of the scene.
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
@@ -17,12 +17,10 @@ __all__ = ["DisconnectedSpace"]
 @define(str=False, repr=False, init=False)
 class DisconnectedSpace(DisconnectedSpaceExt, Archetype):
     """
-    **Archetype**: Specifies that the entity path at which this is logged is disconnected from its parent.
+    **Archetype**: Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
 
+    It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
     This is useful for specifying that a subgraph is independent of the rest of the scene.
-
-    If a transform or pinhole is logged on the same path, this archetype's components
-    will be ignored.
 
     Example
     -------

--- a/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
@@ -27,8 +27,10 @@ __all__ = [
 @define(init=False)
 class DisconnectedSpace(DisconnectedSpaceExt):
     """
-    **Component**: Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
+    **Component**: Spatially disconnect this entity from its parent.
 
+    Specifies that the entity path at which this is logged is spatially disconnected from its parent,
+    making it impossible to transform the entity path into its parent's space and vice versa.
     It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
     This is useful for specifying that a subgraph is independent of the rest of the scene.
     """

--- a/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
@@ -27,11 +27,10 @@ __all__ = [
 @define(init=False)
 class DisconnectedSpace(DisconnectedSpaceExt):
     """
-    **Component**: Specifies that the entity path at which this is logged is disconnected from its parent.
+    **Component**: Specifies that the entity path at which this is logged is spatially disconnected from its parent, making it impossible to transform the entity path into its parent's space and vice versa.
 
+    It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
     This is useful for specifying that a subgraph is independent of the rest of the scene.
-
-    If a transform or pinhole is logged on the same path, this component will be ignored.
     """
 
     # __init__ can be found in disconnected_space_ext.py


### PR DESCRIPTION
### What


* Part of #4388
* Fixes #4465

This PR only addresses the documentation. `main` is actually in a slightly mixed state right now: Visualizability is already determined strictly with `DisconnectedSpace` only applying to spatial views, but we still have the legacy `SpaceInfo` used in some places that applies this concept to everything. This will be removed in a a follow-up.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4935/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4935/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4935/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4935)
- [Docs preview](https://rerun.io/preview/4eec4acd74c6d5a8f132bd8490895ae45e90aac7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4eec4acd74c6d5a8f132bd8490895ae45e90aac7/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)