### PR TITLE
Mark TimeSeriesScalar as deprecated in all SDKs and documentation

### DIFF
--- a/.github/workflows/auto_release_crates.yml
+++ b/.github/workflows/auto_release_crates.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -208,7 +208,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       - run: pixi run lint-taplo
         shell: bash
@@ -296,7 +296,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       # TODO(emilk): make this work somehow. Right now this just results in
       # > Compiler: GNU 12.3.0 (/__w/rerun/rerun/.pixi/env/bin/x86_64-conda-linux-gnu-c++)

--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -99,11 +99,14 @@ jobs:
         run: |
           pip install -r rerun_py/requirements-lint.txt
 
-      - name: Codegen
-        uses: actions-rs/cargo@v1
+      - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          command: codegen
-          args: --force --check
+          pixi-version: v0.13.0
+
+      - name: Codegen check
+        shell: bash
+        run: |
+          pixi run codegen --force --check
 
   rs-lints:
     name: Rust lints (fmt, check, cranky, tests, doc)

--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       # These should already be in the docker container, but run for good measure. A no-op install
       # should be fast, and this way things don't break if we add new packages without rebuilding

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       - name: Update crate versions
         id: versioning
@@ -399,7 +399,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       - run: pixi run toml-fmt
         shell: bash

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -139,7 +139,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       - name: Build web-viewer
         shell: bash

--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -127,7 +127,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/reusable_build_examples.yml
+++ b/.github/workflows/reusable_build_examples.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       - name: Download Wheel
         uses: actions/download-artifact@v3

--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       - name: Build web-viewer (release)
         shell: bash

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -145,11 +145,14 @@ jobs:
         run: |
           pip install -r rerun_py/requirements-lint.txt
 
-      - name: Codegen
-        uses: actions-rs/cargo@v1
+      - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          command: codegen
-          args: --force --check
+          pixi-version: v0.13.0
+
+      - name: Codegen check
+        shell: bash
+        run: |
+          pixi run codegen --force --check
 
   rs-lints:
     name: Rust lints (fmt, check, cranky, tests, doc)

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -229,7 +229,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       - name: Taplo check
         shell: bash
@@ -342,7 +342,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       - name: prettier --check
         run: pixi run misc-fmt-check

--- a/.github/workflows/reusable_checks_cpp.yml
+++ b/.github/workflows/reusable_checks_cpp.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -206,7 +206,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       - name: Doxygen C++ docs
         shell: bash

--- a/.github/workflows/reusable_publish_npm.yml
+++ b/.github/workflows/reusable_publish_npm.yml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.3.0
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       - name: Publish packages
         env:

--- a/.github/workflows/reusable_publish_web.yml
+++ b/.github/workflows/reusable_publish_web.yml
@@ -74,7 +74,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       # built by `reusable_build_and_publish_wheels`
       - name: Download Wheel

--- a/.github/workflows/reusable_release_crates.yml
+++ b/.github/workflows/reusable_release_crates.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       - name: Build web-viewer
         shell: bash

--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -123,7 +123,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.6.0
+          pixi-version: v0.13.0
 
       # The pip-cache setup logic doesn't work in the ubuntu docker container
       # That's probably fine since we bake these deps into the container already

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ if(DEFINED ENV{RERUN_SET_CXX_VERSION})
 endif()
 
 # ------------------------------------------------------------------------------
-
 function(rerun_strict_warning_settings target)
     if(MSVC)
         # TODO(andreas): Try to enable /Wall
@@ -85,6 +84,7 @@ function(rerun_strict_warning_settings target)
                 -Wno-unreachable-code-break # TODO(emilk): remove this exception - we only need this because of codegen
                 -Wno-unreachable-code-return # TODO(emilk): remove this exception - we only need this because of codegen
                 -Wno-unused-macros
+                -Wno-unsafe-buffer-usage # There's a few helper ctors that run into this.
             )
         endif()
 

--- a/crates/re_data_store/benches/gc.rs
+++ b/crates/re_data_store/benches/gc.rs
@@ -81,9 +81,8 @@ fn plotting_dashboard(c: &mut Criterion) {
         .into()
     };
 
-    let mut datagen = |i| {
-        Box::new(re_types::archetypes::TimeSeriesScalar::new(i as f64)) as Box<dyn AsComponents>
-    };
+    let mut datagen =
+        |i| Box::new(re_types::archetypes::Scalar::new(i as f64)) as Box<dyn AsComponents>;
 
     // Default config
     group.bench_function("default", |b| {

--- a/crates/re_space_view_time_series/src/legacy_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/legacy_visualizer_system.rs
@@ -1,7 +1,6 @@
 use itertools::Itertools;
 use re_query_cache::QueryError;
 use re_types::{
-    archetypes::TimeSeriesScalar,
     components::{Color, Radius, Scalar, ScalarScattering, Text},
     Archetype, Loggable,
 };
@@ -15,6 +14,9 @@ use crate::{
     util::{determine_plot_bounds_and_time_per_pixel, determine_time_range, points_to_series},
     PlotPoint, PlotPointAttrs, PlotSeries, PlotSeriesKind, ScatterAttrs,
 };
+
+#[allow(deprecated)]
+use re_types::archetypes::TimeSeriesScalar;
 
 /// The legacy system for rendering [`TimeSeriesScalar`] archetypes.
 #[derive(Default, Debug)]
@@ -30,6 +32,7 @@ impl IdentifiedViewSystem for LegacyTimeSeriesSystem {
 }
 
 impl VisualizerSystem for LegacyTimeSeriesSystem {
+    #[allow(deprecated)]
     fn visualizer_query_info(&self) -> VisualizerQueryInfo {
         let mut query_info = VisualizerQueryInfo::from_archetype::<TimeSeriesScalar>();
         // Although we don't normally include indicator components in required components,
@@ -85,6 +88,7 @@ impl VisualizerSystem for LegacyTimeSeriesSystem {
 }
 
 impl LegacyTimeSeriesSystem {
+    #[allow(deprecated)]
     fn load_scalars(
         &mut self,
         ctx: &ViewerContext<'_>,

--- a/crates/re_types/definitions/rerun/archetypes/time_series_scalar.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/time_series_scalar.fbs
@@ -1,5 +1,6 @@
 include "fbs/attributes.fbs";
 
+include "rerun/attributes.fbs";
 include "rerun/datatypes.fbs";
 include "rerun/components.fbs";
 
@@ -22,6 +23,7 @@ namespace rerun.archetypes;
 /// \example scalar_simple title="Simple line plot" image="https://static.rerun.io/scalar_simple/8bcc92f56268739f8cd24d60d1fe72a655f62a46/1200w.png"
 /// \example scalar_multiple_plots !api title="Multiple time series plots" image="https://static.rerun.io/scalar_multiple/15845c2a348f875248fbd694e03eabd922741c4c/1200w.png"
 table TimeSeriesScalar (
+  "attr.rerun.deprecated": "Use the `Scalar` + (optional) `SeriesLine`/`SeriesPoint` archetypes instead, logged on the same entity.",
   "attr.rust.derive": "PartialEq"
 ) {
   // --- Required ---

--- a/crates/re_types/definitions/rerun/attributes.fbs
+++ b/crates/re_types/definitions/rerun/attributes.fbs
@@ -30,7 +30,7 @@ attribute "attr.rerun.override_type";
 /// This is used for example to scope blueprint types.
 attribute "attr.rerun.scope";
 
-/// Markes something as deprecated followed by a (non-optional!) migration note.
+/// Marks something as deprecated followed by a (non-optional!) migration note.
 ///
 /// If specified on an object (struct/enum/union), it becomes deprecated such
 /// that using the object should emit a warning in all target languages.

--- a/crates/re_types/definitions/rerun/attributes.fbs
+++ b/crates/re_types/definitions/rerun/attributes.fbs
@@ -29,3 +29,13 @@ attribute "attr.rerun.override_type";
 ///
 /// This is used for example to scope blueprint types.
 attribute "attr.rerun.scope";
+
+/// Markes something as deprecated followed by a (non-optional!) migration note.
+///
+/// If specified on an object (struct/enum/union), it becomes deprecated such
+/// that using the object should emit a warning in all target languages.
+/// Furthermore, documentation will mention that the object is deprecated and display
+/// the specified migration note.
+///
+/// TODO(andreas): This is not yet supported on fields.
+attribute "attr.rerun.deprecated";

--- a/crates/re_types/definitions/rerun/attributes.fbs
+++ b/crates/re_types/definitions/rerun/attributes.fbs
@@ -30,7 +30,7 @@ attribute "attr.rerun.override_type";
 /// This is used for example to scope blueprint types.
 attribute "attr.rerun.scope";
 
-/// Marks something as deprecated followed by a (non-optional!) migration note.
+/// Marks something as deprecated followed by a (mandatory!) migration note.
 ///
 /// If specified on an object (struct/enum/union), it becomes deprecated such
 /// that using the object should emit a warning in all target languages.

--- a/crates/re_types/src/archetypes/mod.rs
+++ b/crates/re_types/src/archetypes/mod.rs
@@ -65,7 +65,8 @@ pub use self::series_point::SeriesPoint;
 pub use self::tensor::Tensor;
 pub use self::text_document::TextDocument;
 pub use self::text_log::TextLog;
-#[allow(deprecated)]
-pub use self::time_series_scalar::TimeSeriesScalar;
 pub use self::transform3d::Transform3D;
 pub use self::view_coordinates::ViewCoordinates;
+
+#[allow(deprecated)]
+pub use self::time_series_scalar::TimeSeriesScalar;

--- a/crates/re_types/src/archetypes/mod.rs
+++ b/crates/re_types/src/archetypes/mod.rs
@@ -65,6 +65,7 @@ pub use self::series_point::SeriesPoint;
 pub use self::tensor::Tensor;
 pub use self::text_document::TextDocument;
 pub use self::text_log::TextLog;
+#[allow(deprecated)]
 pub use self::time_series_scalar::TimeSeriesScalar;
 pub use self::transform3d::Transform3D;
 pub use self::view_coordinates::ViewCoordinates;

--- a/crates/re_types/src/archetypes/time_series_scalar.rs
+++ b/crates/re_types/src/archetypes/time_series_scalar.rs
@@ -14,6 +14,7 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unnecessary_cast)]
+#![allow(deprecated)]
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::ComponentName;
@@ -57,6 +58,9 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// </picture>
 /// </center>
 #[derive(Clone, Debug, PartialEq)]
+#[deprecated(
+    note = "Use the `Scalar` + (optional) `SeriesLine`/`SeriesPoint` archetypes instead, logged on the same entity."
+)]
 pub struct TimeSeriesScalar {
     /// The scalar value to log.
     pub scalar: crate::components::Scalar,

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -559,13 +559,25 @@ impl QuotedObject {
         let indicator_fqname =
             format!("{}Indicator", obj.fqname).replace("archetypes", "components");
         let doc_hide_comment = quote_hide_from_docs();
+        let deprecation_notice = quote_deprecation_notice(obj);
+        let (deprecation_ignore_start, deprecation_ignore_end) =
+            if obj.deprecation_notice().is_some() {
+                hpp_includes.insert_rerun("compiler_utils.hpp");
+                (
+                    // Semicolon is just there to trick the formatter in not messing up indentation.
+                    quote! { RR_PUSH_WARNINGS RR_DISABLE_DEPRECATION_WARNING; #NEWLINE_TOKEN },
+                    quote! { RR_POP_WARNINGS },
+                )
+            } else {
+                (quote!(), quote!())
+            };
 
         let hpp = quote! {
             #hpp_includes
 
             namespace rerun::#quoted_namespace {
                 #quoted_docs
-                struct #type_ident {
+                struct #deprecation_notice #type_ident {
                     #(#field_declarations;)*
 
                 public:
@@ -594,16 +606,22 @@ impl QuotedObject {
                 template<typename T>
                 struct AsComponents;
 
+                #deprecation_ignore_start
+
                 #doc_hide_comment
                 template<>
                 struct AsComponents<#quoted_namespace::#type_ident> {
                     #serialize_hpp
                 };
+
+                #deprecation_ignore_end
             }
         };
 
         let cpp = quote! {
             #cpp_includes
+
+            #deprecation_ignore_start
 
             namespace rerun::#quoted_namespace {
                 #(#methods_cpp)*
@@ -614,6 +632,8 @@ impl QuotedObject {
                 #NEWLINE_TOKEN
                 #serialize_cpp
             }
+
+            #deprecation_ignore_end
         };
 
         Self { hpp, cpp }
@@ -636,6 +656,7 @@ impl QuotedObject {
 
         let type_ident = obj.ident();
         let quoted_docs = quote_obj_docs(obj);
+        let deprecation_notice = quote_deprecation_notice(obj);
 
         let mut cpp_includes = Includes::new(obj.fqname.clone(), obj.scope());
         let mut hpp_declarations = ForwardDecls::default();
@@ -711,7 +732,7 @@ impl QuotedObject {
 
             namespace rerun::#quoted_namespace {
                 #quoted_docs
-                struct #type_ident {
+                struct #deprecation_notice #type_ident {
                     #(#field_declarations;)*
 
                     #hpp_type_extensions
@@ -780,6 +801,7 @@ impl QuotedObject {
         let pascal_case_name = &obj.name;
         let pascal_case_ident = obj.ident();
         let quoted_docs = quote_obj_docs(obj);
+        let deprecation_notice = quote_deprecation_notice(obj);
 
         let tag_typename = format_ident!("{pascal_case_name}Tag");
         let data_typename = format_ident!("{pascal_case_name}Data");
@@ -1068,7 +1090,7 @@ impl QuotedObject {
                 }
 
                 #quoted_docs
-                struct #pascal_case_ident {
+                struct #deprecation_notice #pascal_case_ident {
                     #pascal_case_ident() : _tag(detail::#tag_typename::None) {}
 
                     #copy_constructor
@@ -2295,4 +2317,15 @@ fn quote_loggable_hpp_and_cpp(
     };
 
     (hpp, cpp)
+}
+
+fn quote_deprecation_notice(obj: &Object) -> TokenStream {
+    if let Some(deprecation_notice) = obj.deprecation_notice() {
+        // https://en.cppreference.com/w/cpp/language/attributes/deprecated
+        quote! {
+            [[deprecated(#deprecation_notice)]]
+        }
+    } else {
+        quote! {}
+    }
 }

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -564,8 +564,10 @@ impl QuotedObject {
             if obj.deprecation_notice().is_some() {
                 hpp_includes.insert_rerun("compiler_utils.hpp");
                 (
-                    // Semicolon is just there to trick the formatter in not messing up indentation.
-                    quote! { RR_PUSH_WARNINGS RR_DISABLE_DEPRECATION_WARNING; #NEWLINE_TOKEN },
+                    quote! {
+                        RR_PUSH_WARNINGS #NEWLINE_TOKEN
+                        RR_DISABLE_DEPRECATION_WARNING #NEWLINE_TOKEN
+                    },
                     quote! { RR_POP_WARNINGS },
                 )
             } else {

--- a/crates/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/re_types_builder/src/codegen/docs/mod.rs
@@ -108,9 +108,10 @@ fn index_page(kind: ObjectKind, order: u64, prelude: &str, objects: &[&Object]) 
     putln!(page, "{prelude}");
     putln!(page);
     if !objects.is_empty() {
+        // First all non deprecated ones:
         putln!(page, "## Available {}", kind.plural_name().to_lowercase());
         putln!(page);
-        for object in objects {
+        for object in objects.iter().filter(|o| o.deprecation_notice().is_none()) {
             putln!(
                 page,
                 "* [`{}`]({}/{}.md)",
@@ -118,6 +119,23 @@ fn index_page(kind: ObjectKind, order: u64, prelude: &str, objects: &[&Object]) 
                 object.kind.plural_snake_case(),
                 object.snake_case_name()
             );
+        }
+
+        // Then all deprecated ones:
+        if objects.iter().any(|o| o.deprecation_notice().is_some()) {
+            putln!(page);
+            putln!(page);
+            putln!(page, "## Deprecated {}", kind.plural_name().to_lowercase());
+            putln!(page);
+            for object in objects.iter().filter(|o| o.deprecation_notice().is_some()) {
+                putln!(
+                    page,
+                    "* [`{}`]({}/{}.md)",
+                    object.name,
+                    object.kind.plural_snake_case(),
+                    object.snake_case_name()
+                );
+            }
         }
     }
 

--- a/crates/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/re_types_builder/src/codegen/docs/mod.rs
@@ -144,8 +144,24 @@ fn object_page(reporter: &Reporter, object: &Object, object_map: &ObjectMap) -> 
 
     let mut page = String::new();
 
-    write_frontmatter(&mut page, &object.name, None);
+    let title = if object.deprecation_notice().is_some() {
+        format!("{} (deprecated)", object.name)
+    } else {
+        object.name.clone()
+    };
+
+    write_frontmatter(&mut page, &title, None);
     putln!(page);
+
+    if let Some(deprecation_notice) = object.deprecation_notice() {
+        putln!(
+            page,
+            "**⚠️ This type is deprecated and may be removed in future versions**"
+        );
+        putln!(page, "{deprecation_notice}");
+        putln!(page);
+    }
+
     for line in top_level_docs {
         putln!(page, "{line}");
     }

--- a/crates/re_types_builder/src/codegen/python.rs
+++ b/crates/re_types_builder/src/codegen/python.rs
@@ -362,6 +362,7 @@ impl PythonCodeGenerator {
 
             from typing import (Any, Dict, Iterable, Optional, Sequence, Set, Tuple, Union,
                 TYPE_CHECKING, SupportsFloat, Literal)
+            from typing_extensions import deprecated # type: ignore[misc, unused-ignore]
 
             from attrs import define, field
             import numpy as np
@@ -593,6 +594,10 @@ fn code_for_struct(
         ));
     }
 
+    if let Some(deprecation_notice) = obj.deprecation_notice() {
+        code.push_unindented_text(format!(r#"@deprecated("""{deprecation_notice}""")"#), 1);
+    }
+
     if !obj.is_delegating_component() {
         let define_args = if *kind == ObjectKind::Archetype {
             "str=False, repr=False, init=False"
@@ -788,6 +793,10 @@ fn code_for_union(
     } else {
         format!("({})", superclasses.join(","))
     };
+
+    if let Some(deprecation_notice) = obj.deprecation_notice() {
+        code.push_unindented_text(format!(r#"@deprecated("""{deprecation_notice}""")"#), 1);
+    }
 
     code.push_unindented_text(
         format!(

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -244,10 +244,25 @@ fn generate_mod_file(
 
     code += "\n\n";
 
-    for obj in objects {
+    // Non-deprecated first.
+    for obj in objects
+        .iter()
+        .filter(|obj| obj.deprecation_notice().is_none())
+    {
         let module_name = obj.snake_case_name();
         let type_name = &obj.name;
-
+        code.push_str(&format!("pub use self::{module_name}::{type_name};\n"));
+    }
+    // And then deprecated.
+    if objects.iter().any(|obj| obj.deprecation_notice().is_some()) {
+        code.push_str("\n\n");
+    }
+    for obj in objects
+        .iter()
+        .filter(|obj| obj.deprecation_notice().is_some())
+    {
+        let module_name = obj.snake_case_name();
+        let type_name = &obj.name;
         if obj.deprecation_notice().is_some() {
             code.push_str("#[allow(deprecated)]\n");
         }

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -171,6 +171,7 @@ pub const ATTR_RERUN_COMPONENT_RECOMMENDED: &str = "attr.rerun.component_recomme
 pub const ATTR_RERUN_COMPONENT_REQUIRED: &str = "attr.rerun.component_required";
 pub const ATTR_RERUN_OVERRIDE_TYPE: &str = "attr.rerun.override_type";
 pub const ATTR_RERUN_SCOPE: &str = "attr.rerun.scope";
+pub const ATTR_RERUN_DEPRECATED: &str = "attr.rerun.deprecated";
 
 pub const ATTR_PYTHON_ALIASES: &str = "attr.python.aliases";
 pub const ATTR_PYTHON_ARRAY_ALIASES: &str = "attr.python.array_aliases";

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -671,6 +671,10 @@ impl Object {
         self.try_get_attr::<String>(crate::ATTR_RERUN_SCOPE)
     }
 
+    pub fn deprecation_notice(&self) -> Option<String> {
+        self.try_get_attr::<String>(crate::ATTR_RERUN_DEPRECATED)
+    }
+
     /// Returns the crate name of an object, accounting for overrides.
     pub fn crate_name(&self) -> String {
         self.try_get_attr::<String>(crate::ATTR_RUST_OVERRIDE_CRATE)

--- a/docs/content/reference/types.md
+++ b/docs/content/reference/types.md
@@ -35,6 +35,12 @@ generic container for arrays of data. Images are restricted to tensors of rank 2
 * [SegmentationImage](types/archetypes/segmentation_image.md)
 * [Tensor](types/archetypes/tensor.md)
 
+## Time Series **Archetypes**
+* [Scalar](types/archetypes/time_series_scalar.md): a single scalar / metric value.
+* [SeriesPoint](types/archetypes/series_point.md): define the style properties for a point series in a chart.
+* [SeriesLine](types/archetypes/series_line.md): define the style properties for a line series in a chart.
+* [TimeSeriesScalar (deprecated)](types/archetypes/time_series_scalar.md): a single scalar / metric value as well as styling options. Can be viewed in the `TimeSeries` space view.
+
 ## Other **Archetypes**
 * [AnnotationContext](types/archetypes/annotation_context.md): not viewed directly, but provides classes, labels, and connectivity information for other entities.
 * [BarChart](types/archetypes/bar_chart.md): data displayed in a `BarChart` space view.
@@ -42,6 +48,5 @@ generic container for arrays of data. Images are restricted to tensors of rank 2
 * [DisconnectedSpace](types/archetypes/disconnected_space.md): disconnect an entity path from its parent.
 * [TextDocument](types/archetypes/text_document.md): text displayed in a `TextDocument` space view.
 * [TextLog](types/archetypes/text_log.md): a log entry in a `TextLog` space view.
-* [TimeSeriesScalar](types/archetypes/time_series_scalar.md): a single scalar / metric value. Can be viewed in the `TimeSeries` space view.
 * [ViewCoordinates](types/archetypes/view_coordinates.md): determines how we interpret the coordinate system of an entity/space.
 

--- a/docs/content/reference/types/archetypes.md
+++ b/docs/content/reference/types/archetypes.md
@@ -31,6 +31,6 @@ Archetypes are bundles of components
 * [`Tensor`](archetypes/tensor.md)
 * [`TextDocument`](archetypes/text_document.md)
 * [`TextLog`](archetypes/text_log.md)
-* [`TimeSeriesScalar`](archetypes/time_series_scalar.md)
+* [`TimeSeriesScalar`(deprecated)](archetypes/time_series_scalar.md)
 * [`Transform3D`](archetypes/transform3d.md)
 * [`ViewCoordinates`](archetypes/view_coordinates.md)

--- a/docs/content/reference/types/archetypes.md
+++ b/docs/content/reference/types/archetypes.md
@@ -31,6 +31,6 @@ Archetypes are bundles of components
 * [`Tensor`](archetypes/tensor.md)
 * [`TextDocument`](archetypes/text_document.md)
 * [`TextLog`](archetypes/text_log.md)
-* [`TimeSeriesScalar`(deprecated)](archetypes/time_series_scalar.md)
+* [`TimeSeriesScalar`](archetypes/time_series_scalar.md)
 * [`Transform3D`](archetypes/transform3d.md)
 * [`ViewCoordinates`](archetypes/view_coordinates.md)

--- a/docs/content/reference/types/archetypes.md
+++ b/docs/content/reference/types/archetypes.md
@@ -31,6 +31,10 @@ Archetypes are bundles of components
 * [`Tensor`](archetypes/tensor.md)
 * [`TextDocument`](archetypes/text_document.md)
 * [`TextLog`](archetypes/text_log.md)
-* [`TimeSeriesScalar`](archetypes/time_series_scalar.md)
 * [`Transform3D`](archetypes/transform3d.md)
 * [`ViewCoordinates`](archetypes/view_coordinates.md)
+
+
+## Deprecated archetypes
+
+* [`TimeSeriesScalar`](archetypes/time_series_scalar.md)

--- a/docs/content/reference/types/archetypes/time_series_scalar.md
+++ b/docs/content/reference/types/archetypes/time_series_scalar.md
@@ -1,6 +1,9 @@
 ---
-title: "TimeSeriesScalar"
+title: "TimeSeriesScalar (deprecated)"
 ---
+
+**⚠️ This type is deprecated and may be removed in future versions**
+Use the `Scalar` + (optional) `SeriesLine`/`SeriesPoint` archetypes instead, logged on the same entity.
 
 Log a double-precision scalar that will be visualized as a time-series plot.
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,302 +1,896 @@
-metadata:
-  content_hash:
-    linux-64: e90c2ee71ad70fc0a1c8302029533a7d1498f2bffcd0eaa8d2934700e775dc1d
-    osx-64: e90c2ee71ad70fc0a1c8302029533a7d1498f2bffcd0eaa8d2934700e775dc1d
-    osx-arm64: e90c2ee71ad70fc0a1c8302029533a7d1498f2bffcd0eaa8d2934700e775dc1d
-    win-64: e90c2ee71ad70fc0a1c8302029533a7d1498f2bffcd0eaa8d2934700e775dc1d
-  channels:
-  - url: https://conda.anaconda.org/conda-forge/
-    used_env_vars: []
-  platforms:
-  - linux-64
-  - osx-64
-  - osx-arm64
-  - win-64
-  sources: []
-  time_metadata: null
-  git_metadata: null
-  inputs_metadata: null
-  custom_metadata: null
-package:
-- platform: linux-64
+version: 4
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.10-h0100c56_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.9-h5d48c4d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.10-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h7f92143_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.0-h0bcb0bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.0-hd268abd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.36-hb3b01f7_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.0-hf5d392a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.4.7-he8c168f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.13-h7f92143_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h7f92143_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.0-h3b5eec7_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.210-hac0d6e5_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binaryen-116-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-hdd6e379_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hbdbef99_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/black-23.3.0-py311h38be061_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.24.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.6.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-16-16.0.6-default_hb11cfb5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-16.0.6-hda56bd4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-16-16.0.6-default_hb11cfb5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-16.0.6-default_hb11cfb5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-tools-16.0.6-default_hb11cfb5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.27.6-hcfe8598_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/colorlog-4.8.0-py311h38be061_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.6.0-h00ab1b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/doxygen-1.9.7-h661eb56_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-23.5.26-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h8d2909c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h76fc315_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h8d2909c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h8a814eb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/just-1.15.0-he8a937b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.2-h84dd17c_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.2-h59595ed_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.2-h59595ed_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.2-h120cb0d_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.2-h61ff412_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.2-hacb8726_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.2-h61ff412_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-18_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-18_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp16-16.0.6-default_hb11cfb5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-17.0.5-default_h4d60ac6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.5.0-hca28451_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-12.3.0-h8bca6fd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-h5206363_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.59.3-hd6c4280_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-18_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-h5cf9203_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm16-16.0.6-h5cf9203_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm17-17.0.5-h5cf9203_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.16-h0b41bf4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.2-h352af49_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.24.4-hf27288f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.06.02-h7a70373_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.43.0-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.46.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.5-h232c23b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py311h459d7ec_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-0.14.17-py311h46250e7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.4.1-py311h459d7ec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.1-h924138e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-18.18.2-hb753e55_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.0-py311h64a7726_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.2-h4b38347_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/prettier-2.8.8-h75cfd52_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py311h459d7ec_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.2-py311h39c9aba_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.6-hab00c5b_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-28.9-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.06.02-h2873b5e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.4-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.1.2-py311h7145743_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.1-h06160fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.8.1-he8a937b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/typos-1.16.20-he8a937b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-h64cca9d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-4.13.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.13.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nox-2021.10.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.24.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-16.0.6-ha38d28d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-4.13.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.13.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nox-2021.10.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.24.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.10-h5ed86db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.9-had988b7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.10-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-hb45f1eb_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.0-h451788f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.0-h1fa4523_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.13.36-h3728bb0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.0-hdd2773f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.4.7-hfc07516_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.13-hb45f1eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-hb45f1eb_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.0-h88f2ebf_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.210-heeba50e_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/binaryen-116-he965462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/black-23.3.0-py311h6eed73b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.24.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.6.0-h282daa2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-973.0.1-h40f6528_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-973.0.1-ha1c5b94_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-16-16.0.6-default_h7151d67_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-16.0.6-hdae98eb_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-format-16-16.0.6-default_h7151d67_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-format-16.0.6-default_h7151d67_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-tools-16.0.6-default_h7151d67_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-16.0.6-h8787910_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-16.0.6-hb91bd55_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx-16.0.6-default_h7151d67_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-16.0.6-h6d92fbe_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-16.0.6-hb91bd55_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.27.6-hf40c264_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/colorlog-4.8.0-py311h6eed73b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-16.0.6-ha38d28d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.6.0-h7728843_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/doxygen-1.9.7-hd7636e7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-23.5.26-he965462_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/just-1.15.0-h63b85fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-609-ha02d983_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-609-ha20a434_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.2-h1aaacd4_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.2-h000cb23_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.2-h000cb23_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.2-ha1803ca_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.2-h8ec153b_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.2-h01dce7f_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.2-h8ec153b_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-18_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-18_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp16-16.0.6-default_h7151d67_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang13-17.0.5-default_hb2321db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.5.0-h726d00d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-hc0857f6_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.59.3-ha7f534c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-18_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-he4b1e75_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm16-16.0.6-he4b1e75_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm17-17.0.5-h0a7b4ec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.2-h381d950_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.24.4-h0ee05dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.06.02-h4694dbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.43.2-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.46.0-h0c2f820_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.5-h3346baf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.2-hff08bdf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-16.0.6-he4b1e75_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py311h2725bcf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-0.14.17-py311h5b17fdd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.4.1-py311h2725bcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.1-hb8565cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nodejs-18.18.2-h2713218_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.0-py311hc44ba51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.0-hd75f5a5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.2-h9ab30d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/prettier-2.8.8-h3db311d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py311h2725bcf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.2-py311h54e7ce8_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.6-h30d4d87_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.06.02-hd34609a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.4-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.1.2-py311hec6fdf1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.8.1-h7205ca4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/typos-1.16.20-h63b85fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-16.0.6-h3808999_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-4.13.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.13.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nox-2021.10.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.24.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.10-h8e8137d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.9-hb1772db_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.10-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-hb1772db_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.0-h0ed9fda_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.0-hd747585_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.36-h1112932_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.0-hefd2eba_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.4.7-h0d871e0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.13-hb1772db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-hb1772db_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.26.0-hcc526ff_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.210-ha042220_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/binaryen-116-h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/black-23.3.0-py311h267d04e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.24.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.6.0-h6aa9301_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.7.22-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-973.0.1-h4faf515_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-973.0.1-h62378fb_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16-16.0.6-default_he012953_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16.0.6-h30cc82d_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-16-16.0.6-default_he012953_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-16.0.6-default_he012953_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-tools-16.0.6-default_he012953_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-16.0.6-hc421ffc_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-16.0.6-h54d7cd3_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-16.0.6-default_h4cf2255_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-16.0.6-hcd7bac0_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-16.0.6-h54d7cd3_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.27.6-h1c59155_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/colorlog-4.8.0-py311h267d04e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-16.0.6-h3808999_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.6.0-h2ffa867_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/doxygen-1.9.7-h0e2417a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-23.5.26-h13dd4ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/just-1.15.0-h5ef7bb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-609-h634c8be_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-609-ha4bd21c_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.2-h4ce3932_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.2-h13dd4ca_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.2-h13dd4ca_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.2-ha94d253_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.2-h39a9b85_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.2-hf757142_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.2-h7fd9903_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-18_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-18_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp16-16.0.6-default_he012953_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-17.0.5-default_he2e1a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.5.0-h2d989ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-hfb399a7_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.59.3-hbcf6334_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-18_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h504e6bf_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm16-16.0.6-he79909e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.5-hc359061_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.2-hf6ce1d5_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.24.4-hc9861d8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.06.02-h1753957_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.43.0-hb31c410_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.19.0-h026a170_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.46.0-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.5-h25269f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.2-h1c12783_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-16.0.6-he79909e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py311heffc1b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-0.14.17-py311h0563b04_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.4.1-py311heffc1b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.1-hffc8910_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-18.18.2-h7ed3092_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.0-py311hb8f3215_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.0-h0d3ecfb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.2-h7c018df_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-2.8.8-ha12bae2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py311heffc1b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.2-py311hd7bc329_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.6-h47c9636_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.06.02-h6135d0a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.4-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.1.2-py311h6fc163c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.8.1-h69fbcac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.16.20-h5ef7bb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-4.13.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.13.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nox-2021.10.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.24.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.10-h9ca94be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.9-h7f0e5be_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.10-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.17-h7f0e5be_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.0-h51e6447_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.0-h80119a0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.13.36-ha737126_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.0-h2889a98_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.4.7-hb620688_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.13-h7f0e5be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.17-h7f0e5be_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.26.0-hda755dc_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.210-h79fa1a6_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/binaryen-116-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/black-23.3.0-py311h1ea47a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.24.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/clang-format-16.0.6-default_h3a3e6c3_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/clang-tools-16.0.6-default_h3a3e6c3_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-3.27.6-hf0feee3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/colorlog-4.8.0-py311h1ea47a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/doxygen-1.9.7-h849606c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-23.5.26-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50496.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/just-1.15.0-h7f3b576_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230802.1-cxx17_h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-14.0.2-he5f67d5_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-14.0.2-h63175ca_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-14.0.2-h63175ca_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-14.0.2-h53b1db0_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-14.0.2-h78eab7c_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-14.0.2-hb2eaab1_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-14.0.2-hd4c9904_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-18_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-18_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-17.0.6-default_h85b4d89_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.5.0-hd5e4a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-h39f2fc6_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.59.3-h5bbd4a7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-18_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-14.0.2-h7ec3a38_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.24.4-hb8276f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.06.02-h8c5ae5e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.43.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.44.2-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.5-hc3477c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py311ha68e1ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/maturin-0.14.17-py311h9a9e57f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2022.1.0-h6a75c08_874.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.4.1-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ninja-1.11.1-h91493d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/nodejs-18.18.2-h57928b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.0-py311h0b4df5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.2-hf0b6bd4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/prettier-2.8.8-hd2f1330_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py311ha68e1ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-14.0.2-py311h6a6099b_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.6-h2628c8c_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2023.06.02-hcbb65ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.1.2-py311hc14472d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/taplo-0.8.1-h7f3b576_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/typos-1.16.20-h7f3b576_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.37.32822-h0123c8e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
+packages:
+- kind: conda
   name: _libgcc_mutex
   version: '0.1'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-  hash:
-    md5: d7c89558ba9fa0495403155b64376d81
-    sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   build: conda_forge
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  arch: x86_64
+  platform: linux
   license: None
   size: 2562
   timestamp: 1578324546067
-- platform: linux-64
+- kind: conda
   name: _openmp_mutex
   version: '4.5'
-  category: main
-  manager: conda
-  dependencies:
+  build: 2_gnu
+  build_number: 16
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
   - _libgcc_mutex ==0.1 conda_forge
   - libgomp >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-  hash:
-    md5: 73aaf86a425cc6e73fcf236a5a46396d
-    sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
-  build: 2_gnu
-  arch: x86_64
-  subdir: linux-64
-  build_number: 16
   constrains:
   - openmp_impl 9999
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 23621
   timestamp: 1650670423406
-- platform: linux-64
+- kind: conda
   name: argcomplete
   version: 1.12.3
-  category: main
-  manager: conda
-  dependencies:
-  - importlib_metadata >=0.23,<5
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.tar.bz2
-  hash:
-    md5: b8152341fc3fc9880c6e1b9d188974e5
-    sha256: 2abb116f5bdc62d5e83c9dd15e5fc30c2a9571f728ccc012fad03350ed1d581e
   build: pyhd8ed1ab_2
-  arch: x86_64
+  build_number: 2
   subdir: linux-64
-  build_number: 2
-  license: Apache-2.0
-  license_family: Apache
   noarch: python
-  size: 35310
-  timestamp: 1619128850100
-- platform: osx-64
-  name: argcomplete
-  version: 1.12.3
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.tar.bz2
+  sha256: 2abb116f5bdc62d5e83c9dd15e5fc30c2a9571f728ccc012fad03350ed1d581e
+  md5: b8152341fc3fc9880c6e1b9d188974e5
+  depends:
   - importlib_metadata >=0.23,<5
   - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.tar.bz2
-  hash:
-    md5: b8152341fc3fc9880c6e1b9d188974e5
-    sha256: 2abb116f5bdc62d5e83c9dd15e5fc30c2a9571f728ccc012fad03350ed1d581e
-  build: pyhd8ed1ab_2
   arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  license_family: Apache
+  size: 35310
+  timestamp: 1619128850100
+- kind: conda
+  name: argcomplete
+  version: 1.12.3
+  build: pyhd8ed1ab_2
+  build_number: 2
   subdir: osx-64
-  build_number: 2
-  license: Apache-2.0
-  license_family: Apache
   noarch: python
-  size: 35310
-  timestamp: 1619128850100
-- platform: osx-arm64
-  name: argcomplete
-  version: 1.12.3
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.tar.bz2
+  sha256: 2abb116f5bdc62d5e83c9dd15e5fc30c2a9571f728ccc012fad03350ed1d581e
+  md5: b8152341fc3fc9880c6e1b9d188974e5
+  depends:
   - importlib_metadata >=0.23,<5
   - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.tar.bz2
-  hash:
-    md5: b8152341fc3fc9880c6e1b9d188974e5
-    sha256: 2abb116f5bdc62d5e83c9dd15e5fc30c2a9571f728ccc012fad03350ed1d581e
-  build: pyhd8ed1ab_2
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  noarch: python
-  size: 35310
-  timestamp: 1619128850100
-- platform: win-64
-  name: argcomplete
-  version: 1.12.3
-  category: main
-  manager: conda
-  dependencies:
-  - importlib_metadata >=0.23,<5
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.tar.bz2
-  hash:
-    md5: b8152341fc3fc9880c6e1b9d188974e5
-    sha256: 2abb116f5bdc62d5e83c9dd15e5fc30c2a9571f728ccc012fad03350ed1d581e
-  build: pyhd8ed1ab_2
   arch: x86_64
-  subdir: win-64
-  build_number: 2
+  platform: osx
   license: Apache-2.0
   license_family: Apache
-  noarch: python
   size: 35310
   timestamp: 1619128850100
-- platform: linux-64
+- kind: conda
+  name: argcomplete
+  version: 1.12.3
+  build: pyhd8ed1ab_2
+  build_number: 2
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.tar.bz2
+  sha256: 2abb116f5bdc62d5e83c9dd15e5fc30c2a9571f728ccc012fad03350ed1d581e
+  md5: b8152341fc3fc9880c6e1b9d188974e5
+  depends:
+  - importlib_metadata >=0.23,<5
+  - python >=3.5
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 35310
+  timestamp: 1619128850100
+- kind: conda
+  name: argcomplete
+  version: 1.12.3
+  build: pyhd8ed1ab_2
+  build_number: 2
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.tar.bz2
+  sha256: 2abb116f5bdc62d5e83c9dd15e5fc30c2a9571f728ccc012fad03350ed1d581e
+  md5: b8152341fc3fc9880c6e1b9d188974e5
+  depends:
+  - importlib_metadata >=0.23,<5
+  - python >=3.5
+  arch: x86_64
+  platform: win
+  license: Apache-2.0
+  license_family: Apache
+  size: 35310
+  timestamp: 1619128850100
+- kind: conda
   name: attrs
   version: 23.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
-  hash:
-    md5: 3edfead7cedd1ab4400a6c588f3e75f8
-    sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
   build: pyh71513ae_1
-  arch: x86_64
+  build_number: 1
   subdir: linux-64
-  build_number: 1
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+  sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
+  md5: 3edfead7cedd1ab4400a6c588f3e75f8
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 55022
   timestamp: 1683424195402
-- platform: osx-64
+- kind: conda
   name: attrs
   version: 23.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
-  hash:
-    md5: 3edfead7cedd1ab4400a6c588f3e75f8
-    sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
   build: pyh71513ae_1
-  arch: x86_64
+  build_number: 1
   subdir: osx-64
-  build_number: 1
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 55022
-  timestamp: 1683424195402
-- platform: osx-arm64
-  name: attrs
-  version: 23.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
-  hash:
-    md5: 3edfead7cedd1ab4400a6c588f3e75f8
-    sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
-  build: pyh71513ae_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 55022
-  timestamp: 1683424195402
-- platform: win-64
-  name: attrs
-  version: 23.1.0
-  category: main
-  manager: conda
-  dependencies:
+  sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
+  md5: 3edfead7cedd1ab4400a6c588f3e75f8
+  depends:
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
-  hash:
-    md5: 3edfead7cedd1ab4400a6c588f3e75f8
-    sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
-  build: pyh71513ae_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 55022
   timestamp: 1683424195402
-- platform: linux-64
+- kind: conda
+  name: attrs
+  version: 23.1.0
+  build: pyh71513ae_1
+  build_number: 1
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+  sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
+  md5: 3edfead7cedd1ab4400a6c588f3e75f8
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 55022
+  timestamp: 1683424195402
+- kind: conda
+  name: attrs
+  version: 23.1.0
+  build: pyh71513ae_1
+  build_number: 1
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+  sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
+  md5: 3edfead7cedd1ab4400a6c588f3e75f8
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 55022
+  timestamp: 1683424195402
+- kind: conda
   name: aws-c-auth
   version: 0.7.10
-  category: main
-  manager: conda
-  dependencies:
+  build: h0100c56_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.10-h0100c56_1.conda
+  sha256: c822e61835f090e0fc321817d722a6053faca660057c33bd95954d80c679f36a
+  md5: 00f2ad7c8c2fb1da92d977e295db497f
+  depends:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
   - aws-c-io >=0.13.36,<0.13.37.0a0
   - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.10-h0100c56_1.conda
-  hash:
-    md5: 00f2ad7c8c2fb1da92d977e295db497f
-    sha256: c822e61835f090e0fc321817d722a6053faca660057c33bd95954d80c679f36a
-  build: h0100c56_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: linux
   license: Apache-2.0
   license_family: Apache
   size: 102789
   timestamp: 1704305750207
-- platform: osx-64
+- kind: conda
   name: aws-c-auth
   version: 0.7.10
-  category: main
-  manager: conda
-  dependencies:
+  build: h5ed86db_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.10-h5ed86db_1.conda
+  sha256: 120cf938c27b84a1c097fe5d1cecd1795f1a931c1927b4d8a660e3ae4c51c612
+  md5: d73780e88fdb08b65d2feac9d3146489
+  depends:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
   - aws-c-io >=0.13.36,<0.13.37.0a0
   - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.10-h5ed86db_1.conda
-  hash:
-    md5: d73780e88fdb08b65d2feac9d3146489
-    sha256: 120cf938c27b84a1c097fe5d1cecd1795f1a931c1927b4d8a660e3ae4c51c612
-  build: h5ed86db_1
   arch: x86_64
-  subdir: osx-64
-  build_number: 1
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 89858
   timestamp: 1704306024343
-- platform: osx-arm64
+- kind: conda
   name: aws-c-auth
   version: 0.7.10
-  category: main
-  manager: conda
-  dependencies:
+  build: h8e8137d_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.10-h8e8137d_1.conda
+  sha256: adfad1ddb4aad1cb2b0a83971cd80c82910cdcd092ef52e137a0c571a6d89f56
+  md5: cc56487f52b54dd9c1cccdc24f0249ea
+  depends:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
   - aws-c-io >=0.13.36,<0.13.37.0a0
   - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.10-h8e8137d_1.conda
-  hash:
-    md5: cc56487f52b54dd9c1cccdc24f0249ea
-    sha256: adfad1ddb4aad1cb2b0a83971cd80c82910cdcd092ef52e137a0c571a6d89f56
-  build: h8e8137d_1
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 89155
   timestamp: 1704306064106
-- platform: win-64
+- kind: conda
   name: aws-c-auth
   version: 0.7.10
-  category: main
-  manager: conda
-  dependencies:
+  build: h9ca94be_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.10-h9ca94be_1.conda
+  sha256: 66d6fa8cd3f2ad8525776dc1b31ce2174c05db72114c41232dba49f86a9b0ffd
+  md5: e1eac5752ab1e8e6c7337a3d7d67d369
+  depends:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
@@ -305,419 +899,326 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.10-h9ca94be_1.conda
-  hash:
-    md5: e1eac5752ab1e8e6c7337a3d7d67d369
-    sha256: 66d6fa8cd3f2ad8525776dc1b31ce2174c05db72114c41232dba49f86a9b0ffd
-  build: h9ca94be_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 98828
   timestamp: 1704306645080
-- platform: linux-64
+- kind: conda
   name: aws-c-cal
   version: 0.6.9
-  category: main
-  manager: conda
-  dependencies:
+  build: h5d48c4d_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.9-h5d48c4d_2.conda
+  sha256: ec56734a24eee51e2f89bec3d686dd2c4dbb09d0305248b1d14e4c748065dc23
+  md5: 9e51dfd5da37c1817d2a850188861987
+  depends:
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - libgcc-ng >=12
   - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.9-h5d48c4d_2.conda
-  hash:
-    md5: 9e51dfd5da37c1817d2a850188861987
-    sha256: ec56734a24eee51e2f89bec3d686dd2c4dbb09d0305248b1d14e4c748065dc23
-  build: h5d48c4d_2
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: Apache-2.0
   license_family: Apache
   size: 55554
   timestamp: 1701212359409
-- platform: osx-64
+- kind: conda
   name: aws-c-cal
   version: 0.6.9
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.9-had988b7_2.conda
-  hash:
-    md5: 2a5755b9c5f9765a9967b277fb8a832b
-    sha256: 22f1272836f73b133912b0b77a0c832366d3bcdfef3a4df1dd4efd2409128e60
-  build: had988b7_2
-  arch: x86_64
-  subdir: osx-64
+  build: h7f0e5be_2
   build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  size: 45613
-  timestamp: 1701212818559
-- platform: osx-arm64
-  name: aws-c-cal
-  version: 0.6.9
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.9-hb1772db_2.conda
-  hash:
-    md5: 412ec63d1ac917e45f3206dd29dcc7e8
-    sha256: 7059960c1e765461227da57112fa3aabcef2292c83499d0440da46ec938ba017
-  build: hb1772db_2
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  size: 39662
-  timestamp: 1701212885323
-- platform: win-64
-  name: aws-c-cal
-  version: 0.6.9
-  category: main
-  manager: conda
-  dependencies:
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.9-h7f0e5be_2.conda
+  sha256: bdbe7e12e6956b2ebcbe6d2db358cf59175de74b3e76d9b7ec692f216f49a814
+  md5: 0fdb0a1d40c981aa16aa3d62ee0690b0
+  depends:
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.9-h7f0e5be_2.conda
-  hash:
-    md5: 0fdb0a1d40c981aa16aa3d62ee0690b0
-    sha256: bdbe7e12e6956b2ebcbe6d2db358cf59175de74b3e76d9b7ec692f216f49a814
-  build: h7f0e5be_2
   arch: x86_64
-  subdir: win-64
-  build_number: 2
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 55762
   timestamp: 1701212916082
-- platform: linux-64
-  name: aws-c-common
-  version: 0.9.10
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.10-hd590300_0.conda
-  hash:
-    md5: 93729f7a54b25cb135ac2b67ea3a7603
-    sha256: dba8a20acedc6bc3574e4068c196969881462ad831aae267d25fbc9409785a6b
-  build: hd590300_0
+- kind: conda
+  name: aws-c-cal
+  version: 0.6.9
+  build: had988b7_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.9-had988b7_2.conda
+  sha256: 22f1272836f73b133912b0b77a0c832366d3bcdfef3a4df1dd4efd2409128e60
+  md5: 2a5755b9c5f9765a9967b277fb8a832b
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: osx
   license: Apache-2.0
   license_family: Apache
-  size: 225475
-  timestamp: 1701169650086
-- platform: osx-64
+  size: 45613
+  timestamp: 1701212818559
+- kind: conda
+  name: aws-c-cal
+  version: 0.6.9
+  build: hb1772db_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.9-hb1772db_2.conda
+  sha256: 7059960c1e765461227da57112fa3aabcef2292c83499d0440da46ec938ba017
+  md5: 412ec63d1ac917e45f3206dd29dcc7e8
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 39662
+  timestamp: 1701212885323
+- kind: conda
   name: aws-c-common
   version: 0.9.10
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.10-h10d778d_0.conda
-  hash:
-    md5: d639668144f530bf8b6f56d4b5a64f3c
-    sha256: 34d04f691bc4ff924627314ecbb7f4c7b9dd779f3ed5576f12d61e073536a8bb
   build: h10d778d_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.10-h10d778d_0.conda
+  sha256: 34d04f691bc4ff924627314ecbb7f4c7b9dd779f3ed5576f12d61e073536a8bb
+  md5: d639668144f530bf8b6f56d4b5a64f3c
+  arch: x86_64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 207354
   timestamp: 1701170066323
-- platform: osx-arm64
+- kind: conda
   name: aws-c-common
   version: 0.9.10
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.10-h93a5062_0.conda
-  hash:
-    md5: 7b7bd1f14689ddec8131a0c4111790ca
-    sha256: 3269c3773d02262132cff14819bb606360c2ca44cdf9373e1a67f118c7a5232b
   build: h93a5062_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.10-h93a5062_0.conda
+  sha256: 3269c3773d02262132cff14819bb606360c2ca44cdf9373e1a67f118c7a5232b
+  md5: 7b7bd1f14689ddec8131a0c4111790ca
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 204196
   timestamp: 1701169900533
-- platform: win-64
+- kind: conda
   name: aws-c-common
   version: 0.9.10
-  category: main
-  manager: conda
-  dependencies:
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.10-hcfcfb64_0.conda
+  sha256: 1b684b9f5bf6ab632c8b6053f49398543035f342bef854ff3920620b02523527
+  md5: 3f7811fe6edcc81c4d4177ad0ce487e5
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.10-hcfcfb64_0.conda
-  hash:
-    md5: 3f7811fe6edcc81c4d4177ad0ce487e5
-    sha256: 1b684b9f5bf6ab632c8b6053f49398543035f342bef854ff3920620b02523527
-  build: hcfcfb64_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 221072
   timestamp: 1701169989150
-- platform: linux-64
-  name: aws-c-compression
-  version: 0.2.17
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h7f92143_7.conda
-  hash:
-    md5: c55a1a0c1419fcdfce6d21c41b0f92ab
-    sha256: ce508018c1109d4e5c6b65695639deaa2beea31edc39145bb810efb13ffed2c3
-  build: h7f92143_7
-  arch: x86_64
+- kind: conda
+  name: aws-c-common
+  version: 0.9.10
+  build: hd590300_0
   subdir: linux-64
-  build_number: 7
-  license: Apache-2.0
-  license_family: Apache
-  size: 19185
-  timestamp: 1701212362896
-- platform: osx-64
-  name: aws-c-compression
-  version: 0.2.17
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-hb45f1eb_7.conda
-  hash:
-    md5: 745ce5b224f24179d94287c190464ecb
-    sha256: 0d8e18977a54eea25826836cd20cc05f620f4165d3d94b7d4300583fb698a3a8
-  build: hb45f1eb_7
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.10-hd590300_0.conda
+  sha256: dba8a20acedc6bc3574e4068c196969881462ad831aae267d25fbc9409785a6b
+  md5: 93729f7a54b25cb135ac2b67ea3a7603
+  depends:
+  - libgcc-ng >=12
   arch: x86_64
-  subdir: osx-64
-  build_number: 7
+  platform: linux
   license: Apache-2.0
   license_family: Apache
-  size: 18129
-  timestamp: 1701212675008
-- platform: osx-arm64
+  size: 225475
+  timestamp: 1701169650086
+- kind: conda
   name: aws-c-compression
   version: 0.2.17
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-hb1772db_7.conda
-  hash:
-    md5: 5363bbd9ffcea69e9ef383766dcc49e0
-    sha256: e74330ffc64ac9bd9eb89c1e9d1004fe9b2aa689ecf8d5a94fdb17438237659b
-  build: hb1772db_7
-  arch: aarch64
-  subdir: osx-arm64
+  build: h7f0e5be_7
   build_number: 7
-  license: Apache-2.0
-  license_family: Apache
-  size: 18255
-  timestamp: 1701212799172
-- platform: win-64
-  name: aws-c-compression
-  version: 0.2.17
-  category: main
-  manager: conda
-  dependencies:
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.17-h7f0e5be_7.conda
+  sha256: e06ed4e1f8e010956dff1a95829705870686731f0c98379e9fa7b826e45e679a
+  md5: 69d748215192102a575970ee5e973b5a
+  depends:
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.17-h7f0e5be_7.conda
-  hash:
-    md5: 69d748215192102a575970ee5e973b5a
-    sha256: e06ed4e1f8e010956dff1a95829705870686731f0c98379e9fa7b826e45e679a
-  build: h7f0e5be_7
   arch: x86_64
-  subdir: win-64
-  build_number: 7
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 22425
   timestamp: 1701212989240
-- platform: linux-64
+- kind: conda
+  name: aws-c-compression
+  version: 0.2.17
+  build: h7f92143_7
+  build_number: 7
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h7f92143_7.conda
+  sha256: ce508018c1109d4e5c6b65695639deaa2beea31edc39145bb810efb13ffed2c3
+  md5: c55a1a0c1419fcdfce6d21c41b0f92ab
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  license_family: Apache
+  size: 19185
+  timestamp: 1701212362896
+- kind: conda
+  name: aws-c-compression
+  version: 0.2.17
+  build: hb1772db_7
+  build_number: 7
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-hb1772db_7.conda
+  sha256: e74330ffc64ac9bd9eb89c1e9d1004fe9b2aa689ecf8d5a94fdb17438237659b
+  md5: 5363bbd9ffcea69e9ef383766dcc49e0
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 18255
+  timestamp: 1701212799172
+- kind: conda
+  name: aws-c-compression
+  version: 0.2.17
+  build: hb45f1eb_7
+  build_number: 7
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-hb45f1eb_7.conda
+  sha256: 0d8e18977a54eea25826836cd20cc05f620f4165d3d94b7d4300583fb698a3a8
+  md5: 745ce5b224f24179d94287c190464ecb
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 18129
+  timestamp: 1701212675008
+- kind: conda
   name: aws-c-event-stream
   version: 0.4.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h0bcb0bb_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.0-h0bcb0bb_0.conda
+  sha256: d17a3e562f3166cbff44b7e4e0682a3a62102de3f55b8ac5f947a6e9a74023d3
+  md5: 9bbc75881d8fe9a6803a8c5a0432efaa
+  depends:
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - aws-c-io >=0.13.36,<0.13.37.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.0-h0bcb0bb_0.conda
-  hash:
-    md5: 9bbc75881d8fe9a6803a8c5a0432efaa
-    sha256: d17a3e562f3166cbff44b7e4e0682a3a62102de3f55b8ac5f947a6e9a74023d3
-  build: h0bcb0bb_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: Apache-2.0
   license_family: Apache
   size: 53782
   timestamp: 1703907019941
-- platform: osx-64
+- kind: conda
   name: aws-c-event-stream
   version: 0.4.0
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  - aws-checksums >=0.1.17,<0.1.18.0a0
-  - libcxx >=15
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.0-h451788f_0.conda
-  hash:
-    md5: 1ae42d84a8228e5068325cb407c0ad9f
-    sha256: a6538855dd93800c2e7235875e3616cd10dc6d0fa1b6993d2c4c0ce3b9f72b57
-  build: h451788f_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 46862
-  timestamp: 1703907246896
-- platform: osx-arm64
-  name: aws-c-event-stream
-  version: 0.4.0
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  - aws-checksums >=0.1.17,<0.1.18.0a0
-  - libcxx >=15
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.0-h0ed9fda_0.conda
-  hash:
-    md5: c55732ba808815f3a03d2b5794134280
-    sha256: 2e575e82e96e4a51dac746788b020934614d852a2a835a3d7e059676fac9e14b
   build: h0ed9fda_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.0-h0ed9fda_0.conda
+  sha256: 2e575e82e96e4a51dac746788b020934614d852a2a835a3d7e059676fac9e14b
+  md5: c55732ba808815f3a03d2b5794134280
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libcxx >=15
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 46786
   timestamp: 1703907291564
-- platform: win-64
+- kind: conda
   name: aws-c-event-stream
   version: 0.4.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h451788f_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.0-h451788f_0.conda
+  sha256: a6538855dd93800c2e7235875e3616cd10dc6d0fa1b6993d2c4c0ce3b9f72b57
+  md5: 1ae42d84a8228e5068325cb407c0ad9f
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libcxx >=15
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 46862
+  timestamp: 1703907246896
+- kind: conda
+  name: aws-c-event-stream
+  version: 0.4.0
+  build: h51e6447_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.0-h51e6447_0.conda
+  sha256: 2670ae79526739fc52c7c765b0de61799dc3ca8f0eee107b8e72acc929fbe1b0
+  md5: 800d13259e8dc2b433a58b0cbbe8b583
+  depends:
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - aws-c-io >=0.13.36,<0.13.37.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.0-h51e6447_0.conda
-  hash:
-    md5: 800d13259e8dc2b433a58b0cbbe8b583
-    sha256: 2670ae79526739fc52c7c765b0de61799dc3ca8f0eee107b8e72acc929fbe1b0
-  build: h51e6447_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 55245
   timestamp: 1703907564028
-- platform: linux-64
+- kind: conda
   name: aws-c-http
   version: 0.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-compression >=0.2.17,<0.2.18.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.0-hd268abd_0.conda
-  hash:
-    md5: 1599ecff110d53e20423f7849eec49d5
-    sha256: 4ec9f1d427587e57dcd5777a6aa38efd3b9492023b2ea10ba3ff2b3ef288b3a5
-  build: hd268abd_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 195138
-  timestamp: 1703907239593
-- platform: osx-64
-  name: aws-c-http
-  version: 0.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-compression >=0.2.17,<0.2.18.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.0-h1fa4523_0.conda
-  hash:
-    md5: b1e224c2d021d01fcb7a9320ecd3c8af
-    sha256: afb48dedc10cb9cab50aee069bc0232190928f65416bad814d07d77d7305da79
   build: h1fa4523_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.0-h1fa4523_0.conda
+  sha256: afb48dedc10cb9cab50aee069bc0232190928f65416bad814d07d77d7305da79
+  md5: b1e224c2d021d01fcb7a9320ecd3c8af
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  arch: x86_64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 162823
   timestamp: 1703907372701
-- platform: osx-arm64
+- kind: conda
   name: aws-c-http
   version: 0.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-compression >=0.2.17,<0.2.18.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.0-hd747585_0.conda
-  hash:
-    md5: 506d80c1882e0368b58e0e348469a452
-    sha256: d4757939742d600180f85827801f486ba53208b9216780e0d741cebd4cdd5546
-  build: hd747585_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 151658
-  timestamp: 1703907442170
-- platform: win-64
-  name: aws-c-http
-  version: 0.8.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h80119a0_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.0-h80119a0_0.conda
+  sha256: 0705fde59a6f3894d53fb597c79ad0514cbd245b6f06fec71b0a801e123563de
+  md5: b6bdba53d4f89d5b74009499bddd80b2
+  depends:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - aws-c-compression >=0.2.17,<0.2.18.0a0
@@ -725,271 +1226,240 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.0-h80119a0_0.conda
-  hash:
-    md5: b6bdba53d4f89d5b74009499bddd80b2
-    sha256: 0705fde59a6f3894d53fb597c79ad0514cbd245b6f06fec71b0a801e123563de
-  build: h80119a0_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 180505
   timestamp: 1703907512117
-- platform: linux-64
-  name: aws-c-io
-  version: 0.13.36
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - libgcc-ng >=12
-  - s2n >=1.4.1,<1.4.2.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.36-hb3b01f7_3.conda
-  hash:
-    md5: e699c37931ecbb452a6d074c1c738b07
-    sha256: ed17d57f20e62b77680d91eec3b98ce4f208ad58deb87c1ca6114942ecb9aecd
-  build: hb3b01f7_3
-  arch: x86_64
+- kind: conda
+  name: aws-c-http
+  version: 0.8.0
+  build: hd268abd_0
   subdir: linux-64
-  build_number: 3
-  license: Apache-2.0
-  license_family: Apache
-  size: 156739
-  timestamp: 1703277263617
-- platform: osx-64
-  name: aws-c-io
-  version: 0.13.36
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.0-hd268abd_0.conda
+  sha256: 4ec9f1d427587e57dcd5777a6aa38efd3b9492023b2ea10ba3ff2b3ef288b3a5
+  md5: 1599ecff110d53e20423f7849eec49d5
+  depends:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.13.36-h3728bb0_3.conda
-  hash:
-    md5: 5fb516f968b8465843147e70502b3b30
-    sha256: 6e6698f3f7ccc3b7adc4eff3c1fc0f01f28960a67b7cfbd8ada2f9e1e5aae957
-  build: h3728bb0_3
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - libgcc-ng >=12
   arch: x86_64
-  subdir: osx-64
-  build_number: 3
+  platform: linux
   license: Apache-2.0
   license_family: Apache
-  size: 137884
-  timestamp: 1703277470793
-- platform: osx-arm64
-  name: aws-c-io
-  version: 0.13.36
-  category: main
-  manager: conda
-  dependencies:
+  size: 195138
+  timestamp: 1703907239593
+- kind: conda
+  name: aws-c-http
+  version: 0.8.0
+  build: hd747585_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.0-hd747585_0.conda
+  sha256: d4757939742d600180f85827801f486ba53208b9216780e0d741cebd4cdd5546
+  md5: 506d80c1882e0368b58e0e348469a452
+  depends:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.36-h1112932_3.conda
-  hash:
-    md5: 732c739df5de131665801871650c2399
-    sha256: 8770803baa7323891abcf892e36abce13d6f67d675ebe91ab538621f90e8319f
-  build: h1112932_3
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
   arch: aarch64
-  subdir: osx-arm64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 151658
+  timestamp: 1703907442170
+- kind: conda
+  name: aws-c-io
+  version: 0.13.36
+  build: h1112932_3
   build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.36-h1112932_3.conda
+  sha256: 8770803baa7323891abcf892e36abce13d6f67d675ebe91ab538621f90e8319f
+  md5: 732c739df5de131665801871650c2399
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 136832
   timestamp: 1703277731454
-- platform: win-64
+- kind: conda
   name: aws-c-io
   version: 0.13.36
-  category: main
-  manager: conda
-  dependencies:
+  build: h3728bb0_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.13.36-h3728bb0_3.conda
+  sha256: 6e6698f3f7ccc3b7adc4eff3c1fc0f01f28960a67b7cfbd8ada2f9e1e5aae957
+  md5: 5fb516f968b8465843147e70502b3b30
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 137884
+  timestamp: 1703277470793
+- kind: conda
+  name: aws-c-io
+  version: 0.13.36
+  build: ha737126_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.13.36-ha737126_3.conda
+  sha256: 909ab6d661cdea988cccc501d0920759ad436d73f2e29b0b94898812b78a61f0
+  md5: 615c52e4ca99d6f05115bdcaf7989e4a
+  depends:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.13.36-ha737126_3.conda
-  hash:
-    md5: 615c52e4ca99d6f05115bdcaf7989e4a
-    sha256: 909ab6d661cdea988cccc501d0920759ad436d73f2e29b0b94898812b78a61f0
-  build: ha737126_3
   arch: x86_64
-  subdir: win-64
-  build_number: 3
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 158048
   timestamp: 1703277767799
-- platform: linux-64
-  name: aws-c-mqtt
-  version: 0.10.0
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.0-hf5d392a_2.conda
-  hash:
-    md5: 18eb32f275d7294045298f69fbed6ad1
-    sha256: 3fcd61a58aaeadcc6be2af3a3014647d72d78f3e0dcfa34d34d36c7363f465c9
-  build: hf5d392a_2
-  arch: x86_64
+- kind: conda
+  name: aws-c-io
+  version: 0.13.36
+  build: hb3b01f7_3
+  build_number: 3
   subdir: linux-64
-  build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  size: 163855
-  timestamp: 1704306435642
-- platform: osx-64
-  name: aws-c-mqtt
-  version: 0.10.0
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.36-hb3b01f7_3.conda
+  sha256: ed17d57f20e62b77680d91eec3b98ce4f208ad58deb87c1ca6114942ecb9aecd
+  md5: e699c37931ecbb452a6d074c1c738b07
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.0-hdd2773f_2.conda
-  hash:
-    md5: a8f39569f96c7aa29df8719bd221c37b
-    sha256: e08fa33b2a8e2d912524b9bb58a9cb243665e44735fddd885b6a1d9623168cc8
-  build: hdd2773f_2
+  - libgcc-ng >=12
+  - s2n >=1.4.1,<1.4.2.0a0
   arch: x86_64
-  subdir: osx-64
-  build_number: 2
+  platform: linux
   license: Apache-2.0
   license_family: Apache
-  size: 138442
-  timestamp: 1704306696839
-- platform: osx-arm64
+  size: 156739
+  timestamp: 1703277263617
+- kind: conda
   name: aws-c-mqtt
   version: 0.10.0
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.0-hefd2eba_2.conda
-  hash:
-    md5: 36b6e920548d1a9862214d6b85f3cda4
-    sha256: ffd577632ab5847b678070079f1eb796706fee641e1bd123676d72ccaab4c359
-  build: hefd2eba_2
-  arch: aarch64
-  subdir: osx-arm64
+  build: h2889a98_2
   build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  size: 117880
-  timestamp: 1704306343120
-- platform: win-64
-  name: aws-c-mqtt
-  version: 0.10.0
-  category: main
-  manager: conda
-  dependencies:
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.0-h2889a98_2.conda
+  sha256: b068b77bb7bda33edab25e5f97756127bd985850156068f5d879a6cbe492c72c
+  md5: e97e0269641768be849c4b7d4ac6acd1
+  depends:
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
   - aws-c-io >=0.13.36,<0.13.37.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.0-h2889a98_2.conda
-  hash:
-    md5: e97e0269641768be849c4b7d4ac6acd1
-    sha256: b068b77bb7bda33edab25e5f97756127bd985850156068f5d879a6cbe492c72c
-  build: h2889a98_2
   arch: x86_64
-  subdir: win-64
-  build_number: 2
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 158809
   timestamp: 1704306951855
-- platform: linux-64
-  name: aws-c-s3
-  version: 0.4.7
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-auth >=0.7.10,<0.7.11.0a0
-  - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  - aws-checksums >=0.1.17,<0.1.18.0a0
-  - libgcc-ng >=12
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.4.7-he8c168f_2.conda
-  hash:
-    md5: 8efc4a83d09d0985a1209e7db46a85df
-    sha256: 5dd6fe2c6008ecf36828364b737013bc3f577eabc087d521c739d16fa1b54e6d
-  build: he8c168f_2
-  arch: x86_64
-  subdir: linux-64
+- kind: conda
+  name: aws-c-mqtt
+  version: 0.10.0
+  build: hdd2773f_2
   build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  size: 103912
-  timestamp: 1704321466794
-- platform: osx-64
-  name: aws-c-s3
-  version: 0.4.7
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-auth >=0.7.10,<0.7.11.0a0
-  - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  - aws-checksums >=0.1.17,<0.1.18.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.4.7-hfc07516_2.conda
-  hash:
-    md5: 86621c40b75c87e88ed649dc67baca4a
-    sha256: 1fa26b0d77f38b381376240fd264427c45e8e54f18ed894bb0d3edcdc3bfbf36
-  build: hfc07516_2
-  arch: x86_64
   subdir: osx-64
-  build_number: 2
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.0-hdd2773f_2.conda
+  sha256: e08fa33b2a8e2d912524b9bb58a9cb243665e44735fddd885b6a1d9623168cc8
+  md5: a8f39569f96c7aa29df8719bd221c37b
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-http >=0.8.0,<0.8.1.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  arch: x86_64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
-  size: 90455
-  timestamp: 1704321754265
-- platform: osx-arm64
+  size: 138442
+  timestamp: 1704306696839
+- kind: conda
+  name: aws-c-mqtt
+  version: 0.10.0
+  build: hefd2eba_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.0-hefd2eba_2.conda
+  sha256: ffd577632ab5847b678070079f1eb796706fee641e1bd123676d72ccaab4c359
+  md5: 36b6e920548d1a9862214d6b85f3cda4
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-http >=0.8.0,<0.8.1.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 117880
+  timestamp: 1704306343120
+- kind: conda
+  name: aws-c-mqtt
+  version: 0.10.0
+  build: hf5d392a_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.0-hf5d392a_2.conda
+  sha256: 3fcd61a58aaeadcc6be2af3a3014647d72d78f3e0dcfa34d34d36c7363f465c9
+  md5: 18eb32f275d7294045298f69fbed6ad1
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-http >=0.8.0,<0.8.1.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  license_family: Apache
+  size: 163855
+  timestamp: 1704306435642
+- kind: conda
   name: aws-c-s3
   version: 0.4.7
-  category: main
-  manager: conda
-  dependencies:
+  build: h0d871e0_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.4.7-h0d871e0_2.conda
+  sha256: d94cee3ef3842e4200cd9535f27567fa1047f843dd31d3fa3e529ccd06ca32da
+  md5: 6367f7720abb8c4a8d12af09686dac6b
+  depends:
   - aws-c-auth >=0.7.10,<0.7.11.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
   - aws-c-io >=0.13.36,<0.13.37.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.4.7-h0d871e0_2.conda
-  hash:
-    md5: 6367f7720abb8c4a8d12af09686dac6b
-    sha256: d94cee3ef3842e4200cd9535f27567fa1047f843dd31d3fa3e529ccd06ca32da
-  build: h0d871e0_2
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 89206
   timestamp: 1704321752655
-- platform: win-64
+- kind: conda
   name: aws-c-s3
   version: 0.4.7
-  category: main
-  manager: conda
-  dependencies:
+  build: hb620688_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.4.7-hb620688_2.conda
+  sha256: 7be77cb9ff14834ff360ece85c5ba0a43ac3971c20f6276cd3c5a8792fea21e8
+  md5: 414c1d6c071e7a43fe0700d2df846905
+  depends:
   - aws-c-auth >=0.7.10,<0.7.11.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
@@ -999,184 +1469,208 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.4.7-hb620688_2.conda
-  hash:
-    md5: 414c1d6c071e7a43fe0700d2df846905
-    sha256: 7be77cb9ff14834ff360ece85c5ba0a43ac3971c20f6276cd3c5a8792fea21e8
-  build: hb620688_2
   arch: x86_64
-  subdir: win-64
-  build_number: 2
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 99991
   timestamp: 1704322032884
-- platform: linux-64
-  name: aws-c-sdkutils
-  version: 0.1.13
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.13-h7f92143_0.conda
-  hash:
-    md5: a4a83424ad4eab023c6e5b4adf264006
-    sha256: 8696e7023fde7c4588db8aedd08ffc0b4041c8449bd9edd50f237534cbcfac93
-  build: h7f92143_0
-  arch: x86_64
+- kind: conda
+  name: aws-c-s3
+  version: 0.4.7
+  build: he8c168f_2
+  build_number: 2
   subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 53339
-  timestamp: 1701999463183
-- platform: osx-64
-  name: aws-c-sdkutils
-  version: 0.1.13
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.4.7-he8c168f_2.conda
+  sha256: 5dd6fe2c6008ecf36828364b737013bc3f577eabc087d521c739d16fa1b54e6d
+  md5: 8efc4a83d09d0985a1209e7db46a85df
+  depends:
+  - aws-c-auth >=0.7.10,<0.7.11.0a0
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.13-hb45f1eb_0.conda
-  hash:
-    md5: 7bd97891383c905c06f1508405290cc0
-    sha256: 8224bc5d6a9659e165e7c1cd4b22f3b9ca5cda5ae5d7ce0ac54961035bf0c535
-  build: hb45f1eb_0
+  - aws-c-http >=0.8.0,<0.8.1.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libgcc-ng >=12
+  - openssl >=3.2.0,<4.0a0
   arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  license_family: Apache
+  size: 103912
+  timestamp: 1704321466794
+- kind: conda
+  name: aws-c-s3
+  version: 0.4.7
+  build: hfc07516_2
+  build_number: 2
   subdir: osx-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 47467
-  timestamp: 1701999663058
-- platform: osx-arm64
-  name: aws-c-sdkutils
-  version: 0.1.13
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.4.7-hfc07516_2.conda
+  sha256: 1fa26b0d77f38b381376240fd264427c45e8e54f18ed894bb0d3edcdc3bfbf36
+  md5: 86621c40b75c87e88ed649dc67baca4a
+  depends:
+  - aws-c-auth >=0.7.10,<0.7.11.0a0
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.13-hb1772db_0.conda
-  hash:
-    md5: 90291cf2e5e350b154f3fe1de4390af8
-    sha256: d9a89a98fea5d371cf0370c3f43479450932de070e960961d834624d00ead950
-  build: hb1772db_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  - aws-c-http >=0.8.0,<0.8.1.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  arch: x86_64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
-  size: 47384
-  timestamp: 1701999707452
-- platform: win-64
+  size: 90455
+  timestamp: 1704321754265
+- kind: conda
   name: aws-c-sdkutils
   version: 0.1.13
-  category: main
-  manager: conda
-  dependencies:
+  build: h7f0e5be_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.13-h7f0e5be_0.conda
+  sha256: 8da125c371f4e0205f0c0e8c39f650191cd8396407eeac05de5229e5532c920a
+  md5: cf9ffbe60dcb80c27928d57026334bc3
+  depends:
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.13-h7f0e5be_0.conda
-  hash:
-    md5: cf9ffbe60dcb80c27928d57026334bc3
-    sha256: 8da125c371f4e0205f0c0e8c39f650191cd8396407eeac05de5229e5532c920a
-  build: h7f0e5be_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 51515
   timestamp: 1702000014124
-- platform: linux-64
-  name: aws-checksums
-  version: 0.1.17
-  category: main
-  manager: conda
-  dependencies:
+- kind: conda
+  name: aws-c-sdkutils
+  version: 0.1.13
+  build: h7f92143_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.13-h7f92143_0.conda
+  sha256: 8696e7023fde7c4588db8aedd08ffc0b4041c8449bd9edd50f237534cbcfac93
+  md5: a4a83424ad4eab023c6e5b4adf264006
+  depends:
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h7f92143_6.conda
-  hash:
-    md5: 46bd4e9c2fd10de83bae22f0bb71139b
-    sha256: ac2082211e7d5fd3036f9abd7e398ef67d5327efb3808f17a30fcab59acacbfb
-  build: h7f92143_6
   arch: x86_64
-  subdir: linux-64
-  build_number: 6
+  platform: linux
   license: Apache-2.0
   license_family: Apache
-  size: 50162
-  timestamp: 1701246709430
-- platform: osx-64
-  name: aws-checksums
-  version: 0.1.17
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-hb45f1eb_6.conda
-  hash:
-    md5: 3c93bf40376489c5c880be77ba47f5c0
-    sha256: a09f546c5d9a658bd4ce51f4432a7f82e59c9416faf3b7902b06d1aaffcbeb56
-  build: hb45f1eb_6
-  arch: x86_64
-  subdir: osx-64
-  build_number: 6
-  license: Apache-2.0
-  license_family: Apache
-  size: 48848
-  timestamp: 1701246965518
-- platform: osx-arm64
-  name: aws-checksums
-  version: 0.1.17
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-hb1772db_6.conda
-  hash:
-    md5: da58c3c6dcf40cfa69a0a74a7acf355c
-    sha256: 9c72adde6dd106aa0ce0bc21252a9a5c9645c9efb93b5f9c08a914e45a3ad78c
-  build: hb1772db_6
-  arch: aarch64
+  size: 53339
+  timestamp: 1701999463183
+- kind: conda
+  name: aws-c-sdkutils
+  version: 0.1.13
+  build: hb1772db_0
   subdir: osx-arm64
-  build_number: 6
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.13-hb1772db_0.conda
+  sha256: d9a89a98fea5d371cf0370c3f43479450932de070e960961d834624d00ead950
+  md5: 90291cf2e5e350b154f3fe1de4390af8
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
-  size: 49237
-  timestamp: 1701247014330
-- platform: win-64
+  size: 47384
+  timestamp: 1701999707452
+- kind: conda
+  name: aws-c-sdkutils
+  version: 0.1.13
+  build: hb45f1eb_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.13-hb45f1eb_0.conda
+  sha256: 8224bc5d6a9659e165e7c1cd4b22f3b9ca5cda5ae5d7ce0ac54961035bf0c535
+  md5: 7bd97891383c905c06f1508405290cc0
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 47467
+  timestamp: 1701999663058
+- kind: conda
   name: aws-checksums
   version: 0.1.17
-  category: main
-  manager: conda
-  dependencies:
+  build: h7f0e5be_6
+  build_number: 6
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.17-h7f0e5be_6.conda
+  sha256: 6dbe39ecb73b46b83aa988e07e7227b24ee8d51f032a4045a0019a51f4afc46f
+  md5: b32576f8734446040f525baacb93480c
+  depends:
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.17-h7f0e5be_6.conda
-  hash:
-    md5: b32576f8734446040f525baacb93480c
-    sha256: 6dbe39ecb73b46b83aa988e07e7227b24ee8d51f032a4045a0019a51f4afc46f
-  build: h7f0e5be_6
   arch: x86_64
-  subdir: win-64
-  build_number: 6
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 52402
   timestamp: 1701247480992
-- platform: linux-64
+- kind: conda
+  name: aws-checksums
+  version: 0.1.17
+  build: h7f92143_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h7f92143_6.conda
+  sha256: ac2082211e7d5fd3036f9abd7e398ef67d5327efb3808f17a30fcab59acacbfb
+  md5: 46bd4e9c2fd10de83bae22f0bb71139b
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  license_family: Apache
+  size: 50162
+  timestamp: 1701246709430
+- kind: conda
+  name: aws-checksums
+  version: 0.1.17
+  build: hb1772db_6
+  build_number: 6
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-hb1772db_6.conda
+  sha256: 9c72adde6dd106aa0ce0bc21252a9a5c9645c9efb93b5f9c08a914e45a3ad78c
+  md5: da58c3c6dcf40cfa69a0a74a7acf355c
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 49237
+  timestamp: 1701247014330
+- kind: conda
+  name: aws-checksums
+  version: 0.1.17
+  build: hb45f1eb_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-hb45f1eb_6.conda
+  sha256: a09f546c5d9a658bd4ce51f4432a7f82e59c9416faf3b7902b06d1aaffcbeb56
+  md5: 3c93bf40376489c5c880be77ba47f5c0
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 48848
+  timestamp: 1701246965518
+- kind: conda
   name: aws-crt-cpp
   version: 0.26.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h3b5eec7_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.0-h3b5eec7_3.conda
+  sha256: 6a4638caea971b7588842309e8ceda7e9c422ac7877e66ffb371be9499ab7f52
+  md5: 76a7d5e9caccda4194477b6040863f27
+  depends:
   - aws-c-auth >=0.7.10,<0.7.11.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
@@ -1188,24 +1682,22 @@ package:
   - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.0-h3b5eec7_3.conda
-  hash:
-    md5: 76a7d5e9caccda4194477b6040863f27
-    sha256: 6a4638caea971b7588842309e8ceda7e9c422ac7877e66ffb371be9499ab7f52
-  build: h3b5eec7_3
   arch: x86_64
-  subdir: linux-64
-  build_number: 3
+  platform: linux
   license: Apache-2.0
   license_family: Apache
   size: 332540
   timestamp: 1704352136069
-- platform: osx-64
+- kind: conda
   name: aws-crt-cpp
   version: 0.26.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h88f2ebf_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.0-h88f2ebf_3.conda
+  sha256: 84d2cf38803bbdde1b4b6f9034efd9b76c14127d7f8e9e6bfabe89abeded0f88
+  md5: 4f21830317f110bb0c53332d55272587
+  depends:
   - aws-c-auth >=0.7.10,<0.7.11.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
@@ -1216,24 +1708,22 @@ package:
   - aws-c-s3 >=0.4.7,<0.4.8.0a0
   - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
   - libcxx >=15
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.0-h88f2ebf_3.conda
-  hash:
-    md5: 4f21830317f110bb0c53332d55272587
-    sha256: 84d2cf38803bbdde1b4b6f9034efd9b76c14127d7f8e9e6bfabe89abeded0f88
-  build: h88f2ebf_3
   arch: x86_64
-  subdir: osx-64
-  build_number: 3
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 280692
   timestamp: 1704352576363
-- platform: osx-arm64
+- kind: conda
   name: aws-crt-cpp
   version: 0.26.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hcc526ff_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.26.0-hcc526ff_3.conda
+  sha256: a8586d39c8a8c0b2b3f07b702f898c6caaad904ddeab655cfed4b818d753b627
+  md5: 21e0476de051cf3221eebceb21e1e890
+  depends:
   - aws-c-auth >=0.7.10,<0.7.11.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
@@ -1244,24 +1734,22 @@ package:
   - aws-c-s3 >=0.4.7,<0.4.8.0a0
   - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
   - libcxx >=15
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.26.0-hcc526ff_3.conda
-  hash:
-    md5: 21e0476de051cf3221eebceb21e1e890
-    sha256: a8586d39c8a8c0b2b3f07b702f898c6caaad904ddeab655cfed4b818d753b627
-  build: hcc526ff_3
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 3
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 217235
   timestamp: 1704352353546
-- platform: win-64
+- kind: conda
   name: aws-crt-cpp
   version: 0.26.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hda755dc_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.26.0-hda755dc_3.conda
+  sha256: 9c3d6b39a80892766aae30e25f42ebe4362b860eab3383d168797a289f477421
+  md5: 37c6ae5c9f1141b62b1eae46eebc35c8
+  depends:
   - aws-c-auth >=0.7.10,<0.7.11.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
@@ -1274,103 +1762,22 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.26.0-hda755dc_3.conda
-  hash:
-    md5: 37c6ae5c9f1141b62b1eae46eebc35c8
-    sha256: 9c3d6b39a80892766aae30e25f42ebe4362b860eab3383d168797a289f477421
-  build: hda755dc_3
   arch: x86_64
-  subdir: win-64
-  build_number: 3
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 242642
   timestamp: 1704352564082
-- platform: linux-64
+- kind: conda
   name: aws-sdk-cpp
   version: 1.11.210
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-event-stream >=0.4.0,<0.4.1.0a0
-  - aws-checksums >=0.1.17,<0.1.18.0a0
-  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.210-hac0d6e5_8.conda
-  hash:
-    md5: e7adaa813ace3f3b8516689716a28970
-    sha256: a9e58d64d613c075ded9fa812ce028f3d484f96e3f5c03559a004f761bced036
-  build: hac0d6e5_8
-  arch: x86_64
-  subdir: linux-64
+  build: h79fa1a6_8
   build_number: 8
-  license: Apache-2.0
-  license_family: Apache
-  size: 3547874
-  timestamp: 1704352516690
-- platform: osx-64
-  name: aws-sdk-cpp
-  version: 1.11.210
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-event-stream >=0.4.0,<0.4.1.0a0
-  - aws-checksums >=0.1.17,<0.1.18.0a0
-  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libcxx >=15
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.210-heeba50e_8.conda
-  hash:
-    md5: 31af5e0fb37e72362f087ca9e2748f5c
-    sha256: 7128b18540395212d4d6b4f8741f658d3900024bde9b5d3e32d6eaa4448325b3
-  build: heeba50e_8
-  arch: x86_64
-  subdir: osx-64
-  build_number: 8
-  license: Apache-2.0
-  license_family: Apache
-  size: 3267017
-  timestamp: 1704353210503
-- platform: osx-arm64
-  name: aws-sdk-cpp
-  version: 1.11.210
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-event-stream >=0.4.0,<0.4.1.0a0
-  - aws-checksums >=0.1.17,<0.1.18.0a0
-  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libcxx >=15
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.210-ha042220_8.conda
-  hash:
-    md5: e7aa143c60437c1625019add833b143e
-    sha256: 8588fec5385ae35add918a33b9b75fd79ef3007fd5d1c7db59b047bf1cac0311
-  build: ha042220_8
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 8
-  license: Apache-2.0
-  license_family: Apache
-  size: 3304720
-  timestamp: 1704352998014
-- platform: win-64
-  name: aws-sdk-cpp
-  version: 1.11.210
-  category: main
-  manager: conda
-  dependencies:
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.210-h79fa1a6_8.conda
+  sha256: b3d98f4d88953d70a71a25c0878656e3629663377904b80630346a267c240461
+  md5: f065f24d6d6276cf251eb97a0c6037ab
+  depends:
   - aws-c-common >=0.9.10,<0.9.11.0a0
   - aws-c-event-stream >=0.4.0,<0.4.1.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
@@ -1379,162 +1786,213 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.210-h79fa1a6_8.conda
-  hash:
-    md5: f065f24d6d6276cf251eb97a0c6037ab
-    sha256: b3d98f4d88953d70a71a25c0878656e3629663377904b80630346a267c240461
-  build: h79fa1a6_8
   arch: x86_64
-  subdir: win-64
-  build_number: 8
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 3334520
   timestamp: 1704353765135
-- platform: linux-64
-  name: binaryen
-  version: '116'
-  category: main
-  manager: conda
-  dependencies:
+- kind: conda
+  name: aws-sdk-cpp
+  version: 1.11.210
+  build: ha042220_8
+  build_number: 8
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.210-ha042220_8.conda
+  sha256: 8588fec5385ae35add918a33b9b75fd79ef3007fd5d1c7db59b047bf1cac0311
+  md5: e7aa143c60437c1625019add833b143e
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-event-stream >=0.4.0,<0.4.1.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
+  - libcurl >=8.5.0,<9.0a0
+  - libcxx >=15
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 3304720
+  timestamp: 1704352998014
+- kind: conda
+  name: aws-sdk-cpp
+  version: 1.11.210
+  build: hac0d6e5_8
+  build_number: 8
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.210-hac0d6e5_8.conda
+  sha256: a9e58d64d613c075ded9fa812ce028f3d484f96e3f5c03559a004f761bced036
+  md5: e7adaa813ace3f3b8516689716a28970
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-event-stream >=0.4.0,<0.4.1.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
+  - libcurl >=8.5.0,<9.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/binaryen-116-h59595ed_0.conda
-  hash:
-    md5: 52dff2370624a2be1e323c41e3882ed4
-    sha256: 84704b46b2bfde6d35fdd479bfe2769a6ef4c899677618ce1d6f8c926657cbf8
-  build: h59595ed_0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: Apache-2.0
-  license_family: APACHE
-  size: 5215096
-  timestamp: 1694722302360
-- platform: osx-64
-  name: binaryen
-  version: '116'
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-64/binaryen-116-he965462_0.conda
-  hash:
-    md5: 8c5fcc736f62d68f1807f87b3f36708b
-    sha256: ccdf062ca035f8087619c454d3a676dd1598626ee753799cdf8cba1e497bebbd
-  build: he965462_0
-  arch: x86_64
+  license_family: Apache
+  size: 3547874
+  timestamp: 1704352516690
+- kind: conda
+  name: aws-sdk-cpp
+  version: 1.11.210
+  build: heeba50e_8
+  build_number: 8
   subdir: osx-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.210-heeba50e_8.conda
+  sha256: 7128b18540395212d4d6b4f8741f658d3900024bde9b5d3e32d6eaa4448325b3
+  md5: 31af5e0fb37e72362f087ca9e2748f5c
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-event-stream >=0.4.0,<0.4.1.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
+  - libcurl >=8.5.0,<9.0a0
+  - libcxx >=15
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  arch: x86_64
+  platform: osx
   license: Apache-2.0
-  license_family: APACHE
-  size: 3440338
-  timestamp: 1694723081095
-- platform: osx-arm64
+  license_family: Apache
+  size: 3267017
+  timestamp: 1704353210503
+- kind: conda
   name: binaryen
   version: '116'
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/binaryen-116-h13dd4ca_0.conda
-  hash:
-    md5: e4aad775b4f2c3b336b8e2eea63eaff2
-    sha256: 80aba7f9d8f311ba103e6a4806231a404b0f39f130be5af07ea9574cd42afebf
   build: h13dd4ca_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/binaryen-116-h13dd4ca_0.conda
+  sha256: 80aba7f9d8f311ba103e6a4806231a404b0f39f130be5af07ea9574cd42afebf
+  md5: e4aad775b4f2c3b336b8e2eea63eaff2
+  depends:
+  - libcxx >=15.0.7
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 3505018
   timestamp: 1694723361260
-- platform: win-64
+- kind: conda
   name: binaryen
   version: '116'
-  category: main
-  manager: conda
-  dependencies:
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/binaryen-116-h59595ed_0.conda
+  sha256: 84704b46b2bfde6d35fdd479bfe2769a6ef4c899677618ce1d6f8c926657cbf8
+  md5: 52dff2370624a2be1e323c41e3882ed4
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5215096
+  timestamp: 1694722302360
+- kind: conda
+  name: binaryen
+  version: '116'
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/binaryen-116-h63175ca_0.conda
+  sha256: 531c4be009192cfb1b53ef1724fc3c670d16f629c20a77b5664b90f3c4d048c9
+  md5: eee203f471868cf9c078ddfae586f221
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/binaryen-116-h63175ca_0.conda
-  hash:
-    md5: eee203f471868cf9c078ddfae586f221
-    sha256: 531c4be009192cfb1b53ef1724fc3c670d16f629c20a77b5664b90f3c4d048c9
-  build: h63175ca_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: Apache-2.0
   license_family: APACHE
   size: 36575639
   timestamp: 1694723421705
-- platform: linux-64
+- kind: conda
+  name: binaryen
+  version: '116'
+  build: he965462_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/binaryen-116-he965462_0.conda
+  sha256: ccdf062ca035f8087619c454d3a676dd1598626ee753799cdf8cba1e497bebbd
+  md5: 8c5fcc736f62d68f1807f87b3f36708b
+  depends:
+  - libcxx >=15.0.7
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3440338
+  timestamp: 1694723081095
+- kind: conda
   name: binutils
   version: '2.40'
-  category: main
-  manager: conda
-  dependencies:
-  - binutils_impl_linux-64 >=2.40,<2.41.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-hdd6e379_0.conda
-  hash:
-    md5: ccc940fddbc3fcd3d79cd4c654c4b5c4
-    sha256: 35f3b042f295fd7387de11cf426ca8ee5257e5c98b88560c6c5ad4ef3c85d38c
   build: hdd6e379_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-hdd6e379_0.conda
+  sha256: 35f3b042f295fd7387de11cf426ca8ee5257e5c98b88560c6c5ad4ef3c85d38c
+  md5: ccc940fddbc3fcd3d79cd4c654c4b5c4
+  depends:
+  - binutils_impl_linux-64 >=2.40,<2.41.0a0
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   size: 30469
   timestamp: 1674833987166
-- platform: linux-64
+- kind: conda
   name: binutils_impl_linux-64
   version: '2.40'
-  category: main
-  manager: conda
-  dependencies:
+  build: hf600244_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
+  sha256: a7e0ea2b71a5b03d82e5a58fb6b612ab1c44d72ce161f9aa441f7ba467cd4c8d
+  md5: 33084421a8c0af6aef1b439707f7662a
+  depends:
   - ld_impl_linux-64 ==2.40 h41732ed_0
   - sysroot_linux-64 *
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
-  hash:
-    md5: 33084421a8c0af6aef1b439707f7662a
-    sha256: a7e0ea2b71a5b03d82e5a58fb6b612ab1c44d72ce161f9aa441f7ba467cd4c8d
-  build: hf600244_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   size: 5414922
   timestamp: 1674833958334
-- platform: linux-64
+- kind: conda
   name: binutils_linux-64
   version: '2.40'
-  category: main
-  manager: conda
-  dependencies:
+  build: hbdbef99_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hbdbef99_2.conda
+  sha256: 333f3339d94c93bcc02a723e3e460cb6ff6075e05f5247e15bef5dcdcec541a3
+  md5: adfebae9fdc63a598495dfe3b006973a
+  depends:
   - binutils_impl_linux-64 2.40.*
   - sysroot_linux-64 *
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hbdbef99_2.conda
-  hash:
-    md5: adfebae9fdc63a598495dfe3b006973a
-    sha256: 333f3339d94c93bcc02a723e3e460cb6ff6075e05f5247e15bef5dcdcec541a3
-  build: hbdbef99_2
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 28178
   timestamp: 1694604071236
-- platform: linux-64
+- kind: conda
   name: black
   version: 23.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py311h1ea47a8_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/black-23.3.0-py311h1ea47a8_1.conda
+  sha256: 12f319748c11697ee3ea154413c7c4895db2dfcc18b44b0bdb2019da1144abdb
+  md5: cff72d53d4ea05005adc2f478447a0a1
+  depends:
   - click >=8.0.0
   - mypy_extensions >=0.4.3
   - packaging >=22.0
@@ -1542,49 +2000,22 @@ package:
   - platformdirs >=2
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/black-23.3.0-py311h38be061_1.conda
-  hash:
-    md5: b0d621848bfba5aacbdfc43dfdeabfec
-    sha256: c729ebbdca2ca7286305ad51cc3beea6b85e68cd02794fb9895f3d5e16540b86
-  build: py311h38be061_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: win
   license: MIT
   license_family: MIT
-  size: 354716
-  timestamp: 1682492111062
-- platform: osx-64
+  size: 369420
+  timestamp: 1682492626505
+- kind: conda
   name: black
   version: 23.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - click >=8.0.0
-  - mypy_extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9
-  - platformdirs >=2
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/black-23.3.0-py311h6eed73b_1.conda
-  hash:
-    md5: 2783c68e84c0573fece0880488c7c001
-    sha256: 78b007b394be2e0ddd42224970be1b212639a8941fee0e7d724986155e517e24
-  build: py311h6eed73b_1
-  arch: x86_64
-  subdir: osx-64
+  build: py311h267d04e_1
   build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 355441
-  timestamp: 1682492328351
-- platform: osx-arm64
-  name: black
-  version: 23.3.0
-  category: main
-  manager: conda
-  dependencies:
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-23.3.0-py311h267d04e_1.conda
+  sha256: 6968e8bcc232a32cd34934d14ada2a9a2549db7f8276ba9709eb16595e5545fd
+  md5: 6df8788f081abb97d20ffa83de27d029
+  depends:
   - click >=8.0.0
   - mypy_extensions >=0.4.3
   - packaging >=22.0
@@ -1592,24 +2023,22 @@ package:
   - platformdirs >=2
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-23.3.0-py311h267d04e_1.conda
-  hash:
-    md5: 6df8788f081abb97d20ffa83de27d029
-    sha256: 6968e8bcc232a32cd34934d14ada2a9a2549db7f8276ba9709eb16595e5545fd
-  build: py311h267d04e_1
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
+  platform: osx
   license: MIT
   license_family: MIT
   size: 355456
   timestamp: 1682492376012
-- platform: win-64
+- kind: conda
   name: black
   version: 23.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py311h38be061_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/black-23.3.0-py311h38be061_1.conda
+  sha256: c729ebbdca2ca7286305ad51cc3beea6b85e68cd02794fb9895f3d5e16540b86
+  md5: b0d621848bfba5aacbdfc43dfdeabfec
+  depends:
   - click >=8.0.0
   - mypy_extensions >=0.4.3
   - packaging >=22.0
@@ -1617,1225 +2046,1088 @@ package:
   - platformdirs >=2
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/win-64/black-23.3.0-py311h1ea47a8_1.conda
-  hash:
-    md5: cff72d53d4ea05005adc2f478447a0a1
-    sha256: 12f319748c11697ee3ea154413c7c4895db2dfcc18b44b0bdb2019da1144abdb
-  build: py311h1ea47a8_1
   arch: x86_64
-  subdir: win-64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 354716
+  timestamp: 1682492111062
+- kind: conda
+  name: black
+  version: 23.3.0
+  build: py311h6eed73b_1
   build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 369420
-  timestamp: 1682492626505
-- platform: linux-64
-  name: blackdoc
-  version: 0.3.8
-  category: main
-  manager: conda
-  dependencies:
-  - black *
-  - importlib-metadata *
-  - more-itertools *
-  - python >=3.7
-  - rich *
-  - tomli *
-  url: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: c03749cb0d5874fd5b9c1620a3d230c4
-    sha256: ec7b75c0f88db3e8c8b506ec48fa4fa210b0c1d09b0969df726a68b5563d151d
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 30092
-  timestamp: 1667565048643
-- platform: osx-64
-  name: blackdoc
-  version: 0.3.8
-  category: main
-  manager: conda
-  dependencies:
-  - black *
-  - importlib-metadata *
-  - more-itertools *
-  - python >=3.7
-  - rich *
-  - tomli *
-  url: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: c03749cb0d5874fd5b9c1620a3d230c4
-    sha256: ec7b75c0f88db3e8c8b506ec48fa4fa210b0c1d09b0969df726a68b5563d151d
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-64/black-23.3.0-py311h6eed73b_1.conda
+  sha256: 78b007b394be2e0ddd42224970be1b212639a8941fee0e7d724986155e517e24
+  md5: 2783c68e84c0573fece0880488c7c001
+  depends:
+  - click >=8.0.0
+  - mypy_extensions >=0.4.3
+  - packaging >=22.0
+  - pathspec >=0.9
+  - platformdirs >=2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 30092
-  timestamp: 1667565048643
-- platform: osx-arm64
+  size: 355441
+  timestamp: 1682492328351
+- kind: conda
   name: blackdoc
   version: 0.3.8
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
+  sha256: ec7b75c0f88db3e8c8b506ec48fa4fa210b0c1d09b0969df726a68b5563d151d
+  md5: c03749cb0d5874fd5b9c1620a3d230c4
+  depends:
   - black *
   - importlib-metadata *
   - more-itertools *
   - python >=3.7
   - rich *
   - tomli *
-  url: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: c03749cb0d5874fd5b9c1620a3d230c4
-    sha256: ec7b75c0f88db3e8c8b506ec48fa4fa210b0c1d09b0969df726a68b5563d151d
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 30092
+  timestamp: 1667565048643
+- kind: conda
+  name: blackdoc
+  version: 0.3.8
   build: pyhd8ed1ab_0
-  arch: aarch64
+  subdir: osx-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
+  sha256: ec7b75c0f88db3e8c8b506ec48fa4fa210b0c1d09b0969df726a68b5563d151d
+  md5: c03749cb0d5874fd5b9c1620a3d230c4
+  depends:
+  - black *
+  - importlib-metadata *
+  - more-itertools *
+  - python >=3.7
+  - rich *
+  - tomli *
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 30092
+  timestamp: 1667565048643
+- kind: conda
+  name: blackdoc
+  version: 0.3.8
+  build: pyhd8ed1ab_0
   subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 30092
-  timestamp: 1667565048643
-- platform: win-64
-  name: blackdoc
-  version: 0.3.8
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
+  sha256: ec7b75c0f88db3e8c8b506ec48fa4fa210b0c1d09b0969df726a68b5563d151d
+  md5: c03749cb0d5874fd5b9c1620a3d230c4
+  depends:
   - black *
   - importlib-metadata *
   - more-itertools *
   - python >=3.7
   - rich *
   - tomli *
-  url: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: c03749cb0d5874fd5b9c1620a3d230c4
-    sha256: ec7b75c0f88db3e8c8b506ec48fa4fa210b0c1d09b0969df726a68b5563d151d
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 30092
   timestamp: 1667565048643
-- platform: linux-64
-  name: bzip2
-  version: 1.0.8
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
-  hash:
-    md5: a1fd65c7ccbf10880423d82bca54eb54
-    sha256: cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa
-  build: h7f98852_4
+- kind: conda
+  name: blackdoc
+  version: 0.3.8
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
+  sha256: ec7b75c0f88db3e8c8b506ec48fa4fa210b0c1d09b0969df726a68b5563d151d
+  md5: c03749cb0d5874fd5b9c1620a3d230c4
+  depends:
+  - black *
+  - importlib-metadata *
+  - more-itertools *
+  - python >=3.7
+  - rich *
+  - tomli *
   arch: x86_64
-  subdir: linux-64
-  build_number: 4
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 495686
-  timestamp: 1606604745109
-- platform: osx-64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 30092
+  timestamp: 1667565048643
+- kind: conda
   name: bzip2
   version: 1.0.8
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
-  hash:
-    md5: 37edc4e6304ca87316e160f5ca0bd1b5
-    sha256: 60ba4c64f5d0afca0d283c7addba577d3e2efc0db86002808dadb0498661b2f2
   build: h0d85af4_4
-  arch: x86_64
-  subdir: osx-64
   build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
+  sha256: 60ba4c64f5d0afca0d283c7addba577d3e2efc0db86002808dadb0498661b2f2
+  md5: 37edc4e6304ca87316e160f5ca0bd1b5
+  arch: x86_64
+  platform: osx
   license: bzip2-1.0.6
   license_family: BSD
   size: 158829
   timestamp: 1618862580095
-- platform: osx-arm64
+- kind: conda
   name: bzip2
   version: 1.0.8
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
-  hash:
-    md5: fc76ace7b94fb1f694988ab1b14dd248
-    sha256: a3efbd06ad1432edb0163c48225421f34c2660f5cc002283a8d27e791320b549
   build: h3422bc3_4
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
+  sha256: a3efbd06ad1432edb0163c48225421f34c2660f5cc002283a8d27e791320b549
+  md5: fc76ace7b94fb1f694988ab1b14dd248
+  arch: aarch64
+  platform: osx
   license: bzip2-1.0.6
   license_family: BSD
   size: 151850
   timestamp: 1618862645215
-- platform: win-64
+- kind: conda
   name: bzip2
   version: 1.0.8
-  category: main
-  manager: conda
-  dependencies:
+  build: h7f98852_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
+  sha256: cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa
+  md5: a1fd65c7ccbf10880423d82bca54eb54
+  depends:
+  - libgcc-ng >=9.3.0
+  arch: x86_64
+  platform: linux
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 495686
+  timestamp: 1606604745109
+- kind: conda
+  name: bzip2
+  version: 1.0.8
+  build: h8ffe710_4
+  build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
+  sha256: 5389dad4e73e4865bb485f460fc60b120bae74404003d457ecb1a62eb7abf0c1
+  md5: 7c03c66026944073040cb19a4f3ec3c9
+  depends:
   - vc >=14.1,<15.0a0
   - vs2015_runtime >=14.16.27012
-  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
-  hash:
-    md5: 7c03c66026944073040cb19a4f3ec3c9
-    sha256: 5389dad4e73e4865bb485f460fc60b120bae74404003d457ecb1a62eb7abf0c1
-  build: h8ffe710_4
   arch: x86_64
-  subdir: win-64
-  build_number: 4
+  platform: win
   license: bzip2-1.0.6
   license_family: BSD
   size: 152247
   timestamp: 1606605223049
-- platform: linux-64
+- kind: conda
   name: c-ares
   version: 1.24.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.24.0-hd590300_0.conda
-  hash:
-    md5: f5842b88e9cbfa177abfaeacd457a45d
-    sha256: b68b0611d1c9d0222b56d5fe3d634e7a26979c3aef30f5f48b1593e7249e8f7a
-  build: hd590300_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 156389
-  timestamp: 1702831601527
-- platform: osx-64
-  name: c-ares
-  version: 1.24.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.24.0-h10d778d_0.conda
-  hash:
-    md5: 5ae247d8280a4581501ffe619b4a438e
-    sha256: d585f5a8142fbf07d58ecaf518d724d4a3feeb61324e81b8cf616a0a57a82c73
   build: h10d778d_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.24.0-h10d778d_0.conda
+  sha256: d585f5a8142fbf07d58ecaf518d724d4a3feeb61324e81b8cf616a0a57a82c73
+  md5: 5ae247d8280a4581501ffe619b4a438e
+  arch: x86_64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 141730
   timestamp: 1702831748124
-- platform: osx-arm64
+- kind: conda
   name: c-ares
   version: 1.24.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.24.0-h93a5062_0.conda
-  hash:
-    md5: 10cffc463301ca93deba3242812f8db9
-    sha256: 377c0fc09449482cf7e0dd579caeeae296620c9f41a67dcfb78d891024e880d6
   build: h93a5062_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.24.0-h93a5062_0.conda
+  sha256: 377c0fc09449482cf7e0dd579caeeae296620c9f41a67dcfb78d891024e880d6
+  md5: 10cffc463301ca93deba3242812f8db9
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 140324
   timestamp: 1702831824733
-- platform: win-64
+- kind: conda
   name: c-ares
   version: 1.24.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.24.0-hcfcfb64_0.conda
+  sha256: db132a4983c458358f26f5db121f2aaeac49fe4f8fee0ffa4bf21b7a40f174b2
+  md5: d21ad5175ca04c56045dc50d29003823
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.24.0-hcfcfb64_0.conda
-  hash:
-    md5: d21ad5175ca04c56045dc50d29003823
-    sha256: db132a4983c458358f26f5db121f2aaeac49fe4f8fee0ffa4bf21b7a40f174b2
-  build: hcfcfb64_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
   size: 148216
   timestamp: 1702832093839
-- platform: linux-64
+- kind: conda
+  name: c-ares
+  version: 1.24.0
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.24.0-hd590300_0.conda
+  sha256: b68b0611d1c9d0222b56d5fe3d634e7a26979c3aef30f5f48b1593e7249e8f7a
+  md5: f5842b88e9cbfa177abfaeacd457a45d
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 156389
+  timestamp: 1702831601527
+- kind: conda
   name: c-compiler
   version: 1.6.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h282daa2_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.6.0-h282daa2_0.conda
+  sha256: c52dcdd9b5fc9fd9a7eb028b7d4bb9f11f4ba3a7361e904d2b28bc12053bac23
+  md5: 2b801fd417843897458f4f8e132e05bb
+  depends:
+  - cctools >=949.0.1
+  - clang_osx-64 16.*
+  - ld64 >=530
+  - llvm-openmp
+  license: BSD
+  size: 6375
+  timestamp: 1701504699534
+- kind: conda
+  name: c-compiler
+  version: 1.6.0
+  build: h6aa9301_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.6.0-h6aa9301_0.conda
+  sha256: c7d7c09724e7c324ecd3ad2dee4f016149b93f9bd8ee67661cafb20993f5b8a9
+  md5: 0b204833d66694f214a5b3d7d2b87700
+  depends:
+  - cctools >=949.0.1
+  - clang_osx-arm64 16.*
+  - ld64 >=530
+  - llvm-openmp
+  license: BSD
+  size: 6380
+  timestamp: 1701504712958
+- kind: conda
+  name: c-compiler
+  version: 1.6.0
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.6.0-hd590300_0.conda
+  sha256: d741ff93d5f71a83a9be0f592682f31ca2d468c37177f18a8d1a2469bb821c05
+  md5: ea6c792f792bdd7ae6e7e2dee32f0a48
+  depends:
   - binutils *
   - gcc *
   - gcc_linux-64 12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.6.0-hd590300_0.conda
-  hash:
-    md5: ea6c792f792bdd7ae6e7e2dee32f0a48
-    sha256: d741ff93d5f71a83a9be0f592682f31ca2d468c37177f18a8d1a2469bb821c05
-  build: hd590300_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: BSD
   size: 6184
   timestamp: 1689097480051
-- platform: osx-64
-  name: c-compiler
-  version: 1.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - cctools >=949.0.1
-  - clang_osx-64 15.*
-  - ld64 >=530
-  - llvm-openmp *
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.6.0-h63c33a9_0.conda
-  hash:
-    md5: d7f3b8d3a85b4e7eded31adb611bb665
-    sha256: fe43bbe1b7c809b618808123a662333c20417bc98ffa5dc7d6da23c3c8ec236b
-  build: h63c33a9_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD
-  size: 6250
-  timestamp: 1689097835926
-- platform: osx-arm64
-  name: c-compiler
-  version: 1.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - cctools >=949.0.1
-  - clang_osx-arm64 15.*
-  - ld64 >=530
-  - llvm-openmp *
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.6.0-hd291e01_0.conda
-  hash:
-    md5: 7d58fb216ad601b545826449d8d4c34e
-    sha256: f2e837668ff628ef8b5d54fffbfe9596cdd3820f7c5a3fc5ad48b259ff99a501
-  build: hd291e01_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD
-  size: 6269
-  timestamp: 1689097851052
-- platform: linux-64
+- kind: conda
   name: ca-certificates
   version: 2023.7.22
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
-  hash:
-    md5: a73ecd2988327ad4c8f2c331482917f2
-    sha256: 525b7b6b5135b952ec1808de84e5eca57c7c7ff144e29ef3e96ae4040ff432c1
-  build: hbcca054_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: ISC
-  size: 149515
-  timestamp: 1690026108541
-- platform: osx-64
-  name: ca-certificates
-  version: 2023.7.22
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
-  hash:
-    md5: bf2c54c18997bf3542af074c10191771
-    sha256: 27de15e18a12117e83ac1eb8a8e52eb65731cc7f0b607a7922206a15e2460c7b
-  build: h8857fd0_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: ISC
-  size: 149911
-  timestamp: 1690026363769
-- platform: osx-arm64
-  name: ca-certificates
-  version: 2023.7.22
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.7.22-hf0a4a13_0.conda
-  hash:
-    md5: e1b99ac4dbcee71a71682996f67f7965
-    sha256: b220c001b0c1448a47cc49b42a622e06a540ec60b3f7a1e057fca1f37ce515e4
-  build: hf0a4a13_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: ISC
-  size: 149918
-  timestamp: 1690026385821
-- platform: win-64
-  name: ca-certificates
-  version: 2023.7.22
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
-  hash:
-    md5: b1c2327b36f1a25d96f2039b0d3e3739
-    sha256: b85a6f307f8e1c803cb570bdfb9e4d811a361417873ecd2ecf687587405a72e0
   build: h56e8100_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
+  sha256: b85a6f307f8e1c803cb570bdfb9e4d811a361417873ecd2ecf687587405a72e0
+  md5: b1c2327b36f1a25d96f2039b0d3e3739
+  arch: x86_64
+  platform: win
   license: ISC
   size: 150013
   timestamp: 1690026269050
-- platform: osx-64
-  name: cctools
-  version: 973.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - cctools_osx-64 ==973.0.1 habff3f6_15
-  - ld64 ==609 ha91a046_15
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/cctools-973.0.1-hd9ad811_15.conda
-  hash:
-    md5: 00374d616829d1e4d2266e571147848a
-    sha256: 6fc0e86e24687cde3476e04f001ac1edf5813c0caa15b72c913b660533428987
-  build: hd9ad811_15
-  arch: x86_64
+- kind: conda
+  name: ca-certificates
+  version: 2023.7.22
+  build: h8857fd0_0
   subdir: osx-64
-  build_number: 15
-  license: APSL-2.0
-  license_family: Other
-  size: 21917
-  timestamp: 1697075797642
-- platform: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
+  sha256: 27de15e18a12117e83ac1eb8a8e52eb65731cc7f0b607a7922206a15e2460c7b
+  md5: bf2c54c18997bf3542af074c10191771
+  arch: x86_64
+  platform: osx
+  license: ISC
+  size: 149911
+  timestamp: 1690026363769
+- kind: conda
+  name: ca-certificates
+  version: 2023.7.22
+  build: hbcca054_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
+  sha256: 525b7b6b5135b952ec1808de84e5eca57c7c7ff144e29ef3e96ae4040ff432c1
+  md5: a73ecd2988327ad4c8f2c331482917f2
+  arch: x86_64
+  platform: linux
+  license: ISC
+  size: 149515
+  timestamp: 1690026108541
+- kind: conda
+  name: ca-certificates
+  version: 2023.7.22
+  build: hf0a4a13_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.7.22-hf0a4a13_0.conda
+  sha256: b220c001b0c1448a47cc49b42a622e06a540ec60b3f7a1e057fca1f37ce515e4
+  md5: e1b99ac4dbcee71a71682996f67f7965
+  arch: aarch64
+  platform: osx
+  license: ISC
+  size: 149918
+  timestamp: 1690026385821
+- kind: conda
   name: cctools
   version: 973.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - cctools_osx-arm64 ==973.0.1 h2a25c60_14
-  - ld64 ==609 h89fa09d_14
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-973.0.1-hd1ac623_14.conda
-  hash:
-    md5: 46c0f28ac1c5f417f46e028212f72f91
-    sha256: d7520a360b9d9ea0690f20403d19a9bee5069f5844aa2f092c5bd24816f0a84d
-  build: hd1ac623_14
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 14
+  build: h40f6528_16
+  build_number: 16
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/cctools-973.0.1-h40f6528_16.conda
+  sha256: ef3afa0ca2e159360575d5de6cba102494d2dd03c0fda77e858ae9fba73b9e61
+  md5: b7234c329d4503600b032f168f4b65e7
+  depends:
+  - cctools_osx-64 973.0.1 ha1c5b94_16
+  - ld64 609 ha02d983_16
+  - libllvm16 >=16.0.6,<16.1.0a0
   license: APSL-2.0
   license_family: Other
-  size: 22053
-  timestamp: 1690768497252
-- platform: osx-64
+  size: 22144
+  timestamp: 1706798167450
+- kind: conda
+  name: cctools
+  version: 973.0.1
+  build: h4faf515_16
+  build_number: 16
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-973.0.1-h4faf515_16.conda
+  sha256: eb62575b0a4f306ed4fb8b874f109af7c622013eace2d9e533d6b3c88fea6c42
+  md5: 5fd71c6d5cef61d41af51b460265ef6f
+  depends:
+  - cctools_osx-arm64 973.0.1 h62378fb_16
+  - ld64 609 h634c8be_16
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: APSL-2.0
+  license_family: Other
+  size: 22117
+  timestamp: 1706798232449
+- kind: conda
   name: cctools_osx-64
   version: 973.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - ld64_osx-64 >=609,<610.0a0
-  - libcxx *
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - sigtool *
-  url: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-973.0.1-habff3f6_15.conda
-  hash:
-    md5: 015a19b3900b9fce20a48551e66f7699
-    sha256: ca00afdafb22d6c363921f1c81b35fabd9b7eefee7e1ea2ad4f0fe920b63d035
-  build: habff3f6_15
-  arch: x86_64
+  build: ha1c5b94_16
+  build_number: 16
   subdir: osx-64
-  build_number: 15
+  url: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-973.0.1-ha1c5b94_16.conda
+  sha256: aa69f18388246169ac603148501bdd507bf935e97f384cf8f78ef94e3b296158
+  md5: 00eb71204323fa6449b38dd34ab9c65d
+  depends:
+  - ld64_osx-64 >=609,<610.0a0
+  - libcxx
+  - libllvm16 >=16.0.6,<16.1.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - sigtool
   constrains:
   - cctools 973.0.1.*
+  - clang 16.0.*
   - ld64 609.*
-  - clang 15.0.*
   license: APSL-2.0
   license_family: Other
-  size: 1116869
-  timestamp: 1697075736696
-- platform: osx-arm64
+  size: 1116102
+  timestamp: 1706798100072
+- kind: conda
   name: cctools_osx-arm64
   version: 973.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - ld64_osx-arm64 >=609,<610.0a0
-  - libcxx *
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - sigtool *
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-973.0.1-h2a25c60_14.conda
-  hash:
-    md5: 09f973985e770a7fbbca9a299af51a8b
-    sha256: 3c0b4237f5751617c2fa63180ae56ae8c39c349b1b30d78a651b0274758b65d1
-  build: h2a25c60_14
-  arch: aarch64
+  build: h62378fb_16
+  build_number: 16
   subdir: osx-arm64
-  build_number: 14
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-973.0.1-h62378fb_16.conda
+  sha256: cdd2ce1a4d17084096626e9d074f19ab5abef1e330901358533455e12895572d
+  md5: be98824be7fa378bd06cb2670ad0b4cc
+  depends:
+  - ld64_osx-arm64 >=609,<610.0a0
+  - libcxx
+  - libllvm16 >=16.0.6,<16.1.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - sigtool
   constrains:
-  - ld64 609.*
-  - clang 15.0.*
   - cctools 973.0.1.*
+  - clang 16.0.*
+  - ld64 609.*
   license: APSL-2.0
   license_family: Other
-  size: 1122294
-  timestamp: 1690768462517
-- platform: linux-64
+  size: 1124537
+  timestamp: 1706798177156
+- kind: conda
   name: clang
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang-15 ==15.0.7 default_h7634d5b_3
-  - gcc_impl_linux-64 *
-  url: https://conda.anaconda.org/conda-forge/linux-64/clang-15.0.7-ha770c72_3.conda
-  hash:
-    md5: d6d3417df41b77a4ffdc3955a1bedb20
-    sha256: 0119454827f79a3ee489482c7f439abf9107fb02286f928d5f6599f51e1dc220
-  build: ha770c72_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
-  constrains:
-  - clang-tools 15.0.7.*
-  - llvm 15.0.7.*
-  - llvm-tools 15.0.7.*
-  - llvmdev 15.0.7.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 132855
-  timestamp: 1690549739551
-- platform: osx-64
-  name: clang
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang-15 ==15.0.7 default_hdb78580_3
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang-15.0.7-h694c41f_3.conda
-  hash:
-    md5: 8a48d466e519b8db7dda7c5d27cc1d31
-    sha256: 3eab054ba786b0b80609bea17342385dcbdce69c6158e6ec7443f4f940c92883
-  build: h694c41f_3
-  arch: x86_64
-  subdir: osx-64
-  build_number: 3
-  constrains:
-  - clang-tools 15.0.7.*
-  - llvm 15.0.7.*
-  - llvm-tools 15.0.7.*
-  - llvmdev 15.0.7.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 132843
-  timestamp: 1690549855885
-- platform: osx-arm64
-  name: clang
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang-15 ==15.0.7 default_h5dc8d65_3
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-15.0.7-hce30654_3.conda
-  hash:
-    md5: 0871ba77c4bec31504b371a4f2525a7b
-    sha256: 7eceef0863863c7e6c8752ca8359dedebc87cc9fba108856533115e2d9a8d9ba
-  build: hce30654_3
-  arch: aarch64
+  version: 16.0.6
+  build: h30cc82d_5
+  build_number: 5
   subdir: osx-arm64
-  build_number: 3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16.0.6-h30cc82d_5.conda
+  sha256: 09d5c870768512e3439bf2a33346a0092fc728bbf2ef3efba1c187220636507d
+  md5: f3bbbf40f13424248d9ff9650d9379af
+  depends:
+  - clang-16 16.0.6 default_he012953_5
   constrains:
-  - clang-tools 15.0.7.*
-  - llvm 15.0.7.*
-  - llvm-tools 15.0.7.*
-  - llvmdev 15.0.7.*
+  - clang-tools 16.0.6.*
+  - llvm 16.0.6.*
+  - llvm-tools 16.0.6.*
+  - llvmdev 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 133018
-  timestamp: 1690549798814
-- platform: linux-64
-  name: clang-15
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libclang-cpp15 ==15.0.7 default_h7634d5b_3
+  size: 21610
+  timestamp: 1706894245139
+- kind: conda
+  name: clang
+  version: 16.0.6
+  build: hda56bd4_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/clang-16.0.6-hda56bd4_4.conda
+  sha256: 3d096e2c7f4140d2319cb22a11ce0a8707102232586d4dd56d4686e6481896b1
+  md5: 0fd1424bcd8968ac3d5c268379228545
+  depends:
+  - binutils_impl_linux-64
+  - clang-16 16.0.6 default_hb11cfb5_4
+  - libgcc-devel_linux-64
+  - sysroot_linux-64
+  constrains:
+  - clang-tools 16.0.6.*
+  - llvm 16.0.6.*
+  - llvm-tools 16.0.6.*
+  - llvmdev 16.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 21598
+  timestamp: 1704262301016
+- kind: conda
+  name: clang
+  version: 16.0.6
+  build: hdae98eb_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang-16.0.6-hdae98eb_5.conda
+  sha256: df7180f4ee7bed92849cb36e46a9641e71eb6c99b990dedc48f7469c080d5f5f
+  md5: 5f020dce5a00342141d87f952c9c0282
+  depends:
+  - clang-16 16.0.6 default_h7151d67_5
+  constrains:
+  - clang-tools 16.0.6.*
+  - llvm 16.0.6.*
+  - llvm-tools 16.0.6.*
+  - llvmdev 16.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 21576
+  timestamp: 1706894282581
+- kind: conda
+  name: clang-16
+  version: 16.0.6
+  build: default_h7151d67_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang-16-16.0.6-default_h7151d67_5.conda
+  sha256: 1ddcdef73115b5584f171a0182c1fdbbf168c667d8dcde19178d18f5c837fb43
+  md5: e132cf98d775fd7ec3b43859373bc070
+  depends:
+  - libclang-cpp16 16.0.6 default_h7151d67_5
+  - libcxx >=16.0.6
+  - libllvm16 >=16.0.6,<16.1.0a0
+  constrains:
+  - clangxx 16.0.6
+  - clangdev 16.0.6
+  - llvm-tools 16.0.6
+  - clang-tools 16.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 692571
+  timestamp: 1706894157239
+- kind: conda
+  name: clang-16
+  version: 16.0.6
+  build: default_hb11cfb5_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/clang-16-16.0.6-default_hb11cfb5_4.conda
+  sha256: 6c2c179cfb5e30990cb181fdc6a7a3ce9ddde48157f88042ed4f0692847ccdfd
+  md5: ba37f22007062c68b14ec4598b646f1f
+  depends:
+  - libclang-cpp16 16.0.6 default_hb11cfb5_4
   - libgcc-ng >=12
-  - libllvm15 >=15.0.7,<15.1.0a0
+  - libllvm16 >=16.0.6,<16.1.0a0
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/clang-15-15.0.7-default_h7634d5b_3.conda
-  hash:
-    md5: 7245ec4bd999e025455c80b6ea493143
-    sha256: 0b40914ea7070af1113b2fd86af79b42a6180d0f39bcdae3ad8dbc68a9e9ab83
-  build: default_h7634d5b_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
   constrains:
-  - llvm-tools 15.0.7
-  - clang-tools 15.0.7
-  - clangxx 15.0.7
-  - clangdev 15.0.7
+  - clangxx 16.0.6
+  - clang-tools 16.0.6
+  - llvm-tools 16.0.6
+  - clangdev 16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 809528
-  timestamp: 1690549681144
-- platform: osx-64
-  name: clang-15
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libclang-cpp15 ==15.0.7 default_hdb78580_3
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang-15-15.0.7-default_hdb78580_3.conda
-  hash:
-    md5: 688d6b9e178cb7786a07e3cfca2a8f09
-    sha256: 686abd626e3fe42c040c77e38b5c07d4fe5cd6f1561feb4b92ffbbba6b36e262
-  build: default_hdb78580_3
-  arch: x86_64
-  subdir: osx-64
-  build_number: 3
-  constrains:
-  - clang-tools 15.0.7
-  - clangdev 15.0.7
-  - llvm-tools 15.0.7
-  - clangxx 15.0.7
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 794748
-  timestamp: 1690549737577
-- platform: osx-arm64
-  name: clang-15
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libclang-cpp15 ==15.0.7 default_h5dc8d65_3
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-15-15.0.7-default_h5dc8d65_3.conda
-  hash:
-    md5: 3b214c8a23030d3a04389cbcd4bb84e4
-    sha256: 92d974b4675fa1f56f5ba1f396cc811a830ecbba0195ef1697235298535fad39
-  build: default_h5dc8d65_3
-  arch: aarch64
+  size: 712582
+  timestamp: 1704262190912
+- kind: conda
+  name: clang-16
+  version: 16.0.6
+  build: default_he012953_5
+  build_number: 5
   subdir: osx-arm64
-  build_number: 3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16-16.0.6-default_he012953_5.conda
+  sha256: 38ce232aab29ac5ab6ec6dcbeae855d331c192f756da19c1c95db45e9ad28cbb
+  md5: 5986bf8dc369fc4f55f0393bf94b4494
+  depends:
+  - libclang-cpp16 16.0.6 default_he012953_5
+  - libcxx >=16.0.6
+  - libllvm16 >=16.0.6,<16.1.0a0
   constrains:
-  - clang-tools 15.0.7
-  - clangdev 15.0.7
-  - clangxx 15.0.7
-  - llvm-tools 15.0.7
+  - clangdev 16.0.6
+  - llvm-tools 16.0.6
+  - clang-tools 16.0.6
+  - clangxx 16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 795051
-  timestamp: 1690549670667
-- platform: linux-64
+  size: 692537
+  timestamp: 1706894104516
+- kind: conda
   name: clang-format
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang-format-15 ==15.0.7 default_h7634d5b_3
-  - libclang-cpp15 >=15.0.7,<15.1.0a0
+  version: 16.0.6
+  build: default_h3a3e6c3_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/clang-format-16.0.6-default_h3a3e6c3_5.conda
+  sha256: 3466f084609720bf33e4c6a5cd4edf2022a4f3154b9898dda6500235a2b27356
+  md5: 22d78fcd655d782c5f9746c929756c13
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1131165
+  timestamp: 1706895787433
+- kind: conda
+  name: clang-format
+  version: 16.0.6
+  build: default_h7151d67_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang-format-16.0.6-default_h7151d67_5.conda
+  sha256: 49e52292f342c1784097c537a9cf5a333e8a99de47675f43ace75e810b20ceb2
+  md5: fc510e364c658597881b7e6f95f514aa
+  depends:
+  - clang-format-16 16.0.6 default_h7151d67_5
+  - libclang-cpp16 >=16.0.6,<16.1.0a0
+  - libcxx >=16.0.6
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 21806
+  timestamp: 1706894696246
+- kind: conda
+  name: clang-format
+  version: 16.0.6
+  build: default_hb11cfb5_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/clang-format-16.0.6-default_hb11cfb5_4.conda
+  sha256: 5643482463f23bbdc90cf4fd6dd768152e4bbdbd5de00becb5becc3fee3961b3
+  md5: a95d041cb52e58b80a6018338d5d2bfe
+  depends:
+  - clang-format-16 16.0.6 default_hb11cfb5_4
+  - libclang-cpp16 >=16.0.6,<16.1.0a0
   - libgcc-ng >=12
-  - libllvm15 >=15.0.7,<15.1.0a0
+  - libllvm16 >=16.0.6,<16.1.0a0
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/clang-format-15.0.7-default_h7634d5b_3.conda
-  hash:
-    md5: 5ce1db65053ef3f8f4d093a724c277cc
-    sha256: f976f20823b48a7d95f04dcbddcb33ae81a5900d8b00c31cac0268ce21e3fe07
-  build: default_h7634d5b_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 133277
-  timestamp: 1690549957754
-- platform: osx-64
+  size: 21613
+  timestamp: 1704262844623
+- kind: conda
   name: clang-format
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang-format-15 ==15.0.7 default_hdb78580_3
-  - libclang-cpp15 >=15.0.7,<15.1.0a0
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang-format-15.0.7-default_hdb78580_3.conda
-  hash:
-    md5: 71b6895e2161905506c72b8d705072f7
-    sha256: 06bc8e49cb56acaa0ba50493a6c6689f31ee8573b45eebb5df5ecce4736a1392
-  build: default_hdb78580_3
-  arch: x86_64
-  subdir: osx-64
-  build_number: 3
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 133176
-  timestamp: 1690550267740
-- platform: osx-arm64
-  name: clang-format
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang-format-15 ==15.0.7 default_h5dc8d65_3
-  - libclang-cpp15 >=15.0.7,<15.1.0a0
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-15.0.7-default_h5dc8d65_3.conda
-  hash:
-    md5: c5238e0f10ad14fd48a282bdda50e164
-    sha256: 4e410c58ed91b79aeb9d62945f5981030d121f906c269df93f92c5e73500c185
-  build: default_h5dc8d65_3
-  arch: aarch64
+  version: 16.0.6
+  build: default_he012953_5
+  build_number: 5
   subdir: osx-arm64
-  build_number: 3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-16.0.6-default_he012953_5.conda
+  sha256: 60e474b1583f4f5accb5a26e9cdc093cfea8c465cfdd93441405ade2a078f3c7
+  md5: 66824ce81b162909b65ea8f5a6eede5e
+  depends:
+  - clang-format-16 16.0.6 default_he012953_5
+  - libclang-cpp16 >=16.0.6,<16.1.0a0
+  - libcxx >=16.0.6
+  - libllvm16 >=16.0.6,<16.1.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 133475
-  timestamp: 1690550223126
-- platform: win-64
-  name: clang-format
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
+  size: 21914
+  timestamp: 1706894694897
+- kind: conda
+  name: clang-format-16
+  version: 16.0.6
+  build: default_h7151d67_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang-format-16-16.0.6-default_h7151d67_5.conda
+  sha256: af6c529b6d4cf9f07bb8531bac342941be903f8bc65f4e22965670e0f45d56d8
+  md5: 931c92d179e781729711f0da2e233d94
+  depends:
+  - libclang-cpp16 >=16.0.6,<16.1.0a0
+  - libcxx >=16.0.6
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 58542
+  timestamp: 1706894600420
+- kind: conda
+  name: clang-format-16
+  version: 16.0.6
+  build: default_hb11cfb5_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/clang-format-16-16.0.6-default_hb11cfb5_4.conda
+  sha256: 827eca9f0a496d8efaf2ccb57ae8b97bd2f0ddf6f20a437ffc480cdb8840f7f4
+  md5: 63ab23b9172482ca86ab8966468533d4
+  depends:
+  - libclang-cpp16 >=16.0.6,<16.1.0a0
+  - libgcc-ng >=12
+  - libllvm16 >=16.0.6,<16.1.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 61766
+  timestamp: 1704262713061
+- kind: conda
+  name: clang-format-16
+  version: 16.0.6
+  build: default_he012953_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-16-16.0.6-default_he012953_5.conda
+  sha256: 2df39ab65ef878158c2c13031e2229d708af3fd124ab276aab8c73dfe6a95dd5
+  md5: 64a41c1c1281bac52c6fad92e9616bb2
+  depends:
+  - libclang-cpp16 >=16.0.6,<16.1.0a0
+  - libcxx >=16.0.6
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 56848
+  timestamp: 1706894594045
+- kind: conda
+  name: clang-tools
+  version: 16.0.6
+  build: default_h3a3e6c3_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/clang-tools-16.0.6-default_h3a3e6c3_5.conda
+  sha256: 7ef0b9bc90d522c2e0d14e0363310422b13a2601ff33063900539df7e6891255
+  md5: 3c5bcc0e6dd158e4805392d8687f4219
+  depends:
+  - clang-format 16.0.6 default_h3a3e6c3_5
+  - libclang13 >=16.0.6
+  - libxml2 >=2.12.4,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/clang-format-15.0.7-default_h66ee7f4_3.conda
-  hash:
-    md5: e602a61e64266e854ab2234b8e80957a
-    sha256: 2788d948c2c7eeee1f02d7936d5b84f5547a94521abee10deb5287106c31d393
-  build: default_h66ee7f4_3
-  arch: x86_64
-  subdir: win-64
-  build_number: 3
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - clangdev 16.0.6
+  - clang 16.0.6.*
+  - llvm 16.0.6.*
+  - llvm-tools 16.0.6.*
+  - llvmdev 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 1223464
-  timestamp: 1690553805296
-- platform: linux-64
-  name: clang-format-15
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libclang-cpp15 >=15.0.7,<15.1.0a0
-  - libgcc-ng >=12
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/clang-format-15-15.0.7-default_h7634d5b_3.conda
-  hash:
-    md5: 9c03ef6af3f5a320ce9780dcf705e4d2
-    sha256: ab0eff716fa20c9de8133e2c1987a38abb37aa3d33d52fe8beccd979e3b652ad
-  build: default_h7634d5b_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 259946
-  timestamp: 1690549899367
-- platform: osx-64
-  name: clang-format-15
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libclang-cpp15 >=15.0.7,<15.1.0a0
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang-format-15-15.0.7-default_hdb78580_3.conda
-  hash:
-    md5: 2bb52de137d26760268139c33a16c966
-    sha256: bfcae5a04fb7ec8fb1b097eab18b5222e9380463dd63683f78a171ad58f1df37
-  build: default_hdb78580_3
-  arch: x86_64
+  size: 227348179
+  timestamp: 1706896190792
+- kind: conda
+  name: clang-tools
+  version: 16.0.6
+  build: default_h7151d67_5
+  build_number: 5
   subdir: osx-64
-  build_number: 3
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang-tools-16.0.6-default_h7151d67_5.conda
+  sha256: 681202e3d28101ac7d0682ccbbd5cf6902877b4ce41841d18a50499c052051e6
+  md5: 486159f726a3313d0e2d147c998b607d
+  depends:
+  - clang-format 16.0.6 default_h7151d67_5
+  - libclang-cpp16 >=16.0.6,<16.1.0a0
+  - libclang13 >=16.0.6
+  - libcxx >=16.0.6
+  - libllvm16 >=16.0.6,<16.1.0a0
+  constrains:
+  - clangdev 16.0.6
+  - clang 16.0.6.*
+  - llvm 16.0.6.*
+  - llvm-tools 16.0.6.*
+  - llvmdev 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 257644
-  timestamp: 1690550167340
-- platform: osx-arm64
-  name: clang-format-15
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libclang-cpp15 >=15.0.7,<15.1.0a0
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-15-15.0.7-default_h5dc8d65_3.conda
-  hash:
-    md5: 037fa18a2b6befdc1be50237a07b7827
-    sha256: d3280499403ebe78beaab02d2f20588184f5a6d22863b7c2e67e7f93877eef74
-  build: default_h5dc8d65_3
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 3
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 255409
-  timestamp: 1690550130184
-- platform: linux-64
+  size: 17982262
+  timestamp: 1706894817029
+- kind: conda
   name: clang-tools
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang-format ==15.0.7 default_h7634d5b_3
-  - libclang >=15.0.7,<15.1.0a0
-  - libclang-cpp15 >=15.0.7,<15.1.0a0
-  - libgcc-ng >=12
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/clang-tools-15.0.7-default_h7634d5b_3.conda
-  hash:
-    md5: 0041e55028e791d403bdd0af5272a191
-    sha256: e2863149d76c5cb01656f9f27584b9c4b9494ef7d8c37fbdbae83b4230c0dce0
-  build: default_h7634d5b_3
-  arch: x86_64
+  version: 16.0.6
+  build: default_hb11cfb5_4
+  build_number: 4
   subdir: linux-64
-  build_number: 3
+  url: https://conda.anaconda.org/conda-forge/linux-64/clang-tools-16.0.6-default_hb11cfb5_4.conda
+  sha256: 84a869baae7e16ea1f7fa35fedc959a80d8044dff6d26f77989801296b65d18f
+  md5: 9a875b311f35dcc02d1cfa502a1fa639
+  depends:
+  - clang-format 16.0.6 default_hb11cfb5_4
+  - libclang-cpp16 >=16.0.6,<16.1.0a0
+  - libclang13 >=16.0.6
+  - libgcc-ng >=12
+  - libllvm16 >=16.0.6,<16.1.0a0
+  - libstdcxx-ng >=12
   constrains:
-  - clangdev 15.0.7
-  - clang 15.0.7.*
-  - llvm 15.0.7.*
-  - llvm-tools 15.0.7.*
-  - llvmdev 15.0.7.*
+  - clangdev 16.0.6
+  - clang 16.0.6.*
+  - llvm 16.0.6.*
+  - llvm-tools 16.0.6.*
+  - llvmdev 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 25224796
-  timestamp: 1690550008802
-- platform: osx-64
+  size: 26681224
+  timestamp: 1704262959552
+- kind: conda
   name: clang-tools
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang-format ==15.0.7 default_hdb78580_3
-  - libclang >=15.0.7,<15.1.0a0
-  - libclang-cpp15 >=15.0.7,<15.1.0a0
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang-tools-15.0.7-default_hdb78580_3.conda
-  hash:
-    md5: f3433671cb6c36f66f1d0f81254e0858
-    sha256: f54bca9c18ee9486682f7a796921dad2534920b48a04788f974dfb66550f9f77
-  build: default_hdb78580_3
-  arch: x86_64
-  subdir: osx-64
-  build_number: 3
-  constrains:
-  - clangdev 15.0.7
-  - clang 15.0.7.*
-  - llvm 15.0.7.*
-  - llvm-tools 15.0.7.*
-  - llvmdev 15.0.7.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 17091066
-  timestamp: 1690550394142
-- platform: osx-arm64
-  name: clang-tools
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang-format ==15.0.7 default_h5dc8d65_3
-  - libclang >=15.0.7,<15.1.0a0
-  - libclang-cpp15 >=15.0.7,<15.1.0a0
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-tools-15.0.7-default_h5dc8d65_3.conda
-  hash:
-    md5: ab94653a176bda40d45bb6406f0bcff1
-    sha256: 19585e0a3ff5c0cfcf75c678f1471daa862013532cc9985e2662c1fb7d6a6707
-  build: default_h5dc8d65_3
-  arch: aarch64
+  version: 16.0.6
+  build: default_he012953_5
+  build_number: 5
   subdir: osx-arm64
-  build_number: 3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-tools-16.0.6-default_he012953_5.conda
+  sha256: 1a86cf1334fefb6a4463ed281d57e8826408ada2c06b4367d8b68aa06a5c78da
+  md5: 112fbb989f5a2e82fef7d78e84cb4e8a
+  depends:
+  - clang-format 16.0.6 default_he012953_5
+  - libclang-cpp16 >=16.0.6,<16.1.0a0
+  - libclang13 >=16.0.6
+  - libcxx >=16.0.6
+  - libllvm16 >=16.0.6,<16.1.0a0
   constrains:
-  - clangdev 15.0.7
-  - clang 15.0.7.*
-  - llvm 15.0.7.*
-  - llvm-tools 15.0.7.*
-  - llvmdev 15.0.7.*
+  - clangdev 16.0.6
+  - clang 16.0.6.*
+  - llvm 16.0.6.*
+  - llvm-tools 16.0.6.*
+  - llvmdev 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 16055653
-  timestamp: 1690550344308
-- platform: win-64
-  name: clang-tools
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang-format ==15.0.7 default_h66ee7f4_3
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/clang-tools-15.0.7-default_h66ee7f4_3.conda
-  hash:
-    md5: 1fb8f6a1457d6ed1b9af746d5bc2d9a6
-    sha256: da98cba02f253133a9f727348c1671c0a619c52eba8ab1a7030f223414aba59e
-  build: default_h66ee7f4_3
-  arch: x86_64
-  subdir: win-64
-  build_number: 3
-  constrains:
-  - clangdev 15.0.7
-  - clang 15.0.7.*
-  - llvm 15.0.7.*
-  - llvm-tools 15.0.7.*
-  - llvmdev 15.0.7.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 207487053
-  timestamp: 1690554250567
-- platform: osx-64
+  size: 16957978
+  timestamp: 1706894821989
+- kind: conda
+  name: clang_impl_osx-64
+  version: 16.0.6
+  build: h8787910_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-16.0.6-h8787910_9.conda
+  sha256: 3aeee43c777d67a334a7917a9a6cc43c67fabbf8acbceca31e2bef0702f0c81e
+  md5: 36dc72f20205cf43f63765334a5f0be7
+  depends:
+  - cctools_osx-64
+  - clang 16.0.6.*
+  - compiler-rt 16.0.6.*
+  - ld64_osx-64
+  - llvm-tools 16.0.6.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17576
+  timestamp: 1706817889548
+- kind: conda
+  name: clang_impl_osx-arm64
+  version: 16.0.6
+  build: hc421ffc_9
+  build_number: 9
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-16.0.6-hc421ffc_9.conda
+  sha256: db8d0f1418bd5a6284da7137f278b5ec373b8382791aa550b4af711f7e079f8b
+  md5: 6ba30ea4b866e03cb834447d934d8d5f
+  depends:
+  - cctools_osx-arm64
+  - clang 16.0.6.*
+  - compiler-rt 16.0.6.*
+  - ld64_osx-arm64
+  - llvm-tools 16.0.6.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17585
+  timestamp: 1706831903732
+- kind: conda
   name: clang_osx-64
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - cctools_osx-64 *
-  - clang 15.0.7.*
-  - compiler-rt 15.0.7.*
-  - ld64_osx-64 *
-  - llvm-tools 15.0.7.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-15.0.7-h03d6864_3.conda
-  hash:
-    md5: 9dfd4e8cbc51c07a7b1ad59ad8415fad
-    sha256: 1257bf432219240be7b3eddde72fcfad1e85c8eacea2871e6f9121d66eccd965
-  build: h03d6864_3
-  arch: x86_64
+  version: 16.0.6
+  build: hb91bd55_9
+  build_number: 9
   subdir: osx-64
-  build_number: 3
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-16.0.6-hb91bd55_9.conda
+  sha256: 970a919b17f6c5c04624b6a0269211bd3d7b41b3177e50f5dd7b5d036f4c25c9
+  md5: 3ebda8406efd8c09ebeeba80396ac6bd
+  depends:
+  - clang_impl_osx-64 16.0.6 h8787910_9
   license: BSD-3-Clause
   license_family: BSD
-  size: 20620
-  timestamp: 1684463185776
-- platform: osx-arm64
+  size: 20647
+  timestamp: 1706817901570
+- kind: conda
   name: clang_osx-arm64
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - cctools_osx-arm64 *
-  - clang 15.0.7.*
-  - compiler-rt 15.0.7.*
-  - ld64_osx-arm64 *
-  - llvm-tools 15.0.7.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-15.0.7-h77e971b_3.conda
-  hash:
-    md5: 4799cb60f8ff17edaf3574b28681d2a0
-    sha256: 556ab57b9d190bf3ad2b9e7ba3c164157f8d163489a65235c0cfe52478521da0
-  build: h77e971b_3
-  arch: aarch64
+  version: 16.0.6
+  build: h54d7cd3_9
+  build_number: 9
   subdir: osx-arm64
-  build_number: 3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-16.0.6-h54d7cd3_9.conda
+  sha256: d712ced3aaf31275d3ca1f0b3dbe21ca82ba169e35a5e3e8115a67b381be2197
+  md5: 5df587e67413858308caac4c86b9c92a
+  depends:
+  - clang_impl_osx-arm64 16.0.6 hc421ffc_9
   license: BSD-3-Clause
   license_family: BSD
-  size: 20618
-  timestamp: 1684463162877
-- platform: osx-64
+  size: 20568
+  timestamp: 1706831915550
+- kind: conda
   name: clangxx
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang ==15.0.7 h694c41f_3
-  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx-15.0.7-default_hdb78580_3.conda
-  hash:
-    md5: 58df9ff86fefc7684670be729b41412f
-    sha256: b68fbe1f7c401401622b61f9e65be6fffae4104727c2f39feacede5c393fa65e
-  build: default_hdb78580_3
-  arch: x86_64
-  subdir: osx-64
-  build_number: 3
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 132973
-  timestamp: 1690549872764
-- platform: osx-arm64
-  name: clangxx
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang ==15.0.7 hce30654_3
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-15.0.7-default_h610c423_3.conda
-  hash:
-    md5: 1919a441b26f5cd1181870be6b4ce31a
-    sha256: 59e1545bac0207bb8b82c3718a16ec79dd9ac218eb00679f8cb5ed2cd115ffe3
-  build: default_h610c423_3
-  arch: aarch64
+  version: 16.0.6
+  build: default_h4cf2255_5
+  build_number: 5
   subdir: osx-arm64
-  build_number: 3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-16.0.6-default_h4cf2255_5.conda
+  sha256: d5cdb838c3b67c4fdf1683e7659d011db228d5f762f85e2833e1c67c7c5cccdc
+  md5: 83d1eb2693ad27dec744ac21f1ad9812
+  depends:
+  - clang 16.0.6 h30cc82d_5
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 133212
-  timestamp: 1690549817560
-- platform: osx-64
+  size: 21761
+  timestamp: 1706894272948
+- kind: conda
+  name: clangxx
+  version: 16.0.6
+  build: default_h7151d67_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx-16.0.6-default_h7151d67_5.conda
+  sha256: 9aafb8802adfe804ae38b66b01b00e133f1c14713ed1abed2710ed95ddbaa3e7
+  md5: 8c3fb5d2005174683f3958383643e335
+  depends:
+  - clang 16.0.6 hdae98eb_5
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 21699
+  timestamp: 1706894307583
+- kind: conda
+  name: clangxx_impl_osx-64
+  version: 16.0.6
+  build: h6d92fbe_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-16.0.6-h6d92fbe_9.conda
+  sha256: d0d712b2ea90fd4e0c7215cb319830496ced15c56ee208f6ebba5e0d0b21f765
+  md5: bfea277f004e2815ebd59294e9c08746
+  depends:
+  - clang_osx-64 16.0.6 hb91bd55_9
+  - clangxx 16.0.6.*
+  - libcxx >=16
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17667
+  timestamp: 1706817919437
+- kind: conda
+  name: clangxx_impl_osx-arm64
+  version: 16.0.6
+  build: hcd7bac0_9
+  build_number: 9
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-16.0.6-hcd7bac0_9.conda
+  sha256: db061d8e7d6c1410cb188bbc5485d630cb076ae6981dca42def058822497536f
+  md5: 949089893ce76c6d743b77d6eec251bf
+  depends:
+  - clang_osx-arm64 16.0.6 h54d7cd3_9
+  - clangxx 16.0.6.*
+  - libcxx >=16
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17692
+  timestamp: 1706832802039
+- kind: conda
   name: clangxx_osx-64
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang_osx-64 ==15.0.7 h03d6864_3
-  - clangxx 15.0.7.*
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-15.0.7-h2133e9c_3.conda
-  hash:
-    md5: 2ff16b86a981da4b1a2658423db664bb
-    sha256: 04900d8758347c81d8f3904ba513fced2cb86af258d6ce70f8377e2515c9ec51
-  build: h2133e9c_3
-  arch: x86_64
+  version: 16.0.6
+  build: hb91bd55_9
+  build_number: 9
   subdir: osx-64
-  build_number: 3
+  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-16.0.6-hb91bd55_9.conda
+  sha256: 9225222bf1cd611e63f2b68c0838325f2fd5be930f81a7f3563ff5e2818955a5
+  md5: e7297accf408701c298308eeae807c5e
+  depends:
+  - clang_osx-64 16.0.6 hb91bd55_9
+  - clangxx_impl_osx-64 16.0.6 h6d92fbe_9
   license: BSD-3-Clause
   license_family: BSD
-  size: 19427
-  timestamp: 1684463207952
-- platform: osx-arm64
+  size: 19414
+  timestamp: 1706817934575
+- kind: conda
   name: clangxx_osx-arm64
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang_osx-arm64 ==15.0.7 h77e971b_3
-  - clangxx 15.0.7.*
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-15.0.7-h768a7fd_3.conda
-  hash:
-    md5: 16e11574eeb3cfa3da194692da449aeb
-    sha256: 83c774c3dd206f4772a4a0abd10d21ad4aa9aa472fc9e2af16bf0b9a07476684
-  build: h768a7fd_3
-  arch: aarch64
+  version: 16.0.6
+  build: h54d7cd3_9
+  build_number: 9
   subdir: osx-arm64
-  build_number: 3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-16.0.6-h54d7cd3_9.conda
+  sha256: ee39efac1691f9f2d646bc64f04548179577e3c65c1ca5947cd4f944e4ccbdee
+  md5: e47d40e35f855ad41af35ba60937e41c
+  depends:
+  - clang_osx-arm64 16.0.6 h54d7cd3_9
+  - clangxx_impl_osx-arm64 16.0.6 hcd7bac0_9
   license: BSD-3-Clause
   license_family: BSD
-  size: 19504
-  timestamp: 1684463181478
-- platform: linux-64
+  size: 19330
+  timestamp: 1706832814124
+- kind: conda
   name: click
   version: 8.1.7
-  category: main
-  manager: conda
-  dependencies:
-  - __unix *
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
-  hash:
-    md5: f3ad426304898027fc619827ff428eca
-    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
   build: unix_pyh707e725_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 84437
-  timestamp: 1692311973840
-- platform: osx-64
-  name: click
-  version: 8.1.7
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+  md5: f3ad426304898027fc619827ff428eca
+  depends:
   - __unix *
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
-  hash:
-    md5: f3ad426304898027fc619827ff428eca
-    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
-  build: unix_pyh707e725_0
   arch: x86_64
-  subdir: osx-64
-  build_number: 0
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 84437
   timestamp: 1692311973840
-- platform: osx-arm64
+- kind: conda
   name: click
   version: 8.1.7
-  category: main
-  manager: conda
-  dependencies:
+  build: unix_pyh707e725_0
+  subdir: osx-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+  md5: f3ad426304898027fc619827ff428eca
+  depends:
   - __unix *
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
-  hash:
-    md5: f3ad426304898027fc619827ff428eca
-    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
-  build: unix_pyh707e725_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  arch: x86_64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 84437
   timestamp: 1692311973840
-- platform: win-64
+- kind: conda
   name: click
   version: 8.1.7
-  category: main
-  manager: conda
-  dependencies:
+  build: unix_pyh707e725_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+  md5: f3ad426304898027fc619827ff428eca
+  depends:
+  - __unix *
+  - python >=3.8
+  arch: aarch64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84437
+  timestamp: 1692311973840
+- kind: conda
+  name: click
+  version: 8.1.7
+  build: win_pyh7428d3b_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+  sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
+  md5: 3549ecbceb6cd77b91a105511b7d0786
+  depends:
   - __win *
   - colorama *
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
-  hash:
-    md5: 3549ecbceb6cd77b91a105511b7d0786
-    sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
-  build: win_pyh7428d3b_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 85051
   timestamp: 1692312207348
-- platform: linux-64
+- kind: conda
   name: cmake
   version: 3.27.6
-  category: main
-  manager: conda
-  dependencies:
-  - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.3.0,<9.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libuv >=1.46.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - rhash >=1.4.4,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.27.6-hcfe8598_0.conda
-  hash:
-    md5: 4c0101485c452ea86f846523c4fae698
-    sha256: 64e08c246195d6956f7a04fa7d96a53de696b26b1dae8b08cfe716950f696e12
-  build: hcfe8598_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18494905
-  timestamp: 1695269729661
-- platform: osx-64
-  name: cmake
-  version: 3.27.6
-  category: main
-  manager: conda
-  dependencies:
-  - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.3.0,<9.0a0
-  - libcxx >=15.0.7
-  - libexpat >=2.5.0,<3.0a0
-  - libuv >=1.46.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - rhash >=1.4.4,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.27.6-hf40c264_0.conda
-  hash:
-    md5: 771da6a52aaf0f9d84114d0ed0d0299f
-    sha256: 9216698f88b82e99db950f8c372038931c54ea3e0b0b05e2a3ce03ec4b405df7
-  build: hf40c264_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 16525734
-  timestamp: 1695270838345
-- platform: osx-arm64
-  name: cmake
-  version: 3.27.6
-  category: main
-  manager: conda
-  dependencies:
-  - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.3.0,<9.0a0
-  - libcxx >=15.0.7
-  - libexpat >=2.5.0,<3.0a0
-  - libuv >=1.46.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - rhash >=1.4.4,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.27.6-h1c59155_0.conda
-  hash:
-    md5: 3c0dd04401438fec44cd113247ba2852
-    sha256: 31be31e358e6f6f8818d8f9c9086da4404f8c6fc89d71d55887bed11ce6d463e
   build: h1c59155_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.27.6-h1c59155_0.conda
+  sha256: 31be31e358e6f6f8818d8f9c9086da4404f8c6fc89d71d55887bed11ce6d463e
+  md5: 3c0dd04401438fec44cd113247ba2852
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libcxx >=15.0.7
+  - libexpat >=2.5.0,<3.0a0
+  - libuv >=1.46.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 16007289
   timestamp: 1695270816826
-- platform: win-64
+- kind: conda
   name: cmake
   version: 3.27.6
-  category: main
-  manager: conda
-  dependencies:
+  build: hcfe8598_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.27.6-hcfe8598_0.conda
+  sha256: 64e08c246195d6956f7a04fa7d96a53de696b26b1dae8b08cfe716950f696e12
+  md5: 4c0101485c452ea86f846523c4fae698
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libuv >=1.46.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18494905
+  timestamp: 1695269729661
+- kind: conda
+  name: cmake
+  version: 3.27.6
+  build: hf0feee3_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/cmake-3.27.6-hf0feee3_0.conda
+  sha256: 12b94bce6d7c76ff408f8ea240c7d78987b0bc3cb4f632f381c4b0efd30ebfe0
+  md5: 4dc81f3bf26f0949fedd4e31cecea1d1
+  depends:
   - bzip2 >=1.0.8,<2.0a0
   - libcurl >=8.3.0,<9.0a0
   - libexpat >=2.5.0,<3.0a0
@@ -2845,749 +3137,669 @@ package:
   - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/cmake-3.27.6-hf0feee3_0.conda
-  hash:
-    md5: 4dc81f3bf26f0949fedd4e31cecea1d1
-    sha256: 12b94bce6d7c76ff408f8ea240c7d78987b0bc3cb4f632f381c4b0efd30ebfe0
-  build: hf0feee3_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 13777396
   timestamp: 1695270971791
-- platform: linux-64
-  name: colorama
-  version: 0.4.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3faab06a954c2a04039983f2c4a50d99
-    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 25170
-  timestamp: 1666700778190
-- platform: osx-64
-  name: colorama
-  version: 0.4.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3faab06a954c2a04039983f2c4a50d99
-    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-  build: pyhd8ed1ab_0
-  arch: x86_64
+- kind: conda
+  name: cmake
+  version: 3.27.6
+  build: hf40c264_0
   subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 25170
-  timestamp: 1666700778190
-- platform: osx-arm64
-  name: colorama
-  version: 0.4.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3faab06a954c2a04039983f2c4a50d99
-    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 25170
-  timestamp: 1666700778190
-- platform: win-64
-  name: colorama
-  version: 0.4.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3faab06a954c2a04039983f2c4a50d99
-    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-  build: pyhd8ed1ab_0
+  url: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.27.6-hf40c264_0.conda
+  sha256: 9216698f88b82e99db950f8c372038931c54ea3e0b0b05e2a3ce03ec4b405df7
+  md5: 771da6a52aaf0f9d84114d0ed0d0299f
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libcxx >=15.0.7
+  - libexpat >=2.5.0,<3.0a0
+  - libuv >=1.46.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   arch: x86_64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16525734
+  timestamp: 1695270838345
+- kind: conda
+  name: colorama
+  version: 0.4.6
+  build: pyhd8ed1ab_0
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25170
+  timestamp: 1666700778190
+- kind: conda
+  name: colorama
+  version: 0.4.6
+  build: pyhd8ed1ab_0
+  subdir: osx-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25170
+  timestamp: 1666700778190
+- kind: conda
+  name: colorama
+  version: 0.4.6
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25170
+  timestamp: 1666700778190
+- kind: conda
+  name: colorama
+  version: 0.4.6
+  build: pyhd8ed1ab_0
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 25170
   timestamp: 1666700778190
-- platform: linux-64
+- kind: conda
   name: colorlog
   version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/colorlog-4.8.0-py311h38be061_3.conda
-  hash:
-    md5: 09b2eea88d971b3986ac2cb47c9ea99f
-    sha256: bb52f32dfd32fe73691eebcbb336103db8167c26134c56123b26dc9808a684fa
-  build: py311h38be061_3
-  arch: x86_64
-  subdir: linux-64
+  build: py311h1ea47a8_3
   build_number: 3
-  license: MIT
-  license_family: MIT
-  size: 19834
-  timestamp: 1697026997816
-- platform: osx-64
-  name: colorlog
-  version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/colorlog-4.8.0-py311h6eed73b_3.conda
-  hash:
-    md5: cd35ca12286652e78d1d4c457b6e5a98
-    sha256: b929b2da9e782b6a2f7b559e32e443293c3ecdf628918fc685db928b5570460f
-  build: py311h6eed73b_3
-  arch: x86_64
-  subdir: osx-64
-  build_number: 3
-  license: MIT
-  license_family: MIT
-  size: 20046
-  timestamp: 1697027212659
-- platform: osx-arm64
-  name: colorlog
-  version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/colorlog-4.8.0-py311h267d04e_3.conda
-  hash:
-    md5: e4b2335855768eade29813b85342c990
-    sha256: 86dcaba5a3cd40e9752aa08221c45997a434cf2917d0b32eea56d788522a514a
-  build: py311h267d04e_3
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 3
-  license: MIT
-  license_family: MIT
-  size: 20239
-  timestamp: 1697027319606
-- platform: win-64
-  name: colorlog
-  version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/colorlog-4.8.0-py311h1ea47a8_3.conda
+  sha256: 3b317933f05df326e327faafcf1fd1be643df36f1aa479aab54f2a85062307f0
+  md5: 9881fe3cbeed11cd8138a28c4c9d1f94
+  depends:
   - colorama
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/win-64/colorlog-4.8.0-py311h1ea47a8_3.conda
-  hash:
-    md5: 9881fe3cbeed11cd8138a28c4c9d1f94
-    sha256: 3b317933f05df326e327faafcf1fd1be643df36f1aa479aab54f2a85062307f0
-  build: py311h1ea47a8_3
   arch: x86_64
-  subdir: win-64
-  build_number: 3
+  platform: win
   license: MIT
   license_family: MIT
   size: 20460
   timestamp: 1697027322301
-- platform: osx-64
-  name: compiler-rt
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang 15.0.7.*
-  - clangxx 15.0.7.*
-  - compiler-rt_osx-64 15.0.7.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-15.0.7-he1888fc_1.conda
-  hash:
-    md5: 8ec296a4b097aeb2d85eafaf745c770a
-    sha256: 90a2dd7a9baf8d6ddde9d11ad682dbd74f74c1f40ce0e4e9df7c356b0275ca31
-  build: he1888fc_1
-  arch: x86_64
-  subdir: osx-64
-  build_number: 1
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: APACHE
-  size: 92129
-  timestamp: 1684403261646
-- platform: osx-arm64
-  name: compiler-rt
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang 15.0.7.*
-  - clangxx 15.0.7.*
-  - compiler-rt_osx-arm64 15.0.7.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-15.0.7-hf8d1dfb_1.conda
-  hash:
-    md5: 355703f3e33fd12037800d28680845cb
-    sha256: d2ab8bc610038e40dafdb6b6172343553f1f3aba4e9a4c540e878474062b1b89
-  build: hf8d1dfb_1
-  arch: aarch64
+- kind: conda
+  name: colorlog
+  version: 4.8.0
+  build: py311h267d04e_3
+  build_number: 3
   subdir: osx-arm64
-  build_number: 1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/colorlog-4.8.0-py311h267d04e_3.conda
+  sha256: 86dcaba5a3cd40e9752aa08221c45997a434cf2917d0b32eea56d788522a514a
+  md5: e4b2335855768eade29813b85342c990
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 20239
+  timestamp: 1697027319606
+- kind: conda
+  name: colorlog
+  version: 4.8.0
+  build: py311h38be061_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/colorlog-4.8.0-py311h38be061_3.conda
+  sha256: bb52f32dfd32fe73691eebcbb336103db8167c26134c56123b26dc9808a684fa
+  md5: 09b2eea88d971b3986ac2cb47c9ea99f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 19834
+  timestamp: 1697026997816
+- kind: conda
+  name: colorlog
+  version: 4.8.0
+  build: py311h6eed73b_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/colorlog-4.8.0-py311h6eed73b_3.conda
+  sha256: b929b2da9e782b6a2f7b559e32e443293c3ecdf628918fc685db928b5570460f
+  md5: cd35ca12286652e78d1d4c457b6e5a98
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 20046
+  timestamp: 1697027212659
+- kind: conda
+  name: compiler-rt
+  version: 16.0.6
+  build: h3808999_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-16.0.6-h3808999_2.conda
+  sha256: 67f6883f37ea720f97d016c3384962d86ec8853e5f4b0065aa77e335ca80193e
+  md5: 517f18b3260bb7a508d1f54a96e6285b
+  depends:
+  - clang 16.0.6.*
+  - clangxx 16.0.6.*
+  - compiler-rt_osx-arm64 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 92034
-  timestamp: 1684403020973
-- platform: osx-64
+  size: 93724
+  timestamp: 1701467327657
+- kind: conda
+  name: compiler-rt
+  version: 16.0.6
+  build: ha38d28d_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-16.0.6-ha38d28d_2.conda
+  sha256: de0e2c94d9a04f60ec9aedde863d6c1fad3f261bdb63ec8adc70e2d9ecdb07bb
+  md5: 3b9e8c5c63b8e86234f499490acd85c2
+  depends:
+  - clang 16.0.6.*
+  - clangxx 16.0.6.*
+  - compiler-rt_osx-64 16.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 94198
+  timestamp: 1701467261175
+- kind: conda
   name: compiler-rt_osx-64
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang 15.0.7.*
-  - clangxx 15.0.7.*
-  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-15.0.7-he1888fc_1.conda
-  hash:
-    md5: e1f93ea86259a549f2dcbfd245bf0422
-    sha256: a2c19b4ec885e668266f5dd0e90193d9436c0be63c370c91ae1b840a19071159
-  build: he1888fc_1
-  arch: x86_64
-  subdir: osx-64
-  build_number: 1
+  version: 16.0.6
+  build: ha38d28d_2
+  build_number: 2
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-16.0.6-ha38d28d_2.conda
+  sha256: 75270bd8e306967f6e1a8c17d14f2dfe76602a5c162088f3ea98034fe3d71e0c
+  md5: 7a46507edc35c6c8818db0adaf8d787f
+  depends:
+  - clang 16.0.6.*
+  - clangxx 16.0.6.*
   constrains:
-  - compiler-rt 15.0.7
+  - compiler-rt 16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  noarch: generic
-  size: 11208907
-  timestamp: 1684403213219
-- platform: osx-arm64
+  size: 9895261
+  timestamp: 1701467223753
+- kind: conda
   name: compiler-rt_osx-arm64
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - clang 15.0.7.*
-  - clangxx 15.0.7.*
-  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-15.0.7-hf8d1dfb_1.conda
-  hash:
-    md5: 0722cbdc69a52c82acc4e265913a21cd
-    sha256: 5a801e344b2a18983199190cb34ad798e3ce5966a4a4031c74f7e395d8c38802
-  build: hf8d1dfb_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
+  version: 16.0.6
+  build: h3808999_2
+  build_number: 2
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-16.0.6-h3808999_2.conda
+  sha256: 61f1a10e6e8ec147f17c5e36cf1c2fe77ac6d1907b05443fa319fd59be20fa33
+  md5: 8c7d77d888e1a218cccd9e82b1458ec6
+  depends:
+  - clang 16.0.6.*
+  - clangxx 16.0.6.*
   constrains:
-  - compiler-rt 15.0.7
+  - compiler-rt 16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  noarch: generic
-  size: 11283089
-  timestamp: 1684402974671
-- platform: linux-64
+  size: 9829914
+  timestamp: 1701467293179
+- kind: conda
   name: cxx-compiler
   version: 1.6.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h00ab1b0_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.6.0-h00ab1b0_0.conda
+  sha256: 472b6b7f967df1db634c67d71c6b31cd186d18b5d0548196c2e426833ff17d99
+  md5: 364c6ae36c4e36fcbd4d273cf4db78af
+  depends:
   - c-compiler ==1.6.0 hd590300_0
   - gxx *
   - gxx_linux-64 12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.6.0-h00ab1b0_0.conda
-  hash:
-    md5: 364c6ae36c4e36fcbd4d273cf4db78af
-    sha256: 472b6b7f967df1db634c67d71c6b31cd186d18b5d0548196c2e426833ff17d99
-  build: h00ab1b0_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: BSD
   size: 6179
   timestamp: 1689097484095
-- platform: osx-64
+- kind: conda
   name: cxx-compiler
   version: 1.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - c-compiler ==1.6.0 h63c33a9_0
-  - clangxx_osx-64 15.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.6.0-h1c7c39f_0.conda
-  hash:
-    md5: 9adaf7c9d4e1e15e70a8dd46befbbab2
-    sha256: dc0860c05ef3083192b8ff4ac8242403f05a550cc42c7709ec8c9f4eaa88e993
-  build: h1c7c39f_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD
-  size: 6258
-  timestamp: 1689097854160
-- platform: osx-arm64
-  name: cxx-compiler
-  version: 1.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - c-compiler ==1.6.0 hd291e01_0
-  - clangxx_osx-arm64 15.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.6.0-h1995070_0.conda
-  hash:
-    md5: 35c1be0a08578238276ca9417fc1615c
-    sha256: f0a94c6312d0fd9e3d3c3546894bafa9f9b8b20a411bee0767ad4dac916f3eb5
-  build: h1995070_0
-  arch: aarch64
+  build: h2ffa867_0
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.6.0-h2ffa867_0.conda
+  sha256: c3a4ee7382e548f1e98ca1a348c941094b8d5f38c84d3258c00f9e493c591344
+  md5: b3bf27600fda1f6770fd28c45805d689
+  depends:
+  - c-compiler 1.6.0 h6aa9301_0
+  - clangxx_osx-arm64 16.*
   license: BSD
-  size: 6301
-  timestamp: 1689097905706
-- platform: linux-64
+  size: 6399
+  timestamp: 1701504753445
+- kind: conda
+  name: cxx-compiler
+  version: 1.6.0
+  build: h7728843_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.6.0-h7728843_0.conda
+  sha256: 3d609b7cf397b1d9f8627dedd0abd95a9daffa919d9593b56096a4e6e4a8597e
+  md5: 52efcad0d146779100e46c973cc1cb56
+  depends:
+  - c-compiler 1.6.0 h282daa2_0
+  - clangxx_osx-64 16.*
+  license: BSD
+  size: 6415
+  timestamp: 1701504710176
+- kind: conda
   name: distlib
   version: 0.3.7
-  category: main
-  manager: conda
-  dependencies:
-  - python 2.7|>=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.7-pyhd8ed1ab_0.conda
-  hash:
-    md5: 12d8aae6994f342618443a8f05c652a0
-    sha256: 13c887cb4a29e1e853a118cfc0e42b72a7e1d1c50c66c0974885d37f0db30619
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.7-pyhd8ed1ab_0.conda
+  sha256: 13c887cb4a29e1e853a118cfc0e42b72a7e1d1c50c66c0974885d37f0db30619
+  md5: 12d8aae6994f342618443a8f05c652a0
+  depends:
+  - python 2.7|>=3.6
+  arch: x86_64
+  platform: linux
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 273692
   timestamp: 1689598624555
-- platform: osx-64
+- kind: conda
   name: distlib
   version: 0.3.7
-  category: main
-  manager: conda
-  dependencies:
-  - python 2.7|>=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.7-pyhd8ed1ab_0.conda
-  hash:
-    md5: 12d8aae6994f342618443a8f05c652a0
-    sha256: 13c887cb4a29e1e853a118cfc0e42b72a7e1d1c50c66c0974885d37f0db30619
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
   noarch: python
-  size: 273692
-  timestamp: 1689598624555
-- platform: osx-arm64
-  name: distlib
-  version: 0.3.7
-  category: main
-  manager: conda
-  dependencies:
-  - python 2.7|>=3.6
   url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.7-pyhd8ed1ab_0.conda
-  hash:
-    md5: 12d8aae6994f342618443a8f05c652a0
-    sha256: 13c887cb4a29e1e853a118cfc0e42b72a7e1d1c50c66c0974885d37f0db30619
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 273692
-  timestamp: 1689598624555
-- platform: win-64
-  name: distlib
-  version: 0.3.7
-  category: main
-  manager: conda
-  dependencies:
+  sha256: 13c887cb4a29e1e853a118cfc0e42b72a7e1d1c50c66c0974885d37f0db30619
+  md5: 12d8aae6994f342618443a8f05c652a0
+  depends:
   - python 2.7|>=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.7-pyhd8ed1ab_0.conda
-  hash:
-    md5: 12d8aae6994f342618443a8f05c652a0
-    sha256: 13c887cb4a29e1e853a118cfc0e42b72a7e1d1c50c66c0974885d37f0db30619
-  build: pyhd8ed1ab_0
   arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  license_family: APACHE
+  size: 273692
+  timestamp: 1689598624555
+- kind: conda
+  name: distlib
+  version: 0.3.7
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.7-pyhd8ed1ab_0.conda
+  sha256: 13c887cb4a29e1e853a118cfc0e42b72a7e1d1c50c66c0974885d37f0db30619
+  md5: 12d8aae6994f342618443a8f05c652a0
+  depends:
+  - python 2.7|>=3.6
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  license_family: APACHE
+  size: 273692
+  timestamp: 1689598624555
+- kind: conda
+  name: distlib
+  version: 0.3.7
+  build: pyhd8ed1ab_0
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.7-pyhd8ed1ab_0.conda
+  sha256: 13c887cb4a29e1e853a118cfc0e42b72a7e1d1c50c66c0974885d37f0db30619
+  md5: 12d8aae6994f342618443a8f05c652a0
+  depends:
+  - python 2.7|>=3.6
+  arch: x86_64
+  platform: win
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 273692
   timestamp: 1689598624555
-- platform: linux-64
+- kind: conda
   name: doxygen
   version: 1.9.7
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libiconv >=1.17,<2.0a0
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/doxygen-1.9.7-h661eb56_1.conda
-  hash:
-    md5: cc4690294cdd88059b42428f68ab9def
-    sha256: 41334db7aaea41ca7e5968f598c52dbe714a4f5019d482ebc16f0e1d7ba1992d
-  build: h661eb56_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: GPL-2.0-only
-  license_family: GPL
-  size: 6179024
-  timestamp: 1687332729384
-- platform: osx-64
-  name: doxygen
-  version: 1.9.7
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  - libiconv >=1.17,<2.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/doxygen-1.9.7-hd7636e7_1.conda
-  hash:
-    md5: 00ada1ebe41c7febae72032969017b09
-    sha256: b3a43f399a710dbfff7f0380d43db3c7155ae128af5f14a0a23ac51a48209123
-  build: hd7636e7_1
-  arch: x86_64
-  subdir: osx-64
-  build_number: 1
-  license: GPL-2.0-only
-  license_family: GPL
-  size: 5344962
-  timestamp: 1687332955991
-- platform: osx-arm64
-  name: doxygen
-  version: 1.9.7
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  - libiconv >=1.17,<2.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/doxygen-1.9.7-h0e2417a_1.conda
-  hash:
-    md5: 02c4969f0c780d47e3f95b43f18a8ad7
-    sha256: 4bfaf6721b163301135c2db1268b40a099f51e2a42fdec60262137c72e20b9eb
   build: h0e2417a_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/doxygen-1.9.7-h0e2417a_1.conda
+  sha256: 4bfaf6721b163301135c2db1268b40a099f51e2a42fdec60262137c72e20b9eb
+  md5: 02c4969f0c780d47e3f95b43f18a8ad7
+  depends:
+  - libcxx >=15.0.7
+  - libiconv >=1.17,<2.0a0
+  arch: aarch64
+  platform: osx
   license: GPL-2.0-only
   license_family: GPL
   size: 5103390
   timestamp: 1687332854077
-- platform: win-64
+- kind: conda
   name: doxygen
   version: 1.9.7
-  category: main
-  manager: conda
-  dependencies:
+  build: h661eb56_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/doxygen-1.9.7-h661eb56_1.conda
+  sha256: 41334db7aaea41ca7e5968f598c52dbe714a4f5019d482ebc16f0e1d7ba1992d
+  md5: cc4690294cdd88059b42428f68ab9def
+  depends:
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  arch: x86_64
+  platform: linux
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 6179024
+  timestamp: 1687332729384
+- kind: conda
+  name: doxygen
+  version: 1.9.7
+  build: h849606c_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/doxygen-1.9.7-h849606c_1.conda
+  sha256: b78b504b6c61a7a6252be49f2838c4788332332616fdd427f81adddc650b2520
+  md5: 7c9a71d497a45a053fa85eeef616f936
+  depends:
   - libiconv >=1.17,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/doxygen-1.9.7-h849606c_1.conda
-  hash:
-    md5: 7c9a71d497a45a053fa85eeef616f936
-    sha256: b78b504b6c61a7a6252be49f2838c4788332332616fdd427f81adddc650b2520
-  build: h849606c_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: win
   license: GPL-2.0-only
   license_family: GPL
   size: 4861033
   timestamp: 1687333355663
-- platform: linux-64
-  name: exceptiongroup
-  version: 1.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: e6518222753f519e911e83136d2158d9
-    sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 19262
-  timestamp: 1692026296517
-- platform: osx-64
-  name: exceptiongroup
-  version: 1.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: e6518222753f519e911e83136d2158d9
-    sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 19262
-  timestamp: 1692026296517
-- platform: osx-arm64
-  name: exceptiongroup
-  version: 1.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: e6518222753f519e911e83136d2158d9
-    sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 19262
-  timestamp: 1692026296517
-- platform: win-64
-  name: exceptiongroup
-  version: 1.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: e6518222753f519e911e83136d2158d9
-    sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 19262
-  timestamp: 1692026296517
-- platform: linux-64
-  name: filelock
-  version: 3.13.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0c1729b74a8152fde6a38ba0a2ab9f45
-    sha256: 4d742d91412d1f163e5399d2b50c5d479694ebcd309127abb549ca3977f89d2b
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Unlicense
-  noarch: python
-  size: 15605
-  timestamp: 1698715139726
-- platform: osx-64
-  name: filelock
-  version: 3.13.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0c1729b74a8152fde6a38ba0a2ab9f45
-    sha256: 4d742d91412d1f163e5399d2b50c5d479694ebcd309127abb549ca3977f89d2b
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: Unlicense
-  noarch: python
-  size: 15605
-  timestamp: 1698715139726
-- platform: osx-arm64
-  name: filelock
-  version: 3.13.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0c1729b74a8152fde6a38ba0a2ab9f45
-    sha256: 4d742d91412d1f163e5399d2b50c5d479694ebcd309127abb549ca3977f89d2b
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Unlicense
-  noarch: python
-  size: 15605
-  timestamp: 1698715139726
-- platform: win-64
-  name: filelock
-  version: 3.13.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0c1729b74a8152fde6a38ba0a2ab9f45
-    sha256: 4d742d91412d1f163e5399d2b50c5d479694ebcd309127abb549ca3977f89d2b
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: Unlicense
-  noarch: python
-  size: 15605
-  timestamp: 1698715139726
-- platform: linux-64
-  name: flatbuffers
-  version: 23.5.26
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-23.5.26-h59595ed_1.conda
-  hash:
-    md5: 913a1c6fd00b66f33392a129e835ceca
-    sha256: 898446f402c14da0e74cd2062e78ebcfbc531e08a8207f4df36dd596d30ccb70
-  build: h59595ed_1
-  arch: x86_64
-  subdir: linux-64
+- kind: conda
+  name: doxygen
+  version: 1.9.7
+  build: hd7636e7_1
   build_number: 1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1578461
-  timestamp: 1685303689874
-- platform: osx-64
-  name: flatbuffers
-  version: 23.5.26
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-23.5.26-he965462_1.conda
-  hash:
-    md5: 76123c120b7b701941234d774e18c7c0
-    sha256: 4b1c90079e7bb323dd22f13b9bc014da7f0105b29323efb9097b0610997c9e04
-  build: he965462_1
-  arch: x86_64
   subdir: osx-64
-  build_number: 1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1303407
-  timestamp: 1685304046679
-- platform: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-64/doxygen-1.9.7-hd7636e7_1.conda
+  sha256: b3a43f399a710dbfff7f0380d43db3c7155ae128af5f14a0a23ac51a48209123
+  md5: 00ada1ebe41c7febae72032969017b09
+  depends:
+  - libcxx >=15.0.7
+  - libiconv >=1.17,<2.0a0
+  arch: x86_64
+  platform: osx
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 5344962
+  timestamp: 1687332955991
+- kind: conda
+  name: exceptiongroup
+  version: 1.1.3
+  build: pyhd8ed1ab_0
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+  sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
+  md5: e6518222753f519e911e83136d2158d9
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19262
+  timestamp: 1692026296517
+- kind: conda
+  name: exceptiongroup
+  version: 1.1.3
+  build: pyhd8ed1ab_0
+  subdir: osx-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+  sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
+  md5: e6518222753f519e911e83136d2158d9
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19262
+  timestamp: 1692026296517
+- kind: conda
+  name: exceptiongroup
+  version: 1.1.3
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+  sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
+  md5: e6518222753f519e911e83136d2158d9
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19262
+  timestamp: 1692026296517
+- kind: conda
+  name: exceptiongroup
+  version: 1.1.3
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+  sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
+  md5: e6518222753f519e911e83136d2158d9
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19262
+  timestamp: 1692026296517
+- kind: conda
+  name: filelock
+  version: 3.13.1
+  build: pyhd8ed1ab_0
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
+  sha256: 4d742d91412d1f163e5399d2b50c5d479694ebcd309127abb549ca3977f89d2b
+  md5: 0c1729b74a8152fde6a38ba0a2ab9f45
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: linux
+  license: Unlicense
+  size: 15605
+  timestamp: 1698715139726
+- kind: conda
+  name: filelock
+  version: 3.13.1
+  build: pyhd8ed1ab_0
+  subdir: osx-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
+  sha256: 4d742d91412d1f163e5399d2b50c5d479694ebcd309127abb549ca3977f89d2b
+  md5: 0c1729b74a8152fde6a38ba0a2ab9f45
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: osx
+  license: Unlicense
+  size: 15605
+  timestamp: 1698715139726
+- kind: conda
+  name: filelock
+  version: 3.13.1
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
+  sha256: 4d742d91412d1f163e5399d2b50c5d479694ebcd309127abb549ca3977f89d2b
+  md5: 0c1729b74a8152fde6a38ba0a2ab9f45
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
+  license: Unlicense
+  size: 15605
+  timestamp: 1698715139726
+- kind: conda
+  name: filelock
+  version: 3.13.1
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
+  sha256: 4d742d91412d1f163e5399d2b50c5d479694ebcd309127abb549ca3977f89d2b
+  md5: 0c1729b74a8152fde6a38ba0a2ab9f45
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
+  license: Unlicense
+  size: 15605
+  timestamp: 1698715139726
+- kind: conda
   name: flatbuffers
   version: 23.5.26
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-23.5.26-h13dd4ca_1.conda
-  hash:
-    md5: 789ac6fe52a8b2ce8dade900eb30f482
-    sha256: 83b28e6f3c1737f4aa250473ecc77fdcdf2802019b77515d95d95daa55111ad0
   build: h13dd4ca_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-23.5.26-h13dd4ca_1.conda
+  sha256: 83b28e6f3c1737f4aa250473ecc77fdcdf2802019b77515d95d95daa55111ad0
+  md5: 789ac6fe52a8b2ce8dade900eb30f482
+  depends:
+  - libcxx >=15.0.7
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 1279401
   timestamp: 1685304189845
-- platform: win-64
+- kind: conda
   name: flatbuffers
   version: 23.5.26
-  category: main
-  manager: conda
-  dependencies:
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-23.5.26-h59595ed_1.conda
+  sha256: 898446f402c14da0e74cd2062e78ebcfbc531e08a8207f4df36dd596d30ccb70
+  md5: 913a1c6fd00b66f33392a129e835ceca
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1578461
+  timestamp: 1685303689874
+- kind: conda
+  name: flatbuffers
+  version: 23.5.26
+  build: h63175ca_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-23.5.26-h63175ca_1.conda
+  sha256: 70de98e6e01129a518fad72e46a0b6b937d633b59d61b61abb8b84843fcc1c90
+  md5: 45c48934e47a0b2e80536e395f722f3b
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-23.5.26-h63175ca_1.conda
-  hash:
-    md5: 45c48934e47a0b2e80536e395f722f3b
-    sha256: 70de98e6e01129a518fad72e46a0b6b937d633b59d61b61abb8b84843fcc1c90
-  build: h63175ca_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: win
   license: Apache-2.0
   license_family: APACHE
   size: 1695306
   timestamp: 1685303935893
-- platform: linux-64
+- kind: conda
+  name: flatbuffers
+  version: 23.5.26
+  build: he965462_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-23.5.26-he965462_1.conda
+  sha256: 4b1c90079e7bb323dd22f13b9bc014da7f0105b29323efb9097b0610997c9e04
+  md5: 76123c120b7b701941234d774e18c7c0
+  depends:
+  - libcxx >=15.0.7
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1303407
+  timestamp: 1685304046679
+- kind: conda
   name: gcc
   version: 12.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - gcc_impl_linux-64 12.3.0.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h8d2909c_2.conda
-  hash:
-    md5: e2f2f81f367e14ca1f77a870bda2fe59
-    sha256: 1bbf077688822993c39518056fb43d83ff0920eb42fef11e8714d2a298cc0f27
   build: h8d2909c_2
-  arch: x86_64
-  subdir: linux-64
   build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h8d2909c_2.conda
+  sha256: 1bbf077688822993c39518056fb43d83ff0920eb42fef11e8714d2a298cc0f27
+  md5: e2f2f81f367e14ca1f77a870bda2fe59
+  depends:
+  - gcc_impl_linux-64 12.3.0.*
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 27086
   timestamp: 1694604171830
-- platform: linux-64
+- kind: conda
   name: gcc_impl_linux-64
   version: 12.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: he2b93b0_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_2.conda
+  sha256: 62a897343229e6dc4a3ace4f419a30e60a0a22ce7d0eac0b9bfb8f0308cf3de5
+  md5: 2f4d8677dc7dd87f93e9abfb2ce86808
+  depends:
   - binutils_impl_linux-64 >=2.39
   - libgcc-devel_linux-64 ==12.3.0 h8bca6fd_2
   - libgcc-ng >=12.3.0
@@ -3595,1330 +3807,1107 @@ package:
   - libsanitizer ==12.3.0 h0f45ef3_2
   - libstdcxx-ng >=12.3.0
   - sysroot_linux-64 *
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_2.conda
-  hash:
-    md5: 2f4d8677dc7dd87f93e9abfb2ce86808
-    sha256: 62a897343229e6dc4a3ace4f419a30e60a0a22ce7d0eac0b9bfb8f0308cf3de5
-  build: he2b93b0_2
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 51573870
   timestamp: 1695218760476
-- platform: linux-64
+- kind: conda
   name: gcc_linux-64
   version: 12.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h76fc315_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h76fc315_2.conda
+  sha256: 86f6db7399ec0362e4c4025939debbfebc8ad9ccef75e3c0e4069f85b149f24d
+  md5: 11517e7b5c910c5b5d6985c0c7eb7f50
+  depends:
   - binutils_linux-64 ==2.40 hbdbef99_2
   - gcc_impl_linux-64 12.3.0.*
   - sysroot_linux-64 *
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h76fc315_2.conda
-  hash:
-    md5: 11517e7b5c910c5b5d6985c0c7eb7f50
-    sha256: 86f6db7399ec0362e4c4025939debbfebc8ad9ccef75e3c0e4069f85b149f24d
-  build: h76fc315_2
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 30351
   timestamp: 1694604476800
-- platform: linux-64
+- kind: conda
   name: gflags
   version: 2.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.5.0
-  - libstdcxx-ng >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
-  hash:
-    md5: cddaf2c63ea4a5901cf09524c490ecdc
-    sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
-  build: he1b5a44_1004
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1004
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 116549
-  timestamp: 1594303828933
-- platform: osx-64
-  name: gflags
-  version: 2.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=10.0.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
-  hash:
-    md5: 3f59cc77a929537e42120faf104e0d16
-    sha256: 39540f879057ae529cad131644af111a8c3c48b384ec6212de6a5381e0863948
   build: hb1e8313_1004
-  arch: x86_64
-  subdir: osx-64
   build_number: 1004
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
+  sha256: 39540f879057ae529cad131644af111a8c3c48b384ec6212de6a5381e0863948
+  md5: 3f59cc77a929537e42120faf104e0d16
+  depends:
+  - libcxx >=10.0.1
+  arch: x86_64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 94612
   timestamp: 1599590973213
-- platform: osx-arm64
+- kind: conda
   name: gflags
   version: 2.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=11.0.0.rc1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
-  hash:
-    md5: aab9ddfad863e9ef81229a1f8852211b
-    sha256: 25d4a20af2e5ace95fdec88970f6d190e77e20074d2f6d3cef766198b76a4289
   build: hc88da5d_1004
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1004
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
+  sha256: 25d4a20af2e5ace95fdec88970f6d190e77e20074d2f6d3cef766198b76a4289
+  md5: aab9ddfad863e9ef81229a1f8852211b
+  depends:
+  - libcxx >=11.0.0.rc1
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 86690
   timestamp: 1599590990520
-- platform: linux-64
-  name: gitdb
-  version: 4.0.11
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  - smmap >=3.0.1,<6
-  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
-  hash:
-    md5: 623b19f616f2ca0c261441067e18ae40
-    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
-  build: pyhd8ed1ab_0
-  arch: x86_64
+- kind: conda
+  name: gflags
+  version: 2.2.2
+  build: he1b5a44_1004
+  build_number: 1004
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
+  sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
+  md5: cddaf2c63ea4a5901cf09524c490ecdc
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 52872
-  timestamp: 1697791718749
-- platform: osx-64
+  size: 116549
+  timestamp: 1594303828933
+- kind: conda
   name: gitdb
   version: 4.0.11
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  - smmap >=3.0.1,<6
-  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
-  hash:
-    md5: 623b19f616f2ca0c261441067e18ae40
-    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 52872
-  timestamp: 1697791718749
-- platform: osx-arm64
-  name: gitdb
-  version: 4.0.11
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  - smmap >=3.0.1,<6
-  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
-  hash:
-    md5: 623b19f616f2ca0c261441067e18ae40
-    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 52872
-  timestamp: 1697791718749
-- platform: win-64
-  name: gitdb
-  version: 4.0.11
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  - smmap >=3.0.1,<6
-  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
-  hash:
-    md5: 623b19f616f2ca0c261441067e18ae40
-    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 52872
-  timestamp: 1697791718749
-- platform: linux-64
-  name: gitignore-parser
-  version: 0.1.9
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: d7a00f5bb919ecb71b3da47f33b23825
-    sha256: c35e803e65892d2757a9d713fd03bac57b7f5a38cbbb19ccc067831f3df409b4
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 11371
-  timestamp: 1696511979480
-- platform: osx-64
-  name: gitignore-parser
-  version: 0.1.9
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+  sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
+  md5: 623b19f616f2ca0c261441067e18ae40
+  depends:
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: d7a00f5bb919ecb71b3da47f33b23825
-    sha256: c35e803e65892d2757a9d713fd03bac57b7f5a38cbbb19ccc067831f3df409b4
-  build: pyhd8ed1ab_0
+  - smmap >=3.0.1,<6
   arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52872
+  timestamp: 1697791718749
+- kind: conda
+  name: gitdb
+  version: 4.0.11
+  build: pyhd8ed1ab_0
   subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 11371
-  timestamp: 1696511979480
-- platform: osx-arm64
-  name: gitignore-parser
-  version: 0.1.9
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+  sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
+  md5: 623b19f616f2ca0c261441067e18ae40
+  depends:
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: d7a00f5bb919ecb71b3da47f33b23825
-    sha256: c35e803e65892d2757a9d713fd03bac57b7f5a38cbbb19ccc067831f3df409b4
+  - smmap >=3.0.1,<6
+  arch: x86_64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52872
+  timestamp: 1697791718749
+- kind: conda
+  name: gitdb
+  version: 4.0.11
   build: pyhd8ed1ab_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 11371
-  timestamp: 1696511979480
-- platform: win-64
+  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+  sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
+  md5: 623b19f616f2ca0c261441067e18ae40
+  depends:
+  - python >=3.7
+  - smmap >=3.0.1,<6
+  arch: aarch64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52872
+  timestamp: 1697791718749
+- kind: conda
+  name: gitdb
+  version: 4.0.11
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+  sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
+  md5: 623b19f616f2ca0c261441067e18ae40
+  depends:
+  - python >=3.7
+  - smmap >=3.0.1,<6
+  arch: x86_64
+  platform: win
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52872
+  timestamp: 1697791718749
+- kind: conda
   name: gitignore-parser
   version: 0.1.9
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: d7a00f5bb919ecb71b3da47f33b23825
-    sha256: c35e803e65892d2757a9d713fd03bac57b7f5a38cbbb19ccc067831f3df409b4
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 11371
-  timestamp: 1696511979480
-- platform: linux-64
-  name: gitpython
-  version: 3.1.40
-  category: main
-  manager: conda
-  dependencies:
-  - gitdb >=4.0.1,<5
-  - python >=3.7
-  - typing_extensions >=3.7.4.3
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6bf74c3b7c13079a91d4bd3da51cefcf
-    sha256: 6b85809ffbfe5c1887b674bf0492cc4dd1ac8a25f4d9fa20ef404be92186259b
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 147305
-  timestamp: 1697650463508
-- platform: osx-64
-  name: gitpython
-  version: 3.1.40
-  category: main
-  manager: conda
-  dependencies:
-  - gitdb >=4.0.1,<5
+  url: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
+  sha256: c35e803e65892d2757a9d713fd03bac57b7f5a38cbbb19ccc067831f3df409b4
+  md5: d7a00f5bb919ecb71b3da47f33b23825
+  depends:
   - python >=3.7
-  - typing_extensions >=3.7.4.3
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6bf74c3b7c13079a91d4bd3da51cefcf
-    sha256: 6b85809ffbfe5c1887b674bf0492cc4dd1ac8a25f4d9fa20ef404be92186259b
-  build: pyhd8ed1ab_0
   arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1696511979480
+- kind: conda
+  name: gitignore-parser
+  version: 0.1.9
+  build: pyhd8ed1ab_0
   subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 147305
-  timestamp: 1697650463508
-- platform: osx-arm64
-  name: gitpython
-  version: 3.1.40
-  category: main
-  manager: conda
-  dependencies:
-  - gitdb >=4.0.1,<5
+  url: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
+  sha256: c35e803e65892d2757a9d713fd03bac57b7f5a38cbbb19ccc067831f3df409b4
+  md5: d7a00f5bb919ecb71b3da47f33b23825
+  depends:
   - python >=3.7
-  - typing_extensions >=3.7.4.3
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6bf74c3b7c13079a91d4bd3da51cefcf
-    sha256: 6b85809ffbfe5c1887b674bf0492cc4dd1ac8a25f4d9fa20ef404be92186259b
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 147305
-  timestamp: 1697650463508
-- platform: win-64
-  name: gitpython
-  version: 3.1.40
-  category: main
-  manager: conda
-  dependencies:
-  - gitdb >=4.0.1,<5
-  - python >=3.7
-  - typing_extensions >=3.7.4.3
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6bf74c3b7c13079a91d4bd3da51cefcf
-    sha256: 6b85809ffbfe5c1887b674bf0492cc4dd1ac8a25f4d9fa20ef404be92186259b
-  build: pyhd8ed1ab_0
   arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1696511979480
+- kind: conda
+  name: gitignore-parser
+  version: 0.1.9
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
+  sha256: c35e803e65892d2757a9d713fd03bac57b7f5a38cbbb19ccc067831f3df409b4
+  md5: d7a00f5bb919ecb71b3da47f33b23825
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1696511979480
+- kind: conda
+  name: gitignore-parser
+  version: 0.1.9
+  build: pyhd8ed1ab_0
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.9-pyhd8ed1ab_0.conda
+  sha256: c35e803e65892d2757a9d713fd03bac57b7f5a38cbbb19ccc067831f3df409b4
+  md5: d7a00f5bb919ecb71b3da47f33b23825
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1696511979480
+- kind: conda
+  name: gitpython
+  version: 3.1.40
+  build: pyhd8ed1ab_0
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
+  sha256: 6b85809ffbfe5c1887b674bf0492cc4dd1ac8a25f4d9fa20ef404be92186259b
+  md5: 6bf74c3b7c13079a91d4bd3da51cefcf
+  depends:
+  - gitdb >=4.0.1,<5
+  - python >=3.7
+  - typing_extensions >=3.7.4.3
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 147305
   timestamp: 1697650463508
-- platform: linux-64
+- kind: conda
+  name: gitpython
+  version: 3.1.40
+  build: pyhd8ed1ab_0
+  subdir: osx-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
+  sha256: 6b85809ffbfe5c1887b674bf0492cc4dd1ac8a25f4d9fa20ef404be92186259b
+  md5: 6bf74c3b7c13079a91d4bd3da51cefcf
+  depends:
+  - gitdb >=4.0.1,<5
+  - python >=3.7
+  - typing_extensions >=3.7.4.3
+  arch: x86_64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147305
+  timestamp: 1697650463508
+- kind: conda
+  name: gitpython
+  version: 3.1.40
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
+  sha256: 6b85809ffbfe5c1887b674bf0492cc4dd1ac8a25f4d9fa20ef404be92186259b
+  md5: 6bf74c3b7c13079a91d4bd3da51cefcf
+  depends:
+  - gitdb >=4.0.1,<5
+  - python >=3.7
+  - typing_extensions >=3.7.4.3
+  arch: aarch64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147305
+  timestamp: 1697650463508
+- kind: conda
+  name: gitpython
+  version: 3.1.40
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.40-pyhd8ed1ab_0.conda
+  sha256: 6b85809ffbfe5c1887b674bf0492cc4dd1ac8a25f4d9fa20ef404be92186259b
+  md5: 6bf74c3b7c13079a91d4bd3da51cefcf
+  depends:
+  - gitdb >=4.0.1,<5
+  - python >=3.7
+  - typing_extensions >=3.7.4.3
+  arch: x86_64
+  platform: win
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147305
+  timestamp: 1697650463508
+- kind: conda
   name: glog
   version: 0.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - gflags >=2.2.2,<2.3.0a0
-  - libgcc-ng >=10.3.0
-  - libstdcxx-ng >=10.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
-  hash:
-    md5: b31f3565cb84435407594e548a2fb7b2
-    sha256: 888cbcfb67f6e3d88a4c4ab9d26c9a406f620c4101a35dc6d2dbadb95f2221d4
-  build: h6f12383_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 114321
-  timestamp: 1649143789233
-- platform: osx-64
-  name: glog
-  version: 0.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - gflags >=2.2.2,<2.3.0a0
-  - libcxx >=12.0.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
-  hash:
-    md5: 69eb97ca709a136c53fdca1f2fd33ddf
-    sha256: fdb38560094fb4a952346dc72a79b3cb09e23e4d0cae9ba4f524e6e88203d3c8
-  build: h8ac2a54_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 100624
-  timestamp: 1649143914155
-- platform: osx-arm64
-  name: glog
-  version: 0.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - gflags >=2.2.2,<2.3.0a0
-  - libcxx >=12.0.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
-  hash:
-    md5: 5a570729c7709399cf8511aeeda6f989
-    sha256: 4d772c42477f64be708594ac45870feba3e838977871118eb25e00deb0e9a73c
   build: h6da1cb0_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
+  sha256: 4d772c42477f64be708594ac45870feba3e838977871118eb25e00deb0e9a73c
+  md5: 5a570729c7709399cf8511aeeda6f989
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=12.0.1
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 97658
   timestamp: 1649144191039
-- platform: linux-64
+- kind: conda
+  name: glog
+  version: 0.6.0
+  build: h6f12383_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
+  sha256: 888cbcfb67f6e3d88a4c4ab9d26c9a406f620c4101a35dc6d2dbadb95f2221d4
+  md5: b31f3565cb84435407594e548a2fb7b2
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 114321
+  timestamp: 1649143789233
+- kind: conda
+  name: glog
+  version: 0.6.0
+  build: h8ac2a54_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
+  sha256: fdb38560094fb4a952346dc72a79b3cb09e23e4d0cae9ba4f524e6e88203d3c8
+  md5: 69eb97ca709a136c53fdca1f2fd33ddf
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=12.0.1
+  arch: x86_64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100624
+  timestamp: 1649143914155
+- kind: conda
   name: gxx
   version: 12.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h8d2909c_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h8d2909c_2.conda
+  sha256: 5fd65768fb602fd21466831c96e7a2355a4df692507abbd481aa65a777151d85
+  md5: 673bac341be6b90ef9e8abae7e52ca46
+  depends:
   - gcc 12.3.0.*
   - gxx_impl_linux-64 12.3.0.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h8d2909c_2.conda
-  hash:
-    md5: 673bac341be6b90ef9e8abae7e52ca46
-    sha256: 5fd65768fb602fd21466831c96e7a2355a4df692507abbd481aa65a777151d85
-  build: h8d2909c_2
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 26539
   timestamp: 1694604501713
-- platform: linux-64
+- kind: conda
   name: gxx_impl_linux-64
   version: 12.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: he2b93b0_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_2.conda
+  sha256: 1ca91c1a3892b61da7efe150f9a1830e18aac82f563b27bf707520cb3297cc7a
+  md5: f89b9916afc36fc5562fbfc11330a8a2
+  depends:
   - gcc_impl_linux-64 ==12.3.0 he2b93b0_2
   - libstdcxx-devel_linux-64 ==12.3.0 h8bca6fd_2
   - sysroot_linux-64 *
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_2.conda
-  hash:
-    md5: f89b9916afc36fc5562fbfc11330a8a2
-    sha256: 1ca91c1a3892b61da7efe150f9a1830e18aac82f563b27bf707520cb3297cc7a
-  build: he2b93b0_2
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 12667490
   timestamp: 1695218983245
-- platform: linux-64
+- kind: conda
   name: gxx_linux-64
   version: 12.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h8a814eb_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h8a814eb_2.conda
+  sha256: 9878771cf1316230150a795d213a2f1dd7dead07dc0bccafae20533d631d5e69
+  md5: f517b1525e9783849bd56a5dc45a9960
+  depends:
   - binutils_linux-64 ==2.40 hbdbef99_2
   - gcc_linux-64 ==12.3.0 h76fc315_2
   - gxx_impl_linux-64 12.3.0.*
   - sysroot_linux-64 *
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h8a814eb_2.conda
-  hash:
-    md5: f517b1525e9783849bd56a5dc45a9960
-    sha256: 9878771cf1316230150a795d213a2f1dd7dead07dc0bccafae20533d631d5e69
-  build: h8a814eb_2
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 28640
   timestamp: 1694604524890
-- platform: linux-64
+- kind: conda
   name: icu
   version: '73.2'
-  category: main
-  manager: conda
-  dependencies:
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+  sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
+  md5: cc47e1facc155f91abd89b11e48e72ff
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
-  hash:
-    md5: cc47e1facc155f91abd89b11e48e72ff
-    sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
-  build: h59595ed_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: MIT
   license_family: MIT
   size: 12089150
   timestamp: 1692900650789
-- platform: osx-64
+- kind: conda
   name: icu
   version: '73.2'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
-  hash:
-    md5: 5cc301d759ec03f28328428e28f65591
-    sha256: f66362dc36178ac9b7c7a9b012948a9d2d050b3debec24bbd94aadbc44854185
-  build: hf5e326d_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 11787527
-  timestamp: 1692901622519
-- platform: osx-arm64
-  name: icu
-  version: '73.2'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
-  hash:
-    md5: 8521bd47c0e11c5902535bb1a17c565f
-    sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
   build: hc8870d7_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+  sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
+  md5: 8521bd47c0e11c5902535bb1a17c565f
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 11997841
   timestamp: 1692902104771
-- platform: linux-64
-  name: importlib-metadata
-  version: 4.13.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  - zipp >=0.5
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-4.13.0-pyha770c72_0.conda
-  hash:
-    md5: 80d2ed5fd22d7eb804f70c03f0d40b45
-    sha256: 81c149c12dc6dadc9836873282fa51a9c16507da94e89ccc6f3bdeb870b1cb73
-  build: pyha770c72_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 25527
-  timestamp: 1676330831614
-- platform: osx-64
-  name: importlib-metadata
-  version: 4.13.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  - zipp >=0.5
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-4.13.0-pyha770c72_0.conda
-  hash:
-    md5: 80d2ed5fd22d7eb804f70c03f0d40b45
-    sha256: 81c149c12dc6dadc9836873282fa51a9c16507da94e89ccc6f3bdeb870b1cb73
-  build: pyha770c72_0
-  arch: x86_64
+- kind: conda
+  name: icu
+  version: '73.2'
+  build: hf5e326d_0
   subdir: osx-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 25527
-  timestamp: 1676330831614
-- platform: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
+  sha256: f66362dc36178ac9b7c7a9b012948a9d2d050b3debec24bbd94aadbc44854185
+  md5: 5cc301d759ec03f28328428e28f65591
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 11787527
+  timestamp: 1692901622519
+- kind: conda
   name: importlib-metadata
   version: 4.13.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyha770c72_0
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-4.13.0-pyha770c72_0.conda
+  sha256: 81c149c12dc6dadc9836873282fa51a9c16507da94e89ccc6f3bdeb870b1cb73
+  md5: 80d2ed5fd22d7eb804f70c03f0d40b45
+  depends:
   - python >=3.8
   - zipp >=0.5
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-4.13.0-pyha770c72_0.conda
-  hash:
-    md5: 80d2ed5fd22d7eb804f70c03f0d40b45
-    sha256: 81c149c12dc6dadc9836873282fa51a9c16507da94e89ccc6f3bdeb870b1cb73
-  build: pyha770c72_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  arch: x86_64
+  platform: linux
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 25527
   timestamp: 1676330831614
-- platform: win-64
+- kind: conda
   name: importlib-metadata
   version: 4.13.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyha770c72_0
+  subdir: osx-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-4.13.0-pyha770c72_0.conda
+  sha256: 81c149c12dc6dadc9836873282fa51a9c16507da94e89ccc6f3bdeb870b1cb73
+  md5: 80d2ed5fd22d7eb804f70c03f0d40b45
+  depends:
   - python >=3.8
   - zipp >=0.5
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-4.13.0-pyha770c72_0.conda
-  hash:
-    md5: 80d2ed5fd22d7eb804f70c03f0d40b45
-    sha256: 81c149c12dc6dadc9836873282fa51a9c16507da94e89ccc6f3bdeb870b1cb73
-  build: pyha770c72_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 25527
   timestamp: 1676330831614
-- platform: linux-64
-  name: importlib_metadata
+- kind: conda
+  name: importlib-metadata
   version: 4.13.0
-  category: main
-  manager: conda
-  dependencies:
-  - importlib-metadata >=4.13.0,<4.13.1.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.13.0-hd8ed1ab_0.conda
-  hash:
-    md5: eb09e30f586f5d8f8e8b784824be7017
-    sha256: 3721a25eddddf46e562cfe04aa36c7c6417ae7056cd0c9d0a42d0349ce3bbcc8
-  build: hd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: generic
-  size: 9145
-  timestamp: 1676330837094
-- platform: osx-64
-  name: importlib_metadata
-  version: 4.13.0
-  category: main
-  manager: conda
-  dependencies:
-  - importlib-metadata >=4.13.0,<4.13.1.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.13.0-hd8ed1ab_0.conda
-  hash:
-    md5: eb09e30f586f5d8f8e8b784824be7017
-    sha256: 3721a25eddddf46e562cfe04aa36c7c6417ae7056cd0c9d0a42d0349ce3bbcc8
-  build: hd8ed1ab_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: generic
-  size: 9145
-  timestamp: 1676330837094
-- platform: osx-arm64
-  name: importlib_metadata
-  version: 4.13.0
-  category: main
-  manager: conda
-  dependencies:
-  - importlib-metadata >=4.13.0,<4.13.1.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.13.0-hd8ed1ab_0.conda
-  hash:
-    md5: eb09e30f586f5d8f8e8b784824be7017
-    sha256: 3721a25eddddf46e562cfe04aa36c7c6417ae7056cd0c9d0a42d0349ce3bbcc8
-  build: hd8ed1ab_0
-  arch: aarch64
+  build: pyha770c72_0
   subdir: osx-arm64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-4.13.0-pyha770c72_0.conda
+  sha256: 81c149c12dc6dadc9836873282fa51a9c16507da94e89ccc6f3bdeb870b1cb73
+  md5: 80d2ed5fd22d7eb804f70c03f0d40b45
+  depends:
+  - python >=3.8
+  - zipp >=0.5
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  noarch: generic
-  size: 9145
-  timestamp: 1676330837094
-- platform: win-64
+  size: 25527
+  timestamp: 1676330831614
+- kind: conda
+  name: importlib-metadata
+  version: 4.13.0
+  build: pyha770c72_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-4.13.0-pyha770c72_0.conda
+  sha256: 81c149c12dc6dadc9836873282fa51a9c16507da94e89ccc6f3bdeb870b1cb73
+  md5: 80d2ed5fd22d7eb804f70c03f0d40b45
+  depends:
+  - python >=3.8
+  - zipp >=0.5
+  arch: x86_64
+  platform: win
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25527
+  timestamp: 1676330831614
+- kind: conda
   name: importlib_metadata
   version: 4.13.0
-  category: main
-  manager: conda
-  dependencies:
-  - importlib-metadata >=4.13.0,<4.13.1.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.13.0-hd8ed1ab_0.conda
-  hash:
-    md5: eb09e30f586f5d8f8e8b784824be7017
-    sha256: 3721a25eddddf46e562cfe04aa36c7c6417ae7056cd0c9d0a42d0349ce3bbcc8
   build: hd8ed1ab_0
+  subdir: linux-64
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.13.0-hd8ed1ab_0.conda
+  sha256: 3721a25eddddf46e562cfe04aa36c7c6417ae7056cd0c9d0a42d0349ce3bbcc8
+  md5: eb09e30f586f5d8f8e8b784824be7017
+  depends:
+  - importlib-metadata >=4.13.0,<4.13.1.0a0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: linux
   license: Apache-2.0
   license_family: APACHE
-  noarch: generic
   size: 9145
   timestamp: 1676330837094
-- platform: linux-64
-  name: iniconfig
-  version: 2.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f800d2da156d08e289b14e87e43c1ae5
-    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 11101
-  timestamp: 1673103208955
-- platform: osx-64
-  name: iniconfig
-  version: 2.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f800d2da156d08e289b14e87e43c1ae5
-    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  build: pyhd8ed1ab_0
-  arch: x86_64
+- kind: conda
+  name: importlib_metadata
+  version: 4.13.0
+  build: hd8ed1ab_0
   subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 11101
-  timestamp: 1673103208955
-- platform: osx-arm64
-  name: iniconfig
-  version: 2.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f800d2da156d08e289b14e87e43c1ae5
-    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 11101
-  timestamp: 1673103208955
-- platform: win-64
-  name: iniconfig
-  version: 2.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f800d2da156d08e289b14e87e43c1ae5
-    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  build: pyhd8ed1ab_0
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.13.0-hd8ed1ab_0.conda
+  sha256: 3721a25eddddf46e562cfe04aa36c7c6417ae7056cd0c9d0a42d0349ce3bbcc8
+  md5: eb09e30f586f5d8f8e8b784824be7017
+  depends:
+  - importlib-metadata >=4.13.0,<4.13.1.0a0
   arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  license_family: APACHE
+  size: 9145
+  timestamp: 1676330837094
+- kind: conda
+  name: importlib_metadata
+  version: 4.13.0
+  build: hd8ed1ab_0
+  subdir: osx-arm64
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.13.0-hd8ed1ab_0.conda
+  sha256: 3721a25eddddf46e562cfe04aa36c7c6417ae7056cd0c9d0a42d0349ce3bbcc8
+  md5: eb09e30f586f5d8f8e8b784824be7017
+  depends:
+  - importlib-metadata >=4.13.0,<4.13.1.0a0
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  license_family: APACHE
+  size: 9145
+  timestamp: 1676330837094
+- kind: conda
+  name: importlib_metadata
+  version: 4.13.0
+  build: hd8ed1ab_0
   subdir: win-64
-  build_number: 0
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.13.0-hd8ed1ab_0.conda
+  sha256: 3721a25eddddf46e562cfe04aa36c7c6417ae7056cd0c9d0a42d0349ce3bbcc8
+  md5: eb09e30f586f5d8f8e8b784824be7017
+  depends:
+  - importlib-metadata >=4.13.0,<4.13.1.0a0
+  arch: x86_64
+  platform: win
+  license: Apache-2.0
+  license_family: APACHE
+  size: 9145
+  timestamp: 1676330837094
+- kind: conda
+  name: iniconfig
+  version: 2.0.0
+  build: pyhd8ed1ab_0
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+  sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+  md5: f800d2da156d08e289b14e87e43c1ae5
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 11101
   timestamp: 1673103208955
-- platform: win-64
+- kind: conda
+  name: iniconfig
+  version: 2.0.0
+  build: pyhd8ed1ab_0
+  subdir: osx-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+  sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+  md5: f800d2da156d08e289b14e87e43c1ae5
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 11101
+  timestamp: 1673103208955
+- kind: conda
+  name: iniconfig
+  version: 2.0.0
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+  sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+  md5: f800d2da156d08e289b14e87e43c1ae5
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 11101
+  timestamp: 1673103208955
+- kind: conda
+  name: iniconfig
+  version: 2.0.0
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+  sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+  md5: f800d2da156d08e289b14e87e43c1ae5
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 11101
+  timestamp: 1673103208955
+- kind: conda
   name: intel-openmp
   version: 2023.2.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50496.conda
-  hash:
-    md5: 519f9c42672f1e8a334ec9471e93f4fe
-    sha256: 38367c264bace64d6f939c1170cda3aba2eb0fb2300570c16a8c63aff9ca8031
   build: h57928b3_50496
-  arch: x86_64
-  subdir: win-64
   build_number: 50496
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50496.conda
+  sha256: 38367c264bace64d6f939c1170cda3aba2eb0fb2300570c16a8c63aff9ca8031
+  md5: 519f9c42672f1e8a334ec9471e93f4fe
+  arch: x86_64
+  platform: win
   license: LicenseRef-ProprietaryIntel
   license_family: Proprietary
   size: 2520627
   timestamp: 1695994411378
-- platform: linux-64
+- kind: conda
   name: jinja2
   version: 3.1.2
-  category: main
-  manager: conda
-  dependencies:
-  - markupsafe >=2.0
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: c8490ed5c70966d232fdd389d0dbed37
-    sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
   build: pyhd8ed1ab_1
-  arch: x86_64
+  build_number: 1
   subdir: linux-64
-  build_number: 1
-  license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 101443
-  timestamp: 1654302514195
-- platform: osx-64
-  name: jinja2
-  version: 3.1.2
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+  sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+  md5: c8490ed5c70966d232fdd389d0dbed37
+  depends:
   - markupsafe >=2.0
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: c8490ed5c70966d232fdd389d0dbed37
-    sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-  build: pyhd8ed1ab_1
   arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101443
+  timestamp: 1654302514195
+- kind: conda
+  name: jinja2
+  version: 3.1.2
+  build: pyhd8ed1ab_1
+  build_number: 1
   subdir: osx-64
-  build_number: 1
-  license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 101443
-  timestamp: 1654302514195
-- platform: osx-arm64
-  name: jinja2
-  version: 3.1.2
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+  sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+  md5: c8490ed5c70966d232fdd389d0dbed37
+  depends:
   - markupsafe >=2.0
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: c8490ed5c70966d232fdd389d0dbed37
-    sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-  build: pyhd8ed1ab_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 101443
-  timestamp: 1654302514195
-- platform: win-64
-  name: jinja2
-  version: 3.1.2
-  category: main
-  manager: conda
-  dependencies:
-  - markupsafe >=2.0
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: c8490ed5c70966d232fdd389d0dbed37
-    sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-  build: pyhd8ed1ab_1
   arch: x86_64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101443
+  timestamp: 1654302514195
+- kind: conda
+  name: jinja2
+  version: 3.1.2
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+  sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+  md5: c8490ed5c70966d232fdd389d0dbed37
+  depends:
+  - markupsafe >=2.0
+  - python >=3.7
+  arch: aarch64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101443
+  timestamp: 1654302514195
+- kind: conda
+  name: jinja2
+  version: 3.1.2
+  build: pyhd8ed1ab_1
+  build_number: 1
   subdir: win-64
-  build_number: 1
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+  sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+  md5: c8490ed5c70966d232fdd389d0dbed37
+  depends:
+  - markupsafe >=2.0
+  - python >=3.7
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 101443
   timestamp: 1654302514195
-- platform: linux-64
+- kind: conda
   name: just
   version: 1.15.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/just-1.15.0-he8a937b_0.conda
-  hash:
-    md5: 7e60e76dd956032a16543773f1488955
-    sha256: 3df9d0c1674c41699533211dc43b6f85a5650a987746faad659eb3c222cd6168
-  build: he8a937b_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: CC0-1.0
-  size: 1119533
-  timestamp: 1697287198405
-- platform: osx-64
-  name: just
-  version: 1.15.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/just-1.15.0-h63b85fc_0.conda
-  hash:
-    md5: 9d17474a2fd0286a95e472369a27f4a0
-    sha256: 32cfa40bed1c71342488e02c4c984c7e7c515645ac7286b2e866afbd017e2234
-  build: h63b85fc_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: CC0-1.0
-  size: 1045840
-  timestamp: 1697287468425
-- platform: osx-arm64
-  name: just
-  version: 1.15.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/just-1.15.0-h5ef7bb8_0.conda
-  hash:
-    md5: a283dd994c0181833cd289e1a0d374e5
-    sha256: 457c259b027cd035aa9fa11d9eeedfbe2298e6cfcebe6c2e1f4cdfce47cc5fc9
   build: h5ef7bb8_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/just-1.15.0-h5ef7bb8_0.conda
+  sha256: 457c259b027cd035aa9fa11d9eeedfbe2298e6cfcebe6c2e1f4cdfce47cc5fc9
+  md5: a283dd994c0181833cd289e1a0d374e5
+  arch: aarch64
+  platform: osx
   license: CC0-1.0
   size: 967137
   timestamp: 1697287585467
-- platform: win-64
+- kind: conda
   name: just
   version: 1.15.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h63b85fc_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/just-1.15.0-h63b85fc_0.conda
+  sha256: 32cfa40bed1c71342488e02c4c984c7e7c515645ac7286b2e866afbd017e2234
+  md5: 9d17474a2fd0286a95e472369a27f4a0
+  arch: x86_64
+  platform: osx
+  license: CC0-1.0
+  size: 1045840
+  timestamp: 1697287468425
+- kind: conda
+  name: just
+  version: 1.15.0
+  build: h7f3b576_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/just-1.15.0-h7f3b576_0.conda
+  sha256: c70bc660ef68da0a7128a133ac3d41b1aa4a6f8ace1894b11b691ae2464ad3ab
+  md5: c99de86aee5b1280526e717881fb31f4
+  depends:
   - m2w64-gcc-libs *
   - m2w64-gcc-libs-core *
-  url: https://conda.anaconda.org/conda-forge/win-64/just-1.15.0-h7f3b576_0.conda
-  hash:
-    md5: c99de86aee5b1280526e717881fb31f4
-    sha256: c70bc660ef68da0a7128a133ac3d41b1aa4a6f8ace1894b11b691ae2464ad3ab
-  build: h7f3b576_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: CC0-1.0
   size: 1075396
   timestamp: 1697288439231
-- platform: linux-64
+- kind: conda
+  name: just
+  version: 1.15.0
+  build: he8a937b_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/just-1.15.0-he8a937b_0.conda
+  sha256: 3df9d0c1674c41699533211dc43b6f85a5650a987746faad659eb3c222cd6168
+  md5: 7e60e76dd956032a16543773f1488955
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
+  license: CC0-1.0
+  size: 1119533
+  timestamp: 1697287198405
+- kind: conda
   name: kernel-headers_linux-64
   version: 2.6.32
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_16.conda
-  hash:
-    md5: 7ca122655873935e02c91279c5b03c8c
-    sha256: aaa8aa6dc776d734a6702032588ff3c496721da905366d91162e3654c082aef0
   build: he073ed8_16
-  arch: x86_64
-  subdir: linux-64
   build_number: 16
+  subdir: linux-64
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_16.conda
+  sha256: aaa8aa6dc776d734a6702032588ff3c496721da905366d91162e3654c082aef0
+  md5: 7ca122655873935e02c91279c5b03c8c
   constrains:
   - sysroot_linux-64 ==2.12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
-  noarch: generic
   size: 709007
   timestamp: 1689214970644
-- platform: linux-64
+- kind: conda
   name: keyutils
   version: 1.6.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=10.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
-  hash:
-    md5: 30186d27e2c9fa62b45fb1476b7200e3
-    sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
   build: h166bdaf_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-or-later
   size: 117831
   timestamp: 1646151697040
-- platform: linux-64
+- kind: conda
   name: krb5
   version: 1.21.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h659d440_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+  sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
+  md5: cd95826dbd331ed1be26bdf401432844
+  depends:
   - keyutils >=1.6.1,<2.0a0
   - libedit >=3.1.20191231,<4.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - openssl >=3.1.2,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
-  hash:
-    md5: cd95826dbd331ed1be26bdf401432844
-    sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
-  build: h659d440_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: MIT
   license_family: MIT
   size: 1371181
   timestamp: 1692097755782
-- platform: osx-64
+- kind: conda
   name: krb5
   version: 1.21.2
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  - libedit >=3.1.20191231,<4.0a0
-  - openssl >=3.1.2,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
-  hash:
-    md5: 80505a68783f01dc8d7308c075261b2f
-    sha256: 081ae2008a21edf57c048f331a17c65d1ccb52d6ca2f87ee031a73eff4dc0fc6
-  build: hb884880_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 1183568
-  timestamp: 1692098004387
-- platform: osx-arm64
-  name: krb5
-  version: 1.21.2
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  - libedit >=3.1.20191231,<4.0a0
-  - openssl >=3.1.2,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
-  hash:
-    md5: 92f1cff174a538e0722bf2efb16fc0b2
-    sha256: 70bdb9b4589ec7c7d440e485ae22b5a352335ffeb91a771d4c162996c3070875
   build: h92f50d5_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
+  sha256: 70bdb9b4589ec7c7d440e485ae22b5a352335ffeb91a771d4c162996c3070875
+  md5: 92f1cff174a538e0722bf2efb16fc0b2
+  depends:
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.1.2,<4.0a0
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 1195575
   timestamp: 1692098070699
-- platform: win-64
+- kind: conda
   name: krb5
   version: 1.21.2
-  category: main
-  manager: conda
-  dependencies:
+  build: hb884880_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
+  sha256: 081ae2008a21edf57c048f331a17c65d1ccb52d6ca2f87ee031a73eff4dc0fc6
+  md5: 80505a68783f01dc8d7308c075261b2f
+  depends:
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.1.2,<4.0a0
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 1183568
+  timestamp: 1692098004387
+- kind: conda
+  name: krb5
+  version: 1.21.2
+  build: heb0366b_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
+  sha256: 6002adff9e3dcfc9732b861730cb9e33d45fd76b2035b2cdb4e6daacb8262c0b
+  md5: 6e8b0f22b4eef3b3cb3849bb4c3d47f9
+  depends:
   - openssl >=3.1.2,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
-  hash:
-    md5: 6e8b0f22b4eef3b3cb3849bb4c3d47f9
-    sha256: 6002adff9e3dcfc9732b861730cb9e33d45fd76b2035b2cdb4e6daacb8262c0b
-  build: heb0366b_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
   size: 710894
   timestamp: 1692098129546
-- platform: osx-64
+- kind: conda
   name: ld64
   version: '609'
-  category: main
-  manager: conda
-  dependencies:
-  - ld64_osx-64 ==609 h0fd476b_15
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/ld64-609-ha91a046_15.conda
-  hash:
-    md5: 3c27099076bcf8fdde53785efb46dbf1
-    sha256: 5c13ce2916f592adb29301dfbbcfe773437744f2890881615210b041b6276fc2
-  build: ha91a046_15
-  arch: x86_64
-  subdir: osx-64
-  build_number: 15
-  constrains:
-  - cctools 973.0.1.*
-  - cctools_osx-64 973.0.1.*
-  license: APSL-2.0
-  license_family: Other
-  size: 19091
-  timestamp: 1697075759131
-- platform: osx-arm64
-  name: ld64
-  version: '609'
-  category: main
-  manager: conda
-  dependencies:
-  - ld64_osx-arm64 ==609 hc4dc95b_14
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-609-h89fa09d_14.conda
-  hash:
-    md5: 5d2c82c220addd4630baaa7118a301d3
-    sha256: 1bddb451bb0f2e95414239c43a528ec6039f8c84a9b84a212a3a0d851c74306b
-  build: h89fa09d_14
-  arch: aarch64
+  build: h634c8be_16
+  build_number: 16
   subdir: osx-arm64
-  build_number: 14
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-609-h634c8be_16.conda
+  sha256: 50c54ec77602fd553d1ca7965bb63fee0983154bbc044fe3209575881be42310
+  md5: 82582e7ed6bb5db878d4a01d9b70aad7
+  depends:
+  - ld64_osx-arm64 609 ha4bd21c_16
+  - libllvm16 >=16.0.6,<16.1.0a0
   constrains:
+  - cctools 973.0.1.*
   - cctools_osx-arm64 973.0.1.*
+  license: APSL-2.0
+  license_family: Other
+  size: 19326
+  timestamp: 1706798204562
+- kind: conda
+  name: ld64
+  version: '609'
+  build: ha02d983_16
+  build_number: 16
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ld64-609-ha02d983_16.conda
+  sha256: 63cd1976379a7e0ff8b0e57b0e16b112a0077acce83af364251ab309128a227d
+  md5: 6dfb00e6cab263fe598d48df153d3288
+  depends:
+  - ld64_osx-64 609 ha20a434_16
+  - libllvm16 >=16.0.6,<16.1.0a0
+  constrains:
+  - cctools_osx-64 973.0.1.*
   - cctools 973.0.1.*
   license: APSL-2.0
   license_family: Other
-  size: 19226
-  timestamp: 1690768480431
-- platform: osx-64
+  size: 19310
+  timestamp: 1706798136816
+- kind: conda
   name: ld64_osx-64
   version: '609'
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx *
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - sigtool *
-  - tapi >=1100.0.11,<1101.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-609-h0fd476b_15.conda
-  hash:
-    md5: f98d11f8e568521e1e3f88cbe5a4d53c
-    sha256: 6d793058554a46ffd4a059bf3bd33741856bfcbdaeab8e11cc1dc2df1137f7f0
-  build: h0fd476b_15
-  arch: x86_64
+  build: ha20a434_16
+  build_number: 16
   subdir: osx-64
-  build_number: 15
+  url: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-609-ha20a434_16.conda
+  sha256: eef540c95a418169617bdda1699d8f5441f819ed673d81f363c5c728a6273749
+  md5: db19844278d11471e5f4eddf50277f4f
+  depends:
+  - libcxx
+  - libllvm16 >=16.0.6,<16.1.0a0
+  - sigtool
+  - tapi >=1100.0.11,<1101.0a0
   constrains:
-  - cctools 973.0.1.*
-  - ld 609.*
-  - clang >=15.0.7,<16.0a0
   - cctools_osx-64 973.0.1.*
+  - cctools 973.0.1.*
+  - clang >=16.0.6,<17.0a0
+  - ld 609.*
   license: APSL-2.0
   license_family: Other
-  size: 1062203
-  timestamp: 1697075547194
-- platform: osx-arm64
+  size: 1055029
+  timestamp: 1706798033425
+- kind: conda
   name: ld64_osx-arm64
   version: '609'
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx *
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - sigtool *
-  - tapi >=1100.0.11,<1101.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-609-hc4dc95b_14.conda
-  hash:
-    md5: 1d41ae30b0c077ef3feab2f2e27bd593
-    sha256: 138f187e16d6952cb4f54ae1abef014a368948f0eb568c472f0798aa76fd959d
-  build: hc4dc95b_14
-  arch: aarch64
+  build: ha4bd21c_16
+  build_number: 16
   subdir: osx-arm64
-  build_number: 14
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-609-ha4bd21c_16.conda
+  sha256: 08acf7129ec9298d78943ecc913d09d500608ae7b3920fb88ec3aa4a052759c6
+  md5: 538b338b3a9f8712915ef9149606687b
+  depends:
+  - libcxx
+  - libllvm16 >=16.0.6,<16.1.0a0
+  - sigtool
+  - tapi >=1100.0.11,<1101.0a0
   constrains:
-  - cctools_osx-arm64 973.0.1.*
-  - clang >=15.0.7,<16.0a0
   - cctools 973.0.1.*
   - ld 609.*
+  - clang >=16.0.6,<17.0a0
+  - cctools_osx-arm64 973.0.1.*
   license: APSL-2.0
   license_family: Other
-  size: 1041974
-  timestamp: 1690768191902
-- platform: linux-64
+  size: 1047208
+  timestamp: 1706798110129
+- kind: conda
   name: ld_impl_linux-64
   version: '2.40'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
-  hash:
-    md5: 7aca3059a1729aa76c597603f10b0dd3
-    sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
   build: h41732ed_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+  sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
+  md5: 7aca3059a1729aa76c597603f10b0dd3
   constrains:
   - binutils_impl_linux-64 2.40
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   size: 704696
   timestamp: 1674833944779
-- platform: linux-64
+- kind: conda
   name: libabseil
   version: '20230802.1'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
-  hash:
-    md5: 2785ddf4cb0e7e743477991d64353947
-    sha256: 8729021a93e67bb93b4e73ef0a132499db516accfea11561b667635bcd0507e7
-  build: cxx17_h59595ed_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  constrains:
-  - abseil-cpp =20230802.1
-  - libabseil-static =20230802.1=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1263396
-  timestamp: 1695063868515
-- platform: osx-64
-  name: libabseil
-  version: '20230802.1'
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
-  hash:
-    md5: 6554f5fb47c025273268bcdb7bf3cd48
-    sha256: 05431a6adb376a865e10d4ae673399d7890083c06f61cf18edb7c6629e75f39e
   build: cxx17_h048a20a_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
+  sha256: 05431a6adb376a865e10d4ae673399d7890083c06f61cf18edb7c6629e75f39e
+  md5: 6554f5fb47c025273268bcdb7bf3cd48
+  depends:
+  - libcxx >=15.0.7
   constrains:
   - __osx >=10.13
   - libabseil-static =20230802.1=cxx17*
   - abseil-cpp =20230802.1
+  arch: x86_64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 1148356
   timestamp: 1695064289396
-- platform: osx-arm64
+- kind: conda
   name: libabseil
   version: '20230802.1'
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
-  hash:
-    md5: fb6dfadc1898666616dfda242d8aea10
-    sha256: 459a58f36607246b4483d7a370c2d9a03e7f824e79da2c6e3e9d62abf80393e7
   build: cxx17_h13dd4ca_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
+  sha256: 459a58f36607246b4483d7a370c2d9a03e7f824e79da2c6e3e9d62abf80393e7
+  md5: fb6dfadc1898666616dfda242d8aea10
+  depends:
+  - libcxx >=15.0.7
   constrains:
   - libabseil-static =20230802.1=cxx17*
   - abseil-cpp =20230802.1
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 1173407
   timestamp: 1695064439482
-- platform: win-64
+- kind: conda
   name: libabseil
   version: '20230802.1'
-  category: main
-  manager: conda
-  dependencies:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230802.1-cxx17_h63175ca_0.conda
-  hash:
-    md5: 02674c18394394ee4f76cdbd1012f526
-    sha256: 8a016d49fad3d4216ce5ae4a60869b5384d31b2009e1ed9f445b6551ce7ef9e8
-  build: cxx17_h63175ca_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
+  build: cxx17_h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
+  sha256: 8729021a93e67bb93b4e73ef0a132499db516accfea11561b667635bcd0507e7
+  md5: 2785ddf4cb0e7e743477991d64353947
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   constrains:
   - abseil-cpp =20230802.1
   - libabseil-static =20230802.1=cxx17*
+  arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  license_family: Apache
+  size: 1263396
+  timestamp: 1695063868515
+- kind: conda
+  name: libabseil
+  version: '20230802.1'
+  build: cxx17_h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230802.1-cxx17_h63175ca_0.conda
+  sha256: 8a016d49fad3d4216ce5ae4a60869b5384d31b2009e1ed9f445b6551ce7ef9e8
+  md5: 02674c18394394ee4f76cdbd1012f526
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - abseil-cpp =20230802.1
+  - libabseil-static =20230802.1=cxx17*
+  arch: x86_64
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 1733638
   timestamp: 1695064265262
-- platform: linux-64
+- kind: conda
   name: libarrow
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
-  - aws-sdk-cpp >=1.11.210,<1.11.211.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - glog >=0.6.0,<0.7.0a0
-  - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libbrotlidec >=1.1.0,<1.2.0a0
-  - libbrotlienc >=1.1.0,<1.2.0a0
-  - libgcc-ng >=12
-  - libgoogle-cloud >=2.12.0,<2.13.0a0
-  - libre2-11 >=2023.6.2,<2024.0a0
-  - libstdcxx-ng >=12
-  - libutf8proc >=2.8.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - orc >=1.9.2,<1.9.3.0a0
-  - re2
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.2-h84dd17c_2_cpu.conda
-  hash:
-    md5: 571e88947e7cadb42bfacb517c346662
-    sha256: 3490212354a8dc8960eeaa8de43cb85356c5318fd49a243a7108818e09aca982
-  build: h84dd17c_2_cpu
-  arch: x86_64
-  subdir: linux-64
+  build: h1aaacd4_2_cpu
   build_number: 2
-  constrains:
-  - parquet-cpp <0.0a0
-  - arrow-cpp <0.0a0
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  size: 22721490
-  timestamp: 1704354970709
-- platform: osx-64
-  name: libarrow
-  version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.2-h1aaacd4_2_cpu.conda
+  sha256: 13fde6b9ca0357272c9710a438a769a18921490051e2dbcc815853d0c17a2a1c
+  md5: ab5d6d9fc2f3304d99bbe6e50059a4f0
+  depends:
   - __osx >=10.13
   - aws-crt-cpp >=0.26.0,<0.26.1.0a0
   - aws-sdk-cpp >=1.11.210,<1.11.211.0a0
@@ -4938,27 +4927,25 @@ package:
   - re2
   - snappy >=1.1.10,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.2-h1aaacd4_2_cpu.conda
-  hash:
-    md5: ab5d6d9fc2f3304d99bbe6e50059a4f0
-    sha256: 13fde6b9ca0357272c9710a438a769a18921490051e2dbcc815853d0c17a2a1c
-  build: h1aaacd4_2_cpu
-  arch: x86_64
-  subdir: osx-64
-  build_number: 2
   constrains:
   - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
   - arrow-cpp <0.0a0
+  arch: x86_64
+  platform: osx
   license: Apache-2.0
   size: 15783377
   timestamp: 1704355600914
-- platform: osx-arm64
+- kind: conda
   name: libarrow
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h4ce3932_2_cpu
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.2-h4ce3932_2_cpu.conda
+  sha256: 6c176a5ece3c72c0c1b7d7be5cc0f0a8dc637e634c936730a6d744e564fb75cb
+  md5: d61d4cee3c195a5f574b3ade7a85ef94
+  depends:
   - aws-crt-cpp >=0.26.0,<0.26.1.0a0
   - aws-sdk-cpp >=1.11.210,<1.11.211.0a0
   - bzip2 >=1.0.8,<2.0a0
@@ -4977,27 +4964,63 @@ package:
   - re2
   - snappy >=1.1.10,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.2-h4ce3932_2_cpu.conda
-  hash:
-    md5: d61d4cee3c195a5f574b3ade7a85ef94
-    sha256: 6c176a5ece3c72c0c1b7d7be5cc0f0a8dc637e634c936730a6d744e564fb75cb
-  build: h4ce3932_2_cpu
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
   constrains:
   - apache-arrow-proc =*=cpu
   - arrow-cpp <0.0a0
   - parquet-cpp <0.0a0
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   size: 14634457
   timestamp: 1704355766916
-- platform: win-64
+- kind: conda
   name: libarrow
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h84dd17c_2_cpu
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.2-h84dd17c_2_cpu.conda
+  sha256: 3490212354a8dc8960eeaa8de43cb85356c5318fd49a243a7108818e09aca982
+  md5: 571e88947e7cadb42bfacb517c346662
+  depends:
+  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
+  - aws-sdk-cpp >=1.11.210,<1.11.211.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libgcc-ng >=12
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libre2-11 >=2023.6.2,<2024.0a0
+  - libstdcxx-ng >=12
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=1.9.2,<1.9.3.0a0
+  - re2
+  - snappy >=1.1.10,<2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  size: 22721490
+  timestamp: 1704354970709
+- kind: conda
+  name: libarrow
+  version: 14.0.2
+  build: he5f67d5_2_cpu
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-14.0.2-he5f67d5_2_cpu.conda
+  sha256: 12f7d520b023579cf9229ed4e20206254212f6faead301077c1204e4a2ccf879
+  md5: 4deff1889c1047ab2920e63ce527e840
+  depends:
   - aws-crt-cpp >=0.26.0,<0.26.1.0a0
   - aws-sdk-cpp >=1.11.210,<1.11.211.0a0
   - bzip2 >=1.0.8,<2.0a0
@@ -5020,193 +5043,175 @@ package:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-14.0.2-he5f67d5_2_cpu.conda
-  hash:
-    md5: 4deff1889c1047ab2920e63ce527e840
-    sha256: 12f7d520b023579cf9229ed4e20206254212f6faead301077c1204e4a2ccf879
-  build: he5f67d5_2_cpu
-  arch: x86_64
-  subdir: win-64
-  build_number: 2
   constrains:
   - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
   - arrow-cpp <0.0a0
+  arch: x86_64
+  platform: win
   license: Apache-2.0
   size: 5000205
   timestamp: 1704355416005
-- platform: linux-64
+- kind: conda
   name: libarrow-acero
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - libarrow 14.0.2 h84dd17c_2_cpu
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.2-h59595ed_2_cpu.conda
-  hash:
-    md5: 4b00f12f1f3c7350a0345aa9c18798d6
-    sha256: 4b847de73614a65edd892250ccd6e617d44fe88c2f56f10dfa0370b5c84120a7
-  build: h59595ed_2_cpu
-  arch: x86_64
-  subdir: linux-64
+  build: h000cb23_2_cpu
   build_number: 2
-  license: Apache-2.0
-  size: 576913
-  timestamp: 1704355059610
-- platform: osx-64
-  name: libarrow-acero
-  version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.2-h000cb23_2_cpu.conda
+  sha256: dea3527b02eaf5eede8c94d3eb10d16c08f413aa61c574a941579e1a9b0a5a59
+  md5: 4e2fc03720088ab54db18aa84fbb75fe
+  depends:
   - libarrow 14.0.2 h1aaacd4_2_cpu
   - libcxx >=14
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.2-h000cb23_2_cpu.conda
-  hash:
-    md5: 4e2fc03720088ab54db18aa84fbb75fe
-    sha256: dea3527b02eaf5eede8c94d3eb10d16c08f413aa61c574a941579e1a9b0a5a59
-  build: h000cb23_2_cpu
   arch: x86_64
-  subdir: osx-64
-  build_number: 2
+  platform: osx
   license: Apache-2.0
   size: 511952
   timestamp: 1704355744885
-- platform: osx-arm64
+- kind: conda
   name: libarrow-acero
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h13dd4ca_2_cpu
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.2-h13dd4ca_2_cpu.conda
+  sha256: 93784ab7aec5fe72a96bb028868037fc95ee0f72a43c5cdcdc98b31b3f6b3ef6
+  md5: b4b1760597af9889cd2f5311b0c34e7f
+  depends:
   - libarrow 14.0.2 h4ce3932_2_cpu
   - libcxx >=14
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.2-h13dd4ca_2_cpu.conda
-  hash:
-    md5: b4b1760597af9889cd2f5311b0c34e7f
-    sha256: 93784ab7aec5fe72a96bb028868037fc95ee0f72a43c5cdcdc98b31b3f6b3ef6
-  build: h13dd4ca_2_cpu
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
+  platform: osx
   license: Apache-2.0
   size: 494126
   timestamp: 1704355933680
-- platform: win-64
+- kind: conda
   name: libarrow-acero
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h59595ed_2_cpu
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.2-h59595ed_2_cpu.conda
+  sha256: 4b847de73614a65edd892250ccd6e617d44fe88c2f56f10dfa0370b5c84120a7
+  md5: 4b00f12f1f3c7350a0345aa9c18798d6
+  depends:
+  - libarrow 14.0.2 h84dd17c_2_cpu
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  size: 576913
+  timestamp: 1704355059610
+- kind: conda
+  name: libarrow-acero
+  version: 14.0.2
+  build: h63175ca_2_cpu
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-14.0.2-h63175ca_2_cpu.conda
+  sha256: 46e4fda9f254981875138e4dd42624806081886b62b15216c7977a5edeff79bf
+  md5: e3425ace09ee0422e654638f21fb2a9e
+  depends:
   - libarrow 14.0.2 he5f67d5_2_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-14.0.2-h63175ca_2_cpu.conda
-  hash:
-    md5: e3425ace09ee0422e654638f21fb2a9e
-    sha256: 46e4fda9f254981875138e4dd42624806081886b62b15216c7977a5edeff79bf
-  build: h63175ca_2_cpu
   arch: x86_64
-  subdir: win-64
-  build_number: 2
+  platform: win
   license: Apache-2.0
   size: 430004
   timestamp: 1704355525077
-- platform: linux-64
+- kind: conda
   name: libarrow-dataset
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h000cb23_2_cpu
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.2-h000cb23_2_cpu.conda
+  sha256: 9c7773e8068d8230bc1a7af3bca60fd23ab69b0ee58bd1327e5ea7a4349f9b5c
+  md5: 912e66fb84d6979da1d37535691b0a1b
+  depends:
+  - libarrow 14.0.2 h1aaacd4_2_cpu
+  - libarrow-acero 14.0.2 h000cb23_2_cpu
+  - libcxx >=14
+  - libparquet 14.0.2 h381d950_2_cpu
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  size: 511562
+  timestamp: 1704356220922
+- kind: conda
+  name: libarrow-dataset
+  version: 14.0.2
+  build: h13dd4ca_2_cpu
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.2-h13dd4ca_2_cpu.conda
+  sha256: 4a72d1476f49b5c234a2ef798ef33c473f8d6307aaceec65341a4f11db5ba23c
+  md5: bec70ec592be6a282cb06250fa5e71a4
+  depends:
+  - libarrow 14.0.2 h4ce3932_2_cpu
+  - libarrow-acero 14.0.2 h13dd4ca_2_cpu
+  - libcxx >=14
+  - libparquet 14.0.2 hf6ce1d5_2_cpu
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  size: 526384
+  timestamp: 1704356487597
+- kind: conda
+  name: libarrow-dataset
+  version: 14.0.2
+  build: h59595ed_2_cpu
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.2-h59595ed_2_cpu.conda
+  sha256: edd010a1edcd73dc0b1e9b0fed1bd42f2e4252e0390a7f5432ae796fc39f2144
+  md5: 5561fbdff1a630b3768fcbcd1307bcc2
+  depends:
   - libarrow 14.0.2 h84dd17c_2_cpu
   - libarrow-acero 14.0.2 h59595ed_2_cpu
   - libgcc-ng >=12
   - libparquet 14.0.2 h352af49_2_cpu
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.2-h59595ed_2_cpu.conda
-  hash:
-    md5: 5561fbdff1a630b3768fcbcd1307bcc2
-    sha256: edd010a1edcd73dc0b1e9b0fed1bd42f2e4252e0390a7f5432ae796fc39f2144
-  build: h59595ed_2_cpu
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: Apache-2.0
   size: 582023
   timestamp: 1704355222590
-- platform: osx-64
+- kind: conda
   name: libarrow-dataset
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - libarrow 14.0.2 h1aaacd4_2_cpu
-  - libarrow-acero 14.0.2 h000cb23_2_cpu
-  - libcxx >=14
-  - libparquet 14.0.2 h381d950_2_cpu
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.2-h000cb23_2_cpu.conda
-  hash:
-    md5: 912e66fb84d6979da1d37535691b0a1b
-    sha256: 9c7773e8068d8230bc1a7af3bca60fd23ab69b0ee58bd1327e5ea7a4349f9b5c
-  build: h000cb23_2_cpu
-  arch: x86_64
-  subdir: osx-64
+  build: h63175ca_2_cpu
   build_number: 2
-  license: Apache-2.0
-  size: 511562
-  timestamp: 1704356220922
-- platform: osx-arm64
-  name: libarrow-dataset
-  version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - libarrow 14.0.2 h4ce3932_2_cpu
-  - libarrow-acero 14.0.2 h13dd4ca_2_cpu
-  - libcxx >=14
-  - libparquet 14.0.2 hf6ce1d5_2_cpu
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.2-h13dd4ca_2_cpu.conda
-  hash:
-    md5: bec70ec592be6a282cb06250fa5e71a4
-    sha256: 4a72d1476f49b5c234a2ef798ef33c473f8d6307aaceec65341a4f11db5ba23c
-  build: h13dd4ca_2_cpu
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
-  license: Apache-2.0
-  size: 526384
-  timestamp: 1704356487597
-- platform: win-64
-  name: libarrow-dataset
-  version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-14.0.2-h63175ca_2_cpu.conda
+  sha256: 53ae88b6b05f80309fa1789885b8b13a435d1c0cef71d2eb635da45417db8327
+  md5: de680262729b7a718ee3427b7af68416
+  depends:
   - libarrow 14.0.2 he5f67d5_2_cpu
   - libarrow-acero 14.0.2 h63175ca_2_cpu
   - libparquet 14.0.2 h7ec3a38_2_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-14.0.2-h63175ca_2_cpu.conda
-  hash:
-    md5: de680262729b7a718ee3427b7af68416
-    sha256: 53ae88b6b05f80309fa1789885b8b13a435d1c0cef71d2eb635da45417db8327
-  build: h63175ca_2_cpu
   arch: x86_64
-  subdir: win-64
-  build_number: 2
+  platform: win
   license: Apache-2.0
   size: 428399
   timestamp: 1704355889001
-- platform: linux-64
+- kind: conda
   name: libarrow-flight
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h120cb0d_2_cpu
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.2-h120cb0d_2_cpu.conda
+  sha256: aa6ca307db6fb91cff2712a6c6091a3f9277ce054550fbe26c7bb93d65e395fb
+  md5: e03930dbf4508a5153cd0fc237756a75
+  depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - libarrow 14.0.2 h84dd17c_2_cpu
@@ -5215,70 +5220,21 @@ package:
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libstdcxx-ng >=12
   - ucx >=1.15.0,<1.16.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.2-h120cb0d_2_cpu.conda
-  hash:
-    md5: e03930dbf4508a5153cd0fc237756a75
-    sha256: aa6ca307db6fb91cff2712a6c6091a3f9277ce054550fbe26c7bb93d65e395fb
-  build: h120cb0d_2_cpu
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: Apache-2.0
   size: 500908
   timestamp: 1704355109389
-- platform: osx-64
+- kind: conda
   name: libarrow-flight
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.13
-  - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 14.0.2 h1aaacd4_2_cpu
-  - libcxx >=14
-  - libgrpc >=1.59.3,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.2-ha1803ca_2_cpu.conda
-  hash:
-    md5: ea3430af75e5aad9d123eeae096e7413
-    sha256: 2c41f0edfa2ec26ede42d17211bac938a862252cc9ffb47a1e65d88ab53bf00e
-  build: ha1803ca_2_cpu
-  arch: x86_64
-  subdir: osx-64
+  build: h53b1db0_2_cpu
   build_number: 2
-  license: Apache-2.0
-  size: 319741
-  timestamp: 1704355863264
-- platform: osx-arm64
-  name: libarrow-flight
-  version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 14.0.2 h4ce3932_2_cpu
-  - libcxx >=14
-  - libgrpc >=1.59.3,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.2-ha94d253_2_cpu.conda
-  hash:
-    md5: 9acf1572e3db073db00e67d21cfb7477
-    sha256: 6e18f49f8c6b58958882d9735529ebfec402ce3443e0934b9fd89ac1d7d22c57
-  build: ha94d253_2_cpu
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
-  license: Apache-2.0
-  size: 331157
-  timestamp: 1704356092185
-- platform: win-64
-  name: libarrow-flight
-  version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-14.0.2-h53b1db0_2_cpu.conda
+  sha256: d1abcb363232ab848fd556f9861af14d846d5ad8ecbd3225af36d1a9bd45f5eb
+  md5: 65b3299f58b837ec5dd5de3ea9a9ac73
+  depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - libarrow 14.0.2 he5f67d5_2_cpu
@@ -5287,111 +5243,166 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-14.0.2-h53b1db0_2_cpu.conda
-  hash:
-    md5: 65b3299f58b837ec5dd5de3ea9a9ac73
-    sha256: d1abcb363232ab848fd556f9861af14d846d5ad8ecbd3225af36d1a9bd45f5eb
-  build: h53b1db0_2_cpu
   arch: x86_64
-  subdir: win-64
-  build_number: 2
+  platform: win
   license: Apache-2.0
   size: 285319
   timestamp: 1704355615110
-- platform: linux-64
+- kind: conda
+  name: libarrow-flight
+  version: 14.0.2
+  build: ha1803ca_2_cpu
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.2-ha1803ca_2_cpu.conda
+  sha256: 2c41f0edfa2ec26ede42d17211bac938a862252cc9ffb47a1e65d88ab53bf00e
+  md5: ea3430af75e5aad9d123eeae096e7413
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libarrow 14.0.2 h1aaacd4_2_cpu
+  - libcxx >=14
+  - libgrpc >=1.59.3,<1.60.0a0
+  - libprotobuf >=4.24.4,<4.24.5.0a0
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  size: 319741
+  timestamp: 1704355863264
+- kind: conda
+  name: libarrow-flight
+  version: 14.0.2
+  build: ha94d253_2_cpu
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.2-ha94d253_2_cpu.conda
+  sha256: 6e18f49f8c6b58958882d9735529ebfec402ce3443e0934b9fd89ac1d7d22c57
+  md5: 9acf1572e3db073db00e67d21cfb7477
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libarrow 14.0.2 h4ce3932_2_cpu
+  - libcxx >=14
+  - libgrpc >=1.59.3,<1.60.0a0
+  - libprotobuf >=4.24.4,<4.24.5.0a0
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  size: 331157
+  timestamp: 1704356092185
+- kind: conda
   name: libarrow-flight-sql
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h39a9b85_2_cpu
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.2-h39a9b85_2_cpu.conda
+  sha256: 3621589405facf900779210f9f49556290cee0861a9797585eb6af7933017d65
+  md5: c6e0c75f69f3c31b0a4f02d415e0739d
+  depends:
+  - libarrow 14.0.2 h4ce3932_2_cpu
+  - libarrow-flight 14.0.2 ha94d253_2_cpu
+  - libcxx >=14
+  - libprotobuf >=4.24.4,<4.24.5.0a0
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  size: 161406
+  timestamp: 1704356624291
+- kind: conda
+  name: libarrow-flight-sql
+  version: 14.0.2
+  build: h61ff412_2_cpu
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.2-h61ff412_2_cpu.conda
+  sha256: 839f7e2682e9b1b004df3c2c28ac4c0c04e1e9bd8f1942d48a3abe24700f1437
+  md5: 1afaafe003abec8aec34f46ec418980a
+  depends:
   - libarrow 14.0.2 h84dd17c_2_cpu
   - libarrow-flight 14.0.2 h120cb0d_2_cpu
   - libgcc-ng >=12
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.2-h61ff412_2_cpu.conda
-  hash:
-    md5: 1afaafe003abec8aec34f46ec418980a
-    sha256: 839f7e2682e9b1b004df3c2c28ac4c0c04e1e9bd8f1942d48a3abe24700f1437
-  build: h61ff412_2_cpu
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: Apache-2.0
   size: 193226
   timestamp: 1704355263191
-- platform: osx-64
+- kind: conda
   name: libarrow-flight-sql
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.13
-  - libarrow 14.0.2 h1aaacd4_2_cpu
-  - libarrow-flight 14.0.2 ha1803ca_2_cpu
-  - libcxx >=14
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.2-h8ec153b_2_cpu.conda
-  hash:
-    md5: 67d65eb4d9921ab25a440db879138d09
-    sha256: a961db70a5256049e8cd6f08fcfbec1f397a33e79e8ad103e57e801b4fc3675f
-  build: h8ec153b_2_cpu
-  arch: x86_64
-  subdir: osx-64
+  build: h78eab7c_2_cpu
   build_number: 2
-  license: Apache-2.0
-  size: 154235
-  timestamp: 1704356322848
-- platform: osx-arm64
-  name: libarrow-flight-sql
-  version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - libarrow 14.0.2 h4ce3932_2_cpu
-  - libarrow-flight 14.0.2 ha94d253_2_cpu
-  - libcxx >=14
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.2-h39a9b85_2_cpu.conda
-  hash:
-    md5: c6e0c75f69f3c31b0a4f02d415e0739d
-    sha256: 3621589405facf900779210f9f49556290cee0861a9797585eb6af7933017d65
-  build: h39a9b85_2_cpu
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
-  license: Apache-2.0
-  size: 161406
-  timestamp: 1704356624291
-- platform: win-64
-  name: libarrow-flight-sql
-  version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-14.0.2-h78eab7c_2_cpu.conda
+  sha256: 6dd037f69f153308f6c16009d76bc75ba12adf8c7f69b3006e57b2e07528f84f
+  md5: 27731c55915b881c92112baac7fd4f04
+  depends:
   - libarrow 14.0.2 he5f67d5_2_cpu
   - libarrow-flight 14.0.2 h53b1db0_2_cpu
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-14.0.2-h78eab7c_2_cpu.conda
-  hash:
-    md5: 27731c55915b881c92112baac7fd4f04
-    sha256: 6dd037f69f153308f6c16009d76bc75ba12adf8c7f69b3006e57b2e07528f84f
-  build: h78eab7c_2_cpu
   arch: x86_64
-  subdir: win-64
-  build_number: 2
+  platform: win
   license: Apache-2.0
   size: 222701
   timestamp: 1704355966327
-- platform: linux-64
+- kind: conda
+  name: libarrow-flight-sql
+  version: 14.0.2
+  build: h8ec153b_2_cpu
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.2-h8ec153b_2_cpu.conda
+  sha256: a961db70a5256049e8cd6f08fcfbec1f397a33e79e8ad103e57e801b4fc3675f
+  md5: 67d65eb4d9921ab25a440db879138d09
+  depends:
+  - __osx >=10.13
+  - libarrow 14.0.2 h1aaacd4_2_cpu
+  - libarrow-flight 14.0.2 ha1803ca_2_cpu
+  - libcxx >=14
+  - libprotobuf >=4.24.4,<4.24.5.0a0
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  size: 154235
+  timestamp: 1704356322848
+- kind: conda
   name: libarrow-gandiva
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h01dce7f_2_cpu
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.2-h01dce7f_2_cpu.conda
+  sha256: d17c1474d202bac57c590b9f2cf062c837a69991c59135b422a520bff4bbae57
+  md5: 3903071e62de031ce169187cdb2e32af
+  depends:
+  - libarrow 14.0.2 h1aaacd4_2_cpu
+  - libcxx >=14
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libre2-11 >=2023.6.2,<2024.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - re2
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  size: 699571
+  timestamp: 1704355988767
+- kind: conda
+  name: libarrow-gandiva
+  version: 14.0.2
+  build: hacb8726_2_cpu
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.2-hacb8726_2_cpu.conda
+  sha256: bc3c180af8e842877455d1d429c28a3207da4f3f243390b0ba8e06051525ff48
+  md5: db1a164476c3b26f4425542ab9ce11df
+  depends:
   - libarrow 14.0.2 h84dd17c_2_cpu
   - libgcc-ng >=12
   - libllvm15 >=15.0.7,<15.1.0a0
@@ -5400,71 +5411,21 @@ package:
   - libutf8proc >=2.8.0,<3.0a0
   - openssl >=3.2.0,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.2-hacb8726_2_cpu.conda
-  hash:
-    md5: db1a164476c3b26f4425542ab9ce11df
-    sha256: bc3c180af8e842877455d1d429c28a3207da4f3f243390b0ba8e06051525ff48
-  build: hacb8726_2_cpu
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: Apache-2.0
   size: 893895
   timestamp: 1704355148995
-- platform: osx-64
+- kind: conda
   name: libarrow-gandiva
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - libarrow 14.0.2 h1aaacd4_2_cpu
-  - libcxx >=14
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libre2-11 >=2023.6.2,<2024.0a0
-  - libutf8proc >=2.8.0,<3.0a0
-  - openssl >=3.2.0,<4.0a0
-  - re2
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.2-h01dce7f_2_cpu.conda
-  hash:
-    md5: 3903071e62de031ce169187cdb2e32af
-    sha256: d17c1474d202bac57c590b9f2cf062c837a69991c59135b422a520bff4bbae57
-  build: h01dce7f_2_cpu
-  arch: x86_64
-  subdir: osx-64
+  build: hb2eaab1_2_cpu
   build_number: 2
-  license: Apache-2.0
-  size: 699571
-  timestamp: 1704355988767
-- platform: osx-arm64
-  name: libarrow-gandiva
-  version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - libarrow 14.0.2 h4ce3932_2_cpu
-  - libcxx >=14
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libre2-11 >=2023.6.2,<2024.0a0
-  - libutf8proc >=2.8.0,<3.0a0
-  - openssl >=3.2.0,<4.0a0
-  - re2
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.2-hf757142_2_cpu.conda
-  hash:
-    md5: f4285d86a247a339bf7bf43fda4ded17
-    sha256: 237007a5c35c612823762327ae355f396ba34b66b40317e87de41f36a2f839bc
-  build: hf757142_2_cpu
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
-  license: Apache-2.0
-  size: 689008
-  timestamp: 1704356234671
-- platform: win-64
-  name: libarrow-gandiva
-  version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-14.0.2-hb2eaab1_2_cpu.conda
+  sha256: c5681de79ecc4e054f32814927d918103f1a72a762990f8745c154a36a955fc7
+  md5: dfaa10cd86363d7509cd4dbe8f13f031
+  depends:
   - libarrow 14.0.2 he5f67d5_2_cpu
   - libre2-11 >=2023.6.2,<2024.0a0
   - libutf8proc >=2.8.0,<3.0a0
@@ -5474,91 +5435,105 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-14.0.2-hb2eaab1_2_cpu.conda
-  hash:
-    md5: dfaa10cd86363d7509cd4dbe8f13f031
-    sha256: c5681de79ecc4e054f32814927d918103f1a72a762990f8745c154a36a955fc7
-  build: hb2eaab1_2_cpu
   arch: x86_64
-  subdir: win-64
-  build_number: 2
+  platform: win
   license: Apache-2.0
   size: 10173801
   timestamp: 1704355710068
-- platform: linux-64
+- kind: conda
+  name: libarrow-gandiva
+  version: 14.0.2
+  build: hf757142_2_cpu
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.2-hf757142_2_cpu.conda
+  sha256: 237007a5c35c612823762327ae355f396ba34b66b40317e87de41f36a2f839bc
+  md5: f4285d86a247a339bf7bf43fda4ded17
+  depends:
+  - libarrow 14.0.2 h4ce3932_2_cpu
+  - libcxx >=14
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libre2-11 >=2023.6.2,<2024.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - re2
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  size: 689008
+  timestamp: 1704356234671
+- kind: conda
   name: libarrow-substrait
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h61ff412_2_cpu
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.2-h61ff412_2_cpu.conda
+  sha256: 675d616f8454d38f41b1833e8deffc51dbb2c2b4b48c54e8adba4795ff606bec
+  md5: 838d3d33c458225578f64e59c4410a9f
+  depends:
   - libarrow 14.0.2 h84dd17c_2_cpu
   - libarrow-acero 14.0.2 h59595ed_2_cpu
   - libarrow-dataset 14.0.2 h59595ed_2_cpu
   - libgcc-ng >=12
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.2-h61ff412_2_cpu.conda
-  hash:
-    md5: 838d3d33c458225578f64e59c4410a9f
-    sha256: 675d616f8454d38f41b1833e8deffc51dbb2c2b4b48c54e8adba4795ff606bec
-  build: h61ff412_2_cpu
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: Apache-2.0
   size: 508750
   timestamp: 1704355298174
-- platform: osx-64
+- kind: conda
   name: libarrow-substrait
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h7fd9903_2_cpu
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.2-h7fd9903_2_cpu.conda
+  sha256: f7712ad3916fb83171c82ba5031f4356df7cb96cff2a6fa9ef17e44fe9940270
+  md5: 98b3c3e9288e0d451d9329fa784fe256
+  depends:
+  - libarrow 14.0.2 h4ce3932_2_cpu
+  - libarrow-acero 14.0.2 h13dd4ca_2_cpu
+  - libarrow-dataset 14.0.2 h13dd4ca_2_cpu
+  - libcxx >=14
+  - libprotobuf >=4.24.4,<4.24.5.0a0
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  size: 474175
+  timestamp: 1704356753787
+- kind: conda
+  name: libarrow-substrait
+  version: 14.0.2
+  build: h8ec153b_2_cpu
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.2-h8ec153b_2_cpu.conda
+  sha256: eabb1705fbd324b55a2f6cc7b7451b7a15882bab25cfd05113f3f1f05f2a787e
+  md5: 3e279309bd00e8115283665bdbe257b8
+  depends:
   - __osx >=10.13
   - libarrow 14.0.2 h1aaacd4_2_cpu
   - libarrow-acero 14.0.2 h000cb23_2_cpu
   - libarrow-dataset 14.0.2 h000cb23_2_cpu
   - libcxx >=14
   - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.2-h8ec153b_2_cpu.conda
-  hash:
-    md5: 3e279309bd00e8115283665bdbe257b8
-    sha256: eabb1705fbd324b55a2f6cc7b7451b7a15882bab25cfd05113f3f1f05f2a787e
-  build: h8ec153b_2_cpu
   arch: x86_64
-  subdir: osx-64
-  build_number: 2
+  platform: osx
   license: Apache-2.0
   size: 453318
   timestamp: 1704356431617
-- platform: osx-arm64
+- kind: conda
   name: libarrow-substrait
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - libarrow 14.0.2 h4ce3932_2_cpu
-  - libarrow-acero 14.0.2 h13dd4ca_2_cpu
-  - libarrow-dataset 14.0.2 h13dd4ca_2_cpu
-  - libcxx >=14
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.2-h7fd9903_2_cpu.conda
-  hash:
-    md5: 98b3c3e9288e0d451d9329fa784fe256
-    sha256: f7712ad3916fb83171c82ba5031f4356df7cb96cff2a6fa9ef17e44fe9940270
-  build: h7fd9903_2_cpu
-  arch: aarch64
-  subdir: osx-arm64
+  build: hd4c9904_2_cpu
   build_number: 2
-  license: Apache-2.0
-  size: 474175
-  timestamp: 1704356753787
-- platform: win-64
-  name: libarrow-substrait
-  version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-14.0.2-hd4c9904_2_cpu.conda
+  sha256: cec14db792abd05497b40bfcc4c41ec3ad463cfcceeec5bd1422da5c297b4228
+  md5: 3d267143a5827a81b607619a12e3f7cd
+  depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - libarrow 14.0.2 he5f67d5_2_cpu
@@ -5568,1463 +5543,1162 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-14.0.2-hd4c9904_2_cpu.conda
-  hash:
-    md5: 3d267143a5827a81b607619a12e3f7cd
-    sha256: cec14db792abd05497b40bfcc4c41ec3ad463cfcceeec5bd1422da5c297b4228
-  build: hd4c9904_2_cpu
   arch: x86_64
-  subdir: win-64
-  build_number: 2
+  platform: win
   license: Apache-2.0
   size: 346667
   timestamp: 1704356049987
-- platform: linux-64
+- kind: conda
   name: libblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libopenblas >=0.3.24,<1.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-18_linux64_openblas.conda
-  hash:
-    md5: bcddbb497582ece559465b9cd11042e7
-    sha256: 92142c12eb42172365c96c865be8f164a2653649b28b23bded0e658f8d5d0815
   build: 18_linux64_openblas
-  arch: x86_64
-  subdir: linux-64
   build_number: 18
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-18_linux64_openblas.conda
+  sha256: 92142c12eb42172365c96c865be8f164a2653649b28b23bded0e658f8d5d0815
+  md5: bcddbb497582ece559465b9cd11042e7
+  depends:
+  - libopenblas >=0.3.24,<1.0a0
   constrains:
   - liblapacke 3.9.0 18_linux64_openblas
   - libcblas 3.9.0 18_linux64_openblas
   - liblapack 3.9.0 18_linux64_openblas
   - blas * openblas
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 14545
   timestamp: 1693951361891
-- platform: osx-64
+- kind: conda
   name: libblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libopenblas >=0.3.24,<1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-18_osx64_openblas.conda
-  hash:
-    md5: 6461cded280f7a46ebef0f1b687d4883
-    sha256: 6df6e9c008a1a68493c8c394e6dcdd51cfeb7e51f91c0699a596f62f4d9d8995
   build: 18_osx64_openblas
-  arch: x86_64
-  subdir: osx-64
   build_number: 18
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-18_osx64_openblas.conda
+  sha256: 6df6e9c008a1a68493c8c394e6dcdd51cfeb7e51f91c0699a596f62f4d9d8995
+  md5: 6461cded280f7a46ebef0f1b687d4883
+  depends:
+  - libopenblas >=0.3.24,<1.0a0
   constrains:
   - blas * openblas
   - libcblas 3.9.0 18_osx64_openblas
   - liblapacke 3.9.0 18_osx64_openblas
   - liblapack 3.9.0 18_osx64_openblas
+  arch: x86_64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 14765
   timestamp: 1693951714123
-- platform: osx-arm64
+- kind: conda
   name: libblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libopenblas >=0.3.24,<1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-18_osxarm64_openblas.conda
-  hash:
-    md5: 928d0c0b57e342a8629f5f5e001ee0d0
-    sha256: efef2710d5309124e200dccb883cdd66531f3f4dcb4af2eb4b7b1e5cf1bac57d
   build: 18_osxarm64_openblas
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 18
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-18_osxarm64_openblas.conda
+  sha256: efef2710d5309124e200dccb883cdd66531f3f4dcb4af2eb4b7b1e5cf1bac57d
+  md5: 928d0c0b57e342a8629f5f5e001ee0d0
+  depends:
+  - libopenblas >=0.3.24,<1.0a0
   constrains:
   - liblapack 3.9.0 18_osxarm64_openblas
   - liblapacke 3.9.0 18_osxarm64_openblas
   - blas * openblas
   - libcblas 3.9.0 18_osxarm64_openblas
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 14859
   timestamp: 1693951888126
-- platform: win-64
+- kind: conda
   name: libblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - mkl ==2022.1.0 h6a75c08_874
-  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-18_win64_mkl.conda
-  hash:
-    md5: b241da5b7a888f72bb3c3e82747334f4
-    sha256: 5aef8d69197108f3c320a5d4ad4d19ab9c809cdbbf731c7ab988c227de42d6b5
   build: 18_win64_mkl
-  arch: x86_64
-  subdir: win-64
   build_number: 18
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-18_win64_mkl.conda
+  sha256: 5aef8d69197108f3c320a5d4ad4d19ab9c809cdbbf731c7ab988c227de42d6b5
+  md5: b241da5b7a888f72bb3c3e82747334f4
+  depends:
+  - mkl ==2022.1.0 h6a75c08_874
   constrains:
   - liblapacke 3.9.0 18_win64_mkl
   - blas * mkl
   - libcblas 3.9.0 18_win64_mkl
   - liblapack 3.9.0 18_win64_mkl
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 3656012
   timestamp: 1693952074690
-- platform: linux-64
+- kind: conda
   name: libbrotlicommon
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
-  hash:
-    md5: aec6c91c7371c26392a06708a73c70e5
-    sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
-  build: hd590300_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 69403
-  timestamp: 1695990007212
-- platform: osx-64
-  name: libbrotlicommon
-  version: 1.1.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
-  hash:
-    md5: 9e6c31441c9aa24e41ace40d6151aab6
-    sha256: f57c57c442ef371982619f82af8735f93a4f50293022cfd1ffaf2ff89c2e0b2a
   build: h0dc2134_1
-  arch: x86_64
-  subdir: osx-64
   build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
+  sha256: f57c57c442ef371982619f82af8735f93a4f50293022cfd1ffaf2ff89c2e0b2a
+  md5: 9e6c31441c9aa24e41ace40d6151aab6
+  arch: x86_64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 67476
   timestamp: 1695990207321
-- platform: osx-arm64
+- kind: conda
   name: libbrotlicommon
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
-  hash:
-    md5: cd68f024df0304be41d29a9088162b02
-    sha256: 556f0fddf4bd4d35febab404d98cb6862ce3b7ca843e393da0451bfc4654cf07
   build: hb547adb_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
+  sha256: 556f0fddf4bd4d35febab404d98cb6862ce3b7ca843e393da0451bfc4654cf07
+  md5: cd68f024df0304be41d29a9088162b02
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 68579
   timestamp: 1695990426128
-- platform: win-64
+- kind: conda
   name: libbrotlicommon
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hcfcfb64_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
+  sha256: f75fed29b0cc503d1b149a4945eaa32df56e19da5e2933de29e8f03947203709
+  md5: f77f319fb82980166569e1280d5b2864
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
-  hash:
-    md5: f77f319fb82980166569e1280d5b2864
-    sha256: f75fed29b0cc503d1b149a4945eaa32df56e19da5e2933de29e8f03947203709
-  build: hcfcfb64_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: win
   license: MIT
   license_family: MIT
   size: 70598
   timestamp: 1695990405143
-- platform: linux-64
-  name: libbrotlidec
+- kind: conda
+  name: libbrotlicommon
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - libbrotlicommon ==1.1.0 hd590300_1
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
-  hash:
-    md5: f07002e225d7a60a694d42a7bf5ff53f
-    sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
   build: hd590300_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
+  sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
+  md5: aec6c91c7371c26392a06708a73c70e5
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  size: 32775
-  timestamp: 1695990022788
-- platform: osx-64
+  size: 69403
+  timestamp: 1695990007212
+- kind: conda
   name: libbrotlidec
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - libbrotlicommon ==1.1.0 h0dc2134_1
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
-  hash:
-    md5: 9ee0bab91b2ca579e10353738be36063
-    sha256: b11939c4c93c29448660ab5f63273216969d1f2f315dd9be60f3c43c4e61a50c
   build: h0dc2134_1
-  arch: x86_64
-  subdir: osx-64
   build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
+  sha256: b11939c4c93c29448660ab5f63273216969d1f2f315dd9be60f3c43c4e61a50c
+  md5: 9ee0bab91b2ca579e10353738be36063
+  depends:
+  - libbrotlicommon ==1.1.0 h0dc2134_1
+  arch: x86_64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 30327
   timestamp: 1695990232422
-- platform: osx-arm64
+- kind: conda
   name: libbrotlidec
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - libbrotlicommon ==1.1.0 hb547adb_1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
-  hash:
-    md5: ee1a519335cc10d0ec7e097602058c0a
-    sha256: c1c85937828ad3bc434ac60b7bcbde376f4d2ea4ee42d15d369bf2a591775b4a
   build: hb547adb_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
+  sha256: c1c85937828ad3bc434ac60b7bcbde376f4d2ea4ee42d15d369bf2a591775b4a
+  md5: ee1a519335cc10d0ec7e097602058c0a
+  depends:
+  - libbrotlicommon ==1.1.0 hb547adb_1
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 28928
   timestamp: 1695990463780
-- platform: win-64
+- kind: conda
   name: libbrotlidec
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hcfcfb64_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
+  sha256: 1b352ee05931ea24c11cd4a994d673890fd1cc690c21e023e736bdaac2632e93
+  md5: 19ce3e1dacc7912b3d6ff40690ba9ae0
+  depends:
   - libbrotlicommon ==1.1.0 hcfcfb64_1
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
-  hash:
-    md5: 19ce3e1dacc7912b3d6ff40690ba9ae0
-    sha256: 1b352ee05931ea24c11cd4a994d673890fd1cc690c21e023e736bdaac2632e93
-  build: hcfcfb64_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: win
   license: MIT
   license_family: MIT
   size: 32788
   timestamp: 1695990443165
-- platform: linux-64
-  name: libbrotlienc
+- kind: conda
+  name: libbrotlidec
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
+  sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
+  md5: f07002e225d7a60a694d42a7bf5ff53f
+  depends:
   - libbrotlicommon ==1.1.0 hd590300_1
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
-  hash:
-    md5: 5fc11c6020d421960607d821310fcd4d
-    sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
-  build: hd590300_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: linux
   license: MIT
   license_family: MIT
-  size: 282523
-  timestamp: 1695990038302
-- platform: osx-64
+  size: 32775
+  timestamp: 1695990022788
+- kind: conda
   name: libbrotlienc
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - libbrotlicommon ==1.1.0 h0dc2134_1
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
-  hash:
-    md5: 8a421fe09c6187f0eb5e2338a8a8be6d
-    sha256: bc964c23e1a60ca1afe7bac38a9c1f2af3db4a8072c9f2eac4e4de537a844ac7
   build: h0dc2134_1
-  arch: x86_64
-  subdir: osx-64
   build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
+  sha256: bc964c23e1a60ca1afe7bac38a9c1f2af3db4a8072c9f2eac4e4de537a844ac7
+  md5: 8a421fe09c6187f0eb5e2338a8a8be6d
+  depends:
+  - libbrotlicommon ==1.1.0 h0dc2134_1
+  arch: x86_64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 299092
   timestamp: 1695990259225
-- platform: osx-arm64
+- kind: conda
   name: libbrotlienc
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - libbrotlicommon ==1.1.0 hb547adb_1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
-  hash:
-    md5: d7e077f326a98b2cc60087eaff7c730b
-    sha256: 690dfc98e891ee1871c54166d30f6e22edfc2d7d6b29e7988dde5f1ce271c81a
   build: hb547adb_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
+  sha256: 690dfc98e891ee1871c54166d30f6e22edfc2d7d6b29e7988dde5f1ce271c81a
+  md5: d7e077f326a98b2cc60087eaff7c730b
+  depends:
+  - libbrotlicommon ==1.1.0 hb547adb_1
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 280943
   timestamp: 1695990509392
-- platform: win-64
+- kind: conda
   name: libbrotlienc
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hcfcfb64_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
+  sha256: eae6b76154e594c6d211160c6d1aeed848672618152a562e0eabdfa641d34aca
+  md5: 71e890a0b361fd58743a13f77e1506b7
+  depends:
   - libbrotlicommon ==1.1.0 hcfcfb64_1
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
-  hash:
-    md5: 71e890a0b361fd58743a13f77e1506b7
-    sha256: eae6b76154e594c6d211160c6d1aeed848672618152a562e0eabdfa641d34aca
-  build: hcfcfb64_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: win
   license: MIT
   license_family: MIT
   size: 246515
   timestamp: 1695990479484
-- platform: linux-64
+- kind: conda
+  name: libbrotlienc
+  version: 1.1.0
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
+  sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
+  md5: 5fc11c6020d421960607d821310fcd4d
+  depends:
+  - libbrotlicommon ==1.1.0 hd590300_1
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 282523
+  timestamp: 1695990038302
+- kind: conda
   name: libcblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas ==3.9.0 18_linux64_openblas
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-18_linux64_openblas.conda
-  hash:
-    md5: 93dd9ab275ad888ed8113953769af78c
-    sha256: b5a3eac5a1e14ad7054a19249afeee6536ab8c9fb6d6ddc26e277f5c3b1acce4
   build: 18_linux64_openblas
-  arch: x86_64
-  subdir: linux-64
   build_number: 18
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-18_linux64_openblas.conda
+  sha256: b5a3eac5a1e14ad7054a19249afeee6536ab8c9fb6d6ddc26e277f5c3b1acce4
+  md5: 93dd9ab275ad888ed8113953769af78c
+  depends:
+  - libblas ==3.9.0 18_linux64_openblas
   constrains:
   - liblapacke 3.9.0 18_linux64_openblas
   - liblapack 3.9.0 18_linux64_openblas
   - blas * openblas
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 14455
   timestamp: 1693951371996
-- platform: osx-64
+- kind: conda
   name: libcblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas ==3.9.0 18_osx64_openblas
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-18_osx64_openblas.conda
-  hash:
-    md5: b359d4c7d91ff6bf5442604d06538985
-    sha256: 7e8d8bc42c2c21d75b2121cfee0842bd0cf5500e6306c964bea4a9fafd3abba5
   build: 18_osx64_openblas
-  arch: x86_64
-  subdir: osx-64
   build_number: 18
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-18_osx64_openblas.conda
+  sha256: 7e8d8bc42c2c21d75b2121cfee0842bd0cf5500e6306c964bea4a9fafd3abba5
+  md5: b359d4c7d91ff6bf5442604d06538985
+  depends:
+  - libblas ==3.9.0 18_osx64_openblas
   constrains:
   - blas * openblas
   - liblapacke 3.9.0 18_osx64_openblas
   - liblapack 3.9.0 18_osx64_openblas
+  arch: x86_64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 14699
   timestamp: 1693951732651
-- platform: osx-arm64
+- kind: conda
   name: libcblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas ==3.9.0 18_osxarm64_openblas
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-18_osxarm64_openblas.conda
-  hash:
-    md5: ee0108105d7181f1c6f8c4269883ff3b
-    sha256: d01e63f9b02b3b45283319341662b2fc5e5598019ba3bceb131b0f79c6962ca8
   build: 18_osxarm64_openblas
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 18
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-18_osxarm64_openblas.conda
+  sha256: d01e63f9b02b3b45283319341662b2fc5e5598019ba3bceb131b0f79c6962ca8
+  md5: ee0108105d7181f1c6f8c4269883ff3b
+  depends:
+  - libblas ==3.9.0 18_osxarm64_openblas
   constrains:
   - liblapack 3.9.0 18_osxarm64_openblas
   - liblapacke 3.9.0 18_osxarm64_openblas
   - blas * openblas
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 14733
   timestamp: 1693951904664
-- platform: win-64
+- kind: conda
   name: libcblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas ==3.9.0 18_win64_mkl
-  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-18_win64_mkl.conda
-  hash:
-    md5: fb0b514194c14342a97dfe31a41d60fc
-    sha256: d5f60ed6508b3889a77caf5ff2b66203714e45ec4eea6e5cdb12fe6e8ef2bbdb
   build: 18_win64_mkl
-  arch: x86_64
-  subdir: win-64
   build_number: 18
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-18_win64_mkl.conda
+  sha256: d5f60ed6508b3889a77caf5ff2b66203714e45ec4eea6e5cdb12fe6e8ef2bbdb
+  md5: fb0b514194c14342a97dfe31a41d60fc
+  depends:
+  - libblas ==3.9.0 18_win64_mkl
   constrains:
   - liblapacke 3.9.0 18_win64_mkl
   - blas * mkl
   - liblapack 3.9.0 18_win64_mkl
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 3655770
   timestamp: 1693952109193
-- platform: linux-64
-  name: libclang
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libclang13 ==15.0.7 default_h9986a30_3
+- kind: conda
+  name: libclang-cpp16
+  version: 16.0.6
+  build: default_h7151d67_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp16-16.0.6-default_h7151d67_5.conda
+  sha256: b308b6faee84c4646dca87221d8a0d1e293a8b9a2a1b83a4500abcd4dd6c8eca
+  md5: 3189f83f21974fa2a9204f949d2aff18
+  depends:
+  - libcxx >=16.0.6
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 12713468
+  timestamp: 1706894023056
+- kind: conda
+  name: libclang-cpp16
+  version: 16.0.6
+  build: default_hb11cfb5_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp16-16.0.6-default_hb11cfb5_4.conda
+  sha256: c4e3525bae987b7781c1011ac1caba1d377e201006f9ec9ee31e204f1f9c28fa
+  md5: 66436cad20a1f976e401cedcc47abb31
+  depends:
   - libgcc-ng >=12
-  - libllvm15 >=15.0.7,<15.1.0a0
+  - libllvm16 >=16.0.6,<16.1.0a0
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_h7634d5b_3.conda
-  hash:
-    md5: 0922208521c0463e690bbaebba7eb551
-    sha256: c2b0c8dd675e30d86bad410679f258820bc36723fbadffc13c2f60249be91815
-  build: default_h7634d5b_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 133162
-  timestamp: 1690549855318
-- platform: osx-64
-  name: libclang
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libclang13 ==15.0.7 default_h953c2e9_3
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-15.0.7-default_hdb78580_3.conda
-  hash:
-    md5: 23c66251664b188887eb702a02d22517
-    sha256: 5f958cf2b82934b9a244fdb9bd2ccd782da1a1460c44957190eea64ea9f9588c
-  build: default_hdb78580_3
-  arch: x86_64
-  subdir: osx-64
-  build_number: 3
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 133142
-  timestamp: 1690550061681
-- platform: osx-arm64
-  name: libclang
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libclang13 ==15.0.7 default_hc7183e1_3
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-15.0.7-default_h5dc8d65_3.conda
-  hash:
-    md5: c89d217a6315d89044ed531292678456
-    sha256: 9aa880fbcd910b2ead0ad1c629fd13fae0fa39717192481345f64caf7fb5ed26
-  build: default_h5dc8d65_3
-  arch: aarch64
+  size: 17942324
+  timestamp: 1704262063346
+- kind: conda
+  name: libclang-cpp16
+  version: 16.0.6
+  build: default_he012953_5
+  build_number: 5
   subdir: osx-arm64
-  build_number: 3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp16-16.0.6-default_he012953_5.conda
+  sha256: a6b4c11571e3c20dc0e977d9a7b1670d991ef0cf807595b857405548706853eb
+  md5: 77908ba1789d35c808eeaae28b4c9dd4
+  depends:
+  - libcxx >=16.0.6
+  - libllvm16 >=16.0.6,<16.1.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 133359
-  timestamp: 1690550025084
-- platform: linux-64
-  name: libclang-cpp15
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
+  size: 11813500
+  timestamp: 1706893965706
+- kind: conda
+  name: libclang13
+  version: 17.0.5
+  build: default_h4d60ac6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-17.0.5-default_h4d60ac6_0.conda
+  sha256: 2dc99cc2060bd3e112523efaca76e29a5f4e7808c55663fe5475e1347663bf99
+  md5: 6ba4c0273e7e1dae744d0aa7d62f4d35
+  depends:
   - libgcc-ng >=12
-  - libllvm15 >=15.0.7,<15.1.0a0
+  - libllvm17 >=17.0.5,<17.1.0a0
   - libstdcxx-ng >=12
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 10531072
+  timestamp: 1700030055297
+- kind: conda
+  name: libclang13
+  version: 17.0.5
+  build: default_hb2321db_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libclang13-17.0.5-default_hb2321db_0.conda
+  sha256: 3696062be1ec98540f8ae631ca831090fd34c6e55c73d31872a50704d996175d
+  md5: 7d2dcc63e60a892bc86b18c61d2f18d9
+  depends:
+  - libcxx >=16.0.6
+  - libllvm17 >=17.0.5,<17.1.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 7671787
+  timestamp: 1700031880310
+- kind: conda
+  name: libclang13
+  version: 17.0.5
+  build: default_he2e1a71_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-17.0.5-default_he2e1a71_0.conda
+  sha256: d63330c30914876cdc552cd8e1ed792ba96b8ff3c261cc37514d2f8b229e3385
+  md5: 548d445c20a12c2d5812167f177c75e9
+  depends:
+  - libcxx >=16.0.6
+  - libllvm17 >=17.0.5,<17.1.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 7164297
+  timestamp: 1700030805789
+- kind: conda
+  name: libclang13
+  version: 17.0.6
+  build: default_h85b4d89_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-17.0.6-default_h85b4d89_2.conda
+  sha256: 0e9ead973cf6e91365ec54ce3d8798aed67890317692a99743f7264f0719039c
+  md5: e69bebdddf07c63e59d4a562c63e2517
+  depends:
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp15-15.0.7-default_h7634d5b_3.conda
-  hash:
-    md5: 3dc837e8d805debd6c62a6dd89005811
-    sha256: 4d112ee1ccb56054fb266d61a3e75077129a299bcdc83547b701e528ce2e7d17
-  build: default_h7634d5b_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 17212684
-  timestamp: 1690549595833
-- platform: osx-64
-  name: libclang-cpp15
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp15-15.0.7-default_hdb78580_3.conda
-  hash:
-    md5: 73639154fe4a7ca500d1361eef58fb65
-    sha256: 413c923b922c6d440f5e10012b65a733ff53d00af01298935b31a1567af2cb12
-  build: default_hdb78580_3
-  arch: x86_64
-  subdir: osx-64
-  build_number: 3
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 12426526
-  timestamp: 1690549605370
-- platform: osx-arm64
-  name: libclang-cpp15
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp15-15.0.7-default_h5dc8d65_3.conda
-  hash:
-    md5: 99c37593de0f76769f089218e493f083
-    sha256: 33375e4e41f06c90c3a50f5efe15e9ad488243585a1dc994d3d9a897313d1cc4
-  build: default_h5dc8d65_3
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 3
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 11402301
-  timestamp: 1690549536998
-- platform: linux-64
-  name: libclang13
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_h9986a30_3.conda
-  hash:
-    md5: 1720df000b48e31842500323cb7be18c
-    sha256: df1221a9a05b9bb3bd9b43c08a7e2fe57a0e15a0010ef26065f7ed7666083f45
-  build: default_h9986a30_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 9557507
-  timestamp: 1690549793486
-- platform: osx-64
-  name: libclang13
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libclang13-15.0.7-default_h953c2e9_3.conda
-  hash:
-    md5: fb8bc95ebc36a4682d3f45a3a31304a8
-    sha256: 87b42a1a905bdd77e8e000536c986edb91fbec6e8af2dec3db39c6ececfa872f
-  build: default_h953c2e9_3
-  arch: x86_64
-  subdir: osx-64
-  build_number: 3
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 7000324
-  timestamp: 1690549961410
-- platform: osx-arm64
-  name: libclang13
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  - libllvm15 >=15.0.7,<15.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-15.0.7-default_hc7183e1_3.conda
-  hash:
-    md5: 3d011fbc2c7d55b4d6716a9b26da1185
-    sha256: 10e2f651456fa5869b944394093ed153616cc0ddaca69966b57d33f51e4d0316
-  build: default_hc7183e1_3
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 3
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 6453035
-  timestamp: 1690549917828
-- platform: linux-64
+  size: 23959094
+  timestamp: 1704280658341
+- kind: conda
   name: libcrc32c
   version: 1.1.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.4.0
-  - libstdcxx-ng >=9.4.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
-  hash:
-    md5: c965a5aa0d5c1c37ffc62dff36e28400
-    sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
-  build: h9c3ff4c_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 20440
-  timestamp: 1633683576494
-- platform: osx-64
-  name: libcrc32c
-  version: 1.1.2
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=11.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
-  hash:
-    md5: 23d6d5a69918a438355d7cbc4c3d54c9
-    sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
-  build: he49afe7_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 20128
-  timestamp: 1633683906221
-- platform: osx-arm64
-  name: libcrc32c
-  version: 1.1.2
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=11.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
-  hash:
-    md5: 32bd82a6a625ea6ce090a81c3d34edeb
-    sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
-  build: hbdafb3b_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18765
-  timestamp: 1633683992603
-- platform: win-64
-  name: libcrc32c
-  version: 1.1.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h0e60522_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+  sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
+  md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
+  depends:
   - vc >=14.1,<15.0a0
   - vs2015_runtime >=14.16.27012
-  url: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
-  hash:
-    md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
-    sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
-  build: h0e60522_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 25694
   timestamp: 1633684287072
-- platform: linux-64
-  name: libcurl
-  version: 8.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - krb5 >=1.21.2,<1.22.0a0
-  - libgcc-ng >=12
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.5.0-hca28451_0.conda
-  hash:
-    md5: 7144d5a828e2cae218e0e3c98d8a0aeb
-    sha256: 00a6bea5ff90ca58eeb15ebc98e08ffb88bddaff27396bb62640064f59d29cf0
-  build: hca28451_0
-  arch: x86_64
+- kind: conda
+  name: libcrc32c
+  version: 1.1.2
+  build: h9c3ff4c_0
   subdir: linux-64
-  build_number: 0
-  license: curl
-  license_family: MIT
-  size: 389164
-  timestamp: 1701860147844
-- platform: osx-64
-  name: libcurl
-  version: 8.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - krb5 >=1.21.2,<1.22.0a0
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.5.0-h726d00d_0.conda
-  hash:
-    md5: 86d749e27fe00fa6b7d790a6feaa22a2
-    sha256: 7ec7e026be90da0965dfa6b92bbc905c852c13b27f3f83c47156db66ed0668f0
-  build: h726d00d_0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+  sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+  md5: c965a5aa0d5c1c37ffc62dff36e28400
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
   arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20440
+  timestamp: 1633683576494
+- kind: conda
+  name: libcrc32c
+  version: 1.1.2
+  build: hbdafb3b_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+  sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
+  md5: 32bd82a6a625ea6ce090a81c3d34edeb
+  depends:
+  - libcxx >=11.1.0
+  arch: aarch64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18765
+  timestamp: 1633683992603
+- kind: conda
+  name: libcrc32c
+  version: 1.1.2
+  build: he49afe7_0
   subdir: osx-64
-  build_number: 0
-  license: curl
-  license_family: MIT
-  size: 367821
-  timestamp: 1701860630644
-- platform: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+  sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
+  md5: 23d6d5a69918a438355d7cbc4c3d54c9
+  depends:
+  - libcxx >=11.1.0
+  arch: x86_64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20128
+  timestamp: 1633683906221
+- kind: conda
   name: libcurl
   version: 8.5.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h2d989ff_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.5.0-h2d989ff_0.conda
+  sha256: f1c04be217aaf161ce3c99a8d618871295b5dc1eae2f7ff7b32078af50303f5b
+  md5: f1211ed00947a84e15a964a8f459f620
+  depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libnghttp2 >=1.58.0,<2.0a0
   - libssh2 >=1.11.0,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.2.0,<4.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.5.0-h2d989ff_0.conda
-  hash:
-    md5: f1211ed00947a84e15a964a8f459f620
-    sha256: f1c04be217aaf161ce3c99a8d618871295b5dc1eae2f7ff7b32078af50303f5b
-  build: h2d989ff_0
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  platform: osx
   license: curl
   license_family: MIT
   size: 350298
   timestamp: 1701860532373
-- platform: win-64
+- kind: conda
   name: libcurl
   version: 8.5.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h726d00d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.5.0-h726d00d_0.conda
+  sha256: 7ec7e026be90da0965dfa6b92bbc905c852c13b27f3f83c47156db66ed0668f0
+  md5: 86d749e27fe00fa6b7d790a6feaa22a2
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  arch: x86_64
+  platform: osx
+  license: curl
+  license_family: MIT
+  size: 367821
+  timestamp: 1701860630644
+- kind: conda
+  name: libcurl
+  version: 8.5.0
+  build: hca28451_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.5.0-hca28451_0.conda
+  sha256: 00a6bea5ff90ca58eeb15ebc98e08ffb88bddaff27396bb62640064f59d29cf0
+  md5: 7144d5a828e2cae218e0e3c98d8a0aeb
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  arch: x86_64
+  platform: linux
+  license: curl
+  license_family: MIT
+  size: 389164
+  timestamp: 1701860147844
+- kind: conda
+  name: libcurl
+  version: 8.5.0
+  build: hd5e4a3a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.5.0-hd5e4a3a_0.conda
+  sha256: 8c933416c61445ab51515a5ca8c32ddc4f83180d5dc43684e4a80915022ffe1f
+  md5: c95eb3d60266dd47b8eb864e10d6bcf3
+  depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libssh2 >=1.11.0,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.5.0-hd5e4a3a_0.conda
-  hash:
-    md5: c95eb3d60266dd47b8eb864e10d6bcf3
-    sha256: 8c933416c61445ab51515a5ca8c32ddc4f83180d5dc43684e4a80915022ffe1f
-  build: hd5e4a3a_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: curl
   license_family: MIT
   size: 323619
   timestamp: 1701860670113
-- platform: osx-64
+- kind: conda
   name: libcxx
   version: 16.0.6
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
-  hash:
-    md5: 7d6972792161077908b62971802f289a
-    sha256: 9063271847cf05f3a6cc6cae3e7f0ced032ab5f3a3c9d3f943f876f39c5c2549
-  build: hd57cbcb_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 1142172
-  timestamp: 1686896907750
-- platform: osx-arm64
-  name: libcxx
-  version: 16.0.6
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
-  hash:
-    md5: 9d7d724faf0413bf1dbc5a85935700c8
-    sha256: 11d3fb51c14832d9e4f6d84080a375dec21ea8a3a381a1910e67ff9cedc20355
   build: h4653b0c_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
+  sha256: 11d3fb51c14832d9e4f6d84080a375dec21ea8a3a381a1910e67ff9cedc20355
+  md5: 9d7d724faf0413bf1dbc5a85935700c8
+  arch: aarch64
+  platform: osx
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1160232
   timestamp: 1686896993785
-- platform: linux-64
-  name: libedit
-  version: 3.1.20191231
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.5.0
-  - ncurses >=6.2,<7.0.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
-  hash:
-    md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
-    sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
-  build: he28a2e2_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 123878
-  timestamp: 1597616541093
-- platform: osx-64
-  name: libedit
-  version: 3.1.20191231
-  category: main
-  manager: conda
-  dependencies:
-  - ncurses >=6.2,<7.0.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
-  hash:
-    md5: 6016a8a1d0e63cac3de2c352cd40208b
-    sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
-  build: h0678c8f_2
-  arch: x86_64
+- kind: conda
+  name: libcxx
+  version: 16.0.6
+  build: hd57cbcb_0
   subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
+  sha256: 9063271847cf05f3a6cc6cae3e7f0ced032ab5f3a3c9d3f943f876f39c5c2549
+  md5: 7d6972792161077908b62971802f289a
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1142172
+  timestamp: 1686896907750
+- kind: conda
+  name: libedit
+  version: 3.1.20191231
+  build: h0678c8f_2
   build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  arch: x86_64
+  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 105382
   timestamp: 1597616576726
-- platform: osx-arm64
+- kind: conda
   name: libedit
   version: 3.1.20191231
-  category: main
-  manager: conda
-  dependencies:
-  - ncurses >=6.2,<7.0.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
-  hash:
-    md5: 30e4362988a2623e9eb34337b83e01f9
-    sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
   build: hc8eb9b7_2
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  arch: aarch64
+  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 96607
   timestamp: 1597616630749
-- platform: linux-64
+- kind: conda
+  name: libedit
+  version: 3.1.20191231
+  build: he28a2e2_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  arch: x86_64
+  platform: linux
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 123878
+  timestamp: 1597616541093
+- kind: conda
   name: libev
   version: '4.33'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
-  hash:
-    md5: 6f8720dff19e17ce5d48cfe7f3d2f0a3
-    sha256: 8c9635aa0ea28922877dc96358f9547f6a55fc7e2eb75a556b05f1725496baf9
   build: h516909a_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+  sha256: 8c9635aa0ea28922877dc96358f9547f6a55fc7e2eb75a556b05f1725496baf9
+  md5: 6f8720dff19e17ce5d48cfe7f3d2f0a3
+  depends:
+  - libgcc-ng >=7.5.0
+  arch: x86_64
+  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   size: 106190
   timestamp: 1598867915
-- platform: osx-64
+- kind: conda
   name: libev
   version: '4.33'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
-  hash:
-    md5: 79dc2be110b2a3d1e97ec21f691c50ad
-    sha256: c4154d424431898d84d6afb8b32e3ba749fe5d270d322bb0af74571a3cb09c6b
-  build: haf1e3a3_1
-  arch: x86_64
-  subdir: osx-64
-  build_number: 1
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 101424
-  timestamp: 1598868359024
-- platform: osx-arm64
-  name: libev
-  version: '4.33'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
-  hash:
-    md5: 566dbf70fe79eacdb3c3d3d195a27f55
-    sha256: eb7325eb2e6bd4c291cb9682781b35b8c0f68cb72651c35a5b9dd22707ebd25c
   build: h642e427_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
+  sha256: eb7325eb2e6bd4c291cb9682781b35b8c0f68cb72651c35a5b9dd22707ebd25c
+  md5: 566dbf70fe79eacdb3c3d3d195a27f55
+  arch: aarch64
+  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 100668
   timestamp: 1598868103393
-- platform: linux-64
-  name: libevent
-  version: 2.1.12
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-  hash:
-    md5: a1cfcc585f0c42bf8d5546bb1dfb668d
-    sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
-  build: hf998b51_1
-  arch: x86_64
-  subdir: linux-64
+- kind: conda
+  name: libev
+  version: '4.33'
+  build: haf1e3a3_1
   build_number: 1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 427426
-  timestamp: 1685725977222
-- platform: osx-64
-  name: libevent
-  version: 2.1.12
-  category: main
-  manager: conda
-  dependencies:
-  - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
-  hash:
-    md5: e38e467e577bd193a7d5de7c2c540b04
-    sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
-  build: ha90c15b_1
-  arch: x86_64
   subdir: osx-64
-  build_number: 1
-  license: BSD-3-Clause
+  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
+  sha256: c4154d424431898d84d6afb8b32e3ba749fe5d270d322bb0af74571a3cb09c6b
+  md5: 79dc2be110b2a3d1e97ec21f691c50ad
+  arch: x86_64
+  platform: osx
+  license: BSD-2-Clause
   license_family: BSD
-  size: 372661
-  timestamp: 1685726378869
-- platform: osx-arm64
+  size: 101424
+  timestamp: 1598868359024
+- kind: conda
   name: libevent
   version: 2.1.12
-  category: main
-  manager: conda
-  dependencies:
-  - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
-  hash:
-    md5: 1a109764bff3bdc7bdd84088347d71dc
-    sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
   build: h2757513_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+  sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
+  md5: 1a109764bff3bdc7bdd84088347d71dc
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 368167
   timestamp: 1685726248899
-- platform: win-64
+- kind: conda
   name: libevent
   version: 2.1.12
-  category: main
-  manager: conda
-  dependencies:
+  build: h3671451_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+  sha256: af03882afb7a7135288becf340c2f0cf8aa8221138a9a7b108aaeb308a486da1
+  md5: 25efbd786caceef438be46da78a7b5ef
+  depends:
   - openssl >=3.1.1,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
-  hash:
-    md5: 25efbd786caceef438be46da78a7b5ef
-    sha256: af03882afb7a7135288becf340c2f0cf8aa8221138a9a7b108aaeb308a486da1
-  build: h3671451_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 410555
   timestamp: 1685726568668
-- platform: linux-64
-  name: libexpat
-  version: 2.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
-  hash:
-    md5: 6305a3dd2752c76335295da4e581f2fd
-    sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
-  build: hcb278e6_1
-  arch: x86_64
-  subdir: linux-64
+- kind: conda
+  name: libevent
+  version: 2.1.12
+  build: ha90c15b_1
   build_number: 1
-  constrains:
-  - expat 2.5.0.*
-  license: MIT
-  license_family: MIT
-  size: 77980
-  timestamp: 1680190528313
-- platform: osx-64
-  name: libexpat
-  version: 2.5.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
-  hash:
-    md5: 6c81cb022780ee33435cca0127dd43c9
-    sha256: 80024bd9f44d096c4cc07fb2bac76b5f1f7553390112dab3ad6acb16a05f0b96
-  build: hf0c8a7f_1
-  arch: x86_64
   subdir: osx-64
-  build_number: 1
-  constrains:
-  - expat 2.5.0.*
-  license: MIT
-  license_family: MIT
-  size: 69602
-  timestamp: 1680191040160
-- platform: osx-arm64
-  name: libexpat
-  version: 2.5.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
-  hash:
-    md5: 5a097ad3d17e42c148c9566280481317
-    sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
-  build: hb7217d7_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  constrains:
-  - expat 2.5.0.*
-  license: MIT
-  license_family: MIT
-  size: 63442
-  timestamp: 1680190916539
-- platform: win-64
-  name: libexpat
-  version: 2.5.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
-  hash:
-    md5: 636cc3cbbd2e28bcfd2f73b2044aac2c
-    sha256: 794b2a9be72f176a2767c299574d330ffb76b2ed75d7fd20bee3bbadce5886cf
-  build: h63175ca_1
+  url: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+  sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
+  md5: e38e467e577bd193a7d5de7c2c540b04
+  depends:
+  - openssl >=3.1.1,<4.0a0
   arch: x86_64
-  subdir: win-64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372661
+  timestamp: 1685726378869
+- kind: conda
+  name: libevent
+  version: 2.1.12
+  build: hf998b51_1
   build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+  md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 427426
+  timestamp: 1685725977222
+- kind: conda
+  name: libexpat
+  version: 2.5.0
+  build: h63175ca_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
+  sha256: 794b2a9be72f176a2767c299574d330ffb76b2ed75d7fd20bee3bbadce5886cf
+  md5: 636cc3cbbd2e28bcfd2f73b2044aac2c
   constrains:
   - expat 2.5.0.*
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
   size: 138689
   timestamp: 1680190844101
-- platform: linux-64
-  name: libffi
-  version: 3.4.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.4.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
-  hash:
-    md5: d645c6d2ac96843a2bfaccd2d62b3ac3
-    sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
-  build: h7f98852_5
-  arch: x86_64
-  subdir: linux-64
-  build_number: 5
+- kind: conda
+  name: libexpat
+  version: 2.5.0
+  build: hb7217d7_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+  sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
+  md5: 5a097ad3d17e42c148c9566280481317
+  constrains:
+  - expat 2.5.0.*
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  size: 58292
-  timestamp: 1636488182923
-- platform: osx-64
+  size: 63442
+  timestamp: 1680190916539
+- kind: conda
+  name: libexpat
+  version: 2.5.0
+  build: hcb278e6_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+  sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
+  md5: 6305a3dd2752c76335295da4e581f2fd
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - expat 2.5.0.*
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 77980
+  timestamp: 1680190528313
+- kind: conda
+  name: libexpat
+  version: 2.5.0
+  build: hf0c8a7f_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
+  sha256: 80024bd9f44d096c4cc07fb2bac76b5f1f7553390112dab3ad6acb16a05f0b96
+  md5: 6c81cb022780ee33435cca0127dd43c9
+  constrains:
+  - expat 2.5.0.*
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 69602
+  timestamp: 1680191040160
+- kind: conda
   name: libffi
   version: 3.4.2
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
-  hash:
-    md5: ccb34fb14960ad8b125962d3d79b31a9
-    sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
   build: h0d85af4_5
-  arch: x86_64
-  subdir: osx-64
   build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  arch: x86_64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 51348
   timestamp: 1636488394370
-- platform: osx-arm64
+- kind: conda
   name: libffi
   version: 3.4.2
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
-  hash:
-    md5: 086914b672be056eb70fd4285b6783b6
-    sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
   build: h3422bc3_5
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 39020
   timestamp: 1636488587153
-- platform: win-64
+- kind: conda
   name: libffi
   version: 3.4.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h7f98852_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- kind: conda
+  name: libffi
+  version: 3.4.2
+  build: h8ffe710_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
   - vc >=14.1,<15.0a0
   - vs2015_runtime >=14.16.27012
-  url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
-  hash:
-    md5: 2c96d1b6915b408893f9472569dee135
-    sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
-  build: h8ffe710_5
   arch: x86_64
-  subdir: win-64
-  build_number: 5
+  platform: win
   license: MIT
   license_family: MIT
   size: 42063
   timestamp: 1636489106777
-- platform: linux-64
+- kind: conda
   name: libgcc-devel_linux-64
   version: 12.3.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-12.3.0-h8bca6fd_2.conda
-  hash:
-    md5: ed613582de7b8569fdc53ca141be176a
-    sha256: 7e12d0496389017ca526254913b24d9024e1728c849a0d6476a4b7fde9d03cba
   build: h8bca6fd_2
-  arch: x86_64
-  subdir: linux-64
   build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-12.3.0-h8bca6fd_2.conda
+  sha256: 7e12d0496389017ca526254913b24d9024e1728c849a0d6476a4b7fde9d03cba
+  md5: ed613582de7b8569fdc53ca141be176a
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 2405867
   timestamp: 1695218559716
-- platform: linux-64
+- kind: conda
   name: libgcc-ng
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h807b86a_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
+  sha256: d361d3c87c376642b99c1fc25cddec4b9905d3d9b9203c1c545b8c8c1b04539a
+  md5: c28003b0be0494f9a7664389146716ff
+  depends:
   - _libgcc_mutex ==0.1 conda_forge
   - _openmp_mutex >=4.5
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
-  hash:
-    md5: c28003b0be0494f9a7664389146716ff
-    sha256: d361d3c87c376642b99c1fc25cddec4b9905d3d9b9203c1c545b8c8c1b04539a
-  build: h807b86a_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
   constrains:
   - libgomp 13.2.0 h807b86a_2
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 771133
   timestamp: 1695219384393
-- platform: osx-64
+- kind: conda
   name: libgfortran
   version: 5.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgfortran5 ==13.2.0 h2873a65_1
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
-  hash:
-    md5: b55fd11ab6318a6e67ac191309701d5a
-    sha256: 5be1a59316e5063f4e6492ea86d692600a7b8e32caa25269f8a3b386a028e5f3
   build: 13_2_0_h97931a8_1
-  arch: x86_64
-  subdir: osx-64
   build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
+  sha256: 5be1a59316e5063f4e6492ea86d692600a7b8e32caa25269f8a3b386a028e5f3
+  md5: b55fd11ab6318a6e67ac191309701d5a
+  depends:
+  - libgfortran5 ==13.2.0 h2873a65_1
+  arch: x86_64
+  platform: osx
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 109855
   timestamp: 1694165674845
-- platform: osx-arm64
+- kind: conda
   name: libgfortran
   version: 5.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgfortran5 ==13.2.0 hf226fd6_1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
-  hash:
-    md5: 1ad37a5c60c250bb2b4a9f75563e181c
-    sha256: bc8750e7893e693fa380bf2f342d4a5ce44995467cbdf72e56a00e5106b4892d
   build: 13_2_0_hd922786_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
+  sha256: bc8750e7893e693fa380bf2f342d4a5ce44995467cbdf72e56a00e5106b4892d
+  md5: 1ad37a5c60c250bb2b4a9f75563e181c
+  depends:
+  - libgfortran5 ==13.2.0 hf226fd6_1
+  arch: aarch64
+  platform: osx
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 110095
   timestamp: 1694172198016
-- platform: linux-64
+- kind: conda
   name: libgfortran-ng
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgfortran5 ==13.2.0 ha4646dd_2
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
-  hash:
-    md5: e75a75a6eaf6f318dae2631158c46575
-    sha256: 767d71999e5386210fe2acaf1b67073e7943c2af538efa85c101e3401e94ff62
   build: h69a702a_2
-  arch: x86_64
-  subdir: linux-64
   build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
+  sha256: 767d71999e5386210fe2acaf1b67073e7943c2af538efa85c101e3401e94ff62
+  md5: e75a75a6eaf6f318dae2631158c46575
+  depends:
+  - libgfortran5 ==13.2.0 ha4646dd_2
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 23722
   timestamp: 1695219642066
-- platform: linux-64
+- kind: conda
   name: libgfortran5
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=13.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
-  hash:
-    md5: 78fdab09d9138851dde2b5fe2a11019e
-    sha256: 55ecf5c46c05a98b4822a041d6e1cb196a7b0606126eb96b24131b7d2c8ca561
-  build: ha4646dd_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
-  constrains:
-  - libgfortran-ng 13.2.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 1441830
-  timestamp: 1695219403435
-- platform: osx-64
-  name: libgfortran5
-  version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - llvm-openmp >=8.0.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
-  hash:
-    md5: 3af564516b5163cd8cc08820413854bc
-    sha256: 44de8930eef3b14d4d9fdfe419e6c909c13b7c859617d3616d5a5e964f3fcf63
   build: h2873a65_1
-  arch: x86_64
-  subdir: osx-64
   build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
+  sha256: 44de8930eef3b14d4d9fdfe419e6c909c13b7c859617d3616d5a5e964f3fcf63
+  md5: 3af564516b5163cd8cc08820413854bc
+  depends:
+  - llvm-openmp >=8.0.0
   constrains:
   - libgfortran 5.0.0 13_2_0_*_1
+  arch: x86_64
+  platform: osx
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 1571764
   timestamp: 1694165583047
-- platform: osx-arm64
+- kind: conda
   name: libgfortran5
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - llvm-openmp >=8.0.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
-  hash:
-    md5: 4480d71b98c87faafab132d33e23135e
-    sha256: cb9cb11e49a6a8466ea7556a723080d3aeefd556df9b444b941afc5b54368b22
+  build: ha4646dd_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
+  sha256: 55ecf5c46c05a98b4822a041d6e1cb196a7b0606126eb96b24131b7d2c8ca561
+  md5: 78fdab09d9138851dde2b5fe2a11019e
+  depends:
+  - libgcc-ng >=13.2.0
+  constrains:
+  - libgfortran-ng 13.2.0
+  arch: x86_64
+  platform: linux
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1441830
+  timestamp: 1695219403435
+- kind: conda
+  name: libgfortran5
+  version: 13.2.0
   build: hf226fd6_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
+  sha256: cb9cb11e49a6a8466ea7556a723080d3aeefd556df9b444b941afc5b54368b22
+  md5: 4480d71b98c87faafab132d33e23135e
+  depends:
+  - llvm-openmp >=8.0.0
   constrains:
   - libgfortran 5.0.0 13_2_0_*_1
+  arch: aarch64
+  platform: osx
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 995733
   timestamp: 1694172076009
-- platform: linux-64
+- kind: conda
   name: libgomp
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - _libgcc_mutex ==0.1 conda_forge
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
-  hash:
-    md5: e2042154faafe61969556f28bade94b9
-    sha256: e1e82348f8296abfe344162b3b5f0ddc2f504759ebeb8b337ba99beaae583b15
   build: h807b86a_2
-  arch: x86_64
-  subdir: linux-64
   build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
+  sha256: e1e82348f8296abfe344162b3b5f0ddc2f504759ebeb8b337ba99beaae583b15
+  md5: e2042154faafe61969556f28bade94b9
+  depends:
+  - _libgcc_mutex ==0.1 conda_forge
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 421133
   timestamp: 1695219303065
-- platform: linux-64
+- kind: conda
   name: libgoogle-cloud
   version: 2.12.0
-  category: main
-  manager: conda
-  dependencies:
-  - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libgcc-ng >=12
-  - libgrpc >=1.59.2,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  - libstdcxx-ng >=12
-  - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-h5206363_4.conda
-  hash:
-    md5: b5eb63d2683102be45d17c55021282f6
-    sha256: 82a7d211d0df165b073f9e8ba6d789c4b1c7c4882d546ca12d40f201fc3496fc
-  build: h5206363_4
-  arch: x86_64
-  subdir: linux-64
+  build: h39f2fc6_4
   build_number: 4
-  constrains:
-  - google-cloud-cpp 2.12.0 *_4
-  license: Apache-2.0
-  license_family: Apache
-  size: 43491878
-  timestamp: 1698886698923
-- platform: osx-64
-  name: libgoogle-cloud
-  version: 2.12.0
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.13
-  - __osx >=10.9
-  - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libcxx >=16.0.6
-  - libgrpc >=1.59.2,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-hc0857f6_4.conda
-  hash:
-    md5: 976555c39f83093265491c9c081a801c
-    sha256: 1bf47f43796369ec85a27221ab9a84ecc848f93a88049d046cd8521c25b129f6
-  build: hc0857f6_4
-  arch: x86_64
-  subdir: osx-64
-  build_number: 4
-  constrains:
-  - google-cloud-cpp 2.12.0 *_4
-  license: Apache-2.0
-  license_family: Apache
-  size: 30883666
-  timestamp: 1698889432429
-- platform: osx-arm64
-  name: libgoogle-cloud
-  version: 2.12.0
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libcxx >=16.0.6
-  - libgrpc >=1.59.2,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-hfb399a7_4.conda
-  hash:
-    md5: d62901188ab756c841cbb9a80c6c3f3c
-    sha256: 22122939a462f64a82ca2f305c43e5e5cf5a55f1ae12979c2445f9dc196b7047
-  build: hfb399a7_4
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 4
-  constrains:
-  - google-cloud-cpp 2.12.0 *_4
-  license: Apache-2.0
-  license_family: Apache
-  size: 31440327
-  timestamp: 1698982048456
-- platform: win-64
-  name: libgoogle-cloud
-  version: 2.12.0
-  category: main
-  manager: conda
-  dependencies:
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-h39f2fc6_4.conda
+  sha256: 9621cb3e90aa22123cc7120bc1228df31453a390b7760773a0e5453a2718f7ef
+  md5: f79cf72abe2235de65fb50b386f323a0
+  depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - libcrc32c >=1.1.2,<1.2.0a0
@@ -7035,56 +6709,133 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-h39f2fc6_4.conda
-  hash:
-    md5: f79cf72abe2235de65fb50b386f323a0
-    sha256: 9621cb3e90aa22123cc7120bc1228df31453a390b7760773a0e5453a2718f7ef
-  build: h39f2fc6_4
-  arch: x86_64
-  subdir: win-64
-  build_number: 4
   constrains:
   - google-cloud-cpp 2.12.0 *_4
+  arch: x86_64
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 13270
   timestamp: 1698887885269
-- platform: linux-64
+- kind: conda
+  name: libgoogle-cloud
+  version: 2.12.0
+  build: h5206363_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-h5206363_4.conda
+  sha256: 82a7d211d0df165b073f9e8ba6d789c4b1c7c4882d546ca12d40f201fc3496fc
+  md5: b5eb63d2683102be45d17c55021282f6
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libgcc-ng >=12
+  - libgrpc >=1.59.2,<1.60.0a0
+  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libstdcxx-ng >=12
+  - openssl >=3.1.4,<4.0a0
+  constrains:
+  - google-cloud-cpp 2.12.0 *_4
+  arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  license_family: Apache
+  size: 43491878
+  timestamp: 1698886698923
+- kind: conda
+  name: libgoogle-cloud
+  version: 2.12.0
+  build: hc0857f6_4
+  build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-hc0857f6_4.conda
+  sha256: 1bf47f43796369ec85a27221ab9a84ecc848f93a88049d046cd8521c25b129f6
+  md5: 976555c39f83093265491c9c081a801c
+  depends:
+  - __osx >=10.13
+  - __osx >=10.9
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libcxx >=16.0.6
+  - libgrpc >=1.59.2,<1.60.0a0
+  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - openssl >=3.1.4,<4.0a0
+  constrains:
+  - google-cloud-cpp 2.12.0 *_4
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 30883666
+  timestamp: 1698889432429
+- kind: conda
+  name: libgoogle-cloud
+  version: 2.12.0
+  build: hfb399a7_4
+  build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-hfb399a7_4.conda
+  sha256: 22122939a462f64a82ca2f305c43e5e5cf5a55f1ae12979c2445f9dc196b7047
+  md5: d62901188ab756c841cbb9a80c6c3f3c
+  depends:
+  - __osx >=10.9
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libcxx >=16.0.6
+  - libgrpc >=1.59.2,<1.60.0a0
+  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - openssl >=3.1.4,<4.0a0
+  constrains:
+  - google-cloud-cpp 2.12.0 *_4
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 31440327
+  timestamp: 1698982048456
+- kind: conda
   name: libgrpc
   version: 1.59.3
-  category: main
-  manager: conda
-  dependencies:
+  build: h5bbd4a7_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.59.3-h5bbd4a7_0.conda
+  sha256: 77f29a3d26e87b176416ddf4dbbb076ff95ad09837ea9f100b788d0379700014
+  md5: 70a20bdb4a01daea0e8c12050267294f
+  depends:
   - c-ares >=1.21.0,<2.0a0
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libgcc-ng >=12
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
-  - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.4,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.59.3-hd6c4280_0.conda
-  hash:
-    md5: 896c137eaf0c22f2fef58332eb4a4b83
-    sha256: 3f95a2792e565b628cb284de92017a37a1cddc4a3f83453b8f75d9adc9f8cfdd
-  build: hd6c4280_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   constrains:
   - grpc-cpp =1.59.3
+  arch: x86_64
+  platform: win
   license: Apache-2.0
   license_family: APACHE
-  size: 6600132
-  timestamp: 1700259627150
-- platform: osx-64
+  size: 14228484
+  timestamp: 1700260902057
+- kind: conda
   name: libgrpc
   version: 1.59.3
-  category: main
-  manager: conda
-  dependencies:
+  build: ha7f534c_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.59.3-ha7f534c_0.conda
+  sha256: 1b7330bb2aa16ca0dd319e97a829d5494fb2459a841b54f7631932b144e38624
+  md5: a557d871e80f2dd22efd78e00f9a1597
+  depends:
   - __osx >=10.13
   - __osx >=10.9
   - c-ares >=1.21.0,<2.0a0
@@ -7096,26 +6847,23 @@ package:
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.4,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.59.3-ha7f534c_0.conda
-  hash:
-    md5: a557d871e80f2dd22efd78e00f9a1597
-    sha256: 1b7330bb2aa16ca0dd319e97a829d5494fb2459a841b54f7631932b144e38624
-  build: ha7f534c_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
   constrains:
   - grpc-cpp =1.59.3
+  arch: x86_64
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 4111631
   timestamp: 1700261027372
-- platform: osx-arm64
+- kind: conda
   name: libgrpc
   version: 1.59.3
-  category: main
-  manager: conda
-  dependencies:
+  build: hbcf6334_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.59.3-hbcf6334_0.conda
+  sha256: 54cacd1fc7503d48c135301a775568f15089b537b3c56804767c627a89a20c30
+  md5: e9c7cbc84af929dd47501629a5e19713
+  depends:
   - __osx >=10.9
   - c-ares >=1.21.0,<2.0a0
   - libabseil * cxx17*
@@ -7126,309 +6874,378 @@ package:
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.4,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.59.3-hbcf6334_0.conda
-  hash:
-    md5: e9c7cbc84af929dd47501629a5e19713
-    sha256: 54cacd1fc7503d48c135301a775568f15089b537b3c56804767c627a89a20c30
-  build: hbcf6334_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
   constrains:
   - grpc-cpp =1.59.3
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 3950361
   timestamp: 1700260902499
-- platform: win-64
+- kind: conda
   name: libgrpc
   version: 1.59.3
-  category: main
-  manager: conda
-  dependencies:
+  build: hd6c4280_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.59.3-hd6c4280_0.conda
+  sha256: 3f95a2792e565b628cb284de92017a37a1cddc4a3f83453b8f75d9adc9f8cfdd
+  md5: 896c137eaf0c22f2fef58332eb4a4b83
+  depends:
   - c-ares >=1.21.0,<2.0a0
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
+  - libgcc-ng >=12
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
+  - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.4,<4.0a0
   - re2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.59.3-h5bbd4a7_0.conda
-  hash:
-    md5: 70a20bdb4a01daea0e8c12050267294f
-    sha256: 77f29a3d26e87b176416ddf4dbbb076ff95ad09837ea9f100b788d0379700014
-  build: h5bbd4a7_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
   constrains:
   - grpc-cpp =1.59.3
+  arch: x86_64
+  platform: linux
   license: Apache-2.0
   license_family: APACHE
-  size: 14228484
-  timestamp: 1700260902057
-- platform: win-64
+  size: 6600132
+  timestamp: 1700259627150
+- kind: conda
   name: libhwloc
   version: 2.9.3
-  category: main
-  manager: conda
-  dependencies:
-  - libxml2 >=2.11.5,<2.12.0a0
-  - pthreads-win32 *
+  build: default_haede6df_1009
+  build_number: 1009
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
+  sha256: 2e8c4bb7173f281a8e13f333a23c9fb7a1c86d342d7dccdd74f2eb583ddde450
+  md5: 87da045f6d26ce9fe20ad76a18f6a18a
+  depends:
+  - libxml2 >=2.11.5,<3.0.0a0
+  - pthreads-win32
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
-  hash:
-    md5: 87da045f6d26ce9fe20ad76a18f6a18a
-    sha256: 2e8c4bb7173f281a8e13f333a23c9fb7a1c86d342d7dccdd74f2eb583ddde450
-  build: default_haede6df_1009
-  arch: x86_64
-  subdir: win-64
-  build_number: 1009
   license: BSD-3-Clause
   license_family: BSD
   size: 2578462
   timestamp: 1694533393675
-- platform: linux-64
+- kind: conda
   name: libiconv
   version: '1.17'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=10.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
-  hash:
-    md5: b62b52da46c39ee2bc3c162ac7f1804d
-    sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
   build: h166bdaf_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
+  sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
+  md5: b62b52da46c39ee2bc3c162ac7f1804d
+  depends:
+  - libgcc-ng >=10.3.0
+  arch: x86_64
+  platform: linux
   license: GPL and LGPL
   size: 1450368
   timestamp: 1652700749886
-- platform: osx-64
+- kind: conda
   name: libiconv
   version: '1.17'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2
-  hash:
-    md5: 691d103d11180486154af49c037b7ed9
-    sha256: 4a3294037d595754f7da7c11a41f3922f995aaa333f3cb66f02d8afa032a7bc2
-  build: hac89ed1_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: GPL and LGPL
-  size: 1378276
-  timestamp: 1652702364402
-- platform: osx-arm64
-  name: libiconv
-  version: '1.17'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
-  hash:
-    md5: 686f9c755574aa221f29fbcf36a67265
-    sha256: 2eb33065783b802f71d52bef6f15ce0fafea0adc8506f10ebd0d490244087bec
-  build: he4db4b2_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: GPL and LGPL
-  size: 1407036
-  timestamp: 1652700956112
-- platform: win-64
-  name: libiconv
-  version: '1.17'
-  category: main
-  manager: conda
-  dependencies:
+  build: h8ffe710_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
+  sha256: 657c2a992c896475021a25faebd9ccfaa149c5d70c7dc824d4069784b686cea1
+  md5: 050119977a86e4856f0416e2edcf81bb
+  depends:
   - vc >=14.1,<15
   - vs2015_runtime >=14.16.27033
-  url: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
-  hash:
-    md5: 050119977a86e4856f0416e2edcf81bb
-    sha256: 657c2a992c896475021a25faebd9ccfaa149c5d70c7dc824d4069784b686cea1
-  build: h8ffe710_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: GPL and LGPL
   size: 714518
   timestamp: 1652702326553
-- platform: linux-64
+- kind: conda
+  name: libiconv
+  version: '1.17'
+  build: hac89ed1_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2
+  sha256: 4a3294037d595754f7da7c11a41f3922f995aaa333f3cb66f02d8afa032a7bc2
+  md5: 691d103d11180486154af49c037b7ed9
+  arch: x86_64
+  platform: osx
+  license: GPL and LGPL
+  size: 1378276
+  timestamp: 1652702364402
+- kind: conda
+  name: libiconv
+  version: '1.17'
+  build: he4db4b2_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
+  sha256: 2eb33065783b802f71d52bef6f15ce0fafea0adc8506f10ebd0d490244087bec
+  md5: 686f9c755574aa221f29fbcf36a67265
+  arch: aarch64
+  platform: osx
+  license: GPL and LGPL
+  size: 1407036
+  timestamp: 1652700956112
+- kind: conda
   name: liblapack
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas ==3.9.0 18_linux64_openblas
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-18_linux64_openblas.conda
-  hash:
-    md5: a1244707531e5b143c420c70573c8ec5
-    sha256: 7b59c9bf8399b34818d36c7bbd30cd447649fe4ff2136d3102bb67da0af67a3a
   build: 18_linux64_openblas
-  arch: x86_64
-  subdir: linux-64
   build_number: 18
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-18_linux64_openblas.conda
+  sha256: 7b59c9bf8399b34818d36c7bbd30cd447649fe4ff2136d3102bb67da0af67a3a
+  md5: a1244707531e5b143c420c70573c8ec5
+  depends:
+  - libblas ==3.9.0 18_linux64_openblas
   constrains:
   - liblapacke 3.9.0 18_linux64_openblas
   - libcblas 3.9.0 18_linux64_openblas
   - blas * openblas
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 14482
   timestamp: 1693951382004
-- platform: osx-64
+- kind: conda
   name: liblapack
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas ==3.9.0 18_osx64_openblas
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-18_osx64_openblas.conda
-  hash:
-    md5: e3e4572494c68a638faea31e7b72ec56
-    sha256: 2a297c50fdd566f8a1685ca3da2d3fc3e8b33806240b20ce9e1dc3a739cd48ff
   build: 18_osx64_openblas
-  arch: x86_64
-  subdir: osx-64
   build_number: 18
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-18_osx64_openblas.conda
+  sha256: 2a297c50fdd566f8a1685ca3da2d3fc3e8b33806240b20ce9e1dc3a739cd48ff
+  md5: e3e4572494c68a638faea31e7b72ec56
+  depends:
+  - libblas ==3.9.0 18_osx64_openblas
   constrains:
   - blas * openblas
   - libcblas 3.9.0 18_osx64_openblas
   - liblapacke 3.9.0 18_osx64_openblas
+  arch: x86_64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 14676
   timestamp: 1693951751596
-- platform: osx-arm64
+- kind: conda
   name: liblapack
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas ==3.9.0 18_osxarm64_openblas
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-18_osxarm64_openblas.conda
-  hash:
-    md5: 92cd5c16ed732ac6c439145aa21ec7c5
-    sha256: 8e19b14ba16d286d889e3d1c78aaa3344e4c6dff50a21b54ee00ee88a95bb2e9
   build: 18_osxarm64_openblas
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 18
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-18_osxarm64_openblas.conda
+  sha256: 8e19b14ba16d286d889e3d1c78aaa3344e4c6dff50a21b54ee00ee88a95bb2e9
+  md5: 92cd5c16ed732ac6c439145aa21ec7c5
+  depends:
+  - libblas ==3.9.0 18_osxarm64_openblas
   constrains:
   - liblapacke 3.9.0 18_osxarm64_openblas
   - blas * openblas
   - libcblas 3.9.0 18_osxarm64_openblas
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 14767
   timestamp: 1693951919599
-- platform: win-64
+- kind: conda
   name: liblapack
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas ==3.9.0 18_win64_mkl
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-18_win64_mkl.conda
-  hash:
-    md5: 82117ef735a916ace2df6f2de4df4824
-    sha256: f90d96695938659fad4dd47d92dbeebff4a3824979bfb1aac33c8287a83e9d23
   build: 18_win64_mkl
-  arch: x86_64
-  subdir: win-64
   build_number: 18
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-18_win64_mkl.conda
+  sha256: f90d96695938659fad4dd47d92dbeebff4a3824979bfb1aac33c8287a83e9d23
+  md5: 82117ef735a916ace2df6f2de4df4824
+  depends:
+  - libblas ==3.9.0 18_win64_mkl
   constrains:
   - liblapacke 3.9.0 18_win64_mkl
   - blas * mkl
   - libcblas 3.9.0 18_win64_mkl
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 3655780
   timestamp: 1693952143445
-- platform: linux-64
+- kind: conda
   name: libllvm15
   version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxml2 >=2.11.4,<2.12.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-h5cf9203_3.conda
-  hash:
-    md5: 9efe82d44b76a7529a1d702e5a37752e
-    sha256: bb94e7535a309c2a8d58585cb82bac954ed59f473eef2cac6ea677d6f576a3b6
-  build: h5cf9203_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 33333655
-  timestamp: 1690527825436
-- platform: osx-64
-  name: libllvm15
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15
-  - libxml2 >=2.11.4,<2.12.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-he4b1e75_3.conda
-  hash:
-    md5: ecc6df80c4b0445ac0de9cabae189db3
-    sha256: 02c7f5fe1ae9cdf4b0152cc76fef0ccb26137075054bdd9336ebf956fd22d8c9
-  build: he4b1e75_3
-  arch: x86_64
-  subdir: osx-64
-  build_number: 3
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 23877550
-  timestamp: 1690533932497
-- platform: osx-arm64
-  name: libllvm15
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15
-  - libxml2 >=2.11.4,<2.12.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h504e6bf_3.conda
-  hash:
-    md5: cef4a00532f06f6797fbe2425d4db2a7
-    sha256: 8fbe19f2133c501a43a45f4dab701adf5206ed61f4bd6317f287a8d87409fdee
   build: h504e6bf_3
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h504e6bf_3.conda
+  sha256: 8fbe19f2133c501a43a45f4dab701adf5206ed61f4bd6317f287a8d87409fdee
+  md5: cef4a00532f06f6797fbe2425d4db2a7
+  depends:
+  - libcxx >=15
+  - libxml2 >=2.11.4,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: aarch64
+  platform: osx
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 21956912
   timestamp: 1690530007064
-- platform: linux-64
+- kind: conda
+  name: libllvm15
+  version: 15.0.7
+  build: h5cf9203_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-h5cf9203_3.conda
+  sha256: bb94e7535a309c2a8d58585cb82bac954ed59f473eef2cac6ea677d6f576a3b6
+  md5: 9efe82d44b76a7529a1d702e5a37752e
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.11.4,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  arch: x86_64
+  platform: linux
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 33333655
+  timestamp: 1690527825436
+- kind: conda
+  name: libllvm15
+  version: 15.0.7
+  build: he4b1e75_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-he4b1e75_3.conda
+  sha256: 02c7f5fe1ae9cdf4b0152cc76fef0ccb26137075054bdd9336ebf956fd22d8c9
+  md5: ecc6df80c4b0445ac0de9cabae189db3
+  depends:
+  - libcxx >=15
+  - libxml2 >=2.11.4,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 23877550
+  timestamp: 1690533932497
+- kind: conda
+  name: libllvm16
+  version: 16.0.6
+  build: h5cf9203_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm16-16.0.6-h5cf9203_2.conda
+  sha256: 38b6b4e5aa4784feeb4c7c1887f2facfc18a5996720d35c1b8c3a6e3eeff7687
+  md5: dbfb446bd165f61f9c82aed9188e297a
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.11.4,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 35432923
+  timestamp: 1691576970516
+- kind: conda
+  name: libllvm16
+  version: 16.0.6
+  build: he4b1e75_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm16-16.0.6-he4b1e75_2.conda
+  sha256: 449ca9c7312e693b61214c47c2f607b45f3df7d834ff471ed6d1a346d2b68585
+  md5: 22f7290639ab045be330423476fc9933
+  depends:
+  - libcxx >=15
+  - libxml2 >=2.11.4,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 25336098
+  timestamp: 1691579910107
+- kind: conda
+  name: libllvm16
+  version: 16.0.6
+  build: he79909e_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm16-16.0.6-he79909e_2.conda
+  sha256: 91f42ba27db3cc25e271146d9016eccb99c7b948d22025f39748468cee2dc05f
+  md5: ce01d4aa770fc6910bce0d47b4e4c538
+  depends:
+  - libcxx >=15
+  - libxml2 >=2.11.4,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 23239572
+  timestamp: 1691574275053
+- kind: conda
+  name: libllvm17
+  version: 17.0.5
+  build: h0a7b4ec_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm17-17.0.5-h0a7b4ec_0.conda
+  sha256: 34362faf39c96d3d620f88e431a6d6a3303563b4b7713f25eeb7580bb5fcc803
+  md5: 1a5301272f57502017f5b9e12ed90e6b
+  depends:
+  - libcxx >=16
+  - libxml2 >=2.11.5,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 26314438
+  timestamp: 1699997312185
+- kind: conda
+  name: libllvm17
+  version: 17.0.5
+  build: h5cf9203_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm17-17.0.5-h5cf9203_0.conda
+  sha256: b5aad9f2cdd6fca84a04fb094d210f1349a2332c9bd6de353bf35d85f099c266
+  md5: 138cfe47d60fcaf81e7be46d775c1469
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.11.5,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 36637322
+  timestamp: 1699993372343
+- kind: conda
+  name: libllvm17
+  version: 17.0.5
+  build: hc359061_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.5-hc359061_0.conda
+  sha256: 39ee0eadfacb87f258459dcea156686a1503f2345b2a7459ff887df4c264f2d9
+  md5: 83fcd7fe8b23af7a7e5bb70cd12e805e
+  depends:
+  - libcxx >=16
+  - libxml2 >=2.11.5,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 24640963
+  timestamp: 1699991940680
+- kind: conda
   name: libnghttp2
   version: 1.58.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h47da74e_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+  sha256: 1910c5306c6aa5bcbd623c3c930c440e9c77a5a019008e1487810e3c1d3716cb
+  md5: 700ac6ea6d53d5510591c4344d5c989a
+  depends:
   - c-ares >=1.23.0,<2.0a0
   - libev >=4.33,<4.34.0a0
   - libev >=4.33,<5.0a0
@@ -7436,24 +7253,22 @@ package:
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
-  hash:
-    md5: 700ac6ea6d53d5510591c4344d5c989a
-    sha256: 1910c5306c6aa5bcbd623c3c930c440e9c77a5a019008e1487810e3c1d3716cb
-  build: h47da74e_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: linux
   license: MIT
   license_family: MIT
   size: 631936
   timestamp: 1702130036271
-- platform: osx-64
+- kind: conda
   name: libnghttp2
   version: 1.58.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h64cf6d3_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
+  sha256: 412fd768e787e586602f8e9ea52bf089f3460fc630f6987f0cbd89b70e9a4380
+  md5: faecc55c2a8155d9ff1c0ff9a0fef64f
+  depends:
   - __osx >=10.9
   - c-ares >=1.23.0,<2.0a0
   - libcxx >=16.0.6
@@ -7461,24 +7276,22 @@ package:
   - libev >=4.33,<5.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
-  hash:
-    md5: faecc55c2a8155d9ff1c0ff9a0fef64f
-    sha256: 412fd768e787e586602f8e9ea52bf089f3460fc630f6987f0cbd89b70e9a4380
-  build: h64cf6d3_1
   arch: x86_64
-  subdir: osx-64
-  build_number: 1
+  platform: osx
   license: MIT
   license_family: MIT
   size: 599736
   timestamp: 1702130398536
-- platform: osx-arm64
+- kind: conda
   name: libnghttp2
   version: 1.58.0
-  category: main
-  manager: conda
-  dependencies:
+  build: ha4dd798_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
+  sha256: fc97aaaf0c6d0f508be313d86c2705b490998d382560df24be918b8e977802cd
+  md5: 1813e066bfcef82de579a0be8a766df4
+  depends:
   - __osx >=10.9
   - c-ares >=1.23.0,<2.0a0
   - libcxx >=16.0.6
@@ -7486,1788 +7299,1576 @@ package:
   - libev >=4.33,<5.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
-  hash:
-    md5: 1813e066bfcef82de579a0be8a766df4
-    sha256: fc97aaaf0c6d0f508be313d86c2705b490998d382560df24be918b8e977802cd
-  build: ha4dd798_1
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
+  platform: osx
   license: MIT
   license_family: MIT
   size: 565451
   timestamp: 1702130473930
-- platform: linux-64
+- kind: conda
   name: libnsl
   version: 2.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.0-hd590300_1.conda
-  hash:
-    md5: 854e3e1623b39777140f199c5f9ab952
-    sha256: c0a0c0abc1c17983168c3239d79a62d53c424bc5dd1764dbcd0fa953d6fce5e0
   build: hd590300_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.0-hd590300_1.conda
+  sha256: c0a0c0abc1c17983168c3239d79a62d53c424bc5dd1764dbcd0fa953d6fce5e0
+  md5: 854e3e1623b39777140f199c5f9ab952
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-only
   license_family: GPL
   size: 33210
   timestamp: 1695799598317
-- platform: linux-64
+- kind: conda
   name: libnuma
   version: 2.0.16
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.16-h0b41bf4_1.conda
-  hash:
-    md5: 28bfe2cb11357ccc5be21101a6b7ce86
-    sha256: 814a50cba215548ec3ebfb53033ffb9b3b070b2966570ff44910b8d9ba1c359d
   build: h0b41bf4_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.16-h0b41bf4_1.conda
+  sha256: 814a50cba215548ec3ebfb53033ffb9b3b070b2966570ff44910b8d9ba1c359d
+  md5: 28bfe2cb11357ccc5be21101a6b7ce86
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-only
   size: 41107
   timestamp: 1676004391774
-- platform: linux-64
+- kind: conda
   name: libopenblas
   version: 0.3.24
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libgfortran-ng *
-  - libgfortran5 >=12.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
-  hash:
-    md5: 6e4ef6ca28655124dcde9bd500e44c32
-    sha256: c8e080ae4d57506238023e98869928ae93564e6407ef5b0c4d3a337e8c2b7662
-  build: pthreads_h413a1c8_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  constrains:
-  - openblas >=0.3.24,<0.3.25.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5492091
-  timestamp: 1693785223074
-- platform: osx-64
-  name: libopenblas
-  version: 0.3.24
-  category: main
-  manager: conda
-  dependencies:
+  build: openmp_h48a4ad5_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
+  sha256: ff2c14f7ed121f1df3ad06bea353288eade77c12fb891212a27af88a61483490
+  md5: 077718837dd06cf0c3089070108869f6
+  depends:
   - libgfortran 5.*
   - libgfortran5 >=12.3.0
   - llvm-openmp >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
-  hash:
-    md5: 077718837dd06cf0c3089070108869f6
-    sha256: ff2c14f7ed121f1df3ad06bea353288eade77c12fb891212a27af88a61483490
-  build: openmp_h48a4ad5_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
   constrains:
   - openblas >=0.3.24,<0.3.25.0a0
+  arch: x86_64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 6157393
   timestamp: 1693785988209
-- platform: osx-arm64
+- kind: conda
   name: libopenblas
   version: 0.3.24
-  category: main
-  manager: conda
-  dependencies:
+  build: openmp_hd76b1f2_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
+  sha256: 21edfdf620ac5c93571aab452199b6b4622c445441dad88ab4d2eb326a7b91b3
+  md5: aacb05989f358affe1bafd4ea7294db4
+  depends:
   - libgfortran 5.*
   - libgfortran5 >=12.3.0
   - llvm-openmp >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
-  hash:
-    md5: aacb05989f358affe1bafd4ea7294db4
-    sha256: 21edfdf620ac5c93571aab452199b6b4622c445441dad88ab4d2eb326a7b91b3
-  build: openmp_hd76b1f2_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
   constrains:
   - openblas >=0.3.24,<0.3.25.0a0
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 2849225
   timestamp: 1693784744674
-- platform: linux-64
+- kind: conda
+  name: libopenblas
+  version: 0.3.24
+  build: pthreads_h413a1c8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
+  sha256: c8e080ae4d57506238023e98869928ae93564e6407ef5b0c4d3a337e8c2b7662
+  md5: 6e4ef6ca28655124dcde9bd500e44c32
+  depends:
+  - libgcc-ng >=12
+  - libgfortran-ng *
+  - libgfortran5 >=12.3.0
+  constrains:
+  - openblas >=0.3.24,<0.3.25.0a0
+  arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5492091
+  timestamp: 1693785223074
+- kind: conda
   name: libparquet
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h352af49_2_cpu
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.2-h352af49_2_cpu.conda
+  sha256: 4d0113cb62bb15c7fde3da36b4bb1862182ec5f89e0165ebcf5ae0bce155097f
+  md5: b265698e6c69269fe78a8cc972269c35
+  depends:
   - libarrow 14.0.2 h84dd17c_2_cpu
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libthrift >=0.19.0,<0.19.1.0a0
   - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.2-h352af49_2_cpu.conda
-  hash:
-    md5: b265698e6c69269fe78a8cc972269c35
-    sha256: 4d0113cb62bb15c7fde3da36b4bb1862182ec5f89e0165ebcf5ae0bce155097f
-  build: h352af49_2_cpu
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: Apache-2.0
   size: 1163710
   timestamp: 1704355184404
-- platform: osx-64
+- kind: conda
   name: libparquet
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h381d950_2_cpu
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.2-h381d950_2_cpu.conda
+  sha256: 8f58f4a46ae7eb500fff04a26e6f15de111999df4017bd4c4aac8f7245c95016
+  md5: c9b769d78c837821bfabc4fbd3cf3936
+  depends:
   - libarrow 14.0.2 h1aaacd4_2_cpu
   - libcxx >=14
   - libthrift >=0.19.0,<0.19.1.0a0
   - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.2-h381d950_2_cpu.conda
-  hash:
-    md5: c9b769d78c837821bfabc4fbd3cf3936
-    sha256: 8f58f4a46ae7eb500fff04a26e6f15de111999df4017bd4c4aac8f7245c95016
-  build: h381d950_2_cpu
   arch: x86_64
-  subdir: osx-64
-  build_number: 2
+  platform: osx
   license: Apache-2.0
   size: 928914
   timestamp: 1704356105480
-- platform: osx-arm64
+- kind: conda
   name: libparquet
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - libarrow 14.0.2 h4ce3932_2_cpu
-  - libcxx >=14
-  - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.2-hf6ce1d5_2_cpu.conda
-  hash:
-    md5: 3ec6dde23ee1ecea255c788e5ce16c82
-    sha256: e1deb2b68a0a24c85f75831e44a59d582168b5b9481ab7138683226e702416c2
-  build: hf6ce1d5_2_cpu
-  arch: aarch64
-  subdir: osx-arm64
+  build: h7ec3a38_2_cpu
   build_number: 2
-  license: Apache-2.0
-  size: 911760
-  timestamp: 1704356359375
-- platform: win-64
-  name: libparquet
-  version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-14.0.2-h7ec3a38_2_cpu.conda
+  sha256: 929bb7e2a0903d9442aac788969b8626017e97193929bceae991a4ddcdde3875
+  md5: 4de7b992bc7bc1a71b07fa893c80fcfb
+  depends:
   - libarrow 14.0.2 he5f67d5_2_cpu
   - libthrift >=0.19.0,<0.19.1.0a0
   - openssl >=3.2.0,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-14.0.2-h7ec3a38_2_cpu.conda
-  hash:
-    md5: 4de7b992bc7bc1a71b07fa893c80fcfb
-    sha256: 929bb7e2a0903d9442aac788969b8626017e97193929bceae991a4ddcdde3875
-  build: h7ec3a38_2_cpu
   arch: x86_64
-  subdir: win-64
-  build_number: 2
+  platform: win
   license: Apache-2.0
   size: 780687
   timestamp: 1704355806769
-- platform: linux-64
+- kind: conda
+  name: libparquet
+  version: 14.0.2
+  build: hf6ce1d5_2_cpu
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.2-hf6ce1d5_2_cpu.conda
+  sha256: e1deb2b68a0a24c85f75831e44a59d582168b5b9481ab7138683226e702416c2
+  md5: 3ec6dde23ee1ecea255c788e5ce16c82
+  depends:
+  - libarrow 14.0.2 h4ce3932_2_cpu
+  - libcxx >=14
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - openssl >=3.2.0,<4.0a0
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  size: 911760
+  timestamp: 1704356359375
+- kind: conda
   name: libprotobuf
   version: 4.24.4
-  category: main
-  manager: conda
-  dependencies:
-  - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.24.4-hf27288f_0.conda
-  hash:
-    md5: 1a0287ab734591ad63603734f923016b
-    sha256: 3e0f6454190abb27edd2aeb724688ee440de133edb02cbb17d5609ba36aa8be0
-  build: hf27288f_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2568098
-  timestamp: 1696556878001
-- platform: osx-64
-  name: libprotobuf
-  version: 4.24.4
-  category: main
-  manager: conda
-  dependencies:
+  build: h0ee05dc_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.24.4-h0ee05dc_0.conda
+  sha256: 4c0cd48fa2b0ac5cad6204d686bcb8e51bc5906c25180919ecf8f3000c0eade5
+  md5: c0f2660a38d96e55c6aae15a06ee277b
+  depends:
   - __osx >=10.13
   - __osx >=10.9
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - libcxx >=16.0.6
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.24.4-h0ee05dc_0.conda
-  hash:
-    md5: c0f2660a38d96e55c6aae15a06ee277b
-    sha256: 4c0cd48fa2b0ac5cad6204d686bcb8e51bc5906c25180919ecf8f3000c0eade5
-  build: h0ee05dc_0
   arch: x86_64
-  subdir: osx-64
-  build_number: 0
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 2134003
   timestamp: 1696557204512
-- platform: osx-arm64
+- kind: conda
   name: libprotobuf
   version: 4.24.4
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libcxx >=16.0.6
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.24.4-hc9861d8_0.conda
-  hash:
-    md5: ac5438d981e105e053b341eb30c44273
-    sha256: 2e81e023f463ef239e2fb7f56a4e8eed61a1d8e9ca3f2f07bec1668cc369b2ce
-  build: hc9861d8_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2060711
-  timestamp: 1696556460522
-- platform: win-64
-  name: libprotobuf
-  version: 4.24.4
-  category: main
-  manager: conda
-  dependencies:
+  build: hb8276f3_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.24.4-hb8276f3_0.conda
+  sha256: 2c2b9c1f65458c2f2a4b57d49bf8113781b933b63f8fc976f050627bddcf983d
+  md5: db95f0bafffb9a5b6b9f398d35d693ad
+  depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.24.4-hb8276f3_0.conda
-  hash:
-    md5: db95f0bafffb9a5b6b9f398d35d693ad
-    sha256: 2c2b9c1f65458c2f2a4b57d49bf8113781b933b63f8fc976f050627bddcf983d
-  build: hb8276f3_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 5281089
   timestamp: 1696556929616
-- platform: linux-64
-  name: libre2-11
-  version: 2023.06.02
-  category: main
-  manager: conda
-  dependencies:
+- kind: conda
+  name: libprotobuf
+  version: 4.24.4
+  build: hc9861d8_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.24.4-hc9861d8_0.conda
+  sha256: 2e81e023f463ef239e2fb7f56a4e8eed61a1d8e9ca3f2f07bec1668cc369b2ce
+  md5: ac5438d981e105e053b341eb30c44273
+  depends:
+  - __osx >=10.9
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=16.0.6
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: aarch64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2060711
+  timestamp: 1696556460522
+- kind: conda
+  name: libprotobuf
+  version: 4.24.4
+  build: hf27288f_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.24.4-hf27288f_0.conda
+  sha256: 3e0f6454190abb27edd2aeb724688ee440de133edb02cbb17d5609ba36aa8be0
+  md5: 1a0287ab734591ad63603734f923016b
+  depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.06.02-h7a70373_0.conda
-  hash:
-    md5: c0e7eacd9694db3ef5ef2979a7deea70
-    sha256: 22b0b2169c80b65665ba0d6418bd5d3d4c7d89915ee0f9613403efe871c27db8
-  build: h7a70373_0
+  - libzlib >=1.2.13,<1.3.0a0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  constrains:
-  - re2 2023.06.02.*
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
-  size: 232708
-  timestamp: 1697065825934
-- platform: osx-64
+  size: 2568098
+  timestamp: 1696556878001
+- kind: conda
   name: libre2-11
   version: 2023.06.02
-  category: main
-  manager: conda
-  dependencies:
+  build: h1753957_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.06.02-h1753957_0.conda
+  sha256: 8bafee8f8ef27f4cb0afffe5404dd1abfc5fd6eac1ee9b4847a756d440bd7aa7
+  md5: 3b8652db4bf4e27fa1446526f7a78498
+  depends:
+  - __osx >=10.9
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=16.0.6
+  constrains:
+  - re2 2023.06.02.*
+  arch: aarch64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169587
+  timestamp: 1697065827986
+- kind: conda
+  name: libre2-11
+  version: 2023.06.02
+  build: h4694dbf_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.06.02-h4694dbf_0.conda
+  sha256: 73acd1ade87762c3f1aacf2a7c6271dd1e1c972d46ea7c44d8781595bca9218e
+  md5: d7c00395eaf2446eec6ce0f34cfd5b78
+  depends:
   - __osx >=10.13
   - __osx >=10.9
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - libcxx >=16.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.06.02-h4694dbf_0.conda
-  hash:
-    md5: d7c00395eaf2446eec6ce0f34cfd5b78
-    sha256: 73acd1ade87762c3f1aacf2a7c6271dd1e1c972d46ea7c44d8781595bca9218e
-  build: h4694dbf_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
   constrains:
   - re2 2023.06.02.*
+  arch: x86_64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 182813
   timestamp: 1697065869791
-- platform: osx-arm64
+- kind: conda
   name: libre2-11
   version: 2023.06.02
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
+  build: h7a70373_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.06.02-h7a70373_0.conda
+  sha256: 22b0b2169c80b65665ba0d6418bd5d3d4c7d89915ee0f9613403efe871c27db8
+  md5: c0e7eacd9694db3ef5ef2979a7deea70
+  depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libcxx >=16.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.06.02-h1753957_0.conda
-  hash:
-    md5: 3b8652db4bf4e27fa1446526f7a78498
-    sha256: 8bafee8f8ef27f4cb0afffe5404dd1abfc5fd6eac1ee9b4847a756d440bd7aa7
-  build: h1753957_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   constrains:
   - re2 2023.06.02.*
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
-  size: 169587
-  timestamp: 1697065827986
-- platform: win-64
+  size: 232708
+  timestamp: 1697065825934
+- kind: conda
   name: libre2-11
   version: 2023.06.02
-  category: main
-  manager: conda
-  dependencies:
+  build: h8c5ae5e_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.06.02-h8c5ae5e_0.conda
+  sha256: c468915951532d0455737e08e5fb2a4e2a862c123a13feeaa12fe72671070e13
+  md5: b5c24e75399edf13660f317f5d7d751e
+  depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.06.02-h8c5ae5e_0.conda
-  hash:
-    md5: b5c24e75399edf13660f317f5d7d751e
-    sha256: c468915951532d0455737e08e5fb2a4e2a862c123a13feeaa12fe72671070e13
-  build: h8c5ae5e_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
   constrains:
   - re2 2023.06.02.*
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 253568
   timestamp: 1697066113767
-- platform: linux-64
+- kind: conda
   name: libsanitizer
   version: 12.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_2.conda
-  hash:
-    md5: 4655db64eca78a6fcc4fb654fc1f8d57
-    sha256: a58add0b4477c59aee324b508d834267360b659f9c543f551ca4442196e656fe
   build: h0f45ef3_2
-  arch: x86_64
-  subdir: linux-64
   build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_2.conda
+  sha256: a58add0b4477c59aee324b508d834267360b659f9c543f551ca4442196e656fe
+  md5: 4655db64eca78a6fcc4fb654fc1f8d57
+  depends:
+  - libgcc-ng >=12.3.0
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 3910499
   timestamp: 1695218679356
-- platform: linux-64
+- kind: conda
   name: libsqlite
   version: 3.43.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h2797004_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.43.0-h2797004_0.conda
+  sha256: e715fab7ec6b3f3df2a5962ef372ff0f871d215fe819482dcd80357999513652
+  md5: 903fa782a9067d5934210df6d79220f6
+  depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.43.0-h2797004_0.conda
-  hash:
-    md5: 903fa782a9067d5934210df6d79220f6
-    sha256: e715fab7ec6b3f3df2a5962ef372ff0f871d215fe819482dcd80357999513652
-  build: h2797004_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: Unlicense
   size: 840871
   timestamp: 1692911324643
-- platform: osx-64
-  name: libsqlite
-  version: 3.43.2
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.43.2-h92b6c6a_0.conda
-  hash:
-    md5: 61b88c5f99f1537ed30b34758bd54d54
-    sha256: e0ba6181738d5250213576167935a97dc3ee581032f716dd4e2acbc817c763dc
-  build: h92b6c6a_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: Unlicense
-  size: 885196
-  timestamp: 1696959083399
-- platform: osx-arm64
+- kind: conda
   name: libsqlite
   version: 3.43.0
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.43.0-hb31c410_0.conda
-  hash:
-    md5: 060a9948665e56a38060a1ed3ebc553a
-    sha256: ddc90cc7a33563cd1f2b179a4964d144c221f9148634c006fd83ec9e1c667907
   build: hb31c410_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.43.0-hb31c410_0.conda
+  sha256: ddc90cc7a33563cd1f2b179a4964d144c221f9148634c006fd83ec9e1c667907
+  md5: 060a9948665e56a38060a1ed3ebc553a
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: aarch64
+  platform: osx
   license: Unlicense
   size: 834286
   timestamp: 1692911796861
-- platform: win-64
+- kind: conda
   name: libsqlite
   version: 3.43.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.43.0-hcfcfb64_0.conda
+  sha256: d79128a279c8e8b4afeef5cfe9d4302a2fd65b1af3973732d92a7cc396d5332f
+  md5: 16c6f482e70cb3da41d0bee5d49c6bf3
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.43.0-hcfcfb64_0.conda
-  hash:
-    md5: 16c6f482e70cb3da41d0bee5d49c6bf3
-    sha256: d79128a279c8e8b4afeef5cfe9d4302a2fd65b1af3973732d92a7cc396d5332f
-  build: hcfcfb64_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: Unlicense
   size: 846526
   timestamp: 1692911612959
-- platform: linux-64
+- kind: conda
+  name: libsqlite
+  version: 3.43.2
+  build: h92b6c6a_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.43.2-h92b6c6a_0.conda
+  sha256: e0ba6181738d5250213576167935a97dc3ee581032f716dd4e2acbc817c763dc
+  md5: 61b88c5f99f1537ed30b34758bd54d54
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: x86_64
+  platform: osx
+  license: Unlicense
+  size: 885196
+  timestamp: 1696959083399
+- kind: conda
   name: libssh2
   version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h0841786_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+  sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+  md5: 1f5a58e686b13bcfde88b93f547d23fe
+  depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
-  hash:
-    md5: 1f5a58e686b13bcfde88b93f547d23fe
-    sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
-  build: h0841786_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 271133
   timestamp: 1685837707056
-- platform: osx-64
+- kind: conda
   name: libssh2
   version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
-  hash:
-    md5: ca3a72efba692c59a90d4b9fc0dfe774
-    sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
-  build: hd019ec5_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 259556
-  timestamp: 1685837820566
-- platform: osx-arm64
-  name: libssh2
-  version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
-  hash:
-    md5: 029f7dc931a3b626b94823bc77830b01
-    sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
   build: h7a5bd25_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+  sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
+  md5: 029f7dc931a3b626b94823bc77830b01
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 255610
   timestamp: 1685837894256
-- platform: win-64
+- kind: conda
   name: libssh2
   version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h7dfc565_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+  sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
+  md5: dc262d03aae04fe26825062879141a41
+  depends:
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.1,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
-  hash:
-    md5: dc262d03aae04fe26825062879141a41
-    sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
-  build: h7dfc565_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 266806
   timestamp: 1685838242099
-- platform: linux-64
+- kind: conda
+  name: libssh2
+  version: 1.11.0
+  build: hd019ec5_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+  sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
+  md5: ca3a72efba692c59a90d4b9fc0dfe774
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
+  arch: x86_64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259556
+  timestamp: 1685837820566
+- kind: conda
   name: libstdcxx-devel_linux-64
   version: 12.3.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_2.conda
-  hash:
-    md5: 7268a17e56eb099d1b8869bbbf46de4c
-    sha256: e8483069599561ef24b884c898442eadc510190f978fa388db3281b10c3c084e
   build: h8bca6fd_2
-  arch: x86_64
-  subdir: linux-64
   build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_2.conda
+  sha256: e8483069599561ef24b884c898442eadc510190f978fa388db3281b10c3c084e
+  md5: 7268a17e56eb099d1b8869bbbf46de4c
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 8542654
   timestamp: 1695218598349
-- platform: linux-64
+- kind: conda
   name: libstdcxx-ng
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
-  hash:
-    md5: 9172c297304f2a20134fc56c97fbe229
-    sha256: ab22ecdc974cdbe148874ea876d9c564294d5eafa760f403ed4fd495307b4243
   build: h7e041cc_2
-  arch: x86_64
-  subdir: linux-64
   build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
+  sha256: ab22ecdc974cdbe148874ea876d9c564294d5eafa760f403ed4fd495307b4243
+  md5: 9172c297304f2a20134fc56c97fbe229
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 3842773
   timestamp: 1695219454837
-- platform: linux-64
+- kind: conda
   name: libthrift
   version: 0.19.0
-  category: main
-  manager: conda
-  dependencies:
-  - libevent >=2.1.12,<2.1.13.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.3,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
-  hash:
-    md5: 8cdb7d41faa0260875ba92414c487e2d
-    sha256: 719add2cf20d144ef9962c57cd0f77178259bdb3aae1cded2e2b2b7c646092f5
-  build: hb90f79a_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 409409
-  timestamp: 1695958011498
-- platform: osx-64
-  name: libthrift
-  version: 0.19.0
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  - libevent >=2.1.12,<2.1.13.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.3,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
-  hash:
-    md5: b152655bfad7c2374ff03be0596052b6
-    sha256: 4346c25ef6e2ff3d0fc93074238508531188ecd0dbea6414f6cb93a7775072c4
-  build: h064b379_1
-  arch: x86_64
-  subdir: osx-64
-  build_number: 1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 325415
-  timestamp: 1695958330036
-- platform: osx-arm64
-  name: libthrift
-  version: 0.19.0
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  - libevent >=2.1.12,<2.1.13.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.3,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.19.0-h026a170_1.conda
-  hash:
-    md5: 4b8b21eb00d9019e9fa351141da2a6ac
-    sha256: b2c1b30d36f0412c0c0313db76a0236d736f3a9b887b8ed16182f531e4b7cb80
   build: h026a170_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.19.0-h026a170_1.conda
+  sha256: b2c1b30d36f0412c0c0313db76a0236d736f3a9b887b8ed16182f531e4b7cb80
+  md5: 4b8b21eb00d9019e9fa351141da2a6ac
+  depends:
+  - libcxx >=15.0.7
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 331154
   timestamp: 1695958512679
-- platform: win-64
+- kind: conda
   name: libthrift
   version: 0.19.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h064b379_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
+  sha256: 4346c25ef6e2ff3d0fc93074238508531188ecd0dbea6414f6cb93a7775072c4
+  md5: b152655bfad7c2374ff03be0596052b6
+  depends:
+  - libcxx >=15.0.7
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  license_family: APACHE
+  size: 325415
+  timestamp: 1695958330036
+- kind: conda
+  name: libthrift
+  version: 0.19.0
+  build: ha2b3283_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
+  sha256: 89bbc59898c827429a52315c9c0dd888ea73ab1157a8c86098aeae7d13454ac4
+  md5: d3432b9d4950e91d2fdf3bed91248ee0
+  depends:
   - libevent >=2.1.12,<2.1.13.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.3,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
-  hash:
-    md5: d3432b9d4950e91d2fdf3bed91248ee0
-    sha256: 89bbc59898c827429a52315c9c0dd888ea73ab1157a8c86098aeae7d13454ac4
-  build: ha2b3283_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: win
   license: Apache-2.0
   license_family: APACHE
   size: 612342
   timestamp: 1695958519927
-- platform: linux-64
+- kind: conda
+  name: libthrift
+  version: 0.19.0
+  build: hb90f79a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
+  sha256: 719add2cf20d144ef9962c57cd0f77178259bdb3aae1cded2e2b2b7c646092f5
+  md5: 8cdb7d41faa0260875ba92414c487e2d
+  depends:
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  license_family: APACHE
+  size: 409409
+  timestamp: 1695958011498
+- kind: conda
   name: libutf8proc
   version: 2.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
-  hash:
-    md5: ede4266dc02e875fe1ea77b25dd43747
-    sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
   build: h166bdaf_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+  sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
+  md5: ede4266dc02e875fe1ea77b25dd43747
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   size: 101070
   timestamp: 1667316029302
-- platform: osx-64
+- kind: conda
   name: libutf8proc
   version: 2.8.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
-  hash:
-    md5: db98dc3e58cbc11583180609c429c17d
-    sha256: 55a7f96b2802e94def207fdfe92bc52c24d705d139bb6cdb3d936cbe85e1c505
-  build: hb7f2c08_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 98942
-  timestamp: 1667316472080
-- platform: osx-arm64
-  name: libutf8proc
-  version: 2.8.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
-  hash:
-    md5: f8c9c41a122ab3abdf8943b13f4957ee
-    sha256: a3faddac08efd930fa3a1cc254b5053b4ed9428c49a888d437bf084d403c931a
   build: h1a8c8d9_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+  sha256: a3faddac08efd930fa3a1cc254b5053b4ed9428c49a888d437bf084d403c931a
+  md5: f8c9c41a122ab3abdf8943b13f4957ee
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 103492
   timestamp: 1667316405233
-- platform: win-64
+- kind: conda
   name: libutf8proc
   version: 2.8.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h82a8f57_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+  sha256: 6efa83e3f2fb9acaf096a18d21d0f679d110934798348c5defc780d4b759a76c
+  md5: 076894846fe9f068f91c57d158c90cba
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vs2015_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
-  hash:
-    md5: 076894846fe9f068f91c57d158c90cba
-    sha256: 6efa83e3f2fb9acaf096a18d21d0f679d110934798348c5defc780d4b759a76c
-  build: h82a8f57_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
   size: 104389
   timestamp: 1667316359211
-- platform: linux-64
+- kind: conda
+  name: libutf8proc
+  version: 2.8.0
+  build: hb7f2c08_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+  sha256: 55a7f96b2802e94def207fdfe92bc52c24d705d139bb6cdb3d936cbe85e1c505
+  md5: db98dc3e58cbc11583180609c429c17d
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 98942
+  timestamp: 1667316472080
+- kind: conda
   name: libuuid
   version: 2.38.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
-  hash:
-    md5: 40b61aab5c7ba9ff276c41cfffe6b80b
-    sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
   build: h0b41bf4_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 33601
   timestamp: 1680112270483
-- platform: linux-64
-  name: libuv
-  version: 1.46.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.46.0-hd590300_0.conda
-  hash:
-    md5: d23c76f7e6dcd6243d1b6ef5e62d17d2
-    sha256: 4bc4c946e9a532c066442714eeeeb1ffbd03cd89789c4047293f5e782b5fedd7
-  build: hd590300_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 893348
-  timestamp: 1693539405436
-- platform: osx-64
-  name: libuv
-  version: 1.46.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.46.0-h0c2f820_0.conda
-  hash:
-    md5: 27664a5d39d9c32ae38880fec2b33b36
-    sha256: e51667c756f15580d3ce131d6157f0238d931c05af118c89f019854f2a7c125e
-  build: h0c2f820_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 396101
-  timestamp: 1693539567563
-- platform: osx-arm64
-  name: libuv
-  version: 1.46.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.46.0-hb547adb_0.conda
-  hash:
-    md5: 5f1d535f82e8210ac80d191610b92325
-    sha256: f2fe8e22a99f91761c16dc7b00408bff0f5c30d4cccc6ea562db00a4041c5579
-  build: hb547adb_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 402723
-  timestamp: 1693539587068
-- platform: win-64
+- kind: conda
   name: libuv
   version: 1.44.2
-  category: main
-  manager: conda
-  dependencies:
+  build: hcfcfb64_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libuv-1.44.2-hcfcfb64_1.conda
+  sha256: d602dc13e1b0a955aa5f14772a3b8dc5ee72a4f68a4d63adb82a1ee105ffe4b2
+  md5: db1816a489a1b69dd1fd93e523cf026a
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libuv-1.44.2-hcfcfb64_1.conda
-  hash:
-    md5: db1816a489a1b69dd1fd93e523cf026a
-    sha256: d602dc13e1b0a955aa5f14772a3b8dc5ee72a4f68a4d63adb82a1ee105ffe4b2
-  build: hcfcfb64_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: win
   license: MIT
   license_family: MIT
   size: 285183
   timestamp: 1690371821520
-- platform: linux-64
+- kind: conda
+  name: libuv
+  version: 1.46.0
+  build: h0c2f820_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.46.0-h0c2f820_0.conda
+  sha256: e51667c756f15580d3ce131d6157f0238d931c05af118c89f019854f2a7c125e
+  md5: 27664a5d39d9c32ae38880fec2b33b36
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 396101
+  timestamp: 1693539567563
+- kind: conda
+  name: libuv
+  version: 1.46.0
+  build: hb547adb_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.46.0-hb547adb_0.conda
+  sha256: f2fe8e22a99f91761c16dc7b00408bff0f5c30d4cccc6ea562db00a4041c5579
+  md5: 5f1d535f82e8210ac80d191610b92325
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 402723
+  timestamp: 1693539587068
+- kind: conda
+  name: libuv
+  version: 1.46.0
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.46.0-hd590300_0.conda
+  sha256: 4bc4c946e9a532c066442714eeeeb1ffbd03cd89789c4047293f5e782b5fedd7
+  md5: d23c76f7e6dcd6243d1b6ef5e62d17d2
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 893348
+  timestamp: 1693539405436
+- kind: conda
   name: libxml2
   version: 2.11.5
-  category: main
-  manager: conda
-  dependencies:
+  build: h232c23b_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.5-h232c23b_1.conda
+  sha256: 1b3cb6864de1a558ea5fb144c780121d52507837d15df0600491d8ed92cff90c
+  md5: f3858448893839820d4bcfb14ad3ecdf
+  depends:
   - icu >=73.2,<74.0a0
   - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.5-h232c23b_1.conda
-  hash:
-    md5: f3858448893839820d4bcfb14ad3ecdf
-    sha256: 1b3cb6864de1a558ea5fb144c780121d52507837d15df0600491d8ed92cff90c
-  build: h232c23b_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: linux
   license: MIT
   license_family: MIT
   size: 705542
   timestamp: 1692960341690
-- platform: osx-64
+- kind: conda
   name: libxml2
   version: 2.11.5
-  category: main
-  manager: conda
-  dependencies:
-  - icu >=73.2,<74.0a0
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.5-h3346baf_1.conda
-  hash:
-    md5: 7584dee6af7de378aed0ae49aebedb8a
-    sha256: d901fab32e57a43c44e630fb1c4d0a163d23b109eecd6c68b9ee371800760bca
-  build: h3346baf_1
-  arch: x86_64
-  subdir: osx-64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 623399
-  timestamp: 1692960844532
-- platform: osx-arm64
-  name: libxml2
-  version: 2.11.5
-  category: main
-  manager: conda
-  dependencies:
-  - icu >=73.2,<74.0a0
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.5-h25269f3_1.conda
-  hash:
-    md5: 627b5d1377536b5b632ba53cd1455555
-    sha256: 8291549b87aca48e9cd4aec124af01b5037acd16f8ad14083d7af23c8bb6bebe
   build: h25269f3_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.5-h25269f3_1.conda
+  sha256: 8291549b87aca48e9cd4aec124af01b5037acd16f8ad14083d7af23c8bb6bebe
+  md5: 627b5d1377536b5b632ba53cd1455555
+  depends:
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 614831
   timestamp: 1692960705224
-- platform: win-64
+- kind: conda
   name: libxml2
   version: 2.11.5
-  category: main
-  manager: conda
-  dependencies:
+  build: h3346baf_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.5-h3346baf_1.conda
+  sha256: d901fab32e57a43c44e630fb1c4d0a163d23b109eecd6c68b9ee371800760bca
+  md5: 7584dee6af7de378aed0ae49aebedb8a
+  depends:
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 623399
+  timestamp: 1692960844532
+- kind: conda
+  name: libxml2
+  version: 2.12.5
+  build: hc3477c8_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.5-hc3477c8_0.conda
+  sha256: 15696b049911b3ea5d37672408e500fb27e375d865f8cceac9cb02f9349e6804
+  md5: d8c3c1c8242db352f38cd1dc0bf44f77
+  depends:
   - libiconv >=1.17,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
-  hash:
-    md5: 27974f880a010b1441093d9f737a949f
-    sha256: ad3b5a510be2c5f9fe90b2c20e10adb135717304bcb3a197f256feb48d713d99
-  build: hc3477c8_1
-  arch: x86_64
-  subdir: win-64
-  build_number: 1
   license: MIT
   license_family: MIT
-  size: 1600640
-  timestamp: 1692960798126
-- platform: linux-64
+  size: 1567894
+  timestamp: 1707084720091
+- kind: conda
   name: libzlib
   version: 1.2.13
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
-  hash:
-    md5: f36c115f1ee199da648e0597ec2047ad
-    sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
-  build: hd590300_5
-  arch: x86_64
-  subdir: linux-64
-  build_number: 5
-  constrains:
-  - zlib 1.2.13 *_5
-  license: Zlib
-  license_family: Other
-  size: 61588
-  timestamp: 1686575217516
-- platform: osx-64
-  name: libzlib
-  version: 1.2.13
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
-  hash:
-    md5: 4a3ad23f6e16f99c04e166767193d700
-    sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
-  build: h8a1eda9_5
-  arch: x86_64
-  subdir: osx-64
-  build_number: 5
-  constrains:
-  - zlib 1.2.13 *_5
-  license: Zlib
-  license_family: Other
-  size: 59404
-  timestamp: 1686575566695
-- platform: osx-arm64
-  name: libzlib
-  version: 1.2.13
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
-  hash:
-    md5: 1a47f5236db2e06a320ffa0392f81bd8
-    sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
   build: h53f4e23_5
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+  sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
+  md5: 1a47f5236db2e06a320ffa0392f81bd8
   constrains:
   - zlib 1.2.13 *_5
+  arch: aarch64
+  platform: osx
   license: Zlib
   license_family: Other
   size: 48102
   timestamp: 1686575426584
-- platform: win-64
+- kind: conda
   name: libzlib
   version: 1.2.13
-  category: main
-  manager: conda
-  dependencies:
+  build: h8a1eda9_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+  sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
+  md5: 4a3ad23f6e16f99c04e166767193d700
+  constrains:
+  - zlib 1.2.13 *_5
+  arch: x86_64
+  platform: osx
+  license: Zlib
+  license_family: Other
+  size: 59404
+  timestamp: 1686575566695
+- kind: conda
+  name: libzlib
+  version: 1.2.13
+  build: hcfcfb64_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+  sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
+  md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
-  hash:
-    md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
-    sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
-  build: hcfcfb64_5
-  arch: x86_64
-  subdir: win-64
-  build_number: 5
   constrains:
   - zlib 1.2.13 *_5
+  arch: x86_64
+  platform: win
   license: Zlib
   license_family: Other
   size: 55800
   timestamp: 1686575452215
-- platform: osx-64
-  name: llvm-openmp
-  version: 17.0.2
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.2-hff08bdf_0.conda
-  hash:
-    md5: fe9a7b6676832e214e7b135b611592bc
-    sha256: c251012a7504b67907bd22efa1df13ac88a4f3bce2d83850665b465125b43e18
-  build: hff08bdf_0
+- kind: conda
+  name: libzlib
+  version: 1.2.13
+  build: hd590300_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+  sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
+  md5: f36c115f1ee199da648e0597ec2047ad
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - zlib 1.2.13 *_5
   arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  constrains:
-  - openmp 17.0.2|17.0.2.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: APACHE
-  size: 304623
-  timestamp: 1696555642332
-- platform: osx-arm64
+  platform: linux
+  license: Zlib
+  license_family: Other
+  size: 61588
+  timestamp: 1686575217516
+- kind: conda
   name: llvm-openmp
   version: 17.0.2
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.2-h1c12783_0.conda
-  hash:
-    md5: cc2d5e802daf2135a1eaa5983ee47827
-    sha256: 4bbe783de0fafa9e05b0af28c8afbfde5b9525acd65e8f387562c5e80f5ec4bd
   build: h1c12783_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.2-h1c12783_0.conda
+  sha256: 4bbe783de0fafa9e05b0af28c8afbfde5b9525acd65e8f387562c5e80f5ec4bd
+  md5: cc2d5e802daf2135a1eaa5983ee47827
   constrains:
   - openmp 17.0.2|17.0.2.*
+  arch: aarch64
+  platform: osx
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   size: 275849
   timestamp: 1696555855843
-- platform: osx-64
+- kind: conda
+  name: llvm-openmp
+  version: 17.0.2
+  build: hff08bdf_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.2-hff08bdf_0.conda
+  sha256: c251012a7504b67907bd22efa1df13ac88a4f3bce2d83850665b465125b43e18
+  md5: fe9a7b6676832e214e7b135b611592bc
+  constrains:
+  - openmp 17.0.2|17.0.2.*
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 304623
+  timestamp: 1696555642332
+- kind: conda
   name: llvm-tools
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libllvm15 ==15.0.7 he4b1e75_3
-  - libxml2 >=2.11.4,<2.12.0a0
+  version: 16.0.6
+  build: he4b1e75_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-16.0.6-he4b1e75_2.conda
+  sha256: 6f2e1ce3c869d232b8638df629394d4b211b58983bdc65c458ca07416b613723
+  md5: 301727f6047e65138071deccd0d8bafb
+  depends:
+  - libllvm16 16.0.6 he4b1e75_2
+  - libxml2 >=2.11.4,<3.0.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - zstd >=1.5.2,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-15.0.7-he4b1e75_3.conda
-  hash:
-    md5: 7177e9334a86af1b1581f14607ced61c
-    sha256: 93bf3db0bb0db82d91be7226374c239e88d885b850ab9791ec6755c63ffecc82
-  build: he4b1e75_3
-  arch: x86_64
-  subdir: osx-64
-  build_number: 3
   constrains:
-  - llvmdev   15.0.7
-  - clang 15.0.7.*
-  - clang-tools 15.0.7.*
-  - llvm 15.0.7.*
+  - llvmdev   16.0.6
+  - clang 16.0.6.*
+  - clang-tools 16.0.6.*
+  - llvm 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 11380889
-  timestamp: 1690534088911
-- platform: osx-arm64
+  size: 22337339
+  timestamp: 1691580099339
+- kind: conda
   name: llvm-tools
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libllvm15 ==15.0.7 h504e6bf_3
-  - libxml2 >=2.11.4,<2.12.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-15.0.7-h504e6bf_3.conda
-  hash:
-    md5: 56a351b4eba7ce574fa2702770e74252
-    sha256: 102c7da379f508e55b60a24625a3174b85d7e716ead452c1d7c88f84174b7a99
-  build: h504e6bf_3
-  arch: aarch64
+  version: 16.0.6
+  build: he79909e_2
+  build_number: 2
   subdir: osx-arm64
-  build_number: 3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-16.0.6-he79909e_2.conda
+  sha256: 134921812fb11630c2920f2f33b49ba485acac1db9b13cac2847927a99b294f7
+  md5: 1be8e193b74101ac2bde79a27e9444c1
+  depends:
+  - libllvm16 16.0.6 he79909e_2
+  - libxml2 >=2.11.4,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
   constrains:
-  - llvmdev   15.0.7
-  - clang 15.0.7.*
-  - clang-tools 15.0.7.*
-  - llvm 15.0.7.*
+  - llvmdev   16.0.6
+  - clang 16.0.6.*
+  - clang-tools 16.0.6.*
+  - llvm 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 10034129
-  timestamp: 1690530165545
-- platform: linux-64
+  size: 20650993
+  timestamp: 1691574442545
+- kind: conda
   name: lz4-c
   version: 1.9.4
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
-  hash:
-    md5: 318b08df404f9c9be5712aaa5a6f0bb0
-    sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
-  build: hcb278e6_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 143402
-  timestamp: 1674727076728
-- platform: osx-64
-  name: lz4-c
-  version: 1.9.4
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=14.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
-  hash:
-    md5: aa04f7143228308662696ac24023f991
-    sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
-  build: hf0c8a7f_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 156415
-  timestamp: 1674727335352
-- platform: osx-arm64
-  name: lz4-c
-  version: 1.9.4
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=14.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
-  hash:
-    md5: 45505bec548634f7d05e02fb25262cb9
-    sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
   build: hb7217d7_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+  sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
+  md5: 45505bec548634f7d05e02fb25262cb9
+  depends:
+  - libcxx >=14.0.6
+  arch: aarch64
+  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 141188
   timestamp: 1674727268278
-- platform: win-64
+- kind: conda
   name: lz4-c
   version: 1.9.4
-  category: main
-  manager: conda
-  dependencies:
+  build: hcb278e6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+  sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+  md5: 318b08df404f9c9be5712aaa5a6f0bb0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  arch: x86_64
+  platform: linux
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143402
+  timestamp: 1674727076728
+- kind: conda
+  name: lz4-c
+  version: 1.9.4
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+  sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
+  md5: e34720eb20a33fc3bfb8451dd837ab7a
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vs2015_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
-  hash:
-    md5: e34720eb20a33fc3bfb8451dd837ab7a
-    sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
-  build: hcfcfb64_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: BSD-2-Clause
   license_family: BSD
   size: 134235
   timestamp: 1674728465431
-- platform: win-64
+- kind: conda
+  name: lz4-c
+  version: 1.9.4
+  build: hf0c8a7f_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+  sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
+  md5: aa04f7143228308662696ac24023f991
+  depends:
+  - libcxx >=14.0.6
+  arch: x86_64
+  platform: osx
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156415
+  timestamp: 1674727335352
+- kind: conda
   name: m2w64-gcc-libgfortran
   version: 5.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: '6'
+  build_number: 6
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+  sha256: 9de95a7996d5366ae0808eef2acbc63f9b11b874aa42375f55379e6715845dc6
+  md5: 066552ac6b907ec6d72c0ddab29050dc
+  depends:
   - m2w64-gcc-libs-core *
   - msys2-conda-epoch ==20160418
-  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
-  hash:
-    md5: 066552ac6b907ec6d72c0ddab29050dc
-    sha256: 9de95a7996d5366ae0808eef2acbc63f9b11b874aa42375f55379e6715845dc6
-  build: '6'
   arch: x86_64
-  subdir: win-64
-  build_number: 6
+  platform: win
   license: GPL, LGPL, FDL, custom
   size: 350687
   timestamp: 1608163451316
-- platform: win-64
+- kind: conda
   name: m2w64-gcc-libs
   version: 5.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: '7'
+  build_number: 7
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+  sha256: 3bd1ab02b7c89a5b153a17be03b36d833f1517ff2a6a77ead7c4a808b88196aa
+  md5: fe759119b8b3bfa720b8762c6fdc35de
+  depends:
   - m2w64-gcc-libgfortran *
   - m2w64-gcc-libs-core *
   - m2w64-gmp *
   - m2w64-libwinpthread-git *
   - msys2-conda-epoch ==20160418
-  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
-  hash:
-    md5: fe759119b8b3bfa720b8762c6fdc35de
-    sha256: 3bd1ab02b7c89a5b153a17be03b36d833f1517ff2a6a77ead7c4a808b88196aa
-  build: '7'
   arch: x86_64
-  subdir: win-64
-  build_number: 7
+  platform: win
   license: GPL3+, partial:GCCRLE, partial:LGPL2+
   size: 532390
   timestamp: 1608163512830
-- platform: win-64
+- kind: conda
   name: m2w64-gcc-libs-core
   version: 5.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: '7'
+  build_number: 7
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+  sha256: 58afdfe859ed2e9a9b1cc06bc408720cb2c3a6a132e59d4805b090d7574f4ee0
+  md5: 4289d80fb4d272f1f3b56cfe87ac90bd
+  depends:
   - m2w64-gmp *
   - m2w64-libwinpthread-git *
   - msys2-conda-epoch ==20160418
-  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
-  hash:
-    md5: 4289d80fb4d272f1f3b56cfe87ac90bd
-    sha256: 58afdfe859ed2e9a9b1cc06bc408720cb2c3a6a132e59d4805b090d7574f4ee0
-  build: '7'
   arch: x86_64
-  subdir: win-64
-  build_number: 7
+  platform: win
   license: GPL3+, partial:GCCRLE, partial:LGPL2+
   size: 219240
   timestamp: 1608163481341
-- platform: win-64
+- kind: conda
   name: m2w64-gmp
   version: 6.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - msys2-conda-epoch ==20160418
-  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
-  hash:
-    md5: 53a1c73e1e3d185516d7e3af177596d9
-    sha256: 7e3cd95f554660de45f8323fca359e904e8d203efaf07a4d311e46d611481ed1
   build: '2'
-  arch: x86_64
-  subdir: win-64
   build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+  sha256: 7e3cd95f554660de45f8323fca359e904e8d203efaf07a4d311e46d611481ed1
+  md5: 53a1c73e1e3d185516d7e3af177596d9
+  depends:
+  - msys2-conda-epoch ==20160418
+  arch: x86_64
+  platform: win
   license: LGPL3
   size: 743501
   timestamp: 1608163782057
-- platform: win-64
+- kind: conda
   name: m2w64-libwinpthread-git
   version: 5.0.0.4634.697f757
-  category: main
-  manager: conda
-  dependencies:
-  - msys2-conda-epoch ==20160418
-  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
-  hash:
-    md5: 774130a326dee16f1ceb05cc687ee4f0
-    sha256: f63a09b2cae7defae0480f1740015d6235f1861afa6fe2e2d3e10bd0d1314ee0
   build: '2'
-  arch: x86_64
-  subdir: win-64
   build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+  sha256: f63a09b2cae7defae0480f1740015d6235f1861afa6fe2e2d3e10bd0d1314ee0
+  md5: 774130a326dee16f1ceb05cc687ee4f0
+  depends:
+  - msys2-conda-epoch ==20160418
+  arch: x86_64
+  platform: win
   license: MIT, BSD
   size: 31928
   timestamp: 1608166099896
-- platform: linux-64
+- kind: conda
   name: markdown-it-py
   version: 3.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - mdurl >=0.1,<1
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 93a8e71256479c62074356ef6ebf501b
-    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 64356
-  timestamp: 1686175179621
-- platform: osx-64
-  name: markdown-it-py
-  version: 3.0.0
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  md5: 93a8e71256479c62074356ef6ebf501b
+  depends:
   - mdurl >=0.1,<1
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 93a8e71256479c62074356ef6ebf501b
-    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: osx-64
-  build_number: 0
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 64356
   timestamp: 1686175179621
-- platform: osx-arm64
+- kind: conda
   name: markdown-it-py
   version: 3.0.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  md5: 93a8e71256479c62074356ef6ebf501b
+  depends:
   - mdurl >=0.1,<1
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 93a8e71256479c62074356ef6ebf501b
-    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 64356
+  timestamp: 1686175179621
+- kind: conda
+  name: markdown-it-py
+  version: 3.0.0
   build: pyhd8ed1ab_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 64356
-  timestamp: 1686175179621
-- platform: win-64
-  name: markdown-it-py
-  version: 3.0.0
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  md5: 93a8e71256479c62074356ef6ebf501b
+  depends:
   - mdurl >=0.1,<1
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 93a8e71256479c62074356ef6ebf501b
-    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 64356
   timestamp: 1686175179621
-- platform: linux-64
-  name: markupsafe
-  version: 2.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py311h459d7ec_1.conda
-  hash:
-    md5: 71120b5155a0c500826cf81536721a15
-    sha256: e1a9930f35e39bf65bc293e24160b83ebf9f800f02749f65358e1c04882ee6b0
-  build: py311h459d7ec_1
+- kind: conda
+  name: markdown-it-py
+  version: 3.0.0
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  md5: 93a8e71256479c62074356ef6ebf501b
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.8
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27174
-  timestamp: 1695367575909
-- platform: osx-64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 64356
+  timestamp: 1686175179621
+- kind: conda
   name: markupsafe
   version: 2.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py311h2725bcf_1.conda
-  hash:
-    md5: 52ee86f482b552e547e2b1d6c01adf55
-    sha256: 5a8f8caa89eeba6ea6e9e96d3e7c109b675bc3c6ed4b109b8931757da2411d48
   build: py311h2725bcf_1
-  arch: x86_64
-  subdir: osx-64
   build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py311h2725bcf_1.conda
+  sha256: 5a8f8caa89eeba6ea6e9e96d3e7c109b675bc3c6ed4b109b8931757da2411d48
+  md5: 52ee86f482b552e547e2b1d6c01adf55
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   constrains:
   - jinja2 >=3.0.0
+  arch: x86_64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 25917
   timestamp: 1695367980802
-- platform: osx-arm64
+- kind: conda
   name: markupsafe
   version: 2.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py311heffc1b2_1.conda
-  hash:
-    md5: 5a7b68cb9eea46bea31aaf2d11d0dd2f
-    sha256: 307c1e3b2e4a2a992a6c94975910adff88cc523e2c9a41e81b2d506d8c9e7359
-  build: py311heffc1b2_1
-  arch: aarch64
-  subdir: osx-arm64
+  build: py311h459d7ec_1
   build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py311h459d7ec_1.conda
+  sha256: e1a9930f35e39bf65bc293e24160b83ebf9f800f02749f65358e1c04882ee6b0
+  md5: 71120b5155a0c500826cf81536721a15
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   constrains:
   - jinja2 >=3.0.0
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
-  size: 26764
-  timestamp: 1695368008221
-- platform: win-64
+  size: 27174
+  timestamp: 1695367575909
+- kind: conda
   name: markupsafe
   version: 2.1.3
-  category: main
-  manager: conda
-  dependencies:
+  build: py311ha68e1ae_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py311ha68e1ae_1.conda
+  sha256: 435c4c2df8d98cd49d8332d22b6f4847fc4b594500f0cdf0f9437274c668642b
+  md5: bc93b9d445824cfce3933b5dcc1087b4
+  depends:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py311ha68e1ae_1.conda
-  hash:
-    md5: bc93b9d445824cfce3933b5dcc1087b4
-    sha256: 435c4c2df8d98cd49d8332d22b6f4847fc4b594500f0cdf0f9437274c668642b
-  build: py311ha68e1ae_1
-  arch: x86_64
-  subdir: win-64
-  build_number: 1
   constrains:
   - jinja2 >=3.0.0
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 29466
   timestamp: 1695367841578
-- platform: linux-64
-  name: maturin
-  version: 0.14.17
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - tomli >=1.1.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/maturin-0.14.17-py311h46250e7_1.conda
-  hash:
-    md5: bffeab02e3f3b01122bf48fbc463e2a6
-    sha256: 9a408d448521ec66e413e2d07fa0455c7b84ee8c19a04092f0a0d1a5804ebe10
-  build: py311h46250e7_1
-  arch: x86_64
-  subdir: linux-64
+- kind: conda
+  name: markupsafe
+  version: 2.1.3
+  build: py311heffc1b2_1
   build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 7051949
-  timestamp: 1695991411795
-- platform: osx-64
-  name: maturin
-  version: 0.14.17
-  category: main
-  manager: conda
-  dependencies:
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py311heffc1b2_1.conda
+  sha256: 307c1e3b2e4a2a992a6c94975910adff88cc523e2c9a41e81b2d506d8c9e7359
+  md5: 5a7b68cb9eea46bea31aaf2d11d0dd2f
+  depends:
   - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
-  - tomli >=1.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/maturin-0.14.17-py311h5b17fdd_1.conda
-  hash:
-    md5: 951219fb757f9a441c778e3be0caa610
-    sha256: befcdd1dd7d43f2e4076e0f88094377165152421496ec625a7187628f388b3ec
-  build: py311h5b17fdd_1
-  arch: x86_64
-  subdir: osx-64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 5465974
-  timestamp: 1695991988214
-- platform: osx-arm64
+  constrains:
+  - jinja2 >=3.0.0
+  arch: aarch64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26764
+  timestamp: 1695368008221
+- kind: conda
   name: maturin
   version: 0.14.17
-  category: main
-  manager: conda
-  dependencies:
+  build: py311h0563b04_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-0.14.17-py311h0563b04_1.conda
+  sha256: f5cb528ece8bcdb7ae07327a4eafa6b2e877a4a5a45afd40308004e444a8d684
+  md5: 7a107334132e3ae17a010ecc0fd47352
+  depends:
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
   - tomli >=1.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-0.14.17-py311h0563b04_1.conda
-  hash:
-    md5: 7a107334132e3ae17a010ecc0fd47352
-    sha256: f5cb528ece8bcdb7ae07327a4eafa6b2e877a4a5a45afd40308004e444a8d684
-  build: py311h0563b04_1
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
+  platform: osx
   license: MIT
   license_family: MIT
   size: 5394957
   timestamp: 1695992435269
-- platform: win-64
+- kind: conda
   name: maturin
   version: 0.14.17
-  category: main
-  manager: conda
-  dependencies:
+  build: py311h46250e7_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/maturin-0.14.17-py311h46250e7_1.conda
+  sha256: 9a408d448521ec66e413e2d07fa0455c7b84ee8c19a04092f0a0d1a5804ebe10
+  md5: bffeab02e3f3b01122bf48fbc463e2a6
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli >=1.1.0
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 7051949
+  timestamp: 1695991411795
+- kind: conda
+  name: maturin
+  version: 0.14.17
+  build: py311h5b17fdd_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/maturin-0.14.17-py311h5b17fdd_1.conda
+  sha256: befcdd1dd7d43f2e4076e0f88094377165152421496ec625a7187628f388b3ec
+  md5: 951219fb757f9a441c778e3be0caa610
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli >=1.1.0
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 5465974
+  timestamp: 1695991988214
+- kind: conda
+  name: maturin
+  version: 0.14.17
+  build: py311h9a9e57f_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/maturin-0.14.17-py311h9a9e57f_1.conda
+  sha256: db786d65b3f603c42a9a44311358016f7edadb9cc8af6e9842c75a4a0dcb83f1
+  md5: 290aae658b0aa0894f8066403ba7997b
+  depends:
   - m2w64-gcc-libs *
   - m2w64-gcc-libs-core *
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - tomli >=1.1.0
-  url: https://conda.anaconda.org/conda-forge/win-64/maturin-0.14.17-py311h9a9e57f_1.conda
-  hash:
-    md5: 290aae658b0aa0894f8066403ba7997b
-    sha256: db786d65b3f603c42a9a44311358016f7edadb9cc8af6e9842c75a4a0dcb83f1
-  build: py311h9a9e57f_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: win
   license: MIT
   license_family: MIT
   size: 5146488
   timestamp: 1695992858881
-- platform: linux-64
+- kind: conda
   name: mdurl
   version: 0.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: f8dab71fdc13b1bf29a01248b156d268
-    sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
+  md5: f8dab71fdc13b1bf29a01248b156d268
+  depends:
+  - python >=3.6
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 13707
   timestamp: 1639515992326
-- platform: osx-64
+- kind: conda
   name: mdurl
   version: 0.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: f8dab71fdc13b1bf29a01248b156d268
-    sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 13707
-  timestamp: 1639515992326
-- platform: osx-arm64
-  name: mdurl
-  version: 0.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
   url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: f8dab71fdc13b1bf29a01248b156d268
-    sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 13707
-  timestamp: 1639515992326
-- platform: win-64
-  name: mdurl
-  version: 0.1.0
-  category: main
-  manager: conda
-  dependencies:
+  sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
+  md5: f8dab71fdc13b1bf29a01248b156d268
+  depends:
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: f8dab71fdc13b1bf29a01248b156d268
-    sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 13707
   timestamp: 1639515992326
-- platform: win-64
+- kind: conda
+  name: mdurl
+  version: 0.1.0
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
+  md5: f8dab71fdc13b1bf29a01248b156d268
+  depends:
+  - python >=3.6
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 13707
+  timestamp: 1639515992326
+- kind: conda
+  name: mdurl
+  version: 0.1.0
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
+  md5: f8dab71fdc13b1bf29a01248b156d268
+  depends:
+  - python >=3.6
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 13707
+  timestamp: 1639515992326
+- kind: conda
   name: mkl
   version: 2022.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h6a75c08_874
+  build_number: 874
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2022.1.0-h6a75c08_874.tar.bz2
+  sha256: b130d13dba6a798cbcce8f19c52e9765b75b8668d2f8f95ba8210c63b6fa84eb
+  md5: 2ff89a7337a9636029b4db9466e9f8e3
+  depends:
   - intel-openmp *
   - tbb 2021.*
-  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2022.1.0-h6a75c08_874.tar.bz2
-  hash:
-    md5: 2ff89a7337a9636029b4db9466e9f8e3
-    sha256: b130d13dba6a798cbcce8f19c52e9765b75b8668d2f8f95ba8210c63b6fa84eb
-  build: h6a75c08_874
   arch: x86_64
-  subdir: win-64
-  build_number: 874
+  platform: win
   license: LicenseRef-ProprietaryIntel
   license_family: Proprietary
   size: 191569511
   timestamp: 1652946602922
-- platform: linux-64
+- kind: conda
   name: more-itertools
   version: 10.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
-    sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
+  sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
+  md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
+  depends:
+  - python >=3.8
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 53654
   timestamp: 1691087125209
-- platform: osx-64
+- kind: conda
   name: more-itertools
   version: 10.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
-    sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 53654
-  timestamp: 1691087125209
-- platform: osx-arm64
-  name: more-itertools
-  version: 10.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
-    sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 53654
-  timestamp: 1691087125209
-- platform: win-64
-  name: more-itertools
-  version: 10.1.0
-  category: main
-  manager: conda
-  dependencies:
+  sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
+  md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
+  depends:
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
-    sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 53654
   timestamp: 1691087125209
-- platform: win-64
+- kind: conda
+  name: more-itertools
+  version: 10.1.0
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
+  sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
+  md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
+  depends:
+  - python >=3.8
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 53654
+  timestamp: 1691087125209
+- kind: conda
+  name: more-itertools
+  version: 10.1.0
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
+  sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
+  md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
+  depends:
+  - python >=3.8
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 53654
+  timestamp: 1691087125209
+- kind: conda
   name: msys2-conda-epoch
   version: '20160418'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
-  hash:
-    md5: b0309b72560df66f71a9d5e34a5efdfa
-    sha256: 99358d58d778abee4dca82ad29fb58058571f19b0f86138363c260049d4ac7f1
   build: '1'
-  arch: x86_64
-  subdir: win-64
   build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+  sha256: 99358d58d778abee4dca82ad29fb58058571f19b0f86138363c260049d4ac7f1
+  md5: b0309b72560df66f71a9d5e34a5efdfa
+  arch: x86_64
+  platform: win
   size: 3227
   timestamp: 1608166968312
-- platform: linux-64
+- kind: conda
   name: mypy
   version: 1.4.1
-  category: main
-  manager: conda
-  dependencies:
+  build: py311h2725bcf_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.4.1-py311h2725bcf_0.conda
+  sha256: cd4c55fa0ad4ae2cd2ace3f9f4c3b5680c640cef4eb837ab81967a9dc052dba6
+  md5: a29b75d2d8ddd4a6208ba8e6548e661f
+  depends:
+  - mypy_extensions >=0.4.3
+  - psutil >=4.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli >=1.1.0
+  - typing_extensions >=3.10
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 9803193
+  timestamp: 1687821896289
+- kind: conda
+  name: mypy
+  version: 1.4.1
+  build: py311h459d7ec_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.4.1-py311h459d7ec_0.conda
+  sha256: 235514c25d96fe726403893509c573aa1071fba49a57dcfa88ae37d87ba317c8
+  md5: 70099a5eee9a60f4bd52e388b77b3378
+  depends:
   - libgcc-ng >=12
   - mypy_extensions >=0.4.3
   - psutil >=4.0
@@ -9275,72 +8876,21 @@ package:
   - python_abi 3.11.* *_cp311
   - tomli >=1.1.0
   - typing_extensions >=3.10
-  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.4.1-py311h459d7ec_0.conda
-  hash:
-    md5: 70099a5eee9a60f4bd52e388b77b3378
-    sha256: 235514c25d96fe726403893509c573aa1071fba49a57dcfa88ae37d87ba317c8
-  build: py311h459d7ec_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: MIT
   license_family: MIT
   size: 15268473
   timestamp: 1687821217638
-- platform: osx-64
+- kind: conda
   name: mypy
   version: 1.4.1
-  category: main
-  manager: conda
-  dependencies:
-  - mypy_extensions >=0.4.3
-  - psutil >=4.0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - tomli >=1.1.0
-  - typing_extensions >=3.10
-  url: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.4.1-py311h2725bcf_0.conda
-  hash:
-    md5: a29b75d2d8ddd4a6208ba8e6548e661f
-    sha256: cd4c55fa0ad4ae2cd2ace3f9f4c3b5680c640cef4eb837ab81967a9dc052dba6
-  build: py311h2725bcf_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 9803193
-  timestamp: 1687821896289
-- platform: osx-arm64
-  name: mypy
-  version: 1.4.1
-  category: main
-  manager: conda
-  dependencies:
-  - mypy_extensions >=0.4.3
-  - psutil >=4.0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  - tomli >=1.1.0
-  - typing_extensions >=3.10
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.4.1-py311heffc1b2_0.conda
-  hash:
-    md5: 388c8df4d57c047bec3f17bd274843e2
-    sha256: 534eb1914c32392372c236740868bf72f769563315c3df54deef145a2924ebfa
-  build: py311heffc1b2_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 9520844
-  timestamp: 1687822156007
-- platform: win-64
-  name: mypy
-  version: 1.4.1
-  category: main
-  manager: conda
-  dependencies:
+  build: py311ha68e1ae_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.4.1-py311ha68e1ae_0.conda
+  sha256: 821f051883edbee804c3f1be27fa3e0fe652d0e686dca5c98bc3d031f5a919ad
+  md5: 6d8c5eed03be56e4ceedee017d5edb83
+  depends:
   - mypy_extensions >=0.4.3
   - psutil >=4.0
   - python >=3.11,<3.12.0a0
@@ -9350,235 +8900,282 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.4.1-py311ha68e1ae_0.conda
-  hash:
-    md5: 6d8c5eed03be56e4ceedee017d5edb83
-    sha256: 821f051883edbee804c3f1be27fa3e0fe652d0e686dca5c98bc3d031f5a919ad
-  build: py311ha68e1ae_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
   size: 7927695
   timestamp: 1687821196175
-- platform: linux-64
-  name: mypy_extensions
-  version: 1.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-  hash:
-    md5: 4eccaeba205f0aed9ac3a9ea58568ca3
-    sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-  build: pyha770c72_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 10492
-  timestamp: 1675543414256
-- platform: osx-64
-  name: mypy_extensions
-  version: 1.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-  hash:
-    md5: 4eccaeba205f0aed9ac3a9ea58568ca3
-    sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-  build: pyha770c72_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 10492
-  timestamp: 1675543414256
-- platform: osx-arm64
-  name: mypy_extensions
-  version: 1.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-  hash:
-    md5: 4eccaeba205f0aed9ac3a9ea58568ca3
-    sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-  build: pyha770c72_0
-  arch: aarch64
+- kind: conda
+  name: mypy
+  version: 1.4.1
+  build: py311heffc1b2_0
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.4.1-py311heffc1b2_0.conda
+  sha256: 534eb1914c32392372c236740868bf72f769563315c3df54deef145a2924ebfa
+  md5: 388c8df4d57c047bec3f17bd274843e2
+  depends:
+  - mypy_extensions >=0.4.3
+  - psutil >=4.0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tomli >=1.1.0
+  - typing_extensions >=3.10
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 10492
-  timestamp: 1675543414256
-- platform: win-64
+  size: 9520844
+  timestamp: 1687822156007
+- kind: conda
   name: mypy_extensions
   version: 1.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-  hash:
-    md5: 4eccaeba205f0aed9ac3a9ea58568ca3
-    sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
   build: pyha770c72_0
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
+  sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
+  md5: 4eccaeba205f0aed9ac3a9ea58568ca3
+  depends:
+  - python >=3.5
   arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 10492
+  timestamp: 1675543414256
+- kind: conda
+  name: mypy_extensions
+  version: 1.0.0
+  build: pyha770c72_0
+  subdir: osx-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
+  sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
+  md5: 4eccaeba205f0aed9ac3a9ea58568ca3
+  depends:
+  - python >=3.5
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 10492
+  timestamp: 1675543414256
+- kind: conda
+  name: mypy_extensions
+  version: 1.0.0
+  build: pyha770c72_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
+  sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
+  md5: 4eccaeba205f0aed9ac3a9ea58568ca3
+  depends:
+  - python >=3.5
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 10492
+  timestamp: 1675543414256
+- kind: conda
+  name: mypy_extensions
+  version: 1.0.0
+  build: pyha770c72_0
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
+  sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
+  md5: 4eccaeba205f0aed9ac3a9ea58568ca3
+  depends:
+  - python >=3.5
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 10492
   timestamp: 1675543414256
-- platform: linux-64
+- kind: conda
   name: ncurses
   version: '6.4'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
-  hash:
-    md5: 681105bccc2a3f7f1a837d47d39c9179
-    sha256: ccf61e61d58a8a7b2d66822d5568e2dc9387883dd9b2da61e1d787ece4c4979a
-  build: hcb278e6_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: X11 AND BSD-3-Clause
-  size: 880967
-  timestamp: 1686076725450
-- platform: osx-64
-  name: ncurses
-  version: '6.4'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-hf0c8a7f_0.conda
-  hash:
-    md5: c3dbae2411164d9b02c69090a9a91857
-    sha256: 7841b1fce1ffb0bfb038f9687b92f04d64acab1f7cb96431972386ea98c7b2fd
-  build: hf0c8a7f_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: X11 AND BSD-3-Clause
-  size: 828118
-  timestamp: 1686077056765
-- platform: osx-arm64
-  name: ncurses
-  version: '6.4'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
-  hash:
-    md5: 318337fb9d0c53ba635efb7888242373
-    sha256: 017e230a1f912e15005d4c4f3d387119190b53240f9ae0ba8a319dd958901780
   build: h7ea286d_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
+  sha256: 017e230a1f912e15005d4c4f3d387119190b53240f9ae0ba8a319dd958901780
+  md5: 318337fb9d0c53ba635efb7888242373
+  arch: aarch64
+  platform: osx
   license: X11 AND BSD-3-Clause
   size: 799196
   timestamp: 1686077139703
-- platform: linux-64
-  name: ninja
-  version: 1.11.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.1-h924138e_0.conda
-  hash:
-    md5: 73a4953a2d9c115bdc10ff30a52f675f
-    sha256: b555247ac8859b4ff311e3d708a0640f1bfe9fae7125c485b444072474a84c41
-  build: h924138e_0
-  arch: x86_64
+- kind: conda
+  name: ncurses
+  version: '6.4'
+  build: hcb278e6_0
   subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 2251263
-  timestamp: 1676837602636
-- platform: osx-64
-  name: ninja
-  version: 1.11.1
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=14.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.1-hb8565cd_0.conda
-  hash:
-    md5: 49ad513efe39447aa51affd47e3aa68f
-    sha256: 6f738d9a26fa275317b95b2b96832daab9059ef64af9a338f904a3cb684ae426
-  build: hb8565cd_0
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
+  sha256: ccf61e61d58a8a7b2d66822d5568e2dc9387883dd9b2da61e1d787ece4c4979a
+  md5: 681105bccc2a3f7f1a837d47d39c9179
+  depends:
+  - libgcc-ng >=12
   arch: x86_64
+  platform: linux
+  license: X11 AND BSD-3-Clause
+  size: 880967
+  timestamp: 1686076725450
+- kind: conda
+  name: ncurses
+  version: '6.4'
+  build: hf0c8a7f_0
   subdir: osx-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 121284
-  timestamp: 1676837793132
-- platform: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-hf0c8a7f_0.conda
+  sha256: 7841b1fce1ffb0bfb038f9687b92f04d64acab1f7cb96431972386ea98c7b2fd
+  md5: c3dbae2411164d9b02c69090a9a91857
+  arch: x86_64
+  platform: osx
+  license: X11 AND BSD-3-Clause
+  size: 828118
+  timestamp: 1686077056765
+- kind: conda
   name: ninja
   version: 1.11.1
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=14.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.1-hffc8910_0.conda
-  hash:
-    md5: fdecec4002f41cf6ea1eea5b52947ee0
-    sha256: a594e90b0ed8202c280fff4a008f6a355d0db54a62b17067dc4a950370ddffc0
-  build: hffc8910_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 107047
-  timestamp: 1676837935565
-- platform: win-64
-  name: ninja
-  version: 1.11.1
-  category: main
-  manager: conda
-  dependencies:
+  build: h91493d7_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ninja-1.11.1-h91493d7_0.conda
+  sha256: 0ffb1912768af8354a930f482368ef170bf3d8217db328dfea1c8b09772c8c71
+  md5: 44a99ef26178ea98626ff8e027702795
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vs2015_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/ninja-1.11.1-h91493d7_0.conda
-  hash:
-    md5: 44a99ef26178ea98626ff8e027702795
-    sha256: 0ffb1912768af8354a930f482368ef170bf3d8217db328dfea1c8b09772c8c71
-  build: h91493d7_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 279200
   timestamp: 1676838681615
-- platform: linux-64
+- kind: conda
+  name: ninja
+  version: 1.11.1
+  build: h924138e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.1-h924138e_0.conda
+  sha256: b555247ac8859b4ff311e3d708a0640f1bfe9fae7125c485b444072474a84c41
+  md5: 73a4953a2d9c115bdc10ff30a52f675f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  license_family: Apache
+  size: 2251263
+  timestamp: 1676837602636
+- kind: conda
+  name: ninja
+  version: 1.11.1
+  build: hb8565cd_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.1-hb8565cd_0.conda
+  sha256: 6f738d9a26fa275317b95b2b96832daab9059ef64af9a338f904a3cb684ae426
+  md5: 49ad513efe39447aa51affd47e3aa68f
+  depends:
+  - libcxx >=14.0.6
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 121284
+  timestamp: 1676837793132
+- kind: conda
+  name: ninja
+  version: 1.11.1
+  build: hffc8910_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.1-hffc8910_0.conda
+  sha256: a594e90b0ed8202c280fff4a008f6a355d0db54a62b17067dc4a950370ddffc0
+  md5: fdecec4002f41cf6ea1eea5b52947ee0
+  depends:
+  - libcxx >=14.0.6
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 107047
+  timestamp: 1676837935565
+- kind: conda
   name: nodejs
   version: 18.18.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h2713218_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-18.18.2-h2713218_1.conda
+  sha256: 4dc7c4c31a2def43db597e2a621e8b2a9ea2b682ffc55f8ee88d518ee02cc492
+  md5: 8c68a4522ddc0c08aaae6ef7c6979b92
+  depends:
+  - __osx >=10.9
+  - icu >=73.2,<74.0a0
+  - libcxx >=15.0.7
+  - libuv >=1.46.0,<1.47.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.4,<4.0a0
+  - zlib
+  constrains:
+  - __osx >=10.15
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 11230468
+  timestamp: 1700392695108
+- kind: conda
+  name: nodejs
+  version: 18.18.2
+  build: h57928b3_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/nodejs-18.18.2-h57928b3_1.conda
+  sha256: 3121574f788fef2e11269a0e77dff71f4dea586d1d8da5a9c36911afa20c0480
+  md5: 83569101477048efb6dd12086ef0ba08
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 22438481
+  timestamp: 1700384983430
+- kind: conda
+  name: nodejs
+  version: 18.18.2
+  build: h7ed3092_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-18.18.2-h7ed3092_1.conda
+  sha256: cc52406588c489c1fcccd37148b714e14ae71205c554064abdf07db06394ca07
+  md5: 2e8ae468a6ecaa076bc6acc7d796761e
+  depends:
+  - __osx >=10.9
+  - icu >=73.2,<74.0a0
+  - libcxx >=15.0.7
+  - libuv >=1.46.0,<1.47.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.4,<4.0a0
+  - zlib
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 10718633
+  timestamp: 1700399218159
+- kind: conda
+  name: nodejs
+  version: 18.18.2
+  build: hb753e55_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-18.18.2-hb753e55_1.conda
+  sha256: 89a88ef9b8d6d138b64bcd95d7edcee42e4c0012bde0665a8d66f812bf5c13be
+  md5: d3aceb714a24e2bd2655cc9948d23bc9
+  depends:
   - __glibc >=2.17,<3.0.a0
   - icu >=73.2,<74.0a0
   - libgcc-ng >=12
@@ -9587,121 +9184,22 @@ package:
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.4,<4.0a0
   - zlib
-  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-18.18.2-hb753e55_1.conda
-  hash:
-    md5: d3aceb714a24e2bd2655cc9948d23bc9
-    sha256: 89a88ef9b8d6d138b64bcd95d7edcee42e4c0012bde0665a8d66f812bf5c13be
-  build: hb753e55_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: linux
   license: MIT
   license_family: MIT
   size: 15614862
   timestamp: 1700389549489
-- platform: osx-64
-  name: nodejs
-  version: 18.18.2
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - icu >=73.2,<74.0a0
-  - libcxx >=15.0.7
-  - libuv >=1.46.0,<1.47.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.4,<4.0a0
-  - zlib
-  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-18.18.2-h2713218_1.conda
-  hash:
-    md5: 8c68a4522ddc0c08aaae6ef7c6979b92
-    sha256: 4dc7c4c31a2def43db597e2a621e8b2a9ea2b682ffc55f8ee88d518ee02cc492
-  build: h2713218_1
-  arch: x86_64
-  subdir: osx-64
-  build_number: 1
-  constrains:
-  - __osx >=10.15
-  license: MIT
-  license_family: MIT
-  size: 11230468
-  timestamp: 1700392695108
-- platform: osx-arm64
-  name: nodejs
-  version: 18.18.2
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - icu >=73.2,<74.0a0
-  - libcxx >=15.0.7
-  - libuv >=1.46.0,<1.47.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.4,<4.0a0
-  - zlib
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-18.18.2-h7ed3092_1.conda
-  hash:
-    md5: 2e8ae468a6ecaa076bc6acc7d796761e
-    sha256: cc52406588c489c1fcccd37148b714e14ae71205c554064abdf07db06394ca07
-  build: h7ed3092_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 10718633
-  timestamp: 1700399218159
-- platform: win-64
-  name: nodejs
-  version: 18.18.2
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/nodejs-18.18.2-h57928b3_1.conda
-  hash:
-    md5: 83569101477048efb6dd12086ef0ba08
-    sha256: 3121574f788fef2e11269a0e77dff71f4dea586d1d8da5a9c36911afa20c0480
-  build: h57928b3_1
-  arch: x86_64
-  subdir: win-64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 22438481
-  timestamp: 1700384983430
-- platform: linux-64
+- kind: conda
   name: nox
   version: 2021.10.1
-  category: main
-  manager: conda
-  dependencies:
-  - argcomplete >=1.9.4,<2.0
-  - colorlog >=2.6.1,<5.0.0
-  - importlib_metadata
-  - jinja2
-  - packaging >=20.9
-  - py >=1.4.0,<2.0.0
-  - python >=3.6
-  - virtualenv >=14.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/nox-2021.10.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: c29de03dc9c5595cb011a6b2204c14f5
-    sha256: 2f453a747762a186a500c2dbbc8dd78bc717223725d3701686083e79b02aee50
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
   noarch: python
-  size: 39937
-  timestamp: 1633199959832
-- platform: osx-64
-  name: nox
-  version: 2021.10.1
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/nox-2021.10.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 2f453a747762a186a500c2dbbc8dd78bc717223725d3701686083e79b02aee50
+  md5: c29de03dc9c5595cb011a6b2204c14f5
+  depends:
   - argcomplete >=1.9.4,<2.0
   - colorlog >=2.6.1,<5.0.0
   - importlib_metadata
@@ -9710,25 +9208,22 @@ package:
   - py >=1.4.0,<2.0.0
   - python >=3.6
   - virtualenv >=14.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/nox-2021.10.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: c29de03dc9c5595cb011a6b2204c14f5
-    sha256: 2f453a747762a186a500c2dbbc8dd78bc717223725d3701686083e79b02aee50
-  build: pyhd8ed1ab_0
   arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  license_family: Apache
+  size: 39937
+  timestamp: 1633199959832
+- kind: conda
+  name: nox
+  version: 2021.10.1
+  build: pyhd8ed1ab_0
   subdir: osx-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
   noarch: python
-  size: 39937
-  timestamp: 1633199959832
-- platform: osx-arm64
-  name: nox
-  version: 2021.10.1
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/nox-2021.10.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 2f453a747762a186a500c2dbbc8dd78bc717223725d3701686083e79b02aee50
+  md5: c29de03dc9c5595cb011a6b2204c14f5
+  depends:
   - argcomplete >=1.9.4,<2.0
   - colorlog >=2.6.1,<5.0.0
   - importlib_metadata
@@ -9737,52 +9232,94 @@ package:
   - py >=1.4.0,<2.0.0
   - python >=3.6
   - virtualenv >=14.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/nox-2021.10.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: c29de03dc9c5595cb011a6b2204c14f5
-    sha256: 2f453a747762a186a500c2dbbc8dd78bc717223725d3701686083e79b02aee50
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  noarch: python
-  size: 39937
-  timestamp: 1633199959832
-- platform: win-64
-  name: nox
-  version: 2021.10.1
-  category: main
-  manager: conda
-  dependencies:
-  - argcomplete >=1.9.4,<2.0
-  - colorlog >=2.6.1,<5.0.0
-  - importlib_metadata
-  - jinja2
-  - packaging >=20.9
-  - py >=1.4.0,<2.0.0
-  - python >=3.6
-  - virtualenv >=14.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/nox-2021.10.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: c29de03dc9c5595cb011a6b2204c14f5
-    sha256: 2f453a747762a186a500c2dbbc8dd78bc717223725d3701686083e79b02aee50
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: Apache-2.0
   license_family: Apache
-  noarch: python
   size: 39937
   timestamp: 1633199959832
-- platform: linux-64
+- kind: conda
+  name: nox
+  version: 2021.10.1
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/nox-2021.10.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 2f453a747762a186a500c2dbbc8dd78bc717223725d3701686083e79b02aee50
+  md5: c29de03dc9c5595cb011a6b2204c14f5
+  depends:
+  - argcomplete >=1.9.4,<2.0
+  - colorlog >=2.6.1,<5.0.0
+  - importlib_metadata
+  - jinja2
+  - packaging >=20.9
+  - py >=1.4.0,<2.0.0
+  - python >=3.6
+  - virtualenv >=14.0.0
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 39937
+  timestamp: 1633199959832
+- kind: conda
+  name: nox
+  version: 2021.10.1
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/nox-2021.10.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 2f453a747762a186a500c2dbbc8dd78bc717223725d3701686083e79b02aee50
+  md5: c29de03dc9c5595cb011a6b2204c14f5
+  depends:
+  - argcomplete >=1.9.4,<2.0
+  - colorlog >=2.6.1,<5.0.0
+  - importlib_metadata
+  - jinja2
+  - packaging >=20.9
+  - py >=1.4.0,<2.0.0
+  - python >=3.6
+  - virtualenv >=14.0.0
+  arch: x86_64
+  platform: win
+  license: Apache-2.0
+  license_family: Apache
+  size: 39937
+  timestamp: 1633199959832
+- kind: conda
   name: numpy
   version: 1.26.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py311h0b4df5a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.0-py311h0b4df5a_0.conda
+  sha256: 3da6bcf524a4418d7d0dbc084c23c74e1f2fc4b19c34a5805f5e201e5d7fcd8f
+  md5: a65e57fff208fd1d0f632e0afa8985d4
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  arch: x86_64
+  platform: win
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7085715
+  timestamp: 1694920741486
+- kind: conda
+  name: numpy
+  version: 1.26.0
+  build: py311h64a7726_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.0-py311h64a7726_0.conda
+  sha256: 0aab5cef67cc2a1cd584f6e9cc6f2065c7a28c142d7defcb8096e8f719d9b3bf
+  md5: bf16a9f625126e378302f08e7ed67517
+  depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - libgcc-ng >=12
@@ -9790,194 +9327,149 @@ package:
   - libstdcxx-ng >=12
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.0-py311h64a7726_0.conda
-  hash:
-    md5: bf16a9f625126e378302f08e7ed67517
-    sha256: 0aab5cef67cc2a1cd584f6e9cc6f2065c7a28c142d7defcb8096e8f719d9b3bf
-  build: py311h64a7726_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - numpy-base <0a0
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 8039946
   timestamp: 1694920380273
-- platform: osx-64
+- kind: conda
   name: numpy
   version: 1.26.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=15.0.7
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.0-py311hc44ba51_0.conda
-  hash:
-    md5: f95605c5b73f5f6a0f5f1b0aabfc2f39
-    sha256: 517cb22d5594fdb934523dd1951929961f686b5d994c684201acbf282433ec9b
-  build: py311hc44ba51_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7616817
-  timestamp: 1694920728660
-- platform: osx-arm64
-  name: numpy
-  version: 1.26.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py311hb8f3215_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.0-py311hb8f3215_0.conda
+  sha256: fca5ee1363f22a160c97e92d6400d4636f4b05987b08085e4f79fb6efb75fd0a
+  md5: 97f8632bf2ad5c179ff68fc90c71c2ae
+  depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - libcxx >=15.0.7
   - liblapack >=3.9.0,<4.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.0-py311hb8f3215_0.conda
-  hash:
-    md5: 97f8632bf2ad5c179ff68fc90c71c2ae
-    sha256: fca5ee1363f22a160c97e92d6400d4636f4b05987b08085e4f79fb6efb75fd0a
-  build: py311hb8f3215_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
   constrains:
   - numpy-base <0a0
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 6780798
   timestamp: 1694920700859
-- platform: win-64
+- kind: conda
   name: numpy
   version: 1.26.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py311hc44ba51_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.0-py311hc44ba51_0.conda
+  sha256: 517cb22d5594fdb934523dd1951929961f686b5d994c684201acbf282433ec9b
+  md5: f95605c5b73f5f6a0f5f1b0aabfc2f39
+  depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
   - liblapack >=3.9.0,<4.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.0-py311h0b4df5a_0.conda
-  hash:
-    md5: a65e57fff208fd1d0f632e0afa8985d4
-    sha256: 3da6bcf524a4418d7d0dbc084c23c74e1f2fc4b19c34a5805f5e201e5d7fcd8f
-  build: py311h0b4df5a_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
   constrains:
   - numpy-base <0a0
+  arch: x86_64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  size: 7085715
-  timestamp: 1694920741486
-- platform: linux-64
+  size: 7616817
+  timestamp: 1694920728660
+- kind: conda
   name: openssl
   version: 3.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - ca-certificates
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.0-hd590300_1.conda
-  hash:
-    md5: 603827b39ea2b835268adb8c821b8570
-    sha256: 80efc6f429bd8e622d999652e5cba2ca56fcdb9c16a439d2ce9b4313116e4a87
-  build: hd590300_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 2854103
-  timestamp: 1701162437033
-- platform: osx-64
-  name: openssl
-  version: 3.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - ca-certificates
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.0-hd75f5a5_1.conda
-  hash:
-    md5: 06cb561619487c88891839b9beb5244c
-    sha256: 99161bf349f5dc80322f2a2c188588d11efa662566e4e19f2ac0a36d9fa3de25
-  build: hd75f5a5_1
-  arch: x86_64
-  subdir: osx-64
-  build_number: 1
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 2508164
-  timestamp: 1701163123673
-- platform: osx-arm64
-  name: openssl
-  version: 3.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - ca-certificates
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.0-h0d3ecfb_1.conda
-  hash:
-    md5: 47d16d26100f19ca495882882b7bc93b
-    sha256: a53e1c6c058b621fd1d13cca6f9cccd534d2b3f4b4ac789fe26f7902031d6c41
   build: h0d3ecfb_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.0-h0d3ecfb_1.conda
+  sha256: a53e1c6c058b621fd1d13cca6f9cccd534d2b3f4b4ac789fe26f7902031d6c41
+  md5: 47d16d26100f19ca495882882b7bc93b
+  depends:
+  - ca-certificates
   constrains:
   - pyopenssl >=22.1
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 2856233
   timestamp: 1701162541844
-- platform: win-64
+- kind: conda
   name: openssl
   version: 3.2.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hcfcfb64_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.0-hcfcfb64_1.conda
+  sha256: 373b9671173ef3413d2a95f3781176b818db904ba82298f8447b9658d71e2cc9
+  md5: d10167022f99bad12ee07dea022d5830
+  depends:
   - ca-certificates
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.0-hcfcfb64_1.conda
-  hash:
-    md5: d10167022f99bad12ee07dea022d5830
-    sha256: 373b9671173ef3413d2a95f3781176b818db904ba82298f8447b9658d71e2cc9
-  build: hcfcfb64_1
-  arch: x86_64
-  subdir: win-64
-  build_number: 1
   constrains:
   - pyopenssl >=22.1
+  arch: x86_64
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 8248125
   timestamp: 1701164404616
-- platform: linux-64
+- kind: conda
+  name: openssl
+  version: 3.2.0
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.0-hd590300_1.conda
+  sha256: 80efc6f429bd8e622d999652e5cba2ca56fcdb9c16a439d2ce9b4313116e4a87
+  md5: 603827b39ea2b835268adb8c821b8570
+  depends:
+  - ca-certificates
+  - libgcc-ng >=12
+  constrains:
+  - pyopenssl >=22.1
+  arch: x86_64
+  platform: linux
+  license: Apache-2.0
+  license_family: Apache
+  size: 2854103
+  timestamp: 1701162437033
+- kind: conda
+  name: openssl
+  version: 3.2.0
+  build: hd75f5a5_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.0-hd75f5a5_1.conda
+  sha256: 99161bf349f5dc80322f2a2c188588d11efa662566e4e19f2ac0a36d9fa3de25
+  md5: 06cb561619487c88891839b9beb5244c
+  depends:
+  - ca-certificates
+  constrains:
+  - pyopenssl >=22.1
+  arch: x86_64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 2508164
+  timestamp: 1701163123673
+- kind: conda
   name: orc
   version: 1.9.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h4b38347_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.2-h4b38347_0.conda
+  sha256: a06dd76bc0f2f99f5db5e348298c906007c3aa9e31b963f71d16e63f770b900b
+  md5: 6e6f990b097d3e237e18a8e321d08484
+  depends:
   - libgcc-ng >=12
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libstdcxx-ng >=12
@@ -9985,24 +9477,43 @@ package:
   - lz4-c >=1.9.3,<1.10.0a0
   - snappy >=1.1.10,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.2-h4b38347_0.conda
-  hash:
-    md5: 6e6f990b097d3e237e18a8e321d08484
-    sha256: a06dd76bc0f2f99f5db5e348298c906007c3aa9e31b963f71d16e63f770b900b
-  build: h4b38347_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: Apache-2.0
   license_family: Apache
   size: 1018308
   timestamp: 1700372809593
-- platform: osx-64
+- kind: conda
   name: orc
   version: 1.9.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h7c018df_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.2-h7c018df_0.conda
+  sha256: b1ad0f09dc69a8956079371d9853534f991f8311352e4e21503e6e5d20e4017b
+  md5: 1ef4159e9686d95ce8ea9f1d4d999f29
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  license_family: Apache
+  size: 405599
+  timestamp: 1700373052638
+- kind: conda
+  name: orc
+  version: 1.9.2
+  build: h9ab30d4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.2-h9ab30d4_0.conda
+  sha256: a948db80c0b756db07abce1972d6b8d1a08a7ced5a687b02435348c81443de08
+  md5: 8fb76f7b135aec885cfe47c52b2eb4b5
+  depends:
   - __osx >=10.13
   - __osx >=10.9
   - libcxx >=16.0.6
@@ -10011,49 +9522,21 @@ package:
   - lz4-c >=1.9.3,<1.10.0a0
   - snappy >=1.1.10,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.2-h9ab30d4_0.conda
-  hash:
-    md5: 8fb76f7b135aec885cfe47c52b2eb4b5
-    sha256: a948db80c0b756db07abce1972d6b8d1a08a7ced5a687b02435348c81443de08
-  build: h9ab30d4_0
   arch: x86_64
-  subdir: osx-64
-  build_number: 0
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 423917
   timestamp: 1700373043647
-- platform: osx-arm64
+- kind: conda
   name: orc
   version: 1.9.2
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.2-h7c018df_0.conda
-  hash:
-    md5: 1ef4159e9686d95ce8ea9f1d4d999f29
-    sha256: b1ad0f09dc69a8956079371d9853534f991f8311352e4e21503e6e5d20e4017b
-  build: h7c018df_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 405599
-  timestamp: 1700373052638
-- platform: win-64
-  name: orc
-  version: 1.9.2
-  category: main
-  manager: conda
-  dependencies:
+  build: hf0b6bd4_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.2-hf0b6bd4_0.conda
+  sha256: 14d81cf427dec751709b86b4d501388f2a51ea8851f73d82116865bf4cca2667
+  md5: 29af097d73ea38cf72e666ec90e0044e
+  depends:
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - lz4-c >=1.9.3,<1.10.0a0
@@ -10062,715 +9545,620 @@ package:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.2-hf0b6bd4_0.conda
-  hash:
-    md5: 29af097d73ea38cf72e666ec90e0044e
-    sha256: 14d81cf427dec751709b86b4d501388f2a51ea8851f73d82116865bf4cca2667
-  build: hf0b6bd4_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 884906
   timestamp: 1700373245961
-- platform: linux-64
+- kind: conda
   name: packaging
   version: '23.2'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 79002079284aa895f883c6b7f3f88fd6
-    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+  sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+  md5: 79002079284aa895f883c6b7f3f88fd6
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: linux
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 49452
   timestamp: 1696202521121
-- platform: osx-64
+- kind: conda
   name: packaging
   version: '23.2'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 79002079284aa895f883c6b7f3f88fd6
-    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
   noarch: python
-  size: 49452
-  timestamp: 1696202521121
-- platform: osx-arm64
-  name: packaging
-  version: '23.2'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 79002079284aa895f883c6b7f3f88fd6
-    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 49452
-  timestamp: 1696202521121
-- platform: win-64
-  name: packaging
-  version: '23.2'
-  category: main
-  manager: conda
-  dependencies:
+  sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+  md5: 79002079284aa895f883c6b7f3f88fd6
+  depends:
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 79002079284aa895f883c6b7f3f88fd6
-    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 49452
   timestamp: 1696202521121
-- platform: linux-64
+- kind: conda
+  name: packaging
+  version: '23.2'
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+  sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+  md5: 79002079284aa895f883c6b7f3f88fd6
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  license_family: APACHE
+  size: 49452
+  timestamp: 1696202521121
+- kind: conda
+  name: packaging
+  version: '23.2'
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+  sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+  md5: 79002079284aa895f883c6b7f3f88fd6
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
+  license: Apache-2.0
+  license_family: APACHE
+  size: 49452
+  timestamp: 1696202521121
+- kind: conda
   name: patchelf
   version: 0.17.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h58526e2_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
+  sha256: eb355ac225be2f698e19dba4dcab7cb0748225677a9799e9cc8e4cadc3cb738f
+  md5: ba76a6a448819560b5f8b08a9c74f415
+  depends:
   - libgcc-ng >=7.5.0
   - libstdcxx-ng >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
-  hash:
-    md5: ba76a6a448819560b5f8b08a9c74f415
-    sha256: eb355ac225be2f698e19dba4dcab7cb0748225677a9799e9cc8e4cadc3cb738f
-  build: h58526e2_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: GPL-3.0-or-later
   license_family: GPL
   size: 94048
   timestamp: 1673473024463
-- platform: linux-64
+- kind: conda
   name: pathspec
   version: 0.11.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e41debb259e68490e3ab81e46b639ab6
-    sha256: 7bcfa6d86359d45572ba9ccaeaedc04b0452e2654fe44b6fe378d0d37b8745e1
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
+  sha256: 7bcfa6d86359d45572ba9ccaeaedc04b0452e2654fe44b6fe378d0d37b8745e1
+  md5: e41debb259e68490e3ab81e46b639ab6
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: linux
   license: MPL-2.0
   license_family: MOZILLA
-  noarch: python
   size: 38649
   timestamp: 1690598108100
-- platform: osx-64
+- kind: conda
   name: pathspec
   version: 0.11.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e41debb259e68490e3ab81e46b639ab6
-    sha256: 7bcfa6d86359d45572ba9ccaeaedc04b0452e2654fe44b6fe378d0d37b8745e1
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: MPL-2.0
-  license_family: MOZILLA
   noarch: python
-  size: 38649
-  timestamp: 1690598108100
-- platform: osx-arm64
-  name: pathspec
-  version: 0.11.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e41debb259e68490e3ab81e46b639ab6
-    sha256: 7bcfa6d86359d45572ba9ccaeaedc04b0452e2654fe44b6fe378d0d37b8745e1
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MPL-2.0
-  license_family: MOZILLA
-  noarch: python
-  size: 38649
-  timestamp: 1690598108100
-- platform: win-64
-  name: pathspec
-  version: 0.11.2
-  category: main
-  manager: conda
-  dependencies:
+  sha256: 7bcfa6d86359d45572ba9ccaeaedc04b0452e2654fe44b6fe378d0d37b8745e1
+  md5: e41debb259e68490e3ab81e46b639ab6
+  depends:
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e41debb259e68490e3ab81e46b639ab6
-    sha256: 7bcfa6d86359d45572ba9ccaeaedc04b0452e2654fe44b6fe378d0d37b8745e1
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: MPL-2.0
   license_family: MOZILLA
-  noarch: python
   size: 38649
   timestamp: 1690598108100
-- platform: linux-64
+- kind: conda
+  name: pathspec
+  version: 0.11.2
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
+  sha256: 7bcfa6d86359d45572ba9ccaeaedc04b0452e2654fe44b6fe378d0d37b8745e1
+  md5: e41debb259e68490e3ab81e46b639ab6
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 38649
+  timestamp: 1690598108100
+- kind: conda
+  name: pathspec
+  version: 0.11.2
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.11.2-pyhd8ed1ab_0.conda
+  sha256: 7bcfa6d86359d45572ba9ccaeaedc04b0452e2654fe44b6fe378d0d37b8745e1
+  md5: e41debb259e68490e3ab81e46b639ab6
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 38649
+  timestamp: 1690598108100
+- kind: conda
   name: pip
   version: 23.2.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
+  sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
+  md5: e2783aa3f9235225eec92f9081c5b801
+  depends:
   - python >=3.7
   - setuptools *
   - wheel *
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e2783aa3f9235225eec92f9081c5b801
-    sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 1386212
   timestamp: 1690024763393
-- platform: osx-64
+- kind: conda
   name: pip
   version: 23.2.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
+  sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
+  md5: e2783aa3f9235225eec92f9081c5b801
+  depends:
   - python >=3.7
   - setuptools *
   - wheel *
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e2783aa3f9235225eec92f9081c5b801
-    sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: osx-64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 1386212
   timestamp: 1690024763393
-- platform: osx-arm64
+- kind: conda
   name: pip
   version: 23.2.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
+  sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
+  md5: e2783aa3f9235225eec92f9081c5b801
+  depends:
   - python >=3.7
   - setuptools *
   - wheel *
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e2783aa3f9235225eec92f9081c5b801
-    sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
-  build: pyhd8ed1ab_0
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 1386212
   timestamp: 1690024763393
-- platform: win-64
+- kind: conda
   name: pip
   version: 23.2.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
+  sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
+  md5: e2783aa3f9235225eec92f9081c5b801
+  depends:
   - python >=3.7
   - setuptools *
   - wheel *
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e2783aa3f9235225eec92f9081c5b801
-    sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 1386212
   timestamp: 1690024763393
-- platform: linux-64
+- kind: conda
   name: platformdirs
   version: 3.11.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  - typing-extensions >=4.6.3
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8f567c0a74aa44cf732f15773b4083b0
-    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 19985
-  timestamp: 1696272419779
-- platform: osx-64
-  name: platformdirs
-  version: 3.11.0
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+  sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
+  md5: 8f567c0a74aa44cf732f15773b4083b0
+  depends:
   - python >=3.7
   - typing-extensions >=4.6.3
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8f567c0a74aa44cf732f15773b4083b0
-    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
-  build: pyhd8ed1ab_0
   arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 19985
+  timestamp: 1696272419779
+- kind: conda
+  name: platformdirs
+  version: 3.11.0
+  build: pyhd8ed1ab_0
   subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 19985
-  timestamp: 1696272419779
-- platform: osx-arm64
-  name: platformdirs
-  version: 3.11.0
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+  sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
+  md5: 8f567c0a74aa44cf732f15773b4083b0
+  depends:
   - python >=3.7
   - typing-extensions >=4.6.3
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8f567c0a74aa44cf732f15773b4083b0
-    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 19985
-  timestamp: 1696272419779
-- platform: win-64
-  name: platformdirs
-  version: 3.11.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  - typing-extensions >=4.6.3
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8f567c0a74aa44cf732f15773b4083b0
-    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 19985
   timestamp: 1696272419779
-- platform: linux-64
+- kind: conda
+  name: platformdirs
+  version: 3.11.0
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+  sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
+  md5: 8f567c0a74aa44cf732f15773b4083b0
+  depends:
+  - python >=3.7
+  - typing-extensions >=4.6.3
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 19985
+  timestamp: 1696272419779
+- kind: conda
+  name: platformdirs
+  version: 3.11.0
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+  sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
+  md5: 8f567c0a74aa44cf732f15773b4083b0
+  depends:
+  - python >=3.7
+  - typing-extensions >=4.6.3
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 19985
+  timestamp: 1696272419779
+- kind: conda
   name: pluggy
   version: 1.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2390bd10bed1f3fdc7a537fb5a447d8d
-    sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
+  sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
+  md5: 2390bd10bed1f3fdc7a537fb5a447d8d
+  depends:
+  - python >=3.8
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 22548
   timestamp: 1693086745921
-- platform: osx-64
+- kind: conda
   name: pluggy
   version: 1.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2390bd10bed1f3fdc7a537fb5a447d8d
-    sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 22548
-  timestamp: 1693086745921
-- platform: osx-arm64
-  name: pluggy
-  version: 1.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2390bd10bed1f3fdc7a537fb5a447d8d
-    sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 22548
-  timestamp: 1693086745921
-- platform: win-64
-  name: pluggy
-  version: 1.3.0
-  category: main
-  manager: conda
-  dependencies:
+  sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
+  md5: 2390bd10bed1f3fdc7a537fb5a447d8d
+  depends:
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2390bd10bed1f3fdc7a537fb5a447d8d
-    sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 22548
   timestamp: 1693086745921
-- platform: linux-64
+- kind: conda
+  name: pluggy
+  version: 1.3.0
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
+  sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
+  md5: 2390bd10bed1f3fdc7a537fb5a447d8d
+  depends:
+  - python >=3.8
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 22548
+  timestamp: 1693086745921
+- kind: conda
+  name: pluggy
+  version: 1.3.0
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
+  sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
+  md5: 2390bd10bed1f3fdc7a537fb5a447d8d
+  depends:
+  - python >=3.8
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 22548
+  timestamp: 1693086745921
+- kind: conda
   name: prettier
   version: 2.8.8
-  category: main
-  manager: conda
-  dependencies:
-  - __glibc >=2.17,<3.0.a0
-  - nodejs >=18.16.1,<19.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/prettier-2.8.8-h75cfd52_1.conda
-  hash:
-    md5: d50d94592df03b7fbd1739d8804bb2d2
-    sha256: 41d3c3327a4c42faf230a511a25587206853c29e2ef02df60c623cb8ce8a3339
-  build: h75cfd52_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 12599147
-  timestamp: 1691677147431
-- platform: osx-64
-  name: prettier
-  version: 2.8.8
-  category: main
-  manager: conda
-  dependencies:
-  - nodejs >=18.16.1,<19.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/prettier-2.8.8-h3db311d_1.conda
-  hash:
-    md5: 127e15574684a4468947a4e7ab36cca9
-    sha256: 54789919043574af735297e26414ff75ab6e846bbfcd69a9182223180daa61f0
   build: h3db311d_1
-  arch: x86_64
-  subdir: osx-64
   build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/prettier-2.8.8-h3db311d_1.conda
+  sha256: 54789919043574af735297e26414ff75ab6e846bbfcd69a9182223180daa61f0
+  md5: 127e15574684a4468947a4e7ab36cca9
+  depends:
+  - nodejs >=18.16.1,<19.0a0
+  arch: x86_64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 12678689
   timestamp: 1691677487574
-- platform: osx-arm64
+- kind: conda
   name: prettier
   version: 2.8.8
-  category: main
-  manager: conda
-  dependencies:
-  - nodejs >=18.16.1,<19.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-2.8.8-ha12bae2_1.conda
-  hash:
-    md5: 864da5c7f1895a224e7440cfc8d3a69c
-    sha256: 9eea51372d7b30fbbae579a0e812fe48cb5cd13d34e7a4bdadec38f91e5d6b9e
-  build: ha12bae2_1
-  arch: aarch64
-  subdir: osx-arm64
+  build: h75cfd52_1
   build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/prettier-2.8.8-h75cfd52_1.conda
+  sha256: 41d3c3327a4c42faf230a511a25587206853c29e2ef02df60c623cb8ce8a3339
+  md5: d50d94592df03b7fbd1739d8804bb2d2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - nodejs >=18.16.1,<19.0a0
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 12599147
+  timestamp: 1691677147431
+- kind: conda
+  name: prettier
+  version: 2.8.8
+  build: ha12bae2_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-2.8.8-ha12bae2_1.conda
+  sha256: 9eea51372d7b30fbbae579a0e812fe48cb5cd13d34e7a4bdadec38f91e5d6b9e
+  md5: 864da5c7f1895a224e7440cfc8d3a69c
+  depends:
+  - nodejs >=18.16.1,<19.0a0
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 12979886
   timestamp: 1691677482320
-- platform: win-64
+- kind: conda
   name: prettier
   version: 2.8.8
-  category: main
-  manager: conda
-  dependencies:
-  - nodejs >=18.16.1,<19.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/prettier-2.8.8-hd2f1330_1.conda
-  hash:
-    md5: eaf3bf247960303f7f782d2b103549d9
-    sha256: f9f84462a772d3ab986fdd9f901bce8eef7ea6345e14edf265ec17013ea6ff71
   build: hd2f1330_1
-  arch: x86_64
-  subdir: win-64
   build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/prettier-2.8.8-hd2f1330_1.conda
+  sha256: f9f84462a772d3ab986fdd9f901bce8eef7ea6345e14edf265ec17013ea6ff71
+  md5: eaf3bf247960303f7f782d2b103549d9
+  depends:
+  - nodejs >=18.16.1,<19.0a0
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
   size: 1398331
   timestamp: 1691677409088
-- platform: linux-64
+- kind: conda
   name: psutil
   version: 5.9.5
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py311h459d7ec_1.conda
-  hash:
-    md5: 490d7fa8675afd1aa6f1b2332d156a45
-    sha256: e92d2120fc4b98fe838b3d52d4907fae97808bdd504fb84aa33aea8c4be7bc61
-  build: py311h459d7ec_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 498698
-  timestamp: 1695367306421
-- platform: osx-64
-  name: psutil
-  version: 5.9.5
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py311h2725bcf_1.conda
-  hash:
-    md5: 16221cd0488a32152a6b3f1a301ccf19
-    sha256: 2eee900e0e5a103cff0159cdd81d401b67ccfb919be6cd868fc34c22dab981f1
   build: py311h2725bcf_1
-  arch: x86_64
-  subdir: osx-64
   build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py311h2725bcf_1.conda
+  sha256: 2eee900e0e5a103cff0159cdd81d401b67ccfb919be6cd868fc34c22dab981f1
+  md5: 16221cd0488a32152a6b3f1a301ccf19
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 506611
   timestamp: 1695367402674
-- platform: osx-arm64
+- kind: conda
   name: psutil
   version: 5.9.5
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py311heffc1b2_1.conda
-  hash:
-    md5: a40123b40642b8b08b3830a3f6bc7fd9
-    sha256: a12a525d3bcaed04e0885b2bd00f4f626c80c19d7c0ae8bb7cf7121aefb39e52
-  build: py311heffc1b2_1
-  arch: aarch64
-  subdir: osx-arm64
+  build: py311h459d7ec_1
   build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py311h459d7ec_1.conda
+  sha256: e92d2120fc4b98fe838b3d52d4907fae97808bdd504fb84aa33aea8c4be7bc61
+  md5: 490d7fa8675afd1aa6f1b2332d156a45
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
-  size: 506971
-  timestamp: 1695367619126
-- platform: win-64
+  size: 498698
+  timestamp: 1695367306421
+- kind: conda
   name: psutil
   version: 5.9.5
-  category: main
-  manager: conda
-  dependencies:
+  build: py311ha68e1ae_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py311ha68e1ae_1.conda
+  sha256: e5c09eee9902e0c56d89f88210009b34d819d241ac5b7dde38266324a85fde51
+  md5: f64b2d9577e753fea9662dae11339ac2
+  depends:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py311ha68e1ae_1.conda
-  hash:
-    md5: f64b2d9577e753fea9662dae11339ac2
-    sha256: e5c09eee9902e0c56d89f88210009b34d819d241ac5b7dde38266324a85fde51
-  build: py311ha68e1ae_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 516106
   timestamp: 1695367685028
-- platform: win-64
+- kind: conda
+  name: psutil
+  version: 5.9.5
+  build: py311heffc1b2_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py311heffc1b2_1.conda
+  sha256: a12a525d3bcaed04e0885b2bd00f4f626c80c19d7c0ae8bb7cf7121aefb39e52
+  md5: a40123b40642b8b08b3830a3f6bc7fd9
+  depends:
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  arch: aarch64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 506971
+  timestamp: 1695367619126
+- kind: conda
   name: pthreads-win32
   version: 2.9.1
-  category: main
-  manager: conda
-  dependencies:
-  - vc 14.*
-  url: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
-  hash:
-    md5: e2da8758d7d51ff6aa78a14dfb9dbed4
-    sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
   build: hfa6e2cd_3
-  arch: x86_64
-  subdir: win-64
   build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+  sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
+  md5: e2da8758d7d51ff6aa78a14dfb9dbed4
+  depends:
+  - vc 14.*
+  arch: x86_64
+  platform: win
   license: LGPL 2
   size: 144301
   timestamp: 1537755684331
-- platform: linux-64
+- kind: conda
   name: py
   version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2.7
-  url: https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2
-  hash:
-    md5: b4613d7e7a493916d867842a6a148054
-    sha256: 268be33a290e3d51467ab29cbb5a80cf79f69dade2f2dead25d7f80d76c3543a
   build: pyh6c4a22f_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2
+  sha256: 268be33a290e3d51467ab29cbb5a80cf79f69dade2f2dead25d7f80d76c3543a
+  md5: b4613d7e7a493916d867842a6a148054
+  depends:
+  - python >=2.7
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 76038
   timestamp: 1636301988765
-- platform: osx-64
+- kind: conda
   name: py
   version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2.7
-  url: https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2
-  hash:
-    md5: b4613d7e7a493916d867842a6a148054
-    sha256: 268be33a290e3d51467ab29cbb5a80cf79f69dade2f2dead25d7f80d76c3543a
   build: pyh6c4a22f_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 76038
-  timestamp: 1636301988765
-- platform: osx-arm64
-  name: py
-  version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2.7
   url: https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2
-  hash:
-    md5: b4613d7e7a493916d867842a6a148054
-    sha256: 268be33a290e3d51467ab29cbb5a80cf79f69dade2f2dead25d7f80d76c3543a
-  build: pyh6c4a22f_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 76038
-  timestamp: 1636301988765
-- platform: win-64
-  name: py
-  version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
+  sha256: 268be33a290e3d51467ab29cbb5a80cf79f69dade2f2dead25d7f80d76c3543a
+  md5: b4613d7e7a493916d867842a6a148054
+  depends:
   - python >=2.7
-  url: https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2
-  hash:
-    md5: b4613d7e7a493916d867842a6a148054
-    sha256: 268be33a290e3d51467ab29cbb5a80cf79f69dade2f2dead25d7f80d76c3543a
-  build: pyh6c4a22f_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 76038
   timestamp: 1636301988765
-- platform: linux-64
+- kind: conda
+  name: py
+  version: 1.11.0
+  build: pyh6c4a22f_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2
+  sha256: 268be33a290e3d51467ab29cbb5a80cf79f69dade2f2dead25d7f80d76c3543a
+  md5: b4613d7e7a493916d867842a6a148054
+  depends:
+  - python >=2.7
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 76038
+  timestamp: 1636301988765
+- kind: conda
+  name: py
+  version: 1.11.0
+  build: pyh6c4a22f_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2
+  sha256: 268be33a290e3d51467ab29cbb5a80cf79f69dade2f2dead25d7f80d76c3543a
+  md5: b4613d7e7a493916d867842a6a148054
+  depends:
+  - python >=2.7
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 76038
+  timestamp: 1636301988765
+- kind: conda
   name: pyarrow
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: py311h39c9aba_2_cpu
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.2-py311h39c9aba_2_cpu.conda
+  sha256: 9117ea0cf236f9bb43cc05ec2d0744c9f789132dbc255d82f1fd2b6fd9e0b3ba
+  md5: 07fb7193fa96aab8e61c4483b9e61e51
+  depends:
   - libarrow 14.0.2 h84dd17c_2_cpu
   - libarrow-acero 14.0.2 h59595ed_2_cpu
   - libarrow-dataset 14.0.2 h59595ed_2_cpu
@@ -10784,25 +10172,23 @@ package:
   - numpy >=1.23.5,<2.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.2-py311h39c9aba_2_cpu.conda
-  hash:
-    md5: 07fb7193fa96aab8e61c4483b9e61e51
-    sha256: 9117ea0cf236f9bb43cc05ec2d0744c9f789132dbc255d82f1fd2b6fd9e0b3ba
-  build: py311h39c9aba_2_cpu
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
   constrains:
   - apache-arrow-proc =*=cpu
+  arch: x86_64
+  platform: linux
   license: Apache-2.0
   size: 4515359
   timestamp: 1704356601353
-- platform: osx-64
+- kind: conda
   name: pyarrow
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: py311h54e7ce8_2_cpu
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.2-py311h54e7ce8_2_cpu.conda
+  sha256: fb631eb88510f59c2a5dc21764ce554e961e7970ea952e17bfb5742b54b322ba
+  md5: a4c277c33b47c06b3c3fd2939fdb9c9a
+  depends:
   - libarrow 14.0.2 h1aaacd4_2_cpu
   - libarrow-acero 14.0.2 h000cb23_2_cpu
   - libarrow-dataset 14.0.2 h000cb23_2_cpu
@@ -10815,57 +10201,23 @@ package:
   - numpy >=1.23.5,<2.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.2-py311h54e7ce8_2_cpu.conda
-  hash:
-    md5: a4c277c33b47c06b3c3fd2939fdb9c9a
-    sha256: fb631eb88510f59c2a5dc21764ce554e961e7970ea952e17bfb5742b54b322ba
-  build: py311h54e7ce8_2_cpu
-  arch: x86_64
-  subdir: osx-64
-  build_number: 2
   constrains:
   - apache-arrow-proc =*=cpu
+  arch: x86_64
+  platform: osx
   license: Apache-2.0
   size: 4029309
   timestamp: 1704362351224
-- platform: osx-arm64
+- kind: conda
   name: pyarrow
   version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - libarrow 14.0.2 h4ce3932_2_cpu
-  - libarrow-acero 14.0.2 h13dd4ca_2_cpu
-  - libarrow-dataset 14.0.2 h13dd4ca_2_cpu
-  - libarrow-flight 14.0.2 ha94d253_2_cpu
-  - libarrow-flight-sql 14.0.2 h39a9b85_2_cpu
-  - libarrow-gandiva 14.0.2 hf757142_2_cpu
-  - libarrow-substrait 14.0.2 h7fd9903_2_cpu
-  - libcxx >=14
-  - libparquet 14.0.2 hf6ce1d5_2_cpu
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.2-py311hd7bc329_2_cpu.conda
-  hash:
-    md5: 6a599e9f9b2ab76b1006cf60fe1730a1
-    sha256: 382cae1613f740afac2bedf7b4b3d7d19775ab7c31b419553351806d0ac9bc29
-  build: py311hd7bc329_2_cpu
-  arch: aarch64
-  subdir: osx-arm64
+  build: py311h6a6099b_2_cpu
   build_number: 2
-  constrains:
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  size: 4090895
-  timestamp: 1704361615592
-- platform: win-64
-  name: pyarrow
-  version: 14.0.2
-  category: main
-  manager: conda
-  dependencies:
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-14.0.2-py311h6a6099b_2_cpu.conda
+  sha256: cd32ac9c0b740933f5c47eb3b9e731b7ff171cc648fe72434de3c95585d7af5e
+  md5: 3e9caae94be752658cbe9449440681ee
+  depends:
   - libarrow 14.0.2 he5f67d5_2_cpu
   - libarrow-acero 14.0.2 h63175ca_2_cpu
   - libarrow-dataset 14.0.2 h63175ca_2_cpu
@@ -10880,217 +10232,302 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-14.0.2-py311h6a6099b_2_cpu.conda
-  hash:
-    md5: 3e9caae94be752658cbe9449440681ee
-    sha256: cd32ac9c0b740933f5c47eb3b9e731b7ff171cc648fe72434de3c95585d7af5e
-  build: py311h6a6099b_2_cpu
-  arch: x86_64
-  subdir: win-64
-  build_number: 2
   constrains:
   - apache-arrow-proc =*=cpu
+  arch: x86_64
+  platform: win
   license: Apache-2.0
   size: 3486905
   timestamp: 1704357865002
-- platform: linux-64
-  name: pygments
-  version: 2.16.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 40e5cb18165466773619e5c963f00a7b
-    sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 853439
-  timestamp: 1691408777841
-- platform: osx-64
-  name: pygments
-  version: 2.16.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 40e5cb18165466773619e5c963f00a7b
-    sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 853439
-  timestamp: 1691408777841
-- platform: osx-arm64
-  name: pygments
-  version: 2.16.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 40e5cb18165466773619e5c963f00a7b
-    sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
-  build: pyhd8ed1ab_0
-  arch: aarch64
+- kind: conda
+  name: pyarrow
+  version: 14.0.2
+  build: py311hd7bc329_2_cpu
+  build_number: 2
   subdir: osx-arm64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 853439
-  timestamp: 1691408777841
-- platform: win-64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.2-py311hd7bc329_2_cpu.conda
+  sha256: 382cae1613f740afac2bedf7b4b3d7d19775ab7c31b419553351806d0ac9bc29
+  md5: 6a599e9f9b2ab76b1006cf60fe1730a1
+  depends:
+  - libarrow 14.0.2 h4ce3932_2_cpu
+  - libarrow-acero 14.0.2 h13dd4ca_2_cpu
+  - libarrow-dataset 14.0.2 h13dd4ca_2_cpu
+  - libarrow-flight 14.0.2 ha94d253_2_cpu
+  - libarrow-flight-sql 14.0.2 h39a9b85_2_cpu
+  - libarrow-gandiva 14.0.2 hf757142_2_cpu
+  - libarrow-substrait 14.0.2 h7fd9903_2_cpu
+  - libcxx >=14
+  - libparquet 14.0.2 hf6ce1d5_2_cpu
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - apache-arrow-proc =*=cpu
+  arch: aarch64
+  platform: osx
+  license: Apache-2.0
+  size: 4090895
+  timestamp: 1704361615592
+- kind: conda
   name: pygments
   version: 2.16.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 40e5cb18165466773619e5c963f00a7b
-    sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
   build: pyhd8ed1ab_0
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+  sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
+  md5: 40e5cb18165466773619e5c963f00a7b
+  depends:
+  - python >=3.7
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: linux
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
   size: 853439
   timestamp: 1691408777841
-- platform: linux-64
-  name: pytest
-  version: 7.4.2
-  category: main
-  manager: conda
-  dependencies:
-  - colorama *
-  - exceptiongroup >=1.0.0rc8
-  - iniconfig *
-  - packaging *
-  - pluggy >=0.12,<2.0
-  - python >=3.7
-  - tomli >=1.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6dd662ff5ac9a783e5c940ce9f3fe649
-    sha256: 150bfb2a86dffd4ce1e91c2d61dde5779fb3ee338675e210fec4ef508ffff28c
+- kind: conda
+  name: pygments
+  version: 2.16.1
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  constrains:
-  - pytest-faulthandler >=2
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 244691
-  timestamp: 1694128618921
-- platform: osx-64
-  name: pytest
-  version: 7.4.2
-  category: main
-  manager: conda
-  dependencies:
-  - colorama *
-  - exceptiongroup >=1.0.0rc8
-  - iniconfig *
-  - packaging *
-  - pluggy >=0.12,<2.0
-  - python >=3.7
-  - tomli >=1.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6dd662ff5ac9a783e5c940ce9f3fe649
-    sha256: 150bfb2a86dffd4ce1e91c2d61dde5779fb3ee338675e210fec4ef508ffff28c
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  constrains:
-  - pytest-faulthandler >=2
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 244691
-  timestamp: 1694128618921
-- platform: osx-arm64
-  name: pytest
-  version: 7.4.2
-  category: main
-  manager: conda
-  dependencies:
-  - colorama *
-  - exceptiongroup >=1.0.0rc8
-  - iniconfig *
-  - packaging *
-  - pluggy >=0.12,<2.0
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+  sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
+  md5: 40e5cb18165466773619e5c963f00a7b
+  depends:
   - python >=3.7
-  - tomli >=1.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6dd662ff5ac9a783e5c940ce9f3fe649
-    sha256: 150bfb2a86dffd4ce1e91c2d61dde5779fb3ee338675e210fec4ef508ffff28c
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  constrains:
-  - pytest-faulthandler >=2
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 244691
-  timestamp: 1694128618921
-- platform: win-64
-  name: pytest
-  version: 7.4.2
-  category: main
-  manager: conda
-  dependencies:
-  - colorama *
-  - exceptiongroup >=1.0.0rc8
-  - iniconfig *
-  - packaging *
-  - pluggy >=0.12,<2.0
-  - python >=3.7
-  - tomli >=1.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6dd662ff5ac9a783e5c940ce9f3fe649
-    sha256: 150bfb2a86dffd4ce1e91c2d61dde5779fb3ee338675e210fec4ef508ffff28c
-  build: pyhd8ed1ab_0
   arch: x86_64
+  platform: osx
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 853439
+  timestamp: 1691408777841
+- kind: conda
+  name: pygments
+  version: 2.16.1
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+  sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
+  md5: 40e5cb18165466773619e5c963f00a7b
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 853439
+  timestamp: 1691408777841
+- kind: conda
+  name: pygments
+  version: 2.16.1
+  build: pyhd8ed1ab_0
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+  sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
+  md5: 40e5cb18165466773619e5c963f00a7b
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 853439
+  timestamp: 1691408777841
+- kind: conda
+  name: pytest
+  version: 7.4.2
+  build: pyhd8ed1ab_0
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
+  sha256: 150bfb2a86dffd4ce1e91c2d61dde5779fb3ee338675e210fec4ef508ffff28c
+  md5: 6dd662ff5ac9a783e5c940ce9f3fe649
+  depends:
+  - colorama *
+  - exceptiongroup >=1.0.0rc8
+  - iniconfig *
+  - packaging *
+  - pluggy >=0.12,<2.0
+  - python >=3.7
+  - tomli >=1.0.0
   constrains:
   - pytest-faulthandler >=2
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 244691
   timestamp: 1694128618921
-- platform: linux-64
+- kind: conda
+  name: pytest
+  version: 7.4.2
+  build: pyhd8ed1ab_0
+  subdir: osx-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
+  sha256: 150bfb2a86dffd4ce1e91c2d61dde5779fb3ee338675e210fec4ef508ffff28c
+  md5: 6dd662ff5ac9a783e5c940ce9f3fe649
+  depends:
+  - colorama *
+  - exceptiongroup >=1.0.0rc8
+  - iniconfig *
+  - packaging *
+  - pluggy >=0.12,<2.0
+  - python >=3.7
+  - tomli >=1.0.0
+  constrains:
+  - pytest-faulthandler >=2
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 244691
+  timestamp: 1694128618921
+- kind: conda
+  name: pytest
+  version: 7.4.2
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
+  sha256: 150bfb2a86dffd4ce1e91c2d61dde5779fb3ee338675e210fec4ef508ffff28c
+  md5: 6dd662ff5ac9a783e5c940ce9f3fe649
+  depends:
+  - colorama *
+  - exceptiongroup >=1.0.0rc8
+  - iniconfig *
+  - packaging *
+  - pluggy >=0.12,<2.0
+  - python >=3.7
+  - tomli >=1.0.0
+  constrains:
+  - pytest-faulthandler >=2
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 244691
+  timestamp: 1694128618921
+- kind: conda
+  name: pytest
+  version: 7.4.2
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
+  sha256: 150bfb2a86dffd4ce1e91c2d61dde5779fb3ee338675e210fec4ef508ffff28c
+  md5: 6dd662ff5ac9a783e5c940ce9f3fe649
+  depends:
+  - colorama *
+  - exceptiongroup >=1.0.0rc8
+  - iniconfig *
+  - packaging *
+  - pluggy >=0.12,<2.0
+  - python >=3.7
+  - tomli >=1.0.0
+  constrains:
+  - pytest-faulthandler >=2
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 244691
+  timestamp: 1694128618921
+- kind: conda
   name: python
   version: 3.11.6
-  category: main
-  manager: conda
-  dependencies:
+  build: h2628c8c_0_cpython
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.6-h2628c8c_0_cpython.conda
+  sha256: 7fb38fda8296b2651ef727bb57603f0952c07fc533b172044395744a2641a00a
+  md5: 80b761856b20383615a3fe8b1b13eef8
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata *
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: win
+  license: Python-2.0
+  size: 18121128
+  timestamp: 1696329396864
+- kind: conda
+  name: python
+  version: 3.11.6
+  build: h30d4d87_0_cpython
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.6-h30d4d87_0_cpython.conda
+  sha256: e3ed331204fbeb03a9a2c2fa834e74997ad4f732ba2124b36f327d38b0cded93
+  md5: 4d66c5fc01e9be526afe5d828d4de24d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata *
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: osx
+  license: Python-2.0
+  size: 15393521
+  timestamp: 1696330855485
+- kind: conda
+  name: python
+  version: 3.11.6
+  build: h47c9636_0_cpython
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.6-h47c9636_0_cpython.conda
+  sha256: 77054fa9a8fc30f71a18f599ee2897905a3c515202b614fa0f793add7a04a155
+  md5: 2271df1db9534f5cac7c2d0820c3359d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata *
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  arch: aarch64
+  platform: osx
+  license: Python-2.0
+  size: 14626958
+  timestamp: 1696329727433
+- kind: conda
+  name: python
+  version: 3.11.6
+  build: hab00c5b_0_cpython
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.6-hab00c5b_0_cpython.conda
+  sha256: 84f13bd70cff5dcdaee19263b2d4291d5793856a718efc1b63a9cfa9eb6e2ca1
+  md5: b0dfbe2fcbfdb097d321bfd50ecddab1
+  depends:
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-64 >=2.36.1
   - libexpat >=2.5.0,<3.0a0
@@ -11106,2261 +10543,1840 @@ package:
   - tk >=8.6.13,<8.7.0a0
   - tzdata *
   - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.6-hab00c5b_0_cpython.conda
-  hash:
-    md5: b0dfbe2fcbfdb097d321bfd50ecddab1
-    sha256: 84f13bd70cff5dcdaee19263b2d4291d5793856a718efc1b63a9cfa9eb6e2ca1
-  build: hab00c5b_0_cpython
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   size: 30720625
   timestamp: 1696331287478
-- platform: osx-64
-  name: python
-  version: 3.11.6
-  category: main
-  manager: conda
-  dependencies:
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.43.0,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.1.3,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata *
-  - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.6-h30d4d87_0_cpython.conda
-  hash:
-    md5: 4d66c5fc01e9be526afe5d828d4de24d
-    sha256: e3ed331204fbeb03a9a2c2fa834e74997ad4f732ba2124b36f327d38b0cded93
-  build: h30d4d87_0_cpython
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  constrains:
-  - python_abi 3.11.* *_cp311
-  license: Python-2.0
-  size: 15393521
-  timestamp: 1696330855485
-- platform: osx-arm64
-  name: python
-  version: 3.11.6
-  category: main
-  manager: conda
-  dependencies:
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.43.0,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.1.3,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata *
-  - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.6-h47c9636_0_cpython.conda
-  hash:
-    md5: 2271df1db9534f5cac7c2d0820c3359d
-    sha256: 77054fa9a8fc30f71a18f599ee2897905a3c515202b614fa0f793add7a04a155
-  build: h47c9636_0_cpython
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  constrains:
-  - python_abi 3.11.* *_cp311
-  license: Python-2.0
-  size: 14626958
-  timestamp: 1696329727433
-- platform: win-64
-  name: python
-  version: 3.11.6
-  category: main
-  manager: conda
-  dependencies:
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.43.0,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.3,<4.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata *
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.6-h2628c8c_0_cpython.conda
-  hash:
-    md5: 80b761856b20383615a3fe8b1b13eef8
-    sha256: 7fb38fda8296b2651ef727bb57603f0952c07fc533b172044395744a2641a00a
-  build: h2628c8c_0_cpython
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  constrains:
-  - python_abi 3.11.* *_cp311
-  license: Python-2.0
-  size: 18121128
-  timestamp: 1696329396864
-- platform: linux-64
+- kind: conda
   name: python_abi
   version: '3.11'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
-  hash:
-    md5: d786502c97404c94d7d58d258a445a65
-    sha256: 0be3ac1bf852d64f553220c7e6457e9c047dfb7412da9d22fbaa67e60858b3cf
   build: 4_cp311
-  arch: x86_64
-  subdir: linux-64
   build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
+  sha256: 0be3ac1bf852d64f553220c7e6457e9c047dfb7412da9d22fbaa67e60858b3cf
+  md5: d786502c97404c94d7d58d258a445a65
   constrains:
   - python 3.11.* *_cpython
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 6385
   timestamp: 1695147338551
-- platform: osx-64
+- kind: conda
   name: python_abi
   version: '3.11'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
-  hash:
-    md5: fef7a52f0eca6bae9e8e2e255bc86394
-    sha256: f56dfe2a57b3b27bad3f9527f943548e8b2526e949d9d6fc0a383020d9359afe
   build: 4_cp311
-  arch: x86_64
-  subdir: osx-64
   build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
+  sha256: f56dfe2a57b3b27bad3f9527f943548e8b2526e949d9d6fc0a383020d9359afe
+  md5: fef7a52f0eca6bae9e8e2e255bc86394
   constrains:
   - python 3.11.* *_cpython
+  arch: x86_64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 6478
   timestamp: 1695147518012
-- platform: osx-arm64
+- kind: conda
   name: python_abi
   version: '3.11'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
-  hash:
-    md5: 8d3751bc73d3bbb66f216fa2331d5649
-    sha256: 4837089c477b9b84fa38a17f453e6634e68237267211b27a8a2f5ccd847f4e55
   build: 4_cp311
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
+  sha256: 4837089c477b9b84fa38a17f453e6634e68237267211b27a8a2f5ccd847f4e55
+  md5: 8d3751bc73d3bbb66f216fa2331d5649
   constrains:
   - python 3.11.* *_cpython
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 6492
   timestamp: 1695147509940
-- platform: win-64
+- kind: conda
   name: python_abi
   version: '3.11'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
-  hash:
-    md5: 70513332c71b56eace4ee6441e66c012
-    sha256: 67c2aade3e2160642eec0742384e766b20c766055e3d99335681e3e05d88ed7b
   build: 4_cp311
-  arch: x86_64
-  subdir: win-64
   build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
+  sha256: 67c2aade3e2160642eec0742384e766b20c766055e3d99335681e3e05d88ed7b
+  md5: 70513332c71b56eace4ee6441e66c012
   constrains:
   - python 3.11.* *_cpython
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 6755
   timestamp: 1695147711935
-- platform: linux-64
+- kind: conda
   name: rdma-core
   version: '28.9'
-  category: main
-  manager: conda
-  dependencies:
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-28.9-h59595ed_1.conda
+  sha256: 832f9393ab3144ce6468c6f150db9d398fad4451e96a8879afb3059f0c9902f6
+  md5: aeffb7c06b5f65e55e6c637408dc4100
+  depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-28.9-h59595ed_1.conda
-  hash:
-    md5: aeffb7c06b5f65e55e6c637408dc4100
-    sha256: 832f9393ab3144ce6468c6f150db9d398fad4451e96a8879afb3059f0c9902f6
-  build: h59595ed_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: linux
   license: Linux-OpenIB
   license_family: BSD
   size: 3735644
   timestamp: 1684785130341
-- platform: linux-64
+- kind: conda
   name: re2
   version: 2023.06.02
-  category: main
-  manager: conda
-  dependencies:
-  - libre2-11 2023.06.02 h7a70373_0
-  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.06.02-h2873b5e_0.conda
-  hash:
-    md5: bb2d5e593ef13fe4aff0bc9440f945ae
-    sha256: 3e0bfb04b6d43312d711c5b49dbc3c7660b2e6e681ed504b1b322794462a1bcd
   build: h2873b5e_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.06.02-h2873b5e_0.conda
+  sha256: 3e0bfb04b6d43312d711c5b49dbc3c7660b2e6e681ed504b1b322794462a1bcd
+  md5: bb2d5e593ef13fe4aff0bc9440f945ae
+  depends:
+  - libre2-11 2023.06.02 h7a70373_0
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 26953
   timestamp: 1697065840782
-- platform: osx-64
+- kind: conda
   name: re2
   version: 2023.06.02
-  category: main
-  manager: conda
-  dependencies:
-  - libre2-11 2023.06.02 h4694dbf_0
-  url: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.06.02-hd34609a_0.conda
-  hash:
-    md5: e498042c254db56d398b6ee858888b9d
-    sha256: dd749346b868ac9a8765cd18e102f808103330b3fc1fac5d267fbf4257ea31c9
-  build: hd34609a_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27005
-  timestamp: 1697065900029
-- platform: osx-arm64
-  name: re2
-  version: 2023.06.02
-  category: main
-  manager: conda
-  dependencies:
-  - libre2-11 2023.06.02 h1753957_0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.06.02-h6135d0a_0.conda
-  hash:
-    md5: 8f23674174b155300696a2be8b5c1407
-    sha256: 963847258a82d9647311c5eb8829a49ac2161df12a304d5d6e61f788f0563442
   build: h6135d0a_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.06.02-h6135d0a_0.conda
+  sha256: 963847258a82d9647311c5eb8829a49ac2161df12a304d5d6e61f788f0563442
+  md5: 8f23674174b155300696a2be8b5c1407
+  depends:
+  - libre2-11 2023.06.02 h1753957_0
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 27073
   timestamp: 1697065856329
-- platform: win-64
+- kind: conda
   name: re2
   version: 2023.06.02
-  category: main
-  manager: conda
-  dependencies:
-  - libre2-11 2023.06.02 h8c5ae5e_0
-  url: https://conda.anaconda.org/conda-forge/win-64/re2-2023.06.02-hcbb65ff_0.conda
-  hash:
-    md5: aabaf2fe639029a25b39b6b14a1aa760
-    sha256: 97cfa7fe2e4111bd0915b8e14f1f1a00ee3fab14758ac89620c5e119c668e5b8
   build: hcbb65ff_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/win-64/re2-2023.06.02-hcbb65ff_0.conda
+  sha256: 97cfa7fe2e4111bd0915b8e14f1f1a00ee3fab14758ac89620c5e119c668e5b8
+  md5: aabaf2fe639029a25b39b6b14a1aa760
+  depends:
+  - libre2-11 2023.06.02 h8c5ae5e_0
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 203957
   timestamp: 1697066138562
-- platform: linux-64
+- kind: conda
+  name: re2
+  version: 2023.06.02
+  build: hd34609a_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.06.02-hd34609a_0.conda
+  sha256: dd749346b868ac9a8765cd18e102f808103330b3fc1fac5d267fbf4257ea31c9
+  md5: e498042c254db56d398b6ee858888b9d
+  depends:
+  - libre2-11 2023.06.02 h4694dbf_0
+  arch: x86_64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27005
+  timestamp: 1697065900029
+- kind: conda
   name: readline
   version: '8.2'
-  category: main
-  manager: conda
-  dependencies:
+  build: h8228510_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
   - libgcc-ng >=12
   - ncurses >=6.3,<7.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
-  hash:
-    md5: 47d31b792659ce70f470b5c82fdfb7a4
-    sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
-  build: h8228510_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   size: 281456
   timestamp: 1679532220005
-- platform: osx-64
+- kind: conda
   name: readline
   version: '8.2'
-  category: main
-  manager: conda
-  dependencies:
-  - ncurses >=6.3,<7.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
-  hash:
-    md5: f17f77f2acf4d344734bda76829ce14e
-    sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
-  build: h9e318b2_1
-  arch: x86_64
-  subdir: osx-64
-  build_number: 1
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 255870
-  timestamp: 1679532707590
-- platform: osx-arm64
-  name: readline
-  version: '8.2'
-  category: main
-  manager: conda
-  dependencies:
-  - ncurses >=6.3,<7.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
-  hash:
-    md5: 8cbb776a2f641b943d413b3e19df71f4
-    sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
   build: h92ec313_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  arch: aarch64
+  platform: osx
   license: GPL-3.0-only
   license_family: GPL
   size: 250351
   timestamp: 1679532511311
-- platform: linux-64
-  name: rhash
-  version: 1.4.4
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.4-hd590300_0.conda
-  hash:
-    md5: ec972a9a2925ac8d7a19eb9606561fff
-    sha256: 12711d2d4a808a503c2e49b25d26ecb351435521e814c154e682dd2be71c2611
-  build: hd590300_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 185144
-  timestamp: 1693455923632
-- platform: osx-64
-  name: rhash
-  version: 1.4.4
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.4-h0dc2134_0.conda
-  hash:
-    md5: 55a2ada70c8a208c01f77978f2783121
-    sha256: f1ae47e8c4e46f856faf5d8ee1e5291f55627aa93401b61a877f18ade5780c87
-  build: h0dc2134_0
-  arch: x86_64
+- kind: conda
+  name: readline
+  version: '8.2'
+  build: h9e318b2_1
+  build_number: 1
   subdir: osx-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  md5: f17f77f2acf4d344734bda76829ce14e
+  depends:
+  - ncurses >=6.3,<7.0a0
+  arch: x86_64
+  platform: osx
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 255870
+  timestamp: 1679532707590
+- kind: conda
+  name: rhash
+  version: 1.4.4
+  build: h0dc2134_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.4-h0dc2134_0.conda
+  sha256: f1ae47e8c4e46f856faf5d8ee1e5291f55627aa93401b61a877f18ade5780c87
+  md5: 55a2ada70c8a208c01f77978f2783121
+  arch: x86_64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 177229
   timestamp: 1693456080514
-- platform: osx-arm64
+- kind: conda
   name: rhash
   version: 1.4.4
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.4-hb547adb_0.conda
-  hash:
-    md5: 710c4b1abf65b697c1d9716eba16dbb0
-    sha256: 3ab595e2280ed2118b6b1e8ce7e5949da2047846c81b6af1bbf5ac859d062edd
   build: hb547adb_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.4-hb547adb_0.conda
+  sha256: 3ab595e2280ed2118b6b1e8ce7e5949da2047846c81b6af1bbf5ac859d062edd
+  md5: 710c4b1abf65b697c1d9716eba16dbb0
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 177491
   timestamp: 1693456037505
-- platform: linux-64
-  name: rich
-  version: 13.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.7.0
-  - typing_extensions >=4.0.0,<5.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3ca4829f40710f581ca1d76bc907e99f
-    sha256: a2f8838a75ab8c2c1da0a813c7569d4f6efba0d2b5dc3a7659e2cb6d96bd8e19
-  build: pyhd8ed1ab_0
-  arch: x86_64
+- kind: conda
+  name: rhash
+  version: 1.4.4
+  build: hd590300_0
   subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 183200
-  timestamp: 1696096819794
-- platform: osx-64
-  name: rich
-  version: 13.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.7.0
-  - typing_extensions >=4.0.0,<5.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3ca4829f40710f581ca1d76bc907e99f
-    sha256: a2f8838a75ab8c2c1da0a813c7569d4f6efba0d2b5dc3a7659e2cb6d96bd8e19
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 183200
-  timestamp: 1696096819794
-- platform: osx-arm64
-  name: rich
-  version: 13.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.7.0
-  - typing_extensions >=4.0.0,<5.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3ca4829f40710f581ca1d76bc907e99f
-    sha256: a2f8838a75ab8c2c1da0a813c7569d4f6efba0d2b5dc3a7659e2cb6d96bd8e19
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 183200
-  timestamp: 1696096819794
-- platform: win-64
-  name: rich
-  version: 13.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.7.0
-  - typing_extensions >=4.0.0,<5.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3ca4829f40710f581ca1d76bc907e99f
-    sha256: a2f8838a75ab8c2c1da0a813c7569d4f6efba0d2b5dc3a7659e2cb6d96bd8e19
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 183200
-  timestamp: 1696096819794
-- platform: linux-64
-  name: ruff
-  version: 0.1.2
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.4-hd590300_0.conda
+  sha256: 12711d2d4a808a503c2e49b25d26ecb351435521e814c154e682dd2be71c2611
+  md5: ec972a9a2925ac8d7a19eb9606561fff
+  depends:
   - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.1.2-py311h7145743_0.conda
-  hash:
-    md5: 4c457c2b25f5b58e75e052ada556314d
-    sha256: fb600b02d9d20266a7f9ee9eed4b63a8a5829d7f1c0ed7c290720560bb7dac39
-  build: py311h7145743_0
   arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 185144
+  timestamp: 1693455923632
+- kind: conda
+  name: rich
+  version: 13.6.0
+  build: pyhd8ed1ab_0
   subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 4784587
-  timestamp: 1698171225351
-- platform: osx-64
-  name: ruff
-  version: 0.1.2
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.1.2-py311hec6fdf1_0.conda
-  hash:
-    md5: aa5b695132c2c78232b93d80f1e5e04c
-    sha256: cf0b66945d13d1fa4840421ca169c4cfd68e791931f6316f528ddae6b74f9845
-  build: py311hec6fdf1_0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
+  sha256: a2f8838a75ab8c2c1da0a813c7569d4f6efba0d2b5dc3a7659e2cb6d96bd8e19
+  md5: 3ca4829f40710f581ca1d76bc907e99f
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.7.0
+  - typing_extensions >=4.0.0,<5.0.0
   arch: x86_64
-  subdir: osx-64
-  build_number: 0
+  platform: linux
   license: MIT
   license_family: MIT
-  size: 4544170
-  timestamp: 1698171913911
-- platform: osx-arm64
+  size: 183200
+  timestamp: 1696096819794
+- kind: conda
+  name: rich
+  version: 13.6.0
+  build: pyhd8ed1ab_0
+  subdir: osx-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
+  sha256: a2f8838a75ab8c2c1da0a813c7569d4f6efba0d2b5dc3a7659e2cb6d96bd8e19
+  md5: 3ca4829f40710f581ca1d76bc907e99f
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.7.0
+  - typing_extensions >=4.0.0,<5.0.0
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 183200
+  timestamp: 1696096819794
+- kind: conda
+  name: rich
+  version: 13.6.0
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
+  sha256: a2f8838a75ab8c2c1da0a813c7569d4f6efba0d2b5dc3a7659e2cb6d96bd8e19
+  md5: 3ca4829f40710f581ca1d76bc907e99f
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.7.0
+  - typing_extensions >=4.0.0,<5.0.0
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 183200
+  timestamp: 1696096819794
+- kind: conda
+  name: rich
+  version: 13.6.0
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
+  sha256: a2f8838a75ab8c2c1da0a813c7569d4f6efba0d2b5dc3a7659e2cb6d96bd8e19
+  md5: 3ca4829f40710f581ca1d76bc907e99f
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.7.0
+  - typing_extensions >=4.0.0,<5.0.0
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 183200
+  timestamp: 1696096819794
+- kind: conda
   name: ruff
   version: 0.1.2
-  category: main
-  manager: conda
-  dependencies:
+  build: py311h6fc163c_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.1.2-py311h6fc163c_0.conda
+  sha256: 4eaab7aaa52989e02e5ed672c16a0da3237e3c24a412f25246ef66e08d7abbf9
+  md5: 4eae3a2a9b8ae663b4c0c599221d088d
+  depends:
   - __osx >=10.9
   - libcxx >=16.0.6
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.1.2-py311h6fc163c_0.conda
-  hash:
-    md5: 4eae3a2a9b8ae663b4c0c599221d088d
-    sha256: 4eaab7aaa52989e02e5ed672c16a0da3237e3c24a412f25246ef66e08d7abbf9
-  build: py311h6fc163c_0
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
   size: 4310473
   timestamp: 1698171765257
-- platform: win-64
+- kind: conda
   name: ruff
   version: 0.1.2
-  category: main
-  manager: conda
-  dependencies:
+  build: py311h7145743_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.1.2-py311h7145743_0.conda
+  sha256: fb600b02d9d20266a7f9ee9eed4b63a8a5829d7f1c0ed7c290720560bb7dac39
+  md5: 4c457c2b25f5b58e75e052ada556314d
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 4784587
+  timestamp: 1698171225351
+- kind: conda
+  name: ruff
+  version: 0.1.2
+  build: py311hc14472d_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.1.2-py311hc14472d_0.conda
+  sha256: 0456eb29fb927927371df97edba3391eccb6f93a6a554f2bc8221b9913aa9875
+  md5: aeb1cc6180bf34af39f4c6c567bb7b4d
+  depends:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.1.2-py311hc14472d_0.conda
-  hash:
-    md5: aeb1cc6180bf34af39f4c6c567bb7b4d
-    sha256: 0456eb29fb927927371df97edba3391eccb6f93a6a554f2bc8221b9913aa9875
-  build: py311hc14472d_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
   size: 4698356
   timestamp: 1698172312917
-- platform: linux-64
+- kind: conda
+  name: ruff
+  version: 0.1.2
+  build: py311hec6fdf1_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.1.2-py311hec6fdf1_0.conda
+  sha256: cf0b66945d13d1fa4840421ca169c4cfd68e791931f6316f528ddae6b74f9845
+  md5: aa5b695132c2c78232b93d80f1e5e04c
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 4544170
+  timestamp: 1698171913911
+- kind: conda
   name: s2n
   version: 1.4.1
-  category: main
-  manager: conda
-  dependencies:
+  build: h06160fa_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.1-h06160fa_0.conda
+  sha256: 6f21a270e5fcf824d71b637ea26e389e469b3dc44a7e51062c27556c6e771b37
+  md5: 54ae57d17d038b6a7aa7fdb55350d338
+  depends:
   - libgcc-ng >=12
   - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.1-h06160fa_0.conda
-  hash:
-    md5: 54ae57d17d038b6a7aa7fdb55350d338
-    sha256: 6f21a270e5fcf824d71b637ea26e389e469b3dc44a7e51062c27556c6e771b37
-  build: h06160fa_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: Apache-2.0
   license_family: Apache
   size: 331403
   timestamp: 1703228891919
-- platform: linux-64
+- kind: conda
   name: semver
   version: 2.13.0
-  category: main
-  manager: conda
-  dependencies:
-  - python *
-  url: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 2cab9f3a9683cb40a2176ccaf76e66c6
-    sha256: 673ef5ef04cef60c3584b1d9b81024646b9d9a4c50749356c7ba5cede755e61d
   build: pyh9f0ad1d_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
+  sha256: 673ef5ef04cef60c3584b1d9b81024646b9d9a4c50749356c7ba5cede755e61d
+  md5: 2cab9f3a9683cb40a2176ccaf76e66c6
+  depends:
+  - python *
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 15712
   timestamp: 1603697876069
-- platform: osx-64
+- kind: conda
   name: semver
   version: 2.13.0
-  category: main
-  manager: conda
-  dependencies:
-  - python *
-  url: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 2cab9f3a9683cb40a2176ccaf76e66c6
-    sha256: 673ef5ef04cef60c3584b1d9b81024646b9d9a4c50749356c7ba5cede755e61d
   build: pyh9f0ad1d_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 15712
-  timestamp: 1603697876069
-- platform: osx-arm64
-  name: semver
-  version: 2.13.0
-  category: main
-  manager: conda
-  dependencies:
-  - python *
   url: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 2cab9f3a9683cb40a2176ccaf76e66c6
-    sha256: 673ef5ef04cef60c3584b1d9b81024646b9d9a4c50749356c7ba5cede755e61d
-  build: pyh9f0ad1d_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 15712
-  timestamp: 1603697876069
-- platform: win-64
-  name: semver
-  version: 2.13.0
-  category: main
-  manager: conda
-  dependencies:
+  sha256: 673ef5ef04cef60c3584b1d9b81024646b9d9a4c50749356c7ba5cede755e61d
+  md5: 2cab9f3a9683cb40a2176ccaf76e66c6
+  depends:
   - python *
-  url: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 2cab9f3a9683cb40a2176ccaf76e66c6
-    sha256: 673ef5ef04cef60c3584b1d9b81024646b9d9a4c50749356c7ba5cede755e61d
-  build: pyh9f0ad1d_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 15712
   timestamp: 1603697876069
-- platform: linux-64
+- kind: conda
+  name: semver
+  version: 2.13.0
+  build: pyh9f0ad1d_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
+  sha256: 673ef5ef04cef60c3584b1d9b81024646b9d9a4c50749356c7ba5cede755e61d
+  md5: 2cab9f3a9683cb40a2176ccaf76e66c6
+  depends:
+  - python *
+  arch: aarch64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15712
+  timestamp: 1603697876069
+- kind: conda
+  name: semver
+  version: 2.13.0
+  build: pyh9f0ad1d_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
+  sha256: 673ef5ef04cef60c3584b1d9b81024646b9d9a4c50749356c7ba5cede755e61d
+  md5: 2cab9f3a9683cb40a2176ccaf76e66c6
+  depends:
+  - python *
+  arch: x86_64
+  platform: win
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15712
+  timestamp: 1603697876069
+- kind: conda
   name: setuptools
   version: 68.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: fc2166155db840c634a1291a5c35a709
-    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+  sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
+  md5: fc2166155db840c634a1291a5c35a709
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 464399
   timestamp: 1694548452441
-- platform: osx-64
+- kind: conda
   name: setuptools
   version: 68.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: fc2166155db840c634a1291a5c35a709
-    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 464399
-  timestamp: 1694548452441
-- platform: osx-arm64
-  name: setuptools
-  version: 68.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: fc2166155db840c634a1291a5c35a709
-    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 464399
-  timestamp: 1694548452441
-- platform: win-64
-  name: setuptools
-  version: 68.2.2
-  category: main
-  manager: conda
-  dependencies:
+  sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
+  md5: fc2166155db840c634a1291a5c35a709
+  depends:
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: fc2166155db840c634a1291a5c35a709
-    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 464399
   timestamp: 1694548452441
-- platform: osx-64
+- kind: conda
+  name: setuptools
+  version: 68.2.2
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+  sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
+  md5: fc2166155db840c634a1291a5c35a709
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 464399
+  timestamp: 1694548452441
+- kind: conda
+  name: setuptools
+  version: 68.2.2
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+  sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
+  md5: fc2166155db840c634a1291a5c35a709
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 464399
+  timestamp: 1694548452441
+- kind: conda
   name: sigtool
   version: 0.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - openssl >=3.0.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
-  hash:
-    md5: fbfb84b9de9a6939cb165c02c69b1865
-    sha256: 46fdeadf8f8d725819c4306838cdfd1099cd8fe3e17bd78862a5dfdcd6de61cf
-  build: h88f4db0_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 213817
-  timestamp: 1643442169866
-- platform: osx-arm64
-  name: sigtool
-  version: 0.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - openssl >=3.0.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
-  hash:
-    md5: 4a2cac04f86a4540b8c9b8d8f597848f
-    sha256: 70791ae00a3756830cb50451db55f63e2a42a2fa2a8f1bab1ebd36bbb7d55bff
   build: h44b9a77_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
+  sha256: 70791ae00a3756830cb50451db55f63e2a42a2fa2a8f1bab1ebd36bbb7d55bff
+  md5: 4a2cac04f86a4540b8c9b8d8f597848f
+  depends:
+  - openssl >=3.0.0,<4.0a0
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 210264
   timestamp: 1643442231687
-- platform: linux-64
-  name: smmap
-  version: 5.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 62f26a3d1387acee31322208f0cfa3e0
-    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 22483
-  timestamp: 1634310465482
-- platform: osx-64
-  name: smmap
-  version: 5.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 62f26a3d1387acee31322208f0cfa3e0
-    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  build: pyhd8ed1ab_0
-  arch: x86_64
+- kind: conda
+  name: sigtool
+  version: 0.1.3
+  build: h88f4db0_0
   subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 22483
-  timestamp: 1634310465482
-- platform: osx-arm64
-  name: smmap
-  version: 5.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 62f26a3d1387acee31322208f0cfa3e0
-    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 22483
-  timestamp: 1634310465482
-- platform: win-64
-  name: smmap
-  version: 5.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 62f26a3d1387acee31322208f0cfa3e0
-    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  build: pyhd8ed1ab_0
+  url: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
+  sha256: 46fdeadf8f8d725819c4306838cdfd1099cd8fe3e17bd78862a5dfdcd6de61cf
+  md5: fbfb84b9de9a6939cb165c02c69b1865
+  depends:
+  - openssl >=3.0.0,<4.0a0
   arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 213817
+  timestamp: 1643442169866
+- kind: conda
+  name: smmap
+  version: 5.0.0
+  build: pyhd8ed1ab_0
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
+  md5: 62f26a3d1387acee31322208f0cfa3e0
+  depends:
+  - python >=3.5
+  arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22483
+  timestamp: 1634310465482
+- kind: conda
+  name: smmap
+  version: 5.0.0
+  build: pyhd8ed1ab_0
+  subdir: osx-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
+  md5: 62f26a3d1387acee31322208f0cfa3e0
+  depends:
+  - python >=3.5
+  arch: x86_64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22483
+  timestamp: 1634310465482
+- kind: conda
+  name: smmap
+  version: 5.0.0
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
+  md5: 62f26a3d1387acee31322208f0cfa3e0
+  depends:
+  - python >=3.5
+  arch: aarch64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22483
+  timestamp: 1634310465482
+- kind: conda
+  name: smmap
+  version: 5.0.0
+  build: pyhd8ed1ab_0
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
+  md5: 62f26a3d1387acee31322208f0cfa3e0
+  depends:
+  - python >=3.5
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 22483
   timestamp: 1634310465482
-- platform: linux-64
+- kind: conda
   name: snappy
   version: 1.1.10
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
-  hash:
-    md5: e6d228cd0bb74a51dd18f5bfce0b4115
-    sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
-  build: h9fff704_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 38865
-  timestamp: 1678534590321
-- platform: osx-64
-  name: snappy
-  version: 1.1.10
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=14.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
-  hash:
-    md5: 4320a8781f14cd959689b86e349f3b73
-    sha256: 575915dc13152e446a84e2f88de70a14f8b6af1a870e708f9370bd4be105583b
-  build: h225ccf5_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 34657
-  timestamp: 1678534768395
-- platform: osx-arm64
-  name: snappy
-  version: 1.1.10
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=14.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
-  hash:
-    md5: ac82a611d1a67a598096ebaa857198e3
-    sha256: dfae03cd2339587871e53b42833657faa4c9e42e3e2c56ee9e32bc60797c7f62
   build: h17c5cce_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+  sha256: dfae03cd2339587871e53b42833657faa4c9e42e3e2c56ee9e32bc60797c7f62
+  md5: ac82a611d1a67a598096ebaa857198e3
+  depends:
+  - libcxx >=14.0.6
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 33879
   timestamp: 1678534968831
-- platform: win-64
+- kind: conda
   name: snappy
   version: 1.1.10
-  category: main
-  manager: conda
-  dependencies:
+  build: h225ccf5_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+  sha256: 575915dc13152e446a84e2f88de70a14f8b6af1a870e708f9370bd4be105583b
+  md5: 4320a8781f14cd959689b86e349f3b73
+  depends:
+  - libcxx >=14.0.6
+  arch: x86_64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34657
+  timestamp: 1678534768395
+- kind: conda
+  name: snappy
+  version: 1.1.10
+  build: h9fff704_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+  sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
+  md5: e6d228cd0bb74a51dd18f5bfce0b4115
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38865
+  timestamp: 1678534590321
+- kind: conda
+  name: snappy
+  version: 1.1.10
+  build: hfb803bf_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+  sha256: 2a195b38cb63f03ad9f73a82db52434ebefe216fb70f7ea3defe4ddf263d408a
+  md5: cff1df79c9cff719460eb2dd172568de
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vs2015_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
-  hash:
-    md5: cff1df79c9cff719460eb2dd172568de
-    sha256: 2a195b38cb63f03ad9f73a82db52434ebefe216fb70f7ea3defe4ddf263d408a
-  build: hfb803bf_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 57065
   timestamp: 1678534804734
-- platform: linux-64
+- kind: conda
   name: sysroot_linux-64
   version: '2.12'
-  category: main
-  manager: conda
-  dependencies:
-  - kernel-headers_linux-64 ==2.6.32 he073ed8_16
-  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_16.conda
-  hash:
-    md5: 071ea8dceff4d30ac511f4a2f8437cd1
-    sha256: 4c024b2eee24c6da7d3e08723111ec02665c578844c5b3e9e6b38f89000bec41
   build: he073ed8_16
-  arch: x86_64
-  subdir: linux-64
   build_number: 16
+  subdir: linux-64
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_16.conda
+  sha256: 4c024b2eee24c6da7d3e08723111ec02665c578844c5b3e9e6b38f89000bec41
+  md5: 071ea8dceff4d30ac511f4a2f8437cd1
+  depends:
+  - kernel-headers_linux-64 ==2.6.32 he073ed8_16
+  arch: x86_64
+  platform: linux
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
-  noarch: generic
   size: 15277813
   timestamp: 1689214980563
-- platform: osx-64
+- kind: conda
   name: tapi
   version: 1100.0.11
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=10.0.0.a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
-  hash:
-    md5: f9ff42ccf809a21ba6f8607f8de36108
-    sha256: 34b18ce8d1518b67e333ca1d3af733c3976ecbdf3a36b727f9b4dedddcc588fa
   build: h9ce4665_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
+  sha256: 34b18ce8d1518b67e333ca1d3af733c3976ecbdf3a36b727f9b4dedddcc588fa
+  md5: f9ff42ccf809a21ba6f8607f8de36108
+  depends:
+  - libcxx >=10.0.0.a0
+  arch: x86_64
+  platform: osx
   license: NCSA
   license_family: MIT
   size: 201044
   timestamp: 1602664232074
-- platform: osx-arm64
+- kind: conda
   name: tapi
   version: 1100.0.11
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=11.0.0.a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
-  hash:
-    md5: d83362e7d0513f35f454bc50b0ca591d
-    sha256: 1709265fbee693a9e8b4126b0a3e68a6c4718b05821c659279c1af051f2d40f3
   build: he4954df_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
+  sha256: 1709265fbee693a9e8b4126b0a3e68a6c4718b05821c659279c1af051f2d40f3
+  md5: d83362e7d0513f35f454bc50b0ca591d
+  depends:
+  - libcxx >=11.0.0.a0
+  arch: aarch64
+  platform: osx
   license: NCSA
   license_family: MIT
   size: 191416
   timestamp: 1602687595316
-- platform: linux-64
+- kind: conda
   name: taplo
   version: 0.8.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.8.1-he8a937b_0.conda
-  hash:
-    md5: 3d83fa9962fc353485bab815c9df9fe4
-    sha256: 901e0ba452bd249db45cbea25e7d865e43eb5322078e4724f43d83641b73335b
-  build: he8a937b_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 3586993
-  timestamp: 1689047789269
-- platform: osx-64
-  name: taplo
-  version: 0.8.1
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.8.1-h7205ca4_0.conda
-  hash:
-    md5: 8e99d4b2850401094fe7c83273d3c4e8
-    sha256: 493b5f8db450f37e8bb50fdfd02c06499c18391c806d2220e65ac801f6b7c2f0
-  build: h7205ca4_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 3446470
-  timestamp: 1689048461323
-- platform: osx-arm64
-  name: taplo
-  version: 0.8.1
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.8.1-h69fbcac_0.conda
-  hash:
-    md5: 268425eeb6db286378bb05f69331feea
-    sha256: 5a46bbdac42c2aa1d59f3f7f61aa92eaed5f6936b01de4f3519f5ad40374973f
   build: h69fbcac_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.8.1-h69fbcac_0.conda
+  sha256: 5a46bbdac42c2aa1d59f3f7f61aa92eaed5f6936b01de4f3519f5ad40374973f
+  md5: 268425eeb6db286378bb05f69331feea
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 3339855
   timestamp: 1689048706766
-- platform: win-64
+- kind: conda
   name: taplo
   version: 0.8.1
-  category: main
-  manager: conda
-  dependencies:
+  build: h7205ca4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.8.1-h7205ca4_0.conda
+  sha256: 493b5f8db450f37e8bb50fdfd02c06499c18391c806d2220e65ac801f6b7c2f0
+  md5: 8e99d4b2850401094fe7c83273d3c4e8
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 3446470
+  timestamp: 1689048461323
+- kind: conda
+  name: taplo
+  version: 0.8.1
+  build: h7f3b576_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/taplo-0.8.1-h7f3b576_0.conda
+  sha256: 4f0ddb3c2942ff9b2d627de9093075df30f28f64bf71520710c031cb7fff8d9d
+  md5: 2041cd474504dd82b83aa58ccec82a78
+  depends:
   - m2w64-gcc-libs *
   - m2w64-gcc-libs-core *
-  url: https://conda.anaconda.org/conda-forge/win-64/taplo-0.8.1-h7f3b576_0.conda
-  hash:
-    md5: 2041cd474504dd82b83aa58ccec82a78
-    sha256: 4f0ddb3c2942ff9b2d627de9093075df30f28f64bf71520710c031cb7fff8d9d
-  build: h7f3b576_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
   size: 3652740
   timestamp: 1689048946860
-- platform: win-64
+- kind: conda
+  name: taplo
+  version: 0.8.1
+  build: he8a937b_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.8.1-he8a937b_0.conda
+  sha256: 901e0ba452bd249db45cbea25e7d865e43eb5322078e4724f43d83641b73335b
+  md5: 3d83fa9962fc353485bab815c9df9fe4
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 3586993
+  timestamp: 1689047789269
+- kind: conda
   name: tbb
   version: 2021.10.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h91493d7_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_1.conda
+  sha256: 492c57a480ad283e467c0bdfc8ea55eaf20c4c7e73340a0c1b200a077c9ba2d9
+  md5: 57ea1be8408c5a9a737648b5f919e725
+  depends:
   - libhwloc >=2.9.3,<2.9.4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_1.conda
-  hash:
-    md5: 57ea1be8408c5a9a737648b5f919e725
-    sha256: 492c57a480ad283e467c0bdfc8ea55eaf20c4c7e73340a0c1b200a077c9ba2d9
-  build: h91493d7_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: win
   license: Apache-2.0
   license_family: APACHE
   size: 156524
   timestamp: 1695626239415
-- platform: linux-64
+- kind: conda
   name: tk
   version: 8.6.13
-  category: main
-  manager: conda
-  dependencies:
+  build: h2797004_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
+  sha256: 679e944eb93fde45d0963a22598fafacbb429bb9e7ee26009ba81c4e0c435055
+  md5: 513336054f884f95d9fd925748f41ef3
+  depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
-  hash:
-    md5: 513336054f884f95d9fd925748f41ef3
-    sha256: 679e944eb93fde45d0963a22598fafacbb429bb9e7ee26009ba81c4e0c435055
-  build: h2797004_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: TCL
   license_family: BSD
   size: 3290187
   timestamp: 1695506262576
-- platform: osx-64
+- kind: conda
   name: tk
   version: 8.6.13
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
-  hash:
-    md5: 0c25eedcc888b6d765948ab62a18c03e
-    sha256: 573e5d7dde0a63b06ceef2c574295cbc2ec8668ec08e35d2f2c6220f4aa7fb98
-  build: hef22860_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: TCL
-  license_family: BSD
-  size: 3273909
-  timestamp: 1695506576288
-- platform: osx-arm64
-  name: tk
-  version: 8.6.13
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
-  hash:
-    md5: aa913a828b65f30ee3aba9c59bb0b514
-    sha256: 6df6ff49dba487eb891ddc0099642a36af2fe3929ed8023f76b745f0485c54a6
   build: hb31c410_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
+  sha256: 6df6ff49dba487eb891ddc0099642a36af2fe3929ed8023f76b745f0485c54a6
+  md5: aa913a828b65f30ee3aba9c59bb0b514
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: aarch64
+  platform: osx
   license: TCL
   license_family: BSD
   size: 3223549
   timestamp: 1695506653047
-- platform: win-64
+- kind: conda
   name: tk
   version: 8.6.13
-  category: main
-  manager: conda
-  dependencies:
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
+  sha256: 7e42db6b5f1c5ef8d4660e6ce41b52802b6c2fdc270d5e1eccc0048d0a3f03a8
+  md5: 74405f2ccbb40af409fee1a71ce70dc6
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
-  hash:
-    md5: 74405f2ccbb40af409fee1a71ce70dc6
-    sha256: 7e42db6b5f1c5ef8d4660e6ce41b52802b6c2fdc270d5e1eccc0048d0a3f03a8
-  build: hcfcfb64_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: TCL
   license_family: BSD
   size: 3478482
   timestamp: 1695506766462
-- platform: linux-64
+- kind: conda
+  name: tk
+  version: 8.6.13
+  build: hef22860_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
+  sha256: 573e5d7dde0a63b06ceef2c574295cbc2ec8668ec08e35d2f2c6220f4aa7fb98
+  md5: 0c25eedcc888b6d765948ab62a18c03e
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: x86_64
+  platform: osx
+  license: TCL
+  license_family: BSD
+  size: 3273909
+  timestamp: 1695506576288
+- kind: conda
   name: tomli
   version: 2.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  md5: 5844808ffab9ebdb694585b50ba02a96
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 15940
   timestamp: 1644342331069
-- platform: osx-64
+- kind: conda
   name: tomli
   version: 2.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  md5: 5844808ffab9ebdb694585b50ba02a96
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 15940
   timestamp: 1644342331069
-- platform: osx-arm64
+- kind: conda
   name: tomli
   version: 2.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
   build: pyhd8ed1ab_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  md5: 5844808ffab9ebdb694585b50ba02a96
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 15940
   timestamp: 1644342331069
-- platform: win-64
+- kind: conda
   name: tomli
   version: 2.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  md5: 5844808ffab9ebdb694585b50ba02a96
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 15940
   timestamp: 1644342331069
-- platform: linux-64
+- kind: conda
   name: tomlkit
   version: 0.12.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
-  hash:
-    md5: 074d0ce7a6261ab8b497c3518796ef3e
-    sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
   build: pyha770c72_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
+  sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
+  md5: 074d0ce7a6261ab8b497c3518796ef3e
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 37132
   timestamp: 1700046842169
-- platform: osx-64
+- kind: conda
   name: tomlkit
   version: 0.12.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
-  hash:
-    md5: 074d0ce7a6261ab8b497c3518796ef3e
-    sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
   build: pyha770c72_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 37132
-  timestamp: 1700046842169
-- platform: osx-arm64
-  name: tomlkit
-  version: 0.12.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
-  hash:
-    md5: 074d0ce7a6261ab8b497c3518796ef3e
-    sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
-  build: pyha770c72_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 37132
-  timestamp: 1700046842169
-- platform: win-64
-  name: tomlkit
-  version: 0.12.3
-  category: main
-  manager: conda
-  dependencies:
+  sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
+  md5: 074d0ce7a6261ab8b497c3518796ef3e
+  depends:
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
-  hash:
-    md5: 074d0ce7a6261ab8b497c3518796ef3e
-    sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
-  build: pyha770c72_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 37132
   timestamp: 1700046842169
-- platform: linux-64
+- kind: conda
+  name: tomlkit
+  version: 0.12.3
+  build: pyha770c72_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
+  sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
+  md5: 074d0ce7a6261ab8b497c3518796ef3e
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 37132
+  timestamp: 1700046842169
+- kind: conda
+  name: tomlkit
+  version: 0.12.3
+  build: pyha770c72_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
+  sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
+  md5: 074d0ce7a6261ab8b497c3518796ef3e
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 37132
+  timestamp: 1700046842169
+- kind: conda
   name: typing-extensions
   version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - typing_extensions ==4.8.0 pyha770c72_0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
-  hash:
-    md5: 384462e63262a527bda564fa2d9126c0
-    sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
   build: hd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+  sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
+  md5: 384462e63262a527bda564fa2d9126c0
+  depends:
+  - typing_extensions ==4.8.0 pyha770c72_0
+  arch: x86_64
+  platform: linux
   license: PSF-2.0
   license_family: PSF
-  noarch: python
   size: 10104
   timestamp: 1695040958008
-- platform: osx-64
+- kind: conda
   name: typing-extensions
   version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - typing_extensions ==4.8.0 pyha770c72_0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
-  hash:
-    md5: 384462e63262a527bda564fa2d9126c0
-    sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
   build: hd8ed1ab_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: PSF-2.0
-  license_family: PSF
   noarch: python
-  size: 10104
-  timestamp: 1695040958008
-- platform: osx-arm64
-  name: typing-extensions
-  version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - typing_extensions ==4.8.0 pyha770c72_0
   url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
-  hash:
-    md5: 384462e63262a527bda564fa2d9126c0
-    sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
-  build: hd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: PSF-2.0
-  license_family: PSF
-  noarch: python
-  size: 10104
-  timestamp: 1695040958008
-- platform: win-64
-  name: typing-extensions
-  version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
+  sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
+  md5: 384462e63262a527bda564fa2d9126c0
+  depends:
   - typing_extensions ==4.8.0 pyha770c72_0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
-  hash:
-    md5: 384462e63262a527bda564fa2d9126c0
-    sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
-  build: hd8ed1ab_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: PSF-2.0
   license_family: PSF
-  noarch: python
   size: 10104
   timestamp: 1695040958008
-- platform: linux-64
+- kind: conda
+  name: typing-extensions
+  version: 4.8.0
+  build: hd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+  sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
+  md5: 384462e63262a527bda564fa2d9126c0
+  depends:
+  - typing_extensions ==4.8.0 pyha770c72_0
+  arch: aarch64
+  platform: osx
+  license: PSF-2.0
+  license_family: PSF
+  size: 10104
+  timestamp: 1695040958008
+- kind: conda
+  name: typing-extensions
+  version: 4.8.0
+  build: hd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+  sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
+  md5: 384462e63262a527bda564fa2d9126c0
+  depends:
+  - typing_extensions ==4.8.0 pyha770c72_0
+  arch: x86_64
+  platform: win
+  license: PSF-2.0
+  license_family: PSF
+  size: 10104
+  timestamp: 1695040958008
+- kind: conda
   name: typing_extensions
   version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
-  hash:
-    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
-    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
   build: pyha770c72_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+  sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+  md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+  depends:
+  - python >=3.8
+  arch: x86_64
+  platform: linux
   license: PSF-2.0
   license_family: PSF
-  noarch: python
   size: 35108
   timestamp: 1695040948828
-- platform: osx-64
+- kind: conda
   name: typing_extensions
   version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
-  hash:
-    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
-    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
   build: pyha770c72_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: PSF-2.0
-  license_family: PSF
   noarch: python
-  size: 35108
-  timestamp: 1695040948828
-- platform: osx-arm64
-  name: typing_extensions
-  version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
-  hash:
-    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
-    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
-  build: pyha770c72_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: PSF-2.0
-  license_family: PSF
-  noarch: python
-  size: 35108
-  timestamp: 1695040948828
-- platform: win-64
-  name: typing_extensions
-  version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
+  sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+  md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+  depends:
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
-  hash:
-    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
-    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
-  build: pyha770c72_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: PSF-2.0
   license_family: PSF
-  noarch: python
   size: 35108
   timestamp: 1695040948828
-- platform: linux-64
+- kind: conda
+  name: typing_extensions
+  version: 4.8.0
+  build: pyha770c72_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+  sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+  md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+  depends:
+  - python >=3.8
+  arch: aarch64
+  platform: osx
+  license: PSF-2.0
+  license_family: PSF
+  size: 35108
+  timestamp: 1695040948828
+- kind: conda
+  name: typing_extensions
+  version: 4.8.0
+  build: pyha770c72_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+  sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+  md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+  depends:
+  - python >=3.8
+  arch: x86_64
+  platform: win
+  license: PSF-2.0
+  license_family: PSF
+  size: 35108
+  timestamp: 1695040948828
+- kind: conda
   name: typos
   version: 1.16.20
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/typos-1.16.20-he8a937b_0.conda
-  hash:
-    md5: 947fb92bd27a9b50f3595110b383cda1
-    sha256: 7d62a430a0b2265405db223bccfc5cf72f28953bc64617a2cb2ea5ba5e78fbd2
-  build: he8a937b_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 3604039
-  timestamp: 1697488922704
-- platform: osx-64
-  name: typos
-  version: 1.16.20
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/typos-1.16.20-h63b85fc_0.conda
-  hash:
-    md5: 0a1d328583703fd1b2b24d840ede73c2
-    sha256: 25db319c9a9ab2f15a25195f29f2606769974a6ade7acf0e5b546ff010a51188
-  build: h63b85fc_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 3329339
-  timestamp: 1697489265161
-- platform: osx-arm64
-  name: typos
-  version: 1.16.20
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.16.20-h5ef7bb8_0.conda
-  hash:
-    md5: 1556f9ec74d6d4324d0914eb87bacb2f
-    sha256: 97a5ea5c6594eb18ff0fba16f833c971d08c524e1b14d68235a874f4b4233bd7
   build: h5ef7bb8_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.16.20-h5ef7bb8_0.conda
+  sha256: 97a5ea5c6594eb18ff0fba16f833c971d08c524e1b14d68235a874f4b4233bd7
+  md5: 1556f9ec74d6d4324d0914eb87bacb2f
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 3313786
   timestamp: 1697489550453
-- platform: win-64
+- kind: conda
   name: typos
   version: 1.16.20
-  category: main
-  manager: conda
-  dependencies:
+  build: h63b85fc_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/typos-1.16.20-h63b85fc_0.conda
+  sha256: 25db319c9a9ab2f15a25195f29f2606769974a6ade7acf0e5b546ff010a51188
+  md5: 0a1d328583703fd1b2b24d840ede73c2
+  arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 3329339
+  timestamp: 1697489265161
+- kind: conda
+  name: typos
+  version: 1.16.20
+  build: h7f3b576_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/typos-1.16.20-h7f3b576_0.conda
+  sha256: c0adea11c394812d068a1ab14bb2d58ae01dd9b2f2d1be1c934367908eb520d0
+  md5: f651424355b19e3af998a185d52d14ca
+  depends:
   - m2w64-gcc-libs *
   - m2w64-gcc-libs-core *
-  url: https://conda.anaconda.org/conda-forge/win-64/typos-1.16.20-h7f3b576_0.conda
-  hash:
-    md5: f651424355b19e3af998a185d52d14ca
-    sha256: c0adea11c394812d068a1ab14bb2d58ae01dd9b2f2d1be1c934367908eb520d0
-  build: h7f3b576_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
   size: 2575765
   timestamp: 1697490297038
-- platform: linux-64
-  name: tzdata
-  version: 2023c
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
-  hash:
-    md5: 939e3e74d8be4dac89ce83b20de2492a
-    sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  build: h71feb2d_0
-  arch: x86_64
+- kind: conda
+  name: typos
+  version: 1.16.20
+  build: he8a937b_0
   subdir: linux-64
-  build_number: 0
-  license: LicenseRef-Public-Domain
-  noarch: generic
-  size: 117580
-  timestamp: 1680041306008
-- platform: osx-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/typos-1.16.20-he8a937b_0.conda
+  sha256: 7d62a430a0b2265405db223bccfc5cf72f28953bc64617a2cb2ea5ba5e78fbd2
+  md5: 947fb92bd27a9b50f3595110b383cda1
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 3604039
+  timestamp: 1697488922704
+- kind: conda
   name: tzdata
   version: 2023c
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
-  hash:
-    md5: 939e3e74d8be4dac89ce83b20de2492a
-    sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
   build: h71feb2d_0
+  subdir: linux-64
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+  sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
+  md5: 939e3e74d8be4dac89ce83b20de2492a
   arch: x86_64
+  platform: linux
+  license: LicenseRef-Public-Domain
+  size: 117580
+  timestamp: 1680041306008
+- kind: conda
+  name: tzdata
+  version: 2023c
+  build: h71feb2d_0
   subdir: osx-64
-  build_number: 0
-  license: LicenseRef-Public-Domain
   noarch: generic
-  size: 117580
-  timestamp: 1680041306008
-- platform: osx-arm64
-  name: tzdata
-  version: 2023c
-  category: main
-  manager: conda
-  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
-  hash:
-    md5: 939e3e74d8be4dac89ce83b20de2492a
-    sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  build: h71feb2d_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: LicenseRef-Public-Domain
-  noarch: generic
-  size: 117580
-  timestamp: 1680041306008
-- platform: win-64
-  name: tzdata
-  version: 2023c
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
-  hash:
-    md5: 939e3e74d8be4dac89ce83b20de2492a
-    sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  build: h71feb2d_0
+  sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
+  md5: 939e3e74d8be4dac89ce83b20de2492a
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: LicenseRef-Public-Domain
-  noarch: generic
   size: 117580
   timestamp: 1680041306008
-- platform: win-64
+- kind: conda
+  name: tzdata
+  version: 2023c
+  build: h71feb2d_0
+  subdir: osx-arm64
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+  sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
+  md5: 939e3e74d8be4dac89ce83b20de2492a
+  arch: aarch64
+  platform: osx
+  license: LicenseRef-Public-Domain
+  size: 117580
+  timestamp: 1680041306008
+- kind: conda
+  name: tzdata
+  version: 2023c
+  build: h71feb2d_0
+  subdir: win-64
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+  sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
+  md5: 939e3e74d8be4dac89ce83b20de2492a
+  arch: x86_64
+  platform: win
+  license: LicenseRef-Public-Domain
+  size: 117580
+  timestamp: 1680041306008
+- kind: conda
   name: ucrt
   version: 10.0.22621.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
-  hash:
-    md5: 72608f6cd3e5898229c3ea16deb1ac43
-    sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
   build: h57928b3_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+  sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
+  md5: 72608f6cd3e5898229c3ea16deb1ac43
   constrains:
   - vs2015_runtime >=14.29.30037
+  arch: x86_64
+  platform: win
   license: LicenseRef-Proprietary
   license_family: PROPRIETARY
   size: 1283972
   timestamp: 1666630199266
-- platform: linux-64
+- kind: conda
   name: ucx
   version: 1.15.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h64cca9d_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-h64cca9d_0.conda
+  sha256: 8a4dce10304fee0df715addec3d078421aa7aa0824422a6630d621d15bd98e5f
+  md5: b35b1f1a9fdbf93266c91f297dc9060e
+  depends:
   - libgcc-ng >=12
   - libnuma >=2.0.16,<3.0a0
   - libstdcxx-ng >=12
   - rdma-core >=28.9,<29.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-h64cca9d_0.conda
-  hash:
-    md5: b35b1f1a9fdbf93266c91f297dc9060e
-    sha256: 8a4dce10304fee0df715addec3d078421aa7aa0824422a6630d621d15bd98e5f
-  build: h64cca9d_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - cuda-version >=11.2,<12
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 15425900
   timestamp: 1696028080367
-- platform: win-64
+- kind: conda
   name: vc
   version: '14.3'
-  category: main
-  manager: conda
-  dependencies:
-  - vc14_runtime >=14.36.32532
-  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
-  hash:
-    md5: 67ff6791f235bb606659bf2a5c169191
-    sha256: 86ae94bf680980776aa761c2b0909a0ddbe1f817e7eeb8b16a1730f10f8891b6
   build: h64f974e_17
-  arch: x86_64
-  subdir: win-64
   build_number: 17
-  track_features: vc14
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
+  sha256: 86ae94bf680980776aa761c2b0909a0ddbe1f817e7eeb8b16a1730f10f8891b6
+  md5: 67ff6791f235bb606659bf2a5c169191
+  depends:
+  - vc14_runtime >=14.36.32532
+  arch: x86_64
+  platform: win
+  track_features:
+  - vc14
   license: BSD-3-Clause
   license_family: BSD
   size: 17176
   timestamp: 1688020629925
-- platform: win-64
+- kind: conda
   name: vc14_runtime
   version: 14.36.32532
-  category: main
-  manager: conda
-  dependencies:
-  - ucrt >=10.0.20348.0
-  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
-  hash:
-    md5: d0de20f2f3fc806a81b44fcdd941aaf7
-    sha256: b317d49af32d5c031828e62c08d56f01d9a64cd3f40d4cccb052bc38c7a9e62e
   build: hdcecf7f_17
-  arch: x86_64
-  subdir: win-64
   build_number: 17
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
+  sha256: b317d49af32d5c031828e62c08d56f01d9a64cd3f40d4cccb052bc38c7a9e62e
+  md5: d0de20f2f3fc806a81b44fcdd941aaf7
+  depends:
+  - ucrt >=10.0.20348.0
   constrains:
   - vs2015_runtime 14.36.32532.* *_17
+  arch: x86_64
+  platform: win
   license: LicenseRef-ProprietaryMicrosoft
   license_family: Proprietary
   size: 739437
   timestamp: 1694292382336
-- platform: linux-64
+- kind: conda
   name: virtualenv
   version: 20.24.6
-  category: main
-  manager: conda
-  dependencies:
-  - distlib <1,>=0.3.7
-  - filelock <4,>=3.12.2
-  - platformdirs <4,>=3.9.1
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.24.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: fb1fc875719e217ed799a7aae11d3be4
-    sha256: 09492f89a22dc17d9b32f2a791deee93d06e99fb312c3d47430fe35343b7fbde
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 3067859
-  timestamp: 1698092779433
-- platform: osx-64
-  name: virtualenv
-  version: 20.24.6
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.24.6-pyhd8ed1ab_0.conda
+  sha256: 09492f89a22dc17d9b32f2a791deee93d06e99fb312c3d47430fe35343b7fbde
+  md5: fb1fc875719e217ed799a7aae11d3be4
+  depends:
   - distlib <1,>=0.3.7
   - filelock <4,>=3.12.2
   - platformdirs <4,>=3.9.1
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.24.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: fb1fc875719e217ed799a7aae11d3be4
-    sha256: 09492f89a22dc17d9b32f2a791deee93d06e99fb312c3d47430fe35343b7fbde
-  build: pyhd8ed1ab_0
   arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 3067859
+  timestamp: 1698092779433
+- kind: conda
+  name: virtualenv
+  version: 20.24.6
+  build: pyhd8ed1ab_0
   subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 3067859
-  timestamp: 1698092779433
-- platform: osx-arm64
-  name: virtualenv
-  version: 20.24.6
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.24.6-pyhd8ed1ab_0.conda
+  sha256: 09492f89a22dc17d9b32f2a791deee93d06e99fb312c3d47430fe35343b7fbde
+  md5: fb1fc875719e217ed799a7aae11d3be4
+  depends:
   - distlib <1,>=0.3.7
   - filelock <4,>=3.12.2
   - platformdirs <4,>=3.9.1
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.24.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: fb1fc875719e217ed799a7aae11d3be4
-    sha256: 09492f89a22dc17d9b32f2a791deee93d06e99fb312c3d47430fe35343b7fbde
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 3067859
-  timestamp: 1698092779433
-- platform: win-64
-  name: virtualenv
-  version: 20.24.6
-  category: main
-  manager: conda
-  dependencies:
-  - distlib <1,>=0.3.7
-  - filelock <4,>=3.12.2
-  - platformdirs <4,>=3.9.1
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.24.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: fb1fc875719e217ed799a7aae11d3be4
-    sha256: 09492f89a22dc17d9b32f2a791deee93d06e99fb312c3d47430fe35343b7fbde
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 3067859
   timestamp: 1698092779433
-- platform: win-64
+- kind: conda
+  name: virtualenv
+  version: 20.24.6
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.24.6-pyhd8ed1ab_0.conda
+  sha256: 09492f89a22dc17d9b32f2a791deee93d06e99fb312c3d47430fe35343b7fbde
+  md5: fb1fc875719e217ed799a7aae11d3be4
+  depends:
+  - distlib <1,>=0.3.7
+  - filelock <4,>=3.12.2
+  - platformdirs <4,>=3.9.1
+  - python >=3.8
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 3067859
+  timestamp: 1698092779433
+- kind: conda
+  name: virtualenv
+  version: 20.24.6
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.24.6-pyhd8ed1ab_0.conda
+  sha256: 09492f89a22dc17d9b32f2a791deee93d06e99fb312c3d47430fe35343b7fbde
+  md5: fb1fc875719e217ed799a7aae11d3be4
+  depends:
+  - distlib <1,>=0.3.7
+  - filelock <4,>=3.12.2
+  - platformdirs <4,>=3.9.1
+  - python >=3.8
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 3067859
+  timestamp: 1698092779433
+- kind: conda
   name: vs2015_runtime
   version: 14.36.32532
-  category: main
-  manager: conda
-  dependencies:
-  - vc14_runtime >=14.36.32532
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
-  hash:
-    md5: 4618046c39f7c81861e53ded842e738a
-    sha256: 5ecbd731dc7f13762d67be0eadc47eb7f14713005e430d9b5fc680e965ac0f81
   build: h05e6639_17
-  arch: x86_64
-  subdir: win-64
   build_number: 17
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
+  sha256: 5ecbd731dc7f13762d67be0eadc47eb7f14713005e430d9b5fc680e965ac0f81
+  md5: 4618046c39f7c81861e53ded842e738a
+  depends:
+  - vc14_runtime >=14.36.32532
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 17207
   timestamp: 1688020635322
-- platform: win-64
+- kind: conda
   name: vs2022_win-64
   version: 19.37.32822
-  category: main
-  manager: conda
-  dependencies:
-  - vswhere *
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.37.32822-h0123c8e_17.conda
-  hash:
-    md5: 8b02594cf497f7516a3ed20a164de75e
-    sha256: 259b5d4ac07b131bf15bf1a2d101eb9eb039e32cfef57de79061cb4c8f1889fe
   build: h0123c8e_17
-  arch: x86_64
-  subdir: win-64
   build_number: 17
-  track_features: vc14
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.37.32822-h0123c8e_17.conda
+  sha256: 259b5d4ac07b131bf15bf1a2d101eb9eb039e32cfef57de79061cb4c8f1889fe
+  md5: 8b02594cf497f7516a3ed20a164de75e
+  depends:
+  - vswhere *
+  arch: x86_64
+  platform: win
+  track_features:
+  - vc14
   license: BSD-3-Clause
   license_family: BSD
   size: 19405
   timestamp: 1694292390059
-- platform: win-64
+- kind: conda
   name: vswhere
   version: 3.1.4
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
-  hash:
-    md5: b1d1d6a1f874d8c93a57b5efece52f03
-    sha256: 553c41fc1a883415a39444313f8d99236685529776fdd04e8d97288b73496002
   build: h57928b3_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
+  sha256: 553c41fc1a883415a39444313f8d99236685529776fdd04e8d97288b73496002
+  md5: b1d1d6a1f874d8c93a57b5efece52f03
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
   size: 218421
   timestamp: 1682376911339
-- platform: linux-64
+- kind: conda
   name: wheel
   version: 0.38.4
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: c829cfb8cb826acb9de0ac1a2df0a940
-    sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
+  sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
+  md5: c829cfb8cb826acb9de0ac1a2df0a940
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 32521
   timestamp: 1668051714265
-- platform: osx-64
+- kind: conda
   name: wheel
   version: 0.38.4
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: c829cfb8cb826acb9de0ac1a2df0a940
-    sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 32521
-  timestamp: 1668051714265
-- platform: osx-arm64
-  name: wheel
-  version: 0.38.4
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: c829cfb8cb826acb9de0ac1a2df0a940
-    sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 32521
-  timestamp: 1668051714265
-- platform: win-64
-  name: wheel
-  version: 0.38.4
-  category: main
-  manager: conda
-  dependencies:
+  sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
+  md5: c829cfb8cb826acb9de0ac1a2df0a940
+  depends:
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: c829cfb8cb826acb9de0ac1a2df0a940
-    sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
   size: 32521
   timestamp: 1668051714265
-- platform: linux-64
+- kind: conda
+  name: wheel
+  version: 0.38.4
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
+  sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
+  md5: c829cfb8cb826acb9de0ac1a2df0a940
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 32521
+  timestamp: 1668051714265
+- kind: conda
+  name: wheel
+  version: 0.38.4
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
+  sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
+  md5: c829cfb8cb826acb9de0ac1a2df0a940
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 32521
+  timestamp: 1668051714265
+- kind: conda
   name: xz
   version: 5.2.6
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
-  hash:
-    md5: 2161070d867d1b1204ea749c8eec4ef0
-    sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
   build: h166bdaf_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1 and GPL-2.0
   size: 418368
   timestamp: 1660346797927
-- platform: osx-64
+- kind: conda
   name: xz
   version: 5.2.6
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
-  hash:
-    md5: a72f9d4ea13d55d745ff1ed594747f10
-    sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
-  build: h775f41a_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: LGPL-2.1 and GPL-2.0
-  size: 238119
-  timestamp: 1660346964847
-- platform: osx-arm64
-  name: xz
-  version: 5.2.6
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
-  hash:
-    md5: 39c6b54e94014701dd157f4f576ed211
-    sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
   build: h57fd34a_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  md5: 39c6b54e94014701dd157f4f576ed211
+  arch: aarch64
+  platform: osx
   license: LGPL-2.1 and GPL-2.0
   size: 235693
   timestamp: 1660346961024
-- platform: win-64
+- kind: conda
   name: xz
   version: 5.2.6
-  category: main
-  manager: conda
-  dependencies:
+  build: h775f41a_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+  md5: a72f9d4ea13d55d745ff1ed594747f10
+  arch: x86_64
+  platform: osx
+  license: LGPL-2.1 and GPL-2.0
+  size: 238119
+  timestamp: 1660346964847
+- kind: conda
+  name: xz
+  version: 5.2.6
+  build: h8d14728_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+  sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
+  md5: 515d77642eaa3639413c6b1bc3f94219
+  depends:
   - vc >=14.1,<15
   - vs2015_runtime >=14.16.27033
-  url: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
-  hash:
-    md5: 515d77642eaa3639413c6b1bc3f94219
-    sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
-  build: h8d14728_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: LGPL-2.1 and GPL-2.0
   size: 217804
   timestamp: 1660346976440
-- platform: linux-64
+- kind: conda
   name: zipp
   version: 3.17.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
+  md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+  depends:
+  - python >=3.8
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 18954
   timestamp: 1695255262261
-- platform: osx-64
+- kind: conda
   name: zipp
   version: 3.17.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
   noarch: python
-  size: 18954
-  timestamp: 1695255262261
-- platform: osx-arm64
-  name: zipp
-  version: 3.17.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 18954
-  timestamp: 1695255262261
-- platform: win-64
-  name: zipp
-  version: 3.17.0
-  category: main
-  manager: conda
-  dependencies:
+  sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
+  md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+  depends:
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
-  build: pyhd8ed1ab_0
   arch: x86_64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 18954
+  timestamp: 1695255262261
+- kind: conda
+  name: zipp
+  version: 3.17.0
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
+  md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+  depends:
+  - python >=3.8
+  arch: aarch64
+  platform: osx
+  license: MIT
+  license_family: MIT
+  size: 18954
+  timestamp: 1695255262261
+- kind: conda
+  name: zipp
+  version: 3.17.0
+  build: pyhd8ed1ab_0
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
+  md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+  depends:
+  - python >=3.8
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 18954
   timestamp: 1695255262261
-- platform: linux-64
+- kind: conda
   name: zlib
   version: 1.2.13
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libzlib 1.2.13 hd590300_5
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
-  hash:
-    md5: 68c34ec6149623be41a1933ab996a209
-    sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
-  build: hd590300_5
-  arch: x86_64
-  subdir: linux-64
-  build_number: 5
-  license: Zlib
-  license_family: Other
-  size: 92825
-  timestamp: 1686575231103
-- platform: osx-64
-  name: zlib
-  version: 1.2.13
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib 1.2.13 h8a1eda9_5
-  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
-  hash:
-    md5: 75a8a98b1c4671c5d2897975731da42d
-    sha256: d1f4c82fd7bd240a78ce8905e931e68dca5f523c7da237b6b63c87d5625c5b35
-  build: h8a1eda9_5
-  arch: x86_64
-  subdir: osx-64
-  build_number: 5
-  license: Zlib
-  license_family: Other
-  size: 90764
-  timestamp: 1686575574678
-- platform: osx-arm64
-  name: zlib
-  version: 1.2.13
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib 1.2.13 h53f4e23_5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
-  hash:
-    md5: a08383f223b10b71492d27566fafbf6c
-    sha256: de0ee1e24aa6867058d3b852a15c8d7f49f262f5828772700c647186d4a96bbe
   build: h53f4e23_5
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
+  sha256: de0ee1e24aa6867058d3b852a15c8d7f49f262f5828772700c647186d4a96bbe
+  md5: a08383f223b10b71492d27566fafbf6c
+  depends:
+  - libzlib 1.2.13 h53f4e23_5
+  arch: aarch64
+  platform: osx
   license: Zlib
   license_family: Other
   size: 79577
   timestamp: 1686575471024
-- platform: linux-64
-  name: zstd
-  version: 1.5.5
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
-  hash:
-    md5: 04b88013080254850d6c01ed54810589
-    sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
-  build: hfc55251_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 545199
-  timestamp: 1693151163452
-- platform: osx-64
-  name: zstd
-  version: 1.5.5
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
-  hash:
-    md5: 80abc41d0c48b82fe0f04e7f42f5cb7e
-    sha256: d54e31d3d8de5e254c0804abd984807b8ae5cd3708d758a8bf1adff1f5df166c
-  build: h829000d_0
-  arch: x86_64
+- kind: conda
+  name: zlib
+  version: 1.2.13
+  build: h8a1eda9_5
+  build_number: 5
   subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 499383
-  timestamp: 1693151312586
-- platform: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
+  sha256: d1f4c82fd7bd240a78ce8905e931e68dca5f523c7da237b6b63c87d5625c5b35
+  md5: 75a8a98b1c4671c5d2897975731da42d
+  depends:
+  - libzlib 1.2.13 h8a1eda9_5
+  arch: x86_64
+  platform: osx
+  license: Zlib
+  license_family: Other
+  size: 90764
+  timestamp: 1686575574678
+- kind: conda
+  name: zlib
+  version: 1.2.13
+  build: hd590300_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+  sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
+  md5: 68c34ec6149623be41a1933ab996a209
+  depends:
+  - libgcc-ng >=12
+  - libzlib 1.2.13 hd590300_5
+  arch: x86_64
+  platform: linux
+  license: Zlib
+  license_family: Other
+  size: 92825
+  timestamp: 1686575231103
+- kind: conda
   name: zstd
   version: 1.5.5
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
-  hash:
-    md5: 5b212cfb7f9d71d603ad891879dc7933
-    sha256: 7e1fe6057628bbb56849a6741455bbb88705bae6d6646257e57904ac5ee5a481
-  build: h4f39d0f_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 400508
-  timestamp: 1693151393180
-- platform: win-64
-  name: zstd
-  version: 1.5.5
-  category: main
-  manager: conda
-  dependencies:
+  build: h12be248_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
+  sha256: d540dd56c5ec772b60e4ce7d45f67f01c6614942225885911964ea1e70bb99e3
+  md5: 792bb5da68bf0a6cac6a6072ecb8dbeb
+  depends:
   - libzlib >=1.2.13,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
-  hash:
-    md5: 792bb5da68bf0a6cac6a6072ecb8dbeb
-    sha256: d540dd56c5ec772b60e4ce7d45f67f01c6614942225885911964ea1e70bb99e3
-  build: h12be248_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 343428
   timestamp: 1693151615801
-version: 1
+- kind: conda
+  name: zstd
+  version: 1.5.5
+  build: h4f39d0f_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
+  sha256: 7e1fe6057628bbb56849a6741455bbb88705bae6d6646257e57904ac5ee5a481
+  md5: 5b212cfb7f9d71d603ad891879dc7933
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: aarch64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 400508
+  timestamp: 1693151393180
+- kind: conda
+  name: zstd
+  version: 1.5.5
+  build: h829000d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+  sha256: d54e31d3d8de5e254c0804abd984807b8ae5cd3708d758a8bf1adff1f5df166c
+  md5: 80abc41d0c48b82fe0f04e7f42f5cb7e
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: x86_64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 499383
+  timestamp: 1693151312586
+- kind: conda
+  name: zstd
+  version: 1.5.5
+  build: hfc55251_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+  sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
+  md5: 04b88013080254850d6c01ed54810589
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 545199
+  timestamp: 1693151163452

--- a/pixi.toml
+++ b/pixi.toml
@@ -101,7 +101,7 @@ cpp-prepare-msvc = "cmake -G 'Visual Studio 17 2022' -B build-msvc -S ."
 [dependencies]
 attrs = ">=23.1.0"
 blackdoc = "0.3.8"
-clang-tools = "=16"          # clang-format
+clang-tools = "16.0.6"       # clang-format
 cmake = "3.27.6"
 flatbuffers = ">=23"
 gitignore-parser = ">=0.1.9"
@@ -131,19 +131,19 @@ tomlkit = "0.12.3.*"
 
 [target.linux-64.dependencies]
 patchelf = ">=0.17"
-clang = "=16"
+clang = "16.0.6"
 c-compiler = "1.6.0.*"
 cxx-compiler = "1.6.0.*"
 ninja = "1.11.1"
 
 [target.osx-64.dependencies]
-clang = "=16"
+clang = "16.0.6"
 c-compiler = "1.6.0.*"
 cxx-compiler = "1.6.0.*"
 ninja = "1.11.1"
 
 [target.osx-arm64.dependencies]
-clang = "=16"
+clang = "16.0.6"
 c-compiler = "1.6.0.*"
 cxx-compiler = "1.6.0.*"
 ninja = "1.11.1"

--- a/pixi.toml
+++ b/pixi.toml
@@ -101,7 +101,7 @@ cpp-prepare-msvc = "cmake -G 'Visual Studio 17 2022' -B build-msvc -S ."
 [dependencies]
 attrs = ">=23.1.0"
 blackdoc = "0.3.8"
-clang-tools = ">=15,<16"     # clang-format
+clang-tools = "=16"          # clang-format
 cmake = "3.27.6"
 flatbuffers = ">=23"
 gitignore-parser = ">=0.1.9"
@@ -131,19 +131,19 @@ tomlkit = "0.12.3.*"
 
 [target.linux-64.dependencies]
 patchelf = ">=0.17"
-clang = ">=15,<16"
+clang = "=16"
 c-compiler = "1.6.0.*"
 cxx-compiler = "1.6.0.*"
 ninja = "1.11.1"
 
 [target.osx-64.dependencies]
-clang = ">=15,<16"
+clang = "=16"
 c-compiler = "1.6.0.*"
 cxx-compiler = "1.6.0.*"
 ninja = "1.11.1"
 
 [target.osx-arm64.dependencies]
-clang = ">=15,<16"
+clang = "=16"
 c-compiler = "1.6.0.*"
 cxx-compiler = "1.6.0.*"
 ninja = "1.11.1"

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
@@ -5,7 +5,8 @@
 
 #include "../collection_adapter_builtins.hpp"
 
-RR_PUSH_WARNINGS RR_DISABLE_DEPRECATION_WARNING;
+RR_PUSH_WARNINGS
+RR_DISABLE_DEPRECATION_WARNING
 
 namespace rerun::archetypes {}
 

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.cpp
@@ -5,6 +5,8 @@
 
 #include "../collection_adapter_builtins.hpp"
 
+RR_PUSH_WARNINGS RR_DISABLE_DEPRECATION_WARNING;
+
 namespace rerun::archetypes {}
 
 namespace rerun {
@@ -51,3 +53,5 @@ namespace rerun {
         return cells;
     }
 } // namespace rerun
+
+RR_POP_WARNINGS

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -51,7 +51,9 @@ namespace rerun::archetypes {
     ///     }
     /// }
     /// ```
-    struct TimeSeriesScalar {
+    struct [[deprecated(
+        "Use the `Scalar` + (optional) `SeriesLine`/`SeriesPoint` archetypes instead, logged on the same entity."
+    )]] TimeSeriesScalar {
         /// The scalar value to log.
         rerun::components::Scalar scalar;
 
@@ -106,7 +108,7 @@ namespace rerun::archetypes {
 
       public:
         TimeSeriesScalar() = default;
-        TimeSeriesScalar(TimeSeriesScalar&& other) = default;
+        TimeSeriesScalar(TimeSeriesScalar && other) = default;
 
         explicit TimeSeriesScalar(rerun::components::Scalar _scalar) : scalar(std::move(_scalar)) {}
 
@@ -118,7 +120,7 @@ namespace rerun::archetypes {
         /// If all points within a single entity path (i.e. a line) share the same
         /// radius, then this radius will be used as the line width too. Otherwise, the
         /// line will use the default width of `1.0`.
-        TimeSeriesScalar with_radius(rerun::components::Radius _radius) && {
+        TimeSeriesScalar with_radius(rerun::components::Radius _radius)&& {
             radius = std::move(_radius);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
@@ -135,7 +137,7 @@ namespace rerun::archetypes {
         /// If all points within a single entity path (i.e. a line) share the same
         /// color, then this color will be used as the line color in the plot legend.
         /// Otherwise, the line will appear gray in the legend.
-        TimeSeriesScalar with_color(rerun::components::Color _color) && {
+        TimeSeriesScalar with_color(rerun::components::Color _color)&& {
             color = std::move(_color);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
@@ -149,7 +151,7 @@ namespace rerun::archetypes {
         /// this label will be used as the label for the line itself. Otherwise, the
         /// line will be named after the entity path. The plot itself is named after
         /// the space it's in.
-        TimeSeriesScalar with_label(rerun::components::Text _label) && {
+        TimeSeriesScalar with_label(rerun::components::Text _label)&& {
             label = std::move(_label);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
@@ -162,7 +164,7 @@ namespace rerun::archetypes {
         /// Points within a single line do not have to all share the same scatteredness:
         /// the line will switch between a scattered and a continuous representation as
         /// required.
-        TimeSeriesScalar with_scattered(rerun::components::ScalarScattering _scattered) && {
+        TimeSeriesScalar with_scattered(rerun::components::ScalarScattering _scattered)&& {
             scattered = std::move(_scattered);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
@@ -180,6 +182,7 @@ namespace rerun {
     /// \private
     template <typename T>
     struct AsComponents;
+    RR_PUSH_WARNINGS RR_DISABLE_DEPRECATION_WARNING;
 
     /// \private
     template <>
@@ -188,4 +191,6 @@ namespace rerun {
         static Result<std::vector<DataCell>> serialize(const archetypes::TimeSeriesScalar& archetype
         );
     };
+
+    RR_POP_WARNINGS
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/time_series_scalar.hpp
@@ -108,7 +108,7 @@ namespace rerun::archetypes {
 
       public:
         TimeSeriesScalar() = default;
-        TimeSeriesScalar(TimeSeriesScalar && other) = default;
+        TimeSeriesScalar(TimeSeriesScalar&& other) = default;
 
         explicit TimeSeriesScalar(rerun::components::Scalar _scalar) : scalar(std::move(_scalar)) {}
 
@@ -120,7 +120,7 @@ namespace rerun::archetypes {
         /// If all points within a single entity path (i.e. a line) share the same
         /// radius, then this radius will be used as the line width too. Otherwise, the
         /// line will use the default width of `1.0`.
-        TimeSeriesScalar with_radius(rerun::components::Radius _radius)&& {
+        TimeSeriesScalar with_radius(rerun::components::Radius _radius) && {
             radius = std::move(_radius);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
@@ -137,7 +137,7 @@ namespace rerun::archetypes {
         /// If all points within a single entity path (i.e. a line) share the same
         /// color, then this color will be used as the line color in the plot legend.
         /// Otherwise, the line will appear gray in the legend.
-        TimeSeriesScalar with_color(rerun::components::Color _color)&& {
+        TimeSeriesScalar with_color(rerun::components::Color _color) && {
             color = std::move(_color);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
@@ -151,7 +151,7 @@ namespace rerun::archetypes {
         /// this label will be used as the label for the line itself. Otherwise, the
         /// line will be named after the entity path. The plot itself is named after
         /// the space it's in.
-        TimeSeriesScalar with_label(rerun::components::Text _label)&& {
+        TimeSeriesScalar with_label(rerun::components::Text _label) && {
             label = std::move(_label);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
@@ -164,7 +164,7 @@ namespace rerun::archetypes {
         /// Points within a single line do not have to all share the same scatteredness:
         /// the line will switch between a scattered and a continuous representation as
         /// required.
-        TimeSeriesScalar with_scattered(rerun::components::ScalarScattering _scattered)&& {
+        TimeSeriesScalar with_scattered(rerun::components::ScalarScattering _scattered) && {
             scattered = std::move(_scattered);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
@@ -182,7 +182,8 @@ namespace rerun {
     /// \private
     template <typename T>
     struct AsComponents;
-    RR_PUSH_WARNINGS RR_DISABLE_DEPRECATION_WARNING;
+    RR_PUSH_WARNINGS
+    RR_DISABLE_DEPRECATION_WARNING
 
     /// \private
     template <>

--- a/rerun_cpp/src/rerun/compiler_utils.hpp
+++ b/rerun_cpp/src/rerun/compiler_utils.hpp
@@ -1,5 +1,17 @@
 #pragma once
 
+// Push pop warnings
+#if defined(__GNUC__) || defined(__clang__)
+#define RR_PUSH_WARNINGS _Pragma("GCC diagnostic push")
+#define RR_POP_WARNINGS _Pragma("GCC diagnostic pop")
+#elif defined(_MSC_VER)
+#define RR_PUSH_WARNINGS __pragma(warning(push))
+#define RR_POP_WARNINGS __pragma(warning(pop))
+#else
+#define RR_PUSH_WARNINGS
+#define RR_POP_WARNINGS
+#endif
+
 // Macro for enabling and disabling the "-Wmaybe-uninitialized" warning in GCC.
 // See: https://github.com/rerun-io/rerun/issues/4027
 
@@ -8,17 +20,15 @@
     expr RR_DISABLE_MAYBE_UNINITIALIZED_POP
 
 #if defined(__GNUC__) && !defined(__clang__)
+
 #define RERUN_DISABLE_MAYBE_UNINITIALIZED_PUSH \
-    _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+    RR_PUSH_WARNINGS                           \
+    _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
 #else
-#define RERUN_DISABLE_MAYBE_UNINITIALIZED_PUSH
+#define RERUN_DISABLE_MAYBE_UNINITIALIZED_PUSH RR_PUSH_WARNINGS
 #endif
 
-#if defined(__GNUC__) && !defined(__clang__)
-#define RR_DISABLE_MAYBE_UNINITIALIZED_POP _Pragma("GCC diagnostic pop")
-#else
-#define RR_DISABLE_MAYBE_UNINITIALIZED_POP
-#endif
+#define RR_DISABLE_MAYBE_UNINITIALIZED_POP RR_POP_WARNINGS
 
 // Macro for marking code as unreachable.
 // Reaching the code after all is undefined behavior.
@@ -31,4 +41,14 @@
 #define RR_UNREACHABLE() \
     do {                 \
     } while (false)
+#endif
+
+// Disable deprecation warning
+#if defined(__GNUC__) || defined(__clang__)
+#define RR_DISABLE_DEPRECATION_WARNING \
+    _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#elif defined(_MSC_VER)
+#define RR_DISABLE_DEPRECATION_WARNING __pragma(warning(disable : 4996))
+#else
+#define RR_DISABLE_DEPRECATION_WARNING
 #endif

--- a/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 from attrs import define, field
+from typing_extensions import deprecated  # type: ignore[misc, unused-ignore]
 
 from .. import components, datatypes
 from .._baseclasses import Archetype
@@ -16,6 +17,9 @@ from ..error_utils import catch_and_log_exceptions
 __all__ = ["TimeSeriesScalar"]
 
 
+@deprecated(
+    """Use the `Scalar` + (optional) `SeriesLine`/`SeriesPoint` archetypes instead, logged on the same entity."""
+)
 @define(str=False, repr=False, init=False)
 class TimeSeriesScalar(Archetype):
     """

--- a/tests/python/chroma_downsample_image/requirements.txt
+++ b/tests/python/chroma_downsample_image/requirements.txt
@@ -1,3 +1,3 @@
 numpy
-opencv-python==
+opencv-python
 rerun-sdk

--- a/tests/python/chroma_downsample_image/requirements.txt
+++ b/tests/python/chroma_downsample_image/requirements.txt
@@ -1,3 +1,3 @@
 numpy
-opencv-python
+opencv-python==
 rerun-sdk


### PR DESCRIPTION
### What

Our codegen can now deprecate archetypes
* Fixes #4830
* Does *not* address #2366
   * builtin attribute is for fields. Unclear if it can have text? 
   * Fixes #2367

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5102/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5102/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5102/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5102)
- [Docs preview](https://rerun.io/preview/b773eee58d95201fc1f16a023183294d739cf2f9/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b773eee58d95201fc1f16a023183294d739cf2f9/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)