### PR TITLE
Show short component name in the component override menu

### DIFF
--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -334,7 +334,7 @@ impl StoreHub {
                     #[cfg(not(target_arch = "wasm32"))]
                     {
                         let blueprint_path = default_blueprint_path(app_id)?;
-                        re_log::debug!("Saving blueprint for {app_id} to {blueprint_path:?}");
+                        re_log::debug_once!("Saving blueprint for {app_id} to {blueprint_path:?}");
                         // TODO(jleibs): Should we push this into a background thread? Blueprints should generally
                         // be small & fast to save, but maybe not once we start adding big pieces of user data?
                         let file_saver = save_database_to_file(blueprint, blueprint_path, None)?;

--- a/crates/re_viewer/src/ui/override_ui.rs
+++ b/crates/re_viewer/src/ui/override_ui.rs
@@ -226,7 +226,7 @@ pub fn add_new_override(
                         continue;
                     }
 
-                    if ui.button(component.as_str()).clicked() {
+                    if ui.button(component.short_name()).clicked() {
                         // We are creating a new override. We need to decide what initial value to give it.
                         // - First see if there's an existing splat in the recording.
                         // - Next see if visualizer system wants to provide a value.


### PR DESCRIPTION
### What

Show `Color` instead of `rerun.components.Color`

![image](https://github.com/rerun-io/rerun/assets/1148717/d1e6bbf0-6126-4021-9f3a-2d2ac130d148)

The width is unnecessarily wide, but thats's something that I will punt on for now (requires some menu memory in egui: https://github.com/emilk/egui/issues/3974).

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5037/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5037/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5037/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5037)
- [Docs preview](https://rerun.io/preview/2b2b8ad07179a57b58610587568973a0a9aacab4/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2b2b8ad07179a57b58610587568973a0a9aacab4/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)