### PR TITLE
Primary cache: fix crash when using `Clear`

### DIFF
--- a/crates/re_query_cache/src/flat_vec_deque.rs
+++ b/crates/re_query_cache/src/flat_vec_deque.rs
@@ -260,6 +260,10 @@ impl<T> FlatVecDeque<T> {
             .skip(entry_range.start)
             .take(entry_range.len())
             .map(|offsets| {
+                if offsets.is_empty() {
+                    return &[] as &'_ [T];
+                }
+
                 // NOTE: We do not need `make_contiguous` here because we always guarantee
                 // that a single entry's worth of values is fully contained in either the left or
                 // right buffer, but never straddling across both.

--- a/crates/re_query_cache/src/flat_vec_deque.rs
+++ b/crates/re_query_cache/src/flat_vec_deque.rs
@@ -478,6 +478,28 @@ fn insert_empty() {
     assert_deque_eq(&[&[], &[], &[]], &v);
 }
 
+// Simulate the bug that was making everything crash on the face tracking example (ultimately
+// caused by recursive clears).
+#[test]
+fn insert_some_and_empty() {
+    let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+
+    assert_eq!(0, v.num_entries());
+    assert_eq!(0, v.num_values());
+
+    v.push_back([0]);
+    v.push_back([]);
+
+    v.push_back([1]);
+    v.push_back([]);
+
+    v.push_back([2]);
+    v.push_back([]);
+
+    // That used to crash.
+    assert_deque_eq(&[&[0], &[], &[1], &[], &[2], &[]], &v);
+}
+
 #[test]
 fn insert_many() {
     let mut v: FlatVecDeque<i64> = FlatVecDeque::new();


### PR DESCRIPTION
Just a silly mistake in the `FlatVecDeque` iterator.
- Fixes https://github.com/rerun-io/rerun/issues/4925

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4949/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4949/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4949/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4949)
- [Docs preview](https://rerun.io/preview/f03326008f64f3254f0544d7b14c09b5dab4f791/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f03326008f64f3254f0544d7b14c09b5dab4f791/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)