### PR TITLE
Update to latest egui master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
+source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
+source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1602,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
+source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1618,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
+source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1635,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
+source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1664,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
+source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
 dependencies = [
  "egui",
  "ehttp",
@@ -1679,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
+source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1691,12 +1691,13 @@ dependencies = [
  "raw-window-handle 0.5.2",
  "wasm-bindgen",
  "web-sys",
+ "winit",
 ]
 
 [[package]]
 name = "egui_plot"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
+source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
 dependencies = [
  "egui",
 ]
@@ -1738,7 +1739,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
+source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1839,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=ca513ce241c6511275e92b05b2953c38fa6086e1#ca513ce241c6511275e92b05b2953c38fa6086e1"
+source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1849,6 +1850,8 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
+ "puffin",
+ "rayon",
  "serde",
 ]
 
@@ -3235,6 +3238,7 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
+ "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.0",
  "thiserror",
 ]
@@ -7425,6 +7429,7 @@ dependencies = [
  "once_cell",
  "orbclient",
  "percent-encoding",
+ "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.0",
  "redox_syscall 0.3.5",
  "rustix 0.38.24",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ egui = { version = "0.25.0", features = [
   "extra_debug_asserts",
   "log",
   "puffin",
+  "rayon",
 ] }
 egui_commonmark = { version = "0.11", default-features = false }
 egui_extras = { version = "0.25.0", features = ["http", "image", "puffin"] }
@@ -277,13 +278,13 @@ debug = true
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "ca513ce241c6511275e92b05b2953c38fa6086e1" }      # egui Ids on plot items. 2024-01-30
-eframe = { git = "https://github.com/emilk/egui.git", rev = "ca513ce241c6511275e92b05b2953c38fa6086e1" }      # egui Ids on plot items. 2024-01-30
-egui = { git = "https://github.com/emilk/egui.git", rev = "ca513ce241c6511275e92b05b2953c38fa6086e1" }        # egui Ids on plot items. 2024-01-30
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "ca513ce241c6511275e92b05b2953c38fa6086e1" } # egui Ids on plot items. 2024-01-30
-egui_plot = { git = "https://github.com/emilk/egui.git", rev = "ca513ce241c6511275e92b05b2953c38fa6086e1" }   # egui Ids on plot items. 2024-01-30
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "ca513ce241c6511275e92b05b2953c38fa6086e1" }   # egui Ids on plot items. 2024-01-30
-emath = { git = "https://github.com/emilk/egui.git", rev = "ca513ce241c6511275e92b05b2953c38fa6086e1" }       # egui Ids on plot items. 2024-01-30
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "520b28ce22a0daa20e13767af6061e9e40796f2a" }      # egui master 2024-01-31
+eframe = { git = "https://github.com/emilk/egui.git", rev = "520b28ce22a0daa20e13767af6061e9e40796f2a" }      # egui master 2024-01-31
+egui = { git = "https://github.com/emilk/egui.git", rev = "520b28ce22a0daa20e13767af6061e9e40796f2a" }        # egui master 2024-01-31
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "520b28ce22a0daa20e13767af6061e9e40796f2a" } # egui master 2024-01-31
+egui_plot = { git = "https://github.com/emilk/egui.git", rev = "520b28ce22a0daa20e13767af6061e9e40796f2a" }   # egui master 2024-01-31
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "520b28ce22a0daa20e13767af6061e9e40796f2a" }   # egui master 2024-01-31
+emath = { git = "https://github.com/emilk/egui.git", rev = "520b28ce22a0daa20e13767af6061e9e40796f2a" }       # egui master 2024-01-31
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/crates/re_viewer_context/src/annotations.rs
+++ b/crates/re_viewer_context/src/annotations.rs
@@ -66,8 +66,6 @@ impl Annotations {
         &self,
         class_id: Option<re_types::components::ClassId>,
     ) -> ResolvedClassDescription<'_> {
-        re_tracing::profile_function!();
-
         let found = class_id.and_then(|class_id| self.class_map.get(&class_id.0));
         ResolvedClassDescription {
             class_id: class_id.map(|id| id.0),


### PR DESCRIPTION
Now with parallel tessellation! This saves a millisecond or two in applications with a lot of plots.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5002/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5002/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5002/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5002)
- [Docs preview](https://rerun.io/preview/b86400dd40132cb8ae4d8099583e46e5d5623161/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b86400dd40132cb8ae4d8099583e46e5d5623161/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)