### PR TITLE
Fix forever repaint of big scenes

### DIFF
--- a/crates/re_space_view_spatial/src/eye.rs
+++ b/crates/re_space_view_spatial/src/eye.rs
@@ -209,13 +209,19 @@ impl OrbitEye {
     }
 
     pub fn lerp(&self, other: &Self, t: f32) -> Self {
-        Self {
-            orbit_center: self.orbit_center.lerp(other.orbit_center, t),
-            orbit_radius: lerp(self.orbit_radius..=other.orbit_radius, t),
-            world_from_view_rot: self.world_from_view_rot.slerp(other.world_from_view_rot, t),
-            fov_y: egui::lerp(self.fov_y..=other.fov_y, t),
-            up: self.up.lerp(other.up, t).normalize_or_zero(),
-            velocity: self.velocity.lerp(other.velocity, t),
+        if t == 0.0 {
+            *self // avoid rounding errors
+        } else if t == 1.0 {
+            *other // avoid rounding errors
+        } else {
+            Self {
+                orbit_center: self.orbit_center.lerp(other.orbit_center, t),
+                orbit_radius: lerp(self.orbit_radius..=other.orbit_radius, t),
+                world_from_view_rot: self.world_from_view_rot.slerp(other.world_from_view_rot, t),
+                fov_y: egui::lerp(self.fov_y..=other.fov_y, t),
+                up: self.up.lerp(other.up, t).normalize_or_zero(),
+                velocity: self.velocity.lerp(other.velocity, t),
+            }
         }
     }
 


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5018

When first loading a scene, before the user interacts, we want to center the eye-camera on the scene, so each frame we call "interpolate to the default eye". This should be fine, because we have an early-out if we're already at target. However, the interpolation code had a rounding error meaning we reached _very close_ to our goal, but not quite there. In particular, in `arkit_scenes` it would lead to a forever repaint, since the eye-camera would never reach its target, and so thus would require more animation.

This manifested in `arkit_scenes` now due to another bug (https://github.com/rerun-io/rerun/issues/5070) causing enormous point clouds, making the rounding errors larger than usual.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5071/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5071/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5071/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5071)
- [Docs preview](https://rerun.io/preview/d20d34685e6aaba1daf5c6417e1bb39d22448d40/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d20d34685e6aaba1daf5c6417e1bb39d22448d40/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)