### PR TITLE
Remove illegitimate uses of `unwrap_debug_or_log_error`

### DIFF
--- a/crates/re_log/src/result_extensions.rs
+++ b/crates/re_log/src/result_extensions.rs
@@ -2,6 +2,9 @@ pub trait ResultExt<T, E> {
     /// Logs an error if the result is an error and returns the result.
     fn ok_or_log_error(self) -> Option<T>;
 
+    /// Logs an error if the result is an error and returns the result, but only once.
+    fn ok_or_log_error_once(self) -> Option<T>;
+
     /// Log a warning if there is an `Err`, but only log the exact same message once.
     fn warn_on_err_once(self, msg: impl std::fmt::Display) -> Option<T>;
 
@@ -21,6 +24,19 @@ where
                 let loc = std::panic::Location::caller();
                 let (file, line) = (loc.file(), loc.line());
                 log::error!("{file}:{line} {err}");
+                None
+            }
+        }
+    }
+
+    #[track_caller]
+    fn ok_or_log_error_once(self) -> Option<T> {
+        match self {
+            Ok(t) => Some(t),
+            Err(err) => {
+                let loc = std::panic::Location::caller();
+                let (file, line) = (loc.file(), loc.line());
+                crate::error_once!("{file}:{line} {err}");
                 None
             }
         }

--- a/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
+++ b/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
@@ -73,19 +73,19 @@ pub fn create_and_fill_uniform_buffer_batch<T: bytemuck::Pod + Send + Sync>(
         .cpu_write_gpu_read_belt
         .lock()
         .allocate::<T>(&ctx.device, &ctx.gpu_resources.buffers, num_buffers as _)
-        .unwrap_debug_or_log_error()
+        .ok_or_log_error()
     else {
         // This should only fail for zero sized T, which we assert statically on.
         return Vec::new();
     };
-    staging_buffer.extend(content).unwrap_debug_or_log_error();
+    staging_buffer.extend(content).ok_or_log_error();
     staging_buffer
         .copy_to_buffer(
             ctx.active_frame.before_view_builder_encoder.lock().get(),
             &buffer,
             0,
         )
-        .unwrap_debug_or_log_error();
+        .ok_or_log_error();
 
     (0..num_buffers)
         .map(|i| BindGroupEntry::Buffer {

--- a/crates/re_renderer/src/line_strip_builder.rs
+++ b/crates/re_renderer/src/line_strip_builder.rs
@@ -528,6 +528,6 @@ impl<'a> Drop for LineStripBuilder<'a> {
         self.builder
             .picking_instance_ids_buffer
             .fill_n(self.picking_instance_id, self.strip_range.len())
-            .unwrap_debug_or_log_error(); // May run out of space, but we should have already handled that earlier.
+            .ok_or_log_error(); // May run out of space, but we should have already handled that earlier.
     }
 }

--- a/crates/re_renderer/src/line_strip_builder.rs
+++ b/crates/re_renderer/src/line_strip_builder.rs
@@ -528,6 +528,6 @@ impl<'a> Drop for LineStripBuilder<'a> {
         self.builder
             .picking_instance_ids_buffer
             .fill_n(self.picking_instance_id, self.strip_range.len())
-            .ok_or_log_error(); // May run out of space, but we should have already handled that earlier.
+            .ok_or_log_error_once(); // May run out of space, but we should have already handled that earlier.
     }
 }

--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -218,13 +218,13 @@ impl<'a> PointCloudBatchBuilder<'a> {
             self.0
                 .color_buffer
                 .extend_from_slice(colors)
-                .unwrap_debug_or_log_error();
+                .ok_or_log_error();
 
             // Fill up with defaults. Doing this in a separate step is faster than chaining the iterator.
             self.0
                 .color_buffer
                 .fill_n(Color32::WHITE, num_points.saturating_sub(colors.len()))
-                .unwrap_debug_or_log_error();
+                .ok_or_log_error();
         }
         {
             re_tracing::profile_scope!("picking_ids");
@@ -232,7 +232,7 @@ impl<'a> PointCloudBatchBuilder<'a> {
             self.0
                 .picking_instance_ids_buffer
                 .extend_from_slice(picking_ids)
-                .unwrap_debug_or_log_error();
+                .ok_or_log_error();
 
             // Fill up with defaults. Doing this in a separate step is faster than chaining the iterator.
             self.0
@@ -241,7 +241,7 @@ impl<'a> PointCloudBatchBuilder<'a> {
                     PickingLayerInstanceId::default(),
                     num_points.saturating_sub(picking_ids.len()),
                 )
-                .unwrap_debug_or_log_error();
+                .ok_or_log_error();
         }
 
         self


### PR DESCRIPTION
Removed all illegitimate uses of `unwrap_debug_or_log_error`, i.e. any instance where we're just hitting a hard GPU limitation... which turned out to be all of them. :man_shrugging: 

- Fixes #5098

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5110/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5110/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5110/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5110)
- [Docs preview](https://rerun.io/preview/15e46385b84b0458469c978a703b66fe95ec4c36/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/15e46385b84b0458469c978a703b66fe95ec4c36/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)