### PR TITLE
Check "pressing escape" in the new selection check

### DIFF
--- a/tests/python/release_checklist/check_hover_select_reset.py
+++ b/tests/python/release_checklist/check_hover_select_reset.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import rerun as rr
 
 README = """
-# Hover, Select, and Reset
+# Hover, Select, Deselect, and Reset
 
 This checks whether different UIs behave correctly with hover and selection.
 
@@ -30,6 +30,9 @@ For each of the views:
 For each of the views:
 * Zoom and/or pan the view
 * Double-click the background of the view and verify it resets the view to its default state.
+
+### Deselect
+Finally, try hitting escape and check whether that deselects whatever was currently selected.
 """
 
 


### PR DESCRIPTION
- #5096 got merged too fast :ship: 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5106/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5106/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5106/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5106)
- [Docs preview](https://rerun.io/preview/daa17c9ade5d0232a8f1c38056f40b44f5c71128/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/daa17c9ade5d0232a8f1c38056f40b44f5c71128/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)