### PR TITLE
Set tooltip delay to 300ms

### DIFF
--- a/crates/re_ui/src/design_tokens.rs
+++ b/crates/re_ui/src/design_tokens.rs
@@ -190,6 +190,9 @@ fn apply_design_tokens(ctx: &egui::Context) -> DesignTokens {
 
     egui_style.visuals.image_loading_spinners = false;
 
+    // set a reasonable time to show tooltips
+    egui_style.interaction.tooltip_delay = 0.3;
+
     ctx.set_style(egui_style);
 
     DesignTokens {


### PR DESCRIPTION
### What

This PR changes the tooltip delay from 0 to 300ms. This limits the occurrences of the tooltip spuriously "jumping" under the cursor.

https://github.com/rerun-io/rerun/assets/49431240/ef4c6228-2528-4616-836b-ca3d1582f922


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5045/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5045/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5045/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5045)
- [Docs preview](https://rerun.io/preview/680fbd9272bb7d9d93e73eb38cb558dd5dfa9775/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/680fbd9272bb7d9d93e73eb38cb558dd5dfa9775/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)