### PR TITLE
Changed `re_ui::Modal` to use a `egui::Context` instead of a `egui::Ui`

### DIFF
--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -243,7 +243,7 @@ impl eframe::App for ExampleApp {
 
                             self.modal_handler.ui(
                                 &self.re_ui,
-                                ui,
+                                ui.ctx(),
                                 || re_ui::modal::Modal::new("Modal window"),
                                 |_, ui, _| ui.label("This is a modal window."),
                             );
@@ -256,7 +256,7 @@ impl eframe::App for ExampleApp {
 
                             self.full_span_modal_handler.ui(
                                 &self.re_ui,
-                                ui,
+                                ui.ctx(),
                                 || re_ui::modal::Modal::new("Modal window").full_span_content(true),
                                 |_, ui, _| {
                                     for idx in 0..10 {

--- a/crates/re_viewer/src/ui/add_space_view_or_container_modal.rs
+++ b/crates/re_viewer/src/ui/add_space_view_or_container_modal.rs
@@ -20,10 +20,15 @@ impl AddSpaceViewOrContainerModal {
         self.modal_handler.open();
     }
 
-    pub fn ui(&mut self, ui: &mut egui::Ui, ctx: &ViewerContext<'_>, viewport: &Viewport<'_, '_>) {
+    pub fn ui(
+        &mut self,
+        egui_ctx: &egui::Context,
+        ctx: &ViewerContext<'_>,
+        viewport: &Viewport<'_, '_>,
+    ) {
         self.modal_handler.ui(
             ctx.re_ui,
-            ui,
+            egui_ctx,
             || {
                 re_ui::modal::Modal::new("Add Space View or Container")
                     .min_width(500.0)

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -228,7 +228,8 @@ impl SelectionPanel {
             });
         }
 
-        self.add_space_view_or_container_modal.ui(ui, ctx, viewport);
+        self.add_space_view_or_container_modal
+            .ui(ui.ctx(), ctx, viewport);
     }
 
     fn container_children(

--- a/crates/re_viewport/src/space_view_entity_picker.rs
+++ b/crates/re_viewport/src/space_view_entity_picker.rs
@@ -26,13 +26,13 @@ impl SpaceViewEntityPicker {
     #[allow(clippy::unused_self)]
     pub fn ui(
         &mut self,
-        ui: &mut egui::Ui,
+        egui_ctx: &egui::Context,
         ctx: &ViewerContext<'_>,
         viewport_blueprint: &ViewportBlueprint,
     ) {
         self.modal_handler.ui(
             ctx.re_ui,
-            ui,
+            egui_ctx,
             || re_ui::modal::Modal::new("Add/remove Entities").default_height(640.0),
             |_, ui, open| {
                 let Some(space_view_id) = &self.space_view_id else {

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -200,7 +200,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
     pub fn viewport_ui(&mut self, ui: &mut egui::Ui, ctx: &'a ViewerContext<'_>) {
         self.state
             .space_view_entity_window
-            .ui(ui, ctx, self.blueprint);
+            .ui(ui.ctx(), ctx, self.blueprint);
 
         let Viewport {
             blueprint, state, ..


### PR DESCRIPTION
### What

As the title says ☝🏻 

This is for consistency with windows in egui, which are also created using `egui::Context`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5008/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5008/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5008/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5008)
- [Docs preview](https://rerun.io/preview/d93746bd06b26a7c436d33f9baa3ddbc200a8c57/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d93746bd06b26a7c436d33f9baa3ddbc200a8c57/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)