### PR TITLE
Allow SpaceViews to customize the behavior for how default visualizers are chosen

### DIFF
--- a/crates/re_space_view/src/data_query.rs
+++ b/crates/re_space_view/src/data_query.rs
@@ -1,7 +1,5 @@
 use re_entity_db::{external::re_data_store::LatestAtQuery, EntityProperties, EntityPropertyMap};
-use re_viewer_context::{
-    DataQueryResult, IndicatedEntities, PerVisualizer, StoreContext, VisualizableEntities,
-};
+use re_viewer_context::{DataQueryResult, PerVisualizer, StoreContext, VisualizableEntities};
 
 pub struct EntityOverrideContext {
     pub root: EntityProperties,
@@ -36,6 +34,5 @@ pub trait DataQuery {
         &self,
         ctx: &StoreContext<'_>,
         visualizable_entities_for_visualizer_systems: &PerVisualizer<VisualizableEntities>,
-        indicated_entities_per_visualizer: &PerVisualizer<IndicatedEntities>,
     ) -> DataQueryResult;
 }

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -457,7 +457,7 @@ impl DataQueryPropertyResolver<'_> {
                             node.data_result.visualizers =
                                 viz_override.0.iter().map(|v| v.as_str().into()).collect();
                         } else {
-                            // Otherwise ask the SpaceView class to choose.
+                            // Otherwise ask the `SpaceViewClass` to choose.
                             node.data_result.visualizers = self
                                 .space_view
                                 .class(self.space_view_class_registry)

--- a/crates/re_space_view/src/lib.rs
+++ b/crates/re_space_view/src/lib.rs
@@ -9,12 +9,14 @@ mod data_query_blueprint;
 mod heuristics;
 mod screenshot;
 mod space_view;
+mod visualizable;
 
 pub use data_query::{DataQuery, EntityOverrideContext, PropertyResolver};
 pub use data_query_blueprint::DataQueryBlueprint;
 pub use heuristics::suggest_space_view_for_each_entity;
 pub use screenshot::ScreenshotMode;
 pub use space_view::{SpaceViewBlueprint, SpaceViewName};
+pub use visualizable::determine_visualizable_entities;
 
 // -----------
 

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -554,11 +554,7 @@ mod tests {
                 all_recordings: vec![],
             };
 
-            let mut query_result = query.execute_query(
-                &ctx,
-                &visualizable_entities,
-                &indicated_entities_per_visualizer,
-            );
+            let mut query_result = query.execute_query(&ctx, &visualizable_entities);
             resolver.update_overrides(&ctx, &blueprint_query, &mut query_result);
 
             let parent = query_result
@@ -596,11 +592,7 @@ mod tests {
                 all_recordings: vec![],
             };
 
-            let mut query_result = query.execute_query(
-                &ctx,
-                &visualizable_entities,
-                &indicated_entities_per_visualizer,
-            );
+            let mut query_result = query.execute_query(&ctx, &visualizable_entities);
             resolver.update_overrides(&ctx, &blueprint_query, &mut query_result);
 
             let parent_group = query_result
@@ -648,11 +640,7 @@ mod tests {
                 all_recordings: vec![],
             };
 
-            let mut query_result = query.execute_query(
-                &ctx,
-                &visualizable_entities,
-                &indicated_entities_per_visualizer,
-            );
+            let mut query_result = query.execute_query(&ctx, &visualizable_entities);
             resolver.update_overrides(&ctx, &blueprint_query, &mut query_result);
 
             let parent = query_result
@@ -697,11 +685,7 @@ mod tests {
                 recording: Some(&recording),
                 all_recordings: vec![],
             };
-            let mut query_result = query.execute_query(
-                &ctx,
-                &visualizable_entities,
-                &indicated_entities_per_visualizer,
-            );
+            let mut query_result = query.execute_query(&ctx, &visualizable_entities);
             resolver.update_overrides(&ctx, &blueprint_query, &mut query_result);
 
             let parent = query_result
@@ -739,11 +723,7 @@ mod tests {
                 all_recordings: vec![],
             };
 
-            let mut query_result = query.execute_query(
-                &ctx,
-                &visualizable_entities,
-                &indicated_entities_per_visualizer,
-            );
+            let mut query_result = query.execute_query(&ctx, &visualizable_entities);
             resolver.update_overrides(&ctx, &blueprint_query, &mut query_result);
 
             let parent = query_result

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -458,7 +458,8 @@ mod tests {
     use re_log_types::{DataCell, DataRow, EntityPathFilter, RowId, StoreId, TimePoint};
     use re_types::archetypes::Points3D;
     use re_viewer_context::{
-        blueprint_timeline, IndicatedEntities, PerVisualizer, StoreContext, VisualizableEntities,
+        blueprint_timeline, IndicatedEntities, PerVisualizer, SpaceViewClassRegistry, StoreContext,
+        VisualizableEntities,
     };
 
     use super::*;
@@ -479,6 +480,7 @@ mod tests {
 
     #[test]
     fn test_overrides() {
+        let space_view_class_registry = SpaceViewClassRegistry::default();
         let mut recording = EntityDb::new(StoreId::random(re_log_types::StoreKind::Recording));
         let mut blueprint = EntityDb::new(StoreId::random(re_log_types::StoreKind::Blueprint));
 
@@ -536,7 +538,13 @@ mod tests {
         let blueprint_query = LatestAtQuery::latest(blueprint_timeline());
         let query = space_view.queries.first().unwrap();
 
-        let resolver = query.build_resolver(space_view.id, &auto_properties);
+        let resolver = query.build_resolver(
+            &space_view_class_registry,
+            &space_view,
+            &auto_properties,
+            &visualizable_entities,
+            &indicated_entities_per_visualizer,
+        );
 
         // No overrides set. Everybody has default values.
         {

--- a/crates/re_space_view/src/visualizable.rs
+++ b/crates/re_space_view/src/visualizable.rs
@@ -1,0 +1,40 @@
+use re_entity_db::EntityDb;
+use re_log_types::EntityPath;
+use re_viewer_context::{
+    ApplicableEntities, DynSpaceViewClass, PerVisualizer, VisualizableEntities,
+};
+
+/// Determines the set of visible entities for a given space view.
+// TODO(andreas): This should be part of the SpaceView's (non-blueprint) state.
+// Updated whenever `applicable_entities_per_visualizer` or the space view blueprint changes.
+pub fn determine_visualizable_entities(
+    applicable_entities_per_visualizer: &PerVisualizer<ApplicableEntities>,
+    entity_db: &EntityDb,
+    visualizers: &re_viewer_context::VisualizerCollection,
+    class: &dyn DynSpaceViewClass,
+    space_origin: &EntityPath,
+) -> PerVisualizer<VisualizableEntities> {
+    re_tracing::profile_function!();
+
+    let filter_ctx = class.visualizable_filter_context(space_origin, entity_db);
+
+    PerVisualizer::<VisualizableEntities>(
+        visualizers
+            .iter_with_identifiers()
+            .map(|(visualizer_identifier, visualizer_system)| {
+                let entities = if let Some(applicable_entities) =
+                    applicable_entities_per_visualizer.get(&visualizer_identifier)
+                {
+                    visualizer_system.filter_visualizable_entities(
+                        applicable_entities.clone(),
+                        filter_ctx.as_ref(),
+                    )
+                } else {
+                    VisualizableEntities::default()
+                };
+
+                (visualizer_identifier, entities)
+            })
+            .collect(),
+    )
+}

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -252,6 +252,7 @@ It can greatly improve performance (and readability) in such situations as it pr
             })
             .collect();
 
+        // If there were no other visualizers, but the SeriesLineSystem is available, use it.
         if visualizers.is_empty() && available_visualizers.contains(&SeriesLineSystem::identifier())
         {
             visualizers.insert(0, SeriesLineSystem::identifier());

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -204,11 +204,7 @@ impl AppState {
                         .map(|query| {
                             (
                                 query.id,
-                                query.execute_query(
-                                    store_context,
-                                    &visualizable_entities,
-                                    &indicated_entities_per_visualizer,
-                                ),
+                                query.execute_query(store_context, &visualizable_entities),
                             )
                         })
                         .collect::<Vec<_>>()

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -4,13 +4,13 @@ use re_data_store::LatestAtQuery;
 use re_entity_db::EntityDb;
 use re_log_types::{LogMsg, StoreId, TimeRangeF};
 use re_smart_channel::ReceiveSet;
-use re_space_view::{DataQuery as _, PropertyResolver as _};
+use re_space_view::{determine_visualizable_entities, DataQuery as _, PropertyResolver as _};
 use re_viewer_context::{
     blueprint_timeline, AppOptions, ApplicationSelectionState, Caches, CommandSender,
     ComponentUiRegistry, PlayState, RecordingConfig, SpaceViewClassRegistry, StoreContext,
     SystemCommandSender as _, ViewerContext,
 };
-use re_viewport::{determine_visualizable_entities, Viewport, ViewportBlueprint, ViewportState};
+use re_viewport::{Viewport, ViewportBlueprint, ViewportState};
 
 use crate::ui::recordings_panel_ui;
 use crate::{app_blueprint::AppBlueprint, store_hub::StoreHub, ui::blueprint_panel_ui};
@@ -246,8 +246,26 @@ impl AppState {
             for space_view in viewport.blueprint.space_views.values() {
                 for query in &space_view.queries {
                     if let Some(query_result) = query_results.get_mut(&query.id) {
+                        // TODO(andreas): This needs to be done in a store subscriber that exists per space view (instance, not class!).
+                        // Note that right now we determine *all* visualizable entities, not just the queried ones.
+                        // In a store subscriber set this is fine, but on a per-frame basis it's wasteful.
+                        let visualizable_entities = determine_visualizable_entities(
+                            &applicable_entities_per_visualizer,
+                            entity_db,
+                            &space_view_class_registry
+                                .new_visualizer_collection(*space_view.class_identifier()),
+                            space_view.class(space_view_class_registry),
+                            &space_view.space_origin,
+                        );
+
                         let props = viewport.state.space_view_props(space_view.id);
-                        let resolver = query.build_resolver(space_view.id, props);
+                        let resolver = query.build_resolver(
+                            space_view_class_registry,
+                            space_view,
+                            props,
+                            &visualizable_entities,
+                            &indicated_entities_per_visualizer,
+                        );
                         resolver.update_overrides(store_context, &blueprint_query, query_result);
                     }
                 }

--- a/crates/re_viewer/src/ui/override_ui.rs
+++ b/crates/re_viewer/src/ui/override_ui.rs
@@ -6,14 +6,13 @@ use re_data_ui::{is_component_visible_in_ui, item_ui, temporary_style_ui_for_com
 use re_entity_db::{EntityDb, InstancePath};
 use re_log_types::{ComponentPath, DataCell, DataRow, RowId, StoreKind};
 use re_query_cache::external::re_query::get_component_with_instances;
-use re_space_view::SpaceViewBlueprint;
+use re_space_view::{determine_visualizable_entities, SpaceViewBlueprint};
 use re_types_core::components::VisualizerOverrides;
 use re_types_core::{components::InstanceKey, ComponentName};
 use re_viewer_context::{
     blueprint_timepoint_for_writes, DataResult, SystemCommand, SystemCommandSender as _,
     UiVerbosity, ViewSystemIdentifier, ViewerContext,
 };
-use re_viewport::determine_visualizable_entities;
 
 pub fn override_ui(
     ctx: &ViewerContext<'_>,

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -44,13 +44,14 @@ pub use selection_state::{
 };
 pub use space_view::{
     DataResult, DynSpaceViewClass, IdentifiedViewSystem, PerSystemDataResults, PerSystemEntities,
-    PropertyOverrides, RecommendedSpaceView, SpaceViewClass, SpaceViewClassIdentifier,
-    SpaceViewClassLayoutPriority, SpaceViewClassRegistry, SpaceViewClassRegistryError,
-    SpaceViewEntityHighlight, SpaceViewHighlights, SpaceViewOutlineMasks, SpaceViewSpawnHeuristics,
-    SpaceViewState, SpaceViewSystemExecutionError, SpaceViewSystemRegistrator,
-    SystemExecutionOutput, ViewContextCollection, ViewContextSystem, ViewQuery,
-    ViewSystemIdentifier, VisualizableFilterContext, VisualizerAdditionalApplicabilityFilter,
-    VisualizerCollection, VisualizerQueryInfo, VisualizerSystem,
+    PropertyOverrides, RecommendedSpaceView, SmallVisualizerSet, SpaceViewClass,
+    SpaceViewClassIdentifier, SpaceViewClassLayoutPriority, SpaceViewClassRegistry,
+    SpaceViewClassRegistryError, SpaceViewEntityHighlight, SpaceViewHighlights,
+    SpaceViewOutlineMasks, SpaceViewSpawnHeuristics, SpaceViewState, SpaceViewSystemExecutionError,
+    SpaceViewSystemRegistrator, SystemExecutionOutput, ViewContextCollection, ViewContextSystem,
+    ViewQuery, ViewSystemIdentifier, VisualizableFilterContext,
+    VisualizerAdditionalApplicabilityFilter, VisualizerCollection, VisualizerQueryInfo,
+    VisualizerSystem,
 };
 pub use store_context::StoreContext;
 pub use tensor::{TensorDecodeCache, TensorStats, TensorStatsCache};

--- a/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
@@ -116,6 +116,15 @@ pub trait DynSpaceViewClass: Send + Sync {
     ) -> Box<dyn VisualizableFilterContext>;
 
     /// Choose the default visualizers to enable for this entity.
+    ///
+    /// Helpful for customizing fallback behavior for types that are insufficient
+    /// to determine indicated on their own.
+    ///
+    /// Will only be called for entities where the selected visualizers have not
+    /// been overridden by the blueprint.
+    ///
+    /// This interface provides a default implementation which will return all visualizers
+    /// which are both visualizable and indicated for the given entity.
     fn choose_default_visualizers(
         &self,
         entity_path: &EntityPath,

--- a/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
@@ -1,10 +1,12 @@
 use re_entity_db::{EntityProperties, EntityPropertyMap};
 use re_log_types::EntityPath;
 use re_types::ComponentName;
+use smallvec::SmallVec;
 
 use crate::{
-    PerSystemEntities, SpaceViewClassRegistryError, SpaceViewId, SpaceViewSpawnHeuristics,
-    SpaceViewSystemRegistrator, SystemExecutionOutput, ViewQuery, ViewerContext,
+    IndicatedEntities, PerSystemEntities, PerVisualizer, SpaceViewClassRegistryError, SpaceViewId,
+    SpaceViewSpawnHeuristics, SpaceViewSystemRegistrator, SystemExecutionOutput, ViewQuery,
+    ViewSystemIdentifier, ViewerContext, VisualizableEntities,
 };
 
 re_string_interner::declare_new_type!(
@@ -113,6 +115,14 @@ pub trait DynSpaceViewClass: Send + Sync {
         space_origin: &EntityPath,
         entity_db: &re_entity_db::EntityDb,
     ) -> Box<dyn VisualizableFilterContext>;
+
+    /// Choose the default visualizers to enable for this entity.
+    fn choose_default_visualizers(
+        &self,
+        entity_path: &EntityPath,
+        visualizable_entities_per_visualizer: &PerVisualizer<VisualizableEntities>,
+        indicated_entities_per_visualizer: &PerVisualizer<IndicatedEntities>,
+    ) -> SmallVec<[ViewSystemIdentifier; 4]>;
 
     /// Determines which space views should be spawned by default for this class.
     fn spawn_heuristics(&self, ctx: &ViewerContext<'_>) -> SpaceViewSpawnHeuristics;

--- a/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/dyn_space_view_class.rs
@@ -1,12 +1,11 @@
 use re_entity_db::{EntityProperties, EntityPropertyMap};
 use re_log_types::EntityPath;
 use re_types::ComponentName;
-use smallvec::SmallVec;
 
 use crate::{
-    IndicatedEntities, PerSystemEntities, PerVisualizer, SpaceViewClassRegistryError, SpaceViewId,
-    SpaceViewSpawnHeuristics, SpaceViewSystemRegistrator, SystemExecutionOutput, ViewQuery,
-    ViewSystemIdentifier, ViewerContext, VisualizableEntities,
+    IndicatedEntities, PerSystemEntities, PerVisualizer, SmallVisualizerSet,
+    SpaceViewClassRegistryError, SpaceViewId, SpaceViewSpawnHeuristics, SpaceViewSystemRegistrator,
+    SystemExecutionOutput, ViewQuery, ViewerContext, VisualizableEntities,
 };
 
 re_string_interner::declare_new_type!(
@@ -122,7 +121,7 @@ pub trait DynSpaceViewClass: Send + Sync {
         entity_path: &EntityPath,
         visualizable_entities_per_visualizer: &PerVisualizer<VisualizableEntities>,
         indicated_entities_per_visualizer: &PerVisualizer<IndicatedEntities>,
-    ) -> SmallVec<[ViewSystemIdentifier; 4]>;
+    ) -> SmallVisualizerSet;
 
     /// Determines which space views should be spawned by default for this class.
     fn spawn_heuristics(&self, ctx: &ViewerContext<'_>) -> SpaceViewSpawnHeuristics;

--- a/crates/re_viewer_context/src/space_view/mod.rs
+++ b/crates/re_viewer_context/src/space_view/mod.rs
@@ -30,7 +30,9 @@ pub use space_view_class_registry::{
 pub use spawn_heuristics::{RecommendedSpaceView, SpaceViewSpawnHeuristics};
 pub use system_execution_output::SystemExecutionOutput;
 pub use view_context_system::{ViewContextCollection, ViewContextSystem};
-pub use view_query::{DataResult, PerSystemDataResults, PropertyOverrides, ViewQuery};
+pub use view_query::{
+    DataResult, PerSystemDataResults, PropertyOverrides, SmallVisualizerSet, ViewQuery,
+};
 pub use visualizer_entity_subscriber::VisualizerAdditionalApplicabilityFilter;
 pub use visualizer_system::{VisualizerCollection, VisualizerQueryInfo, VisualizerSystem};
 

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -78,6 +78,15 @@ pub trait SpaceViewClass: std::marker::Sized + Send + Sync {
     }
 
     /// Choose the default visualizers to enable for this entity.
+    ///
+    /// Helpful for customizing fallback behavior for types that are insufficient
+    /// to determine indicated on their own.
+    ///
+    /// Will only be called for entities where the selected visualizers have not
+    /// been overridden by the blueprint.
+    ///
+    /// This interface provides a default implementation which will return all visualizers
+    /// which are both visualizable and indicated for the given entity.
     fn choose_default_visualizers(
         &self,
         entity_path: &EntityPath,

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -1,13 +1,12 @@
 use re_entity_db::{EntityProperties, EntityPropertyMap};
 use re_log_types::EntityPath;
 use re_types::ComponentName;
-use smallvec::SmallVec;
 
 use crate::{
-    DynSpaceViewClass, IndicatedEntities, PerSystemEntities, PerVisualizer,
+    DynSpaceViewClass, IndicatedEntities, PerSystemEntities, PerVisualizer, SmallVisualizerSet,
     SpaceViewClassIdentifier, SpaceViewClassRegistryError, SpaceViewId, SpaceViewSpawnHeuristics,
     SpaceViewState, SpaceViewSystemExecutionError, SpaceViewSystemRegistrator,
-    SystemExecutionOutput, ViewQuery, ViewSystemIdentifier, ViewerContext, VisualizableEntities,
+    SystemExecutionOutput, ViewQuery, ViewerContext, VisualizableEntities,
     VisualizableFilterContext,
 };
 
@@ -84,7 +83,7 @@ pub trait SpaceViewClass: std::marker::Sized + Send + Sync {
         entity_path: &EntityPath,
         visualizable_entities_per_visualizer: &PerVisualizer<VisualizableEntities>,
         indicated_entities_per_visualizer: &PerVisualizer<IndicatedEntities>,
-    ) -> SmallVec<[ViewSystemIdentifier; 4]> {
+    ) -> SmallVisualizerSet {
         let available_visualizers =
             visualizable_entities_per_visualizer
                 .iter()
@@ -227,7 +226,7 @@ impl<T: SpaceViewClass + 'static> DynSpaceViewClass for T {
         entity_path: &EntityPath,
         visualizable_entities_per_visualizer: &PerVisualizer<VisualizableEntities>,
         indicated_entities_per_visualizer: &PerVisualizer<IndicatedEntities>,
-    ) -> SmallVec<[ViewSystemIdentifier; 4]> {
+    ) -> SmallVisualizerSet {
         self.choose_default_visualizers(
             entity_path,
             visualizable_entities_per_visualizer,

--- a/crates/re_viewer_context/src/space_view/view_query.rs
+++ b/crates/re_viewer_context/src/space_view/view_query.rs
@@ -34,6 +34,8 @@ pub struct PropertyOverrides {
     pub override_path: EntityPath,
 }
 
+pub type SmallVisualizerSet = SmallVec<[ViewSystemIdentifier; 4]>;
+
 /// This is the primary mechanism through which data is passed to a `SpaceView`.
 ///
 /// It contains everything necessary to properly use this data in the context of the
@@ -49,7 +51,7 @@ pub struct DataResult {
     pub entity_path: EntityPath,
 
     /// Which `ViewSystems`s to pass the `DataResult` to.
-    pub visualizers: SmallVec<[ViewSystemIdentifier; 4]>,
+    pub visualizers: SmallVisualizerSet,
 
     /// This DataResult represents a group
     // TODO(jleibs): Maybe make this an enum instead?

--- a/crates/re_viewport/src/lib.rs
+++ b/crates/re_viewport/src/lib.rs
@@ -32,52 +32,11 @@ pub mod external {
     pub use re_space_view;
 }
 
-use re_entity_db::EntityDb;
-use re_log_types::EntityPath;
 use re_types::datatypes;
-
-use re_viewer_context::{
-    ApplicableEntities, DynSpaceViewClass, PerVisualizer, VisualizableEntities,
-};
 
 // TODO(andreas): Workaround for referencing non-blueprint components from blueprint archetypes.
 pub(crate) mod components {
     pub use re_types::components::Name;
-}
-
-/// Determines the set of visible entities for a given space view.
-// TODO(andreas): This should be part of the SpaceView's (non-blueprint) state.
-// Updated whenever `applicable_entities_per_visualizer` or the space view blueprint changes.
-pub fn determine_visualizable_entities(
-    applicable_entities_per_visualizer: &PerVisualizer<ApplicableEntities>,
-    entity_db: &EntityDb,
-    visualizers: &re_viewer_context::VisualizerCollection,
-    class: &dyn DynSpaceViewClass,
-    space_origin: &EntityPath,
-) -> PerVisualizer<VisualizableEntities> {
-    re_tracing::profile_function!();
-
-    let filter_ctx = class.visualizable_filter_context(space_origin, entity_db);
-
-    PerVisualizer::<VisualizableEntities>(
-        visualizers
-            .iter_with_identifiers()
-            .map(|(visualizer_identifier, visualizer_system)| {
-                let entities = if let Some(applicable_entities) =
-                    applicable_entities_per_visualizer.get(&visualizer_identifier)
-                {
-                    visualizer_system.filter_visualizable_entities(
-                        applicable_entities.clone(),
-                        filter_ctx.as_ref(),
-                    )
-                } else {
-                    VisualizableEntities::default()
-                };
-
-                (visualizer_identifier, entities)
-            })
-            .collect(),
-    )
 }
 
 /// Determines the icon to use for a given container kind.

--- a/crates/re_viewport/src/space_view_entity_picker.rs
+++ b/crates/re_viewport/src/space_view_entity_picker.rs
@@ -4,10 +4,10 @@ use nohash_hasher::IntMap;
 use re_data_ui::item_ui;
 use re_entity_db::{EntityPath, EntityTree, InstancePath};
 use re_log_types::{EntityPathFilter, EntityPathRule};
-use re_space_view::SpaceViewBlueprint;
+use re_space_view::{determine_visualizable_entities, SpaceViewBlueprint};
 use re_viewer_context::{DataQueryResult, SpaceViewId, ViewerContext};
 
-use crate::{determine_visualizable_entities, ViewportBlueprint};
+use crate::ViewportBlueprint;
 
 /// Window for adding/removing entities from a space view.
 ///


### PR DESCRIPTION
### What
- Builds on top of: https://github.com/rerun-io/rerun/pull/5047

We don't want to use Scalar as the indicator for LineSeries or PointSeries or else we would get both any time a user logs a Scalar. Instead we now delegate this choice to the space-view.

Additionally, entities are now always included in the query-results if they are **visualizable**, even if they aren't indicated. Without this there is no way to access the query-result in order to override its visualizers if necessary.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5050/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5050/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5050/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5050)
- [Docs preview](https://rerun.io/preview/49e3cd9b1150d7290589a9f735837e9149864047/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/49e3cd9b1150d7290589a9f735837e9149864047/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)