### PR TITLE
Paint closest labels on top of labels further away

### DIFF
--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -317,7 +317,7 @@ pub fn view_2d(
 
         // Create labels now since their shapes participate are added to scene.ui for picking.
         let (label_shapes, ui_rects) = create_labels(
-            &collect_ui_labels(&parts),
+            collect_ui_labels(&parts),
             ui_from_canvas,
             &eye,
             ui,

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -497,7 +497,7 @@ pub fn view_3d(
 
     // Create labels now since their shapes participate are added to scene.ui for picking.
     let (label_shapes, ui_rects) = create_labels(
-        &collect_ui_labels(&parts),
+        collect_ui_labels(&parts),
         RectTransform::from_to(rect, rect),
         &eye,
         ui,


### PR DESCRIPTION
`arkit_scenes` is a good test for this

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5124/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5124/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5124/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5124)
- [Docs preview](https://rerun.io/preview/7a18b744035e22282df68d04268bae0a974ee35a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7a18b744035e22282df68d04268bae0a974ee35a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)