### PR TITLE
Improve 2d spawn heuristics

### DIFF
--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -252,6 +252,12 @@ impl EntityPath {
         }
         EntityPath::new(common)
     }
+
+    /// Returns the first common ancestor of a list of entity paths.
+    pub fn common_ancestor_of<'a>(mut entities: impl Iterator<Item = &'a Self>) -> Self {
+        let first = entities.next().cloned().unwrap_or(EntityPath::root());
+        entities.fold(first, |acc, e| acc.common_ancestor(e))
+    }
 }
 
 impl SizeBytes for EntityPath {

--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -237,6 +237,21 @@ impl EntityPath {
             itertools::Either::Right(std::iter::empty())
         }
     }
+
+    /// Returns the first common ancestor of two paths.
+    ///
+    /// If both paths are the same, the common ancestor is the path itself.
+    pub fn common_ancestor(&self, other: &EntityPath) -> EntityPath {
+        let mut common = Vec::new();
+        for (a, b) in self.iter().zip(other.iter()) {
+            if a == b {
+                common.push(a.clone());
+            } else {
+                break;
+            }
+        }
+        EntityPath::new(common)
+    }
 }
 
 impl SizeBytes for EntityPath {
@@ -479,6 +494,30 @@ mod tests {
             )
             .collect::<Vec<_>>(),
             vec![EntityPath::from("foo/bar"), EntityPath::from("foo/bar/baz")]
+        );
+    }
+
+    #[test]
+    fn test_common_ancestor() {
+        assert_eq!(
+            EntityPath::from("foo/bar").common_ancestor(&EntityPath::from("foo/bar")),
+            EntityPath::from("foo/bar")
+        );
+        assert_eq!(
+            EntityPath::from("foo/bar").common_ancestor(&EntityPath::from("foo/bar/baz")),
+            EntityPath::from("foo/bar")
+        );
+        assert_eq!(
+            EntityPath::from("foo/bar/baz").common_ancestor(&EntityPath::from("foo/bar")),
+            EntityPath::from("foo/bar")
+        );
+        assert_eq!(
+            EntityPath::from("foo/bar/mario").common_ancestor(&EntityPath::from("foo/bar/luigi")),
+            EntityPath::from("foo/bar")
+        );
+        assert_eq!(
+            EntityPath::from("mario/bowser").common_ancestor(&EntityPath::from("luigi/bowser")),
+            EntityPath::root()
         );
     }
 }

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -204,15 +204,8 @@ impl SpaceViewClass for SpatialSpaceView2D {
                             images_by_bucket
                                 .into_iter()
                                 .map(|(_, entity_bucket)| {
-                                    // Pick a shared parent as origin.
-                                    // Mostly because it looks nicer in the ui.
-                                    let root = entity_bucket.iter().skip(1).fold(
-                                        entity_bucket
-                                            .first()
-                                            .unwrap_or(&EntityPath::root())
-                                            .clone(),
-                                        |acc, e| acc.common_ancestor(e),
-                                    );
+                                    // Pick a shared parent as origin, mostly because it looks nicer in the ui.
+                                    let root = EntityPath::common_ancestor_of(entity_bucket.iter());
 
                                     let mut query_filter = EntityPathFilter::default();
                                     for image in &entity_bucket {

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -15,8 +15,7 @@ use re_viewer_context::{
 use crate::{
     contexts::{register_spatial_contexts, PrimitiveCounter},
     heuristics::{
-        default_visualized_entities_for_visualizer_kind, root_space_split_heuristic,
-        update_object_property_heuristics,
+        default_visualized_entities_for_visualizer_kind, update_object_property_heuristics,
     },
     spatial_topology::{SpatialTopology, SubSpace, SubSpaceDimensionality},
     ui::SpatialSpaceViewState,
@@ -178,19 +177,9 @@ impl SpaceViewClass for SpatialSpaceView2D {
         // Note that visualizability filtering is all about being in the right subspace,
         // so we don't need to call the visualizers' filter functions here.
         let mut heuristics = SpatialTopology::access(ctx.entity_db.store_id(), |topo| {
-            let split_root_spaces =
-                root_space_split_heuristic(topo, &indicated_entities, SubSpaceDimensionality::TwoD);
-
             SpaceViewSpawnHeuristics {
                 recommended_space_views: topo
                     .iter_subspaces()
-                    .flat_map(|subspace| {
-                        if subspace.origin.is_root() && !split_root_spaces.is_empty() {
-                            itertools::Either::Left(split_root_spaces.values())
-                        } else {
-                            itertools::Either::Right(std::iter::once(subspace))
-                        }
-                    })
                     .flat_map(|subspace| {
                         if subspace.dimensionality == SubSpaceDimensionality::ThreeD
                             || subspace.entities.is_empty()
@@ -215,17 +204,24 @@ impl SpaceViewClass for SpatialSpaceView2D {
                             images_by_bucket
                                 .into_iter()
                                 .map(|(_, entity_bucket)| {
+                                    // Pick a shared parent as origin.
+                                    // Mostly because it looks nicer in the ui.
+                                    let root = entity_bucket.iter().skip(1).fold(
+                                        entity_bucket
+                                            .first()
+                                            .unwrap_or(&EntityPath::root())
+                                            .clone(),
+                                        |acc, e| acc.common_ancestor(e),
+                                    );
+
                                     let mut query_filter = EntityPathFilter::default();
-                                    for image in entity_bucket {
+                                    for image in &entity_bucket {
                                         // This might lead to overlapping subtrees and break the same image size bucketing again.
                                         // We just take that risk, the heuristic doesn't need to be perfect.
-                                        query_filter.add_subtree(image);
+                                        query_filter.add_subtree(image.clone());
                                     }
 
-                                    RecommendedSpaceView {
-                                        root: subspace.origin.clone(),
-                                        query_filter,
-                                    }
+                                    RecommendedSpaceView { root, query_filter }
                                 })
                                 .collect()
                         }
@@ -329,10 +325,13 @@ fn bucket_images_in_subspace(
             store.query_latest_component::<TensorData>(image_entity, &ctx.current_query())
         {
             if let Some([height, width, _]) = tensor.image_height_width_channels() {
-                images_by_bucket
-                    .entry((height, width))
-                    .or_default()
-                    .push(image_entity.clone());
+                // 1D tensors are typically handled by tensor or bar chart views and make generally for poor image buckets!
+                if height > 1 && width > 1 {
+                    images_by_bucket
+                        .entry((height, width))
+                        .or_default()
+                        .push(image_entity.clone());
+                }
             }
         }
     }


### PR DESCRIPTION
### What

* partially solves #4926
* fixes new issues where we get two spaces views in our 2d code examples for lines

Removes "child of root" heuristics for 2D space views and improves image grouping behavior a bit.
Had to do slight adjustments to object tracking demo so that it still looks good:

![image](https://github.com/rerun-io/rerun/assets/1220815/5b0987f7-2c3a-4f7e-b954-087e85a1a548)

But imho the adjusted hierarchy also makes a lot of sense. Soon user can configure this from blueprint, we can then think about removing non-explicit bucketing. See
* #3985


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5087/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5087/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5087/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5087)
- [Docs preview](https://rerun.io/preview/4040710e64651d60a9b1f1afacfa899be19e11cc/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4040710e64651d60a9b1f1afacfa899be19e11cc/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)