### PR TITLE
Fix handling very large meshes & plots (allow maximum available gpu buffers)

### DIFF
--- a/crates/re_renderer/src/config.rs
+++ b/crates/re_renderer/src/config.rs
@@ -74,7 +74,7 @@ pub struct DeviceCaps {
 
     /// Maximum buffer size in bytes.
     ///
-    /// Since this has a direct effect much data a user can wrangle on the gpu, we always pick the highest possible.
+    /// Since this has a direct effect on how much data a user can wrangle on the gpu, we always pick the highest possible.
     pub max_buffer_size: u64,
 
     /// Wgpu backend type.

--- a/crates/re_renderer/src/config.rs
+++ b/crates/re_renderer/src/config.rs
@@ -72,6 +72,11 @@ pub struct DeviceCaps {
     /// Since this has a direct effect on the image sizes & screen resolution a user can use, we always pick the highest possible.
     pub max_texture_dimension2d: u32,
 
+    /// Maximum buffer size in bytes.
+    ///
+    /// Since this has a direct effect much data a user can wrangle on the gpu, we always pick the highest possible.
+    pub max_buffer_size: u64,
+
     /// Wgpu backend type.
     ///
     /// Prefer using `tier` and other properties of this struct for distinguishing between abilities.
@@ -132,6 +137,7 @@ impl DeviceCaps {
         Self {
             tier,
             max_texture_dimension2d: adapter.limits().max_texture_dimension_2d,
+            max_buffer_size: adapter.limits().max_buffer_size,
             backend_type,
         }
     }
@@ -140,6 +146,7 @@ impl DeviceCaps {
     pub fn limits(&self) -> wgpu::Limits {
         wgpu::Limits {
             max_texture_dimension_2d: self.max_texture_dimension2d,
+            max_buffer_size: self.max_buffer_size,
             ..wgpu::Limits::downlevel_webgl2_defaults()
         }
     }


### PR DESCRIPTION
### What

We already did this for textures, was overdue to do it for buffers as well.

* fixes #3928
* fixes #5051


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5053/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5053/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5053/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5053)
- [Docs preview](https://rerun.io/preview/3d6c0ddd06db9e8500fd715637e6cbf30c08ab06/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3d6c0ddd06db9e8500fd715637e6cbf30c08ab06/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)