### PR TITLE
Mandatory primary caching

### DIFF
--- a/crates/re_query_cache/benches/latest_at.rs
+++ b/crates/re_query_cache/benches/latest_at.rs
@@ -287,7 +287,6 @@ fn query_and_visit_points(
     for path in paths {
         caches
             .query_archetype_pov1_comp1::<Points2D, Position2D, Color, _>(
-                true, // cached?
                 store,
                 &query.clone().into(),
                 path,
@@ -325,7 +324,6 @@ fn query_and_visit_strings(
     for path in paths {
         caches
             .query_archetype_pov1_comp1::<Points2D, Position2D, Text, _>(
-                true, // cached?
                 store,
                 &query.clone().into(),
                 path,

--- a/crates/re_query_cache/benches/latest_at.rs
+++ b/crates/re_query_cache/benches/latest_at.rs
@@ -328,7 +328,7 @@ fn query_and_visit_strings(
                 &query.clone().into(),
                 path,
                 |(_, _, _, labels)| {
-                    for label in labels.unwrap().iter() {
+                    for label in labels.unwrap() {
                         strings.push(SaveString {
                             _label: label.clone(),
                         });

--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -268,7 +268,8 @@ impl Caches {
         //
         // It's fine, though:
         // - Best case scenario, the data we need is already cached.
-        // - Worst case scenario, the data is missing and we'll simply return the raw data instead.
+        // - Worst case scenario, the data is missing and we'll be missing some data for the current
+        //   frame.
         //   It'll get cached at some point in an upcoming frame (statistically, we're bound to win
         //   the race at some point).
         //
@@ -277,7 +278,8 @@ impl Caches {
         //
         // There is a lot of complexity we could add to make this whole process more efficient:
         // keep track of failed queries in a queue so we don't rely on probabilities, keep track
-        // of the thread-local reentrancy state to skip this logic when it's not needed, etc.
+        // of the thread-local reentrancy state to skip this logic when it's not needed, return raw
+        // data when the lock is busy and the data isn't already cached, etc.
         //
         // In the end, this is a edge-case inherent to our current "immediate query" model that we
         // already know we want -- and have to -- move away from; the extra complexity isn't worth it.

--- a/crates/re_query_cache/src/latest_at.rs
+++ b/crates/re_query_cache/src/latest_at.rs
@@ -302,7 +302,9 @@ macro_rules! impl_query_archetype_latest_at {
                     let bucket = create_and_fill_bucket(TimeInt::MIN, &arch_view)?;
                     *total_size_bytes += bucket.total_size_bytes;
 
-                    *timeless = Some(Arc::new(bucket));
+                    let bucket = Arc::new(bucket);
+                    *timeless = Some(Arc::clone(&bucket));
+                    query_time_bucket_at_query_time.insert(Arc::clone(&bucket));
 
                     Ok(())
                 }

--- a/crates/re_query_cache/src/lib.rs
+++ b/crates/re_query_cache/src/lib.rs
@@ -10,7 +10,7 @@ mod range;
 pub use self::cache::{AnyQuery, Caches};
 pub use self::cache_stats::{CachedComponentStats, CachedEntityStats, CachesStats};
 pub use self::flat_vec_deque::{ErasedFlatVecDeque, FlatVecDeque};
-pub use self::query::MaybeCachedComponentData;
+pub use self::query::iter_or_repeat_opt;
 
 pub(crate) use self::cache::CacheBucket;
 pub(crate) use self::latest_at::LatestAtCache;

--- a/crates/re_query_cache/tests/latest_at.rs
+++ b/crates/re_query_cache/tests/latest_at.rs
@@ -449,35 +449,12 @@ fn query_and_compare(
     ent_path: &EntityPath,
 ) {
     for _ in 0..3 {
-        let mut uncached_data_time = None;
-        let mut uncached_instance_keys = Vec::new();
-        let mut uncached_positions = Vec::new();
-        let mut uncached_colors = Vec::new();
-        caches
-            .query_archetype_pov1_comp1::<MyPoints, MyPoint, MyColor, _>(
-                false, // cached?
-                store,
-                &query.clone().into(),
-                ent_path,
-                |((data_time, _), instance_keys, positions, colors)| {
-                    uncached_data_time = data_time;
-                    uncached_instance_keys.extend(instance_keys.iter().copied());
-                    uncached_positions.extend(positions.iter().copied());
-                    uncached_colors.extend(MaybeCachedComponentData::iter_or_repeat_opt(
-                        &colors,
-                        positions.len(),
-                    ));
-                },
-            )
-            .unwrap();
-
         let mut cached_data_time = None;
         let mut cached_instance_keys = Vec::new();
         let mut cached_positions = Vec::new();
         let mut cached_colors = Vec::new();
         caches
             .query_archetype_pov1_comp1::<MyPoints, MyPoint, MyColor, _>(
-                true, // cached?
                 store,
                 &query.clone().into(),
                 ent_path,
@@ -507,12 +484,7 @@ fn query_and_compare(
             .collect_vec();
 
         // Keep this around for the next unlucky chap.
-        // eprintln!("(expected={expected_data_time:?}, uncached={uncached_data_time:?}, cached={cached_data_time:?})");
-
-        similar_asserts::assert_eq!(expected_data_time, uncached_data_time);
-        similar_asserts::assert_eq!(expected_instance_keys, uncached_instance_keys);
-        similar_asserts::assert_eq!(expected_positions, uncached_positions);
-        similar_asserts::assert_eq!(expected_colors, uncached_colors);
+        // eprintln!("(expected={expected_data_time:?}, cached={cached_data_time:?})");
 
         similar_asserts::assert_eq!(expected_data_time, cached_data_time);
         similar_asserts::assert_eq!(expected_instance_keys, cached_instance_keys);

--- a/crates/re_query_cache/tests/latest_at.rs
+++ b/crates/re_query_cache/tests/latest_at.rs
@@ -10,7 +10,7 @@ use re_log_types::{
     example_components::{MyColor, MyPoint, MyPoints},
     DataRow, EntityPath, RowId, TimePoint,
 };
-use re_query_cache::{Caches, MaybeCachedComponentData};
+use re_query_cache::Caches;
 use re_types_core::{components::InstanceKey, Loggable as _};
 
 // ---
@@ -462,10 +462,8 @@ fn query_and_compare(
                     cached_data_time = data_time;
                     cached_instance_keys.extend(instance_keys.iter().copied());
                     cached_positions.extend(positions.iter().copied());
-                    cached_colors.extend(MaybeCachedComponentData::iter_or_repeat_opt(
-                        &colors,
-                        positions.len(),
-                    ));
+                    cached_colors
+                        .extend(re_query_cache::iter_or_repeat_opt(colors, positions.len()));
                 },
             )
             .unwrap();

--- a/crates/re_query_cache/tests/latest_at.rs
+++ b/crates/re_query_cache/tests/latest_at.rs
@@ -448,6 +448,8 @@ fn query_and_compare(
     query: &LatestAtQuery,
     ent_path: &EntityPath,
 ) {
+    re_log::setup_logging();
+
     for _ in 0..3 {
         let mut cached_data_time = None;
         let mut cached_instance_keys = Vec::new();
@@ -482,7 +484,7 @@ fn query_and_compare(
             .collect_vec();
 
         // Keep this around for the next unlucky chap.
-        // eprintln!("(expected={expected_data_time:?}, cached={cached_data_time:?})");
+        // eprintln!("i={i} (expected={expected_data_time:?}, cached={cached_data_time:?})");
 
         similar_asserts::assert_eq!(expected_data_time, cached_data_time);
         similar_asserts::assert_eq!(expected_instance_keys, cached_instance_keys);

--- a/crates/re_query_cache/tests/range.rs
+++ b/crates/re_query_cache/tests/range.rs
@@ -583,36 +583,12 @@ fn query_and_compare(
     ent_path: &EntityPath,
 ) {
     for _ in 0..3 {
-        let mut uncached_data_times = Vec::new();
-        let mut uncached_instance_keys = Vec::new();
-        let mut uncached_positions = Vec::new();
-        let mut uncached_colors = Vec::new();
-        caches
-            .query_archetype_pov1_comp2::<MyPoints, MyPoint, MyColor, MyLabel, _>(
-                false, // cached?
-                store,
-                &query.clone().into(),
-                ent_path,
-                |((data_time, _), instance_keys, positions, colors, _)| {
-                    uncached_data_times.push(data_time);
-                    uncached_instance_keys.push(instance_keys.to_vec());
-                    uncached_positions.push(positions.to_vec());
-                    uncached_colors.push(
-                        MaybeCachedComponentData::iter_or_repeat_opt(&colors, positions.len())
-                            .copied()
-                            .collect_vec(),
-                    );
-                },
-            )
-            .unwrap();
-
         let mut cached_data_times = Vec::new();
         let mut cached_instance_keys = Vec::new();
         let mut cached_positions = Vec::new();
         let mut cached_colors = Vec::new();
         caches
             .query_archetype_pov1_comp2::<MyPoints, MyPoint, MyColor, MyLabel, _>(
-                true, // cached?
                 store,
                 &query.clone().into(),
                 ent_path,
@@ -654,13 +630,8 @@ fn query_and_compare(
         }
 
         // Keep this around for the next unlucky chap.
-        // eprintln!("(expected={expected_data_times:?}, uncached={uncached_data_times:?}, cached={cached_data_times:?})");
+        // eprintln!("(expected={expected_data_times:?}, cached={cached_data_times:?})");
         // eprintln!("{}", store.to_data_table().unwrap());
-
-        similar_asserts::assert_eq!(expected_data_times, uncached_data_times);
-        similar_asserts::assert_eq!(expected_instance_keys, uncached_instance_keys);
-        similar_asserts::assert_eq!(expected_positions, uncached_positions);
-        similar_asserts::assert_eq!(expected_colors, uncached_colors);
 
         similar_asserts::assert_eq!(expected_data_times, cached_data_times);
         similar_asserts::assert_eq!(expected_instance_keys, cached_instance_keys);

--- a/crates/re_query_cache/tests/range.rs
+++ b/crates/re_query_cache/tests/range.rs
@@ -10,7 +10,7 @@ use re_log_types::{
     example_components::{MyColor, MyLabel, MyPoint, MyPoints},
     DataRow, EntityPath, RowId, TimeInt, TimePoint, TimeRange,
 };
-use re_query_cache::{Caches, MaybeCachedComponentData};
+use re_query_cache::Caches;
 use re_types::components::InstanceKey;
 use re_types_core::Loggable as _;
 
@@ -597,7 +597,7 @@ fn query_and_compare(
                     cached_instance_keys.push(instance_keys.to_vec());
                     cached_positions.push(positions.to_vec());
                     cached_colors.push(
-                        MaybeCachedComponentData::iter_or_repeat_opt(&colors, positions.len())
+                        re_query_cache::iter_or_repeat_opt(colors, positions.len())
                             .copied()
                             .collect_vec(),
                     );

--- a/crates/re_space_view_spatial/benches/bench_points.rs
+++ b/crates/re_space_view_spatial/benches/bench_points.rs
@@ -86,7 +86,7 @@ fn bench_points(c: &mut criterion::Criterion) {
                     &latest_at,
                     &ent_path,
                     |(_, keys, _, _, _, _, _, _)| {
-                        assert_eq!(keys.as_slice().len(), NUM_POINTS);
+                        assert_eq!(keys.len(), NUM_POINTS);
                     },
                 )
                 .unwrap();
@@ -109,13 +109,13 @@ fn bench_points(c: &mut criterion::Criterion) {
         &ent_path,
         |(_, instance_keys, positions, colors, radii, labels, keypoint_ids, class_ids)| {
             let data = Points3DComponentData {
-                instance_keys: instance_keys.as_slice(),
-                positions: positions.as_slice(),
-                colors: colors.as_deref(),
-                radii: radii.as_deref(),
-                labels: labels.as_deref(),
-                keypoint_ids: keypoint_ids.as_deref(),
-                class_ids: class_ids.as_deref(),
+                instance_keys,
+                positions,
+                colors,
+                radii,
+                labels,
+                keypoint_ids,
+                class_ids,
             };
             assert_eq!(data.instance_keys.len(), NUM_POINTS);
 

--- a/crates/re_space_view_spatial/benches/bench_points.rs
+++ b/crates/re_space_view_spatial/benches/bench_points.rs
@@ -23,13 +23,11 @@ criterion::criterion_group!(benches, bench_points);
 #[cfg(debug_assertions)]
 mod constants {
     pub const NUM_POINTS: usize = 10;
-    pub const CACHED: &[bool] = &[true];
 }
 
 #[cfg(not(debug_assertions))]
 mod constants {
     pub const NUM_POINTS: usize = 1_000_000;
-    pub const CACHED: &[bool] = &[false, true];
 }
 
 #[allow(clippy::wildcard_imports)]
@@ -70,9 +68,9 @@ fn bench_points(c: &mut criterion::Criterion) {
         format!("{name}/cached={cached}")
     }
 
-    for cached in CACHED {
+    {
         let mut group = c.benchmark_group("Points3D");
-        group.bench_function(bench_name(*cached, "query_archetype"), |b| {
+        group.bench_function(bench_name(true, "query_archetype"), |b| {
             b.iter(|| {
                 caches.query_archetype_pov1_comp5::<
                     Points3D,
@@ -84,7 +82,6 @@ fn bench_points(c: &mut criterion::Criterion) {
                     ClassId,
                     _,
                 >(
-                    *cached,
                     &store,
                     &latest_at,
                     &ent_path,
@@ -97,103 +94,100 @@ fn bench_points(c: &mut criterion::Criterion) {
         });
     }
 
-    for cached in CACHED {
-        caches.query_archetype_pov1_comp5::<
-            Points3D,
-            Position3D,
-            Color,
-            Radius,
-            Text,
-            KeypointId,
-            ClassId,
-            _,
-        >(
-            *cached,
-            &store,
-            &latest_at,
-            &ent_path,
-            |(_, instance_keys, positions, colors, radii, labels, keypoint_ids, class_ids)| {
-                let data = Points3DComponentData {
-                    instance_keys: instance_keys.as_slice(),
-                    positions: positions.as_slice(),
-                    colors: colors.as_deref(),
-                    radii: radii.as_deref(),
-                    labels: labels.as_deref(),
-                    keypoint_ids: keypoint_ids.as_deref(),
-                    class_ids: class_ids.as_deref(),
-                };
-                assert_eq!(data.instance_keys.len(), NUM_POINTS);
+    caches.query_archetype_pov1_comp5::<
+        Points3D,
+        Position3D,
+        Color,
+        Radius,
+        Text,
+        KeypointId,
+        ClassId,
+        _,
+    >(
+        &store,
+        &latest_at,
+        &ent_path,
+        |(_, instance_keys, positions, colors, radii, labels, keypoint_ids, class_ids)| {
+            let data = Points3DComponentData {
+                instance_keys: instance_keys.as_slice(),
+                positions: positions.as_slice(),
+                colors: colors.as_deref(),
+                radii: radii.as_deref(),
+                labels: labels.as_deref(),
+                keypoint_ids: keypoint_ids.as_deref(),
+                class_ids: class_ids.as_deref(),
+            };
+            assert_eq!(data.instance_keys.len(), NUM_POINTS);
 
-                {
-                    let mut group = c.benchmark_group("Points3D");
-                    group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
-                    group.bench_function(bench_name(*cached, "load_all"), |b| {
-                        b.iter(|| {
-                            let points = LoadedPoints::load(&data, &ent_path, at, &annotations);
-                            assert_eq!(points.positions.len(), NUM_POINTS);
-                            assert_eq!(points.colors.len(), NUM_POINTS);
-                            assert_eq!(points.radii.len(), NUM_POINTS); // NOTE: we don't log radii, but we should get a list of defaults!
-                            points
-                        });
+            {
+                let mut group = c.benchmark_group("Points3D");
+                group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
+                group.bench_function(bench_name(true, "load_all"), |b| {
+                    b.iter(|| {
+                        let points = LoadedPoints::load(&data, &ent_path, at, &annotations);
+                        assert_eq!(points.positions.len(), NUM_POINTS);
+                        assert_eq!(points.colors.len(), NUM_POINTS);
+                        assert_eq!(points.radii.len(), NUM_POINTS); // NOTE: we don't log radii, but we should get a list of defaults!
+                        points
                     });
-                }
+                });
+            }
 
-                {
-                    let mut group = c.benchmark_group("Points3D");
-                    group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
-                    group.bench_function(bench_name(*cached, "load_positions"), |b| {
-                        b.iter(|| {
-                            let positions = LoadedPoints::load_positions(&data);
-                            assert_eq!(positions.len(), NUM_POINTS);
-                            positions
-                        });
+            {
+                let mut group = c.benchmark_group("Points3D");
+                group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
+                group.bench_function(bench_name(true, "load_positions"), |b| {
+                    b.iter(|| {
+                        let positions = LoadedPoints::load_positions(&data);
+                        assert_eq!(positions.len(), NUM_POINTS);
+                        positions
                     });
-                }
+                });
+            }
 
-                {
-                    let points = LoadedPoints::load(&data, &ent_path, at, &annotations);
+            {
+                let points = LoadedPoints::load(&data, &ent_path, at, &annotations);
 
-                    let mut group = c.benchmark_group("Points3D");
-                    group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
-                    group.bench_function(bench_name(*cached, "load_colors"), |b| {
-                        b.iter(|| {
-                            let colors = LoadedPoints::load_colors(
-                                &data,
-                                &ent_path,
-                                &points.annotation_infos,
-                            );
-                            assert_eq!(colors.len(), NUM_POINTS);
-                            colors
-                        });
+                let mut group = c.benchmark_group("Points3D");
+                group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
+                group.bench_function(bench_name(true, "load_colors"), |b| {
+                    b.iter(|| {
+                        let colors = LoadedPoints::load_colors(
+                            &data,
+                            &ent_path,
+                            &points.annotation_infos,
+                        );
+                        assert_eq!(colors.len(), NUM_POINTS);
+                        colors
                     });
-                }
+                });
+            }
 
-                // NOTE: we don't log radii!
-                {
-                    let mut group = c.benchmark_group("Points3D");
-                    group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
-                    group.bench_function(bench_name(*cached, "load_radii"), |b| {
-                        b.iter(|| {
-                            let radii = LoadedPoints::load_radii(&data, &ent_path);
-                            assert_eq!(radii.len(), NUM_POINTS);
-                            radii
-                        });
+            // NOTE: we don't log radii!
+            {
+                let mut group = c.benchmark_group("Points3D");
+                group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
+                group.bench_function(bench_name(true, "load_radii"), |b| {
+                    b.iter(|| {
+                        let radii = LoadedPoints::load_radii(&data, &ent_path);
+                        assert_eq!(radii.len(), NUM_POINTS);
+                        radii
                     });
-                }
+                });
+            }
 
-                {
-                    let mut group = c.benchmark_group("Points3D");
-                    group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
-                    group.bench_function(bench_name(*cached, "load_picking_ids"), |b| {
-                        b.iter(|| {
-                            let picking_ids = LoadedPoints::load_picking_ids(&data);
-                            assert_eq!(picking_ids.len(), NUM_POINTS);
-                            picking_ids
-                        });
+            {
+                let mut group = c.benchmark_group("Points3D");
+                group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
+                group.bench_function(bench_name(true, "load_picking_ids"), |b| {
+                    b.iter(|| {
+                        let picking_ids = LoadedPoints::load_picking_ids(&data);
+                        assert_eq!(picking_ids.len(), NUM_POINTS);
+                        picking_ids
                     });
-                }
-            },
-        )
-        .unwrap();
-    }
+                });
+            }
+        },
+    )
+    .unwrap();
 }

--- a/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
@@ -184,8 +184,8 @@ macro_rules! impl_process_archetype {
                 };
 
                 match ctx.entity_db.query_caches().[<query_archetype_with_history_pov$N _comp$M>]::<A, $($pov,)+ $($comp,)* _>(
-                    ctx.app_options.experimental_primary_caching_latest_at,
-                    ctx.app_options.experimental_primary_caching_range,
+                    true, // TODO
+                    true, // TODO
                     ctx.entity_db.store(),
                     &query.timeline,
                     &query.latest_at,

--- a/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
@@ -192,7 +192,7 @@ macro_rules! impl_process_archetype {
                     |(t, keys, $($pov,)+ $($comp,)*)| {
                         counter
                             .num_primitives
-                            .fetch_add(keys.as_slice().len(), std::sync::atomic::Ordering::Relaxed);
+                            .fetch_add(keys.len(), std::sync::atomic::Ordering::Relaxed);
 
                         if let Err(err) = f(
                             ctx,
@@ -200,8 +200,8 @@ macro_rules! impl_process_archetype {
                             data_result.accumulated_properties(),
                             &entity_context,
                             t,
-                            keys.as_slice(),
-                            $($pov.as_slice(),)+
+                            keys,
+                            $($pov,)+
                             $($comp.as_deref(),)*
                         ) {
                             re_log::error_once!(

--- a/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
@@ -184,8 +184,6 @@ macro_rules! impl_process_archetype {
                 };
 
                 match ctx.entity_db.query_caches().[<query_archetype_with_history_pov$N _comp$M>]::<A, $($pov,)+ $($comp,)* _>(
-                    true, // TODO
-                    true, // TODO
                     ctx.entity_db.store(),
                     &query.timeline,
                     &query.latest_at,

--- a/crates/re_space_view_text_log/src/visualizer_system.rs
+++ b/crates/re_space_view_text_log/src/visualizer_system.rs
@@ -1,7 +1,6 @@
 use re_data_store::TimeRange;
 use re_entity_db::EntityPath;
 use re_log_types::RowId;
-use re_query_cache::MaybeCachedComponentData;
 use re_types::{
     archetypes::TextLog,
     components::{Color, Text, TextLogLevel},
@@ -61,6 +60,7 @@ impl VisualizerSystem for TextLogSystem {
             let timeline_query =
                 re_data_store::RangeQuery::new(query.timeline, TimeRange::EVERYTHING);
 
+            // TODO(cmc): use raw API.
             query_caches.query_archetype_pov1_comp2::<TextLog, Text, TextLogLevel, Color, _>(
                 store,
                 &timeline_query.clone().into(),
@@ -68,8 +68,8 @@ impl VisualizerSystem for TextLogSystem {
                 |((time, row_id), _, bodies, levels, colors)| {
                     for (body, level, color) in itertools::izip!(
                         bodies.iter(),
-                        MaybeCachedComponentData::iter_or_repeat_opt(&levels, bodies.len()),
-                        MaybeCachedComponentData::iter_or_repeat_opt(&colors, bodies.len()),
+                        re_query_cache::iter_or_repeat_opt(levels, bodies.len()),
+                        re_query_cache::iter_or_repeat_opt(colors, bodies.len()),
                     ) {
                         self.entries.push(Entry {
                             row_id,

--- a/crates/re_space_view_text_log/src/visualizer_system.rs
+++ b/crates/re_space_view_text_log/src/visualizer_system.rs
@@ -62,7 +62,6 @@ impl VisualizerSystem for TextLogSystem {
                 re_data_store::RangeQuery::new(query.timeline, TimeRange::EVERYTHING);
 
             query_caches.query_archetype_pov1_comp2::<TextLog, Text, TextLogLevel, Color, _>(
-                true, // TODO
                 store,
                 &timeline_query.clone().into(),
                 &data_result.entity_path,

--- a/crates/re_space_view_text_log/src/visualizer_system.rs
+++ b/crates/re_space_view_text_log/src/visualizer_system.rs
@@ -62,7 +62,7 @@ impl VisualizerSystem for TextLogSystem {
                 re_data_store::RangeQuery::new(query.timeline, TimeRange::EVERYTHING);
 
             query_caches.query_archetype_pov1_comp2::<TextLog, Text, TextLogLevel, Color, _>(
-                ctx.app_options.experimental_primary_caching_range,
+                true, // TODO
                 store,
                 &timeline_query.clone().into(),
                 &data_result.entity_path,

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -409,22 +409,6 @@ fn experimental_feature_ui(
     re_ui
         .checkbox(
             ui,
-            &mut app_options.experimental_primary_caching_latest_at,
-            "Primary caching: latest-at queries",
-        )
-        .on_hover_text("Toggle primary caching for latest-at queries.\nApplies to the 2D/3D point cloud and 2D/3D box space views.");
-
-    re_ui
-        .checkbox(
-            ui,
-            &mut app_options.experimental_primary_caching_range,
-            "Primary caching: range queries",
-        )
-        .on_hover_text("Toggle primary caching for range queries.\nApplies to the 2D/3D point cloud, 2D/3D box and text log space views.\nRange caching is always enabled for time series, independent of this setting.");
-
-    re_ui
-        .checkbox(
-            ui,
             &mut app_options.experimental_plot_query_clamping,
             "Plots: query clamping",
         )

--- a/crates/re_viewer_context/src/app_options.rs
+++ b/crates/re_viewer_context/src/app_options.rs
@@ -22,18 +22,6 @@ pub struct AppOptions {
     /// Enable the experimental support for the container addition workflow.
     pub experimental_additive_workflow: bool,
 
-    /// Toggle primary caching for latest-at queries.
-    ///
-    /// Applies to the 2D/3D point cloud and 2D/3D box space views.
-    pub experimental_primary_caching_latest_at: bool,
-
-    /// Toggle primary caching for range queries.
-    ///
-    /// Applies to the 2D/3D point cloud, 2D/3D box and text log space views.
-    ///
-    /// Range caching is always enabled for time series, independent of this setting.
-    pub experimental_primary_caching_range: bool,
-
     /// Toggle query clamping for the plot visualizers.
     pub experimental_plot_query_clamping: bool,
 
@@ -66,9 +54,6 @@ impl Default for AppOptions {
             experimental_entity_filter_editor: false,
 
             experimental_additive_workflow: cfg!(debug_assertions),
-
-            experimental_primary_caching_latest_at: true,
-            experimental_primary_caching_range: true,
 
             experimental_plot_query_clamping: false,
 


### PR DESCRIPTION
Makes the primary cache mandatory:
- #5048 requires it.
- If we're not confident enough to do this, then we're probably not confident enough to release anyhow.

Feature flags, and most importantly `MaybeCachedComponentData`, are gone.

---

:warning:

The latest-at path will no longer return uncached results in the extremely rare case of a shared query resulting in a busy write-lock _while_ the cache is currently empty; all the complexity it adds (in the form of `MaybeCachedComponentData` just doesn't seem worth it. 

If this ever proves to result in glitches in practice, we can bring that complexity back.
(It never existed on the range path, and we've never seen any glitches there for now.)

UPDATE: Removing this actually uncovered a dormant bug that made us go through the uncached path more than necessary with timeless queries, so I'm even more happy to make it go away now.

---

- DNM: requires #5048 
- Fixes #5015 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5049/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5049/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5049/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5049)
- [Docs preview](https://rerun.io/preview/c039bef888bfc947d076d15773d5f8863e2766f2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c039bef888bfc947d076d15773d5f8863e2766f2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)