### PR TITLE
Add runtime experimental flag for query clamping

### DIFF
--- a/crates/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/line_visualizer_system.rs
@@ -99,7 +99,12 @@ impl SeriesLineSystem {
         for data_result in query.iter_visible_data_results(Self::identifier()) {
             let mut points = Vec::new();
 
-            let time_range = determine_time_range(query, data_result, plot_bounds);
+            let time_range = determine_time_range(
+                query,
+                data_result,
+                plot_bounds,
+                ctx.app_options.experimental_plot_query_clamping,
+            );
 
             {
                 re_tracing::profile_scope!("primary", &data_result.entity_path.to_string());

--- a/crates/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/point_visualizer_system.rs
@@ -99,7 +99,12 @@ impl SeriesPointSystem {
         for data_result in query.iter_visible_data_results(Self::identifier()) {
             let mut points = Vec::new();
 
-            let time_range = determine_time_range(query, data_result, plot_bounds);
+            let time_range = determine_time_range(
+                query,
+                data_result,
+                plot_bounds,
+                ctx.app_options.experimental_plot_query_clamping,
+            );
 
             {
                 re_tracing::profile_scope!("primary", &data_result.entity_path.to_string());

--- a/crates/re_space_view_time_series/src/util.rs
+++ b/crates/re_space_view_time_series/src/util.rs
@@ -30,6 +30,7 @@ pub fn determine_time_range(
     query: &ViewQuery<'_>,
     data_result: &re_viewer_context::DataResult,
     plot_bounds: Option<egui_plot::PlotBounds>,
+    enable_query_clamping: bool,
 ) -> TimeRange {
     let visible_history = match query.timeline.typ() {
         re_log_types::TimeType::Time => data_result.accumulated_properties().visible_history.nanos,
@@ -51,7 +52,7 @@ pub fn determine_time_range(
     // the plot widget handles zoom after we provide it with data for the current frame,
     // this results in an extremely jarring frame delay.
     // Just try it out and you'll see what I mean.
-    if false {
+    if enable_query_clamping {
         if let Some(plot_bounds) = plot_bounds {
             time_range.min = TimeInt::max(
                 time_range.min,

--- a/crates/re_space_view_time_series/src/visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/visualizer_system.rs
@@ -92,7 +92,12 @@ impl LegacyTimeSeriesSystem {
         for data_result in query.iter_visible_data_results(Self::identifier()) {
             let mut points = Vec::new();
 
-            let time_range = determine_time_range(query, data_result, plot_bounds);
+            let time_range = determine_time_range(
+                query,
+                data_result,
+                plot_bounds,
+                ctx.app_options.experimental_plot_query_clamping,
+            );
 
             {
                 re_tracing::profile_scope!("primary", &data_result.entity_path.to_string());

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -421,6 +421,14 @@ fn experimental_feature_ui(
             "Primary caching: range queries",
         )
         .on_hover_text("Toggle primary caching for range queries.\nApplies to the 2D/3D point cloud, 2D/3D box, text log and time series space views.");
+
+    re_ui
+        .checkbox(
+            ui,
+            &mut app_options.experimental_plot_query_clamping,
+            "Plots: query clamping",
+        )
+        .on_hover_text("Toggle query clamping for the plot visualizers.");
 }
 
 #[cfg(debug_assertions)]

--- a/crates/re_viewer_context/src/app_options.rs
+++ b/crates/re_viewer_context/src/app_options.rs
@@ -32,6 +32,9 @@ pub struct AppOptions {
     /// Applies to the 2D/3D point cloud, 2D/3D box, text log and time series space views.
     pub experimental_primary_caching_range: bool,
 
+    /// Toggle query clamping for the plot visualizers.
+    pub experimental_plot_query_clamping: bool,
+
     /// Displays an overlay for debugging picking.
     pub show_picking_debug_overlay: bool,
 
@@ -64,6 +67,8 @@ impl Default for AppOptions {
 
             experimental_primary_caching_latest_at: true,
             experimental_primary_caching_range: true,
+
+            experimental_plot_query_clamping: false,
 
             show_picking_debug_overlay: false,
 


### PR DESCRIPTION
We likely won't ever polish it if we cannot play with it to begin with.

Related:
- #5013 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5014/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5014/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5014/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5014)
- [Docs preview](https://rerun.io/preview/7059ce5629f685d316698ac6cefe41217b2bbe15/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7059ce5629f685d316698ac6cefe41217b2bbe15/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)