### PR TITLE
Don't show the Blueprint header when on the welcome screen

### DIFF
--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -306,6 +306,9 @@ impl AppState {
                     .min_width(120.0)
                     .default_width((0.35 * ui.ctx().screen_rect().width()).min(200.0).round());
 
+                let show_welcome =
+                    store_context.blueprint.app_id() == Some(&StoreHub::welcome_screen_app_id());
+
                 left_panel.show_animated_inside(
                     ui,
                     app_blueprint.blueprint_panel_expanded,
@@ -325,7 +328,9 @@ impl AppState {
                             ui.add_space(4.0);
                         }
 
-                        blueprint_panel_ui(&mut viewport, &ctx, ui);
+                        if !show_welcome {
+                            blueprint_panel_ui(&mut viewport, &ctx, ui);
+                        }
                     },
                 );
 
@@ -333,9 +338,6 @@ impl AppState {
                     fill: ui.style().visuals.panel_fill,
                     ..Default::default()
                 };
-
-                let show_welcome =
-                    store_context.blueprint.app_id() == Some(&StoreHub::welcome_screen_app_id());
 
                 egui::CentralPanel::default()
                     .frame(viewport_frame)


### PR DESCRIPTION
### What

Entirely removes the "Blueprint" header when on the Welcome Screen.

<img width="1476" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/30a8d6b7-d4c7-4c6d-beec-a081d14fba34">

* Fixes #4906 (though I couldn't reproduce it anymore)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5046/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5046/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5046/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5046)
- [Docs preview](https://rerun.io/preview/ec6a3904bd620cd2ad73e1b746bd3a0365bfea3d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ec6a3904bd620cd2ad73e1b746bd3a0365bfea3d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)