### PR TITLE
Allow selection of entitites directly in the plot space view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
+source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
+source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1593,6 +1593,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "web-time",
  "wgpu",
  "winapi",
  "winit",
@@ -1601,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
+source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1617,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
+source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1634,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
+source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1663,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
+source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
 dependencies = [
  "egui",
  "ehttp",
@@ -1678,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
+source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1695,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
+source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
 dependencies = [
  "egui",
 ]
@@ -1738,7 +1739,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
+source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1839,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
+source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ab39420c2933d2e402999043375b64e7cf0ee9ed#ab39420c2933d2e402999043375b64e7cf0ee9ed"
+source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ab39420c2933d2e402999043375b64e7cf0ee9ed#ab39420c2933d2e402999043375b64e7cf0ee9ed"
+source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1593,7 +1593,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "web-time",
  "wgpu",
  "winapi",
  "winit",
@@ -1602,7 +1601,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ab39420c2933d2e402999043375b64e7cf0ee9ed#ab39420c2933d2e402999043375b64e7cf0ee9ed"
+source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1618,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ab39420c2933d2e402999043375b64e7cf0ee9ed#ab39420c2933d2e402999043375b64e7cf0ee9ed"
+source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1635,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ab39420c2933d2e402999043375b64e7cf0ee9ed#ab39420c2933d2e402999043375b64e7cf0ee9ed"
+source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1664,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ab39420c2933d2e402999043375b64e7cf0ee9ed#ab39420c2933d2e402999043375b64e7cf0ee9ed"
+source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
 dependencies = [
  "egui",
  "ehttp",
@@ -1679,7 +1678,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ab39420c2933d2e402999043375b64e7cf0ee9ed#ab39420c2933d2e402999043375b64e7cf0ee9ed"
+source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1696,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ab39420c2933d2e402999043375b64e7cf0ee9ed#ab39420c2933d2e402999043375b64e7cf0ee9ed"
+source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
 dependencies = [
  "egui",
 ]
@@ -1739,7 +1738,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ab39420c2933d2e402999043375b64e7cf0ee9ed#ab39420c2933d2e402999043375b64e7cf0ee9ed"
+source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1840,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ab39420c2933d2e402999043375b64e7cf0ee9ed#ab39420c2933d2e402999043375b64e7cf0ee9ed"
+source = "git+https://github.com/emilk/egui.git?rev=37aa3973a2046e38c502f9fdb941c76fbd7a5f84#37aa3973a2046e38c502f9fdb941c76fbd7a5f84"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -277,13 +277,13 @@ debug = true
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "ab39420c2933d2e402999043375b64e7cf0ee9ed" }      # egui master 2024-01-29
-eframe = { git = "https://github.com/emilk/egui.git", rev = "ab39420c2933d2e402999043375b64e7cf0ee9ed" }      # egui master 2024-01-29
-egui = { git = "https://github.com/emilk/egui.git", rev = "ab39420c2933d2e402999043375b64e7cf0ee9ed" }        # egui master 2024-01-29
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "ab39420c2933d2e402999043375b64e7cf0ee9ed" } # egui master 2024-01-29
-egui_plot = { git = "https://github.com/emilk/egui.git", rev = "ab39420c2933d2e402999043375b64e7cf0ee9ed" }   # egui master 2024-01-29
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "ab39420c2933d2e402999043375b64e7cf0ee9ed" }   # egui master 2024-01-29
-emath = { git = "https://github.com/emilk/egui.git", rev = "ab39420c2933d2e402999043375b64e7cf0ee9ed" }       # egui master 2024-01-29
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "37aa3973a2046e38c502f9fdb941c76fbd7a5f84" }      # egui TODO: 2024-01-29
+eframe = { git = "https://github.com/emilk/egui.git", rev = "37aa3973a2046e38c502f9fdb941c76fbd7a5f84" }      # egui TODO: 2024-01-29
+egui = { git = "https://github.com/emilk/egui.git", rev = "37aa3973a2046e38c502f9fdb941c76fbd7a5f84" }        # egui TODO: 2024-01-29
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "37aa3973a2046e38c502f9fdb941c76fbd7a5f84" } # egui TODO: 2024-01-29
+egui_plot = { git = "https://github.com/emilk/egui.git", rev = "37aa3973a2046e38c502f9fdb941c76fbd7a5f84" }   # egui TODO: 2024-01-29
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "37aa3973a2046e38c502f9fdb941c76fbd7a5f84" }   # egui TODO: 2024-01-29
+emath = { git = "https://github.com/emilk/egui.git", rev = "37aa3973a2046e38c502f9fdb941c76fbd7a5f84" }       # egui TODO: 2024-01-29
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -277,13 +277,13 @@ debug = true
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "37aa3973a2046e38c502f9fdb941c76fbd7a5f84" }      # egui TODO: 2024-01-29
-eframe = { git = "https://github.com/emilk/egui.git", rev = "37aa3973a2046e38c502f9fdb941c76fbd7a5f84" }      # egui TODO: 2024-01-29
-egui = { git = "https://github.com/emilk/egui.git", rev = "37aa3973a2046e38c502f9fdb941c76fbd7a5f84" }        # egui TODO: 2024-01-29
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "37aa3973a2046e38c502f9fdb941c76fbd7a5f84" } # egui TODO: 2024-01-29
-egui_plot = { git = "https://github.com/emilk/egui.git", rev = "37aa3973a2046e38c502f9fdb941c76fbd7a5f84" }   # egui TODO: 2024-01-29
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "37aa3973a2046e38c502f9fdb941c76fbd7a5f84" }   # egui TODO: 2024-01-29
-emath = { git = "https://github.com/emilk/egui.git", rev = "37aa3973a2046e38c502f9fdb941c76fbd7a5f84" }       # egui TODO: 2024-01-29
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "ca513ce241c6511275e92b05b2953c38fa6086e1" }      # egui Ids on plot items. 2024-01-30
+eframe = { git = "https://github.com/emilk/egui.git", rev = "ca513ce241c6511275e92b05b2953c38fa6086e1" }      # egui Ids on plot items. 2024-01-30
+egui = { git = "https://github.com/emilk/egui.git", rev = "ca513ce241c6511275e92b05b2953c38fa6086e1" }        # egui Ids on plot items. 2024-01-30
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "ca513ce241c6511275e92b05b2953c38fa6086e1" } # egui Ids on plot items. 2024-01-30
+egui_plot = { git = "https://github.com/emilk/egui.git", rev = "ca513ce241c6511275e92b05b2953c38fa6086e1" }   # egui Ids on plot items. 2024-01-30
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "ca513ce241c6511275e92b05b2953c38fa6086e1" }   # egui Ids on plot items. 2024-01-30
+emath = { git = "https://github.com/emilk/egui.git", rev = "ca513ce241c6511275e92b05b2953c38fa6086e1" }       # egui Ids on plot items. 2024-01-30
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -6,7 +6,7 @@ use re_entity_db::{EntityTree, InstancePath};
 use re_log_types::{ComponentPath, EntityPath, TimeInt, Timeline};
 use re_ui::SyntaxHighlighting;
 use re_viewer_context::{
-    DataQueryId, HoverHighlight, Item, Selection, SpaceViewId, UiVerbosity, ViewerContext,
+    DataQueryId, HoverHighlight, Item, SpaceViewId, UiVerbosity, ViewerContext,
 };
 
 use super::DataUi;
@@ -330,7 +330,7 @@ pub fn cursor_interact_with_selectable(
     let is_item_hovered =
         ctx.selection_state().highlight_for_ui_element(&item) == HoverHighlight::Hovered;
 
-    select_hovered_on_click(ctx, &response, item);
+    ctx.select_hovered_on_click(&response, item);
     // TODO(andreas): How to deal with shift click for selecting ranges?
 
     if is_item_hovered {
@@ -338,16 +338,6 @@ pub fn cursor_interact_with_selectable(
     } else {
         response
     }
-}
-
-// TODO(andreas): Move elsewhere, this is not directly part of the item_ui.
-pub fn select_hovered_on_click(
-    ctx: &ViewerContext<'_>,
-    response: &egui::Response,
-    selection: impl Into<Selection>,
-) {
-    // TODO: inline everywhere.
-    ctx.select_hovered_on_click(response, selection);
 }
 
 /// Displays the "hover card" (i.e. big tooltip) for an instance or an entity.

--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -6,8 +6,7 @@ use re_entity_db::{EntityTree, InstancePath};
 use re_log_types::{ComponentPath, EntityPath, TimeInt, Timeline};
 use re_ui::SyntaxHighlighting;
 use re_viewer_context::{
-    DataQueryId, HoverHighlight, Item, Selection, SpaceViewId, SystemCommandSender, UiVerbosity,
-    ViewerContext,
+    DataQueryId, HoverHighlight, Item, Selection, SpaceViewId, UiVerbosity, ViewerContext,
 };
 
 use super::DataUi;
@@ -347,30 +346,8 @@ pub fn select_hovered_on_click(
     response: &egui::Response,
     selection: impl Into<Selection>,
 ) {
-    re_tracing::profile_function!();
-
-    let mut selection = selection.into();
-    selection.resolve_mono_instance_path_items(ctx);
-    let selection_state = ctx.selection_state();
-
-    if response.hovered() {
-        selection_state.set_hovered(selection.clone());
-    }
-
-    if response.double_clicked() {
-        if let Some((item, _)) = selection.first() {
-            ctx.command_sender
-                .send_system(re_viewer_context::SystemCommand::SetFocus(item.clone()));
-        }
-    }
-
-    if response.clicked() {
-        if response.ctx.input(|i| i.modifiers.command) {
-            selection_state.toggle_selection(selection);
-        } else {
-            selection_state.set_selection(selection);
-        }
-    }
+    // TODO: inline everywhere.
+    ctx.select_hovered_on_click(response, selection);
 }
 
 /// Displays the "hover card" (i.e. big tooltip) for an instance or an entity.

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -393,13 +393,13 @@ pub fn outline_config(gui_ctx: &egui::Context) -> OutlineConfig {
 
 pub fn screenshot_context_menu(
     _ctx: &ViewerContext<'_>,
-    response: egui::Response,
-) -> (egui::Response, Option<ScreenshotMode>) {
+    response: &egui::Response,
+) -> Option<ScreenshotMode> {
     #[cfg(not(target_arch = "wasm32"))]
     {
         if _ctx.app_options.experimental_space_view_screenshots {
             let mut take_screenshot = None;
-            let response = response.context_menu(|ui| {
+            response.context_menu(|ui| {
                 ui.style_mut().wrap = Some(false);
                 if ui.button("Save screenshot to disk").clicked() {
                     take_screenshot = Some(ScreenshotMode::SaveAndCopyToClipboard);
@@ -409,14 +409,14 @@ pub fn screenshot_context_menu(
                     ui.close_menu();
                 }
             });
-            (response, take_screenshot)
+            take_screenshot
         } else {
-            (response, None)
+            None
         }
     }
     #[cfg(target_arch = "wasm32")]
     {
-        (response, None)
+        None
     }
 }
 
@@ -661,7 +661,7 @@ pub fn picking(
         });
     };
 
-    ctx.select_hovered_on_click( &response, re_viewer_context::Selection(hovered_items));
+    ctx.select_hovered_on_click(&response, re_viewer_context::Selection(hovered_items));
 
     Ok(response)
 }

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -393,13 +393,13 @@ pub fn outline_config(gui_ctx: &egui::Context) -> OutlineConfig {
 
 pub fn screenshot_context_menu(
     _ctx: &ViewerContext<'_>,
-    response: &egui::Response,
+    _response: &egui::Response,
 ) -> Option<ScreenshotMode> {
     #[cfg(not(target_arch = "wasm32"))]
     {
         if _ctx.app_options.experimental_space_view_screenshots {
             let mut take_screenshot = None;
-            response.context_menu(|ui| {
+            _response.context_menu(|ui| {
                 ui.style_mut().wrap = Some(false);
                 if ui.button("Save screenshot to disk").clicked() {
                     take_screenshot = Some(ScreenshotMode::SaveAndCopyToClipboard);

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -661,7 +661,7 @@ pub fn picking(
         });
     };
 
-    item_ui::select_hovered_on_click(ctx, &response, re_viewer_context::Selection(hovered_items));
+    ctx.select_hovered_on_click( &response, re_viewer_context::Selection(hovered_items));
 
     Ok(response)
 }

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -355,8 +355,7 @@ pub fn view_2d(
         // ------------------------------------------------------------------------
 
         // Screenshot context menu.
-        let (_, screenshot_mode) = screenshot_context_menu(ctx, response);
-        if let Some(mode) = screenshot_mode {
+        if let Some(mode) = screenshot_context_menu(ctx, &response) {
             view_builder
                 .schedule_screenshot(ctx.render_ctx, query.space_view_id.gpu_readback_id(), mode)
                 .ok();

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -581,8 +581,7 @@ pub fn view_3d(
     }
 
     // Screenshot context menu.
-    let (_, screenshot_mode) = screenshot_context_menu(ctx, response);
-    if let Some(mode) = screenshot_mode {
+    if let Some(mode) = screenshot_context_menu(ctx, &response) {
         view_builder
             .schedule_screenshot(ctx.render_ctx, query.space_view_id.gpu_readback_id(), mode)
             .ok();

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -426,16 +426,16 @@ impl SpaceViewClass for TimeSeriesSpaceView {
         });
 
         // Interact with the plot items (lines, scatters, etc.)
-        if let Some(hovered_plot_item) = hovered_plot_item {
-            if let Some(entity_path) = plot_item_id_to_entity_path.get(&hovered_plot_item) {
-                ctx.select_hovered_on_click(
-                    &response,
-                    re_viewer_context::Item::InstancePath(
-                        Some(query.space_view_id),
-                        entity_path.clone().into(),
-                    ),
-                );
-            }
+        if let Some(entity_path) = hovered_plot_item
+            .and_then(|hovered_plot_item| plot_item_id_to_entity_path.get(&hovered_plot_item))
+        {
+            ctx.select_hovered_on_click(
+                &response,
+                re_viewer_context::Item::InstancePath(
+                    Some(query.space_view_id),
+                    entity_path.clone().into(),
+                ),
+            );
         }
 
         if let Some(time_x) = time_x {

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -13,7 +13,6 @@ mod time_selection_ui;
 use egui::emath::Rangef;
 use egui::{pos2, Color32, CursorIcon, NumExt, Painter, PointerButton, Rect, Shape, Ui, Vec2};
 
-use re_data_ui::item_ui;
 use re_entity_db::{EntityTree, InstancePath, TimeHistogram};
 use re_log_types::{
     external::re_types_core::ComponentName, ComponentPath, EntityPath, EntityPathPart, TimeInt,
@@ -602,7 +601,7 @@ impl TimePanel {
             );
         });
 
-        item_ui::select_hovered_on_click(ctx, &response, item.to_item());
+        ctx.select_hovered_on_click(&response, item.to_item());
 
         let is_closed = body_response.is_none();
         let response_rect = response.rect;
@@ -713,7 +712,7 @@ impl TimePanel {
 
                 ui.set_clip_rect(clip_rect_save);
 
-                re_data_ui::item_ui::select_hovered_on_click(ctx, &response, item.to_item());
+                ctx.select_hovered_on_click(&response, item.to_item());
 
                 let response_rect = response.rect;
 

--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -43,7 +43,7 @@ impl SelectionHistoryUi {
                 ));
 
             let mut return_current = false;
-            let response = response.context_menu(|ui| {
+            response.context_menu(|ui| {
                 // undo: newest on top, oldest on bottom
                 let cur = history.current;
                 for i in (0..history.current).rev() {
@@ -93,7 +93,7 @@ impl SelectionHistoryUi {
                 ));
 
             let mut return_current = false;
-            let response = response.context_menu(|ui| {
+            response.context_menu(|ui| {
                 // redo: oldest on top, most recent on bottom
                 let cur = history.current;
                 for i in (history.current + 1)..history.stack.len() {

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -764,7 +764,7 @@ fn show_list_item_for_container_child(
 
     let response = list_item.show(ui);
 
-    item_ui::select_hovered_on_click(ctx, &response, std::iter::once(item));
+    ctx.select_hovered_on_click(&response, std::iter::once(item));
 
     if remove_contents {
         viewport.blueprint.mark_user_interaction(ctx);

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -8,7 +8,6 @@ use ahash::HashMap;
 
 use egui_tiles::Behavior as _;
 use once_cell::sync::Lazy;
-use re_data_ui::item_ui;
 use re_entity_db::EntityPropertyMap;
 
 use re_ui::{Icon, ReUi};
@@ -580,7 +579,8 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
         }
 
         if let Some(egui_tiles::Tile::Pane(space_view_id)) = tiles.get(tile_id) {
-            item_ui::select_hovered_on_click(self.ctx, &response, Item::SpaceView(*space_view_id));
+            self.ctx
+                .select_hovered_on_click(&response, Item::SpaceView(*space_view_id));
         }
 
         response

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -1,7 +1,6 @@
 use egui::{Response, Ui};
 use itertools::Itertools;
 
-use re_data_ui::item_ui;
 use re_entity_db::InstancePath;
 use re_log_types::{EntityPath, EntityPathRule};
 use re_space_view::DataQueryBlueprint;
@@ -110,7 +109,7 @@ impl Viewport<'_, '_> {
         })
         .item_response;
 
-        item_ui::select_hovered_on_click(ctx, &response, item);
+        ctx.select_hovered_on_click(&response, item);
 
         if remove {
             self.blueprint.mark_user_interaction(ctx);
@@ -207,7 +206,7 @@ impl Viewport<'_, '_> {
             self.blueprint.focus_tab(space_view.id);
         }
 
-        item_ui::select_hovered_on_click(ctx, &response, item);
+        ctx.select_hovered_on_click(&response, item);
 
         if visibility_changed {
             if self.blueprint.auto_layout {
@@ -402,7 +401,7 @@ impl Viewport<'_, '_> {
             };
             data_result.save_override(Some(properties), ctx);
 
-            item_ui::select_hovered_on_click(ctx, &response, item);
+            ctx.select_hovered_on_click(&response, item);
         }
     }
 

--- a/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
@@ -277,8 +277,7 @@ fn color_space_ui(
                     ctx.entity_db.store(),
                 );
             });
-            item_ui::select_hovered_on_click(
-                ctx,
+            ctx.select_hovered_on_click(
                 &interact,
                 Item::InstancePath(Some(query.space_view_id), instance),
             );


### PR DESCRIPTION
### What

* depends on https://github.com/emilk/egui/pull/3920
* Fixes #4952
* Closes #4828


Wires up the new plot item ids to our hover/selection mechanism.
Moved a utility method from item_ui to ViewerContext since I didn't want to take a dependency on `re_data_ui` here (and this method had a todo about being in the wrong spot anyways 😄 )


https://github.com/rerun-io/rerun/assets/1220815/1ef61a4f-7e13-4661-90c6-fa53ea008823



DRAFT: Uses unpublished egui version!


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4959/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4959/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4959/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4959)
- [Docs preview](https://rerun.io/preview/f3f871cc9d2504b9c12a445787116a69af91f47f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f3f871cc9d2504b9c12a445787116a69af91f47f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)