### PR TITLE
Primary cache: downgrade busy-lock log to trace level

### DIFF
--- a/crates/re_query_cache/src/latest_at.rs
+++ b/crates/re_query_cache/src/latest_at.rs
@@ -330,11 +330,11 @@ macro_rules! impl_query_archetype_latest_at {
                     return iter_results(is_timeless, query_time_bucket_at_query_time, f);
                 }
 
-                re_log::debug!(
+                re_log::trace!(
                     store_id = %store.id(),
                     %entity_path,
                     ?query,
-                    "coudn't upsert cache -- write lock was busy"
+                    "either no data exist at this time or we couldn't upsert the cache (write lock was busy)"
                 );
 
                 Ok(())


### PR DESCRIPTION
See https://github.com/rerun-io/rerun/issues/5126#issuecomment-1933831223:
> All good, it's not finding the data because there's no data at that timestamp for these entities to begin with -- it's a false positive.
> 
> This log was purposefully made very conservative / trigger-happy while bug hunting -- I'll downgrade it to `trace` now.

- Fixes https://github.com/rerun-io/rerun/issues/5126

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5134/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5134/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5134/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5134)
- [Docs preview](https://rerun.io/preview/b2bb29aaf70b595728974fe7aebf4ccb3d59b162/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b2bb29aaf70b595728974fe7aebf4ccb3d59b162/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)