### PR TITLE
Show marker shape in selection dropdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
+source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
+source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1602,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
+source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1618,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
+source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1635,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
+source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1664,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
+source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
 dependencies = [
  "egui",
  "ehttp",
@@ -1679,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
+source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
+source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
 dependencies = [
  "egui",
 ]
@@ -1739,7 +1739,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
+source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=520b28ce22a0daa20e13767af6061e9e40796f2a#520b28ce22a0daa20e13767af6061e9e40796f2a"
+source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -3849,9 +3849,9 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135ede8821cf6376eb7a64148901e1690b788c11ae94dc297ae917dbc91dc0e"
+checksum = "0f0f7f43585c34e4fdd7497d746bc32e14458cf11c69341cc0587b1d825dde42"
 dependencies = [
  "profiling-procmacros",
  "puffin",
@@ -3859,9 +3859,9 @@ dependencies = [
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b322d7d65c1ab449be3c890fcbd0db6e1092d0dd05d79dba2dd28032cebeb05"
+checksum = "ce97fecd27bc49296e5e20518b5a1bb54a14f7d5fe6228bc9686ee2a74915cc8"
 dependencies = [
  "quote",
  "syn 2.0.48",
@@ -3933,9 +3933,9 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02330f795caafc2007510f742624c10aa813b8c3097c77ff344b1b86eb6be846"
+checksum = "b9f76ad4bb049fded4e572df72cbb6381ff5d1f41f85c3a04b56e4eca287a02f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3949,13 +3949,14 @@ dependencies = [
 
 [[package]]
 name = "puffin_http"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf8e52cf00569807b02e8089a85e859c00476182730cda9718c94b12cdc31b8"
+checksum = "4936c085e48efc86f6d96609dc5086d1d236afe3ec4676f09b157a4f4be83ff6"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
  "log",
+ "parking_lot",
  "puffin",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,8 +178,8 @@ pollster = "0.3"
 prettyplease = "0.2"
 proc-macro2 = { version = "1.0", default-features = false }
 profiling = { version = "1.0.12", default-features = false }
-puffin = "0.18"
-puffin_http = "0.15"
+puffin = "0.19"
+puffin_http = "0.16"
 pyo3 = "0.20.2"
 pyo3-build-config = "0.20.2"
 quote = "1.0"
@@ -278,13 +278,13 @@ debug = true
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "520b28ce22a0daa20e13767af6061e9e40796f2a" }      # egui master 2024-01-31
-eframe = { git = "https://github.com/emilk/egui.git", rev = "520b28ce22a0daa20e13767af6061e9e40796f2a" }      # egui master 2024-01-31
-egui = { git = "https://github.com/emilk/egui.git", rev = "520b28ce22a0daa20e13767af6061e9e40796f2a" }        # egui master 2024-01-31
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "520b28ce22a0daa20e13767af6061e9e40796f2a" } # egui master 2024-01-31
-egui_plot = { git = "https://github.com/emilk/egui.git", rev = "520b28ce22a0daa20e13767af6061e9e40796f2a" }   # egui master 2024-01-31
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "520b28ce22a0daa20e13767af6061e9e40796f2a" }   # egui master 2024-01-31
-emath = { git = "https://github.com/emilk/egui.git", rev = "520b28ce22a0daa20e13767af6061e9e40796f2a" }       # egui master 2024-01-31
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432e5abe2c6410f23a70d03" }      # egui master 2024-02-02
+eframe = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432e5abe2c6410f23a70d03" }      # egui master 2024-02-02
+egui = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432e5abe2c6410f23a70d03" }        # egui master 2024-02-02
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432e5abe2c6410f23a70d03" } # egui master 2024-02-02
+egui_plot = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432e5abe2c6410f23a70d03" }   # egui master 2024-02-02
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432e5abe2c6410f23a70d03" }   # egui master 2024-02-02
+emath = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432e5abe2c6410f23a70d03" }       # egui master 2024-02-02
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/crates/re_data_ui/src/editors.rs
+++ b/crates/re_data_ui/src/editors.rs
@@ -218,11 +218,25 @@ fn edit_marker_shape_ui(
     let marker_text = edit_marker.as_str();
 
     egui::ComboBox::from_id_source("marker_shape")
-        .selected_text(marker_text)
+        .selected_text(marker_text) // TODO(emilk): Show marker shape in the selected text
+        .width(100.0)
+        .height(320.0)
         .show_ui(ui, |ui| {
-            ui.style_mut().wrap = Some(false);
+            // Hack needed for ListItem to click its highlight bg rect correctly:
+            ui.set_clip_rect(
+                ui.clip_rect()
+                    .with_max_x(ui.max_rect().max.x + ui.spacing().menu_margin.right),
+            );
+
             for marker in MarkerShape::all_markers() {
-                ui.selectable_value(&mut edit_marker, marker, marker.as_str());
+                let list_item = re_ui::list_item::ListItem::new(ctx.re_ui, marker.as_str())
+                    .with_icon_fn(|_re_ui, ui, rect, visuals| {
+                        paint_marker(ui, marker.into(), rect, visuals.text_color());
+                    })
+                    .selected(edit_marker == marker);
+                if list_item.show(ui).clicked() {
+                    edit_marker = marker;
+                }
             }
         });
 
@@ -239,6 +253,28 @@ fn default_marker_shape(
     _entity_path: &EntityPath,
 ) -> MarkerShape {
     MarkerShape::default()
+}
+
+fn paint_marker(
+    ui: &egui::Ui,
+    marker: egui_plot::MarkerShape,
+    rect: egui::Rect,
+    color: egui::Color32,
+) {
+    use egui_plot::PlotItem as _;
+
+    let points = egui_plot::Points::new([0.0, 0.0])
+        .shape(marker)
+        .color(color)
+        .radius(rect.size().min_elem() / 2.0)
+        .filled(true);
+
+    let bounds = egui_plot::PlotBounds::new_symmetrical(0.5);
+    let transform = egui_plot::PlotTransform::new(rect, bounds, true, true);
+
+    let mut shapes = vec![];
+    points.shapes(ui, &transform, &mut shapes);
+    ui.painter().extend(shapes);
 }
 
 // ----

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -123,8 +123,7 @@ pub struct ListItem<'a> {
     collapse_openness: Option<f32>,
     height: f32,
     width_allocation_mode: WidthAllocationMode,
-    icon_fn:
-        Option<Box<dyn FnOnce(&ReUi, &mut egui::Ui, egui::Rect, egui::style::WidgetVisuals) + 'a>>,
+    icon_fn: Option<Box<dyn FnOnce(&ReUi, &egui::Ui, egui::Rect, egui::style::WidgetVisuals) + 'a>>,
     buttons_fn: Option<Box<dyn FnOnce(&ReUi, &mut egui::Ui) -> egui::Response + 'a>>,
 }
 
@@ -265,7 +264,7 @@ impl<'a> ListItem<'a> {
     #[inline]
     pub fn with_icon_fn(
         mut self,
-        icon_fn: impl FnOnce(&ReUi, &mut egui::Ui, egui::Rect, egui::style::WidgetVisuals) + 'a,
+        icon_fn: impl FnOnce(&ReUi, &egui::Ui, egui::Rect, egui::style::WidgetVisuals) + 'a,
     ) -> Self {
         self.icon_fn = Some(Box::new(icon_fn));
         self


### PR DESCRIPTION
### What
Ideally we want to show it in the "closed" state too, and make the combo-box button a lot nicer in general… but this is at least something.

![markers](https://github.com/rerun-io/rerun/assets/1148717/5095b4cb-894c-4783-85db-60124ccab632)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5019/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5019/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5019/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5019)
- [Docs preview](https://rerun.io/preview/f1b6da68079979eb0af449e7dc76c953caa212ac/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f1b6da68079979eb0af449e7dc76c953caa212ac/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)