### PR TITLE
Add missing inline for EntityPath Index

### DIFF
--- a/crates/re_log_types/src/path/entity_path.rs
+++ b/crates/re_log_types/src/path/entity_path.rs
@@ -310,6 +310,7 @@ where
 {
     type Output = Idx::Output;
 
+    #[inline]
     fn index(&self, index: Idx) -> &Self::Output {
         &self.parts[index]
     }


### PR DESCRIPTION
### What
What the title says

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5097/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5097/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5097/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5097)
- [Docs preview](https://rerun.io/preview/ca067ef77a0b47bf6f708c56a4ced141f270da1e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ca067ef77a0b47bf6f708c56a4ced141f270da1e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)