### PR TITLE
Primary cache: support reentrancy

### DIFF
--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -296,8 +296,13 @@ impl Caches {
         (r1, r2)
     }
 
-    /// Gives write access to the appropriate `RangeCache` according to the specified
-    /// query parameters.
+    /// Gives access to the appropriate `RangeCache` according to the specified query parameters.
+    ///
+    /// `upsert` is a user-defined callback that will be run first, with full mutable access to the cache.
+    /// `iter` is a user-defined callback that will be run last, with shared access.
+    ///
+    /// These callback semantics allow for reentrancy: you can use the same cache from multiple
+    /// query contexts (i.e. space views), even in a work-stealing environment.
     #[inline]
     pub fn with_range<A, F1, F2, R1, R2>(
         &self,

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -299,16 +299,18 @@ impl Caches {
     /// Gives write access to the appropriate `RangeCache` according to the specified
     /// query parameters.
     #[inline]
-    pub fn with_range<A, F, R>(
+    pub fn with_range<A, F1, F2, R1, R2>(
         &self,
         store: &DataStore,
         entity_path: EntityPath,
         query: &RangeQuery,
-        mut f: F,
-    ) -> R
+        mut upsert: F1,
+        mut iter: F2,
+    ) -> (Option<R1>, R2)
     where
         A: Archetype,
-        F: FnMut(&mut RangeCache) -> R,
+        F1: FnMut(&mut RangeCache) -> R1,
+        F2: FnMut(&RangeCache) -> R2,
     {
         assert!(
             self.store_id == *store.id(),
@@ -342,8 +344,46 @@ impl Caches {
             // can run once again.
         };
 
-        let mut cache = cache.write();
-        f(&mut cache)
+        // # Multithreading semantics
+        //
+        // There is only one situation where this `try_write()` might fail: there is another task that
+        // is already in the process of upserting that specific cache (e.g. a cloned space view).
+        //
+        // That task might be on the same thread (due to work-stealing), or a different one.
+        // Either way, we need to give up trying to upsert the cache in order to prevent a
+        // deadlock in case the other task is in fact running on the same thread.
+        //
+        // It's fine, though:
+        // - Best case scenario, the data we need is already cached.
+        // - Worst case scenario, the data is missing and we'll be missing some data for the current
+        //   frame.
+        //   It'll get cached at some point in an upcoming frame (statistically, we're bound to win
+        //   the race at some point).
+        //
+        // Data invalidation happens at the per-archetype cache layer, so this won't return
+        // out-of-date data in either scenario.
+        //
+        // There is a lot of complexity we could add to make this whole process more efficient:
+        // keep track of failed queries in a queue so we don't rely on probabilities, keep track
+        // of the thread-local reentrancy state to skip this logic when it's not needed, keep track
+        // of min-max timestamp values per entity so we can clamp range queries and thus know
+        // whether the data is already cached or not, etc.
+        //
+        // In the end, this is a edge-case inherent to our current "immediate query" model that we
+        // already know we want -- and have to -- move away from; the extra complexity isn't worth it.
+        let r1 = cache.try_write().map(|mut cache| upsert(&mut cache));
+        // Implicitly releasing the write lock -- if any.
+
+        // # Multithreading semantics
+        //
+        // We need the reentrant lock because query contexts (i.e. space views) generally run on a
+        // work-stealing thread-pool and might swap a task on one thread with another task on the
+        // same thread, where both tasks happen to query the same exact data (e.g. cloned space views).
+        //
+        // See comment above for more details.
+        let r2 = iter(&cache.read_recursive());
+
+        (r1, r2)
     }
 }
 

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -203,19 +203,27 @@ impl Caches {
         self.write().clear();
     }
 
-    /// Gives write access to the appropriate `LatestAtCache` according to the specified
+    /// Gives access to the appropriate `LatestAtCache` according to the specified
     /// query parameters.
+    ///
+    /// `upsert` is a user-defined callback that will be run first, with full mutable access to the cache.
+    /// `iter` is a user-defined callback that will be run last, with shared access.
+    ///
+    /// These callback semantics allow for reentrancy: you can use the same cache from multiple
+    /// query contexts (i.e. space views), even in a work-stealing environment.
     #[inline]
-    pub fn with_latest_at<A, F, R>(
+    pub fn with_latest_at<A, F1, F2, R1, R2>(
         &self,
         store: &DataStore,
         entity_path: EntityPath,
         query: &LatestAtQuery,
-        mut f: F,
-    ) -> R
+        mut upsert: F1,
+        mut iter: F2,
+    ) -> (Option<R1>, R2)
     where
         A: Archetype,
-        F: FnMut(&mut LatestAtCache) -> R,
+        F1: FnMut(&mut LatestAtCache) -> R1,
+        F2: FnMut(&LatestAtCache) -> R2,
     {
         assert!(
             self.store_id == *store.id(),
@@ -249,8 +257,43 @@ impl Caches {
             // can run once again.
         };
 
-        let mut cache = cache.write();
-        f(&mut cache)
+        // # Multithreading semantics
+        //
+        // There is only one situation where this `try_write()` might fail: there is another task that
+        // is already in the process of upserting that specific cache (e.g. a cloned space view).
+        //
+        // That task might be on the same thread (due to work-stealing), or a different one.
+        // Either way, we need to give up trying to upsert the cache in order to prevent a
+        // deadlock in case the other task is in fact running on the same thread.
+        //
+        // It's fine, though:
+        // - Best case scenario, the data we need is already cached.
+        // - Worst case scenario, the data is missing and we'll simply return the raw data instead.
+        //   It'll get cached at some point in an upcoming frame (statistically, we're bound to win
+        //   the race at some point).
+        //
+        // Data invalidation happens at the per-archetype cache layer, so this won't return
+        // out-of-date data in either scenario.
+        //
+        // There is a lot of complexity we could add to make this whole process more efficient:
+        // keep track of failed queries in a queue so we don't rely on probabilities, keep track
+        // of the thread-local reentrancy state to skip this logic when it's not needed, etc.
+        //
+        // In the end, this is a edge-case inherent to our current "immediate query" model that we
+        // already know we want -- and have to -- move away from; the extra complexity isn't worth it.
+        let r1 = cache.try_write().map(|mut cache| upsert(&mut cache));
+        // Implicitly releasing the write lock -- if any.
+
+        // # Multithreading semantics
+        //
+        // We need the reentrant lock because query contexts (i.e. space views) generally run on a
+        // work-stealing thread-pool and might swap a task on one thread with another task on the
+        // same thread, where both tasks happen to query the same exact data (e.g. cloned space views).
+        //
+        // See comment above for more details.
+        let r2 = iter(&cache.read_recursive());
+
+        (r1, r2)
     }
 
     /// Gives write access to the appropriate `RangeCache` according to the specified
@@ -288,7 +331,7 @@ impl Caches {
                     store_id=%self.store_id,
                     entity_path = %key.entity_path,
                     removed = removed_bytes,
-                    "invalidated latest-at caches"
+                    "invalidated range caches"
                 );
             }
 

--- a/crates/re_query_cache/src/latest_at.rs
+++ b/crates/re_query_cache/src/latest_at.rs
@@ -96,6 +96,11 @@ impl SizeBytes for LatestAtCache {
 }
 
 impl LatestAtCache {
+    #[inline]
+    pub fn is_cached(&self, query: &LatestAtQuery) -> bool {
+        self.per_query_time.contains_key(&query.at)
+    }
+
     /// Removes everything from the cache that corresponds to a time equal or greater than the
     /// specified `threshold`.
     ///
@@ -174,7 +179,7 @@ macro_rules! impl_query_archetype_latest_at {
                 ),
             ),
         {
-            let mut iter_results = |timeless: bool, bucket: &crate::CacheBucket| -> crate::Result<()> {
+            let iter_results = |timeless: bool, bucket: &crate::CacheBucket, f: &mut F| -> crate::Result<()> {
                 re_tracing::profile_scope!("iter");
 
                 let it = itertools::izip!(
@@ -201,9 +206,9 @@ macro_rules! impl_query_archetype_latest_at {
             };
 
             let create_and_fill_bucket = |
-                    data_time: TimeInt,
-                    arch_view: &::re_query::ArchetypeView<A>,
-                | -> crate::Result< crate::CacheBucket> {
+                data_time: TimeInt,
+                arch_view: &::re_query::ArchetypeView<A>,
+            | -> crate::Result<crate::CacheBucket> {
                 re_log::trace!(data_time=?data_time, ?data_time, "fill");
 
                 // Grabbing the current time is quite costly on web.
@@ -229,7 +234,7 @@ macro_rules! impl_query_archetype_latest_at {
                 Ok(bucket)
             };
 
-            let mut latest_at_callback = |query: &LatestAtQuery, latest_at_cache: &mut crate::LatestAtCache| {
+            let upsert_callback = |query: &LatestAtQuery, latest_at_cache: &mut crate::LatestAtCache| -> crate::Result<()> {
                 re_tracing::profile_scope!("latest_at", format!("{query:?}"));
 
                 let crate::LatestAtCache {
@@ -241,15 +246,14 @@ macro_rules! impl_query_archetype_latest_at {
                 } = latest_at_cache;
 
                 let query_time_bucket_at_query_time = match per_query_time.entry(query.at) {
-                    std::collections::btree_map::Entry::Occupied(mut query_time_bucket_at_query_time) => {
+                    std::collections::btree_map::Entry::Occupied(_) => {
                         // Fastest path: we have an entry for this exact query time, no need to look any
                         // further.
                         re_log::trace!(query_time=?query.at, "cache hit (query time)");
-                        return iter_results(false, query_time_bucket_at_query_time.get_mut());
+                        return Ok(());
                     }
                     std::collections::btree_map::Entry::Vacant(entry) => entry,
                 };
-
 
                 let arch_view = query_archetype::<A>(store, &query, entity_path)?;
                 let data_time = arch_view.data_time();
@@ -270,15 +274,14 @@ macro_rules! impl_query_archetype_latest_at {
                             .and_modify(|v| *v = std::sync::Arc::clone(&data_time_bucket_at_data_time))
                             .or_insert(std::sync::Arc::clone(&data_time_bucket_at_data_time));
 
-                        return iter_results(false, &data_time_bucket_at_data_time);
+                        return Ok(());
                     }
                 } else {
-                    if let Some(timeless_bucket) = timeless.as_ref() {
+                    if timeless.is_some() {
                         re_log::trace!(query_time=?query.at, "cache hit (data time, timeless)");
-                        return iter_results(true, timeless_bucket);
+                        return Ok(());
                     }
                 }
-
 
                 // Slowest path: this is a complete cache miss.
                 if let Some(data_time) = data_time { // Reminder: `None` means timeless.
@@ -293,14 +296,12 @@ macro_rules! impl_query_archetype_latest_at {
                         .and_modify(|v| *v = std::sync::Arc::clone(&query_time_bucket_at_query_time))
                         .or_insert(std::sync::Arc::clone(&query_time_bucket_at_query_time));
 
-                    iter_results(false, &query_time_bucket_at_query_time)
+                    Ok(())
                 } else {
                     re_log::trace!(query_time=?query.at, "cache miss (timeless)");
 
                     let bucket = create_and_fill_bucket(TimeInt::MIN, &arch_view)?;
                     *total_size_bytes += bucket.total_size_bytes;
-
-                    iter_results(true, &bucket)?;
 
                     *timeless = Some(bucket);
 
@@ -308,13 +309,58 @@ macro_rules! impl_query_archetype_latest_at {
                 }
             };
 
+            let iter_callback = |query: &LatestAtQuery, latest_at_cache: &crate::LatestAtCache, f: &mut F| {
+                re_tracing::profile_scope!("latest_at", format!("{query:?}"));
 
-            self.with_latest_at::<A, _, _>(
+                let crate::LatestAtCache {
+                    per_query_time,
+                    per_data_time: _,
+                    timeless: _,
+                    timeline: _,
+                    total_size_bytes: _,
+                } = latest_at_cache;
+
+                // Expected path: cache was properly upserted.
+                if let Some(query_time_bucket_at_query_time) = per_query_time.get(&query.at) {
+                    // TODO(#4832): might or might not be timeless at this point…
+                    return iter_results(false, query_time_bucket_at_query_time, f);
+                }
+
+                // Racy path: the write lock was busy.
+                let arch_view = query_archetype::<A>(store, &query, entity_path)?;
+                let data = (
+                    (arch_view.data_time(), arch_view.primary_row_id()),
+                    MaybeCachedComponentData::Raw(arch_view.iter_instance_keys().collect()),
+                    $(MaybeCachedComponentData::Raw(arch_view.iter_required_component::<$pov>()?.collect()),)+
+                    $(Some(MaybeCachedComponentData::Raw(arch_view.iter_optional_component::<$comp>()?.collect())),)*
+                );
+                f(data);
+
+                re_log::debug!(
+                    store_id = %store.id(),
+                    %entity_path,
+                    ?query,
+                    "coudn't upsert cache -- write lock was busy"
+                );
+
+                Ok(())
+            };
+
+
+            let (res1, res2) = self.with_latest_at::<A, _, _, _, _>(
                 store,
                 entity_path.clone(),
                 query,
-                |latest_at_cache| latest_at_callback(query, latest_at_cache),
-            )
+                |latest_at_cache| upsert_callback(query, latest_at_cache),
+                |latest_at_cache| iter_callback(query, latest_at_cache, &mut f),
+            );
+
+            if let Some(res1) = res1 {
+                res1?;
+            }
+            res2?;
+
+            Ok(())
         } }
     };
 

--- a/crates/re_query_cache/src/latest_at.rs
+++ b/crates/re_query_cache/src/latest_at.rs
@@ -96,11 +96,6 @@ impl SizeBytes for LatestAtCache {
 }
 
 impl LatestAtCache {
-    #[inline]
-    pub fn is_cached(&self, query: &LatestAtQuery) -> bool {
-        self.per_query_time.contains_key(&query.at)
-    }
-
     /// Removes everything from the cache that corresponds to a time equal or greater than the
     /// specified `threshold`.
     ///

--- a/crates/re_query_cache/src/range.rs
+++ b/crates/re_query_cache/src/range.rs
@@ -189,8 +189,12 @@ macro_rules! impl_query_archetype_range {
                 ),
             ),
         {
-            let mut range_results =
-                |timeless: bool, bucket: &crate::CacheBucket, time_range: TimeRange| -> crate::Result<()> {
+            let range_results = |
+                timeless: bool,
+                bucket: &crate::CacheBucket,
+                time_range: TimeRange,
+                f: &mut F,
+            | -> crate::Result<()> {
                 re_tracing::profile_scope!("iter");
 
                 let entry_range = bucket.entry_range(time_range);
@@ -267,7 +271,7 @@ macro_rules! impl_query_archetype_range {
                 Ok(added_size_bytes)
             }
 
-            let mut range_callback = |query: &RangeQuery, range_cache: &mut crate::RangeCache| {
+            let upsert_callback = |query: &RangeQuery, range_cache: &mut crate::RangeCache| -> crate::Result<()> {
                 re_tracing::profile_scope!("range", format!("{query:?}"));
 
                 // NOTE: Same logic as what the store does.
@@ -282,10 +286,6 @@ macro_rules! impl_query_archetype_range {
                     let arch_views =
                         ::re_query::range_archetype::<A, { $N + $M + 2 }>(store, &reduced_query, entity_path);
                     upsert_results::<A, $($pov,)+ $($comp,)*>(arch_views, &mut range_cache.timeless)?;
-
-                    if !range_cache.timeless.is_empty() {
-                        range_results(true, &range_cache.timeless, reduced_query.range)?;
-                    }
                 }
 
                 let mut query = query.clone();
@@ -299,20 +299,56 @@ macro_rules! impl_query_archetype_range {
                     upsert_results::<A, $($pov,)+ $($comp,)*>(arch_views, &mut range_cache.per_data_time)?;
                 }
 
+                Ok(())
+            };
+
+            let iter_callback = |query: &RangeQuery, range_cache: &crate::RangeCache, f: &mut F| -> crate::Result<()> {
+                re_tracing::profile_scope!("range", format!("{query:?}"));
+
+                // We don't bother implementing the slow path here (busy write lock), as that would
+                // require adding a bunch more complexity in order to know whether a range query is
+                // already cached (how can you know whether `TimeInt::MAX` is cached? you need to
+                // clamp queries based on store metadata first, etc).
+                //
+                // We can add the extra complexity if this proves to be glitchy in real-world
+                // scenarios -- otherwise all of this is giant hack meant to go away anyhow.
+
+                // NOTE: Same logic as what the store does.
+                if query.range.min <= TimeInt::MIN {
+                    let mut reduced_query = query.clone();
+                    // This is the reduced query corresponding to the timeless part of the data.
+                    // It is inclusive and so it will yield `MIN..=MIN` = `[MIN]`.
+                    reduced_query.range.max = TimeInt::MIN; // inclusive
+
+                    if !range_cache.timeless.is_empty() {
+                        range_results(true, &range_cache.timeless, reduced_query.range, f)?;
+                    }
+                }
+
+                let mut query = query.clone();
+                query.range.min = TimeInt::max((TimeInt::MIN.as_i64() + 1).into(), query.range.min);
+
                 if !range_cache.per_data_time.is_empty() {
-                    range_results(false, &range_cache.per_data_time, query.range)?;
+                    range_results(false, &range_cache.per_data_time, query.range, f)?;
                 }
 
                 Ok(())
             };
 
-
-            self.with_range::<A, _, _>(
+            let (res1, res2) = self.with_range::<A, _, _, _, _>(
                 store,
                 entity_path.clone(),
                 query,
-                |range_cache| range_callback(query, range_cache),
-            )
+                |range_cache| upsert_callback(query, range_cache),
+                |range_cache| iter_callback(query, range_cache, &mut f),
+            );
+
+            if let Some(res1) = res1 {
+                res1?;
+            }
+            res2?;
+
+            Ok(())
         } }
     };
 


### PR DESCRIPTION
This adds support for reentrancy in the latest-at and range caches in order to support a very nasty edge-case where two rayon tasks (i.e. space views) that query the same exact data (e.g. because they are clones of each other) end up running concurrently _on the same thread_.
This can happen because we execute space views through multiple nested layers of parallel iterators, and because rayon's scheduler is a work-stealing one, this effectively means one thread can jump to anywhere in the code at any point, and might do so while holding a lock it shouldn't.
This becomes a problem now that querying data involves mutations and locks, due to the presence of a cache on the path.

There is a lot of complexity we could add on top of what this PR already does in order to make this edge-case more efficient, but there is no reason to go there unless there is any indication that this is good not enough in practice (i.e. you don't even notice it's going on).
If it turns out that we can see glitches in practice, we'll go there.

Taking a step back, it's important to realize that this is just another side-effect of our current "immediate mode querying model", where each space view computes its dataset on its own at the very last second while it is rendering, therefore mixing up computing the data and using the data, running identical queries multiple times, etc.
We already know that we want to --and have to-- move away from this model in order to make our upcoming features possible (on-disk data, component conversions, data overrides, external store hub, etc); so I'd rather not sink any more complexity than the bare minimum required in this thing -- it has to go away anyhow.


- Fixes #4947 


https://github.com/rerun-io/rerun/assets/2910679/b8d8db83-cafb-46ff-ad38-3e41c9d43cd9


https://github.com/rerun-io/rerun/assets/2910679/c3be6250-31ba-4398-9109-356c9b9a8b4e



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4980/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4980/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4980/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4980)
- [Docs preview](https://rerun.io/preview/d6ad8d745eb93f0a8f544b244d82aeffefe26a50/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d6ad8d745eb93f0a8f544b244d82aeffefe26a50/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)