### PR TITLE
Fix crashes in cache when encountering new component

### DIFF
--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -677,10 +677,12 @@ impl std::fmt::Debug for CacheBucket {
 impl CacheBucket {
     // Check invariants in debug builds
     fn sanity_check(&self) {
-        debug_assert_eq!(self.data_times.len(), self.pov_instance_keys.num_entries());
-        let n = self.data_times.len();
-        for (name, data) in &self.components {
-            debug_assert_eq!(data.dyn_num_entries(), n, "{name}");
+        if cfg!(debug_assertions) {
+            assert_eq!(self.data_times.len(), self.pov_instance_keys.num_entries());
+            let n = self.data_times.len();
+            for (name, data) in &self.components {
+                assert_eq!(data.dyn_num_entries(), n, "{name}");
+            }
         }
     }
 
@@ -964,7 +966,7 @@ impl CacheBucket {
         arch_view: &ArchetypeView<A>,
     ) -> re_query::Result<u64> {
         re_tracing::profile_function!(C::name());
-        // no sanity checks here - we are called while in an invariant-breakign state!
+        // no sanity checks here - we are called while in an invariant-breaking state!
 
         let num_entries = self.data_times.len();
 
@@ -1003,7 +1005,7 @@ impl CacheBucket {
         arch_view: &ArchetypeView<A>,
     ) -> re_query::Result<u64> {
         re_tracing::profile_function!(C::name());
-        // no sanity checks here - we are called while in an invariant-breakign state!
+        // no sanity checks here - we are called while in an invariant-breaking state!
 
         let num_entries = self.num_entries();
 

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -951,10 +951,13 @@ impl CacheBucket {
     ) -> re_query::Result<u64> {
         re_tracing::profile_function!(C::name());
 
-        let data = self
-            .components
-            .entry(C::name())
-            .or_insert_with(|| Box::new(FlatVecDeque::<C>::new()));
+        let num_entries = self.num_entries();
+
+        let data = self.components.entry(C::name()).or_insert_with(|| {
+            Box::new(FlatVecDeque::<C>::from_vecs(
+                std::iter::repeat(vec![]).take(num_entries),
+            ))
+        });
 
         // The `FlatVecDeque` will have to collect the data one way or another: do it ourselves
         // instead, that way we can efficiently compute its size while we're at it.
@@ -980,10 +983,13 @@ impl CacheBucket {
     ) -> re_query::Result<u64> {
         re_tracing::profile_function!(C::name());
 
-        let data = self
-            .components
-            .entry(C::name())
-            .or_insert_with(|| Box::new(FlatVecDeque::<Option<C>>::new()));
+        let num_entries = self.num_entries();
+
+        let data = self.components.entry(C::name()).or_insert_with(|| {
+            Box::new(FlatVecDeque::<Option<C>>::from_vecs(
+                std::iter::repeat(vec![]).take(num_entries),
+            ))
+        });
 
         let added: FlatVecDeque<Option<C>> = if arch_view.has_component::<C>() {
             // The `FlatVecDeque` will have to collect the data one way or another: do it ourselves

--- a/crates/re_query_cache/src/flat_vec_deque.rs
+++ b/crates/re_query_cache/src/flat_vec_deque.rs
@@ -638,11 +638,13 @@ impl<T> FlatVecDeque<T> {
     /// Shortens the deque, keeping all entries up to `entry_index` (excluded), and
     /// dropping the rest.
     ///
-    /// Panics if `entry_index` is out of bounds.
+    /// If `entry_index` is greater or equal to [`Self::num_entries`], this has no effect.
     #[inline]
     pub fn truncate(&mut self, entry_index: usize) {
-        self.values.truncate(self.value_offset(entry_index));
-        self.offsets.truncate(entry_index);
+        if entry_index < self.num_entries() {
+            self.values.truncate(self.value_offset(entry_index));
+            self.offsets.truncate(entry_index);
+        }
     }
 
     /// Removes the entry at `entry_index` from the deque.

--- a/crates/re_query_cache/src/flat_vec_deque.rs
+++ b/crates/re_query_cache/src/flat_vec_deque.rs
@@ -419,7 +419,7 @@ impl<T> FlatVecDeque<T> {
         self.push_back_deque(rhs);
         self.push_back_deque(right);
 
-        debug_assert!(self.iter_offset_ranges().all(|r| r.start < r.end));
+        debug_assert!(self.iter_offset_ranges().all(|r| r.start <= r.end));
     }
 }
 


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5009
* Very similar to https://github.com/rerun-io/rerun/pull/5007

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5016/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5016/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5016/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5016)
- [Docs preview](https://rerun.io/preview/3fe67bd1951e53ddaf936fddd5a40158dd141a8d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3fe67bd1951e53ddaf936fddd5a40158dd141a8d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)