### PR TITLE
Break up plot charts when there's a `Clear`

### DIFF
--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -390,6 +390,8 @@ impl SpaceViewClass for TimeSeriesSpaceView {
                             .color(color)
                             .radius(line.width),
                     ),
+                    // Break up the chart. At some point we might want something fancier.
+                    PlotSeriesKind::Clear => {}
                 }
             }
 

--- a/crates/re_space_view_time_series/src/visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/visualizer_system.rs
@@ -19,7 +19,7 @@ pub struct PlotPointAttrs {
     pub label: Option<String>,
     pub color: egui::Color32,
     pub radius: f32,
-    pub scattered: bool,
+    pub kind: PlotSeriesKind,
 }
 
 impl PartialEq for PlotPointAttrs {
@@ -28,12 +28,12 @@ impl PartialEq for PlotPointAttrs {
             label,
             color,
             radius,
-            scattered,
+            kind,
         } = self;
         label.eq(&rhs.label)
             && color.eq(&rhs.color)
             && radius.total_cmp(&rhs.radius).is_eq()
-            && scattered.eq(&rhs.scattered)
+            && kind.eq(&rhs.kind)
     }
 }
 
@@ -46,10 +46,11 @@ struct PlotPoint {
     attrs: PlotPointAttrs,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PlotSeriesKind {
     Continuous,
     Scatter,
+    Clear,
 }
 
 #[derive(Clone, Debug)]
@@ -240,6 +241,21 @@ impl TimeSeriesSystem {
                             return;
                         }; // scalars cannot be timeless
 
+                        // This is a clear: we want to split the chart.
+                        if scalars.is_empty() {
+                            points.push(PlotPoint {
+                                time: time.as_i64(),
+                                value: 0.0,
+                                attrs: PlotPointAttrs {
+                                    label: None,
+                                    color: egui::Color32::BLACK,
+                                    radius: 0.0,
+                                    kind: PlotSeriesKind::Clear,
+                                },
+                            });
+                            return;
+                        }
+
                         for (scalar, scattered, color, radius, label) in itertools::izip!(
                             scalars.iter(),
                             MaybeCachedComponentData::iter_or_repeat_opt(&scatterings, scalars.len()),
@@ -258,6 +274,12 @@ impl TimeSeriesSystem {
                             let radius = override_radius
                                 .unwrap_or_else(|| radius.map_or(DEFAULT_RADIUS, |r| r.0));
 
+                            let kind = if scattered {
+                                PlotSeriesKind::Scatter
+                            } else {
+                                PlotSeriesKind::Continuous
+                            };
+
                             const DEFAULT_RADIUS: f32 = 0.75;
 
                             points.push(PlotPoint {
@@ -267,7 +289,7 @@ impl TimeSeriesSystem {
                                     label,
                                     color,
                                     radius,
-                                    scattered,
+                                    kind,
                                 },
                             });
                         }
@@ -385,12 +407,8 @@ impl TimeSeriesSystem {
             label: line_label.to_owned(),
             color: attrs.color,
             width: 2.0 * attrs.radius,
-            kind: if attrs.scattered {
-                PlotSeriesKind::Scatter
-            } else {
-                PlotSeriesKind::Continuous
-            },
             points: Vec::with_capacity(num_points),
+            kind: attrs.kind,
         };
 
         for (i, p) in points.into_iter().enumerate() {
@@ -402,20 +420,14 @@ impl TimeSeriesSystem {
                 // Attributes changed since last point, break up the current run into a
                 // line segment, and start the next one.
 
-                attrs = p.attrs.clone();
-                let kind = if attrs.scattered {
-                    PlotSeriesKind::Scatter
-                } else {
-                    PlotSeriesKind::Continuous
-                };
-
+                attrs = p.attrs;
                 let prev_line = std::mem::replace(
                     &mut line,
                     PlotSeries {
                         label: line_label.to_owned(),
                         color: attrs.color,
                         width: 2.0 * attrs.radius,
-                        kind,
+                        kind: attrs.kind,
                         points: Vec::with_capacity(num_points - i),
                     },
                 );
@@ -425,8 +437,8 @@ impl TimeSeriesSystem {
                 // If the previous point was continuous and the current point is continuous
                 // too, then we want the 2 segments to appear continuous even though they
                 // are actually split from a data standpoint.
-                let cur_continuous = matches!(kind, PlotSeriesKind::Continuous);
-                let prev_continuous = matches!(kind, PlotSeriesKind::Continuous);
+                let cur_continuous = matches!(attrs.kind, PlotSeriesKind::Continuous);
+                let prev_continuous = matches!(attrs.kind, PlotSeriesKind::Continuous);
                 if cur_continuous && prev_continuous {
                     line.points.push(prev_point);
                 }
@@ -656,7 +668,7 @@ fn are_aggregatable(point1: &PlotPoint, point2: &PlotPoint, window_size: usize) 
         label,
         color,
         radius: _,
-        scattered,
+        kind,
     } = attrs;
 
     // We cannot aggregate two points that don't live in the same aggregation window to start with.
@@ -664,5 +676,5 @@ fn are_aggregatable(point1: &PlotPoint, point2: &PlotPoint, window_size: usize) 
     time.abs_diff(point2.time) <= window_size as u64
         && *label == point2.attrs.label
         && *color == point2.attrs.color
-        && *scattered == point2.attrs.scattered
+        && *kind == point2.attrs.kind
 }

--- a/crates/re_space_view_time_series/src/visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/visualizer_system.rs
@@ -431,14 +431,16 @@ impl TimeSeriesSystem {
                         points: Vec::with_capacity(num_points - i),
                     },
                 );
+
+                let cur_continuous = matches!(attrs.kind, PlotSeriesKind::Continuous);
+                let prev_continuous = matches!(prev_line.kind, PlotSeriesKind::Continuous);
+
                 let prev_point = *prev_line.points.last().unwrap();
                 self.lines.push(prev_line);
 
                 // If the previous point was continuous and the current point is continuous
                 // too, then we want the 2 segments to appear continuous even though they
                 // are actually split from a data standpoint.
-                let cur_continuous = matches!(attrs.kind, PlotSeriesKind::Continuous);
-                let prev_continuous = matches!(attrs.kind, PlotSeriesKind::Continuous);
                 if cur_continuous && prev_continuous {
                     line.points.push(prev_point);
                 }

--- a/crates/re_types/definitions/rerun/archetypes/clear.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/clear.fbs
@@ -14,8 +14,10 @@ namespace rerun.archetypes;
 /// Any logged components after the clear are unaffected by the clear.
 ///
 /// This implies that a range query that includes time points that are before the clear,
-/// still returns all components at the given path(s), except those logged directly before the clear.
-/// Meaning that in practice clears are ineffective for time series plots and other usages of visible time ranges.
+/// still returns all components at the given path(s).
+/// Meaning that in practice clears are ineffective when making use of visible time ranges.
+/// Scalar plots are an exception: they track clears and use them to represent holes in the
+/// data (i.e. discontinuous lines).
 ///
 /// \example clear_simple title="Flat" image="https://static.rerun.io/clear_simple/2f5df95fcc53e9f0552f65670aef7f94830c5c1a/1200w.png"
 /// \example clear_recursive !api "Recursive"

--- a/crates/re_types_core/src/archetypes/clear.rs
+++ b/crates/re_types_core/src/archetypes/clear.rs
@@ -28,8 +28,10 @@ use crate::{DeserializationError, DeserializationResult};
 /// Any logged components after the clear are unaffected by the clear.
 ///
 /// This implies that a range query that includes time points that are before the clear,
-/// still returns all components at the given path(s), except those logged directly before the clear.
-/// Meaning that in practice clears are ineffective for time series plots and other usages of visible time ranges.
+/// still returns all components at the given path(s).
+/// Meaning that in practice clears are ineffective when making use of visible time ranges.
+/// Scalar plots are an exception: they track clears and use them to represent holes in the
+/// data (i.e. discontinuous lines).
 ///
 /// ## Example
 ///

--- a/docs/content/reference/types/archetypes/clear.md
+++ b/docs/content/reference/types/archetypes/clear.md
@@ -9,8 +9,10 @@ will not return any components that were logged at those paths before the clear.
 Any logged components after the clear are unaffected by the clear.
 
 This implies that a range query that includes time points that are before the clear,
-still returns all components at the given path(s), except those logged directly before the clear.
-Meaning that in practice clears are ineffective for time series plots and other usages of visible time ranges.
+still returns all components at the given path(s).
+Meaning that in practice clears are ineffective when making use of visible time ranges.
+Scalar plots are an exception: they track clears and use them to represent holes in the
+data (i.e. discontinuous lines).
 
 ## Components
 

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -21,8 +21,10 @@ namespace rerun::archetypes {
     /// Any logged components after the clear are unaffected by the clear.
     ///
     /// This implies that a range query that includes time points that are before the clear,
-    /// still returns all components at the given path(s), except those logged directly before the clear.
-    /// Meaning that in practice clears are ineffective for time series plots and other usages of visible time ranges.
+    /// still returns all components at the given path(s).
+    /// Meaning that in practice clears are ineffective when making use of visible time ranges.
+    /// Scalar plots are an exception: they track clears and use them to represent holes in the
+    /// data (i.e. discontinuous lines).
     ///
     /// ## Example
     ///

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -24,8 +24,10 @@ class Clear(ClearExt, Archetype):
     Any logged components after the clear are unaffected by the clear.
 
     This implies that a range query that includes time points that are before the clear,
-    still returns all components at the given path(s), except those logged directly before the clear.
-    Meaning that in practice clears are ineffective for time series plots and other usages of visible time ranges.
+    still returns all components at the given path(s).
+    Meaning that in practice clears are ineffective when making use of visible time ranges.
+    Scalar plots are an exception: they track clears and use them to represent holes in the
+    data (i.e. discontinuous lines).
 
     Example
     -------


### PR DESCRIPTION
Integrate plots with the `Clear` archetype in a useful way.

Before:

https://github.com/rerun-io/rerun/assets/2910679/7088e5e5-95db-4971-8824-818fb1fee425

After:


https://github.com/rerun-io/rerun/assets/2910679/4d5446e3-7df3-431b-9d01-2783b2bf2bda




- Related: #4950 
- Related: #4186 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4957/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4957/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4957/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4957)
- [Docs preview](https://rerun.io/preview/0573c27beb7661594aa4ac4c70b5ad800a49ac86/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0573c27beb7661594aa4ac4c70b5ad800a49ac86/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)