### PR TITLE
Simplify viewport after tile drag-and-drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,7 +1705,7 @@ dependencies = [
 [[package]]
 name = "egui_tiles"
 version = "0.6.0"
-source = "git+https://github.com/rerun-io/egui_tiles?rev=35e711283e7a021ca425d9fbd8e7581548971f49#35e711283e7a021ca425d9fbd8e7581548971f49"
+source = "git+https://github.com/rerun-io/egui_tiles?rev=be78596d3564f696b61a1ba14678b0aa0bfcdb2f#be78596d3564f696b61a1ba14678b0aa0bfcdb2f"
 dependencies = [
  "ahash",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,6 +295,6 @@ emath = { git = "https://github.com/emilk/egui.git", rev = "c5352cf6c16b28d00432
 # egui-wgpu = { path = "../../egui/crates/egui-wgpu" }
 # emath = { path = "../../egui/crates/emath" }
 
-egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "35e711283e7a021ca425d9fbd8e7581548971f49" } # master 2024-01-26
+egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "be78596d3564f696b61a1ba14678b0aa0bfcdb2f" } # master 2024-02-05
 
 # egui_commonmark = { git = "https://github.com/rerun-io/egui_commonmark", rev = "3d83a92f995a1d18ab1172d0b129d496e0eedaae" } # Update to egui 0.25 https://github.com/lampsitter/egui_commonmark/pull/27

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -140,13 +140,17 @@ impl AppState {
         // this, which gives us interior mutability (only a shared reference of `ViewportBlueprint`
         // is available to the UI code) and, if needed in the future, concurrency.
         let (sender, receiver) = std::sync::mpsc::channel();
-        let viewport_blueprint =
-            ViewportBlueprint::try_from_db(store_context.blueprint, &blueprint_query, sender);
+        let viewport_blueprint = ViewportBlueprint::try_from_db(
+            store_context.blueprint,
+            &blueprint_query,
+            sender.clone(),
+        );
         let mut viewport = Viewport::new(
             &viewport_blueprint,
             viewport_state,
             space_view_class_registry,
             receiver,
+            sender,
         );
 
         // If the blueprint is invalid, reset it.


### PR DESCRIPTION
### What

This PR triggers a egui_tile tree simplification of the viewport upon tile drag-and-drop to work around the spurious empty containers typically left behind after a move. This happens only when the additive workflow feature flag is set (otherwise, the on-going simplification takes care of that).

This simplification is **agressive**, and may delete (empty) containers that the user created on purpose, which is why we run it _only_ on drag-and-drop. This is not ideal, but that's the best I can come up with until we stop using egui_tiles as application-level data structure. Still a net usability win.

* Part of #4996

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5044/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5044/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5044/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5044)
- [Docs preview](https://rerun.io/preview/267a55e088273ef961826f97d7d81c9552edcae2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/267a55e088273ef961826f97d7d81c9552edcae2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)