### PR TITLE
Fix miscellaneous issues in doc examples

### DIFF
--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -38,7 +38,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///             .with_vertex_normals([[0.0, 0.0, 1.0]])
 ///             .with_vertex_colors([0x0000FFFF, 0x00FF00FF, 0xFF0000FF])
 ///             .with_mesh_properties(rerun::MeshProperties::from_triangle_indices([[2, 1, 0]]))
-///             .with_mesh_material(rerun::Material::from_albedo_factor(0xCC00CCFF)),
 ///     )?;
 ///
 ///     Ok(())

--- a/docs/code-examples/all/mesh3d_indexed.cpp
+++ b/docs/code-examples/all/mesh3d_indexed.cpp
@@ -26,6 +26,5 @@ int main() {
             .with_vertex_normals({{0.0, 0.0, 1.0}})
             .with_vertex_colors(vertex_colors)
             .with_mesh_properties(rerun::components::MeshProperties::from_triangle_indices(indices))
-            .with_mesh_material(rerun::components::Material::from_albedo_factor(0xCC00CCFF))
     );
 }

--- a/docs/code-examples/all/mesh3d_indexed.py
+++ b/docs/code-examples/all/mesh3d_indexed.py
@@ -10,6 +10,5 @@ rr.log(
         vertex_normals=[0.0, 0.0, 1.0],
         vertex_colors=[[0, 0, 255], [0, 255, 0], [255, 0, 0]],
         indices=[2, 1, 0],
-        mesh_material=rr.Material(albedo_factor=[0xCC, 0x00, 0xCC, 0xFF]),
     ),
 )

--- a/docs/code-examples/all/mesh3d_indexed.rs
+++ b/docs/code-examples/all/mesh3d_indexed.rs
@@ -9,7 +9,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_vertex_normals([[0.0, 0.0, 1.0]])
             .with_vertex_colors([0x0000FFFF, 0x00FF00FF, 0xFF0000FF])
             .with_mesh_properties(rerun::MeshProperties::from_triangle_indices([[2, 1, 0]]))
-            .with_mesh_material(rerun::Material::from_albedo_factor(0xCC00CCFF)),
     )?;
 
     Ok(())

--- a/docs/code-examples/all/mesh3d_partial_updates.cpp
+++ b/docs/code-examples/all/mesh3d_partial_updates.cpp
@@ -14,7 +14,7 @@ int main() {
     rec.spawn().exit_on_failure();
 
     rerun::Position3D vertex_positions[3] = {
-        {0.0f, 0.0f, 0.0f},
+        {-1.0f, 0.0f, 0.0f},
         {1.0f, 0.0f, 0.0f},
         {0.0f, 1.0f, 0.0f},
     };

--- a/docs/code-examples/all/pinhole_simple.cpp
+++ b/docs/code-examples/all/pinhole_simple.cpp
@@ -17,5 +17,5 @@ int main() {
         return static_cast<uint8_t>(std::rand());
     });
 
-    rec.log("world/image", rerun::Image({3, 3}, random_data));
+    rec.log("world/image", rerun::Image({3, 3, 3}, random_data));
 }

--- a/docs/code-examples/all/point2d_random.cpp
+++ b/docs/code-examples/all/point2d_random.cpp
@@ -11,7 +11,7 @@ int main() {
     rec.spawn().exit_on_failure();
 
     std::default_random_engine gen;
-    std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);
+    std::uniform_real_distribution<float> dist_pos(-3.0f, 3.0f);
     std::uniform_real_distribution<float> dist_radius(0.1f, 1.0f);
     // On MSVC uint8_t distributions are not supported.
     std::uniform_int_distribution<int> dist_color(0, 255);
@@ -34,5 +34,5 @@ int main() {
     rec.log("random", rerun::Points2D(points2d).with_colors(colors).with_radii(radii));
 
     // Log an extra rect to set the view bounds
-    rec.log("bounds", rerun::Boxes2D::from_half_sizes({{2.0f, 1.5f}}));
+    rec.log("bounds", rerun::Boxes2D::from_half_sizes({{4.0f, 3.0f}}));
 }

--- a/docs/code-examples/all/series_point_style.cpp
+++ b/docs/code-examples/all/series_point_style.cpp
@@ -7,7 +7,7 @@
 constexpr float TAU = 6.28318530717958647692528676655900577f;
 
 int main() {
-    const auto rec = rerun::RecordingStream("rerun_example_series_line_style");
+    const auto rec = rerun::RecordingStream("rerun_example_series_point_style");
     rec.spawn().exit_on_failure();
 
     // Set up plot styling:

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -58,7 +58,6 @@ namespace rerun::archetypes {
     ///             .with_vertex_normals({{0.0, 0.0, 1.0}})
     ///             .with_vertex_colors(vertex_colors)
     ///             .with_mesh_properties(rerun::components::MeshProperties::from_triangle_indices(indices))
-    ///             .with_mesh_material(rerun::components::Material::from_albedo_factor(0xCC00CCFF))
     ///     );
     /// }
     /// ```

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -43,7 +43,7 @@ namespace rerun::archetypes {
     ///         return static_cast<uint8_t>(std::rand());
     ///     });
     ///
-    ///     rec.log("world/image", rerun::Image({3, 3}, random_data));
+    ///     rec.log("world/image", rerun::Image({3, 3, 3}, random_data));
     /// }
     /// ```
     struct Pinhole {

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -42,7 +42,7 @@ namespace rerun::archetypes {
     ///     rec.spawn().exit_on_failure();
     ///
     ///     std::default_random_engine gen;
-    ///     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);
+    ///     std::uniform_real_distribution<float> dist_pos(-3.0f, 3.0f);
     ///     std::uniform_real_distribution<float> dist_radius(0.1f, 1.0f);
     ///     // On MSVC uint8_t distributions are not supported.
     ///     std::uniform_int_distribution<int> dist_color(0, 255);
@@ -65,7 +65,7 @@ namespace rerun::archetypes {
     ///     rec.log("random", rerun::Points2D(points2d).with_colors(colors).with_radii(radii));
     ///
     ///     // Log an extra rect to set the view bounds
-    ///     rec.log("bounds", rerun::Boxes2D::from_half_sizes({{2.0f, 1.5f}}));
+    ///     rec.log("bounds", rerun::Boxes2D::from_half_sizes({{4.0f, 3.0f}}));
     /// }
     /// ```
     struct Points2D {

--- a/rerun_cpp/src/rerun/archetypes/series_point.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_point.hpp
@@ -40,7 +40,7 @@ namespace rerun::archetypes {
     /// constexpr float TAU = 6.28318530717958647692528676655900577f;
     ///
     /// int main() {
-    ///     const auto rec = rerun::RecordingStream("rerun_example_series_line_style");
+    ///     const auto rec = rerun::RecordingStream("rerun_example_series_point_style");
     ///     rec.spawn().exit_on_failure();
     ///
     ///     // Set up plot styling:

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -36,7 +36,6 @@ class Mesh3D(Mesh3DExt, Archetype):
             vertex_normals=[0.0, 0.0, 1.0],
             vertex_colors=[[0, 0, 255], [0, 255, 0], [255, 0, 0]],
             indices=[2, 1, 0],
-            mesh_material=rr.Material(albedo_factor=[0xCC, 0x00, 0xCC, 0xFF]),
         ),
     )
     ```

--- a/tests/rust/roundtrips/text_document/src/main.rs
+++ b/tests/rust/roundtrips/text_document/src/main.rs
@@ -36,6 +36,6 @@ fn main() -> anyhow::Result<()> {
     use clap::Parser as _;
     let args = Args::parse();
 
-    let (rec, _serve_guard) = args.rerun.init("rerun_example_roundtrip_tensor")?;
+    let (rec, _serve_guard) = args.rerun.init("rerun_example_roundtrip_text_document")?;
     run(&rec, &args)
 }

--- a/tests/rust/roundtrips/text_log/src/main.rs
+++ b/tests/rust/roundtrips/text_log/src/main.rs
@@ -29,6 +29,6 @@ fn main() -> anyhow::Result<()> {
     use clap::Parser as _;
     let args = Args::parse();
 
-    let (rec, _serve_guard) = args.rerun.init("rerun_example_roundtrip_tensor")?;
+    let (rec, _serve_guard) = args.rerun.init("rerun_example_roundtrip_text_log")?;
     run(&rec, &args)
 }


### PR DESCRIPTION
### What

before:
![image](https://github.com/rerun-io/rerun/assets/1220815/37fb0c18-a692-42ed-a661-b4f9e46ac119)

after:
![image](https://github.com/rerun-io/rerun/assets/1220815/aac3b9ec-108e-492e-a56d-9161e8bcc22c)

Big thanks to @teh-cmc for finding these

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5128/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5128/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5128/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5128)
- [Docs preview](https://rerun.io/preview/4536fefd8fd7468e67ec00c15188f7b9563bdaca/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4536fefd8fd7468e67ec00c15188f7b9563bdaca/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)