### PR TITLE
Improve the UI for the entity query

### DIFF
--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -1166,7 +1166,7 @@ pub fn help_hover_button(ui: &mut egui::Ui) -> egui::Response {
 }
 
 /// Show some markdown
-pub fn markdownm_ui(ui: &mut egui::Ui, id: egui::Id, markdown: &str) {
+pub fn markdown_ui(ui: &mut egui::Ui, id: egui::Id, markdown: &str) {
     use parking_lot::Mutex;
     use std::sync::Arc;
 

--- a/crates/re_viewport/src/space_view_entity_picker.rs
+++ b/crates/re_viewport/src/space_view_entity_picker.rs
@@ -30,10 +30,16 @@ impl SpaceViewEntityPicker {
         ctx: &ViewerContext<'_>,
         viewport_blueprint: &ViewportBlueprint,
     ) {
+        let title = if ctx.app_options.experimental_entity_filter_editor {
+            "Edit entity path query"
+        } else {
+            "Add/remove Entities"
+        };
+
         self.modal_handler.ui(
             ctx.re_ui,
             egui_ctx,
-            || re_ui::modal::Modal::new("Add/remove Entities").default_height(640.0),
+            || re_ui::modal::Modal::new(title).default_height(640.0),
             |_, ui, open| {
                 let Some(space_view_id) = &self.space_view_id else {
                     *open = false;


### PR DESCRIPTION
### What

This PR implements the minimal sets of UI touch up to make the new query editor releasable.
**Note**: both commits best reviewed separately (first one is pure refactor)

* Fixes #4962

#### Query DSL feature flag off

<img width="322" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/be2b6747-5254-41c6-874f-d2cd57e8fc83">

<img width="335" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/255d7585-186b-4f9f-8b2d-4f572ac8063c">

#### Query DSL feature flag on

<img width="324" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/35176857-0d87-46f2-9c31-ef42d5ffecc8">

<img width="334" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/9e7c8cdc-55d9-4088-805c-c7d68d19cd9f">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5022/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5022/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5022/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5022)
- [Docs preview](https://rerun.io/preview/d7ff85fab7e650f5cc2f7967e3fa497eb8fdecb0/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d7ff85fab7e650f5cc2f7967e3fa497eb8fdecb0/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)