### PR TITLE
Fix space view cloning to also copy entity properties (visible time range, etc.)

### DIFF
--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -806,12 +806,8 @@ fn blueprint_ui(
                     .on_hover_text("Create an exact duplicate of this Space View including all Blueprint settings")
                     .clicked()
                 {
-                    if let Some(space_view) = viewport.blueprint.space_view(space_view_id) {
-                        let new_space_view = space_view.duplicate();
-                        let new_ids = viewport.blueprint.add_space_views(std::iter::once(new_space_view), ctx, None);
-                        if let Some(new_id) = new_ids.first() {
-                            ctx.selection_state().set_selection(Item::SpaceView(*new_id));
-                        }
+                    if let Some(new_space_view_id) = viewport.blueprint.duplicate_space_view(space_view_id, ctx) {
+                        ctx.selection_state().set_selection(Item::SpaceView(new_space_view_id));
                         viewport.blueprint.mark_user_interaction(ctx);
                     }
                 }

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -61,7 +61,7 @@ impl AsRef<str> for SpaceViewName {
 /// whether the intent is for a clone to write to the same place.
 ///
 /// If you want a new space view otherwise identical to an existing one, use
-/// [`SpaceViewBlueprint::duplicate`].
+/// [`crate::ViewportBlueprint::duplicate_space_view`].
 pub struct SpaceViewBlueprint {
     pub id: SpaceViewId,
     pub display_name: Option<String>,

--- a/crates/re_viewport/src/space_view.rs
+++ b/crates/re_viewport/src/space_view.rs
@@ -253,10 +253,13 @@ impl SpaceViewBlueprint {
             ));
     }
 
-    /// Creates a new [`SpaceViewBlueprint`] with a the same contents, but a different [`SpaceViewId`]
+    /// Creates a new [`SpaceViewBlueprint`] with the same contents, but a different [`SpaceViewId`]
     ///
-    /// Also duplicates all of the queries in the space view.
-    pub fn duplicate(&self) -> Self {
+    /// Also duplicates all the queries in the space view.
+    ///
+    /// Note that this function is a very partial implementation of proper space view cloning. See
+    /// [`crate::ViewportBlueprint::duplicate_space_view`].
+    pub(crate) fn duplicate(&self) -> Self {
         Self {
             id: SpaceViewId::random(),
             display_name: self.display_name.clone(),

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -226,7 +226,9 @@ impl ViewportBlueprint {
         ctx.save_blueprint_component(&VIEWPORT_PATH.into(), component);
     }
 
-    /// Duplicates a space view and its entity property overrides
+    /// Duplicates a space view and its entity property overrides.
+    ///
+    /// TODO(#4977): much more than just entity properties must be cloned: overrides, etc.
     pub fn duplicate_space_view(
         &self,
         space_view_id: &SpaceViewId,

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -226,6 +226,30 @@ impl ViewportBlueprint {
         ctx.save_blueprint_component(&VIEWPORT_PATH.into(), component);
     }
 
+    /// Duplicates a space view and its entity property overrides
+    pub fn duplicate_space_view(
+        &self,
+        space_view_id: &SpaceViewId,
+        ctx: &ViewerContext<'_>,
+    ) -> Option<SpaceViewId> {
+        let Some(space_view) = self.space_view(space_view_id) else {
+            return None;
+        };
+
+        let new_space_view = space_view.duplicate();
+        let new_space_view_id = new_space_view.id;
+
+        // copy entity properties from the old space view
+        let data_result = space_view.root_data_result(ctx.store_context, ctx.blueprint_query);
+        let new_data_result =
+            new_space_view.root_data_result(ctx.store_context, ctx.blueprint_query);
+        new_data_result.save_override(data_result.individual_properties().cloned(), ctx);
+
+        self.add_space_views(std::iter::once(new_space_view), ctx, None);
+
+        Some(new_space_view_id)
+    }
+
     /// If `false`, the item is referring to data that is not present in this blueprint.
     pub fn is_item_valid(&self, item: &Item) -> bool {
         match item {


### PR DESCRIPTION
### What

* Part of #4977 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4978/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4978/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4978/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4978)
- [Docs preview](https://rerun.io/preview/a5e046a0c391cb0928bc2aff540bebfc93e60ce9/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a5e046a0c391cb0928bc2aff540bebfc93e60ce9/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)