### PR TITLE
Fix codegen of python scoped objects to handle mixed-scope imports

### DIFF
--- a/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from . import archetypes, components, datatypes
+
+__all__ = ["archetypes", "datatypes", "components"]

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/container_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/container_blueprint.py
@@ -9,10 +9,9 @@ from typing import Any
 
 from attrs import define, field
 
-from ... import datatypes
+from ... import blueprint, datatypes
 from ..._baseclasses import Archetype
 from ...error_utils import catch_and_log_exceptions
-from .. import components
 
 __all__ = ["ContainerBlueprint"]
 
@@ -23,15 +22,15 @@ class ContainerBlueprint(Archetype):
 
     def __init__(
         self: Any,
-        container_kind: components.ContainerKindLike,
+        container_kind: blueprint.components.ContainerKindLike,
         *,
-        display_name: components.NameLike | None = None,
-        contents: components.IncludedContentsLike | None = None,
-        col_shares: components.ColumnSharesLike | None = None,
-        row_shares: components.RowSharesLike | None = None,
+        display_name: blueprint.components.NameLike | None = None,
+        contents: blueprint.components.IncludedContentsLike | None = None,
+        col_shares: blueprint.components.ColumnSharesLike | None = None,
+        row_shares: blueprint.components.RowSharesLike | None = None,
         active_tab: datatypes.EntityPathLike | None = None,
-        visible: components.VisibleLike | None = None,
-        grid_columns: components.GridColumnsLike | None = None,
+        visible: blueprint.components.VisibleLike | None = None,
+        grid_columns: blueprint.components.GridColumnsLike | None = None,
     ):
         """
         Create a new instance of the ContainerBlueprint archetype.
@@ -107,36 +106,36 @@ class ContainerBlueprint(Archetype):
         inst.__attrs_clear__()
         return inst
 
-    container_kind: components.ContainerKindBatch = field(
+    container_kind: blueprint.components.ContainerKindBatch = field(
         metadata={"component": "required"},
-        converter=components.ContainerKindBatch._required,  # type: ignore[misc]
+        converter=blueprint.components.ContainerKindBatch._required,  # type: ignore[misc]
     )
     # The class of the view.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    display_name: components.NameBatch | None = field(
+    display_name: blueprint.components.NameBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.NameBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.NameBatch._optional,  # type: ignore[misc]
     )
     # The name of the container.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    contents: components.IncludedContentsBatch | None = field(
+    contents: blueprint.components.IncludedContentsBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.IncludedContentsBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.IncludedContentsBatch._optional,  # type: ignore[misc]
     )
     # `ContainerIds`s or `SpaceViewId`s that are children of this container.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    col_shares: components.ColumnSharesBatch | None = field(
+    col_shares: blueprint.components.ColumnSharesBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ColumnSharesBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.ColumnSharesBatch._optional,  # type: ignore[misc]
     )
     # The layout shares of each column in the container.
     #
@@ -146,10 +145,10 @@ class ContainerBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    row_shares: components.RowSharesBatch | None = field(
+    row_shares: blueprint.components.RowSharesBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.RowSharesBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.RowSharesBatch._optional,  # type: ignore[misc]
     )
     # The layout shares of each row of the container.
     #
@@ -159,10 +158,10 @@ class ContainerBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    active_tab: components.ActiveTabBatch | None = field(
+    active_tab: blueprint.components.ActiveTabBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ActiveTabBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.ActiveTabBatch._optional,  # type: ignore[misc]
     )
     # Which tab is active.
     #
@@ -170,10 +169,10 @@ class ContainerBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    visible: components.VisibleBatch | None = field(
+    visible: blueprint.components.VisibleBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.VisibleBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.VisibleBatch._optional,  # type: ignore[misc]
     )
     # Whether this container is visible.
     #
@@ -181,10 +180,10 @@ class ContainerBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    grid_columns: components.GridColumnsBatch | None = field(
+    grid_columns: blueprint.components.GridColumnsBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.GridColumnsBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.GridColumnsBatch._optional,  # type: ignore[misc]
     )
     # How many columns this grid should have.
     #

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/plot_legend.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/plot_legend.py
@@ -9,9 +9,9 @@ from typing import Any
 
 from attrs import define, field
 
+from ... import blueprint
 from ..._baseclasses import Archetype
 from ...error_utils import catch_and_log_exceptions
-from .. import components
 
 __all__ = ["PlotLegend"]
 
@@ -21,7 +21,10 @@ class PlotLegend(Archetype):
     """**Archetype**: Configuration for the legend of a plot."""
 
     def __init__(
-        self: Any, *, corner: components.Corner2DLike | None = None, visible: components.VisibleLike | None = None
+        self: Any,
+        *,
+        corner: blueprint.components.Corner2DLike | None = None,
+        visible: blueprint.components.VisibleLike | None = None,
     ):
         """
         Create a new instance of the PlotLegend archetype.
@@ -58,10 +61,10 @@ class PlotLegend(Archetype):
         inst.__attrs_clear__()
         return inst
 
-    corner: components.Corner2DBatch | None = field(
+    corner: blueprint.components.Corner2DBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.Corner2DBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.Corner2DBatch._optional,  # type: ignore[misc]
     )
     # To what corner the legend is aligned.
     #
@@ -69,10 +72,10 @@ class PlotLegend(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    visible: components.VisibleBatch | None = field(
+    visible: blueprint.components.VisibleBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.VisibleBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.VisibleBatch._optional,  # type: ignore[misc]
     )
     # Whether the legend is shown at all.
     #

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_blueprint.py
@@ -9,10 +9,9 @@ from typing import Any
 
 from attrs import define, field
 
-from ... import datatypes
+from ... import blueprint, datatypes
 from ..._baseclasses import Archetype
 from ...error_utils import catch_and_log_exceptions
-from .. import components
 
 __all__ = ["SpaceViewBlueprint"]
 
@@ -23,13 +22,13 @@ class SpaceViewBlueprint(Archetype):
 
     def __init__(
         self: Any,
-        class_identifier: components.SpaceViewClassLike,
+        class_identifier: blueprint.components.SpaceViewClassLike,
         *,
-        display_name: components.NameLike | None = None,
+        display_name: blueprint.components.NameLike | None = None,
         space_origin: datatypes.EntityPathLike | None = None,
-        entities_determined_by_user: components.EntitiesDeterminedByUserLike | None = None,
-        contents: components.IncludedQueriesLike | None = None,
-        visible: components.VisibleLike | None = None,
+        entities_determined_by_user: blueprint.components.EntitiesDeterminedByUserLike | None = None,
+        contents: blueprint.components.IncludedQueriesLike | None = None,
+        visible: blueprint.components.VisibleLike | None = None,
     ):
         """
         Create a new instance of the SpaceViewBlueprint archetype.
@@ -89,27 +88,27 @@ class SpaceViewBlueprint(Archetype):
         inst.__attrs_clear__()
         return inst
 
-    class_identifier: components.SpaceViewClassBatch = field(
+    class_identifier: blueprint.components.SpaceViewClassBatch = field(
         metadata={"component": "required"},
-        converter=components.SpaceViewClassBatch._required,  # type: ignore[misc]
+        converter=blueprint.components.SpaceViewClassBatch._required,  # type: ignore[misc]
     )
     # The class of the view.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    display_name: components.NameBatch | None = field(
+    display_name: blueprint.components.NameBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.NameBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.NameBatch._optional,  # type: ignore[misc]
     )
     # The name of the view.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    space_origin: components.SpaceViewOriginBatch | None = field(
+    space_origin: blueprint.components.SpaceViewOriginBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.SpaceViewOriginBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.SpaceViewOriginBatch._optional,  # type: ignore[misc]
     )
     # The "anchor point" of this space view.
     #
@@ -119,19 +118,19 @@ class SpaceViewBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    entities_determined_by_user: components.EntitiesDeterminedByUserBatch | None = field(
+    entities_determined_by_user: blueprint.components.EntitiesDeterminedByUserBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.EntitiesDeterminedByUserBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.EntitiesDeterminedByUserBatch._optional,  # type: ignore[misc]
     )
     # True if the user is has added entities themselves. False otherwise.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    contents: components.IncludedQueriesBatch | None = field(
+    contents: blueprint.components.IncludedQueriesBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.IncludedQueriesBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.IncludedQueriesBatch._optional,  # type: ignore[misc]
     )
     # `BlueprintId`s of the `DataQuery`s that make up this `SpaceView`.
     #
@@ -139,10 +138,10 @@ class SpaceViewBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    visible: components.VisibleBatch | None = field(
+    visible: blueprint.components.VisibleBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.VisibleBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.VisibleBatch._optional,  # type: ignore[misc]
     )
     # Whether this space view is visible.
     #

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/viewport_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/viewport_blueprint.py
@@ -9,10 +9,9 @@ from typing import Any
 
 from attrs import define, field
 
-from ... import datatypes
+from ... import blueprint, datatypes
 from ..._baseclasses import Archetype
 from ...error_utils import catch_and_log_exceptions
-from .. import components
 
 __all__ = ["ViewportBlueprint"]
 
@@ -23,13 +22,13 @@ class ViewportBlueprint(Archetype):
 
     def __init__(
         self: Any,
-        space_views: components.IncludedSpaceViewsLike,
+        space_views: blueprint.components.IncludedSpaceViewsLike,
         *,
-        layout: components.ViewportLayoutLike | None = None,
+        layout: blueprint.components.ViewportLayoutLike | None = None,
         root_container: datatypes.UuidLike | None = None,
         maximized: datatypes.UuidLike | None = None,
-        auto_layout: components.AutoLayoutLike | None = None,
-        auto_space_views: components.AutoSpaceViewsLike | None = None,
+        auto_layout: blueprint.components.AutoLayoutLike | None = None,
+        auto_space_views: blueprint.components.AutoSpaceViewsLike | None = None,
     ):
         """
         Create a new instance of the ViewportBlueprint archetype.
@@ -83,45 +82,45 @@ class ViewportBlueprint(Archetype):
         inst.__attrs_clear__()
         return inst
 
-    space_views: components.IncludedSpaceViewsBatch = field(
+    space_views: blueprint.components.IncludedSpaceViewsBatch = field(
         metadata={"component": "required"},
-        converter=components.IncludedSpaceViewsBatch._required,  # type: ignore[misc]
+        converter=blueprint.components.IncludedSpaceViewsBatch._required,  # type: ignore[misc]
     )
     # All of the space-views that belong to the viewport.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    layout: components.ViewportLayoutBatch | None = field(
+    layout: blueprint.components.ViewportLayoutBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.ViewportLayoutBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.ViewportLayoutBatch._optional,  # type: ignore[misc]
     )
     # The layout of the space-views
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    root_container: components.RootContainerBatch | None = field(
+    root_container: blueprint.components.RootContainerBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.RootContainerBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.RootContainerBatch._optional,  # type: ignore[misc]
     )
     # The layout of the space-views
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    maximized: components.SpaceViewMaximizedBatch | None = field(
+    maximized: blueprint.components.SpaceViewMaximizedBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.SpaceViewMaximizedBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.SpaceViewMaximizedBatch._optional,  # type: ignore[misc]
     )
     # Show one tab as maximized?
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    auto_layout: components.AutoLayoutBatch | None = field(
+    auto_layout: blueprint.components.AutoLayoutBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AutoLayoutBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.AutoLayoutBatch._optional,  # type: ignore[misc]
     )
     # Whether the viewport layout is determined automatically.
     #
@@ -129,10 +128,10 @@ class ViewportBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    auto_space_views: components.AutoSpaceViewsBatch | None = field(
+    auto_space_views: blueprint.components.AutoSpaceViewsBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.AutoSpaceViewsBatch._optional,  # type: ignore[misc]
+        converter=blueprint.components.AutoSpaceViewsBatch._optional,  # type: ignore[misc]
     )
     # Whether or not space views should be created automatically.
     #


### PR DESCRIPTION
### What
Previously importing scopes would overlay the `datatypes` / `components`.

We now just import the scope and instead adjust the references. This allows an archetype to contain both "regular" components as well as blueprint components.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5026/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5026/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5026/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5026)
- [Docs preview](https://rerun.io/preview/6a0878c81c8253740c84d56d317febcb6f67aa95/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/6a0878c81c8253740c84d56d317febcb6f67aa95/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)