### PR TITLE
Finer plot aggregation

### DIFF
--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -419,7 +419,7 @@ impl DataQueryPropertyResolver<'_> {
     /// Recursively walk the [`DataResultTree`] and update the [`PropertyOverrides`] for each node.
     ///
     /// This will accumulate the group properties at each step down the tree, and then finally merge
-    /// with individual overrides at the leafs.
+    /// with individual overrides at the leaves.
     fn update_overrides_recursive(
         &self,
         ctx: &StoreContext<'_>,

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -330,15 +330,12 @@ It can greatly improve performance (and readability) in such situations as it pr
                 let is_integer = value.y.round() == value.y;
                 let decimals = if is_integer { 0 } else { 5 };
 
-                let agg_range_is_integer = aggregation_factor.round() == aggregation_factor;
-                let agg_range_decimals = if agg_range_is_integer { 0 } else { 4 };
-
                 if aggregator == TimeSeriesAggregator::Off || aggregation_factor <= 1.0 {
                     format!("{timeline_name}: {label}\n{name}: {:.decimals$}", value.y)
                 } else {
                     format!(
                         "{timeline_name}: {label}\n{name}: {:.decimals$}\n\
-                        {aggregator} over x-range {aggregation_factor:.agg_range_decimals$}",
+                        {aggregator} aggregation over approx. {aggregation_factor:.1} time points",
                         value.y,
                     )
                 }

--- a/crates/re_space_view_time_series/src/visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/visualizer_system.rs
@@ -318,7 +318,7 @@ impl TimeSeriesSystem {
                 //
                 // MinMax does zig-zag between min and max, which causes a very jagged look.
                 // It can be mitigated by lowering the aggregation duration, but that causes
-                // a lot more for for the tessellator and renderer.
+                // a lot more work for the tessellator and renderer.
                 // TODO(#4969): output a thicker line instead of zig-zagging.
                 let aggregation_duration = time_per_pixel; // aggregate all points covering one physical pixel
 

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -84,13 +84,13 @@ def log_parabola() -> None:
 
 def log_trig() -> None:
     # Log a time series
-    for t in range(0, int(tau * 2 * 100.0)):
+    for t in range(0, int(tau * 2 * 1000.0)):
         rr.set_time_sequence("frame_nr", t)
 
-        sin_of_t = sin(float(t) / 100.0)
+        sin_of_t = sin(float(t) / 1000.0)
         rr.log("trig/sin", rr.TimeSeriesScalar(sin_of_t, label="sin(0.01t)", color=[255, 0, 0]))
 
-        cos_of_t = cos(float(t) / 100.0)
+        cos_of_t = cos(float(t) / 1000.0)
         rr.log("trig/cos", rr.TimeSeriesScalar(cos_of_t, label="cos(0.01t)", color=[0, 255, 0]))
 
 


### PR DESCRIPTION
### What
* Workaround for https://github.com/rerun-io/rerun/issues/4969

We would previously aggregate the plots over a time-window equal in width to a ui point.

The MinMax aggregator does a zig-zag between min and max, so this causes a very jagged look, especially on high-dpi screens.

With this PR, we switch to using a physical pixels as the default aggregation width, but for MinMax is is _half_ a pixel. This reduces the jaggedness, but does not completely remove it. It comes at a cost though of higher tessellation cost.

I have an idea for how we can throw rayon on the tessellation problem though.

## Before
<img width="790" alt="Screenshot 2024-02-01 at 14 18 26" src="https://github.com/rerun-io/rerun/assets/1148717/e12fd92c-819b-4ba6-9ce1-0b7e95a0e151">

## After
<img width="790" alt="Screenshot 2024-02-01 at 14 18 00" src="https://github.com/rerun-io/rerun/assets/1148717/52c0f2e7-25d3-4f8b-b431-b4c91a8e67bf">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4998/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4998/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4998/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4998)
- [Docs preview](https://rerun.io/preview/17721aa538a03c890574d14795dce6502f8cc004/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/17721aa538a03c890574d14795dce6502f8cc004/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)