### PR TITLE
Primary cache: allow entirely missing optional component columns

### DIFF
--- a/crates/re_query_cache/src/latest_at.rs
+++ b/crates/re_query_cache/src/latest_at.rs
@@ -183,7 +183,10 @@ macro_rules! impl_query_archetype_latest_at {
                     $(bucket.iter_component::<$pov>()
                         .ok_or_else(|| re_query::ComponentNotFoundError(<$pov>::name()))?,)+
                     $(bucket.iter_component_opt::<$comp>()
-                        .ok_or_else(|| re_query::ComponentNotFoundError(<$comp>::name()))?,)*
+                        .map_or_else(
+                            || itertools::Either::Left(std::iter::repeat(&[] as &[Option<$comp>])),
+                            |it| itertools::Either::Right(it)),
+                    )*
                 ).map(|((time, row_id), instance_keys, $($pov,)+ $($comp,)*)| {
                     (
                         ((!timeless).then_some(*time), *row_id),


### PR DESCRIPTION
The cache would return a `ComponentNotFound` error if the user queried for an optional component that didn't exist at all (as in: we have never even heard of that datatype until now).

This can be triggered with e.g. this:
```
import math

import rerun as rr

rr.init("rerun_example_scalar", spawn=True)

for step in range(0, 64):
    rr.set_time_sequence("step", step)
    rr.log("scalar/cos", rr.archetypes.Scalar(math.cos(step / 10.0)))
    rr.log("scalar/sin", rr.archetypes.Scalar(math.sin(step / 10.0)))
```

The visualizer would ask for `MarkerShape`, which is an optional component that as far as the store and the cache are concerned is completely made up at this point.

- Fixes https://github.com/rerun-io/rerun/issues/5005

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5007/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5007/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5007/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
