### PR TITLE
Defend against inverted time ranges

### DIFF
--- a/crates/re_log_types/src/time_range.rs
+++ b/crates/re_log_types/src/time_range.rs
@@ -26,6 +26,10 @@ impl TimeRange {
 
     #[inline]
     pub fn new(min: TimeInt, max: TimeInt) -> Self {
+        debug_assert!(
+            min <= max,
+            "a TimeRange has to be monotonically increasing, got {min:?}..={max:?} instead"
+        );
         Self { min, max }
     }
 

--- a/crates/re_log_types/src/time_range.rs
+++ b/crates/re_log_types/src/time_range.rs
@@ -26,10 +26,6 @@ impl TimeRange {
 
     #[inline]
     pub fn new(min: TimeInt, max: TimeInt) -> Self {
-        debug_assert!(
-            min <= max,
-            "a TimeRange has to be monotonically increasing, got {min:?}..={max:?} instead"
-        );
         Self { min, max }
     }
 

--- a/crates/re_query/src/util.rs
+++ b/crates/re_query/src/util.rs
@@ -57,12 +57,12 @@ impl VisibleHistory {
         to: VisibleHistoryBoundary::Infinite,
     };
 
-    /// Returns the start boundary of the time range.
+    /// Returns the start boundary of the time range given an input cursor position.
     ///
     /// This is not guaranteed to be lesser than or equal to [`Self::to`].
     /// Do not use this to build a [`TimeRange`], use [`Self::time_range`].
     #[doc(hidden)]
-    pub fn from(&self, cursor: TimeInt) -> TimeInt {
+    pub fn range_start_from_cursor(&self, cursor: TimeInt) -> TimeInt {
         match self.from {
             VisibleHistoryBoundary::Absolute(value) => TimeInt::from(value),
             VisibleHistoryBoundary::RelativeToTimeCursor(value) => cursor + TimeInt::from(value),
@@ -70,12 +70,12 @@ impl VisibleHistory {
         }
     }
 
-    /// Returns the end boundary of the time range.
+    /// Returns the end boundary of the time range given an input cursor position.
     ///
     /// This is not guaranteed to be greater than [`Self::from`].
     /// Do not use this to build a [`TimeRange`], use [`Self::time_range`].
     #[doc(hidden)]
-    pub fn to(&self, cursor: TimeInt) -> TimeInt {
+    pub fn range_end_from_cursor(&self, cursor: TimeInt) -> TimeInt {
         match self.to {
             VisibleHistoryBoundary::Absolute(value) => TimeInt::from(value),
             VisibleHistoryBoundary::RelativeToTimeCursor(value) => cursor + TimeInt::from(value),
@@ -85,8 +85,8 @@ impl VisibleHistory {
 
     /// Returns a _sanitized_ [`TimeRange`], i.e. guaranteed to be monotonically increasing.
     pub fn time_range(&self, cursor: TimeInt) -> TimeRange {
-        let mut from = self.from(cursor);
-        let mut to = self.to(cursor);
+        let mut from = self.range_start_from_cursor(cursor);
+        let mut to = self.range_end_from_cursor(cursor);
 
         // TODO(#4993): visible time range UI can yield inverted ranges
         if from > to {

--- a/crates/re_query/src/util.rs
+++ b/crates/re_query/src/util.rs
@@ -57,8 +57,12 @@ impl VisibleHistory {
         to: VisibleHistoryBoundary::Infinite,
     };
 
+    /// Returns the start boundary of the time range.
+    ///
+    /// This is not guaranteed to be lesser than or equal to [`Self::to`].
     /// Do not use this to build a [`TimeRange`], use [`Self::time_range`].
-    fn from(&self, cursor: TimeInt) -> TimeInt {
+    #[doc(hidden)]
+    pub fn from(&self, cursor: TimeInt) -> TimeInt {
         match self.from {
             VisibleHistoryBoundary::Absolute(value) => TimeInt::from(value),
             VisibleHistoryBoundary::RelativeToTimeCursor(value) => cursor + TimeInt::from(value),
@@ -66,8 +70,12 @@ impl VisibleHistory {
         }
     }
 
+    /// Returns the end boundary of the time range.
+    ///
+    /// This is not guaranteed to be greater than [`Self::from`].
     /// Do not use this to build a [`TimeRange`], use [`Self::time_range`].
-    fn to(&self, cursor: TimeInt) -> TimeInt {
+    #[doc(hidden)]
+    pub fn to(&self, cursor: TimeInt) -> TimeInt {
         match self.to {
             VisibleHistoryBoundary::Absolute(value) => TimeInt::from(value),
             VisibleHistoryBoundary::RelativeToTimeCursor(value) => cursor + TimeInt::from(value),
@@ -75,6 +83,7 @@ impl VisibleHistory {
         }
     }
 
+    /// Returns a _sanitized_ [`TimeRange`], i.e. guaranteed to be monotonically increasing.
     pub fn time_range(&self, cursor: TimeInt) -> TimeRange {
         let mut from = self.from(cursor);
         let mut to = self.to(cursor);

--- a/crates/re_query_cache/src/query.rs
+++ b/crates/re_query_cache/src/query.rs
@@ -1,7 +1,7 @@
 use paste::paste;
 use seq_macro::seq;
 
-use re_data_store::{DataStore, LatestAtQuery, RangeQuery, TimeInt, TimeRange, Timeline};
+use re_data_store::{DataStore, LatestAtQuery, RangeQuery, TimeInt, Timeline};
 use re_log_types::{EntityPath, RowId};
 use re_query::{ExtraQueryHistory, VisibleHistory};
 use re_types_core::{components::InstanceKey, Archetype, Component};
@@ -308,9 +308,7 @@ macro_rules! impl_query_archetype_with_history {
                     format!("cached={cached_range} arch={} pov={} comp={}", A::name(), $N, $M)
                 );
 
-                let min_time = visible_history.from(*time);
-                let max_time = visible_history.to(*time);
-                let query = RangeQuery::new(*timeline, TimeRange::new(min_time, max_time));
+                let query = RangeQuery::new(*timeline, visible_history.time_range(*time));
                 self.[<query_archetype_pov$N _comp$M>]::<A, $($pov,)+ $($comp,)* _>(
                     cached_range,
                     store,

--- a/crates/re_space_view_time_series/src/visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/visualizer_system.rs
@@ -177,14 +177,10 @@ impl TimeSeriesSystem {
                 }
             };
 
-            let (mut from, mut to) = if data_result.accumulated_properties().visible_history.enabled
-            {
-                (
-                    visible_history.from(query.latest_at),
-                    visible_history.to(query.latest_at),
-                )
+            let mut time_range = if data_result.accumulated_properties().visible_history.enabled {
+                visible_history.time_range(query.latest_at)
             } else {
-                (TimeInt::MIN, TimeInt::MAX)
+                TimeRange::new(TimeInt::MIN, TimeInt::MAX)
             };
 
             // TODO(cmc): We would love to reduce the query to match the actual plot bounds, but because
@@ -193,9 +189,14 @@ impl TimeSeriesSystem {
             // Just try it out and you'll see what I mean.
             if false {
                 if let Some(plot_bounds) = plot_bounds {
-                    from =
-                        TimeInt::max(from, (plot_bounds.range_x().start().floor() as i64).into());
-                    to = TimeInt::min(to, (plot_bounds.range_x().end().ceil() as i64).into());
+                    time_range.min = TimeInt::max(
+                        time_range.min,
+                        (plot_bounds.range_x().start().floor() as i64).into(),
+                    );
+                    time_range.max = TimeInt::min(
+                        time_range.max,
+                        (plot_bounds.range_x().end().ceil() as i64).into(),
+                    );
                 }
             }
 
@@ -221,8 +222,7 @@ impl TimeSeriesSystem {
 
                 let override_radius = lookup_override::<Radius>(data_result, ctx).map(|r| r.0);
 
-                let query =
-                    re_data_store::RangeQuery::new(query.timeline, TimeRange::new(from, to));
+                let query = re_data_store::RangeQuery::new(query.timeline, time_range);
 
                 query_caches.query_archetype_pov1_comp4::<
                     TimeSeriesScalar,

--- a/crates/re_viewer/src/ui/visible_history.rs
+++ b/crates/re_viewer/src/ui/visible_history.rs
@@ -4,7 +4,7 @@ use std::ops::RangeInclusive;
 use egui::{NumExt as _, Response, Ui};
 
 use re_entity_db::{ExtraQueryHistory, TimeHistogram, VisibleHistory, VisibleHistoryBoundary};
-use re_log_types::{EntityPath, TimeRange, TimeType, TimeZone};
+use re_log_types::{EntityPath, TimeType, TimeZone};
 use re_space_view_spatial::{SpatialSpaceView2D, SpatialSpaceView3D};
 use re_space_view_time_series::TimeSeriesSpaceView;
 use re_types_core::ComponentName;
@@ -137,8 +137,9 @@ pub fn visible_history_ui(
         };
 
         if visible_history_prop.enabled {
-            let current_low_boundary = visible_history.from(current_time.into()).as_i64();
-            let current_high_boundary = visible_history.to(current_time.into()).as_i64();
+            let time_range = visible_history.time_range(current_time.into());
+            let current_low_boundary = time_range.min.as_i64();
+            let current_high_boundary = time_range.max.as_i64();
 
             interacting_with_controls |= ui
                 .horizontal(|ui| {
@@ -226,10 +227,8 @@ pub fn visible_history_ui(
                 (false, false) => resolved_visible_history_prop.nanos,
             };
 
-            ctx.rec_cfg.time_ctrl.write().highlighted_range = Some(TimeRange::new(
-                visible_history.from(current_time),
-                visible_history.to(current_time),
-            ));
+            ctx.rec_cfg.time_ctrl.write().highlighted_range =
+                Some(visible_history.time_range(current_time));
         }
     }
 
@@ -252,17 +251,12 @@ fn current_range_ui(
         (TimeType::Time, "time")
     };
 
-    let from_formatted = time_type.format(
-        visible_history.from(current_time.into()),
-        ctx.app_options.time_zone_for_timestamps,
-    );
+    let time_range = visible_history.time_range(current_time.into());
+    let from_formatted = time_type.format(time_range.min, ctx.app_options.time_zone_for_timestamps);
 
     ui.label(format!(
         "Showing data between {quantity_name}s {from_formatted} and {} (included).",
-        time_type.format(
-            visible_history.to(current_time.into()),
-            ctx.app_options.time_zone_for_timestamps
-        )
+        time_type.format(time_range.max, ctx.app_options.time_zone_for_timestamps)
     ));
 }
 

--- a/crates/re_viewer/src/ui/visible_history.rs
+++ b/crates/re_viewer/src/ui/visible_history.rs
@@ -137,9 +137,8 @@ pub fn visible_history_ui(
         };
 
         if visible_history_prop.enabled {
-            let time_range = visible_history.time_range(current_time.into());
-            let current_low_boundary = time_range.min.as_i64();
-            let current_high_boundary = time_range.max.as_i64();
+            let current_low_boundary = visible_history.from(current_time.into()).as_i64();
+            let current_high_boundary = visible_history.to(current_time.into()).as_i64();
 
             interacting_with_controls |= ui
                 .horizontal(|ui| {

--- a/crates/re_viewer/src/ui/visible_history.rs
+++ b/crates/re_viewer/src/ui/visible_history.rs
@@ -137,8 +137,12 @@ pub fn visible_history_ui(
         };
 
         if visible_history_prop.enabled {
-            let current_low_boundary = visible_history.range_start_from_cursor(current_time.into()).as_i64();
-            let current_high_boundary = visible_history.range_end_from_cursor(current_time.into()).as_i64();
+            let current_low_boundary = visible_history
+                .range_start_from_cursor(current_time.into())
+                .as_i64();
+            let current_high_boundary = visible_history
+                .range_end_from_cursor(current_time.into())
+                .as_i64();
 
             interacting_with_controls |= ui
                 .horizontal(|ui| {

--- a/crates/re_viewer/src/ui/visible_history.rs
+++ b/crates/re_viewer/src/ui/visible_history.rs
@@ -137,8 +137,8 @@ pub fn visible_history_ui(
         };
 
         if visible_history_prop.enabled {
-            let current_low_boundary = visible_history.from(current_time.into()).as_i64();
-            let current_high_boundary = visible_history.to(current_time.into()).as_i64();
+            let current_low_boundary = visible_history.range_start_from_cursor(current_time.into()).as_i64();
+            let current_high_boundary = visible_history.range_end_from_cursor(current_time.into()).as_i64();
 
             interacting_with_controls |= ui
                 .horizontal(|ui| {


### PR DESCRIPTION
Defend against inverted time ranges yielded by the visible time range UI. 

- Mitigates #4993 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4994/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4994/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4994/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4994)
- [Docs preview](https://rerun.io/preview/c0acdee2ceec18326661272e5daf5198f4d36a08/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c0acdee2ceec18326661272e5daf5198f4d36a08/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)