### PR TITLE
Code examples rust: detect new examples automatically

### DIFF
--- a/docs/code-examples/build.rs
+++ b/docs/code-examples/build.rs
@@ -25,6 +25,7 @@ fn main() {
 
     let mut examples = Vec::new();
 
+    re_build_tools::rerun_if_changed(&all_path);
     for entry in fs::read_dir(&all_path).unwrap().flatten() {
         let path = entry.path();
         if let Some(extension) = path.extension() {


### PR DESCRIPTION
New code examples weren't picked up automatically, thus `build.rs` wouldn't run, etc.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5108/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5108/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5108/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5108)
- [Docs preview](https://rerun.io/preview/bd748eef7dd75e13585df04299ebcf5a63eed558/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bd748eef7dd75e13585df04299ebcf5a63eed558/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)