### PR TITLE
Deadlock playground: disable top-level system exec parallelism 

### DIFF
--- a/crates/re_viewport/src/system_execution.rs
+++ b/crates/re_viewport/src/system_execution.rs
@@ -70,7 +70,7 @@ pub fn execute_systems_for_space_views<'a>(
     re_tracing::profile_wait!("execute_systems");
 
     tree.active_tiles()
-        .into_par_iter()
+        .into_iter()
         .filter_map(|tile_id| {
             tree.tiles.get(tile_id).and_then(|tile| match tile {
                 egui_tiles::Tile::Pane(space_view_id) => {


### PR DESCRIPTION
As far as I can tell, this fixes the deadlock from:
- #4947 

The current theory is that the nested layer of parallel iterators on the space view execution path results in rayon tasks being unscheduled while holding a cache lock.
Removing the first layer of parallelism fixes the issue, although I have no idea whether that's the right thing to do (cc @Wumpf).

To reproduce:
- Load anything with a point cloud in the 3D view
- Make sure primary caching is enabled
- Duplicate the view a bunch of times
- Play with the time cursor

On main, that deadlocks instantly when grabbing the cache lock in
https://github.com/rerun-io/rerun/blob/7923f49f2acb66f5ac6ad79d6a4762fbab1b145e/crates/re_query_cache/src/cache.rs#L252

<details>
  <summary>Main thread backtrace</summary>

```
#0  0x00007ffff7da073d in syscall () from /usr/lib/libc.so.6
#1  0x00005555577ebad1 in std::sys::unix::futex::futex_wait () at library/std/src/sys/unix/futex.rs:62
#2  std::sys::unix::locks::futex_condvar::Condvar::wait_optional_timeout () at library/std/src/sys/unix/locks/futex_condvar.rs:49
#3  std::sys::unix::locks::futex_condvar::Condvar::wait () at library/std/src/sys/unix/locks/futex_condvar.rs:33
#4  0x000055555745f26f in rayon_core::latch::LockLatch::wait_and_reset () at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/sync/condvar.rs:189
#5  0x0000555556632533 in rayon_core::registry::{impl#6}::in_worker_cold::{closure#0}<rayon_core::join::join_context::{closure_env#0}<rayon::iter::plumbing::bridge_producer_consumer::helper::{closure_env#0}<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>, rayon::iter::plumbing::bridge_producer_consumer::helper::{closure_env#1}<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>>, (alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>)> (l=0x7ffff7c90e44)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/registry.rs:546
#6  std::thread::local::LocalKey<rayon_core::latch::LockLatch>::try_with<rayon_core::latch::LockLatch, rayon_core::registry::{impl#6}::in_worker_cold::{closure_env#0}<rayon_core::join::join_context::{closure_env#0}<rayon::iter::plumbing::bridge_producer_consumer::helper::{closure_env#0}<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>, rayon::iter::plumbing::bridge_producer_consumer::helper::{closure_env#1}<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>>, (alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>)>, (alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>)> (f=..., self=<optimized out>)
    at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/thread/local.rs:270
#7  std::thread::local::LocalKey<rayon_core::latch::LockLatch>::with<rayon_core::latch::LockLatch, rayon_core::registry::{impl#6}::in_worker_cold::{closure_env#0}<rayon_core::join::join_context::{closure_env#0}<rayon::iter::plumbing::bridge_producer_consumer::helper::{closure_env#0}<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>, rayon::iter::plumbing::bridge_producer_consumer::helper::{closure_env#1}<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>>, (alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>)>, (alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>)> (f=...) at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/thread/local.rs:246
#8  rayon_core::registry::Registry::in_worker_cold<rayon_core::join::join_context::{closure_env#0}<rayon::iter::plumbing::bridge_producer_consumer::helper::{closure_env#0}<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>, rayon::iter::plumbing::bridge_producer_consumer::helper::{closure_env#1}<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>>, (alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>)> (self=0x42f48174300, op=...)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/registry.rs:534
#9  0x0000555556633232 in rayon_core::registry::Registry::in_worker<rayon_core::join::join_context::{closure_env#0}<rayon::iter::plumbing::bridge_producer_consumer::helper::{closure_env#0}<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>, rayon::iter::plumbing::bridge_producer_consumer::helper::{closure_env#1}<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>>, (alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>)> (self=0x42f48174300, op=...)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/registry.rs:514
#10 0x000055555660865f in rayon_core::registry::in_worker<rayon_core::join::join_context::{closure_env#0}<rayon::iter::plumbing::bridge_producer_consumer::helper::{closure_env#0}<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>, rayon::iter::plumbing::bridge_producer_consumer::helper::{closure_env#1}<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>>, (alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>)> (op=...)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/registry.rs:986
#11 rayon_core::join::join_context<rayon::iter::plumbing::bridge_producer_consumer::helper::{closure_env#0}<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>, rayon::iter::plumbing::bridge_producer_consumer::helper::{closure_env#1}<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>, alloc::collections::linked_list::LinkedList<alloc::vec::Vec<(re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), alloc::alloc::Global>, alloc::alloc::Global>> (oper_a=..., oper_b=...)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-core-1.11.0/src/join/mod.rs:132
#12 rayon::iter::plumbing::bridge_producer_consumer::helper<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>> (len=<optimized out>, migrated=<optimized out>, splitter=..., producer=..., consumer=...) at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/plumbing/mod.rs:416
#13 0x0000555556579ad8 in rayon::iter::plumbing::bridge_producer_consumer<rayon::vec::DrainProducer<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>> (len=11, producer=..., consumer=...) at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/plumbing/mod.rs:397
#14 rayon::iter::plumbing::bridge::{impl#0}::callback<rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>, egui_tiles::tile::TileId, rayon::vec::DrainProducer<egui_tiles::tile::TileId>> (self=..., producer=...) at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/plumbing/mod.rs:373
#15 rayon::vec::{impl#7}::with_producer<egui_tiles::tile::TileId, rayon::iter::plumbing::bridge::Callback<rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>>
    (self=..., callback=...) at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/vec.rs:147
#16 rayon::vec::{impl#4}::with_producer<egui_tiles::tile::TileId, rayon::iter::plumbing::bridge::Callback<rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>>>
    (self=..., callback=...) at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/vec.rs:83
#17 0x0000555556581094 in rayon::iter::plumbing::bridge<rayon::vec::IntoIter<egui_tiles::tile::TileId>, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>> (
    par_iter=..., consumer=...) at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/plumbing/mod.rs:357
#18 rayon::vec::{impl#3}::drive_unindexed<egui_tiles::tile::TileId, rayon::iter::filter_map::FilterMapConsumer<rayon::iter::extend::ListVecConsumer, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>> (self=..., consumer=...)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/vec.rs:58
#19 rayon::iter::filter_map::{impl#2}::drive_unindexed<rayon::vec::IntoIter<egui_tiles::tile::TileId>, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}, (re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput)), rayon::iter::extend::ListVecConsumer> (self=..., consumer=...)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/filter_map.rs:46
#20 rayon::iter::extend::{impl#9}::par_extend<re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput), ahash::random_state::RandomState, rayon::iter::filter_map::FilterMap<rayon::vec::IntoIter<egui_tiles::tile::TileId>, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>> (self=0x7fffffff5d20, par_iter=...)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/extend.rs:222
#21 rayon::iter::from_par_iter::collect_extended<std::collections::hash::map::HashMap<re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput), ahash::random_state::RandomState>, rayon::iter::filter_map::FilterMap<rayon::vec::IntoIter<egui_tiles::tile::TileId>, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>> (par_iter=...)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/from_par_iter.rs:17
#22 rayon::iter::from_par_iter::{impl#4}::from_par_iter<re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput), ahash::random_state::RandomState, rayon::iter::filter_map::FilterMap<rayon::vec::IntoIter<egui_tiles::tile::TileId>, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>> (par_iter=...)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/from_par_iter.rs:89
#23 rayon::iter::ParallelIterator::collect<rayon::iter::filter_map::FilterMap<rayon::vec::IntoIter<egui_tiles::tile::TileId>, re_viewport::system_execution::execute_systems_for_space_views::{closure_env#0}>, std::collections::hash::map::HashMap<re_viewer_context::blueprint_id::BlueprintId<re_viewer_context::blueprint_id::SpaceViewIdRegistry>, (re_viewer_context::space_view::view_query::ViewQuery, re_viewer_context::space_view::system_execution_output::SystemExecutionOutput), ahash::random_state::RandomState>> (self=...)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rayon-1.7.0/src/iter/mod.rs:2056
#24 re_viewport::system_execution::execute_systems_for_space_views (ctx=0x7fffffff6ff0, tree=0x7fffffff7678, space_views=0x7fffffff7870) at crates/re_viewport/src/system_execution.rs:72
#25 0x0000555556611897 in re_viewport::viewport::Viewport::viewport_ui (self=0x7fffffff7678, ui=0x7fffffff60f0, ctx=0x7fffffff6ff0) at crates/re_viewport/src/viewport.rs:214
#26 0x00005555568f83a1 in alloc::boxed::{impl#47}::call_once<(&mut egui::ui::Ui), dyn core::ops::function::FnOnce<(&mut egui::ui::Ui), Output=()>, alloc::alloc::Global> (self=..., args=...)
    at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/boxed.rs:2007
#27 0x000055555690b253 in alloc::boxed::{impl#47}::call_once<(&mut egui::ui::Ui), dyn core::ops::function::FnOnce<(&mut egui::ui::Ui), Output=()>, alloc::alloc::Global> (self=..., args=...)
    at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/boxed.rs:2007
#28 egui::containers::frame::Frame::show_dyn<()> (self=..., ui=0x7fffffff6540, add_contents=...) at /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/ab39420/crates/egui/src/containers/frame.rs:270
#29 0x0000555555f8769d in egui::containers::frame::Frame::show<(), egui::containers::panel::{impl#8}::show_inside_dyn::{closure_env#1}<()>> (self=..., ui=<optimized out>, add_contents=...)
    at /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/ab39420/crates/egui/src/containers/frame.rs:261
#30 egui::containers::panel::CentralPanel::show_inside_dyn<()> (self=..., ui=0x7fffffff6890, add_contents=...) at /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/ab39420/crates/egui/src/containers/panel.rs:1042
#31 0x0000555555f86cca in egui::containers::panel::CentralPanel::show_inside<(), re_viewer::app_state::{impl#1}::show::{closure#2}::{closure_env#1}> (self=..., ui=0x7fffffff6890, add_contents=...)
    at /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/ab39420/crates/egui/src/containers/panel.rs:1027
#32 re_viewer::app_state::{impl#1}::show::{closure#2} (ui=0x7fffffff6890) at crates/re_viewer/src/app_state.rs:346
#33 core::ops::function::FnOnce::call_once<re_viewer::app_state::{impl#1}::show::{closure_env#2}, (&mut egui::ui::Ui)> () at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/ops/function.rs:250
#34 0x00005555568f83a1 in alloc::boxed::{impl#47}::call_once<(&mut egui::ui::Ui), dyn core::ops::function::FnOnce<(&mut egui::ui::Ui), Output=()>, alloc::alloc::Global> (self=..., args=...)
    at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/boxed.rs:2007
#35 0x000055555690b253 in alloc::boxed::{impl#47}::call_once<(&mut egui::ui::Ui), dyn core::ops::function::FnOnce<(&mut egui::ui::Ui), Output=()>, alloc::alloc::Global> (self=..., args=...)
    at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/boxed.rs:2007
#36 egui::containers::frame::Frame::show_dyn<()> (self=..., ui=0x7fffffff6ce0, add_contents=...) at /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/ab39420/crates/egui/src/containers/frame.rs:270
#37 0x0000555555f8769d in egui::containers::frame::Frame::show<(), egui::containers::panel::{impl#8}::show_inside_dyn::{closure_env#1}<()>> (self=..., ui=<optimized out>, add_contents=...)
    at /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/ab39420/crates/egui/src/containers/frame.rs:261
#38 egui::containers::panel::CentralPanel::show_inside_dyn<()> (self=..., ui=0x7fffffff7aa0, add_contents=...) at /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/ab39420/crates/egui/src/containers/panel.rs:1042
#39 0x0000555555f67ff5 in egui::containers::panel::CentralPanel::show_inside<(), re_viewer::app_state::{impl#1}::show::{closure_env#2}> (self=..., ui=0x7fffffff7aa0, add_contents=...)
    at /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/ab39420/crates/egui/src/containers/panel.rs:1027
#40 re_viewer::app_state::AppState::show (self=0x42f48194998, app_blueprint=0x7fffffff8500, ui=0x7fffffff7aa0, render_ctx=0x42f48254600, entity_db=0x42f4839b610, store_context=0x7fffffff83b0, re_ui=0x42f48194f38, component_ui_registry=0x42f48194f68,
    space_view_class_registry=0x42f48195218, rx=0x42f48195390, command_sender=0x42f48194880) at crates/re_viewer/src/app_state.rs:303
#41 0x0000555555f870e0 in re_viewer::app::{impl#1}::ui::{closure#0} (ui=0x7fffffff7aa0) at crates/re_viewer/src/app.rs:820
#42 core::ops::function::FnOnce::call_once<re_viewer::app::{impl#1}::ui::{closure_env#0}, (&mut egui::ui::Ui)> () at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/ops/function.rs:250
#43 0x00005555568f83a1 in alloc::boxed::{impl#47}::call_once<(&mut egui::ui::Ui), dyn core::ops::function::FnOnce<(&mut egui::ui::Ui), Output=()>, alloc::alloc::Global> (self=..., args=...)
    at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/boxed.rs:2007
#44 0x000055555690b253 in alloc::boxed::{impl#47}::call_once<(&mut egui::ui::Ui), dyn core::ops::function::FnOnce<(&mut egui::ui::Ui), Output=()>, alloc::alloc::Global> (self=..., args=...)
    at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/alloc/src/boxed.rs:2007
#45 egui::containers::frame::Frame::show_dyn<()> (self=..., ui=0x7fffffff7ef0, add_contents=...) at /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/ab39420/crates/egui/src/containers/frame.rs:270
#46 0x0000555555f8769d in egui::containers::frame::Frame::show<(), egui::containers::panel::{impl#8}::show_inside_dyn::{closure_env#1}<()>> (self=..., ui=<optimized out>, add_contents=...)
    at /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/ab39420/crates/egui/src/containers/frame.rs:261
#47 egui::containers::panel::CentralPanel::show_inside_dyn<()> (self=..., ui=0x7fffffff8140, add_contents=...) at /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/ab39420/crates/egui/src/containers/panel.rs:1042
#48 0x0000555555f877f7 in egui::containers::panel::CentralPanel::show_dyn<()> (self=..., ctx=<optimized out>, add_contents=...) at /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/ab39420/crates/egui/src/containers/panel.rs:1070
#49 0x0000555555f57459 in egui::containers::panel::CentralPanel::show<(), re_viewer::app::{impl#1}::ui::{closure_env#0}> (self=..., ctx=0x7fffffffada8, add_contents=...)
    at /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/ab39420/crates/egui/src/containers/panel.rs:1054
#50 re_viewer::app::App::ui (self=0x42f48194800, egui_ctx=0x7fffffffada8, frame=0x7fffffffacc0, app_blueprint=0x7fffffff8500, gpu_resource_stats=0x7fffffff9238, store_context=..., store_stats=0x7fffffff9288) at crates/re_viewer/src/app.rs:769
#51 re_viewer::app::{impl#2}::update (self=0x42f48194800, egui_ctx=0x7fffffffada8, frame=0x7fffffffacc0) at crates/re_viewer/src/app.rs:1219
#52 0x00005555563e5ba3 in eframe::native::epi_integration::{impl#0}::update::{closure#0} (egui_ctx=0x7fffffffada8) at src/native/epi_integration.rs:284
#53 egui::context::Context::run<eframe::native::epi_integration::{impl#0}::update::{closure_env#0}> (self=0x7fffffffada8, new_input=..., run_ui=...) at /home/cmc/.cargo/git/checkouts/egui-5e4507fa4153be06/ab39420/crates/egui/src/context.rs:647
#54 0x00005555563e0a00 in eframe::native::epi_integration::EpiIntegration::update (self=0x7fffffffab60, app=..., viewport_ui_cb=..., raw_input=...) at src/native/epi_integration.rs:277
#55 0x0000555556450e4d in eframe::native::wgpu_integration::WgpuWinitRunning::run_ui_and_paint (self=0x7fffffffab60, window_id=...) at src/native/wgpu_integration.rs:605
#56 eframe::native::wgpu_integration::{impl#1}::run_ui_and_paint (self=0x7fffffffab60, event_loop=<optimized out>, window_id=...) at src/native/wgpu_integration.rs:395
#57 0x00005555563a3653 in eframe::native::run::run_and_return::{closure#0}<eframe::native::wgpu_integration::WgpuWinitApp> (event=<optimized out>, event_loop_window_target=0x42f4825b6b0) at src/native/run.rs:99
#58 core::ops::function::impls::{impl#3}::call_mut<(winit::event::Event<eframe::native::winit_integration::UserEvent>, &winit::event_loop::EventLoopWindowTarget<eframe::native::winit_integration::UserEvent>), eframe::native::run::run_and_return::{closure_env#0}<eframe::native::wgpu_integration::WgpuWinitApp>> (self=<optimized out>, args=...) at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/ops/function.rs:294
#59 0x000055555636d535 in core::ops::function::impls::{impl#3}::call_mut<(winit::event::Event<eframe::native::winit_integration::UserEvent>, &winit::event_loop::EventLoopWindowTarget<eframe::native::winit_integration::UserEvent>), &mut eframe::native::run::run_and_return::{closure_env#0}<eframe::native::wgpu_integration::WgpuWinitApp>> (args=..., self=<optimized out>) at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/core/src/ops/function.rs:294
#60 winit::platform_impl::platform::wayland::event_loop::EventLoop<eframe::native::winit_integration::UserEvent>::single_iteration<eframe::native::winit_integration::UserEvent, &mut &mut eframe::native::run::run_and_return::{closure_env#0}<eframe::native::wgpu_integration::WgpuWinitApp>> (self=0x42f4825b600, cause=..., callback=<optimized out>) at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.9/src/platform_impl/linux/wayland/event_loop/mod.rs:504
#61 winit::platform_impl::platform::wayland::event_loop::EventLoop<eframe::native::winit_integration::UserEvent>::poll_events_with_timeout<eframe::native::winit_integration::UserEvent, &mut &mut eframe::native::run::run_and_return::{closure_env#0}<eframe::native::wgpu_integration::WgpuWinitApp>> (self=0x42f4825b600, timeout=..., callback=0x7fffffff9ff0) at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.9/src/platform_impl/linux/wayland/event_loop/mod.rs:323
#62 winit::platform_impl::platform::wayland::event_loop::EventLoop<eframe::native::winit_integration::UserEvent>::pump_events<eframe::native::winit_integration::UserEvent, &mut eframe::native::run::run_and_return::{closure_env#0}<eframe::native::wgpu_integration::WgpuWinitApp>> (self=0x42f4825b600, timeout=..., callback=0x7fffffffa390) at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.9/src/platform_impl/linux/wayland/event_loop/mod.rs:237
#63 0x000055555636dfab in winit::platform_impl::platform::wayland::event_loop::EventLoop<eframe::native::winit_integration::UserEvent>::run_on_demand<eframe::native::winit_integration::UserEvent, eframe::native::run::run_and_return::{closure_env#0}<eframe::native::wgpu_integration::WgpuWinitApp>> (self=0x42f4825b600, event_handler=...) at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.9/src/platform_impl/linux/wayland/event_loop/mod.rs:201
#64 0x00005555563b392f in winit::platform_impl::platform::EventLoop<eframe::native::winit_integration::UserEvent>::run_on_demand<eframe::native::winit_integration::UserEvent, eframe::native::run::run_and_return::{closure_env#0}<eframe::native::wgpu_integration::WgpuWinitApp>> (self=0x7ffff7c90b60, callback=...) at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.9/src/platform_impl/linux/mod.rs:821
#65 winit::platform::run_on_demand::{impl#0}::run_on_demand<eframe::native::winit_integration::UserEvent, eframe::native::run::run_and_return::{closure_env#0}<eframe::native::wgpu_integration::WgpuWinitApp>> (self=0x7ffff7c90b60, event_handler=...)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.9/src/platform/run_on_demand.rs:80
#66 eframe::native::run::run_and_return<eframe::native::wgpu_integration::WgpuWinitApp> (event_loop=0x7ffff7c90b60, winit_app=...) at src/native/run.rs:76
#67 eframe::native::run::run_wgpu::{closure#0} (event_loop=0x7ffff7c90b60, native_options=...) at src/native/run.rs:417
#68 eframe::native::run::with_event_loop::{closure#0}<core::result::Result<(), eframe::Error>, eframe::native::run::run_wgpu::{closure_env#0}> (event_loop=<optimized out>) at src/native/run.rs:58
#69 std::thread::local::LocalKey<core::cell::RefCell<core::option::Option<winit::event_loop::EventLoop<eframe::native::winit_integration::UserEvent>>>>::try_with<core::cell::RefCell<core::option::Option<winit::event_loop::EventLoop<eframe::native::winit_integration::UserEvent>>>, eframe::native::run::with_event_loop::{closure_env#0}<core::result::Result<(), eframe::Error>, eframe::native::run::run_wgpu::{closure_env#0}>, core::result::Result<core::result::Result<(), eframe::Error>, eframe::Error>> (f=..., self=<optimized out>)
    at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/thread/local.rs:270
#70 std::thread::local::LocalKey<core::cell::RefCell<core::option::Option<winit::event_loop::EventLoop<eframe::native::winit_integration::UserEvent>>>>::with<core::cell::RefCell<core::option::Option<winit::event_loop::EventLoop<eframe::native::winit_integration::UserEvent>>>, eframe::native::run::with_event_loop::{closure_env#0}<core::result::Result<(), eframe::Error>, eframe::native::run::run_wgpu::{closure_env#0}>, core::result::Result<core::result::Result<(), eframe::Error>, eframe::Error>> (
    f=<error reading variable: Cannot access memory at address 0x38>) at /rustc/79e9716c980570bfd1f666e3b16ac583f0168962/library/std/src/thread/local.rs:246
#71 eframe::native::run::with_event_loop<core::result::Result<(), eframe::Error>, eframe::native::run::run_wgpu::{closure_env#0}> (f=..., native_options=<error reading variable: Cannot access memory at address 0x38>) at src/native/run.rs:48
#72 eframe::native::run::run_wgpu (app_name=..., native_options=..., app_creator=...) at src/native/run.rs:415
#73 0x00005555564576fa in eframe::run_native (app_name="Rerun Viewer", native_options=..., app_creator=...) at src/lib.rs:268
#74 0x0000555555f92a1a in re_viewer::native::run_native_app (app_creator=...) at crates/re_viewer/src/native.rs:14
#75 0x0000555555eee857 in rerun::run::run_impl::{async_fn#0} () at crates/rerun/src/run.rs:623
#76 rerun::run::run::{async_fn#0}<std::env::Args, alloc::string::String> () at crates/rerun/src/run.rs:350
#77 rerun::main::{async_block#0} () at crates/rerun-cli/src/bin/rerun.rs:31
#78 0x0000555555eeb0f7 in tokio::runtime::park::{impl#4}::block_on::{closure#0}<rerun::main::{async_block_env#0}> () at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.1/src/runtime/park.rs:283
#79 tokio::runtime::coop::with_budget<core::task::poll::Poll<std::process::ExitCode>, tokio::runtime::park::{impl#4}::block_on::{closure_env#0}<rerun::main::{async_block_env#0}>> (budget=<error reading variable: Cannot access memory at address 0x0>, f=...)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.1/src/runtime/coop.rs:107
#80 tokio::runtime::coop::budget<core::task::poll::Poll<std::process::ExitCode>, tokio::runtime::park::{impl#4}::block_on::{closure_env#0}<rerun::main::{async_block_env#0}>> (f=...)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.1/src/runtime/coop.rs:73
#81 tokio::runtime::park::CachedParkThread::block_on<rerun::main::{async_block_env#0}> (self=0x7fffffffcdf7, f=...) at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.1/src/runtime/park.rs:283
#82 0x0000555555efc4b7 in tokio::runtime::context::BlockingRegionGuard::block_on<rerun::main::{async_block_env#0}> (self=<optimized out>, f=<error reading variable: Cannot access memory at address 0x6e0>)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.1/src/runtime/context.rs:315
#83 tokio::runtime::scheduler::multi_thread::MultiThread::block_on<rerun::main::{async_block_env#0}> (handle=0x7fffffffce80, future=..., self=<optimized out>)
    at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.1/src/runtime/scheduler/multi_thread/mod.rs:68
#84 tokio::runtime::runtime::Runtime::block_on<rerun::main::{async_block_env#0}> (self=<optimized out>, future=...) at /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.1/src/runtime/runtime.rs:304
#85 0x0000555555f05011 in rerun::main () at crates/rerun-cli/src/bin/rerun.rs:33
```

</details>

On this branch it should look like this:

https://github.com/rerun-io/rerun/assets/2910679/ff3ac99e-7706-48cd-9fa6-20f0b6f28bf6


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4968/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4968/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4968/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4968)
- [Docs preview](https://rerun.io/preview/7667b70364a2ee54f16dc5795cb0bdcf1972b9f6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7667b70364a2ee54f16dc5795cb0bdcf1972b9f6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)