### PR TITLE
Pin `typos` action to specific version

### DIFF
--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -258,7 +258,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check spelling of entire workspace
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1.18.0
 
   rs-cargo-deny:
     name: Cargo Deny

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -296,7 +296,7 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
 
       - name: Check spelling of entire workspace
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1.18.0
 
   # ---------------------------------------------------------------------------
 

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -419,7 +419,7 @@ impl DataQueryPropertyResolver<'_> {
     /// Recursively walk the [`DataResultTree`] and update the [`PropertyOverrides`] for each node.
     ///
     /// This will accumulate the group properties at each step down the tree, and then finally merge
-    /// with individual overrides at the leafs.
+    /// with individual overrides at the leaves.
     fn update_overrides_recursive(
         &self,
         ctx: &StoreContext<'_>,


### PR DESCRIPTION
All branches are red because `typos` got updated and catches new words now...

Also pinned it to a specific version so this doesn't happen again.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5001/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5001/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5001/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5001)
- [Docs preview](https://rerun.io/preview/c7c6b5470fd4e05496758718f0ad375cf0c94585/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c7c6b5470fd4e05496758718f0ad375cf0c94585/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)