### PR TITLE
Make override component name un-clickable

### DIFF
--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -156,7 +156,7 @@ impl ReUi {
     }
 
     pub fn table_line_height() -> f32 {
-        14.0
+        16.0
     }
 
     pub fn table_header_height() -> f32 {

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -156,7 +156,7 @@ impl ReUi {
     }
 
     pub fn table_line_height() -> f32 {
-        16.0
+        16.0 // should be big enough to contain buttons, i.e. egui_style.spacing.interact_size.y
     }
 
     pub fn table_header_height() -> f32 {

--- a/crates/re_viewer/src/ui/override_ui.rs
+++ b/crates/re_viewer/src/ui/override_ui.rs
@@ -1,14 +1,17 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use itertools::Itertools;
+
 use re_data_store::{DataStore, LatestAtQuery};
-use re_data_ui::{is_component_visible_in_ui, item_ui, temporary_style_ui_for_component};
+use re_data_ui::{is_component_visible_in_ui, temporary_style_ui_for_component};
 use re_entity_db::{EntityDb, InstancePath};
-use re_log_types::{ComponentPath, DataCell, DataRow, RowId, StoreKind};
+use re_log_types::{DataCell, DataRow, RowId, StoreKind};
 use re_query_cache::external::re_query::get_component_with_instances;
 use re_space_view::{determine_visualizable_entities, SpaceViewBlueprint};
-use re_types_core::components::VisualizerOverrides;
-use re_types_core::{components::InstanceKey, ComponentName};
+use re_types_core::{
+    components::{InstanceKey, VisualizerOverrides},
+    ComponentName,
+};
 use re_viewer_context::{
     blueprint_timepoint_for_writes, DataResult, SystemCommand, SystemCommandSender as _,
     UiVerbosity, ViewSystemIdentifier, ViewerContext,
@@ -130,11 +133,10 @@ pub fn override_ui(
                     // Component label
                     row.col(|ui| {
                         temporary_style_ui_for_component(ui, component_name, |ui| {
-                            item_ui::component_path_button(
-                                ctx,
-                                ui,
-                                &ComponentPath::new(entity_path.clone(), *component_name),
-                            );
+                            //  NOTE: this is not a component button because it is not a component that exists in the recording, just in the blueprint.
+                            // So we don't allow users to select it.
+                            ui.label(component_name.short_name())
+                                .on_hover_text(component_name.full_name());
                         });
                     });
                     // Editor last to take up remainder of space

--- a/crates/re_viewer/src/ui/override_ui.rs
+++ b/crates/re_viewer/src/ui/override_ui.rs
@@ -377,11 +377,7 @@ pub fn override_visualizer_ui(
                                     active_visualizers
                                         .iter()
                                         .filter(|v| *v != vis_name)
-                                        .map(|v| {
-                                            let arrow_str: re_types_core::ArrowString =
-                                                v.as_str().into();
-                                            arrow_str
-                                        })
+                                        .map(|v| re_types_core::ArrowString::from(v.as_str()))
                                         .collect::<Vec<_>>(),
                                 );
 


### PR DESCRIPTION
### What
* Closes #4990

Also fixes vertical centering of things in tables, by making each table row slightly higher

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5059/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5059/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5059/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5059)
- [Docs preview](https://rerun.io/preview/c76a386fa53b54ac23a98caecc836fb242a05cf1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c76a386fa53b54ac23a98caecc836fb242a05cf1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)