### PR TITLE
Update all examples that use `TimeSeriesScalar` to use `Scalar` instead

### DIFF
--- a/crates/re_types/src/archetypes/scalar.rs
+++ b/crates/re_types/src/archetypes/scalar.rs
@@ -40,12 +40,13 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn()?;
 ///
+///     // Set up plot styling: Logged timeless since it never changes and affects all timelines.
+///     rec.log_timeless("scalar", &rerun::SeriesPoint::new())?;
+///
+///     // Log the data on a timeline called "step".
 ///     for step in 0..64 {
 ///         rec.set_time_sequence("step", step);
-///         rec.log(
-///             "scalar",
-///             &rerun::TimeSeriesScalar::new((step as f64 / 10.0).sin()),
-///         )?;
+///         rec.log("scalar", &rerun::Scalar::new((step as f64 / 10.0).sin()))?;
 ///     }
 ///
 ///     Ok(())

--- a/crates/re_types/src/archetypes/scalar.rs
+++ b/crates/re_types/src/archetypes/scalar.rs
@@ -40,9 +40,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn()?;
 ///
-///     // Set up plot styling: Logged timeless since it never changes and affects all timelines.
-///     rec.log_timeless("scalar", &rerun::SeriesPoint::new())?;
-///
 ///     // Log the data on a timeline called "step".
 ///     for step in 0..64 {
 ///         rec.set_time_sequence("step", step);

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -38,12 +38,13 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn()?;
 ///
+///     // Set up plot styling: Logged timeless since it never changes and affects all timelines.
+///     rec.log_timeless("scalar", &rerun::SeriesPoint::new())?;
+///
+///     // Log the data on a timeline called "step".
 ///     for step in 0..64 {
 ///         rec.set_time_sequence("step", step);
-///         rec.log(
-///             "scalar",
-///             &rerun::TimeSeriesScalar::new((step as f64 / 10.0).sin()),
-///         )?;
+///         rec.log("scalar", &rerun::Scalar::new((step as f64 / 10.0).sin()))?;
 ///     }
 ///
 ///     Ok(())

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -38,9 +38,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn()?;
 ///
-///     // Set up plot styling: Logged timeless since it never changes and affects all timelines.
-///     rec.log_timeless("scalar", &rerun::SeriesPoint::new())?;
-///
 ///     // Log the data on a timeline called "step".
 ///     for step in 0..64 {
 ///         rec.set_time_sequence("step", step);

--- a/docs/code-examples/all/scalar_multiple_plots.cpp
+++ b/docs/code-examples/all/scalar_multiple_plots.cpp
@@ -15,8 +15,14 @@ int main() {
     // Set up plot styling:
     // They are logged timeless as they don't change over time and apply to all timelines.
     // Log two lines series under a shared root so that they show in the same plot by default.
-    rec.log_timeless("trig/sin", rerun::SeriesLine().with_color({255, 0, 0}));
-    rec.log_timeless("trig/cos", rerun::SeriesLine().with_color({0, 255, 0}));
+    rec.log_timeless(
+        "trig/sin",
+        rerun::SeriesLine().with_color({255, 0, 0}).with_name("sin(0.01t)")
+    );
+    rec.log_timeless(
+        "trig/cos",
+        rerun::SeriesLine().with_color({0, 255, 0}).with_name("cos(0.01t)")
+    );
     // Log scattered points under a different root so that they shows in a different plot by default.
     rec.log_timeless("scatter/lcg", rerun::SeriesPoint());
 
@@ -24,11 +30,8 @@ int main() {
     for (int t = 0; t < static_cast<int>(TAU * 2.0 * 100.0); ++t) {
         rec.set_time_sequence("step", t);
 
-        rec.log("trig/sin", rerun::Scalar(sin(t / 100.0)).with_text("sin(0.01t)"));
-        rec.log(
-            "trig/cos",
-            rerun::Scalar(cos(static_cast<float>(t) / 100.0f)).with_text("cos(0.01t)")
-        );
+        rec.log("trig/sin", rerun::Scalar(sin(t / 100.0)));
+        rec.log("trig/cos", rerun::Scalar(cos(static_cast<float>(t) / 100.0f)));
 
         lcg_state =
             1140671485 * lcg_state + 128201163 % 16777216; // simple linear congruency generator

--- a/docs/code-examples/all/scalar_multiple_plots.cpp
+++ b/docs/code-examples/all/scalar_multiple_plots.cpp
@@ -12,27 +12,26 @@ int main() {
 
     int64_t lcg_state = 0;
 
+    // Set up plot styling:
+    // They are logged timeless as they don't change over time and apply to all timelines.
+    // Log two lines series under a shared root so that they show in the same plot by default.
+    rec.log_timeless("trig/sin", rerun::SeriesLine().with_color({255, 0, 0}));
+    rec.log_timeless("trig/cos", rerun::SeriesLine().with_color({0, 255, 0}));
+    // Log scattered points under a different root so that they shows in a different plot by default.
+    rec.log_timeless("scatter/lcg", rerun::SeriesPoint());
+
+    // Log the data on a timeline called "step".
     for (int t = 0; t < static_cast<int>(TAU * 2.0 * 100.0); ++t) {
         rec.set_time_sequence("step", t);
 
-        // Log two time series under a shared root so that they show in the same plot by default.
-        rec.log(
-            "trig/sin",
-            rerun::TimeSeriesScalar(sin(t / 100.0)).with_label("sin(0.01t)").with_color({255, 0, 0})
-        );
+        rec.log("trig/sin", rerun::Scalar(sin(t / 100.0)).with_text("sin(0.01t)"));
         rec.log(
             "trig/cos",
-            rerun::TimeSeriesScalar(cos(static_cast<float>(t) / 100.0f))
-                .with_label("cos(0.01t)")
-                .with_color({0, 255, 0})
+            rerun::Scalar(cos(static_cast<float>(t) / 100.0f)).with_text("cos(0.01t)")
         );
 
-        // Log scattered points under a different root so that it shows in a different plot by default.
         lcg_state =
             1140671485 * lcg_state + 128201163 % 16777216; // simple linear congruency generator
-        rec.log(
-            "scatter/lcg",
-            rerun::TimeSeriesScalar(static_cast<float>(lcg_state)).with_scattered(true)
-        );
+        rec.log("scatter/lcg", rerun::Scalar(static_cast<float>(lcg_state)));
     }
 }

--- a/docs/code-examples/all/scalar_multiple_plots.cpp
+++ b/docs/code-examples/all/scalar_multiple_plots.cpp
@@ -23,7 +23,7 @@ int main() {
         "trig/cos",
         rerun::SeriesLine().with_color({0, 255, 0}).with_name("cos(0.01t)")
     );
-    // Log scattered points under a different root so that they shows in a different plot by default.
+    // Log scattered points under a different root so that they show in a different plot by default.
     rec.log_timeless("scatter/lcg", rerun::SeriesPoint());
 
     // Log the data on a timeline called "step".

--- a/docs/code-examples/all/scalar_multiple_plots.py
+++ b/docs/code-examples/all/scalar_multiple_plots.py
@@ -11,8 +11,8 @@ lcg_state = np.int64(0)
 # Set up plot styling:
 # They are logged timeless as they don't change over time and apply to all timelines.
 # Log two lines series under a shared root so that they show in the same plot by default.
-rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0]), timeless=True)
-rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0]), timeless=True)
+rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)"), timeless=True)
+rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)"), timeless=True)
 # Log scattered points under a different root so that they shows in a different plot by default.
 rr.log("scatter/lcg", rr.SeriesPoint(), timeless=True)
 
@@ -20,8 +20,8 @@ rr.log("scatter/lcg", rr.SeriesPoint(), timeless=True)
 for t in range(0, int(tau * 2 * 100.0)):
     rr.set_time_sequence("step", t)
 
-    rr.log("trig/sin", rr.Scalar(sin(float(t) / 100.0), text="sin(0.01t)"))
-    rr.log("trig/cos", rr.Scalar(cos(float(t) / 100.0), text="cos(0.01t)"))
+    rr.log("trig/sin", rr.Scalar(sin(float(t) / 100.0)))
+    rr.log("trig/cos", rr.Scalar(cos(float(t) / 100.0)))
 
     lcg_state = (1140671485 * lcg_state + 128201163) % 16777216  # simple linear congruency generator
     rr.log("scatter/lcg", rr.Scalar(lcg_state))

--- a/docs/code-examples/all/scalar_multiple_plots.py
+++ b/docs/code-examples/all/scalar_multiple_plots.py
@@ -13,7 +13,7 @@ lcg_state = np.int64(0)
 # Log two lines series under a shared root so that they show in the same plot by default.
 rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)"), timeless=True)
 rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)"), timeless=True)
-# Log scattered points under a different root so that they shows in a different plot by default.
+# Log scattered points under a different root so that they show in a different plot by default.
 rr.log("scatter/lcg", rr.SeriesPoint(), timeless=True)
 
 # Log the data on a timeline called "step".

--- a/docs/code-examples/all/scalar_multiple_plots.py
+++ b/docs/code-examples/all/scalar_multiple_plots.py
@@ -8,13 +8,20 @@ import rerun as rr
 rr.init("rerun_example_scalar_multiple_plots", spawn=True)
 lcg_state = np.int64(0)
 
+# Set up plot styling:
+# They are logged timeless as they don't change over time and apply to all timelines.
+# Log two lines series under a shared root so that they show in the same plot by default.
+rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0]), timeless=True)
+rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0]), timeless=True)
+# Log scattered points under a different root so that they shows in a different plot by default.
+rr.log("scatter/lcg", rr.SeriesPoint(), timeless=True)
+
+# Log the data on a timeline called "step".
 for t in range(0, int(tau * 2 * 100.0)):
     rr.set_time_sequence("step", t)
 
-    # Log two time series under a shared root so that they show in the same plot by default.
-    rr.log("trig/sin", rr.TimeSeriesScalar(sin(float(t) / 100.0), label="sin(0.01t)", color=[255, 0, 0]))
-    rr.log("trig/cos", rr.TimeSeriesScalar(cos(float(t) / 100.0), label="cos(0.01t)", color=[0, 255, 0]))
+    rr.log("trig/sin", rr.Scalar(sin(float(t) / 100.0), text="sin(0.01t)"))
+    rr.log("trig/cos", rr.Scalar(cos(float(t) / 100.0), text="cos(0.01t)"))
 
-    # Log scattered points under a different root so that they shows in a different plot by default.
     lcg_state = (1140671485 * lcg_state + 128201163) % 16777216  # simple linear congruency generator
-    rr.log("scatter/lcg", rr.TimeSeriesScalar(lcg_state, scattered=True))
+    rr.log("scatter/lcg", rr.Scalar(lcg_state))

--- a/docs/code-examples/all/scalar_multiple_plots.rs
+++ b/docs/code-examples/all/scalar_multiple_plots.rs
@@ -4,21 +4,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar_multiple_plots").spawn()?;
     let mut lcg_state = 0_i64;
 
+    // Set up plot styling:
+    // They are logged timeless as they don't change over time and apply to all timelines.
+    // Log two lines series under a shared root so that they show in the same plot by default.
+    rec.log_timeless(
+        "trig/sin",
+        &rerun::SeriesLine::new().with_color([255, 0, 0]),
+    )?;
+    rec.log_timeless(
+        "trig/cos",
+        &rerun::SeriesLine::new().with_color([0, 255, 0]),
+    )?;
+    // Log scattered points under a different root so that they shows in a different plot by default.
+    rec.log_timeless("scatter/lcg", &rerun::SeriesPoint::new())?;
+
     for t in 0..((std::f32::consts::TAU * 2.0 * 100.0) as i64) {
         rec.set_time_sequence("step", t);
 
         // Log two time series under a shared root so that they show in the same plot by default.
         rec.log(
             "trig/sin",
-            &rerun::TimeSeriesScalar::new((t as f64 / 100.0).sin())
-                .with_label("sin(0.01t)")
-                .with_color([255, 0, 0]),
+            &rerun::Scalar::new((t as f64 / 100.0).sin()).with_text("sin(0.01t)"),
         )?;
         rec.log(
             "trig/cos",
-            &rerun::TimeSeriesScalar::new((t as f64 / 100.0).cos())
-                .with_label("cos(0.01t)")
-                .with_color([0, 255, 0]),
+            &rerun::Scalar::new((t as f64 / 100.0).cos()).with_text("cos(0.01t)"),
         )?;
 
         // Log scattered points under a different root so that it shows in a different plot by default.
@@ -26,10 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .wrapping_mul(lcg_state)
             .wrapping_add(128201163))
             % 16777216; // simple linear congruency generator
-        rec.log(
-            "scatter/lcg",
-            &rerun::TimeSeriesScalar::new(lcg_state as f64).with_scattered(true),
-        )?;
+        rec.log("scatter/lcg", &rerun::Scalar::new(lcg_state as f64))?;
     }
 
     Ok(())

--- a/docs/code-examples/all/scalar_multiple_plots.rs
+++ b/docs/code-examples/all/scalar_multiple_plots.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_color([0, 255, 0])
             .with_name("cos(0.01t)"),
     )?;
-    // Log scattered points under a different root so that they shows in a different plot by default.
+    // Log scattered points under a different root so that they show in a different plot by default.
     rec.log_timeless("scatter/lcg", &rerun::SeriesPoint::new())?;
 
     for t in 0..((std::f32::consts::TAU * 2.0 * 100.0) as i64) {

--- a/docs/code-examples/all/scalar_multiple_plots.rs
+++ b/docs/code-examples/all/scalar_multiple_plots.rs
@@ -9,11 +9,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log two lines series under a shared root so that they show in the same plot by default.
     rec.log_timeless(
         "trig/sin",
-        &rerun::SeriesLine::new().with_color([255, 0, 0]),
+        &rerun::SeriesLine::new()
+            .with_color([255, 0, 0])
+            .with_name("sin(0.01t)"),
     )?;
     rec.log_timeless(
         "trig/cos",
-        &rerun::SeriesLine::new().with_color([0, 255, 0]),
+        &rerun::SeriesLine::new()
+            .with_color([0, 255, 0])
+            .with_name("cos(0.01t)"),
     )?;
     // Log scattered points under a different root so that they shows in a different plot by default.
     rec.log_timeless("scatter/lcg", &rerun::SeriesPoint::new())?;
@@ -22,14 +26,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rec.set_time_sequence("step", t);
 
         // Log two time series under a shared root so that they show in the same plot by default.
-        rec.log(
-            "trig/sin",
-            &rerun::Scalar::new((t as f64 / 100.0).sin()).with_text("sin(0.01t)"),
-        )?;
-        rec.log(
-            "trig/cos",
-            &rerun::Scalar::new((t as f64 / 100.0).cos()).with_text("cos(0.01t)"),
-        )?;
+        rec.log("trig/sin", &rerun::Scalar::new((t as f64 / 100.0).sin()))?;
+        rec.log("trig/cos", &rerun::Scalar::new((t as f64 / 100.0).cos()))?;
 
         // Log scattered points under a different root so that it shows in a different plot by default.
         lcg_state = (1140671485_i64

--- a/docs/code-examples/all/scalar_simple.cpp
+++ b/docs/code-examples/all/scalar_simple.cpp
@@ -8,9 +8,6 @@ int main() {
     const auto rec = rerun::RecordingStream("rerun_example_scalar");
     rec.spawn().exit_on_failure();
 
-    // Set up plot styling: Logged timeless since it never changes and affects all timelines.
-    rec.log_timeless("scalar", rerun::SeriesPoint());
-
     // Log the data on a timeline called "step".
     for (int step = 0; step < 64; ++step) {
         rec.set_time_sequence("step", step);

--- a/docs/code-examples/all/scalar_simple.cpp
+++ b/docs/code-examples/all/scalar_simple.cpp
@@ -8,8 +8,12 @@ int main() {
     const auto rec = rerun::RecordingStream("rerun_example_scalar");
     rec.spawn().exit_on_failure();
 
+    // Set up plot styling: Logged timeless since it never changes and affects all timelines.
+    rec.log_timeless("scalar", rerun::SeriesPoint());
+
+    // Log the data on a timeline called "step".
     for (int step = 0; step < 64; ++step) {
         rec.set_time_sequence("step", step);
-        rec.log("scalar", rerun::TimeSeriesScalar(std::sin(static_cast<double>(step) / 10.0)));
+        rec.log("scalar", rerun::Scalar(std::sin(static_cast<double>(step) / 10.0)));
     }
 }

--- a/docs/code-examples/all/scalar_simple.py
+++ b/docs/code-examples/all/scalar_simple.py
@@ -5,6 +5,10 @@ import rerun as rr
 
 rr.init("rerun_example_scalar", spawn=True)
 
+# Set up plot styling: Logged timeless since it never changes and affects all timelines.
+rr.log("scalar", rr.SeriesPoint(), timeless=True)
+
+# Log the data on a timeline called "step".
 for step in range(0, 64):
     rr.set_time_sequence("step", step)
-    rr.log("scalar", rr.TimeSeriesScalar(math.sin(step / 10.0)))
+    rr.log("scalar", rr.Scalar(math.sin(step / 10.0)))

--- a/docs/code-examples/all/scalar_simple.py
+++ b/docs/code-examples/all/scalar_simple.py
@@ -5,9 +5,6 @@ import rerun as rr
 
 rr.init("rerun_example_scalar", spawn=True)
 
-# Set up plot styling: Logged timeless since it never changes and affects all timelines.
-rr.log("scalar", rr.SeriesPoint(), timeless=True)
-
 # Log the data on a timeline called "step".
 for step in range(0, 64):
     rr.set_time_sequence("step", step)

--- a/docs/code-examples/all/scalar_simple.rs
+++ b/docs/code-examples/all/scalar_simple.rs
@@ -3,12 +3,13 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn()?;
 
+    // Set up plot styling: Logged timeless since it never changes and affects all timelines.
+    rec.log_timeless("scalar", &rerun::SeriesPoint::new())?;
+
+    // Log the data on a timeline called "step".
     for step in 0..64 {
         rec.set_time_sequence("step", step);
-        rec.log(
-            "scalar",
-            &rerun::TimeSeriesScalar::new((step as f64 / 10.0).sin()),
-        )?;
+        rec.log("scalar", &rerun::Scalar::new((step as f64 / 10.0).sin()))?;
     }
 
     Ok(())

--- a/docs/code-examples/all/scalar_simple.rs
+++ b/docs/code-examples/all/scalar_simple.rs
@@ -3,9 +3,6 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn()?;
 
-    // Set up plot styling: Logged timeless since it never changes and affects all timelines.
-    rec.log_timeless("scalar", &rerun::SeriesPoint::new())?;
-
     // Log the data on a timeline called "step".
     for step in 0..64 {
         rec.set_time_sequence("step", step);

--- a/docs/content/howto/ros2-nav-turtlebot.md
+++ b/docs/content/howto/ros2-nav-turtlebot.md
@@ -202,8 +202,8 @@ Note that because we previously called `set_time_nanos` in this callback, this t
 be logged to the same point on the timeline as the data, using a timestamp looked up from TF at the
 matching timepoint.
 
-### Odometry to rr.TimeSeriesScalar and rr.Transform3D
-When receiving odometry messages, we log the linear and angular velocities using `rr.TimeSeriesScalar`.
+### Odometry to rr.Scalar and rr.Transform3D
+When receiving odometry messages, we log the linear and angular velocities using `rr.Scalar`.
 Additionally, since we know that odometry will also update the `map/robot` transform, we use
 this as a cue to look up the corresponding transform and log it.
 ```python
@@ -213,8 +213,8 @@ def odom_callback(self, odom: Odometry) -> None:
     rr.set_time_nanos("ros_time", time.nanoseconds)
 
     # Capture time-series data for the linear and angular velocities
-    rr.log("odometry/vel", rr.TimeSeriesScalar(odom.twist.twist.linear.x))
-    rr.log("odometry/ang_vel", rr.TimeSeriesScalar(odom.twist.twist.angular.z))
+    rr.log("odometry/vel", rr.Scalar(odom.twist.twist.linear.x))
+    rr.log("odometry/ang_vel", rr.Scalar(odom.twist.twist.angular.z))
 
     # Update the robot pose itself via TF
     self.log_tf_as_transform3d("map/robot", time)

--- a/examples/python/face_tracking/main.py
+++ b/examples/python/face_tracking/main.py
@@ -278,7 +278,7 @@ class FaceLandmarkerLogger:
 
             for blendshape in blendshapes:
                 if blendshape.category_name in BLENDSHAPES_CATEGORIES:
-                    rr.log(f"blendshapes/{i}/{blendshape.category_name}", rr.TimeSeriesScalar(blendshape.score))
+                    rr.log(f"blendshapes/{i}/{blendshape.category_name}", rr.Scalar(blendshape.score))
 
 
 # ========================================================================================

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -29,17 +29,19 @@ The [bar chart](recording://bar_chart) is created by logging the [rr.BarChart ar
 
 ### Time series
 All other plots are created using the
-[rr.TimeSeriesScalar archetype](https://www.rerun.io/docs/reference/types/archetypes/bar_chart)
-with different settings. Each plot is created by logging scalars at different time steps (i.e., the x-axis).
+[rr.Scalar archetype](https://www.rerun.io/docs/reference/types/archetypes/scalar?speculative-link)
+archetype.
+Each plot is created by logging scalars at different time steps (i.e., the x-axis).
+Additionally, the plots are styled using the
+[rr.SeriesLine](https://www.rerun.io/docs/reference/types/archetypes/series_line?speculative-link) and
+[rr.SeriesPoint](https://www.rerun.io/docs/reference/types/archetypes/series_point?speculative-link)
+archetypes respectively.
 
-For the [parabola](recording://curves/parabola) the radius and color is changed over time.
+For the [parabola](recording://curves/parabola) the radius and color is changed over time,
+the other plots use timeless for their styling properties where possible.
 
 [sin](recording://trig/sin) and [cos](recording://trig/cos) are logged with the same parent entity (i.e.,
 `trig/{cos,sin}`) which will put them in the same view by default.
-
-For the [classification samples](recording://classification/samples) `rr.TimeSeriesScalar(..., scatter=True)` is used to
-create separate points that do not connect over time. Note, that in the other plots the logged scalars are connected
-over time by lines.
 """.strip()
 
 
@@ -64,7 +66,7 @@ def log_parabola() -> None:
         rr.set_time_sequence("frame_nr", t)
 
         f_of_t = (t * 0.01 - 5) ** 3 + 1
-        radius = clamp(abs(f_of_t) * 0.1, 0.5, 10.0)
+        width = clamp(abs(f_of_t) * 0.1, 0.5, 10.0)
         color = [255, 255, 0]
         if f_of_t < -10.0:
             color = [255, 0, 0]
@@ -73,35 +75,39 @@ def log_parabola() -> None:
 
         rr.log(
             "curves/parabola",
-            rr.TimeSeriesScalar(
+            rr.Scalar(
                 f_of_t,
-                label="f(t) = (0.01t - 3)³ + 1",
-                radius=radius,
-                color=color,
+                text="f(t) = (0.01t - 3)³ + 1",
             ),
+            rr.SeriesLine(width=width, color=color),
         )
 
 
 def log_trig() -> None:
-    # Log a time series
+    # Styling doesn't change over time, log it once with timeless=True.
+    rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0]), timeless=True)
+    rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0]), timeless=True)
+
     for t in range(0, int(tau * 2 * 1000.0)):
         rr.set_time_sequence("frame_nr", t)
 
         sin_of_t = sin(float(t) / 1000.0)
-        rr.log("trig/sin", rr.TimeSeriesScalar(sin_of_t, label="sin(0.01t)", color=[255, 0, 0]))
+        rr.log("trig/sin", rr.Scalar(sin_of_t, text="sin(0.01t)"))
 
         cos_of_t = cos(float(t) / 1000.0)
-        rr.log("trig/cos", rr.TimeSeriesScalar(cos_of_t, label="cos(0.01t)", color=[0, 255, 0]))
+        rr.log("trig/cos", rr.Scalar(cos_of_t, text="cos(0.01t)"))
 
 
 def log_classification() -> None:
-    # Log a time series
+    # Log components that don't change only once:
+    rr.log("classification/line", rr.SeriesLine(width=3.0))
+
     for t in range(0, 1000, 2):
         rr.set_time_sequence("frame_nr", t)
 
         f_of_t = (2 * 0.01 * t) + 2
         color = [255, 255, 0]
-        rr.log("classification/line", rr.TimeSeriesScalar(f_of_t, color=color, radius=3.0))
+        rr.log("classification/line", rr.Scalar(f_of_t), rr.SeriesLine(color=color, width=3.0))
 
         g_of_t = f_of_t + random.uniform(-5.0, 5.0)
         if g_of_t < f_of_t - 1.5:
@@ -110,8 +116,8 @@ def log_classification() -> None:
             color = [0, 255, 0]
         else:
             color = [255, 255, 255]
-        radius = abs(g_of_t - f_of_t)
-        rr.log("classification/samples", rr.TimeSeriesScalar(g_of_t, color=color, scattered=True, radius=radius))
+        # radius = abs(g_of_t - f_of_t)
+        rr.log("classification/samples", rr.Scalar(g_of_t), rr.SeriesPoint(color=color))  # , radius=radius)) # TODO:
 
 
 def main() -> None:

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -100,14 +100,13 @@ def log_trig() -> None:
 
 def log_classification() -> None:
     # Log components that don't change only once:
-    rr.log("classification/line", rr.SeriesLine(width=3.0))
+    rr.log("classification/line", rr.SeriesLine(color=[255, 255, 0], width=3.0), timeless=True)
 
     for t in range(0, 1000, 2):
         rr.set_time_sequence("frame_nr", t)
 
         f_of_t = (2 * 0.01 * t) + 2
-        color = [255, 255, 0]
-        rr.log("classification/line", rr.Scalar(f_of_t), rr.SeriesLine(color=color, width=3.0))
+        rr.log("classification/line", rr.Scalar(f_of_t))
 
         g_of_t = f_of_t + random.uniform(-5.0, 5.0)
         if g_of_t < f_of_t - 1.5:

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -116,8 +116,8 @@ def log_classification() -> None:
             color = [0, 255, 0]
         else:
             color = [255, 255, 255]
-        # radius = abs(g_of_t - f_of_t)
-        rr.log("classification/samples", rr.Scalar(g_of_t), rr.SeriesPoint(color=color))  # , radius=radius)) # TODO:
+        marker_size = abs(g_of_t - f_of_t)
+        rr.log("classification/samples", rr.Scalar(g_of_t), rr.SeriesPoint(color=color, marker_size=marker_size))
 
 
 def main() -> None:

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -61,6 +61,9 @@ def log_bar_chart() -> None:
 
 
 def log_parabola() -> None:
+    # Name never changes, log it only once.
+    rr.log("curves/parabola", rr.SeriesLine(name="f(t) = (0.01t - 3)³ + 1"), timeless=True)
+
     # Log a parabola as a time series
     for t in range(0, 1000, 10):
         rr.set_time_sequence("frame_nr", t)
@@ -75,27 +78,24 @@ def log_parabola() -> None:
 
         rr.log(
             "curves/parabola",
-            rr.Scalar(
-                f_of_t,
-                text="f(t) = (0.01t - 3)³ + 1",
-            ),
+            rr.Scalar(f_of_t),
             rr.SeriesLine(width=width, color=color),
         )
 
 
 def log_trig() -> None:
     # Styling doesn't change over time, log it once with timeless=True.
-    rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0]), timeless=True)
-    rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0]), timeless=True)
+    rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)"), timeless=True)
+    rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)"), timeless=True)
 
     for t in range(0, int(tau * 2 * 1000.0)):
         rr.set_time_sequence("frame_nr", t)
 
         sin_of_t = sin(float(t) / 1000.0)
-        rr.log("trig/sin", rr.Scalar(sin_of_t, text="sin(0.01t)"))
+        rr.log("trig/sin", rr.Scalar(sin_of_t))
 
         cos_of_t = cos(float(t) / 1000.0)
-        rr.log("trig/cos", rr.Scalar(cos_of_t, text="cos(0.01t)"))
+        rr.log("trig/cos", rr.Scalar(cos_of_t))
 
 
 def log_classification() -> None:

--- a/examples/python/ros_node/main.py
+++ b/examples/python/ros_node/main.py
@@ -182,8 +182,8 @@ class TurtleSubscriber(Node):  # type: ignore[misc]
         rr.set_time_nanos("ros_time", time.nanoseconds)
 
         # Capture time-series data for the linear and angular velocities
-        rr.log("odometry/vel", rr.TimeSeriesScalar(odom.twist.twist.linear.x))
-        rr.log("odometry/ang_vel", rr.TimeSeriesScalar(odom.twist.twist.angular.z))
+        rr.log("odometry/vel", rr.Scalar(odom.twist.twist.linear.x))
+        rr.log("odometry/ang_vel", rr.Scalar(odom.twist.twist.angular.z))
 
         # Update the robot pose itself via TF
         self.log_tf_as_transform3d("map/robot", time)

--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -53,7 +53,7 @@ from the 3D camera frame to the 2D image plane. The extrinsics are logged as an
 [camera entity](recording://camera).
 
 ### Reprojection error
-For each image a [rr.TimeSeriesScalar archetype](https://www.rerun.io/docs/reference/types/archetypes/bar_chart)
+For each image a [rr.Scalar archetype](https://www.rerun.io/docs/reference/types/archetypes/scalar?speculative-link)
 containing the average reprojection error of the keypoints is logged to the
 [plot/avg_reproj_err entity](recording://plot/avg_reproj_err).
 
@@ -134,6 +134,7 @@ def read_and_log_sparse_reconstruction(dataset_path: Path, filter_output: bool, 
 
     rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
     rr.log("/", rr.ViewCoordinates.RIGHT_HAND_Y_DOWN, timeless=True)
+    rr.log("plot/avg_reproj_err", rr.SeriesLine(color=[240, 45, 58]), timeless=True)
 
     # Iterate through images (video frames) logging data related to each frame.
     for image in sorted(images.values(), key=lambda im: im.name):  # type: ignore[no-any-return]
@@ -171,7 +172,7 @@ def read_and_log_sparse_reconstruction(dataset_path: Path, filter_output: bool, 
         point_colors = [point.rgb for point in visible_xyzs]
         point_errors = [point.error for point in visible_xyzs]
 
-        rr.log("plot/avg_reproj_err", rr.TimeSeriesScalar(np.mean(point_errors), color=[240, 45, 58]))
+        rr.log("plot/avg_reproj_err", rr.Scalar(np.mean(point_errors)))
 
         rr.log("points", rr.Points3D(points, colors=point_colors), rr.AnyValues(error=point_errors))
 

--- a/rerun_cpp/src/rerun/archetypes/scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/scalar.hpp
@@ -40,9 +40,13 @@ namespace rerun::archetypes {
     ///     const auto rec = rerun::RecordingStream("rerun_example_scalar");
     ///     rec.spawn().exit_on_failure();
     ///
+    ///     // Set up plot styling: Logged timeless since it never changes and affects all timelines.
+    ///     rec.log_timeless("scalar", rerun::SeriesPoint());
+    ///
+    ///     // Log the data on a timeline called "step".
     ///     for (int step = 0; step <64; ++step) {
     ///         rec.set_time_sequence("step", step);
-    ///         rec.log("scalar", rerun::TimeSeriesScalar(std::sin(static_cast<double>(step) / 10.0)));
+    ///         rec.log("scalar", rerun::Scalar(std::sin(static_cast<double>(step) / 10.0)));
     ///     }
     /// }
     /// ```

--- a/rerun_cpp/src/rerun/archetypes/scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/scalar.hpp
@@ -40,9 +40,6 @@ namespace rerun::archetypes {
     ///     const auto rec = rerun::RecordingStream("rerun_example_scalar");
     ///     rec.spawn().exit_on_failure();
     ///
-    ///     // Set up plot styling: Logged timeless since it never changes and affects all timelines.
-    ///     rec.log_timeless("scalar", rerun::SeriesPoint());
-    ///
     ///     // Log the data on a timeline called "step".
     ///     for (int step = 0; step <64; ++step) {
     ///         rec.set_time_sequence("step", step);

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -44,9 +44,6 @@ namespace rerun::archetypes {
     ///     const auto rec = rerun::RecordingStream("rerun_example_scalar");
     ///     rec.spawn().exit_on_failure();
     ///
-    ///     // Set up plot styling: Logged timeless since it never changes and affects all timelines.
-    ///     rec.log_timeless("scalar", rerun::SeriesPoint());
-    ///
     ///     // Log the data on a timeline called "step".
     ///     for (int step = 0; step <64; ++step) {
     ///         rec.set_time_sequence("step", step);

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -44,9 +44,13 @@ namespace rerun::archetypes {
     ///     const auto rec = rerun::RecordingStream("rerun_example_scalar");
     ///     rec.spawn().exit_on_failure();
     ///
+    ///     // Set up plot styling: Logged timeless since it never changes and affects all timelines.
+    ///     rec.log_timeless("scalar", rerun::SeriesPoint());
+    ///
+    ///     // Log the data on a timeline called "step".
     ///     for (int step = 0; step <64; ++step) {
     ///         rec.set_time_sequence("step", step);
-    ///         rec.log("scalar", rerun::TimeSeriesScalar(std::sin(static_cast<double>(step) / 10.0)));
+    ///         rec.log("scalar", rerun::Scalar(std::sin(static_cast<double>(step) / 10.0)));
     ///     }
     /// }
     /// ```

--- a/rerun_cpp/src/rerun/components/name.hpp
+++ b/rerun_cpp/src/rerun/components/name.hpp
@@ -23,6 +23,16 @@ namespace rerun::components {
         rerun::datatypes::Utf8 value;
 
       public:
+        // Extensions to generated type defined in 'name_ext.cpp'
+
+        /// Construct `Name` from a null-terminated UTF8 string.
+        Name(const char* str) : value(str) {}
+
+        const char* c_str() const {
+            return value.c_str();
+        }
+
+      public:
         Name() = default;
 
         Name(rerun::datatypes::Utf8 value_) : value(std::move(value_)) {}

--- a/rerun_cpp/src/rerun/components/name_ext.cpp
+++ b/rerun_cpp/src/rerun/components/name_ext.cpp
@@ -1,0 +1,29 @@
+#include "name.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+
+#ifdef EDIT_EXTENSION
+        struct NameExt {
+            std::string value;
+#define Name NameExt
+
+            // Don't provide a string_view constructor, std::string constructor exists and covers this.
+
+            // <CODEGEN_COPY_TO_HEADER>
+
+            /// Construct `Name` from a null-terminated UTF8 string.
+            Name(const char* str) : value(str) {}
+
+            const char* c_str() const {
+                return value.c_str();
+            }
+
+            // </CODEGEN_COPY_TO_HEADER>
+        };
+#endif
+    } // namespace components
+} // namespace rerun

--- a/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
@@ -41,9 +41,13 @@ class Scalar(Archetype):
 
     rr.init("rerun_example_scalar", spawn=True)
 
+    # Set up plot styling: Logged timeless since it never changes and affects all timelines.
+    rr.log("scalar", rr.SeriesPoint(), timeless=True)
+
+    # Log the data on a timeline called "step".
     for step in range(0, 64):
         rr.set_time_sequence("step", step)
-        rr.log("scalar", rr.TimeSeriesScalar(math.sin(step / 10.0)))
+        rr.log("scalar", rr.Scalar(math.sin(step / 10.0)))
     ```
     <center>
     <picture>

--- a/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
@@ -41,9 +41,6 @@ class Scalar(Archetype):
 
     rr.init("rerun_example_scalar", spawn=True)
 
-    # Set up plot styling: Logged timeless since it never changes and affects all timelines.
-    rr.log("scalar", rr.SeriesPoint(), timeless=True)
-
     # Log the data on a timeline called "step".
     for step in range(0, 64):
         rr.set_time_sequence("step", step)

--- a/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
@@ -39,9 +39,13 @@ class TimeSeriesScalar(Archetype):
 
     rr.init("rerun_example_scalar", spawn=True)
 
+    # Set up plot styling: Logged timeless since it never changes and affects all timelines.
+    rr.log("scalar", rr.SeriesPoint(), timeless=True)
+
+    # Log the data on a timeline called "step".
     for step in range(0, 64):
         rr.set_time_sequence("step", step)
-        rr.log("scalar", rr.TimeSeriesScalar(math.sin(step / 10.0)))
+        rr.log("scalar", rr.Scalar(math.sin(step / 10.0)))
     ```
     <center>
     <picture>

--- a/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
@@ -39,9 +39,6 @@ class TimeSeriesScalar(Archetype):
 
     rr.init("rerun_example_scalar", spawn=True)
 
-    # Set up plot styling: Logged timeless since it never changes and affects all timelines.
-    rr.log("scalar", rr.SeriesPoint(), timeless=True)
-
     # Log the data on a timeline called "step".
     for step in range(0, 64):
         rr.set_time_sequence("step", step)

--- a/rerun_py/rerun_sdk/rerun/components/marker_size.py
+++ b/rerun_py/rerun_sdk/rerun/components/marker_size.py
@@ -13,12 +13,13 @@ import pyarrow as pa
 from attrs import define, field
 
 from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .marker_size_ext import MarkerSizeExt
 
 __all__ = ["MarkerSize", "MarkerSizeArrayLike", "MarkerSizeBatch", "MarkerSizeLike", "MarkerSizeType"]
 
 
 @define(init=False)
-class MarkerSize:
+class MarkerSize(MarkerSizeExt):
     """**Component**: Size of a marker in UI points."""
 
     def __init__(self: Any, value: MarkerSizeLike):
@@ -57,4 +58,4 @@ class MarkerSizeBatch(BaseBatch[MarkerSizeArrayLike], ComponentBatchMixin):
 
     @staticmethod
     def _native_to_pa_array(data: MarkerSizeArrayLike, data_type: pa.DataType) -> pa.Array:
-        raise NotImplementedError  # You need to implement native_to_pa_array_override in marker_size_ext.py
+        return MarkerSizeExt.native_to_pa_array_override(data, data_type)

--- a/rerun_py/rerun_sdk/rerun/components/marker_size_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/marker_size_ext.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pyarrow as pa
+
+if TYPE_CHECKING:
+    from . import MarkerSizeArrayLike
+
+
+class MarkerSizeExt:
+    """Extension for [MarkerSize][rerun.components.MarkerSize]."""
+
+    @staticmethod
+    def native_to_pa_array_override(data: MarkerSizeArrayLike, data_type: pa.DataType) -> pa.Array:
+        array = np.asarray(data, dtype=np.float32).flatten()
+        return pa.array(array, type=data_type)

--- a/rerun_py/rerun_sdk/rerun/components/stroke_width.py
+++ b/rerun_py/rerun_sdk/rerun/components/stroke_width.py
@@ -13,12 +13,13 @@ import pyarrow as pa
 from attrs import define, field
 
 from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .stroke_width_ext import StrokeWidthExt
 
 __all__ = ["StrokeWidth", "StrokeWidthArrayLike", "StrokeWidthBatch", "StrokeWidthLike", "StrokeWidthType"]
 
 
 @define(init=False)
-class StrokeWidth:
+class StrokeWidth(StrokeWidthExt):
     """**Component**: The width of a stroke specified in UI points."""
 
     def __init__(self: Any, width: StrokeWidthLike):
@@ -57,4 +58,4 @@ class StrokeWidthBatch(BaseBatch[StrokeWidthArrayLike], ComponentBatchMixin):
 
     @staticmethod
     def _native_to_pa_array(data: StrokeWidthArrayLike, data_type: pa.DataType) -> pa.Array:
-        raise NotImplementedError  # You need to implement native_to_pa_array_override in stroke_width_ext.py
+        return StrokeWidthExt.native_to_pa_array_override(data, data_type)

--- a/rerun_py/rerun_sdk/rerun/components/stroke_width_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/stroke_width_ext.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pyarrow as pa
+
+if TYPE_CHECKING:
+    from . import StrokeWidthArrayLike
+
+
+class StrokeWidthExt:
+    """Extension for [StrokeWidth][rerun.components.StrokeWidth]."""
+
+    @staticmethod
+    def native_to_pa_array_override(data: StrokeWidthArrayLike, data_type: pa.DataType) -> pa.Array:
+        array = np.asarray(data, dtype=np.float32).flatten()
+        return pa.array(array, type=data_type)

--- a/tests/cpp/plot_dashboard_stress/main.cpp
+++ b/tests/cpp/plot_dashboard_stress/main.cpp
@@ -139,12 +139,6 @@ int main(int argc, char** argv) {
 
     auto tick_start_time = std::chrono::high_resolution_clock::now();
 
-    for (auto plot_path : plot_paths) {
-        for (auto series_path : series_paths) {
-            rec.log_timeless(plot_path + "/" + series_path, rerun::SeriesLine());
-        }
-    }
-
     size_t time_step = 0;
     for (auto sim_time : sim_times) {
         rec.set_time_seconds("sim_time", sim_time);

--- a/tests/python/plot_dashboard_stress/main.py
+++ b/tests/python/plot_dashboard_stress/main.py
@@ -97,10 +97,6 @@ def main() -> None:
         # Just generate random numbers rather than crash
         values = np.random.normal(size=values_shape)
 
-    for plot_path in plot_paths:
-        for series_path in series_paths:
-            rr.log(f"{plot_path}/{series_path}", rr.SeriesLine())
-
     for time_step, sim_time in enumerate(sim_times):
         rr.set_time_seconds("sim_time", sim_time)
 

--- a/tests/python/visible_history_playground/main.py
+++ b/tests/python/visible_history_playground/main.py
@@ -57,7 +57,7 @@ for i in range(0, 100):
     rr.log("world/data/nested/transformed/point", rr.Boxes2D(centers=[0, 3], half_sizes=[0.5, 0.5]))
 
     rr.log("text_log", rr.TextLog(f"hello {i}"))
-    rr.log("scalar", rr.TimeSeriesScalar(math.sin(i / 100 * 2 * math.pi)))
+    rr.log("scalar", rr.Scalar(math.sin(i / 100 * 2 * math.pi)))
 
     depth_image = 100 * np.ones((10, 100), dtype=np.float32)
     depth_image[:, i] = 50

--- a/tests/rust/plot_dashboard_stress/src/main.rs
+++ b/tests/rust/plot_dashboard_stress/src/main.rs
@@ -119,15 +119,6 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
 
     let mut tick_start_time = std::time::Instant::now();
 
-    for plot_path in &plot_paths {
-        for series_path in &series_paths {
-            rec.log_timeless(
-                format!("{plot_path}/{series_path}"),
-                &rerun::SeriesLine::new(),
-            )?;
-        }
-    }
-
     #[allow(clippy::unchecked_duration_subtraction)]
     for (time_step, sim_time) in sim_times.into_iter().enumerate() {
         rec.set_time_seconds("sim_time", sim_time);


### PR DESCRIPTION
### What

Also fixes missing serialization of `StrokeWidth` & `MarkerSize`

![image](https://github.com/rerun-io/rerun/assets/1220815/44a118d4-5dc7-4c6d-a79b-29f83ac7eb77)


blocked by a few things:
* [x] text labels should go on SeriesLine/SeriesPlot  #5043
* [x] SeriesPoint doesn't have a `MarkerSize` component yet #5057
* [x] Need to fix heuristic for only having Scalar -> Line #5050

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5042/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5042/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5042/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5042)
- [Docs preview](https://rerun.io/preview/024cf6cdb5e940b128dde88004692f44a04b8aba/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/024cf6cdb5e940b128dde88004692f44a04b8aba/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)