### PR TITLE
Add `--threads` / `-j` to control number of compute threads

### DIFF
--- a/Cranky.toml
+++ b/Cranky.toml
@@ -148,6 +148,7 @@ warn = [
 ]
 
 allow = [
+  "clippy::comparison_chain",      # annoying
   "clippy::manual_range_contains", # this one is just worse imho
 
   # TODO(emilk): enable more of these lints:

--- a/Cranky.toml
+++ b/Cranky.toml
@@ -148,7 +148,6 @@ warn = [
 ]
 
 allow = [
-  "clippy::comparison_chain",      # annoying
   "clippy::manual_range_contains", # this one is just worse imho
 
   # TODO(emilk): enable more of these lints:

--- a/crates/rerun-cli/src/bin/rerun.rs
+++ b/crates/rerun-cli/src/bin/rerun.rs
@@ -20,12 +20,6 @@ static GLOBAL: AccountingAllocator<mimalloc::MiMalloc> =
 async fn main() -> std::process::ExitCode {
     re_log::setup_logging();
 
-    // Name the rayon threads for the benefit of debuggers and profilers:
-    rayon::ThreadPoolBuilder::new()
-        .thread_name(|i| format!("rayon-{i}"))
-        .build_global()
-        .unwrap();
-
     let build_info = re_build_info::build_info!();
 
     let result = rerun::run(build_info, rerun::CallSource::Cli, std::env::args()).await;

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -342,7 +342,7 @@ where
     use clap::Parser as _;
     let mut args = Args::parse_from(args);
 
-    initialize_thead_pool(args.threads);
+    initialize_thread_pool(args.threads);
 
     if args.web_viewer {
         args.serve = true;
@@ -401,7 +401,7 @@ where
     }
 }
 
-fn initialize_thead_pool(threads_args: i32) {
+fn initialize_thread_pool(threads_args: i32) {
     // Name the rayon threads for the benefit of debuggers and profilers:
     let mut builder = rayon::ThreadPoolBuilder::new().thread_name(|i| format!("rayon-{i}"));
 

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -413,7 +413,10 @@ fn initialize_thread_pool(threads_args: i32) {
                 builder = builder.num_threads(threads);
             }
             Err(err) => {
-                re_log::warn!("Failed to query system of the number of cores: {err}");
+                re_log::warn!("Failed to query system of the number of cores: {err}.");
+                // Let rayon decide for itself how many threads to use.
+                // It's default is to use as many threads as we have cores,
+                // (if rayon manages to figure out how many cores we have).
             }
         }
     } else {


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/4931

You can now control the number of threads in the rayon thread pool using `-j` or `--threads`. The default is `-2`, meaning two less threads than the number of cores. This is to leave some breathing room for other threads the viewer spawns, as well as the rest of the users system.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5021/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5021/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5021/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5021)
- [Docs preview](https://rerun.io/preview/e2052e86d1395fc070e84bd8357ce56081959d87/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e2052e86d1395fc070e84bd8357ce56081959d87/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)