### PR TITLE
Primary cache: keep track of timeless hits

### DIFF
--- a/crates/re_query_cache/src/latest_at.rs
+++ b/crates/re_query_cache/src/latest_at.rs
@@ -262,22 +262,22 @@ macro_rules! impl_query_archetype_latest_at {
                     if let Some(data_time_bucket_at_data_time) = per_data_time.get(&data_time) {
                         re_log::trace!(query_time=?query.at, ?data_time, "cache hit (data time)");
 
-                        query_time_bucket_at_query_time.insert(std::sync::Arc::clone(&data_time_bucket_at_data_time));
+                        query_time_bucket_at_query_time.insert(Arc::clone(&data_time_bucket_at_data_time));
 
                         // We now know for a fact that a query at that data time would yield the same
                         // results: copy the bucket accordingly so that the next cache hit for that query
                         // time ends up taking the fastest path.
                         let query_time_bucket_at_data_time = per_query_time.entry(data_time);
                         query_time_bucket_at_data_time
-                            .and_modify(|v| *v = std::sync::Arc::clone(&data_time_bucket_at_data_time))
-                            .or_insert(std::sync::Arc::clone(&data_time_bucket_at_data_time));
+                            .and_modify(|v| *v = Arc::clone(&data_time_bucket_at_data_time))
+                            .or_insert(Arc::clone(&data_time_bucket_at_data_time));
 
                         return Ok(());
                     }
                 } else {
                     if let Some(timeless) = timeless.as_ref() {
                         re_log::trace!(query_time=?query.at, "cache hit (data time, timeless)");
-                        query_time_bucket_at_query_time.insert(std::sync::Arc::clone(timeless));
+                        query_time_bucket_at_query_time.insert(Arc::clone(timeless));
                         return Ok(());
                     }
                 }
@@ -292,8 +292,8 @@ macro_rules! impl_query_archetype_latest_at {
 
                     let data_time_bucket_at_data_time = per_data_time.entry(data_time);
                     data_time_bucket_at_data_time
-                        .and_modify(|v| *v = std::sync::Arc::clone(&query_time_bucket_at_query_time))
-                        .or_insert(std::sync::Arc::clone(&query_time_bucket_at_query_time));
+                        .and_modify(|v| *v = Arc::clone(&query_time_bucket_at_query_time))
+                        .or_insert(Arc::clone(&query_time_bucket_at_query_time));
 
                     Ok(())
                 } else {

--- a/crates/re_query_cache/tests/latest_at.rs
+++ b/crates/re_query_cache/tests/latest_at.rs
@@ -507,7 +507,7 @@ fn query_and_compare(
             .collect_vec();
 
         // Keep this around for the next unlucky chap.
-        // eprintln!("(expected={expected_data_time:?}, uncached={uncached_data_time:?}, cached={cached_data_time:?})");
+        eprintln!("(expected={expected_data_time:?}, uncached={uncached_data_time:?}, cached={cached_data_time:?})");
 
         similar_asserts::assert_eq!(expected_data_time, uncached_data_time);
         similar_asserts::assert_eq!(expected_instance_keys, uncached_instance_keys);

--- a/crates/re_query_cache/tests/latest_at.rs
+++ b/crates/re_query_cache/tests/latest_at.rs
@@ -507,7 +507,7 @@ fn query_and_compare(
             .collect_vec();
 
         // Keep this around for the next unlucky chap.
-        eprintln!("(expected={expected_data_time:?}, uncached={uncached_data_time:?}, cached={cached_data_time:?})");
+        // eprintln!("(expected={expected_data_time:?}, uncached={uncached_data_time:?}, cached={cached_data_time:?})");
 
         similar_asserts::assert_eq!(expected_data_time, uncached_data_time);
         similar_asserts::assert_eq!(expected_instance_keys, uncached_instance_keys);


### PR DESCRIPTION
Introduced a bug in the reentrancy patch that made us lose track of timeless hits.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5003/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5003/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5003/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5003)
- [Docs preview](https://rerun.io/preview/41e800128eb00f72e95f9d00c86b4b067db96cb0/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/41e800128eb00f72e95f9d00c86b4b067db96cb0/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)