### PR TITLE
`rerun print`: print just summary, unless given `--verbose`

### DIFF
--- a/crates/re_format/src/lib.rs
+++ b/crates/re_format/src/lib.rs
@@ -134,7 +134,7 @@ fn test_format_large_number() {
 /// ```
 /// # use re_format::format_bytes;
 /// assert_eq!(format_bytes(123.0), "123 B");
-/// assert_eq!(format_bytes(12_345.0), "12.1 kiB");
+/// assert_eq!(format_bytes(12_345.0), "12.1 KiB");
 /// assert_eq!(format_bytes(1_234_567.0), "1.2 MiB");
 /// assert_eq!(format_bytes(123_456_789.0), "118 MiB");
 /// ```
@@ -147,7 +147,7 @@ pub fn format_bytes(number_of_bytes: f64) -> String {
         format!("{number_of_bytes:.0} B")
     } else if number_of_bytes < 20.0_f64.exp2() {
         let decimals = (10.0 * number_of_bytes < 20.0_f64.exp2()) as usize;
-        format!("{:.*} kiB", decimals, number_of_bytes / 10.0_f64.exp2())
+        format!("{:.*} KiB", decimals, number_of_bytes / 10.0_f64.exp2())
     } else if number_of_bytes < 30.0_f64.exp2() {
         let decimals = (10.0 * number_of_bytes < 30.0_f64.exp2()) as usize;
         format!("{:.*} MiB", decimals, number_of_bytes / 20.0_f64.exp2())
@@ -164,12 +164,12 @@ fn test_format_bytes() {
         (1000.0, "1000 B"),
         (1001.0, "1001 B"),
         (1023.0, "1023 B"),
-        (1024.0, "1.0 kiB"),
-        (1025.0, "1.0 kiB"),
-        (1024.0 * 1.2345, "1.2 kiB"),
-        (1024.0 * 12.345, "12.3 kiB"),
-        (1024.0 * 123.45, "123 kiB"),
-        (1024f64.powi(2) - 1.0, "1024 kiB"),
+        (1024.0, "1.0 KiB"),
+        (1025.0, "1.0 KiB"),
+        (1024.0 * 1.2345, "1.2 KiB"),
+        (1024.0 * 12.345, "12.3 KiB"),
+        (1024.0 * 123.45, "123 KiB"),
+        (1024f64.powi(2) - 1.0, "1024 KiB"),
         (1024f64.powi(2) + 0.0, "1.0 MiB"),
         (1024f64.powi(2) + 1.0, "1.0 MiB"),
         (1024f64.powi(3) - 1.0, "1024 MiB"),
@@ -182,7 +182,7 @@ fn test_format_bytes() {
         (1024f64.powi(4) + 0.0, "1024 GiB"),
         (1024f64.powi(4) + 1.0, "1024 GiB"),
         (123.0, "123 B"),
-        (12_345.0, "12.1 kiB"),
+        (12_345.0, "12.1 KiB"),
         (1_234_567.0, "1.2 MiB"),
         (123_456_789.0, "118 MiB"),
     ];
@@ -231,7 +231,7 @@ fn test_parse_bytes_base10() {
 }
 
 pub fn parse_bytes_base2(bytes: &str) -> Option<i64> {
-    if let Some(kb) = bytes.strip_suffix("kiB") {
+    if let Some(kb) = bytes.strip_suffix("KiB") {
         Some(kb.parse::<i64>().ok()? * 1024)
     } else if let Some(mb) = bytes.strip_suffix("MiB") {
         Some(mb.parse::<i64>().ok()? * 1024 * 1024)
@@ -252,8 +252,8 @@ fn test_parse_bytes_base2() {
         ("999B", 999),
         ("1023B", 1_023),
         ("1024B", 1_024),
-        ("1kiB", 1_024),
-        ("1000kiB", 1_000 * 1024),
+        ("1KiB", 1_024),
+        ("1000KiB", 1_000 * 1024),
         ("1MiB", 1024 * 1024),
         ("1000MiB", 1_000 * 1024 * 1024),
         ("1GiB", 1024 * 1024 * 1024),
@@ -261,7 +261,7 @@ fn test_parse_bytes_base2() {
         ("1TiB", 1024 * 1024 * 1024 * 1024),
         ("1000TiB", 1_000 * 1024 * 1024 * 1024 * 1024),
         ("123B", 123),
-        ("12kiB", 12 * 1024),
+        ("12KiB", 12 * 1024),
         ("123MiB", 123 * 1024 * 1024),
     ];
     for (value, expected) in test_cases {
@@ -294,8 +294,8 @@ fn test_parse_bytes() {
         ("999B", 999),
         ("1023B", 1_023),
         ("1024B", 1_024),
-        ("1kiB", 1_024),
-        ("1000kiB", 1_000 * 1024),
+        ("1KiB", 1_024),
+        ("1000KiB", 1_000 * 1024),
         ("1MiB", 1024 * 1024),
         ("1000MiB", 1_000 * 1024 * 1024),
         ("1GiB", 1024 * 1024 * 1024),
@@ -303,7 +303,7 @@ fn test_parse_bytes() {
         ("1TiB", 1024 * 1024 * 1024 * 1024),
         ("1000TiB", 1_000 * 1024 * 1024 * 1024 * 1024),
         ("123B", 123),
-        ("12kiB", 12 * 1024),
+        ("12KiB", 12 * 1024),
         ("123MiB", 123 * 1024 * 1024),
     ];
     for (value, expected) in test_cases {

--- a/crates/re_format/src/lib.rs
+++ b/crates/re_format/src/lib.rs
@@ -193,6 +193,7 @@ fn test_format_bytes() {
 }
 
 pub fn parse_bytes_base10(bytes: &str) -> Option<i64> {
+    // Note: intentionally case sensitive so that we don't parse `Mb` (Megabit) as `MB` (Megabyte).
     if let Some(kb) = bytes.strip_suffix("kB") {
         Some(kb.parse::<i64>().ok()? * 1_000)
     } else if let Some(mb) = bytes.strip_suffix("MB") {
@@ -231,6 +232,7 @@ fn test_parse_bytes_base10() {
 }
 
 pub fn parse_bytes_base2(bytes: &str) -> Option<i64> {
+    // Note: intentionally case sensitive so that we don't parse `Mib` (Mebibit) as `MiB` (Mebibyte).
     if let Some(kb) = bytes.strip_suffix("KiB") {
         Some(kb.parse::<i64>().ok()? * 1024)
     } else if let Some(mb) = bytes.strip_suffix("MiB") {

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -290,13 +290,7 @@ pub struct PythonVersion {
 
 impl std::fmt::Debug for PythonVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self {
-            major,
-            minor,
-            patch,
-            suffix,
-        } = self;
-        write!(f, "{major}.{minor}.{patch}{suffix}")
+        std::fmt::Display::fmt(self, f)
     }
 }
 

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -272,7 +272,7 @@ impl StoreInfo {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct PythonVersion {
     /// e.g. 3
@@ -286,6 +286,18 @@ pub struct PythonVersion {
 
     /// e.g. `a0` for alpha releases.
     pub suffix: String,
+}
+
+impl std::fmt::Debug for PythonVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            major,
+            minor,
+            patch,
+            suffix,
+        } = self;
+        write!(f, "{major}.{minor}.{patch}{suffix}")
+    }
 }
 
 impl std::fmt::Display for PythonVersion {


### PR DESCRIPTION
### What
Added when debugging https://github.com/rerun-io/rerun/issues/5078

Example:

```
> rerun print nuscenes.rrd

StoreInfo {
    application_id: ApplicationId(
        "rerun_example_nuscenes",
    ),
    store_id: StoreId {
        kind: Recording,
        id: "58821cc9-d39c-4f78-9e7e-bad4933e9870",
    },
    is_official_example: true,
    started: "2024-02-06 12:34:04.306130Z",
    store_source: PythonSdk(
        3.11.6,
    ),
    store_kind: Recording,
}
StoreInfo {
    application_id: ApplicationId(
        "rerun_example_nuscenes",
    ),
    store_id: StoreId {
        kind: Recording,
        id: "58821cc9-d39c-4f78-9e7e-bad4933e9870",
    },
    is_official_example: true,
    started: "2024-02-06 12:34:04.306130Z",
    store_source: PythonSdk(
        3.11.6,
    ),
    store_kind: Recording,
}
Table with 596 rows (90.6 MiB). Columns: ["Color", "ImageIndicator", "InstanceKey", "PinholeIndicator", "PinholeProjection", "Points3DIndicator", "Position3D", "Resolution", "TensorData", "Transform3D", "Transform3DIndicator", "ViewCoordinates", "ViewCoordinatesIndicator"]
Table with 586 rows (12.0 MiB). Columns: ["Color", "ImageIndicator", "InstanceKey", "Points3DIndicator", "Position3D", "TensorData"]
Table with 179 rows (244 KiB). Columns: ["Boxes3DIndicator", "ClassId", "Color", "HalfSizes3D", "InstanceKey", "Points3DIndicator", "Position3D", "Rotation3D"]
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5079/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5079/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5079/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5079)
- [Docs preview](https://rerun.io/preview/5077a74742e41561744cc03c190dfe8da149559d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5077a74742e41561744cc03c190dfe8da149559d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)