### PR TITLE
Only show the LegacyVisualizer if a user logs with TimeSeriesScalar archetype

### DIFF
--- a/crates/re_space_view_time_series/src/legacy_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/legacy_visualizer_system.rs
@@ -2,7 +2,7 @@ use re_query_cache::{MaybeCachedComponentData, QueryError};
 use re_types::{
     archetypes::TimeSeriesScalar,
     components::{Color, Radius, Scalar, ScalarScattering, Text},
-    Loggable,
+    Archetype, Loggable,
 };
 use re_viewer_context::{
     AnnotationMap, DefaultColor, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewQuery,
@@ -30,7 +30,15 @@ impl IdentifiedViewSystem for LegacyTimeSeriesSystem {
 
 impl VisualizerSystem for LegacyTimeSeriesSystem {
     fn visualizer_query_info(&self) -> VisualizerQueryInfo {
-        VisualizerQueryInfo::from_archetype::<TimeSeriesScalar>()
+        let mut query_info = VisualizerQueryInfo::from_archetype::<TimeSeriesScalar>();
+        // Although we don't normally include indicator components in required components,
+        // we don't want to show this legacy visualizer unless a user is actively using
+        // the legacy archetype for their logging. Users just working with Scalar will
+        // only see the new visualizer options.
+        query_info
+            .required
+            .insert(TimeSeriesScalar::indicator().name());
+        query_info
     }
 
     fn execute(

--- a/crates/re_space_view_time_series/src/lib.rs
+++ b/crates/re_space_view_time_series/src/lib.rs
@@ -3,12 +3,12 @@
 //! A Space View that shows plots over Rerun timelines.
 
 mod aggregation;
+mod legacy_visualizer_system;
 mod line_visualizer_system;
 mod overrides;
 mod point_visualizer_system;
 mod space_view_class;
 mod util;
-mod visualizer_system;
 
 use re_log_types::EntityPath;
 use re_types::components::MarkerShape;

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -17,9 +17,9 @@ use re_viewer_context::{
     SpaceViewSystemExecutionError, SystemExecutionOutput, ViewQuery, ViewerContext,
 };
 
+use crate::legacy_visualizer_system::LegacyTimeSeriesSystem;
 use crate::line_visualizer_system::SeriesLineSystem;
 use crate::point_visualizer_system::SeriesPointSystem;
-use crate::visualizer_system::LegacyTimeSeriesSystem;
 use crate::PlotSeriesKind;
 
 // ---


### PR DESCRIPTION
### What
This avoids showing the LegacyTimeSeries visualizer when a user uses the new Scalar archetype.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5023/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5023/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5023/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5023)
- [Docs preview](https://rerun.io/preview/06ab431c3301707e1b6037b6f7ffe6cb0cbde616/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/06ab431c3301707e1b6037b6f7ffe6cb0cbde616/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)