### PR TITLE
Ensure that every indicated 2D entity_path gets a visualizer

### DIFF
--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -176,7 +176,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
         // Spawn a space view at each subspace that has any potential 2D content.
         // Note that visualizability filtering is all about being in the right subspace,
         // so we don't need to call the visualizers' filter functions here.
-        SpatialTopology::access(ctx.entity_db.store_id(), |topo| {
+        let mut heuristics = SpatialTopology::access(ctx.entity_db.store_id(), |topo| {
             let split_root_spaces =
                 root_space_split_heuristic(topo, &indicated_entities, SubSpaceDimensionality::TwoD);
 
@@ -232,7 +232,29 @@ impl SpaceViewClass for SpatialSpaceView2D {
                     .collect(),
             }
         })
-        .unwrap_or_default()
+        .unwrap_or_default();
+
+        // TODO(jleibs): This is expensive. Would be great to track this as we build up the covering instead.
+        let remaining_entities = indicated_entities
+            .iter()
+            .filter(|entity| {
+                heuristics
+                    .recommended_space_views
+                    .iter()
+                    .all(|r| !r.query_filter.is_included(entity))
+            })
+            .collect::<Vec<_>>();
+
+        for entity in remaining_entities {
+            heuristics
+                .recommended_space_views
+                .push(RecommendedSpaceView {
+                    root: entity.clone(),
+                    query_filter: EntityPathFilter::single_entity_filter(entity),
+                });
+        }
+
+        heuristics
     }
 
     fn selection_ui(


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/5058

The new topological assessment means after logging a Pinhole the root "/" is connected to "img1" and determined to be a 3D view, which can't view an image.

As a fallback, we now create 2D visualizers for any entity that wasn't covered by the initial pass.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5069/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5069/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5069/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5069)
- [Docs preview](https://rerun.io/preview/410471f117777e45543b811fe16ff3e172e4b27c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/410471f117777e45543b811fe16ff3e172e4b27c/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)