### PR TITLE
New empty space view defaults to uncollapsed in blueprint tree

### DIFF
--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -173,7 +173,8 @@ impl Viewport<'_, '_> {
 
         let root_node = result_tree.first_interesting_root();
 
-        let default_open = root_node.map_or(false, Self::default_open_for_data_result);
+        // empty space views should display as open by default to highlight the fact that they are empty
+        let default_open = root_node.map_or(true, Self::default_open_for_data_result);
 
         let collapsing_header_id = ui.id().with(space_view.id);
         let is_item_hovered =
@@ -218,7 +219,7 @@ impl Viewport<'_, '_> {
                         space_view_visible,
                     );
                 } else {
-                    ui.label("No results");
+                    ui.label("No data");
                 }
             });
 


### PR DESCRIPTION
### What

New empty space view default to open and show "No data" (instead of "No results").

* Fixes #4965 


<img width="434" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/e3f5f123-fbd5-4680-a4b9-5ef6a273e199">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4982/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4982/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4982/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4982)
- [Docs preview](https://rerun.io/preview/219da1a0ad95602442c17e003fc3687209bd8b4a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/219da1a0ad95602442c17e003fc3687209bd8b4a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)