### PR TITLE
Adding code examples for SeriesLine and SeriesPoint

### DIFF
--- a/crates/re_types/definitions/rerun/archetypes/series_line.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/series_line.fbs
@@ -17,7 +17,7 @@ namespace rerun.archetypes;
 /// \rs See [`Scalar`][crate::archetypes.Scalar]
 /// \cpp See `rerun::archetypes::Scalar`
 ///
-/// \example series_line_style title="Series Line Style" image="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/1200w.png"
+/// \example series_line_style title="Series Line" image="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/1200w.png"
 table SeriesLine (
     "attr.docs.unreleased"
 ) {

--- a/crates/re_types/definitions/rerun/archetypes/series_line.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/series_line.fbs
@@ -8,6 +8,16 @@ namespace rerun.archetypes;
 // ---
 
 /// Define the style properties for a line series in a chart.
+///
+/// This archetype only provides styling information and should be logged as timeless
+/// when possible. The underlying data needs to be logged to the same entity-path using
+/// the `Scalar` archetype.
+///
+/// \py See [`Scalar`][rerun.archetypes.Scalar]
+/// \rs See [`Scalar`][crate::archetypes.Scalar]
+/// \cpp See `rerun::archetypes::Scalar`
+///
+/// \example series_line_style title="Series Line Style" image="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/1200w.png"
 table SeriesLine (
     "attr.docs.unreleased"
 ) {

--- a/crates/re_types/definitions/rerun/archetypes/series_point.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/series_point.fbs
@@ -8,6 +8,16 @@ namespace rerun.archetypes;
 // ---
 
 /// Define the style properties for a point series in a chart.
+///
+/// This archetype only provides styling information and should be logged as timeless
+/// when possible. The underlying data needs to be logged to the same entity-path using
+/// the `Scalar` archetype.
+///
+/// \py See [`Scalar`][rerun.archetypes.Scalar]
+/// \rs See [`Scalar`][crate::archetypes.Scalar]
+/// \cpp See `rerun::archetypes::Scalar`
+///
+/// \example series_point_style title="Series Point" image="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/1200w.png"
 table SeriesPoint (
     "attr.docs.unreleased"
 ) {

--- a/crates/re_types/definitions/rerun/components/marker_shape.fbs
+++ b/crates/re_types/definitions/rerun/components/marker_shape.fbs
@@ -26,6 +26,8 @@ enum MarkerShape: byte {
 /// Shape of a marker.
 struct MarkerShape (
     "attr.docs.unreleased",
+    "attr.python.aliases": "int, str",
+    "attr.python.array_aliases": "int, str",
     "attr.rust.derive": "PartialEq, Eq, PartialOrd, Copy",
     "attr.rust.repr": "transparent"
 ) {

--- a/crates/re_types/src/archetypes/series_line.rs
+++ b/crates/re_types/src/archetypes/series_line.rs
@@ -22,6 +22,58 @@ use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Define the style properties for a line series in a chart.
+///
+/// This archetype only provides styling information and should be logged as timeless
+/// when possible. The underlying data needs to be logged to the same entity-path using
+/// the `Scalar` archetype.
+///
+/// See [`Scalar`][crate::archetypes.Scalar]
+///
+/// ## Example
+///
+/// ### Series Line Style
+/// ```ignore
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_series_line_style").spawn()?;
+///
+///     // Set up plot styling:
+///     // They are logged timeless as they don't change over time and apply to all timelines.
+///     // Log two lines series under a shared root so that they show in the same plot by default.
+///     rec.log_timeless(
+///         "trig/sin",
+///         &rerun::SeriesLine::new()
+///             .with_color([255, 0, 0])
+///             .with_name("sin(0.01t)")
+///             .with_width(2),
+///     )?;
+///     rec.log_timeless(
+///         "trig/cos",
+///         &rerun::SeriesLine::new()
+///             .with_color([0, 255, 0])
+///             .with_name("cos(0.01t)")
+///             .with_width(4),
+///     )?;
+///
+///     for t in 0..((std::f32::consts::TAU * 2.0 * 100.0) as i64) {
+///         rec.set_time_sequence("step", t);
+///
+///         // Log two time series under a shared root so that they show in the same plot by default.
+///         rec.log("trig/sin", &rerun::Scalar::new((t as f64 / 100.0).sin()))?;
+///         rec.log("trig/cos", &rerun::Scalar::new((t as f64 / 100.0).cos()))?;
+///     }
+///
+///     Ok(())
+/// }
+/// ```
+/// <center>
+/// <picture>
+///   <source media="(max-width: 480px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/480w.png">
+///   <source media="(max-width: 768px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/768w.png">
+///   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/1024w.png">
+///   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/1200w.png">
+///   <img src="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/full.png" width="640">
+/// </picture>
+/// </center>
 #[derive(Clone, Debug)]
 pub struct SeriesLine {
     /// Color for the corresponding series.

--- a/crates/re_types/src/archetypes/series_line.rs
+++ b/crates/re_types/src/archetypes/series_line.rs
@@ -31,7 +31,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// ## Example
 ///
-/// ### Series Line Style
+/// ### Series Line
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_series_line_style").spawn()?;
@@ -67,11 +67,11 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ```
 /// <center>
 /// <picture>
-///   <source media="(max-width: 480px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/480w.png">
-///   <source media="(max-width: 768px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/768w.png">
-///   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/1024w.png">
-///   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/1200w.png">
-///   <img src="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/full.png" width="640">
+///   <source media="(max-width: 480px)" srcset="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/480w.png">
+///   <source media="(max-width: 768px)" srcset="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/768w.png">
+///   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/1024w.png">
+///   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/1200w.png">
+///   <img src="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/full.png" width="640">
 /// </picture>
 /// </center>
 #[derive(Clone, Debug)]

--- a/crates/re_types/src/archetypes/series_line.rs
+++ b/crates/re_types/src/archetypes/series_line.rs
@@ -44,14 +44,14 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         &rerun::SeriesLine::new()
 ///             .with_color([255, 0, 0])
 ///             .with_name("sin(0.01t)")
-///             .with_width(2),
+///             .with_width(2.0),
 ///     )?;
 ///     rec.log_timeless(
 ///         "trig/cos",
 ///         &rerun::SeriesLine::new()
 ///             .with_color([0, 255, 0])
 ///             .with_name("cos(0.01t)")
-///             .with_width(4),
+///             .with_width(4.0),
 ///     )?;
 ///
 ///     for t in 0..((std::f32::consts::TAU * 2.0 * 100.0) as i64) {

--- a/crates/re_types/src/archetypes/series_point.rs
+++ b/crates/re_types/src/archetypes/series_point.rs
@@ -44,7 +44,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         &rerun::SeriesPoint::new()
 ///             .with_color([255, 0, 0])
 ///             .with_name("sin(0.01t)")
-///             .with_marker(1)
+///             .with_marker(rerun::components::MarkerShape::Circle)
 ///             .with_marker_size(4.0),
 ///     )?;
 ///     rec.log_timeless(
@@ -52,7 +52,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         &rerun::SeriesPoint::new()
 ///             .with_color([0, 255, 0])
 ///             .with_name("cos(0.01t)")
-///             .with_marker(4)
+///             .with_marker(rerun::components::MarkerShape::Cross)
 ///             .with_marker_size(2.0),
 ///     )?;
 ///

--- a/crates/re_types/src/archetypes/series_point.rs
+++ b/crates/re_types/src/archetypes/series_point.rs
@@ -38,7 +38,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     // Set up plot styling:
 ///     // They are logged timeless as they don't change over time and apply to all timelines.
-///     // Log two lines series under a shared root so that they show in the same plot by default.
+///     // Log two point series under a shared root so that they show in the same plot by default.
 ///     rec.log_timeless(
 ///         "trig/sin",
 ///         &rerun::SeriesPoint::new()

--- a/crates/re_types/src/archetypes/series_point.rs
+++ b/crates/re_types/src/archetypes/series_point.rs
@@ -28,6 +28,54 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// the `Scalar` archetype.
 ///
 /// See [`Scalar`][crate::archetypes.Scalar]
+///
+/// ## Example
+///
+/// ### Series Point
+/// ```ignore
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_series_line_style").spawn()?;
+///
+///     // Set up plot styling:
+///     // They are logged timeless as they don't change over time and apply to all timelines.
+///     // Log two lines series under a shared root so that they show in the same plot by default.
+///     rec.log_timeless(
+///         "trig/sin",
+///         &rerun::SeriesPoint::new()
+///             .with_color([255, 0, 0])
+///             .with_name("sin(0.01t)")
+///             .with_marker(1)
+///             .with_marker_size(4.0),
+///     )?;
+///     rec.log_timeless(
+///         "trig/cos",
+///         &rerun::SeriesPoint::new()
+///             .with_color([0, 255, 0])
+///             .with_name("cos(0.01t)")
+///             .with_marker(4)
+///             .with_marker_size(2.0),
+///     )?;
+///
+///     for t in 0..((std::f32::consts::TAU * 2.0 * 10.0) as i64) {
+///         rec.set_time_sequence("step", t);
+///
+///         // Log two time series under a shared root so that they show in the same plot by default.
+///         rec.log("trig/sin", &rerun::Scalar::new((t as f64 / 10.0).sin()))?;
+///         rec.log("trig/cos", &rerun::Scalar::new((t as f64 / 10.0).cos()))?;
+///     }
+///
+///     Ok(())
+/// }
+/// ```
+/// <center>
+/// <picture>
+///   <source media="(max-width: 480px)" srcset="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/480w.png">
+///   <source media="(max-width: 768px)" srcset="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/768w.png">
+///   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/1024w.png">
+///   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/1200w.png">
+///   <img src="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/full.png" width="640">
+/// </picture>
+/// </center>
 #[derive(Clone, Debug)]
 pub struct SeriesPoint {
     /// Color for the corresponding series.

--- a/crates/re_types/src/archetypes/series_point.rs
+++ b/crates/re_types/src/archetypes/series_point.rs
@@ -22,6 +22,12 @@ use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Define the style properties for a point series in a chart.
+///
+/// This archetype only provides styling information and should be logged as timeless
+/// when possible. The underlying data needs to be logged to the same entity-path using
+/// the `Scalar` archetype.
+///
+/// See [`Scalar`][crate::archetypes.Scalar]
 #[derive(Clone, Debug)]
 pub struct SeriesPoint {
     /// Color for the corresponding series.

--- a/crates/re_types/src/components/marker_shape_ext.rs
+++ b/crates/re_types/src/components/marker_shape_ext.rs
@@ -1,16 +1,18 @@
 use super::MarkerShape;
 
+// TODO(#3384): This should be generated
+#[allow(non_upper_case_globals)]
 impl MarkerShape {
-    pub const CIRCLE: u8 = 1;
-    pub const DIAMOND: u8 = 2;
-    pub const SQUARE: u8 = 3;
-    pub const CROSS: u8 = 4;
-    pub const PLUS: u8 = 5;
-    pub const UP: u8 = 6;
-    pub const DOWN: u8 = 7;
-    pub const LEFT: u8 = 8;
-    pub const RIGHT: u8 = 9;
-    pub const ASTERISK: u8 = 10;
+    pub const Circle: u8 = 1;
+    pub const Diamond: u8 = 2;
+    pub const Square: u8 = 3;
+    pub const Cross: u8 = 4;
+    pub const Plus: u8 = 5;
+    pub const Up: u8 = 6;
+    pub const Down: u8 = 7;
+    pub const Left: u8 = 8;
+    pub const Right: u8 = 9;
+    pub const Asterisk: u8 = 10;
 }
 
 #[cfg(feature = "egui_plot")]

--- a/crates/re_types/src/components/marker_shape_ext.rs
+++ b/crates/re_types/src/components/marker_shape_ext.rs
@@ -1,5 +1,18 @@
 use super::MarkerShape;
 
+impl MarkerShape {
+    pub const CIRCLE: u8 = 1;
+    pub const DIAMOND: u8 = 2;
+    pub const SQUARE: u8 = 3;
+    pub const CROSS: u8 = 4;
+    pub const PLUS: u8 = 5;
+    pub const UP: u8 = 6;
+    pub const DOWN: u8 = 7;
+    pub const LEFT: u8 = 8;
+    pub const RIGHT: u8 = 9;
+    pub const ASTERISK: u8 = 10;
+}
+
 #[cfg(feature = "egui_plot")]
 fn egui_to_u8(marker: egui_plot::MarkerShape) -> u8 {
     match marker {

--- a/docs/code-examples/all/series_line_style.cpp
+++ b/docs/code-examples/all/series_line_style.cpp
@@ -1,0 +1,32 @@
+// Log a scalar over time.
+
+#include <rerun.hpp>
+
+#include <cmath>
+
+constexpr float TAU = 6.28318530717958647692528676655900577f;
+
+int main() {
+    const auto rec = rerun::RecordingStream("rerun_example_series_line_styling");
+    rec.spawn().exit_on_failure();
+
+    // Set up plot styling:
+    // They are logged timeless as they don't change over time and apply to all timelines.
+    // Log two lines series under a shared root so that they show in the same plot by default.
+    rec.log_timeless(
+        "trig/sin",
+        rerun::SeriesLine().with_color({255, 0, 0}).with_name("sin(0.01t)").with_width(2)
+    );
+    rec.log_timeless(
+        "trig/cos",
+        rerun::SeriesLine().with_color({0, 255, 0}).with_name("cos(0.01t)").with_width(4)
+    );
+
+    // Log the data on a timeline called "step".
+    for (int t = 0; t < static_cast<int>(TAU * 2.0 * 100.0); ++t) {
+        rec.set_time_sequence("step", t);
+
+        rec.log("trig/sin", rerun::Scalar(sin(t / 100.0)));
+        rec.log("trig/cos", rerun::Scalar(cos(static_cast<float>(t) / 100.0f)));
+    }
+}

--- a/docs/code-examples/all/series_line_style.cpp
+++ b/docs/code-examples/all/series_line_style.cpp
@@ -26,7 +26,7 @@ int main() {
     for (int t = 0; t < static_cast<int>(TAU * 2.0 * 100.0); ++t) {
         rec.set_time_sequence("step", t);
 
-        rec.log("trig/sin", rerun::Scalar(sin(t / 100.0)));
-        rec.log("trig/cos", rerun::Scalar(cos(static_cast<float>(t) / 100.0f)));
+        rec.log("trig/sin", rerun::Scalar(sin(static_cast<double>(t) / 100.0)));
+        rec.log("trig/cos", rerun::Scalar(cos(static_cast<double>(t) / 100.0f)));
     }
 }

--- a/docs/code-examples/all/series_line_style.py
+++ b/docs/code-examples/all/series_line_style.py
@@ -1,0 +1,20 @@
+"""Log a scalar over time."""
+
+from math import cos, sin, tau
+
+import rerun as rr
+
+rr.init("rerun_example_series_line_styling", spawn=True)
+
+# Set up plot styling:
+# They are logged timeless as they don't change over time and apply to all timelines.
+# Log two lines series under a shared root so that they show in the same plot by default.
+rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)", width=2), timeless=True)
+rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)", width=4), timeless=True)
+
+# Log the data on a timeline called "step".
+for t in range(0, int(tau * 2 * 100.0)):
+    rr.set_time_sequence("step", t)
+
+    rr.log("trig/sin", rr.Scalar(sin(float(t) / 100.0)))
+    rr.log("trig/cos", rr.Scalar(cos(float(t) / 100.0)))

--- a/docs/code-examples/all/series_line_style.rs
+++ b/docs/code-examples/all/series_line_style.rs
@@ -1,0 +1,33 @@
+//! Log a scalar over time.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_series_line_style").spawn()?;
+
+    // Set up plot styling:
+    // They are logged timeless as they don't change over time and apply to all timelines.
+    // Log two lines series under a shared root so that they show in the same plot by default.
+    rec.log_timeless(
+        "trig/sin",
+        &rerun::SeriesLine::new()
+            .with_color([255, 0, 0])
+            .with_name("sin(0.01t)")
+            .with_width(2),
+    )?;
+    rec.log_timeless(
+        "trig/cos",
+        &rerun::SeriesLine::new()
+            .with_color([0, 255, 0])
+            .with_name("cos(0.01t)")
+            .with_width(4),
+    )?;
+
+    for t in 0..((std::f32::consts::TAU * 2.0 * 100.0) as i64) {
+        rec.set_time_sequence("step", t);
+
+        // Log two time series under a shared root so that they show in the same plot by default.
+        rec.log("trig/sin", &rerun::Scalar::new((t as f64 / 100.0).sin()))?;
+        rec.log("trig/cos", &rerun::Scalar::new((t as f64 / 100.0).cos()))?;
+    }
+
+    Ok(())
+}

--- a/docs/code-examples/all/series_point_style.cpp
+++ b/docs/code-examples/all/series_point_style.cpp
@@ -18,7 +18,7 @@ int main() {
         rerun::SeriesPoint()
             .with_color({255, 0, 0})
             .with_name("sin(0.01t)")
-            .with_marker(1)
+            .with_marker(rerun::components::MarkerShape::CIRCLE)
             .with_marker_size(4)
     );
     rec.log_timeless(
@@ -26,7 +26,7 @@ int main() {
         rerun::SeriesPoint()
             .with_color({0, 255, 0})
             .with_name("cos(0.01t)")
-            .with_marker(4)
+            .with_marker(rerun::components::MarkerShape::CROSS)
             .with_marker_size(2)
     );
 

--- a/docs/code-examples/all/series_point_style.cpp
+++ b/docs/code-examples/all/series_point_style.cpp
@@ -12,7 +12,7 @@ int main() {
 
     // Set up plot styling:
     // They are logged timeless as they don't change over time and apply to all timelines.
-    // Log two lines series under a shared root so that they show in the same plot by default.
+    // Log two point series under a shared root so that they show in the same plot by default.
     rec.log_timeless(
         "trig/sin",
         rerun::SeriesPoint()

--- a/docs/code-examples/all/series_point_style.cpp
+++ b/docs/code-examples/all/series_point_style.cpp
@@ -34,7 +34,7 @@ int main() {
     for (int t = 0; t < static_cast<int>(TAU * 2.0 * 10.0); ++t) {
         rec.set_time_sequence("step", t);
 
-        rec.log("trig/sin", rerun::Scalar(sin(t / 10.0)));
-        rec.log("trig/cos", rerun::Scalar(cos(static_cast<float>(t) / 10.0f)));
+        rec.log("trig/sin", rerun::Scalar(sin(static_cast<double>(t) / 10.0)));
+        rec.log("trig/cos", rerun::Scalar(cos(static_cast<double>(t) / 10.0f)));
     }
 }

--- a/docs/code-examples/all/series_point_style.cpp
+++ b/docs/code-examples/all/series_point_style.cpp
@@ -18,7 +18,7 @@ int main() {
         rerun::SeriesPoint()
             .with_color({255, 0, 0})
             .with_name("sin(0.01t)")
-            .with_marker(rerun::components::MarkerShape::CIRCLE)
+            .with_marker(rerun::components::MarkerShape::Circle)
             .with_marker_size(4)
     );
     rec.log_timeless(
@@ -26,7 +26,7 @@ int main() {
         rerun::SeriesPoint()
             .with_color({0, 255, 0})
             .with_name("cos(0.01t)")
-            .with_marker(rerun::components::MarkerShape::CROSS)
+            .with_marker(rerun::components::MarkerShape::Cross)
             .with_marker_size(2)
     );
 

--- a/docs/code-examples/all/series_point_style.cpp
+++ b/docs/code-examples/all/series_point_style.cpp
@@ -1,0 +1,40 @@
+// Log a scalar over time.
+
+#include <rerun.hpp>
+
+#include <cmath>
+
+constexpr float TAU = 6.28318530717958647692528676655900577f;
+
+int main() {
+    const auto rec = rerun::RecordingStream("rerun_example_series_line_styling");
+    rec.spawn().exit_on_failure();
+
+    // Set up plot styling:
+    // They are logged timeless as they don't change over time and apply to all timelines.
+    // Log two lines series under a shared root so that they show in the same plot by default.
+    rec.log_timeless(
+        "trig/sin",
+        rerun::SeriesPoint()
+            .with_color({255, 0, 0})
+            .with_name("sin(0.01t)")
+            .with_marker(1)
+            .with_marker_size(4)
+    );
+    rec.log_timeless(
+        "trig/cos",
+        rerun::SeriesPoint()
+            .with_color({0, 255, 0})
+            .with_name("cos(0.01t)")
+            .with_marker(4)
+            .with_marker_size(2)
+    );
+
+    // Log the data on a timeline called "step".
+    for (int t = 0; t < static_cast<int>(TAU * 2.0 * 10.0); ++t) {
+        rec.set_time_sequence("step", t);
+
+        rec.log("trig/sin", rerun::Scalar(sin(t / 10.0)));
+        rec.log("trig/cos", rerun::Scalar(cos(static_cast<float>(t) / 10.0f)));
+    }
+}

--- a/docs/code-examples/all/series_point_style.py
+++ b/docs/code-examples/all/series_point_style.py
@@ -1,0 +1,38 @@
+"""Log a scalar over time."""
+
+from math import cos, sin, tau
+
+import rerun as rr
+
+rr.init("rerun_example_series_point_styling", spawn=True)
+
+# Set up plot styling:
+# They are logged timeless as they don't change over time and apply to all timelines.
+# Log two lines series under a shared root so that they show in the same plot by default.
+rr.log(
+    "trig/sin",
+    rr.SeriesPoint(
+        color=[255, 0, 0],
+        name="sin(0.01t)",
+        marker="circle",
+        marker_size=4,
+    ),
+    timeless=True,
+)
+rr.log(
+    "trig/cos",
+    rr.SeriesPoint(
+        color=[0, 255, 0],
+        name="cos(0.01t)",
+        marker="cross",
+        marker_size=2,
+    ),
+    timeless=True,
+)
+
+# Log the data on a timeline called "step".
+for t in range(0, int(tau * 2 * 10.0)):
+    rr.set_time_sequence("step", t)
+
+    rr.log("trig/sin", rr.Scalar(sin(float(t) / 10.0)))
+    rr.log("trig/cos", rr.Scalar(cos(float(t) / 10.0)))

--- a/docs/code-examples/all/series_point_style.py
+++ b/docs/code-examples/all/series_point_style.py
@@ -8,7 +8,7 @@ rr.init("rerun_example_series_point_styling", spawn=True)
 
 # Set up plot styling:
 # They are logged timeless as they don't change over time and apply to all timelines.
-# Log two lines series under a shared root so that they show in the same plot by default.
+# Log two point series under a shared root so that they show in the same plot by default.
 rr.log(
     "trig/sin",
     rr.SeriesPoint(

--- a/docs/code-examples/all/series_point_style.rs
+++ b/docs/code-examples/all/series_point_style.rs
@@ -8,25 +8,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log two lines series under a shared root so that they show in the same plot by default.
     rec.log_timeless(
         "trig/sin",
-        &rerun::SeriesLine::new()
+        &rerun::SeriesPoint::new()
             .with_color([255, 0, 0])
             .with_name("sin(0.01t)")
-            .with_width(2.0),
+            .with_marker(1)
+            .with_marker_size(4.0),
     )?;
     rec.log_timeless(
         "trig/cos",
-        &rerun::SeriesLine::new()
+        &rerun::SeriesPoint::new()
             .with_color([0, 255, 0])
             .with_name("cos(0.01t)")
-            .with_width(4.0),
+            .with_marker(4)
+            .with_marker_size(2.0),
     )?;
 
-    for t in 0..((std::f32::consts::TAU * 2.0 * 100.0) as i64) {
+    for t in 0..((std::f32::consts::TAU * 2.0 * 10.0) as i64) {
         rec.set_time_sequence("step", t);
 
         // Log two time series under a shared root so that they show in the same plot by default.
-        rec.log("trig/sin", &rerun::Scalar::new((t as f64 / 100.0).sin()))?;
-        rec.log("trig/cos", &rerun::Scalar::new((t as f64 / 100.0).cos()))?;
+        rec.log("trig/sin", &rerun::Scalar::new((t as f64 / 10.0).sin()))?;
+        rec.log("trig/cos", &rerun::Scalar::new((t as f64 / 10.0).cos()))?;
     }
 
     Ok(())

--- a/docs/code-examples/all/series_point_style.rs
+++ b/docs/code-examples/all/series_point_style.rs
@@ -5,7 +5,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Set up plot styling:
     // They are logged timeless as they don't change over time and apply to all timelines.
-    // Log two lines series under a shared root so that they show in the same plot by default.
+    // Log two point series under a shared root so that they show in the same plot by default.
     rec.log_timeless(
         "trig/sin",
         &rerun::SeriesPoint::new()

--- a/docs/code-examples/all/series_point_style.rs
+++ b/docs/code-examples/all/series_point_style.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &rerun::SeriesPoint::new()
             .with_color([255, 0, 0])
             .with_name("sin(0.01t)")
-            .with_marker(rerun::components::MarkerShape::CIRCLE)
+            .with_marker(rerun::components::MarkerShape::Circle)
             .with_marker_size(4.0),
     )?;
     rec.log_timeless(
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &rerun::SeriesPoint::new()
             .with_color([0, 255, 0])
             .with_name("cos(0.01t)")
-            .with_marker(rerun::components::MarkerShape::CROSS)
+            .with_marker(rerun::components::MarkerShape::Cross)
             .with_marker_size(2.0),
     )?;
 

--- a/docs/code-examples/all/series_point_style.rs
+++ b/docs/code-examples/all/series_point_style.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &rerun::SeriesPoint::new()
             .with_color([255, 0, 0])
             .with_name("sin(0.01t)")
-            .with_marker(1)
+            .with_marker(rerun::components::MarkerShape::CIRCLE)
             .with_marker_size(4.0),
     )?;
     rec.log_timeless(
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &rerun::SeriesPoint::new()
             .with_color([0, 255, 0])
             .with_name("cos(0.01t)")
-            .with_marker(4)
+            .with_marker(rerun::components::MarkerShape::CROSS)
             .with_marker_size(2.0),
     )?;
 

--- a/docs/code-examples/compare_code_example_output.py
+++ b/docs/code-examples/compare_code_example_output.py
@@ -48,6 +48,8 @@ opt_out_compare = {
     "scalar_multiple_plots": ["cpp"], # trigonometric functions have slightly different outcomes
     "tensor_simple": ["cpp", "py", "rust"], # TODO(#3206): examples use different RNGs
     "text_log_integration": ["cpp", "py", "rust"], # The entity path will differ because the Rust code is part of a library
+    "series_point_style": ["cpp", "py", "rust"], # TODO(#5116): trigonometric functions have slightly different outcomes
+    "series_line_style": ["cpp", "py", "rust"], # TODO(#5116):trigonometric functions have slightly different outcomes
 }
 
 extra_args = {

--- a/docs/content/reference/types/archetypes/series_line.md
+++ b/docs/content/reference/types/archetypes/series_line.md
@@ -19,17 +19,17 @@ the `Scalar` archetype.
 
 ## Example
 
-### Series Line Style
+### Series Line
 
 code-example: series_line_style
 
 <center>
 <picture>
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/1200w.png">
-  <img src="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/full.png" width="640">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/1200w.png">
+  <img src="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/full.png" width="640">
 </picture>
 </center>
 

--- a/docs/content/reference/types/archetypes/series_line.md
+++ b/docs/content/reference/types/archetypes/series_line.md
@@ -4,6 +4,10 @@ title: "SeriesLine"
 
 Define the style properties for a line series in a chart.
 
+This archetype only provides styling information and should be logged as timeless
+when possible. The underlying data needs to be logged to the same entity-path using
+the `Scalar` archetype.
+
 ## Components
 
 **Optional**: [`Color`](../components/color.md), [`StrokeWidth`](../components/stroke_width.md), [`Name`](../components/name.md)
@@ -12,4 +16,20 @@ Define the style properties for a line series in a chart.
  * 🌊 [C++ API docs for `SeriesLine`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1SeriesLine.html?speculative-link)
  * 🐍 [Python API docs for `SeriesLine`](https://ref.rerun.io/docs/python/stable/common/archetypes?speculative-link#rerun.archetypes.SeriesLine)
  * 🦀 [Rust API docs for `SeriesLine`](https://docs.rs/rerun/latest/rerun/archetypes/struct.SeriesLine.html?speculative-link)
+
+## Example
+
+### Series Line Style
+
+code-example: series_line_style
+
+<center>
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/1200w.png">
+  <img src="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/full.png" width="640">
+</picture>
+</center>
 

--- a/docs/content/reference/types/archetypes/series_point.md
+++ b/docs/content/reference/types/archetypes/series_point.md
@@ -4,6 +4,10 @@ title: "SeriesPoint"
 
 Define the style properties for a point series in a chart.
 
+This archetype only provides styling information and should be logged as timeless
+when possible. The underlying data needs to be logged to the same entity-path using
+the `Scalar` archetype.
+
 ## Components
 
 **Optional**: [`Color`](../components/color.md), [`MarkerShape`](../components/marker_shape.md), [`Name`](../components/name.md), [`MarkerSize`](../components/marker_size.md)
@@ -12,4 +16,20 @@ Define the style properties for a point series in a chart.
  * 🌊 [C++ API docs for `SeriesPoint`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1SeriesPoint.html?speculative-link)
  * 🐍 [Python API docs for `SeriesPoint`](https://ref.rerun.io/docs/python/stable/common/archetypes?speculative-link#rerun.archetypes.SeriesPoint)
  * 🦀 [Rust API docs for `SeriesPoint`](https://docs.rs/rerun/latest/rerun/archetypes/struct.SeriesPoint.html?speculative-link)
+
+## Example
+
+### Series Point
+
+code-example: series_point_style
+
+<center>
+<picture>
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/1200w.png">
+  <img src="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/full.png" width="640">
+</picture>
+</center>
 

--- a/rerun_cpp/src/rerun/archetypes/series_line.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_line.hpp
@@ -19,6 +19,50 @@
 
 namespace rerun::archetypes {
     /// **Archetype**: Define the style properties for a line series in a chart.
+    ///
+    /// This archetype only provides styling information and should be logged as timeless
+    /// when possible. The underlying data needs to be logged to the same entity-path using
+    /// the `Scalar` archetype.
+    ///
+    /// See `rerun::archetypes::Scalar`
+    ///
+    /// ## Example
+    ///
+    /// ### Series Line Style
+    /// ![image](https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/full.png)
+    ///
+    /// ```cpp
+    /// #include <rerun.hpp>
+    ///
+    /// #include <cmath>
+    ///
+    /// constexpr float TAU = 6.28318530717958647692528676655900577f;
+    ///
+    /// int main() {
+    ///     const auto rec = rerun::RecordingStream("rerun_example_series_line_styling");
+    ///     rec.spawn().exit_on_failure();
+    ///
+    ///     // Set up plot styling:
+    ///     // They are logged timeless as they don't change over time and apply to all timelines.
+    ///     // Log two lines series under a shared root so that they show in the same plot by default.
+    ///     rec.log_timeless(
+    ///         "trig/sin",
+    ///         rerun::SeriesLine().with_color({255, 0, 0}).with_name("sin(0.01t)").with_width(2)
+    ///     );
+    ///     rec.log_timeless(
+    ///         "trig/cos",
+    ///         rerun::SeriesLine().with_color({0, 255, 0}).with_name("cos(0.01t)").with_width(4)
+    ///     );
+    ///
+    ///     // Log the data on a timeline called "step".
+    ///     for (int t = 0; t <static_cast<int>(TAU * 2.0 * 100.0); ++t) {
+    ///         rec.set_time_sequence("step", t);
+    ///
+    ///         rec.log("trig/sin", rerun::Scalar(sin(t / 100.0)));
+    ///         rec.log("trig/cos", rerun::Scalar(cos(static_cast<float>(t) / 100.0f)));
+    ///     }
+    /// }
+    /// ```
     struct SeriesLine {
         /// Color for the corresponding series.
         std::optional<rerun::components::Color> color;

--- a/rerun_cpp/src/rerun/archetypes/series_line.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_line.hpp
@@ -58,8 +58,8 @@ namespace rerun::archetypes {
     ///     for (int t = 0; t <static_cast<int>(TAU * 2.0 * 100.0); ++t) {
     ///         rec.set_time_sequence("step", t);
     ///
-    ///         rec.log("trig/sin", rerun::Scalar(sin(t / 100.0)));
-    ///         rec.log("trig/cos", rerun::Scalar(cos(static_cast<float>(t) / 100.0f)));
+    ///         rec.log("trig/sin", rerun::Scalar(sin(static_cast<double>(t) / 100.0)));
+    ///         rec.log("trig/cos", rerun::Scalar(cos(static_cast<double>(t) / 100.0f)));
     ///     }
     /// }
     /// ```

--- a/rerun_cpp/src/rerun/archetypes/series_line.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_line.hpp
@@ -28,8 +28,8 @@ namespace rerun::archetypes {
     ///
     /// ## Example
     ///
-    /// ### Series Line Style
-    /// ![image](https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/full.png)
+    /// ### Series Line
+    /// ![image](https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/full.png)
     ///
     /// ```cpp
     /// #include <rerun.hpp>

--- a/rerun_cpp/src/rerun/archetypes/series_point.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_point.hpp
@@ -67,8 +67,8 @@ namespace rerun::archetypes {
     ///     for (int t = 0; t <static_cast<int>(TAU * 2.0 * 10.0); ++t) {
     ///         rec.set_time_sequence("step", t);
     ///
-    ///         rec.log("trig/sin", rerun::Scalar(sin(t / 10.0)));
-    ///         rec.log("trig/cos", rerun::Scalar(cos(static_cast<float>(t) / 10.0f)));
+    ///         rec.log("trig/sin", rerun::Scalar(sin(static_cast<double>(t) / 10.0)));
+    ///         rec.log("trig/cos", rerun::Scalar(cos(static_cast<double>(t) / 10.0f)));
     ///     }
     /// }
     /// ```

--- a/rerun_cpp/src/rerun/archetypes/series_point.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_point.hpp
@@ -45,7 +45,7 @@ namespace rerun::archetypes {
     ///
     ///     // Set up plot styling:
     ///     // They are logged timeless as they don't change over time and apply to all timelines.
-    ///     // Log two lines series under a shared root so that they show in the same plot by default.
+    ///     // Log two point series under a shared root so that they show in the same plot by default.
     ///     rec.log_timeless(
     ///         "trig/sin",
     ///         rerun::SeriesPoint()

--- a/rerun_cpp/src/rerun/archetypes/series_point.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_point.hpp
@@ -26,6 +26,52 @@ namespace rerun::archetypes {
     /// the `Scalar` archetype.
     ///
     /// See `rerun::archetypes::Scalar`
+    ///
+    /// ## Example
+    ///
+    /// ### Series Point
+    /// ![image](https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/full.png)
+    ///
+    /// ```cpp
+    /// #include <rerun.hpp>
+    ///
+    /// #include <cmath>
+    ///
+    /// constexpr float TAU = 6.28318530717958647692528676655900577f;
+    ///
+    /// int main() {
+    ///     const auto rec = rerun::RecordingStream("rerun_example_series_line_styling");
+    ///     rec.spawn().exit_on_failure();
+    ///
+    ///     // Set up plot styling:
+    ///     // They are logged timeless as they don't change over time and apply to all timelines.
+    ///     // Log two lines series under a shared root so that they show in the same plot by default.
+    ///     rec.log_timeless(
+    ///         "trig/sin",
+    ///         rerun::SeriesPoint()
+    ///             .with_color({255, 0, 0})
+    ///             .with_name("sin(0.01t)")
+    ///             .with_marker(1)
+    ///             .with_marker_size(4)
+    ///     );
+    ///     rec.log_timeless(
+    ///         "trig/cos",
+    ///         rerun::SeriesPoint()
+    ///             .with_color({0, 255, 0})
+    ///             .with_name("cos(0.01t)")
+    ///             .with_marker(4)
+    ///             .with_marker_size(2)
+    ///     );
+    ///
+    ///     // Log the data on a timeline called "step".
+    ///     for (int t = 0; t <static_cast<int>(TAU * 2.0 * 10.0); ++t) {
+    ///         rec.set_time_sequence("step", t);
+    ///
+    ///         rec.log("trig/sin", rerun::Scalar(sin(t / 10.0)));
+    ///         rec.log("trig/cos", rerun::Scalar(cos(static_cast<float>(t) / 10.0f)));
+    ///     }
+    /// }
+    /// ```
     struct SeriesPoint {
         /// Color for the corresponding series.
         std::optional<rerun::components::Color> color;

--- a/rerun_cpp/src/rerun/archetypes/series_point.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_point.hpp
@@ -20,6 +20,12 @@
 
 namespace rerun::archetypes {
     /// **Archetype**: Define the style properties for a point series in a chart.
+    ///
+    /// This archetype only provides styling information and should be logged as timeless
+    /// when possible. The underlying data needs to be logged to the same entity-path using
+    /// the `Scalar` archetype.
+    ///
+    /// See `rerun::archetypes::Scalar`
     struct SeriesPoint {
         /// Color for the corresponding series.
         std::optional<rerun::components::Color> color;

--- a/rerun_cpp/src/rerun/archetypes/series_point.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_point.hpp
@@ -51,7 +51,7 @@ namespace rerun::archetypes {
     ///         rerun::SeriesPoint()
     ///             .with_color({255, 0, 0})
     ///             .with_name("sin(0.01t)")
-    ///             .with_marker(1)
+    ///             .with_marker(rerun::components::MarkerShape::Circle)
     ///             .with_marker_size(4)
     ///     );
     ///     rec.log_timeless(
@@ -59,7 +59,7 @@ namespace rerun::archetypes {
     ///         rerun::SeriesPoint()
     ///             .with_color({0, 255, 0})
     ///             .with_name("cos(0.01t)")
-    ///             .with_marker(4)
+    ///             .with_marker(rerun::components::MarkerShape::Cross)
     ///             .with_marker_size(2)
     ///     );
     ///

--- a/rerun_cpp/src/rerun/components/marker_shape.hpp
+++ b/rerun_cpp/src/rerun/components/marker_shape.hpp
@@ -27,16 +27,16 @@ namespace rerun::components {
       public:
         // Extensions to generated type defined in 'marker_shape_ext.cpp'
 
-        static const rerun::components::MarkerShape CIRCLE;
-        static const rerun::components::MarkerShape DIAMOND;
-        static const rerun::components::MarkerShape SQUARE;
-        static const rerun::components::MarkerShape CROSS;
-        static const rerun::components::MarkerShape PLUS;
-        static const rerun::components::MarkerShape UP;
-        static const rerun::components::MarkerShape DOWN;
-        static const rerun::components::MarkerShape LEFT;
-        static const rerun::components::MarkerShape RIGHT;
-        static const rerun::components::MarkerShape ASTERISK;
+        static const rerun::components::MarkerShape Circle;
+        static const rerun::components::MarkerShape Diamond;
+        static const rerun::components::MarkerShape Square;
+        static const rerun::components::MarkerShape Cross;
+        static const rerun::components::MarkerShape Plus;
+        static const rerun::components::MarkerShape Up;
+        static const rerun::components::MarkerShape Down;
+        static const rerun::components::MarkerShape Left;
+        static const rerun::components::MarkerShape Right;
+        static const rerun::components::MarkerShape Asterisk;
 
       public:
         MarkerShape() = default;

--- a/rerun_cpp/src/rerun/components/marker_shape.hpp
+++ b/rerun_cpp/src/rerun/components/marker_shape.hpp
@@ -25,6 +25,20 @@ namespace rerun::components {
         uint8_t shape;
 
       public:
+        // Extensions to generated type defined in 'marker_shape_ext.cpp'
+
+        static const rerun::components::MarkerShape CIRCLE;
+        static const rerun::components::MarkerShape DIAMOND;
+        static const rerun::components::MarkerShape SQUARE;
+        static const rerun::components::MarkerShape CROSS;
+        static const rerun::components::MarkerShape PLUS;
+        static const rerun::components::MarkerShape UP;
+        static const rerun::components::MarkerShape DOWN;
+        static const rerun::components::MarkerShape LEFT;
+        static const rerun::components::MarkerShape RIGHT;
+        static const rerun::components::MarkerShape ASTERISK;
+
+      public:
         MarkerShape() = default;
 
         MarkerShape(uint8_t shape_) : shape(shape_) {}

--- a/rerun_cpp/src/rerun/components/marker_shape_ext.cpp
+++ b/rerun_cpp/src/rerun/components/marker_shape_ext.cpp
@@ -1,0 +1,42 @@
+#include "marker_shape.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+
+#ifdef EDIT_EXTENSION
+        struct MarkerShapeExt {
+            uint8_t shape;
+#define MarkerShape MarkerShapeExt
+
+            // <CODEGEN_COPY_TO_HEADER>
+
+            static const rerun::components::MarkerShape CIRCLE;
+            static const rerun::components::MarkerShape DIAMOND;
+            static const rerun::components::MarkerShape SQUARE;
+            static const rerun::components::MarkerShape CROSS;
+            static const rerun::components::MarkerShape PLUS;
+            static const rerun::components::MarkerShape UP;
+            static const rerun::components::MarkerShape DOWN;
+            static const rerun::components::MarkerShape LEFT;
+            static const rerun::components::MarkerShape RIGHT;
+            static const rerun::components::MarkerShape ASTERISK;
+
+            // </CODEGEN_COPY_TO_HEADER>
+        };
+#endif
+        const MarkerShape MarkerShape::CIRCLE = MarkerShape(1);
+        const MarkerShape MarkerShape::DIAMOND = MarkerShape(2);
+        const MarkerShape MarkerShape::SQUARE = MarkerShape(3);
+        const MarkerShape MarkerShape::CROSS = MarkerShape(4);
+        const MarkerShape MarkerShape::PLUS = MarkerShape(5);
+        const MarkerShape MarkerShape::UP = MarkerShape(6);
+        const MarkerShape MarkerShape::DOWN = MarkerShape(7);
+        const MarkerShape MarkerShape::LEFT = MarkerShape(8);
+        const MarkerShape MarkerShape::RIGHT = MarkerShape(9);
+        const MarkerShape MarkerShape::ASTERISK = MarkerShape(10);
+
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/components/marker_shape_ext.cpp
+++ b/rerun_cpp/src/rerun/components/marker_shape_ext.cpp
@@ -13,30 +13,31 @@ namespace rerun {
 
             // <CODEGEN_COPY_TO_HEADER>
 
-            static const rerun::components::MarkerShape CIRCLE;
-            static const rerun::components::MarkerShape DIAMOND;
-            static const rerun::components::MarkerShape SQUARE;
-            static const rerun::components::MarkerShape CROSS;
-            static const rerun::components::MarkerShape PLUS;
-            static const rerun::components::MarkerShape UP;
-            static const rerun::components::MarkerShape DOWN;
-            static const rerun::components::MarkerShape LEFT;
-            static const rerun::components::MarkerShape RIGHT;
-            static const rerun::components::MarkerShape ASTERISK;
+            static const rerun::components::MarkerShape Circle;
+            static const rerun::components::MarkerShape Diamond;
+            static const rerun::components::MarkerShape Square;
+            static const rerun::components::MarkerShape Cross;
+            static const rerun::components::MarkerShape Plus;
+            static const rerun::components::MarkerShape Up;
+            static const rerun::components::MarkerShape Down;
+            static const rerun::components::MarkerShape Left;
+            static const rerun::components::MarkerShape Right;
+            static const rerun::components::MarkerShape Asterisk;
 
             // </CODEGEN_COPY_TO_HEADER>
         };
 #endif
-        const MarkerShape MarkerShape::CIRCLE = MarkerShape(1);
-        const MarkerShape MarkerShape::DIAMOND = MarkerShape(2);
-        const MarkerShape MarkerShape::SQUARE = MarkerShape(3);
-        const MarkerShape MarkerShape::CROSS = MarkerShape(4);
-        const MarkerShape MarkerShape::PLUS = MarkerShape(5);
-        const MarkerShape MarkerShape::UP = MarkerShape(6);
-        const MarkerShape MarkerShape::DOWN = MarkerShape(7);
-        const MarkerShape MarkerShape::LEFT = MarkerShape(8);
-        const MarkerShape MarkerShape::RIGHT = MarkerShape(9);
-        const MarkerShape MarkerShape::ASTERISK = MarkerShape(10);
+        // TODO(#3384): This should be generated
+        const MarkerShape MarkerShape::Circle = MarkerShape(1);
+        const MarkerShape MarkerShape::Diamond = MarkerShape(2);
+        const MarkerShape MarkerShape::Square = MarkerShape(3);
+        const MarkerShape MarkerShape::Cross = MarkerShape(4);
+        const MarkerShape MarkerShape::Plus = MarkerShape(5);
+        const MarkerShape MarkerShape::Up = MarkerShape(6);
+        const MarkerShape MarkerShape::Down = MarkerShape(7);
+        const MarkerShape MarkerShape::Left = MarkerShape(8);
+        const MarkerShape MarkerShape::Right = MarkerShape(9);
+        const MarkerShape MarkerShape::Asterisk = MarkerShape(10);
 
     } // namespace components
 } // namespace rerun

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
@@ -18,7 +18,48 @@ __all__ = ["SeriesLine"]
 
 @define(str=False, repr=False, init=False)
 class SeriesLine(Archetype):
-    """**Archetype**: Define the style properties for a line series in a chart."""
+    """
+    **Archetype**: Define the style properties for a line series in a chart.
+
+    This archetype only provides styling information and should be logged as timeless
+    when possible. The underlying data needs to be logged to the same entity-path using
+    the `Scalar` archetype.
+
+    See [`Scalar`][rerun.archetypes.Scalar]
+
+    Example
+    -------
+    ### Series Line Style:
+    ```python
+    from math import cos, sin, tau
+
+    import rerun as rr
+
+    rr.init("rerun_example_series_line_styling", spawn=True)
+
+    # Set up plot styling:
+    # They are logged timeless as they don't change over time and apply to all timelines.
+    # Log two lines series under a shared root so that they show in the same plot by default.
+    rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)", width=2), timeless=True)
+    rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)", width=4), timeless=True)
+
+    # Log the data on a timeline called "step".
+    for t in range(0, int(tau * 2 * 100.0)):
+        rr.set_time_sequence("step", t)
+
+        rr.log("trig/sin", rr.Scalar(sin(float(t) / 100.0)))
+        rr.log("trig/cos", rr.Scalar(cos(float(t) / 100.0)))
+    ```
+    <center>
+    <picture>
+      <source media="(max-width: 480px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/480w.png">
+      <source media="(max-width: 768px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/768w.png">
+      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/1024w.png">
+      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/1200w.png">
+      <img src="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/full.png" width="640">
+    </picture>
+    </center>
+    """
 
     def __init__(
         self: Any,

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
@@ -29,7 +29,7 @@ class SeriesLine(Archetype):
 
     Example
     -------
-    ### Series Line Style:
+    ### Series Line:
     ```python
     from math import cos, sin, tau
 
@@ -52,11 +52,11 @@ class SeriesLine(Archetype):
     ```
     <center>
     <picture>
-      <source media="(max-width: 480px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/480w.png">
-      <source media="(max-width: 768px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/768w.png">
-      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/1024w.png">
-      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/1200w.png">
-      <img src="https://static.rerun.io/series_line_style/3b8ab5b4ab4a5096559ab0c64d6501469ae66738/full.png" width="640">
+      <source media="(max-width: 480px)" srcset="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/480w.png">
+      <source media="(max-width: 768px)" srcset="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/768w.png">
+      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/1024w.png">
+      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/1200w.png">
+      <img src="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/full.png" width="640">
     </picture>
     </center>
     """

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
@@ -39,7 +39,7 @@ class SeriesPoint(Archetype):
 
     # Set up plot styling:
     # They are logged timeless as they don't change over time and apply to all timelines.
-    # Log two lines series under a shared root so that they show in the same plot by default.
+    # Log two point series under a shared root so that they show in the same plot by default.
     rr.log(
         "trig/sin",
         rr.SeriesPoint(

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
@@ -18,7 +18,66 @@ __all__ = ["SeriesPoint"]
 
 @define(str=False, repr=False, init=False)
 class SeriesPoint(Archetype):
-    """**Archetype**: Define the style properties for a point series in a chart."""
+    """
+    **Archetype**: Define the style properties for a point series in a chart.
+
+    This archetype only provides styling information and should be logged as timeless
+    when possible. The underlying data needs to be logged to the same entity-path using
+    the `Scalar` archetype.
+
+    See [`Scalar`][rerun.archetypes.Scalar]
+
+    Example
+    -------
+    ### Series Point:
+    ```python
+    from math import cos, sin, tau
+
+    import rerun as rr
+
+    rr.init("rerun_example_series_point_styling", spawn=True)
+
+    # Set up plot styling:
+    # They are logged timeless as they don't change over time and apply to all timelines.
+    # Log two lines series under a shared root so that they show in the same plot by default.
+    rr.log(
+        "trig/sin",
+        rr.SeriesPoint(
+            color=[255, 0, 0],
+            name="sin(0.01t)",
+            marker="circle",
+            marker_size=4,
+        ),
+        timeless=True,
+    )
+    rr.log(
+        "trig/cos",
+        rr.SeriesPoint(
+            color=[0, 255, 0],
+            name="cos(0.01t)",
+            marker="cross",
+            marker_size=2,
+        ),
+        timeless=True,
+    )
+
+    # Log the data on a timeline called "step".
+    for t in range(0, int(tau * 2 * 10.0)):
+        rr.set_time_sequence("step", t)
+
+        rr.log("trig/sin", rr.Scalar(sin(float(t) / 10.0)))
+        rr.log("trig/cos", rr.Scalar(cos(float(t) / 10.0)))
+    ```
+    <center>
+    <picture>
+      <source media="(max-width: 480px)" srcset="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/480w.png">
+      <source media="(max-width: 768px)" srcset="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/768w.png">
+      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/1024w.png">
+      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/1200w.png">
+      <img src="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/full.png" width="640">
+    </picture>
+    </center>
+    """
 
     def __init__(
         self: Any,

--- a/rerun_py/rerun_sdk/rerun/components/marker_shape_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/marker_shape_ext.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import pyarrow as pa
+
+if TYPE_CHECKING:
+    from . import MarkerShape, MarkerShapeArrayLike, MarkerShapeLike
+
+
+class MarkerShapeExt:
+    """Extension for [MarkerShape][rerun.components.MarkerShape]."""
+
+    class Shape(Enum):
+        Circle = 1
+        Diamond = 2
+        Square = 3
+        Cross = 4
+        Plus = 5
+        Up = 6
+        Down = 7
+        Left = 8
+        Right = 9
+        Asterisk = 10
+
+    Circle: MarkerShape = None  # type: ignore[assignment]
+    Diamond: MarkerShape = None  # type: ignore[assignment]
+    Square: MarkerShape = None  # type: ignore[assignment]
+    Cross: MarkerShape = None  # type: ignore[assignment]
+    Plus: MarkerShape = None  # type: ignore[assignment]
+    Up: MarkerShape = None  # type: ignore[assignment]
+    Down: MarkerShape = None  # type: ignore[assignment]
+    Left: MarkerShape = None  # type: ignore[assignment]
+    Right: MarkerShape = None  # type: ignore[assignment]
+    Asterisk: MarkerShape = None  # type: ignore[assignment]
+
+    @staticmethod
+    def shape__field_converter_override(data: MarkerShapeLike) -> int:
+        if isinstance(data, int):
+            return MarkerShapeExt.Shape(data).value
+        elif isinstance(data, str):
+            return MarkerShapeExt.Shape[data.title()].value
+        else:
+            # Must be a MarkerShape
+            return data.shape
+
+    @staticmethod
+    def native_to_pa_array_override(data: MarkerShapeArrayLike, data_type: pa.DataType) -> pa.Array:
+        from . import MarkerShape
+
+        # If it's the singular version, wrap it in an array
+        if isinstance(data, (MarkerShape, int, str)):
+            data = [data]
+
+        # Apply the field-converter to every element
+        data = [MarkerShapeExt.shape__field_converter_override(d) for d in data]
+
+        array = np.asarray(data, dtype=np.uint8).flatten()
+        return pa.array(array, type=data_type)
+
+    @staticmethod
+    def deferred_patch_class(cls: Any) -> None:
+        cls.Circle = cls(cls.Shape.Circle.value)
+        cls.Diamond = cls(cls.Shape.Diamond.value)
+        cls.Square = cls(cls.Shape.Square.value)
+        cls.Cross = cls(cls.Shape.Cross.value)
+        cls.Plus = cls(cls.Shape.Plus.value)
+        cls.Up = cls(cls.Shape.Up.value)
+        cls.Down = cls(cls.Shape.Down.value)
+        cls.Left = cls(cls.Shape.Left.value)
+        cls.Right = cls(cls.Shape.Right.value)
+        cls.Asterisk = cls(cls.Shape.Asterisk.value)

--- a/rerun_py/tests/unit/test_series_styles.py
+++ b/rerun_py/tests/unit/test_series_styles.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from rerun.archetypes import SeriesPoint
+from rerun.components import Color, ColorBatch, MarkerShape, MarkerShapeBatch, MarkerSize, MarkerSizeBatch
+
+
+def test_point_series() -> None:
+    inputs = [
+        SeriesPoint(),
+        SeriesPoint(color=[255, 0, 0]),
+        SeriesPoint(color=0xFF0000FF),
+        SeriesPoint(marker_size=2),
+        SeriesPoint(marker=MarkerShape.Diamond),
+        SeriesPoint(marker="diamond"),
+        SeriesPoint(color=[255, 0, 0], marker_size=2, marker="diamond"),
+    ]
+
+    for input in inputs:
+        if input.color is not None:
+            assert input.color == ColorBatch._optional([Color([255, 0, 0])])
+        if input.marker_size is not None:
+            assert input.marker_size == MarkerSizeBatch._optional([MarkerSize(2.0)])
+        if input.marker is not None:
+            assert input.marker == MarkerShapeBatch._optional([MarkerShape.Diamond])
+
+
+if __name__ == "__main__":
+    test_point_series()

--- a/rerun_py/tests/unit/test_series_styles.py
+++ b/rerun_py/tests/unit/test_series_styles.py
@@ -1,7 +1,38 @@
 from __future__ import annotations
 
-from rerun.archetypes import SeriesPoint
-from rerun.components import Color, ColorBatch, MarkerShape, MarkerShapeBatch, MarkerSize, MarkerSizeBatch
+from rerun.archetypes import SeriesLine, SeriesPoint
+from rerun.components import (
+    Color,
+    ColorBatch,
+    MarkerShape,
+    MarkerShapeBatch,
+    MarkerSize,
+    MarkerSizeBatch,
+    Name,
+    NameBatch,
+    StrokeWidth,
+    StrokeWidthBatch,
+)
+
+
+def test_line_series() -> None:
+    inputs = [
+        SeriesLine(),
+        SeriesLine(color=[255, 0, 0]),
+        SeriesLine(color=0xFF0000FF),
+        SeriesLine(width=2),
+        SeriesLine(width=2.0),
+        SeriesLine(name="my plot"),
+        SeriesLine(color=[255, 0, 0], width=2, name="my plot"),
+    ]
+
+    for input in inputs:
+        if input.color is not None:
+            assert input.color == ColorBatch._optional([Color([255, 0, 0])])
+        if input.width is not None:
+            assert input.width == StrokeWidthBatch._optional([StrokeWidth(2.0)])
+        if input.name is not None:
+            assert input.name == NameBatch._optional([Name("my plot")])
 
 
 def test_point_series() -> None:
@@ -12,7 +43,8 @@ def test_point_series() -> None:
         SeriesPoint(marker_size=2),
         SeriesPoint(marker=MarkerShape.Diamond),
         SeriesPoint(marker="diamond"),
-        SeriesPoint(color=[255, 0, 0], marker_size=2, marker="diamond"),
+        SeriesPoint(name="my plot"),
+        SeriesPoint(color=[255, 0, 0], marker_size=2, marker="diamond", name="my plot"),
     ]
 
     for input in inputs:
@@ -22,6 +54,8 @@ def test_point_series() -> None:
             assert input.marker_size == MarkerSizeBatch._optional([MarkerSize(2.0)])
         if input.marker is not None:
             assert input.marker == MarkerShapeBatch._optional([MarkerShape.Diamond])
+        if input.name is not None:
+            assert input.name == NameBatch._optional([Name("my plot")])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What
 - Adds extensions for the MarkerShape for python, c++, and rust
   - In c++/rust we just add constants
   - In python we cooerce through an enum to allow for string short-hand as well
 - Adds examples in all langues for both using SeriesLine and SeriesPoint

- Comparison tests were still failing, so I opted out for now and created an issue: https://github.com/rerun-io/rerun/issues/5116

Previews:
 - https://www.rerun.io/preview/c75bad6a07c5678aa676bfbe9ad5423745932540/docs/reference/types/archetypes/series_line
 - https://www.rerun.io/preview/c75bad6a07c5678aa676bfbe9ad5423745932540/docs/reference/types/archetypes/series_point

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5112/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5112/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5112/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5112)
- [Docs preview](https://rerun.io/preview/efcf9e1bae2b680c84d9ffbbd15eea7918735345/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/efcf9e1bae2b680c84d9ffbbd15eea7918735345/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)