### PR TITLE
Fix more app ID mismatches

### DIFF
--- a/tests/cpp/roundtrips/line_strips2d/main.cpp
+++ b/tests/cpp/roundtrips/line_strips2d/main.cpp
@@ -3,7 +3,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_line_strip2d");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_line_strips2d");
     rec.save(argv[1]).exit_on_failure();
 
     rec.log(

--- a/tests/cpp/roundtrips/line_strips3d/main.cpp
+++ b/tests/cpp/roundtrips/line_strips3d/main.cpp
@@ -2,7 +2,7 @@
 #include <rerun/recording_stream.hpp>
 
 int main(int, char** argv) {
-    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_line_strip3d");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_line_strips3d");
     rec.save(argv[1]).exit_on_failure();
 
     rec.log(

--- a/tests/cpp/roundtrips/text_document/main.cpp
+++ b/tests/cpp/roundtrips/text_document/main.cpp
@@ -1,7 +1,7 @@
 #include <rerun.hpp>
 
 int main(int, char** argv) {
-    const auto rec = rerun::RecordingStream("rerun_example_text_document");
+    const auto rec = rerun::RecordingStream("rerun_example_roundtrip_text_document");
     rec.save(argv[1]).exit_on_failure();
     rec.log("text_document", rerun::archetypes::TextDocument("Hello, TextDocument!"));
     rec.log(


### PR DESCRIPTION
We fixed the doc examples... but what about the roundtrips? :unamused: 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5137/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5137/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5137/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5137)
- [Docs preview](https://rerun.io/preview/11db1c42bb513fd820aadf627f8700a593aa886e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/11db1c42bb513fd820aadf627f8700a593aa886e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)