### PR TITLE
Populate the available visualizer list so all visualizers get heurisic properties

### DIFF
--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -264,6 +264,8 @@ impl<'a> QueryExpressionEvaluator<'a> {
             // TODO(#5067): For now, we always start by setting visualizers to the full list of available visualizers.
             // This is currently important for evaluating auto-properties during the space-view `on_frame_start`, which
             // is called before the property-overrider has a chance to update this list.
+            // This list will be updated below during `update_overrides_recursive` by calling `choose_default_visualizers`
+            // on the space view.
             let available_visualizers = self
                 .visualizable_entities_for_visualizer_systems
                 .iter()

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -261,10 +261,25 @@ impl<'a> QueryExpressionEvaluator<'a> {
                 .any(|ents| ents.contains(entity_path));
 
         let self_leaf = if visualizable || self.entity_path_filter.is_exact_included(entity_path) {
+            // TODO(#5067): For now, we always start by setting visualizers to the full list of available visualizers.
+            // This is currently important for evaluating auto-properties during the space-view `on_frame_start`, which
+            // is called before the property-overrider has a chance to update this list.
+            let available_visualizers = self
+                .visualizable_entities_for_visualizer_systems
+                .iter()
+                .filter_map(|(visualizer, ents)| {
+                    if ents.contains(entity_path) {
+                        Some(*visualizer)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
             Some(data_results.insert(DataResultNode {
                 data_result: DataResult {
                     entity_path: entity_path.clone(),
-                    visualizers: Default::default(),
+                    visualizers: available_visualizers,
                     is_group: false,
                     direct_included: any_match,
                     property_overrides: None,


### PR DESCRIPTION
### What
 - Resolves: https://github.com/rerun-io/rerun/issues/5060

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5068/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5068/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5068/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5068)
- [Docs preview](https://rerun.io/preview/63ef16eb8d5a92bcc5abe126eeef07e5a338307b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/63ef16eb8d5a92bcc5abe126eeef07e5a338307b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)