### PR TITLE
Do not allow adding Horizontal/Vertical containers inside of containers with the same type

### DIFF
--- a/crates/re_viewport/src/add_space_view_or_container_modal.rs
+++ b/crates/re_viewport/src/add_space_view_or_container_modal.rs
@@ -83,8 +83,10 @@ fn modal_ui(
         // We disallow creating "linear" containers (horizontal/vertical) inside containers of the same kind, because
         // it's not useful and is automatically simplified away.
         let disabled = Some(kind) == target_container_kind
-            && (target_container_kind == Some(egui_tiles::ContainerKind::Horizontal)
-                || target_container_kind == Some(egui_tiles::ContainerKind::Vertical));
+            && matches!(
+                kind,
+                egui_tiles::ContainerKind::Horizontal | egui_tiles::ContainerKind::Vertical
+            );
 
         let resp = ui
             .add_enabled_ui(!disabled, |ui| {


### PR DESCRIPTION
### What

- Fixes #5082

*Note*: due to https://github.com/emilk/egui/issues/3997, the tooltip shows up immediately, which is slightly annoying.

<img width="1898" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/ef64fa2f-7a5b-41f0-aec5-31b2e55c8efc">

<img width="681" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/5ace80d5-eb49-4a1e-9440-6debb54d7d4f">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5091/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5091/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5091/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5091)
- [Docs preview](https://rerun.io/preview/57a22b0a289369057acc1000af69df20df9e3d23/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/57a22b0a289369057acc1000af69df20df9e3d23/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)