### PR TITLE
Fix a Visible Time Range UI issue where the summary string would display the wrong data range

### DIFF
--- a/crates/re_viewer/src/ui/visible_history.rs
+++ b/crates/re_viewer/src/ui/visible_history.rs
@@ -173,6 +173,8 @@ pub fn visible_history_ui(
                     )
                 })
                 .inner;
+
+            current_range_ui(ctx, ui, current_time, is_sequence_timeline, visible_history);
         } else {
             resolved_visible_history_boundary_ui(
                 ctx,
@@ -181,6 +183,7 @@ pub fn visible_history_ui(
                 is_sequence_timeline,
                 true,
             );
+
             resolved_visible_history_boundary_ui(
                 ctx,
                 ui,
@@ -188,9 +191,15 @@ pub fn visible_history_ui(
                 is_sequence_timeline,
                 false,
             );
-        }
 
-        current_range_ui(ctx, ui, current_time, is_sequence_timeline, visible_history);
+            current_range_ui(
+                ctx,
+                ui,
+                current_time,
+                is_sequence_timeline,
+                resolved_visible_history,
+            );
+        }
 
         ui.add(
             egui::Label::new(


### PR DESCRIPTION
### What

The "Override" settings were summarised even when the feature was set to "Default".

![image](https://github.com/rerun-io/rerun/assets/49431240/c9482fa5-cab7-425e-a970-2275f0a1f30f)

This PR fixes the summary line to display the summary for the default value when those apply.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5034/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5034/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5034/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5034)
- [Docs preview](https://rerun.io/preview/8afa01b828b58577a488f2c0b1906747faa7b1bc/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8afa01b828b58577a488f2c0b1906747faa7b1bc/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)