### PR TITLE
Remove parallel iterators in attribute processors

### DIFF
--- a/crates/re_space_view_spatial/src/visualizers/mod.rs
+++ b/crates/re_space_view_spatial/src/visualizers/mod.rs
@@ -132,7 +132,6 @@ pub fn process_color_slice<'a>(
 ) -> Vec<egui::Color32> {
     // This can be rather slow for colors with transparency, since we need to pre-multiply the alpha.
     re_tracing::profile_function!();
-    use rayon::prelude::*;
 
     let default_color = DefaultColor::EntityPath(ent_path);
 
@@ -146,7 +145,7 @@ pub fn process_color_slice<'a>(
         (None, ResolvedAnnotationInfos::Many(annotation_infos)) => {
             re_tracing::profile_scope!("no-colors, many annotations");
             annotation_infos
-                .par_iter()
+                .iter()
                 .map(|annotation_info| annotation_info.color(None, default_color))
                 .collect()
         }
@@ -155,7 +154,7 @@ pub fn process_color_slice<'a>(
             re_tracing::profile_scope!("many-colors, same annotation");
             debug_assert_eq!(colors.len(), *count);
             colors
-                .par_iter()
+                .iter()
                 .map(|color| annotation_info.color(color.map(|c| c.to_array()), default_color))
                 .collect()
         }
@@ -163,8 +162,8 @@ pub fn process_color_slice<'a>(
         (Some(colors), ResolvedAnnotationInfos::Many(annotation_infos)) => {
             re_tracing::profile_scope!("many-colors, many annotations");
             colors
-                .par_iter()
-                .zip(annotation_infos.par_iter())
+                .iter()
+                .zip(annotation_infos.iter())
                 .map(move |(color, annotation_info)| {
                     annotation_info.color(color.map(|c| c.to_array()), default_color)
                 })
@@ -209,8 +208,6 @@ pub fn process_radius_slice(
     ent_path: &EntityPath,
 ) -> Vec<re_renderer::Size> {
     re_tracing::profile_function!();
-    use rayon::prelude::*;
-
     let ent_path = ent_path.clone();
 
     match radii {
@@ -218,7 +215,7 @@ pub fn process_radius_slice(
             vec![re_renderer::Size::AUTO; default_len]
         }
         Some(radii) => radii
-            .par_iter()
+            .iter()
             .map(|radius| process_radius(&ent_path, radius))
             .collect(),
     }


### PR DESCRIPTION
At least on my machine, the parallel iterators that were recently added to the attribute processing methods result in at least an order of magnitude performance loss.

With `par_iter`:
![image](https://github.com/rerun-io/rerun/assets/2910679/f2bbcace-2965-4ecf-b35d-ff565c6b0d98)


Without `par_iter`:
![image](https://github.com/rerun-io/rerun/assets/2910679/2eda2b43-4ab9-418e-a596-3d36ebb03027)

(Screenshots taken from #5000)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/4999/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/4999/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/4999/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/4999)
- [Docs preview](https://rerun.io/preview/2f86d5d04532656088ba149a77e4b220a754c18e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2f86d5d04532656088ba149a77e4b220a754c18e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)