### PR TITLE
Fix broken CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@ To get an auto-generated PR description you can put "copilot:summary" or "copilo
   * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
   * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
 * [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
-* [ ] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!
+* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
 
 - [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
 - [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -37,7 +37,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         &rerun::Mesh3D::new([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
 ///             .with_vertex_normals([[0.0, 0.0, 1.0]])
 ///             .with_vertex_colors([0x0000FFFF, 0x00FF00FF, 0xFF0000FF])
-///             .with_mesh_properties(rerun::MeshProperties::from_triangle_indices([[2, 1, 0]]))
+///             .with_mesh_properties(rerun::MeshProperties::from_triangle_indices([[2, 1, 0]])),
 ///     )?;
 ///
 ///     Ok(())

--- a/docs/code-examples/all/mesh3d_indexed.rs
+++ b/docs/code-examples/all/mesh3d_indexed.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &rerun::Mesh3D::new([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
             .with_vertex_normals([[0.0, 0.0, 1.0]])
             .with_vertex_colors([0x0000FFFF, 0x00FF00FF, 0xFF0000FF])
-            .with_mesh_properties(rerun::MeshProperties::from_triangle_indices([[2, 1, 0]]))
+            .with_mesh_properties(rerun::MeshProperties::from_triangle_indices([[2, 1, 0]])),
     )?;
 
     Ok(())

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -19,7 +19,7 @@ class Timing:
 
 
 def run_cargo(command: str, args: str) -> Timing:
-    cwd = f"cargo {command} --quiet {args}"
+    cwd = f"cargo {command} {args}"
     print(f"Running '{cwd}'")
     start = time.time()
     result = subprocess.call(cwd, shell=True)


### PR DESCRIPTION
And remove `--quiet`, it makes CI debugging painful.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5135/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5135/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5135/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5135)
- [Docs preview](https://rerun.io/preview/482c269daad08e45c234c8dac4f0d384ce85568b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/482c269daad08e45c234c8dac4f0d384ce85568b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)