### PR TITLE
Fix missing dependency when compiling re_data_ui in isolation

### DIFF
--- a/crates/re_data_ui/Cargo.toml
+++ b/crates/re_data_ui/Cargo.toml
@@ -25,7 +25,9 @@ re_log_types.workspace = true
 re_query.workspace = true
 re_renderer.workspace = true
 re_tracing.workspace = true
-re_types.workspace = true
+re_types = { workspace = true, features = [
+  "egui_plot", # Needed to draw marker shapes.
+] }
 re_ui.workspace = true
 re_viewer_context.workspace = true
 


### PR DESCRIPTION
### What

fixes nightly ci

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5031/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5031/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5031/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5031)
- [Docs preview](https://rerun.io/preview/98d1b7724c61e5a2f6a6fd6bc9cfbb77b0636b97/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/98d1b7724c61e5a2f6a6fd6bc9cfbb77b0636b97/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)