### PR TITLE
When duplicating a space-view copy the nested blueprint tree

### DIFF
--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -1,4 +1,4 @@
-use std::{ops::Index, slice::SliceIndex, sync::Arc};
+use std::sync::Arc;
 
 use re_string_interner::InternedString;
 use re_types_core::SizeBytes;

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{ops::Index, slice::SliceIndex, sync::Arc};
 
 use re_string_interner::InternedString;
 use re_types_core::SizeBytes;
@@ -304,6 +304,16 @@ impl From<&EntityPath> for re_types_core::datatypes::EntityPath {
     }
 }
 
+impl<Idx> std::ops::Index<Idx> for EntityPath
+where
+    Idx: std::slice::SliceIndex<[EntityPathPart]>,
+{
+    type Output = Idx::Output;
+
+    fn index(&self, index: Idx) -> &Self::Output {
+        &self.parts[index]
+    }
+}
 // ----------------------------------------------------------------------------
 
 use re_types_core::Loggable;

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -96,13 +96,17 @@ impl DataQueryBlueprint {
     /// Otherwise, incremental calls to `set_` functions will write just the necessary component
     /// update directly to the store.
     pub fn save_to_blueprint_store(&self, ctx: &ViewerContext<'_>) {
-        // Note: pending_writes already contains the whole subtree, including query expressions.
-        // so this is all we need to save.
+        // Save any pending writes from a duplication.
         ctx.command_sender
             .send_system(SystemCommand::UpdateBlueprint(
                 ctx.store_context.blueprint.store_id().clone(),
                 self.pending_writes.clone(),
             ));
+
+        ctx.save_blueprint_component(
+            &self.id.as_entity_path(),
+            QueryExpressions::from(&self.entity_path_filter),
+        );
     }
 
     /// Creates a new [`DataQueryBlueprint`] with a the same contents, but a different [`DataQueryId`]

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -143,7 +143,9 @@ impl DataQueryBlueprint {
                             .and_then(|result| result.2[0].clone())
                     }),
                 ) {
-                    pending_writes.push(row);
+                    if row.num_cells() > 0 {
+                        pending_writes.push(row);
+                    }
                 }
             });
         }

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -123,12 +123,8 @@ impl DataQueryBlueprint {
             tree.visit_children_recursively(&mut |path, info| {
                 let sub_path: EntityPath = new_path
                     .iter()
+                    .chain(&path[current_path.len()..])
                     .cloned()
-                    .chain(
-                        path.as_slice()[current_path.len()..path.len()]
-                            .iter()
-                            .cloned(),
-                    )
                     .collect();
 
                 if let Ok(row) = DataRow::from_cells(
@@ -553,7 +549,7 @@ impl DataQueryPropertyResolver<'_> {
                                 .blueprint
                                 .store()
                                 .latest_at(query, &override_path, *component, &[*component])
-                                .and_then(|result| result.2[0].clone())
+                                .and_then(|(_, _, cells)| cells[0].clone())
                             {
                                 if !component_data.is_empty() {
                                     component_overrides.insert(

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -267,12 +267,8 @@ impl SpaceViewBlueprint {
             tree.visit_children_recursively(&mut |path, info| {
                 let sub_path: EntityPath = new_path
                     .iter()
+                    .chain(&path[current_path.len()..])
                     .cloned()
-                    .chain(
-                        path.as_slice()[current_path.len()..path.len()]
-                            .iter()
-                            .cloned(),
-                    )
                     .collect();
 
                 if let Ok(row) = DataRow::from_cells(
@@ -293,7 +289,7 @@ impl SpaceViewBlueprint {
                             blueprint
                                 .store()
                                 .latest_at(query, path, *component, &[*component])
-                                .and_then(|result| result.2[0].clone())
+                                .and_then(|(_, _, cells)| cells[0].clone())
                         }),
                 ) {
                     if row.num_cells() > 0 {

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -296,7 +296,9 @@ impl SpaceViewBlueprint {
                                 .and_then(|result| result.2[0].clone())
                         }),
                 ) {
-                    pending_writes.push(row);
+                    if row.num_cells() > 0 {
+                        pending_writes.push(row);
+                    }
                 }
             });
         }

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -238,14 +238,8 @@ impl ViewportBlueprint {
             return None;
         };
 
-        let new_space_view = space_view.duplicate();
+        let new_space_view = space_view.duplicate(ctx.store_context.blueprint, ctx.blueprint_query);
         let new_space_view_id = new_space_view.id;
-
-        // copy entity properties from the old space view
-        let data_result = space_view.root_data_result(ctx.store_context, ctx.blueprint_query);
-        let new_data_result =
-            new_space_view.root_data_result(ctx.store_context, ctx.blueprint_query);
-        new_data_result.save_override(data_result.individual_properties().cloned(), ctx);
 
         self.add_space_views(std::iter::once(new_space_view), ctx, None);
 

--- a/tests/python/release_checklist/check_plot_overrides.py
+++ b/tests/python/release_checklist/check_plot_overrides.py
@@ -29,6 +29,9 @@ This checks whether one can override all properties in a plot.
 * Override the `plots/cos` entity Visible time range
   * Verify all 3 offset modes operate as expected
 
+### Overrides are cloned
+* After overriding things on both the space-view and the entity, clone the space-view.
+
 If nothing weird happens, you can close this recording.
 """
 


### PR DESCRIPTION
### What
 - Resolves: https://github.com/rerun-io/rerun/issues/4977

When we duplicate the space-view we now copy the entire subtree and write it into the new view. We do the same, recursively for the DataQueries as well (which is where the component overrides live).

There's definitely some cleanup that could be done here but this seems to work for now to solve the problem of duplicating all the overrides, etc.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5076/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5076/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5076/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5076)
- [Docs preview](https://rerun.io/preview/60420debd92234b2537b29d870aefe44ad6aab54/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/60420debd92234b2537b29d870aefe44ad6aab54/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)