### PR TITLE
Fix empty space-view when dragging away active tab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "egui_tiles"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62644ce60d89c48356e30ae08adaed0ea5856794cbec8ef9157dbd9ffe856e97"
+checksum = "f55cf6a469bfbcb0013899ca8e73cd7a882d57abc1938f2df9845f388bc8edf1"
 dependencies = [
  "ahash",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ egui = { version = "0.26.0", features = [
 egui_commonmark = { version = "0.12", default-features = false }
 egui_extras = { version = "0.26.0", features = ["http", "image", "puffin"] }
 egui_plot = "0.26.0"
-egui_tiles = "0.7"
+egui_tiles = "0.7.1"
 egui-wgpu = "0.26.0"
 emath = "0.26.0"
 

--- a/crates/re_viewport/src/system_execution.rs
+++ b/crates/re_viewport/src/system_execution.rs
@@ -94,7 +94,7 @@ pub fn execute_systems_for_all_space_views<'a>(
         .collect::<HashMap<_, _>>()
 }
 
-fn execute_systems_for_space_view<'a>(
+pub fn execute_systems_for_space_view<'a>(
     ctx: &'a ViewerContext<'_>,
     space_view: &'a SpaceViewBlueprint,
     latest_at: TimeInt,

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -591,24 +591,37 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
             return Default::default();
         }
 
-        if self.ctx.rec_cfg.time_ctrl.read().time_int().is_none() {
+        let Some(latest_at) = self.ctx.rec_cfg.time_ctrl.read().time_int() else {
             ui.centered_and_justified(|ui| {
                 ui.weak("No time selected");
             });
             return Default::default();
         };
 
-        let Some((query, system_output)) =
-            self.executed_systems_per_space_view.remove(space_view_id)
-        else {
+        let (query, system_output) =
+            self.executed_systems_per_space_view.remove(space_view_id).unwrap_or_else(|| {
             // The space view's systems haven't been executed.
-            // This should never happen, but if it does anyways we can't display the space view.
-            re_log::error_once!(
+            // This may indicate that the egui_tiles tree is not in sync
+            // with the blueprint tree.
+            // This shouldn't happen, but better safe than sorry:
+            // TODO(#4433): This should go to analytics
+
+            if cfg!(debug_assertions) {
+                re_log::warn_once!(
                 "Visualizers for space view {:?} haven't been executed prior to display. This should never happen, please report a bug.",
                 space_view_blueprint.display_name_or_default()
-            ); // TODO(#4433): This should go to analytics
-            return Default::default();
-        };
+            );
+            }
+
+            let highlights =
+                crate::space_view_highlights::highlights_for_space_view(self.ctx, *space_view_id);
+            crate::system_execution::execute_systems_for_space_view(
+                self.ctx,
+                space_view_blueprint,
+                latest_at,
+                highlights,
+            )
+        });
 
         let PerSpaceViewState {
             auto_properties: _,


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/4996 (at least problem 1, which is the big one)

The problem was that we would remove the active tab on drag, and a new active tab would be selected by egui_tiles _the next frame_, but never written back to the blueprint.

This does a three-pronged fix, each single one should have been enough.

Two of the fixes are in https://github.com/rerun-io/egui_tiles/pull/50:
* Report new tab selection to the behavior (would trigger a blueprint write)
* Pick a new tab in the same frame

The third fix is adding a fallback in Rerun, in case of any future mismatch between egui_tiles and blueprint.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5063/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5063/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5063/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5063)
- [Docs preview](https://rerun.io/preview/eae73b5d8c2e117eaae15e475f72e7c347be9b5a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/eae73b5d8c2e117eaae15e475f72e7c347be9b5a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)