### PR TITLE
Style container's label as unnamed

### DIFF
--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -739,6 +739,7 @@ fn show_list_item_for_container_child(
             (
                 Item::Container(*container_id),
                 ListItem::new(ctx.re_ui, format!("{:?}", container.container_kind))
+                    .label_style(re_ui::LabelStyle::Unnamed)
                     .with_icon(icon_for_container_kind(&container.container_kind))
                     .with_buttons(|re_ui, ui| {
                         let response = re_ui

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -621,22 +621,16 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
 
         match tiles.get(tile_id) {
             Some(egui_tiles::Tile::Pane(space_view_id)) => {
-                self.ctx.select_hovered_on_click(
-                    self.ctx,
-                    &response,
-                    Item::SpaceView(*space_view_id),
-                );
+                self.ctx
+                    .select_hovered_on_click(&response, Item::SpaceView(*space_view_id));
             }
 
             Some(egui_tiles::Tile::Container(_)) => {
                 if let Some(Contents::Container(container_id)) =
                     self.contents_per_tile_id.get(&tile_id)
                 {
-                    self.ctx.select_hovered_on_click(
-                        self.ctx,
-                        &response,
-                        Item::Container(*container_id),
-                    );
+                    self.ctx
+                        .select_hovered_on_click(&response, Item::Container(*container_id));
                 }
             }
 

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -238,10 +238,10 @@ impl<'a, 'b> Viewport<'a, 'b> {
         let executed_systems_per_space_view =
             execute_systems_for_space_views(ctx, tree, &blueprint.space_views);
 
-        let mut contents_per_tile_id = HashMap::default();
-        blueprint.for_each_contents(&mut |contents| {
-            contents_per_tile_id.insert(contents.as_tile_id(), *contents);
-        });
+        let contents_per_tile_id = blueprint
+            .contents_iter()
+            .map(|contents| (contents.as_tile_id(), contents))
+            .collect();
 
         ui.scope(|ui| {
             ui.spacing_mut().item_spacing.x = re_ui::ReUi::view_padding();

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -305,6 +305,37 @@ impl ViewportBlueprint {
         new_ids
     }
 
+    /// Walk the entire container and space view hierarchy.
+    ///
+    /// The passed function is not called for the root item.
+    pub fn for_each_contents(&self, f: &mut impl FnMut(&Contents)) {
+        if let Some(root_container) = self.root_container {
+            self.for_each_contents_in_container(f, &root_container);
+        }
+    }
+
+    /// Walk a subtree of the container and space view hierarchy.
+    ///
+    /// The passed function is not called for the provided container.
+    pub fn for_each_contents_in_container(
+        &self,
+        f: &mut impl FnMut(&Contents),
+        container_id: &ContainerId,
+    ) {
+        if let Some(container) = self.container(container_id) {
+            for contents in &container.contents {
+                f(contents);
+
+                match contents {
+                    Contents::Container(container_id) => {
+                        self.for_each_contents_in_container(f, container_id);
+                    }
+                    Contents::SpaceView(_) => {}
+                }
+            }
+        }
+    }
+
     /// Given a predicate, finds the (first) matching contents by recursively walking from the root
     /// container.
     pub fn find_contents_by(&self, predicate: &impl Fn(&Contents) -> bool) -> Option<Contents> {

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -305,35 +305,16 @@ impl ViewportBlueprint {
         new_ids
     }
 
-    /// Walk the entire container and space view hierarchy.
-    ///
-    /// The passed function is not called for the root item.
-    pub fn for_each_contents(&self, f: &mut impl FnMut(&Contents)) {
-        if let Some(root_container) = self.root_container {
-            self.for_each_contents_in_container(f, &root_container);
-        }
-    }
-
-    /// Walk a subtree of the container and space view hierarchy.
-    ///
-    /// The passed function is not called for the provided container.
-    pub fn for_each_contents_in_container(
-        &self,
-        f: &mut impl FnMut(&Contents),
-        container_id: &ContainerId,
-    ) {
-        if let Some(container) = self.container(container_id) {
-            for contents in &container.contents {
-                f(contents);
-
-                match contents {
-                    Contents::Container(container_id) => {
-                        self.for_each_contents_in_container(f, container_id);
-                    }
-                    Contents::SpaceView(_) => {}
-                }
-            }
-        }
+    /// Returns an iterator over all the contents (space views and containers) in the viewport.
+    pub fn contents_iter(&self) -> impl Iterator<Item = Contents> + '_ {
+        self.space_views
+            .keys()
+            .map(|space_view_id| Contents::SpaceView(*space_view_id))
+            .chain(
+                self.containers
+                    .keys()
+                    .map(|container_id| Contents::Container(*container_id)),
+            )
     }
 
     /// Given a predicate, finds the (first) matching contents by recursively walking from the root

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -101,6 +101,7 @@ impl Viewport<'_, '_> {
         .selected(ctx.selection().contains_item(&item))
         .draggable(true)
         .drop_target_style(self.state.is_candidate_drop_parent_container(container_id))
+        .label_style(re_ui::LabelStyle::Unnamed)
         .with_icon(crate::icon_for_container_kind(
             &container_blueprint.container_kind,
         ))


### PR DESCRIPTION
### What

This PR styles the container label like unnamed space views in the blueprint tree and the children list (container selection panel). It also fixes the UI and behaviour of tiles tabs for container (which typically appear when a tab container's direct child is also a container).

* Fixes #4966


<img width="2168" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/833d9c56-e371-417a-8bdf-9ebf11a50c1e">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4975/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4975/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4975/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4975)
- [Docs preview](https://rerun.io/preview/62492dfe767dece952ea8c12e62269e42af6053d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/62492dfe767dece952ea8c12e62269e42af6053d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)