### PR TITLE
Remove unused `DrawOrder` component on `Points2D`

### DIFF
--- a/crates/re_types/definitions/rerun/archetypes/points2d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/points2d.fbs
@@ -37,11 +37,6 @@ table Points2D (
   /// Optional text labels for the points.
   labels: [rerun.components.Text] ("attr.rerun.component_optional", nullable, order: 3000);
 
-  /// An optional floating point value that specifies the 2D drawing order.
-  ///
-  /// Objects with higher values are drawn on top of those with lower values.
-  draw_order: rerun.components.DrawOrder ("attr.rerun.component_optional", nullable, order: 3100);
-
   /// Optional class Ids for the points.
   ///
   /// The class ID provides colors and labels if not specified explicitly.

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -71,11 +71,6 @@ pub struct Points2D {
     /// Optional text labels for the points.
     pub labels: Option<Vec<crate::components::Text>>,
 
-    /// An optional floating point value that specifies the 2D drawing order.
-    ///
-    /// Objects with higher values are drawn on top of those with lower values.
-    pub draw_order: Option<crate::components::DrawOrder>,
-
     /// Optional class Ids for the points.
     ///
     /// The class ID provides colors and labels if not specified explicitly.
@@ -102,7 +97,6 @@ impl ::re_types_core::SizeBytes for Points2D {
             + self.radii.heap_size_bytes()
             + self.colors.heap_size_bytes()
             + self.labels.heap_size_bytes()
-            + self.draw_order.heap_size_bytes()
             + self.class_ids.heap_size_bytes()
             + self.keypoint_ids.heap_size_bytes()
             + self.instance_keys.heap_size_bytes()
@@ -114,7 +108,6 @@ impl ::re_types_core::SizeBytes for Points2D {
             && <Option<Vec<crate::components::Radius>>>::is_pod()
             && <Option<Vec<crate::components::Color>>>::is_pod()
             && <Option<Vec<crate::components::Text>>>::is_pod()
-            && <Option<crate::components::DrawOrder>>::is_pod()
             && <Option<Vec<crate::components::ClassId>>>::is_pod()
             && <Option<Vec<crate::components::KeypointId>>>::is_pod()
             && <Option<Vec<crate::components::InstanceKey>>>::is_pod()
@@ -133,18 +126,17 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.ClassId".into(),
-            "rerun.components.DrawOrder".into(),
             "rerun.components.InstanceKey".into(),
             "rerun.components.KeypointId".into(),
             "rerun.components.Text".into(),
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 9usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.Position2D".into(),
@@ -152,7 +144,6 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 9usize]> =
             "rerun.components.Points2DIndicator".into(),
             "rerun.components.Radius".into(),
             "rerun.components.ClassId".into(),
-            "rerun.components.DrawOrder".into(),
             "rerun.components.InstanceKey".into(),
             "rerun.components.KeypointId".into(),
             "rerun.components.Text".into(),
@@ -160,7 +151,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 9usize]> =
     });
 
 impl Points2D {
-    pub const NUM_COMPONENTS: usize = 9usize;
+    pub const NUM_COMPONENTS: usize = 8usize;
 }
 
 /// Indicator component for the [`Points2D`] [`::re_types_core::Archetype`]
@@ -258,15 +249,6 @@ impl ::re_types_core::Archetype for Points2D {
         } else {
             None
         };
-        let draw_order = if let Some(array) = arrays_by_name.get("rerun.components.DrawOrder") {
-            <crate::components::DrawOrder>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.Points2D#draw_order")?
-                .into_iter()
-                .next()
-                .flatten()
-        } else {
-            None
-        };
         let class_ids = if let Some(array) = arrays_by_name.get("rerun.components.ClassId") {
             Some({
                 <crate::components::ClassId>::from_arrow_opt(&**array)
@@ -309,7 +291,6 @@ impl ::re_types_core::Archetype for Points2D {
             radii,
             colors,
             labels,
-            draw_order,
             class_ids,
             keypoint_ids,
             instance_keys,
@@ -333,9 +314,6 @@ impl ::re_types_core::AsComponents for Points2D {
             self.labels
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.draw_order
-                .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
             self.class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
@@ -366,7 +344,6 @@ impl Points2D {
             radii: None,
             colors: None,
             labels: None,
-            draw_order: None,
             class_ids: None,
             keypoint_ids: None,
             instance_keys: None,
@@ -397,12 +374,6 @@ impl Points2D {
         labels: impl IntoIterator<Item = impl Into<crate::components::Text>>,
     ) -> Self {
         self.labels = Some(labels.into_iter().map(Into::into).collect());
-        self
-    }
-
-    #[inline]
-    pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
-        self.draw_order = Some(draw_order.into());
         self
     }
 

--- a/crates/re_types/tests/points2d.rs
+++ b/crates/re_types/tests/points2d.rs
@@ -21,7 +21,6 @@ fn roundtrip() {
             "hello".into(),  //
             "friend".into(), //
         ]),
-        draw_order: Some(components::DrawOrder(300.0)),
         class_ids: Some(vec![
             components::ClassId::from(126), //
             components::ClassId::from(127), //
@@ -40,7 +39,6 @@ fn roundtrip() {
         .with_radii([42.0, 43.0])
         .with_colors([0xAA0000CC, 0x00BB00DD])
         .with_labels(["hello", "friend"])
-        .with_draw_order(300.0)
         .with_class_ids([126, 127])
         .with_keypoint_ids([2, 3])
         .with_instance_keys([u64::MAX - 1, u64::MAX]);

--- a/docs/content/reference/types/archetypes/points2d.md
+++ b/docs/content/reference/types/archetypes/points2d.md
@@ -10,7 +10,7 @@ A 2D point cloud with positions and optional colors, radii, labels, etc.
 
 **Recommended**: [`Radius`](../components/radius.md), [`Color`](../components/color.md)
 
-**Optional**: [`Text`](../components/text.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md), [`KeypointId`](../components/keypoint_id.md), [`InstanceKey`](../components/instance_key.md)
+**Optional**: [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`KeypointId`](../components/keypoint_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
  * 🌊 [C++ API docs for `Points2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Points2D.html)

--- a/docs/content/reference/types/components/draw_order.md
+++ b/docs/content/reference/types/components/draw_order.md
@@ -23,5 +23,4 @@ Draw order for entities with the same draw order is generally undefined.
 * [`DepthImage`](../archetypes/depth_image.md)
 * [`Image`](../archetypes/image.md)
 * [`LineStrips2D`](../archetypes/line_strips2d.md)
-* [`Points2D`](../archetypes/points2d.md)
 * [`SegmentationImage`](../archetypes/segmentation_image.md)

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -14,7 +14,7 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<DataCell> cells;
-        cells.reserve(9);
+        cells.reserve(8);
 
         {
             auto result = DataCell::from_loggable(archetype.positions);
@@ -33,11 +33,6 @@ namespace rerun {
         }
         if (archetype.labels.has_value()) {
             auto result = DataCell::from_loggable(archetype.labels.value());
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
-        }
-        if (archetype.draw_order.has_value()) {
-            auto result = DataCell::from_loggable(archetype.draw_order.value());
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -7,7 +7,6 @@
 #include "../compiler_utils.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
-#include "../components/draw_order.hpp"
 #include "../components/instance_key.hpp"
 #include "../components/keypoint_id.hpp"
 #include "../components/position2d.hpp"
@@ -81,11 +80,6 @@ namespace rerun::archetypes {
         /// Optional text labels for the points.
         std::optional<Collection<rerun::components::Text>> labels;
 
-        /// An optional floating point value that specifies the 2D drawing order.
-        ///
-        /// Objects with higher values are drawn on top of those with lower values.
-        std::optional<rerun::components::DrawOrder> draw_order;
-
         /// Optional class Ids for the points.
         ///
         /// The class ID provides colors and labels if not specified explicitly.
@@ -134,15 +128,6 @@ namespace rerun::archetypes {
         /// Optional text labels for the points.
         Points2D with_labels(Collection<rerun::components::Text> _labels) && {
             labels = std::move(_labels);
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
-        }
-
-        /// An optional floating point value that specifies the 2D drawing order.
-        ///
-        /// Objects with higher values are drawn on top of those with lower values.
-        Points2D with_draw_order(rerun::components::DrawOrder _draw_order) && {
-            draw_order = std::move(_draw_order);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -58,7 +58,6 @@ class Points2D(Points2DExt, Archetype):
             radii=None,  # type: ignore[arg-type]
             colors=None,  # type: ignore[arg-type]
             labels=None,  # type: ignore[arg-type]
-            draw_order=None,  # type: ignore[arg-type]
             class_ids=None,  # type: ignore[arg-type]
             keypoint_ids=None,  # type: ignore[arg-type]
             instance_keys=None,  # type: ignore[arg-type]
@@ -106,17 +105,6 @@ class Points2D(Points2DExt, Archetype):
         converter=components.TextBatch._optional,  # type: ignore[misc]
     )
     # Optional text labels for the points.
-    #
-    # (Docstring intentionally commented out to hide this field from the docs)
-
-    draw_order: components.DrawOrderBatch | None = field(
-        metadata={"component": "optional"},
-        default=None,
-        converter=components.DrawOrderBatch._optional,  # type: ignore[misc]
-    )
-    # An optional floating point value that specifies the 2D drawing order.
-    #
-    # Objects with higher values are drawn on top of those with lower values.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 


### PR DESCRIPTION
- Fixes #4979 

Turns out this is not used, and so when querying for `Points2D` we declare 8 components while on the backend we guess 9, which makes a very old hack of ours break:
https://github.com/rerun-io/rerun/blob/a7356cab563a3783059c11581397dc70a66d03fa/crates/re_query/src/range.rs#L32-L33


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4983/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4983/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4983/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4983)
- [Docs preview](https://rerun.io/preview/54f2b3addc8f103421fd0846c5f4ab5950665a9e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/54f2b3addc8f103421fd0846c5f4ab5950665a9e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)