### PR TITLE
Gaussian Splats 0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5988,6 +5988,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "splat"
+version = "0.13.0-alpha.2"
+dependencies = [
+ "rerun",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/re_renderer/shader/point_cloud.wgsl
+++ b/crates/re_renderer/shader/point_cloud.wgsl
@@ -8,9 +8,19 @@
 
 @group(1) @binding(0)
 var position_data_texture: texture_2d<f32>;
+
 @group(1) @binding(1)
 var color_texture: texture_2d<f32>;
+
+/// 3D scale of point splats.
 @group(1) @binding(2)
+var scale_texture: texture_2d<f32>;
+
+/// XYZW quaternion of point splats.
+@group(1) @binding(3)
+var rotation_texture: texture_2d<f32>;
+
+@group(1) @binding(4)
 var picking_instance_id_texture: texture_2d<u32>;
 
 struct DrawDataUniformBuffer {
@@ -21,7 +31,7 @@ struct DrawDataUniformBuffer {
     // if we wouldn't add padding here, which isn't available on WebGL.
     _padding: vec4f,
 };
-@group(1) @binding(3)
+@group(1) @binding(5)
 var<uniform> draw_data: DrawDataUniformBuffer;
 
 struct BatchUniformBuffer {
@@ -64,12 +74,18 @@ struct VertexOut {
 
     @location(4) @interpolate(flat)
     picking_instance_id: vec2u,
+
+    // [-2, +2] coordinates on the point splat
+    @location(5) @interpolate(perspective)
+    vpos: vec2f,
 };
 
 struct PointData {
     pos: vec3f,
     unresolved_radius: f32,
     color: vec4f,
+    scale: vec3f,
+    rotation_quat_xyzw: vec4f,
     picking_instance_id: vec2u,
 }
 
@@ -83,6 +99,14 @@ fn read_data(idx: u32) -> PointData {
     let color = textureLoad(color_texture,
          vec2u(idx % color_texture_size.x, idx / color_texture_size.x), 0);
 
+    let scale_texture_size = textureDimensions(scale_texture);
+    let scale = textureLoad(scale_texture,
+         vec2u(idx % scale_texture_size.x, idx / scale_texture_size.x), 0).xyz;
+
+    let rotation_texture_size = textureDimensions(rotation_texture);
+    let rotation = textureLoad(rotation_texture,
+         vec2u(idx % rotation_texture_size.x, idx / rotation_texture_size.x), 0);
+
     let picking_instance_id_texture_size = textureDimensions(picking_instance_id_texture);
     let picking_instance_id = textureLoad(picking_instance_id_texture,
          vec2u(idx % picking_instance_id_texture_size.x, idx / picking_instance_id_texture_size.x), 0).xy;
@@ -92,6 +116,8 @@ fn read_data(idx: u32) -> PointData {
     data.pos = pos_4d.xyz / pos_4d.w;
     data.unresolved_radius = position_data.w;
     data.color = color;
+    data.scale = scale;
+    data.rotation_quat_xyzw = rotation;
     data.picking_instance_id = picking_instance_id;
     return data;
 }
@@ -103,24 +129,154 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
     // Read point data (valid for the entire quad)
     let point_data = read_data(quad_idx);
 
-    // Span quad
     let camera_distance = distance(frame.camera_position, point_data.pos);
     let world_scale_factor = average_scale_from_transform(batch.world_from_obj); // TODO(andreas): somewhat costly, should precompute this
-    let world_radius = unresolved_size_to_world(point_data.unresolved_radius, camera_distance,
-                                                frame.auto_size_points, world_scale_factor) +
-                       world_size_from_point_size(draw_data.radius_boost_in_ui_points, camera_distance);
-    let quad = sphere_or_circle_quad_span(vertex_idx, point_data.pos, world_radius,
-                                             has_any_flag(batch.flags, FLAG_DRAW_AS_CIRCLES));
 
-    // Output, transform to projection space and done.
+    let splat = true; // TODO: use batch.flags
+
     var out: VertexOut;
-    out.position = apply_depth_offset(frame.projection_from_world * vec4f(quad.pos_in_world, 1.0), batch.depth_offset);
     out.color = point_data.color;
-    out.radius = quad.point_resolved_radius;
-    out.world_position = quad.pos_in_world;
     out.point_center = point_data.pos;
     out.picking_instance_id = point_data.picking_instance_id;
 
+    if splat {
+        // Gaussian splatting code based on several (sometimes similar) sources:
+        // * https://github.com/antimatter15/splat/blob/main/main.js
+        // * https://github.com/aras-p/UnityGaussianSplatting/blob/main/package/Shaders/GaussianSplatting.hlsl
+        // * https://github.com/BladeTransformerLLC/gauzilla/blob/cef36adf71835eb60d1c6e8b2a2b34af3790c828/src/gsplat.vert
+        // * https://github.com/cvlab-epfl/gaussian-splatting-web  // TODO: read this one!
+        // * https://github.com/huggingface/gsplat.js/blob/4933ddfecf1a859da473013e63b9d883e298cd15/src/renderers/webgl/programs/RenderProgram.ts
+        //
+        // TODO: read https://towardsdatascience.com/a-comprehensive-overview-of-gaussian-splatting-e7d570081362
+        // How to create your own splats: https://docs.spline.design/e17b7c105ef0433f8c5d2b39d512614e
+        //
+        // with references to equations in https://www.cs.umd.edu/~zwicker/publications/EWASplatting-TVCG02.pdf
+        // and https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/3d_gaussian_splatting_low.pdf
+        //
+        // TODO(emilk):
+        // * View-dependent color based on spherical-harmonics
+        // * Tranparency
+        let splat_scale = 1.0; // TODO: let user control it
+
+        let pos2d = frame.projection_from_world * vec4f(out.point_center, 1.0);
+
+        let clip = 1.2 * pos2d.w;
+        if (pos2d.z < -clip || pos2d.x < -clip || pos2d.x > clip || pos2d.y < -clip || pos2d.y > clip) {
+            // Discard
+            out.position = vec4(0.0, 0.0, 0.0, 0.0);
+            out.color = vec4f();
+            return out;
+        }
+
+        // Convert rotation to 3x3 rotation matrix:
+        let rot: vec4f = point_data.rotation_quat_xyzw;
+        let qx = rot.x;
+        let qy = rot.y;
+        let qz = rot.z;
+        let qw = rot.w;
+        let r = mat3x3f(
+            1.0 - 2.0 * (qy * qy + qz * qz),
+            2.0 * (qx * qy + qw * qz),
+            2.0 * (qx * qz - qw * qy),
+
+            2.0 * (qx * qy - qw * qz),
+            1.0 - 2.0 * (qx * qx + qz * qz),
+            2.0 * (qy * qz + qw * qx),
+
+            2.0 * (qx * qz + qw * qy),
+            2.0 * (qy * qz - qw * qx),
+            1.0 - 2.0 * (qx * qx + qy * qy),
+        );
+
+        // Scale matrix:
+        let s = mat3x3f(
+            point_data.scale.x, 0.0,                0.0,
+            0.0,                point_data.scale.y, 0.0,
+            0.0,                0.0,                point_data.scale.z,
+        );
+
+        // world-space covariance matrix (called "Vrk" in other sources).
+        let cov3d_in_world = r * s * transpose(s) * transpose(r);
+
+        let pos_in_cam: vec3f = frame.view_from_world * vec4f(point_data.pos, 1.0);
+
+        // Project to 2D screen space and clamp:
+        let limx: f32 = 1.3 * frame.tan_half_fov.x;
+        let limy: f32 = 1.3 * frame.tan_half_fov.y;
+        let pos_in_2d = vec3f(
+            clamp(pos_in_cam.x / pos_in_cam.z, -limx, limx) * pos_in_cam.z,
+            clamp(pos_in_cam.y / pos_in_cam.z, -limy, limy) * pos_in_cam.z,
+            pos_in_cam.z,
+        );
+
+        // Crate Jacobian for the Taylor approximation of the nonlinear view_from_camera transformation:
+        let z_sqr = pos_in_2d.z * pos_in_2d.z;
+        let t = pos_in_2d;
+        let l = length(t);
+        let aspect_ratio = frame.projection_from_view[1][1] / frame.projection_from_view[0][0];
+        // EWA Splatting eq.29, with some modifications.
+        // I'm not sure how correct this is. The transpose of it also seems to work okish.
+        let j: mat3x3f = mat3x3f(
+             1.0 / (aspect_ratio * t.z), 0.0,        -t.x / (t.z * t.z),
+             0.0,                        1.0 / t.z,  -t.y / (t.z * t.z),
+             0.0,                        0.0,         1.0,
+        );
+
+        let view3 = mat3x3f(frame.view_from_world.x, frame.view_from_world.y, frame.view_from_world.z);
+
+        // eq.5 in https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/3d_gaussian_splatting_low.pdf
+        let jw: mat3x3f = j * view3;
+
+        // covariance matrix in view space
+        let cov2d: mat3x3f = jw * cov3d_in_world * transpose(jw);
+
+        // Find eigen-values of the covariance matrix:
+        let mid: f32 = 0.5 * (cov2d[0][0] + cov2d[1][1]);
+        let radius: f32 = length(vec2(0.5 * (cov2d[0][0] - cov2d[1][1]), cov2d[0][1]));
+        let lambda1: f32 = mid + radius;
+        let lambda2: f32 = mid - radius;
+
+        if (lambda2 < 0.0) {
+            // Discard
+            out.position = vec4(0.0, 0.0, 0.0, 0.0);
+            out.color = vec4f();
+            return out;
+        }
+
+        // Find eigen-vectors of the covariance matrix (the major and minor axes of the ellipsis):
+        let diagonal_vector: vec2f = normalize(vec2f(cov2d[0][1], lambda1 - cov2d[0][0]));
+        let major_axis: vec2f = min(sqrt(2.0 * lambda1), 1024.0) * diagonal_vector;
+        let minor_axis: vec2f = min(sqrt(2.0 * lambda2), 1024.0) * vec2f(diagonal_vector.y, -diagonal_vector.x);
+
+        let local_idx = vertex_idx % 6u;
+        let top_bottom = f32(local_idx <= 1u || local_idx == 5u) * 2.0 - 1.0; // 1 for a top vertex, -1 for a bottom vertex.
+        let left_right = f32(vertex_idx % 2u) * 2.0 - 1.0; // 1 for a right vertex, -1 for a left vertex.
+        let vpos = 2.0 * vec2f(left_right, top_bottom);
+
+        let major: vec2f = (vpos.x * major_axis);
+        let minor: vec2f = (vpos.y * minor_axis);
+
+        // Use a correctish Z so we don't need depth-sorting for opaque splats:
+        let proj = frame.projection_from_world * vec4f(out.point_center, 1.0);
+        let z = proj.z / proj.w;
+
+        out.vpos = vpos;
+        out.position = vec4(pos2d.xy / pos2d.w + splat_scale * (major + minor), z, 1.0);
+        out.color *= clamp(pos2d.z / pos2d.w + 1.0, 0.0, 1.0);
+        out.radius = -666.0; // signal that this is a splat
+    } else {
+        let world_radius = unresolved_size_to_world(point_data.unresolved_radius, camera_distance,
+                                                    frame.auto_size_points, world_scale_factor) +
+                        world_size_from_point_size(draw_data.radius_boost_in_ui_points, camera_distance);
+        let quad = sphere_or_circle_quad_span(vertex_idx, point_data.pos, world_radius,
+                                                has_any_flag(batch.flags, FLAG_DRAW_AS_CIRCLES));
+
+        // Output, transform to projection space and done.
+        out.position = apply_depth_offset(frame.projection_from_world * vec4f(quad.pos_in_world, 1.0), batch.depth_offset);
+        out.radius = quad.point_resolved_radius;
+        out.world_position = quad.pos_in_world;
+
+    }
     return out;
 }
 
@@ -148,6 +304,44 @@ fn coverage(world_position: vec3f, radius: f32, point_center: vec3f) -> f32 {
 
 @fragment
 fn fs_main(in: VertexOut) -> @location(0) vec4f {
+    let splat = in.radius == -666.0;
+    if splat {
+        let A = -dot(in.vpos, in.vpos);
+        if (A < -4.0) {
+            discard; // Outside the ellipsis
+        }
+
+        var alpha = 1.0;
+
+        // The input color comes with premultiplied alpha.
+        // Despite not sorting the splats, this looks okish.
+        // (re_renderer has premul alpha-blending turned on,
+        // despite not sorting, or having any order-independent transparency).
+        var rgba = in.color.rgba;
+
+
+        if false {
+            // In some scenes the alpha seems off, and this seems to help.
+            var a = rgba.a;
+            rgba /= a; // undo premul
+            a = pow(a, 0.1); // change alpha
+            rgba *= a; // redo premul
+        }
+
+        // TODO(#1611): transparency in rerun
+        if false {
+            // Fade the gaussian at the edges.
+            // This makes the splats way too transparent atm,
+            // but I think that is an artifact of use not sorting the splats,
+            // but having the Z buffer on, so a transparent edge will occlude other splats.
+            // Maybe the splats are too small too?
+            // If you turn this on, increase splat_scale to 3-4 or so.
+            rgba *= exp(A);
+        }
+
+        return rgba;
+    }
+
     let coverage = coverage(in.world_position, in.radius, in.point_center);
     if coverage < 0.001 {
         discard;

--- a/crates/re_types/definitions/rerun/archetypes/points3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/points3d.fbs
@@ -30,6 +30,12 @@ table Points3D (
   /// \python As either 0-1 floats or 0-255 integers, with separate alpha.
   colors: [rerun.components.Color] ("attr.rerun.component_recommended", nullable, order: 2100);
 
+  /// Scale of points. Like `radii`, but 3D, allowing for ellipsoids / splats.
+  scales: [rerun.components.HalfSizes3D] ("attr.rerun.component_optional", nullable, order: 2200);
+
+  /// Rotations of point splats.
+  rotations: [rerun.components.Rotation3D] ("attr.rerun.component_optional", nullable, order: 2300);
+
   // --- Optional ---
 
   /// Optional text labels for the points.

--- a/crates/re_types/definitions/rerun/components/rotation3d.fbs
+++ b/crates/re_types/definitions/rerun/components/rotation3d.fbs
@@ -8,7 +8,7 @@ namespace rerun.components;
 
 /// A 3D rotation, represented either by a quaternion or a rotation around axis.
 table Rotation3D (
-  "attr.rust.derive": "PartialEq"
+  "attr.rust.derive": "Copy, PartialEq"
 ) {
   /// Representation of the rotation.
   repr: rerun.datatypes.Rotation3D (order: 100);

--- a/crates/re_types/src/components/rotation3d.rs
+++ b/crates/re_types/src/components/rotation3d.rs
@@ -22,7 +22,7 @@ use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A 3D rotation, represented either by a quaternion or a rotation around axis.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Copy, PartialEq)]
 pub struct Rotation3D(
     /// Representation of the rotation.
     pub crate::datatypes::Rotation3D,

--- a/crates/re_types/src/datatypes/rgba32_ext.rs
+++ b/crates/re_types/src/datatypes/rgba32_ext.rs
@@ -32,6 +32,30 @@ impl Rgba32 {
         ]
     }
 
+    /// Red channel
+    #[inline]
+    pub const fn r(self) -> u8 {
+        (self.0 >> 24) as u8
+    }
+
+    /// Green channel
+    #[inline]
+    pub const fn g(self) -> u8 {
+        (self.0 >> 16) as u8
+    }
+
+    /// Blue channel
+    #[inline]
+    pub const fn b(self) -> u8 {
+        (self.0 >> 8) as u8
+    }
+
+    /// Alpha channel
+    #[inline]
+    pub const fn a(self) -> u8 {
+        self.0 as u8
+    }
+
     /// Most significant byte is `r`, least significant byte is `a`.
     #[inline]
     pub const fn to_u32(self) -> u32 {

--- a/crates/re_types/src/datatypes/rgba32_ext.rs
+++ b/crates/re_types/src/datatypes/rgba32_ext.rs
@@ -1,6 +1,7 @@
 use super::Rgba32;
 
 impl Rgba32 {
+    pub const BLACK: Self = Self::from_rgb(0, 0, 0);
     pub const WHITE: Self = Self::from_rgb(255, 255, 255);
 
     #[inline]

--- a/docs/content/reference/types/archetypes/points3d.md
+++ b/docs/content/reference/types/archetypes/points3d.md
@@ -10,7 +10,7 @@ A 3D point cloud with positions and optional colors, radii, labels, etc.
 
 **Recommended**: [`Radius`](../components/radius.md), [`Color`](../components/color.md)
 
-**Optional**: [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`KeypointId`](../components/keypoint_id.md), [`InstanceKey`](../components/instance_key.md)
+**Optional**: [`HalfSizes3D`](../components/half_sizes3d.md), [`Rotation3D`](../components/rotation3d.md), [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`KeypointId`](../components/keypoint_id.md), [`InstanceKey`](../components/instance_key.md)
 
 ## Links
  * 🌊 [C++ API docs for `Points3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Points3D.html)

--- a/docs/content/reference/types/components/half_sizes3d.md
+++ b/docs/content/reference/types/components/half_sizes3d.md
@@ -20,3 +20,4 @@ Negative sizes indicate that the box is flipped along the respective axis, but t
 ## Used by
 
 * [`Boxes3D`](../archetypes/boxes3d.md)
+* [`Points3D`](../archetypes/points3d.md)

--- a/docs/content/reference/types/components/rotation3d.md
+++ b/docs/content/reference/types/components/rotation3d.md
@@ -17,3 +17,4 @@ A 3D rotation, represented either by a quaternion or a rotation around axis.
 ## Used by
 
 * [`Boxes3D`](../archetypes/boxes3d.md)
+* [`Points3D`](../archetypes/points3d.md)

--- a/examples/rust/splat/Cargo.toml
+++ b/examples/rust/splat/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "splat"
+version = "0.13.0-alpha.2"
+edition = "2021"
+rust-version = "1.72"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+rerun = { path = "../../../crates/rerun" }

--- a/examples/rust/splat/README.md
+++ b/examples/rust/splat/README.md
@@ -1,0 +1,20 @@
+<!--[metadata]
+title = "Minimal example"
+thumbnail = "https://static.rerun.io/minimal/0e47ac513ab25d56cf2b493128097d499a07e5e8/480w.png"
+-->
+
+
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/minimal/0e47ac513ab25d56cf2b493128097d499a07e5e8/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/minimal/0e47ac513ab25d56cf2b493128097d499a07e5e8/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/minimal/0e47ac513ab25d56cf2b493128097d499a07e5e8/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/minimal/0e47ac513ab25d56cf2b493128097d499a07e5e8/1200w.png">
+  <img src="https://static.rerun.io/minimal/0e47ac513ab25d56cf2b493128097d499a07e5e8/full.png" alt="Minimal example screenshot">
+</picture>
+
+The simplest example of how to use Rerun, showing how to log a point cloud.
+This is part of the [Quick Start guide](https://www.rerun.io/docs/getting-started/rust).
+
+```bash
+cargo run --release
+```

--- a/examples/rust/splat/src/main.rs
+++ b/examples/rust/splat/src/main.rs
@@ -1,0 +1,28 @@
+//! Demonstrates the most barebone usage of the Rerun SDK.
+
+use std::f32::consts::TAU;
+
+use rerun::{external::glam::Quat, HalfSizes3D, Position3D, Quaternion, Rgba32};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_splat").spawn()?;
+
+    rec.log(
+        "a",
+        &rerun::Points3D::new([Position3D::new(0.0, 0.0, 0.0); 1])
+            .with_colors([Rgba32::WHITE])
+            .with_radii([0.5])
+            .with_rotations([Quaternion::IDENTITY; 1])
+            .with_scales([HalfSizes3D::new(1.0, 2.0, 0.01); 1]),
+    )?;
+    rec.log(
+        "b",
+        &rerun::Points3D::new([Position3D::new(4.0, 0.0, 0.0); 1])
+            .with_colors([Rgba32::BLACK])
+            .with_radii([0.5])
+            .with_rotations([Quat::from_rotation_x(TAU / 12.0); 1])
+            .with_scales([HalfSizes3D::new(1.0, 2.0, 0.01); 1]),
+    )?;
+
+    Ok(())
+}

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -14,7 +14,7 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<DataCell> cells;
-        cells.reserve(8);
+        cells.reserve(10);
 
         {
             auto result = DataCell::from_loggable(archetype.positions);
@@ -28,6 +28,16 @@ namespace rerun {
         }
         if (archetype.colors.has_value()) {
             auto result = DataCell::from_loggable(archetype.colors.value());
+            RR_RETURN_NOT_OK(result.error);
+            cells.push_back(std::move(result.value));
+        }
+        if (archetype.scales.has_value()) {
+            auto result = DataCell::from_loggable(archetype.scales.value());
+            RR_RETURN_NOT_OK(result.error);
+            cells.push_back(std::move(result.value));
+        }
+        if (archetype.rotations.has_value()) {
+            auto result = DataCell::from_loggable(archetype.rotations.value());
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -7,10 +7,12 @@
 #include "../compiler_utils.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
+#include "../components/half_sizes3d.hpp"
 #include "../components/instance_key.hpp"
 #include "../components/keypoint_id.hpp"
 #include "../components/position3d.hpp"
 #include "../components/radius.hpp"
+#include "../components/rotation3d.hpp"
 #include "../components/text.hpp"
 #include "../data_cell.hpp"
 #include "../indicator_component.hpp"
@@ -74,6 +76,12 @@ namespace rerun::archetypes {
         /// Optional colors for the points.
         std::optional<Collection<rerun::components::Color>> colors;
 
+        /// Scale of points. Like `radii`, but 3D, allowing for ellipsoids / splats.
+        std::optional<Collection<rerun::components::HalfSizes3D>> scales;
+
+        /// Rotations of point splats.
+        std::optional<Collection<rerun::components::Rotation3D>> rotations;
+
         /// Optional text labels for the points.
         std::optional<Collection<rerun::components::Text>> labels;
 
@@ -118,6 +126,20 @@ namespace rerun::archetypes {
         /// Optional colors for the points.
         Points3D with_colors(Collection<rerun::components::Color> _colors) && {
             colors = std::move(_colors);
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        /// Scale of points. Like `radii`, but 3D, allowing for ellipsoids / splats.
+        Points3D with_scales(Collection<rerun::components::HalfSizes3D> _scales) && {
+            scales = std::move(_scales);
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        /// Rotations of point splats.
+        Points3D with_rotations(Collection<rerun::components::Rotation3D> _rotations) && {
+            rotations = std::move(_rotations);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -54,6 +54,8 @@ class Points3D(Points3DExt, Archetype):
             positions=None,  # type: ignore[arg-type]
             radii=None,  # type: ignore[arg-type]
             colors=None,  # type: ignore[arg-type]
+            scales=None,  # type: ignore[arg-type]
+            rotations=None,  # type: ignore[arg-type]
             labels=None,  # type: ignore[arg-type]
             class_ids=None,  # type: ignore[arg-type]
             keypoint_ids=None,  # type: ignore[arg-type]
@@ -93,6 +95,24 @@ class Points3D(Points3DExt, Archetype):
     #
     # The colors are interpreted as RGB or RGBA in sRGB gamma-space,
     # As either 0-1 floats or 0-255 integers, with separate alpha.
+    #
+    # (Docstring intentionally commented out to hide this field from the docs)
+
+    scales: components.HalfSizes3DBatch | None = field(
+        metadata={"component": "optional"},
+        default=None,
+        converter=components.HalfSizes3DBatch._optional,  # type: ignore[misc]
+    )
+    # Scale of points. Like `radii`, but 3D, allowing for ellipsoids / splats.
+    #
+    # (Docstring intentionally commented out to hide this field from the docs)
+
+    rotations: components.Rotation3DBatch | None = field(
+        metadata={"component": "optional"},
+        default=None,
+        converter=components.Rotation3DBatch._optional,  # type: ignore[misc]
+    )
+    # Rotations of point splats.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/4529

MVP for gaussian splats.

Can load .ply files as found on https://poly.cam/tools/gaussian-splatting and display them _without the gaussian transparency_:

<img width="1489" alt="Screenshot 2024-01-31 at 16 32 48" src="https://github.com/rerun-io/rerun/assets/1148717/c3599a6c-ad4a-4427-a942-9dccae0b7f26">

### Implementation
This adds a scale and rotation to points, which are then used to generate splats in the vertex shader (where the 3x3 covariance matrix is calculated)

### Blockers for merging
* [x] Use the same `Points` archetype
* [ ] `HalfSize` is not the right component for splat scale
  * Maybe encode splat size as a `GaussianStdDev3` component or something?
* [ ] Picking for splats
* [ ] Separate `PointSplatBuilder`
* [ ] Separate `point_splat.wgsl`
* [ ] Decide on `point_cloud.rs` - split, or reuse?

### Shortcomings
* No transparency sorting
* No actual gaussian blur
* No support for view-dependent color using Spherical Harmonics
* Gaussians must be decomposed in rotation+scale (no 3x3 covariance support)
* Uses a lot of VRAM
* The .ply loader is really slow

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4991/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4991/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4991/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4991)
- [Docs preview](https://rerun.io/preview/918920671894edc3f052e321321dccb933e8804d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/918920671894edc3f052e321321dccb933e8804d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)