### PR TITLE
Fixes broken tile resize introduced by #5044

### DIFF
--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -797,7 +797,6 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
 
     fn on_edit(&mut self, edit_action: egui_tiles::EditAction) {
         match edit_action {
-            EditAction::TileResized | EditAction::TileDragged => {}
             EditAction::TileDropped => {
                 // TODO(ab): when we finally stop using egui_tiles as application-level data
                 //                  structure, this work-around should be unnecessary.
@@ -832,8 +831,11 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
 
                 self.edited = true;
             }
-            EditAction::TabSelected => {
+            EditAction::TabSelected | EditAction::TileResized => {
                 self.edited = true;
+            }
+            EditAction::TileDragged => {
+                // no synchronisation needed
             }
         }
     }

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -835,7 +835,8 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
                 self.edited = true;
             }
             EditAction::TileDragged => {
-                // no synchronisation needed
+                // No synchronization needed, because TileDragged happens when a drag starts, so no tiles are actually
+                // modified. When the drag completes, then we get `TileDropped` and run the synchronization.
             }
         }
     }


### PR DESCRIPTION
### What

- Fixes #5061

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5064/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5064/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5064/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/5064)
- [Docs preview](https://rerun.io/preview/da3ca8a3ebf53647a43095c403a63b61007417c6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/da3ca8a3ebf53647a43095c403a63b61007417c6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)