### PR TITLE
Make it easier to position 3D eye-camera center

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4732,6 +4732,7 @@ dependencies = [
  "re_viewer_context",
  "serde",
  "smallvec",
+ "web-time",
 ]
 
 [[package]]

--- a/crates/re_space_view_spatial/Cargo.toml
+++ b/crates/re_space_view_spatial/Cargo.toml
@@ -46,6 +46,7 @@ parking_lot.workspace = true
 rayon.workspace = true
 serde.workspace = true
 smallvec = { workspace = true, features = ["serde"] }
+web-time.workspace = true
 
 
 [dev-dependencies]

--- a/crates/re_space_view_spatial/src/eye.rs
+++ b/crates/re_space_view_spatial/src/eye.rs
@@ -1,6 +1,6 @@
 use egui::{lerp, NumExt as _, Rect};
 use glam::Affine3A;
-use macaw::{vec3, BoundingBox, IsoTransform, Mat4, Quat, Vec3};
+use macaw::{vec3, IsoTransform, Mat4, Quat, Vec3};
 
 use re_space_view::controls::{
     RuntimeModifiers, DRAG_PAN3D_BUTTON, ROLL_MOUSE, ROLL_MOUSE_ALT, ROLL_MOUSE_MODIFIER,

--- a/crates/re_space_view_spatial/src/eye.rs
+++ b/crates/re_space_view_spatial/src/eye.rs
@@ -309,18 +309,15 @@ impl OrbitEye {
         if zoom_factor != 1.0 {
             let new_radius = self.orbit_radius / zoom_factor;
 
-            let very_close = scene_bbox.size().length() / 100.0;
-            if very_close.is_finite() && new_radius < very_close && 1.0 < zoom_factor {
-                // The user may be scrolling to move the camera closer, but are not realizing
-                // the radius is now tiny.
-                // Switch to instead dolly the camera forward:
-                self.orbit_center += self.fwd() * very_close * zoom_factor.ln();
-            } else {
-                // Don't let radius go too small or too big because this might cause infinity/nan in some calculations.
-                // Max value is chosen with some generous margin of an observed crash due to infinity.
-                if f32::MIN_POSITIVE < new_radius && new_radius < 1.0e17 {
-                    self.orbit_radius = new_radius;
-                }
+            // The user may be scrolling to move the camera closer, but are not realizing
+            // the radius is now tiny.
+            // TODO(emilk): inform the users somehow that scrolling won't help, and that they should use WSAD instead.
+            // It might be tempting to start moving the camera here on scoll, but that would is bad for other reasons.
+
+            // Don't let radius go too small or too big because this might cause infinity/nan in some calculations.
+            // Max value is chosen with some generous margin of an observed crash due to infinity.
+            if f32::MIN_POSITIVE < new_radius && new_radius < 1.0e17 {
+                self.orbit_radius = new_radius;
             }
         }
 

--- a/crates/re_space_view_spatial/src/eye.rs
+++ b/crates/re_space_view_spatial/src/eye.rs
@@ -266,12 +266,7 @@ impl OrbitEye {
 
     /// Returns `true` if interaction occurred.
     /// I.e. the camera changed via user input.
-    pub fn update(
-        &mut self,
-        response: &egui::Response,
-        drag_threshold: f32,
-        scene_bbox: &BoundingBox,
-    ) -> bool {
+    pub fn update(&mut self, response: &egui::Response, drag_threshold: f32) -> bool {
         // Dragging even below the [`drag_threshold`] should be considered interaction.
         // Otherwise we flicker in and out of "has interacted" too quickly.
         let mut did_interact = response.drag_delta().length() > 0.0;

--- a/crates/re_space_view_spatial/src/eye.rs
+++ b/crates/re_space_view_spatial/src/eye.rs
@@ -312,7 +312,7 @@ impl OrbitEye {
             // The user may be scrolling to move the camera closer, but are not realizing
             // the radius is now tiny.
             // TODO(emilk): inform the users somehow that scrolling won't help, and that they should use WSAD instead.
-            // It might be tempting to start moving the camera here on scoll, but that would is bad for other reasons.
+            // It might be tempting to start moving the camera here on scroll, but that would is bad for other reasons.
 
             // Don't let radius go too small or too big because this might cause infinity/nan in some calculations.
             // Max value is chosen with some generous margin of an observed crash due to infinity.

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -178,11 +178,7 @@ impl View3DState {
             0.0
         };
 
-        if orbit_eye.update(
-            response,
-            orbit_eye_drag_threshold,
-            &bounding_boxes.accumulated,
-        ) {
+        if orbit_eye.update(response, orbit_eye_drag_threshold) {
             self.last_eye_interaction = Some(Instant::now());
             self.eye_interpolation = None;
             self.tracked_entity = None;


### PR DESCRIPTION
### What
With this PR, we show the orbit center when using WSAD (and when focusing on an entity).
This makes it much easier to position the orbit center exactly where you want it.

I also removed the scroll-to-move "feature"

* Closes https://github.com/rerun-io/rerun/issues/4402

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4943/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4943/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4943/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4943)
- [Docs preview](https://rerun.io/preview/efde01b58c234ac13d26c464239ce5015f770641/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/efde01b58c234ac13d26c464239ce5015f770641/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)