### PR TITLE
Clarify aggregation strings

### DIFF
--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -121,8 +121,10 @@ impl SpaceViewClass for TimeSeriesSpaceView {
             .selection_grid(ui, "time_series_selection_ui_aggregation")
             .show(ui, |ui| {
                 ctx.re_ui
-                    .grid_left_hand_label(ui, "Aggregation")
-                    .on_hover_text("Configures the aggregation behavior of the plot when the zoom-level on the X axis goes below 1.0, i.e. a single pixel covers more than one tick worth of data.\nThis can greatly improve performance (and readability) in such situations as it prevents overdraw.");
+                    .grid_left_hand_label(ui, "Zoom Aggregation")
+                    .on_hover_text("Configures the zoom-dependent scalar aggregation.\n
+This is done only if steps on the X axis go below 1.0, i.e. a single pixel covers more than one tick worth of data.\n
+It can greatly improve performance (and readability) in such situations as it prevents overdraw.");
 
                 let mut agg_mode = *root_entity_properties.time_series_aggregator.get();
 
@@ -322,21 +324,21 @@ impl SpaceViewClass for TimeSeriesSpaceView {
                 let name = if name.is_empty() { "y" } else { name };
                 let label = time_type.format(
                     (value.x as i64 + time_offset).into(),
-                    time_zone_for_timestamps
+                    time_zone_for_timestamps,
                 );
 
                 let is_integer = value.y.round() == value.y;
                 let decimals = if is_integer { 0 } else { 5 };
 
                 let agg_range_is_integer = aggregation_factor.round() == aggregation_factor;
-                let agg_range_decimals = if agg_range_is_integer { 0 } else { 5 };
+                let agg_range_decimals = if agg_range_is_integer { 0 } else { 4 };
 
                 if aggregator == TimeSeriesAggregator::Off || aggregation_factor <= 1.0 {
                     format!("{timeline_name}: {label}\n{name}: {:.decimals$}", value.y)
                 } else {
                     format!(
                         "{timeline_name}: {label}\n{name}: {:.decimals$}\n\
-                         Y value aggregated using {aggregator} over {aggregation_factor:.agg_range_decimals$} X increments",
+                        {aggregator} over x-range {aggregation_factor:.agg_range_decimals$}",
                         value.y,
                     )
                 }


### PR DESCRIPTION
### What

* Fixes #4954
* Related to #4969

on hover plot:
![image](https://github.com/rerun-io/rerun/assets/1220815/f1583f64-42a6-4517-af4d-ad2fed1b2b06)

on hover settings:
![image](https://github.com/rerun-io/rerun/assets/1220815/0d5d2256-80a4-4a88-b370-5c5afa7a126c)


Also, made it default to `MinMaxAverage` since this looks better on all my screens for smooth lines.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4987/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4987/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4987/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4987)
- [Docs preview](https://rerun.io/preview/141491880209d44706b04425ff8643f7e8dca9ef/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/141491880209d44706b04425ff8643f7e8dca9ef/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)