### PR TITLE
Don't clear scalars in `face tracking` example

### DIFF
--- a/examples/python/face_tracking/main.py
+++ b/examples/python/face_tracking/main.py
@@ -237,12 +237,28 @@ class FaceLandmarkerLogger:
             if self._video_mode
             else self._detector.detect(image)
         )
-        rr.log("video/landmarker/faces", rr.Clear(recursive=True))
-        rr.log("reconstruction/faces", rr.Clear(recursive=True))
+
+        def is_empty(i):
+            try:
+                next(i)
+                return False
+            except StopIteration:
+                return True
+
+        if is_empty(zip(detection_result.face_landmarks, detection_result.face_blendshapes)):
+            rr.log("video/landmarker/faces", rr.Clear(recursive=True))
+            rr.log("reconstruction/faces", rr.Clear(recursive=True))
+            rr.log("blendshapes", rr.Clear(recursive=True))
 
         for i, (landmark, blendshapes) in enumerate(
             zip(detection_result.face_landmarks, detection_result.face_blendshapes)
         ):
+            if len(landmark) == 0 or len(blendshapes) == 0:
+                rr.log(f"video/landmarker/faces/{i}/landmarks", rr.Clear(recursive=True))
+                rr.log(f"reconstruction/faces/{i}", rr.Clear(recursive=True))
+                rr.log(f"blendshapes/{i}", rr.Clear(recursive=True))
+                continue
+
             # MediaPipe's keypoints are normalized to [0, 1], so we need to scale them to get pixel coordinates.
             pts = [(math.floor(lm.x * width), math.floor(lm.y * height)) for lm in landmark]
             keypoint_ids = list(range(len(landmark)))

--- a/examples/python/face_tracking/main.py
+++ b/examples/python/face_tracking/main.py
@@ -238,7 +238,7 @@ class FaceLandmarkerLogger:
             else self._detector.detect(image)
         )
 
-        def is_empty(i):
+        def is_empty(i):  # type: ignore[no-untyped-def]
             try:
                 next(i)
                 return False

--- a/examples/python/face_tracking/main.py
+++ b/examples/python/face_tracking/main.py
@@ -239,7 +239,6 @@ class FaceLandmarkerLogger:
         )
         rr.log("video/landmarker/faces", rr.Clear(recursive=True))
         rr.log("reconstruction/faces", rr.Clear(recursive=True))
-        rr.log("blendshapes", rr.Clear(recursive=True))
 
         for i, (landmark, blendshapes) in enumerate(
             zip(detection_result.face_landmarks, detection_result.face_blendshapes)


### PR DESCRIPTION
This is what caused the deadlocks/crashes we were after (which I'm glad it did -- those have been fixed in #4949).

Even though they are not a problem anymore, I'm not sure why they're here to begin with? Clearing scalars does nothing unless you specifically intend to use them with latest-at queries (i.e. not plots, which isn't the case here), otherwise it's just inefficient with no upside (which I'd rather not teach users). Am I missing something? :thinking: 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4950/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4950/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4950/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4950)
- [Docs preview](https://rerun.io/preview/04df6b2ec67d725f3d086ce3327d33baa025379d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/04df6b2ec67d725f3d086ce3327d33baa025379d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)