### PR TITLE
Use the nightly manifest by default in dev builds

### DIFF
--- a/crates/re_viewer/src/ui/welcome_screen/example_page.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/example_page.rs
@@ -195,17 +195,19 @@ fn default_manifest_url() -> String {
             version = build_info.version,
         )
     } else if build_info.is_in_rerun_workspace {
-        // Otherwise, always point to `version/main` for rerun devs,
+        // Otherwise, always point to `version/nightly` for rerun devs,
         // because the current commit's manifest is unlikely to be uploaded to GCS.
-        "https://app.rerun.io/version/main/examples_manifest.json".into()
+        // We could point to the main branch, but it's not always finished building, and so doesn't always work.
+        "https://app.rerun.io/version/nightly/examples_manifest.json".into()
     } else if !short_sha.is_empty() {
         // If we have a sha, try to point at it.
         format!("https://app.rerun.io/commit/{short_sha}/examples_manifest.json")
     } else {
-        // If all else fails, point to the main branch
+        // If all else fails, point to the nightly branch
+        // We could point to the main branch, but it's not always finished building, and so doesn't always work.
         // TODO(#4729): this is better than nothing but still likely to have version
         // compatibility issues.
-        "https://app.rerun.io/version/main/examples_manifest.json".into()
+        "https://app.rerun.io/version/nightly/examples_manifest.json".into()
     }
 }
 


### PR DESCRIPTION
### What
The latest `main` manifest often refers to `.rrd` files that aren't there (yet), forcing me to use `DEFAULT_EXAMPLES_MANIFEST_URL=https://app.rerun.io/version/nightly/examples_manifest.json cargo rerun` all the time, which is a mouthful.

The nightly is nicer anyway, since it has more examples ✨ 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
