### PR TITLE
Clean up component grid UI

### DIFF
--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -57,13 +57,11 @@ impl DataUi for InstancePath {
         // First show indicator components, outside the grid:
         if show_indicator_comps {
             for component_name in indicator_components {
-                crate::temporary_style_ui_for_component(ui, &component_name, |ui| {
-                    item_ui::component_path_button(
-                        ctx,
-                        ui,
-                        &ComponentPath::new(entity_path.clone(), component_name),
-                    );
-                });
+                item_ui::component_path_button(
+                    ctx,
+                    ui,
+                    &ComponentPath::new(entity_path.clone(), component_name),
+                );
             }
         }
 
@@ -76,13 +74,11 @@ impl DataUi for InstancePath {
                     continue; // no need to show components that are unset at this point in time
                 };
 
-                crate::temporary_style_ui_for_component(ui, &component_name, |ui| {
-                    item_ui::component_path_button(
-                        ctx,
-                        ui,
-                        &ComponentPath::new(entity_path.clone(), component_name),
-                    );
-                });
+                item_ui::component_path_button(
+                    ctx,
+                    ui,
+                    &ComponentPath::new(entity_path.clone(), component_name),
+                );
 
                 if instance_key.is_splat() {
                     super::component::EntityComponentWithInstances {

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -36,63 +36,76 @@ impl DataUi for InstancePath {
             return;
         };
 
-        let all_are_indicators = components.iter().all(|c| c.is_indicator_component());
+        let mut components = crate::ui_visible_components(&components);
 
-        egui::Grid::new("entity_instance")
-            .num_columns(2)
-            .show(ui, |ui| {
-                for &component_name in crate::ui_visible_components(&components) {
-                    match verbosity {
-                        UiVerbosity::Small | UiVerbosity::Reduced => {
-                            // Skip indicator components in hover ui (unless there are no other
-                            // types of components).
-                            if component_name.is_indicator_component() && !all_are_indicators {
-                                continue;
-                            }
-                        }
-                        UiVerbosity::LimitHeight | UiVerbosity::Full => {}
+        // Put indicator components first:
+        components.sort_by_key(|c| !c.is_indicator_component());
+
+        let split = components.partition_point(|c| c.is_indicator_component());
+        let normal_components = components.split_off(split);
+        let indicator_components = components;
+
+        let show_indicator_comps = match verbosity {
+            UiVerbosity::Small | UiVerbosity::Reduced => {
+                // Skip indicator components in hover ui (unless there are no other
+                // types of components).
+                !normal_components.is_empty()
+            }
+            UiVerbosity::LimitHeight | UiVerbosity::Full => true,
+        };
+
+        // First show indicator components, outside the grid:
+        if show_indicator_comps {
+            for component_name in indicator_components {
+                crate::temporary_style_ui_for_component(ui, &component_name, |ui| {
+                    item_ui::component_path_button(
+                        ctx,
+                        ui,
+                        &ComponentPath::new(entity_path.clone(), component_name),
+                    );
+                });
+            }
+        }
+
+        // Now show the rest of the components:
+        egui::Grid::new("components").num_columns(2).show(ui, |ui| {
+            for component_name in normal_components {
+                let Some((_, _, component_data)) =
+                    get_component_with_instances(store, query, entity_path, component_name)
+                else {
+                    continue; // no need to show components that are unset at this point in time
+                };
+
+                crate::temporary_style_ui_for_component(ui, &component_name, |ui| {
+                    item_ui::component_path_button(
+                        ctx,
+                        ui,
+                        &ComponentPath::new(entity_path.clone(), component_name),
+                    );
+                });
+
+                if instance_key.is_splat() {
+                    super::component::EntityComponentWithInstances {
+                        entity_path: entity_path.clone(),
+                        component_data,
                     }
-
-                    let Some((_, _, component_data)) =
-                        get_component_with_instances(store, query, entity_path, component_name)
-                    else {
-                        continue; // no need to show components that are unset at this point in time
-                    };
-
-                    crate::temporary_style_ui_for_component(ui, &component_name, |ui| {
-                        item_ui::component_path_button(
-                            ctx,
-                            ui,
-                            &ComponentPath::new(entity_path.clone(), component_name),
-                        );
-                    });
-
-                    if let Some(archetype_name) = component_name.indicator_component_archetype() {
-                        ui.weak(format!(
-                            "Indicator component for the {archetype_name} archetype"
-                        ));
-                    } else if instance_key.is_splat() {
-                        super::component::EntityComponentWithInstances {
-                            entity_path: entity_path.clone(),
-                            component_data,
-                        }
-                        .data_ui(ctx, ui, UiVerbosity::Small, query, store);
-                    } else {
-                        ctx.component_ui_registry.ui(
-                            ctx,
-                            ui,
-                            UiVerbosity::Small,
-                            query,
-                            store,
-                            entity_path,
-                            &component_data,
-                            instance_key,
-                        );
-                    }
-
-                    ui.end_row();
+                    .data_ui(ctx, ui, UiVerbosity::Small, query, store);
+                } else {
+                    ctx.component_ui_registry.ui(
+                        ctx,
+                        ui,
+                        UiVerbosity::Small,
+                        query,
+                        store,
+                        entity_path,
+                        &component_data,
+                        instance_key,
+                    );
                 }
-                Some(())
-            });
+
+                ui.end_row();
+            }
+            Some(())
+        });
     }
 }

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -60,28 +60,6 @@ pub fn is_component_visible_in_ui(component_name: &ComponentName) -> bool {
     !HIDDEN_COMPONENTS.contains(&component_name.as_ref())
 }
 
-pub fn temporary_style_ui_for_component<R>(
-    ui: &mut egui::Ui,
-    component_name: &ComponentName,
-    add_contents: impl FnOnce(&mut egui::Ui) -> R,
-) -> R {
-    let old_style: egui::Style = (**ui.style()).clone();
-
-    if component_name.is_indicator_component() {
-        // Make indicator components stand out by making them slightly fainter:
-
-        let inactive = &mut ui.style_mut().visuals.widgets.inactive;
-        // TODO(emilk): get a color from the design-tokens
-        inactive.fg_stroke.color = inactive.fg_stroke.color.linear_multiply(0.45);
-    }
-
-    let ret = add_contents(ui);
-
-    ui.set_style(old_style);
-
-    ret
-}
-
 /// Types implementing [`DataUi`] can display themselves in an [`egui::Ui`].
 pub trait DataUi {
     /// If you need to lookup something in the data store, use the given query to do so.

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -41,16 +41,17 @@ pub use image_meaning::image_meaning_for_entity;
 /// and order the other components in a cosnsiten way.
 pub fn ui_visible_components<'a>(
     iter: impl IntoIterator<Item = &'a ComponentName> + 'a,
-) -> impl Iterator<Item = &'a ComponentName> {
-    let mut components: Vec<&ComponentName> = iter
+) -> Vec<ComponentName> {
+    let mut components: Vec<ComponentName> = iter
         .into_iter()
-        .filter(|c| is_component_visible_in_ui(c))
+        .cloned()
+        .filter(is_component_visible_in_ui)
         .collect();
 
     // Put indicator components first:
     components.sort_by_key(|c| (!c.is_indicator_component(), c.full_name()));
 
-    components.into_iter()
+    components
 }
 
 /// Show this component in the UI.

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -681,11 +681,11 @@ impl TimePanel {
             let clip_rect_save = ui.clip_rect();
 
             for component_name in re_data_ui::ui_visible_components(tree.entity.components.keys()) {
-                let data = &tree.entity.components[component_name];
+                let data = &tree.entity.components[&component_name];
 
                 let component_has_data_in_current_timeline =
                     time_ctrl.component_has_data_in_current_timeline(data);
-                let component_path = ComponentPath::new(tree.path.clone(), *component_name);
+                let component_path = ComponentPath::new(tree.path.clone(), component_name);
                 let short_component_name = component_path.component_name.short_name();
                 let item = TimePanelItem::component_path(component_path);
 
@@ -694,7 +694,7 @@ impl TimePanel {
                 ui.set_clip_rect(clip_rect);
 
                 let response =
-                    re_data_ui::temporary_style_ui_for_component(ui, component_name, |ui| {
+                    re_data_ui::temporary_style_ui_for_component(ui, &component_name, |ui| {
                         ListItem::new(ctx.re_ui, short_component_name)
                             .selected(ctx.selection().contains_item(&item.to_item()))
                             .width_allocation_mode(WidthAllocationMode::Compact)

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -693,22 +693,19 @@ impl TimePanel {
                 clip_rect.max.x = tree_max_y;
                 ui.set_clip_rect(clip_rect);
 
-                let response =
-                    re_data_ui::temporary_style_ui_for_component(ui, &component_name, |ui| {
-                        ListItem::new(ctx.re_ui, short_component_name)
-                            .selected(ctx.selection().contains_item(&item.to_item()))
-                            .width_allocation_mode(WidthAllocationMode::Compact)
-                            .force_hovered(
-                                ctx.selection_state()
-                                    .highlight_for_ui_element(&item.to_item())
-                                    == HoverHighlight::Hovered,
-                            )
-                            .with_icon_fn(|_, ui, rect, visual| {
-                                ui.painter()
-                                    .circle_filled(rect.center(), 2.0, visual.text_color());
-                            })
-                            .show(ui)
-                    });
+                let response = ListItem::new(ctx.re_ui, short_component_name)
+                    .selected(ctx.selection().contains_item(&item.to_item()))
+                    .width_allocation_mode(WidthAllocationMode::Compact)
+                    .force_hovered(
+                        ctx.selection_state()
+                            .highlight_for_ui_element(&item.to_item())
+                            == HoverHighlight::Hovered,
+                    )
+                    .with_icon_fn(|_, ui, rect, visual| {
+                        ui.painter()
+                            .circle_filled(rect.center(), 2.0, visual.text_color());
+                    })
+                    .show(ui);
 
                 ui.set_clip_rect(clip_rect_save);
 

--- a/crates/re_viewer/src/ui/override_ui.rs
+++ b/crates/re_viewer/src/ui/override_ui.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use itertools::Itertools;
 
 use re_data_store::{DataStore, LatestAtQuery};
-use re_data_ui::{is_component_visible_in_ui, temporary_style_ui_for_component};
+use re_data_ui::is_component_visible_in_ui;
 use re_entity_db::{EntityDb, InstancePath};
 use re_log_types::{DataCell, DataRow, RowId, StoreKind};
 use re_query_cache::external::re_query::get_component_with_instances;
@@ -132,12 +132,10 @@ pub fn override_ui(
                     });
                     // Component label
                     row.col(|ui| {
-                        temporary_style_ui_for_component(ui, component_name, |ui| {
-                            //  NOTE: this is not a component button because it is not a component that exists in the recording, just in the blueprint.
-                            // So we don't allow users to select it.
-                            ui.label(component_name.short_name())
-                                .on_hover_text(component_name.full_name());
-                        });
+                        //  NOTE: this is not a component button because it is not a component that exists in the recording, just in the blueprint.
+                        // So we don't allow users to select it.
+                        ui.label(component_name.short_name())
+                            .on_hover_text(component_name.full_name());
                     });
                     // Editor last to take up remainder of space
                     row.col(|ui| {

--- a/crates/re_viewer/src/ui/visible_history.rs
+++ b/crates/re_viewer/src/ui/visible_history.rs
@@ -470,10 +470,10 @@ fn visible_history_boundary_ui(
     let response = match visible_history_boundary {
         VisibleHistoryBoundary::RelativeToTimeCursor(value) => {
             // see note above
-            let low_bound_override = if !low_bound {
-                Some(other_boundary_absolute.saturating_sub(current_time))
-            } else {
+            let low_bound_override = if low_bound {
                 None
+            } else {
+                Some(other_boundary_absolute.saturating_sub(current_time))
             };
 
             match time_type {
@@ -504,10 +504,10 @@ fn visible_history_boundary_ui(
         }
         VisibleHistoryBoundary::Absolute(value) => {
             // see note above
-            let low_bound_override = if !low_bound {
-                Some(other_boundary_absolute)
-            } else {
+            let low_bound_override = if low_bound {
                 None
+            } else {
+                Some(other_boundary_absolute)
             };
 
             match time_type {

--- a/crates/re_viewer_context/src/app_options.rs
+++ b/crates/re_viewer_context/src/app_options.rs
@@ -45,7 +45,7 @@ impl Default for AppOptions {
             low_latency: 0.100,
             warn_latency: 0.200,
 
-            show_metrics: false,
+            show_metrics: cfg!(debug_assertions),
 
             #[cfg(not(target_arch = "wasm32"))]
             experimental_space_view_screenshots: false,


### PR DESCRIPTION
### What
### Before:
![image](https://github.com/rerun-io/rerun/assets/1148717/d0ae0960-667e-4b62-9b11-82d662e0d6df)

### After:
![image](https://github.com/rerun-io/rerun/assets/1148717/5f431099-7c33-4146-b227-fc93b5eb6068)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5093/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5093/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5093/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5093)
- [Docs preview](https://rerun.io/preview/6f43a513569b5f7a703ead0bd754a896362028bc/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/6f43a513569b5f7a703ead0bd754a896362028bc/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)