### PR TITLE
Relax pyarrow dependency to `>=14.0.2`

### DIFF
--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -72,7 +72,7 @@ jobs:
         # TODO(jleibs): understand why deps can't be installed in the same step as the wheel
         shell: bash
         run: |
-          pip install attrs>=23.1.0 'numpy>=1.23,<2' pillow pyarrow==14.0.2 pytest==7.1.2 torch==2.1.0 typing_extensions>=4.5
+          pip install attrs>=23.1.0 'numpy>=1.23,<2' pillow pyarrow>=14.0.2 pytest==7.1.2 torch==2.1.0 typing_extensions>=4.5
 
       - name: Get version
         id: get-version

--- a/.github/workflows/reusable_build_examples.yml
+++ b/.github/workflows/reusable_build_examples.yml
@@ -69,7 +69,7 @@ jobs:
         shell: bash
         run: |
           pixi run pip uninstall rerun-sdk -y
-          pixi run pip install deprecated '"numpy>=1.23,<2"' pyarrow==14.0.2 pytest==7.1.2
+          pixi run pip install deprecated '"numpy>=1.23,<2"' pyarrow>=14.0.2 pytest==7.1.2
           pixi run pip install rerun-sdk --no-index --find-links wheel
 
       - name: Verify built wheel version

--- a/.github/workflows/reusable_publish_web.yml
+++ b/.github/workflows/reusable_publish_web.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           pixi run pip install -r scripts/ci/requirements.txt
           pixi run pip uninstall rerun-sdk -y
-          pixi run pip install deprecated '"numpy>=1.23,<2"' pyarrow==14.0.2 pytest==7.1.2
+          pixi run pip install deprecated '"numpy>=1.23,<2"' pyarrow>=14.0.2 pytest==7.1.2
           pixi run pip install rerun-sdk --no-index --find-links wheel
 
       - name: Installed wheel version

--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -45,7 +45,7 @@ jobs:
         # TODO(jleibs): pull these deps from pyproject.toml
         shell: bash
         run: |
-          pip install deprecated 'numpy>=1.23,<2' pillow>=9.5.0 pyarrow==14.0.2 pytest==7.1.2
+          pip install deprecated 'numpy>=1.23,<2' pillow>=9.5.0 pyarrow>=14.0.2 pytest==7.1.2
 
       - name: Install downloaded wheel_artifact
         # Now install the wheel using a specific version and --no-index to guarantee we get the version from

--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -154,7 +154,7 @@ jobs:
         # TODO(jleibs): understand why deps can't be installed in the same step as the wheel
         shell: bash
         run: |
-          pip install attrs>=23.1.0 'numpy>=1.23,<2' pillow pyarrow==14.0.2 pytest==7.1.2 torch==2.1.0 typing_extensions>=4.5
+          pip install attrs>=23.1.0 'numpy>=1.23,<2' pillow pyarrow>=14.0.2 pytest==7.1.2 torch==2.1.0 typing_extensions>=4.5
 
       - name: Get version
         id: get-version

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "attrs>=23.1.0",
   "numpy>=1.23,<2",
   "pillow",                 # Used for JPEG encoding
-  "pyarrow==14.0.2",
+  "pyarrow>=14.0.2",
   "typing_extensions>=4.5", # Used for PEP-702 deprecated decorator
 ]
 description = "The Rerun Logging SDK"


### PR DESCRIPTION
### What

- Fixes #4976

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5054/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5054/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5054/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5054)
- [Docs preview](https://rerun.io/preview/0ac347f07be6cc14b228c831c39eb50beef32354/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0ac347f07be6cc14b228c831c39eb50beef32354/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)