### PR TITLE
Update egui_tiles to 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "egui_tiles"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55cf6a469bfbcb0013899ca8e73cd7a882d57abc1938f2df9845f388bc8edf1"
+checksum = "1bb10cef7bdbd1adb158aec9cca20f34779fd40ea126e02662ab558189f1c435"
 dependencies = [
  "ahash",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ egui = { version = "0.26.0", features = [
 egui_commonmark = { version = "0.12", default-features = false }
 egui_extras = { version = "0.26.0", features = ["http", "image", "puffin"] }
 egui_plot = "0.26.0"
-egui_tiles = "0.7.1"
+egui_tiles = "0.7.2"
 egui-wgpu = "0.26.0"
 emath = "0.26.0"
 


### PR DESCRIPTION
### What

- Fixes #5081

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5107/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5107/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5107/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5107)
- [Docs preview](https://rerun.io/preview/9760fd92aaa57d7a84e45dce9d6bce36178f6426/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/9760fd92aaa57d7a84e45dce9d6bce36178f6426/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)