### PR TITLE
Batched attributes/overrides PoC

### DIFF
--- a/crates/re_space_view_time_series/src/lib.rs
+++ b/crates/re_space_view_time_series/src/lib.rs
@@ -11,7 +11,7 @@ mod util;
 mod visualizer_system;
 
 use re_log_types::EntityPath;
-use re_types::components::MarkerShape;
+use re_types::components::{MarkerShape, Text};
 use re_viewer_context::external::re_entity_db::TimeSeriesAggregator;
 pub use space_view_class::TimeSeriesSpaceView;
 
@@ -31,7 +31,7 @@ pub(crate) fn plot_id(space_view_id: re_viewer_context::SpaceViewId) -> egui::Id
 
 #[derive(Clone, Debug)]
 pub struct PlotPointAttrs {
-    pub label: Option<String>,
+    pub label: Option<Text>,
     pub color: egui::Color32,
     pub radius: f32,
     pub kind: PlotSeriesKind,

--- a/crates/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/line_visualizer_system.rs
@@ -184,7 +184,7 @@ impl SeriesLineSystem {
                                     time: time.as_i64(),
                                     value: scalar.0,
                                     attrs: PlotPointAttrs {
-                                        label,
+                                        label: label.map(Into::into), // TODO
                                         color,
                                         radius,
                                         kind: PlotSeriesKind::Continuous,

--- a/crates/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/point_visualizer_system.rs
@@ -202,7 +202,7 @@ impl SeriesPointSystem {
                                     time: time.as_i64(),
                                     value: scalar.0,
                                     attrs: PlotPointAttrs {
-                                        label,
+                                        label: label.map(Into::into), // TODO
                                         color,
                                         radius,
                                         kind: PlotSeriesKind::Scatter(ScatterAttrs{marker}),

--- a/crates/re_space_view_time_series/src/util.rs
+++ b/crates/re_space_view_time_series/src/util.rs
@@ -1,4 +1,5 @@
 use re_log_types::{EntityPath, TimeInt, TimeRange};
+use re_types::components::Text;
 use re_viewer_context::{external::re_entity_db::TimeSeriesAggregator, ViewQuery, ViewerContext};
 
 use crate::{
@@ -92,11 +93,12 @@ pub fn points_to_series(
         .entity_min_time(&query.timeline, &data_result.entity_path)
         .map_or(points.first().map_or(0, |p| p.time), |time| time.as_i64());
 
-    let same_label = |points: &[PlotPoint]| -> Option<String> {
+    let same_label = |points: &[PlotPoint]| -> Option<Text> {
         let label = points[0].attrs.label.as_ref()?;
         (points.iter().all(|p| p.attrs.label.as_ref() == Some(label))).then(|| label.clone())
     };
-    let series_label = same_label(&points).unwrap_or_else(|| data_result.entity_path.to_string());
+    let series_label =
+        same_label(&points).map_or_else(|| data_result.entity_path.to_string(), |l| l.to_string());
     if points.len() == 1 {
         // Can't draw a single point as a continuous line, so fall back on scatter
         let mut kind = points[0].attrs.kind;


### PR DESCRIPTION
- Allocate all points at once (TODO: ask the cache how much we expect)
- Pre-fill all overridden/default values as needed
- Move annotation-context related stuff out of the loop
- Make it easy for the optimizer to notice that an attribute can be fully ignored if the override is set

Gives about 2x-3x perf improvement on the 1M_series dataset. 

Proof of concept for #5017:
- #5017

---

`1M_series` on `main` (a5a1d7d):
![image](https://github.com/rerun-io/rerun/assets/2910679/430e277a-24cf-4f46-92c0-7581c0914bd0)

`1M_series` on this branch:
![image](https://github.com/rerun-io/rerun/assets/2910679/9e5fb74a-95c4-48a6-b218-33d2c20b7a53)


### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5024/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5024/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5024/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5024)
- [Docs preview](https://rerun.io/preview/adb61cacc6e026d892e15111a503eccbad75fe47/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/adb61cacc6e026d892e15111a503eccbad75fe47/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)