### PR TITLE
Update to `egui` 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,8 +1558,9 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "ecolor"
-version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169a0e42e2b3d0f663e100f5c10710ffdb9748f7e7565305ecc09044d59e0fbd"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1567,8 +1568,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2230537c7ee42c4c329461bad5933e91a8f938a9314645961e12e57080478731"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1602,8 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493685c2ca33e06b5ad45ae304b13bc084c395f422268bff1377633552f69ac"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1618,8 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "094ce3408f61ead0747b506aeb9e3fa9adbd5d937096a26dfbee24387bce8b3a"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1636,8 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85f8f89d6a937535e164a5bd6e31719fd7db01bc188d7b59425414b160a2ee1"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1654,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1f3092835a5e7b09405d3e6706d6fd913bb86706cbab53828f50c919dbf6e8"
+checksum = "6f491836e627bc98e00dd86c061d6b1be5e331c157f41dd8a8d512196f1b89aa"
 dependencies = [
  "egui",
  "egui_extras",
@@ -1665,8 +1670,9 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34bb4782902b4c314ab3bef2dd8a23c634df2e88978fa358cd2c09fb60bab172"
 dependencies = [
  "egui",
  "ehttp",
@@ -1680,8 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b8d8d33da3d2ae4db39b30ddcbc5f31e9b0d74e65dc028cf711e94b68ec4d6"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1698,8 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "egui_plot"
-version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c9fb26a588e070434a0b23783d8fc22a4c359ac5177401c9029add9dd2685f7"
 dependencies = [
  "egui",
 ]
@@ -1707,7 +1715,7 @@ dependencies = [
 [[package]]
 name = "egui_tiles"
 version = "0.6.0"
-source = "git+https://github.com/rerun-io/egui_tiles?rev=be78596d3564f696b61a1ba14678b0aa0bfcdb2f#be78596d3564f696b61a1ba14678b0aa0bfcdb2f"
+source = "git+https://github.com/rerun-io/egui_tiles?rev=50732cf58528b7060844915bdbcb47a3b0d4d07e#50732cf58528b7060844915bdbcb47a3b0d4d07e"
 dependencies = [
  "ahash",
  "egui",
@@ -1740,8 +1748,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "emath"
-version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba2475f57a416ce2a05e557f3d18e465c7aef23f3f6da2252b428eaaaaa6a65"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1841,8 +1850,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823734a8b7e81302a5f1a8ba041ab4ed7805a43d8dfec4dac0c72b933699bbc"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,8 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "egui_tiles"
-version = "0.6.0"
-source = "git+https://github.com/rerun-io/egui_tiles?rev=50732cf58528b7060844915bdbcb47a3b0d4d07e#50732cf58528b7060844915bdbcb47a3b0d4d07e"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62644ce60d89c48356e30ae08adaed0ea5856794cbec8ef9157dbd9ffe856e97"
 dependencies = [
  "ahash",
  "egui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
+source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1568,11 +1568,12 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
+source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
 dependencies = [
  "bytemuck",
  "cocoa",
  "directories-next",
+ "document-features",
  "egui",
  "egui-wgpu",
  "egui-winit",
@@ -1602,7 +1603,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
+source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1618,9 +1619,10 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
+source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
 dependencies = [
  "bytemuck",
+ "document-features",
  "egui",
  "epaint",
  "log",
@@ -1635,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
+source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1664,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
+source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
 dependencies = [
  "egui",
  "ehttp",
@@ -1679,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
+source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1697,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
+source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
 dependencies = [
  "egui",
 ]
@@ -1739,7 +1741,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
+source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1840,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=c5352cf6c16b28d00432e5abe2c6410f23a70d03#c5352cf6c16b28d00432e5abe2c6410f23a70d03"
+source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
+source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
+source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1603,7 +1603,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
+source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
+source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
+source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1666,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
+source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
 dependencies = [
  "egui",
  "ehttp",
@@ -1681,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
+source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1699,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
+source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
 dependencies = [
  "egui",
 ]
@@ -1741,7 +1741,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
+source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1842,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.25.0"
-source = "git+https://github.com/emilk/egui.git?rev=217e06662683d4377ad475f20f1af3757b52996a#217e06662683d4377ad475f20f1af3757b52996a"
+source = "git+https://github.com/emilk/egui.git?rev=74f00f9017781d193bca6142ce764b6dd32a0e6f#74f00f9017781d193bca6142ce764b6dd32a0e6f"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ egui = { version = "0.26.0", features = [
 egui_commonmark = { version = "0.12", default-features = false }
 egui_extras = { version = "0.26.0", features = ["http", "image", "puffin"] }
 egui_plot = "0.26.0"
-egui_tiles = "0.6"
+egui_tiles = "0.7"
 egui-wgpu = "0.26.0"
 emath = "0.26.0"
 
@@ -295,6 +295,6 @@ debug = true
 # egui-wgpu = { path = "../../egui/crates/egui-wgpu" }
 # emath = { path = "../../egui/crates/emath" }
 
-egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "50732cf58528b7060844915bdbcb47a3b0d4d07e" } # master 2024-02-06
+# egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "50732cf58528b7060844915bdbcb47a3b0d4d07e" } # master 2024-02-06
 
 # egui_commonmark = { git = "https://github.com/rerun-io/egui_commonmark", rev = "3d83a92f995a1d18ab1172d0b129d496e0eedaae" } # Update to egui 0.25 https://github.com/lampsitter/egui_commonmark/pull/27

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,13 +278,13 @@ debug = true
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "217e06662683d4377ad475f20f1af3757b52996a" }      # egui master 2024-02-05
-eframe = { git = "https://github.com/emilk/egui.git", rev = "217e06662683d4377ad475f20f1af3757b52996a" }      # egui master 2024-02-05
-egui = { git = "https://github.com/emilk/egui.git", rev = "217e06662683d4377ad475f20f1af3757b52996a" }        # egui master 2024-02-05
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "217e06662683d4377ad475f20f1af3757b52996a" } # egui master 2024-02-05
-egui_plot = { git = "https://github.com/emilk/egui.git", rev = "217e06662683d4377ad475f20f1af3757b52996a" }   # egui master 2024-02-05
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "217e06662683d4377ad475f20f1af3757b52996a" }   # egui master 2024-02-05
-emath = { git = "https://github.com/emilk/egui.git", rev = "217e06662683d4377ad475f20f1af3757b52996a" }       # egui master 2024-02-05
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }      # egui master 2024-02-05
+eframe = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }      # egui master 2024-02-05
+egui = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }        # egui master 2024-02-05
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" } # egui master 2024-02-05
+egui_plot = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }   # egui master 2024-02-05
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }   # egui master 2024-02-05
+emath = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }       # egui master 2024-02-05
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,13 +278,13 @@ debug = true
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432e5abe2c6410f23a70d03" }      # egui master 2024-02-02
-eframe = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432e5abe2c6410f23a70d03" }      # egui master 2024-02-02
-egui = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432e5abe2c6410f23a70d03" }        # egui master 2024-02-02
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432e5abe2c6410f23a70d03" } # egui master 2024-02-02
-egui_plot = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432e5abe2c6410f23a70d03" }   # egui master 2024-02-02
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432e5abe2c6410f23a70d03" }   # egui master 2024-02-02
-emath = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432e5abe2c6410f23a70d03" }       # egui master 2024-02-02
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "217e06662683d4377ad475f20f1af3757b52996a" }      # egui master 2024-02-05
+eframe = { git = "https://github.com/emilk/egui.git", rev = "217e06662683d4377ad475f20f1af3757b52996a" }      # egui master 2024-02-05
+egui = { git = "https://github.com/emilk/egui.git", rev = "217e06662683d4377ad475f20f1af3757b52996a" }        # egui master 2024-02-05
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "217e06662683d4377ad475f20f1af3757b52996a" } # egui master 2024-02-05
+egui_plot = { git = "https://github.com/emilk/egui.git", rev = "217e06662683d4377ad475f20f1af3757b52996a" }   # egui master 2024-02-05
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "217e06662683d4377ad475f20f1af3757b52996a" }   # egui master 2024-02-05
+emath = { git = "https://github.com/emilk/egui.git", rev = "217e06662683d4377ad475f20f1af3757b52996a" }       # egui master 2024-02-05
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,15 +74,15 @@ re_ws_comms = { path = "crates/re_ws_comms", version = "=0.13.0-alpha.3", defaul
 rerun = { path = "crates/rerun", version = "=0.13.0-alpha.3", default-features = false }
 
 # egui-crates:
-ecolor = "0.25.0"
-eframe = { version = "0.25.0", default-features = false, features = [
+ecolor = "0.26.0"
+eframe = { version = "0.26.0", default-features = false, features = [
   "accesskit",
   "default_fonts",
   "puffin",
   "wayland",
   "x11",
 ] }
-egui = { version = "0.25.0", features = [
+egui = { version = "0.26.0", features = [
   "callstack",
   "extra_debug_asserts",
   "log",
@@ -90,11 +90,11 @@ egui = { version = "0.25.0", features = [
   "rayon",
 ] }
 egui_commonmark = { version = "0.11", default-features = false }
-egui_extras = { version = "0.25.0", features = ["http", "image", "puffin"] }
-egui_plot = "0.25.0"
+egui_extras = { version = "0.26.0", features = ["http", "image", "puffin"] }
+egui_plot = "0.26.0"
 egui_tiles = "0.6"
-egui-wgpu = "0.25.0"
-emath = "0.25.0"
+egui-wgpu = "0.26.0"
+emath = "0.26.0"
 
 # All of our direct external dependencies should be found here:
 ahash = "0.8"
@@ -278,13 +278,13 @@ debug = true
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }      # egui master 2024-02-05
-eframe = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }      # egui master 2024-02-05
-egui = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }        # egui master 2024-02-05
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" } # egui master 2024-02-05
-egui_plot = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }   # egui master 2024-02-05
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }   # egui master 2024-02-05
-emath = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }       # egui master 2024-02-05
+# ecolor = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }      # egui master 2024-02-05
+# eframe = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }      # egui master 2024-02-05
+# egui = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }        # egui master 2024-02-05
+# egui_extras = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" } # egui master 2024-02-05
+# egui_plot = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }   # egui master 2024-02-05
+# egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }   # egui master 2024-02-05
+# emath = { git = "https://github.com/emilk/egui.git", rev = "74f00f9017781d193bca6142ce764b6dd32a0e6f" }       # egui master 2024-02-05
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ egui = { version = "0.26.0", features = [
   "puffin",
   "rayon",
 ] }
-egui_commonmark = { version = "0.11", default-features = false }
+egui_commonmark = { version = "0.12", default-features = false }
 egui_extras = { version = "0.26.0", features = ["http", "image", "puffin"] }
 egui_plot = "0.26.0"
 egui_tiles = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,6 +295,6 @@ debug = true
 # egui-wgpu = { path = "../../egui/crates/egui-wgpu" }
 # emath = { path = "../../egui/crates/emath" }
 
-egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "be78596d3564f696b61a1ba14678b0aa0bfcdb2f" } # master 2024-02-05
+egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "50732cf58528b7060844915bdbcb47a3b0d4d07e" } # master 2024-02-06
 
 # egui_commonmark = { git = "https://github.com/rerun-io/egui_commonmark", rev = "3d83a92f995a1d18ab1172d0b129d496e0eedaae" } # Update to egui 0.25 https://github.com/lampsitter/egui_commonmark/pull/27

--- a/crates/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/re_space_view_tensor/src/space_view_class.rs
@@ -459,6 +459,7 @@ impl Default for TextureSettings {
                 // This is best for low-res depth-images and the like
                 magnification: egui::TextureFilter::Nearest,
                 minification: egui::TextureFilter::Linear,
+                wrap_mode: egui::TextureWrapMode::ClampToEdge,
             },
         }
     }

--- a/crates/re_ui/Cargo.toml
+++ b/crates/re_ui/Cargo.toml
@@ -29,7 +29,7 @@ default = []
 re_entity_db.workspace = true # syntax-highlighting for InstancePath. TODO(emilk): move InstancePath
 re_log_types.workspace = true # syntax-highlighting for EntityPath
 
-egui_commonmark.workspace = true
+egui_commonmark = { workspace = true, features = ["pulldown_cmark"] }
 egui_extras.workspace = true
 egui.workspace = true
 parking_lot.workspace = true

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -39,7 +39,7 @@ pub enum UICommand {
     ToggleBlueprintInspectionPanel,
 
     #[cfg(debug_assertions)]
-    ToggleStylePanel,
+    ToggleEguiDebugPanel,
 
     #[cfg(not(target_arch = "wasm32"))]
     ToggleFullscreen,
@@ -143,11 +143,10 @@ impl UICommand {
             ),
 
             #[cfg(debug_assertions)]
-            Self::ToggleStylePanel => (
-                "Toggle Style Panel",
+            Self::ToggleEguiDebugPanel => (
+                "Toggle Egui Options/Debug Panel",
                 "View and change global egui style settings",
             ),
-
 
 
             #[cfg(not(target_arch = "wasm32"))]
@@ -277,7 +276,7 @@ impl UICommand {
             Self::ToggleBlueprintInspectionPanel => Some(ctrl_shift(Key::I)),
 
             #[cfg(debug_assertions)]
-            Self::ToggleStylePanel => Some(ctrl_shift(Key::U)),
+            Self::ToggleEguiDebugPanel => Some(ctrl_shift(Key::U)),
 
             #[cfg(not(target_arch = "wasm32"))]
             Self::ToggleFullscreen => Some(key(Key::F11)),

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -72,7 +72,7 @@ impl App {
                 UICommand::ToggleMemoryPanel.menu_button_ui(ui, &self.command_sender);
 
                 #[cfg(debug_assertions)]
-                UICommand::ToggleStylePanel.menu_button_ui(ui, &self.command_sender);
+                UICommand::ToggleEguiDebugPanel.menu_button_ui(ui, &self.command_sender);
             }
 
             ui.add_space(SPACING);

--- a/crates/re_viewer_context/src/gpu_bridge/re_renderer_callback.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/re_renderer_callback.rs
@@ -27,6 +27,7 @@ impl egui_wgpu::CallbackTrait for ReRendererCallback {
         &self,
         _device: &wgpu::Device,
         _queue: &wgpu::Queue,
+        _screen_descriptor: &egui_wgpu::ScreenDescriptor,
         _egui_encoder: &mut wgpu::CommandEncoder,
         paint_callback_resources: &mut egui_wgpu::CallbackResources,
     ) -> Vec<wgpu::CommandBuffer> {


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5018

egui now also has a 300ms delay between stopping the mouse pointer over something and showing the tooltip, as discussed during standup.

This expands the egui "style" panel to a debug panel with the egui "inspection" ui in it.

![image](https://github.com/rerun-io/rerun/assets/1148717/1db3ed6d-d43c-4378-89a1-94f9b3ed7266)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5040/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5040/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5040/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5040)
- [Docs preview](https://rerun.io/preview/9069c86b2c65b5f5f84ab519c4fc573105afdb9b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/9069c86b2c65b5f5f84ab519c4fc573105afdb9b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)