### PR TITLE
Remove experimental_additive_workflow

### DIFF
--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -386,19 +386,6 @@ fn experimental_feature_ui(
     re_ui
         .checkbox(
             ui,
-            &mut app_options.experimental_additive_workflow,
-            "Enable the container addition workflow",
-        )
-        .on_hover_text(
-            "This flag enables the experimental container addition workflow, including:\n\
-                - Remove the automatic simplification of the container tree.\n\
-                - Add a 'Content' list in the selection panel when a container is selected.\n\
-                - Add the 'Add space view/container' modal, accessible from the selection panel.",
-        );
-
-    re_ui
-        .checkbox(
-            ui,
             &mut app_options.experimental_plot_query_clamping,
             "Plots: query clamping",
         )

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -153,13 +153,8 @@ impl SelectionPanel {
                 match item {
                     Item::Container(container_id) => {
                         container_top_level_properties(ui, ctx, viewport, container_id);
-
-                        // the container children and related additive workflow is only available with the new container
-                        // blueprints feature
-                        if ctx.app_options.experimental_additive_workflow {
-                            ui.add_space(12.0);
-                            container_children(ui, ctx, viewport, container_id);
-                        }
+                        ui.add_space(12.0);
+                        container_children(ui, ctx, viewport, container_id);
                     }
 
                     Item::SpaceView(space_view_id) => {
@@ -662,26 +657,22 @@ fn container_top_level_properties(
                 ui.end_row();
             }
 
-            // this feature is only available with the new container blueprints feature
-            #[allow(clippy::collapsible_if)]
-            if ctx.app_options.experimental_additive_workflow {
-                if ui
-                    .button("Simplify hierarchy")
-                    .on_hover_text("Simplify this container and its children")
-                    .clicked()
-                {
-                    viewport.blueprint.simplify_container(
-                        container_id,
-                        egui_tiles::SimplificationOptions {
-                            prune_empty_tabs: true,
-                            prune_empty_containers: true,
-                            prune_single_child_tabs: false,
-                            prune_single_child_containers: false,
-                            all_panes_must_have_tabs: true,
-                            join_nested_linear_containers: true,
-                        },
-                    );
-                }
+            if ui
+                .button("Simplify hierarchy")
+                .on_hover_text("Simplify this container and its children")
+                .clicked()
+            {
+                viewport.blueprint.simplify_container(
+                    container_id,
+                    egui_tiles::SimplificationOptions {
+                        prune_empty_tabs: true,
+                        prune_empty_containers: true,
+                        prune_single_child_tabs: false,
+                        prune_single_child_containers: false,
+                        all_panes_must_have_tabs: true,
+                        join_nested_linear_containers: true,
+                    },
+                );
             }
         });
 }

--- a/crates/re_viewer_context/src/app_options.rs
+++ b/crates/re_viewer_context/src/app_options.rs
@@ -19,9 +19,6 @@ pub struct AppOptions {
 
     pub experimental_entity_filter_editor: bool,
 
-    /// Enable the experimental support for the container addition workflow.
-    pub experimental_additive_workflow: bool,
-
     /// Toggle query clamping for the plot visualizers.
     pub experimental_plot_query_clamping: bool,
 
@@ -53,8 +50,6 @@ impl Default for AppOptions {
             experimental_dataframe_space_view: false,
 
             experimental_entity_filter_editor: false,
-
-            experimental_additive_workflow: cfg!(debug_assertions),
 
             experimental_plot_query_clamping: false,
 

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -125,21 +125,13 @@ pub enum TreeAction {
 fn tree_simplification_option_for_app_options(
     app_options: &AppOptions,
 ) -> egui_tiles::SimplificationOptions {
-    if app_options.experimental_additive_workflow {
-        // If the user is using the additive workflow, we don't want to aggressively simplify the tree.
-        egui_tiles::SimplificationOptions {
-            prune_empty_tabs: false,
-            all_panes_must_have_tabs: true,
-            prune_empty_containers: false,
-            prune_single_child_tabs: false,
-            prune_single_child_containers: false,
-            join_nested_linear_containers: true,
-        }
-    } else {
-        egui_tiles::SimplificationOptions {
-            all_panes_must_have_tabs: true,
-            ..Default::default()
-        }
+    egui_tiles::SimplificationOptions {
+        prune_empty_tabs: false,
+        all_panes_must_have_tabs: true,
+        prune_empty_containers: false,
+        prune_single_child_tabs: false,
+        prune_single_child_containers: false,
+        join_nested_linear_containers: true,
     }
 }
 
@@ -818,27 +810,26 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
                 // workflow is enabled. Due to the egui_tiles -> blueprint synchronisation process,
                 // drag and drop operation often lead to many spurious empty containers. To work
                 // around this, we run a simplification pass when a drop occurs.
-                if self.ctx.app_options.experimental_additive_workflow {
-                    if let Some(root_container_id) = self.root_container_id {
-                        if self
-                            .tree_action_sender
-                            .send(TreeAction::SimplifyContainer(
-                                root_container_id,
-                                egui_tiles::SimplificationOptions {
-                                    prune_empty_tabs: true,
-                                    prune_empty_containers: false,
-                                    prune_single_child_tabs: true,
-                                    prune_single_child_containers: false,
-                                    all_panes_must_have_tabs: true,
-                                    join_nested_linear_containers: false,
-                                },
-                            ))
-                            .is_err()
-                        {
-                            re_log::warn_once!(
-                                "Channel between ViewportBlueprint and Viewport is broken"
-                            );
-                        }
+
+                if let Some(root_container_id) = self.root_container_id {
+                    if self
+                        .tree_action_sender
+                        .send(TreeAction::SimplifyContainer(
+                            root_container_id,
+                            egui_tiles::SimplificationOptions {
+                                prune_empty_tabs: true,
+                                prune_empty_containers: false,
+                                prune_single_child_tabs: true,
+                                prune_single_child_containers: false,
+                                all_panes_must_have_tabs: true,
+                                join_nested_linear_containers: false,
+                            },
+                        ))
+                        .is_err()
+                    {
+                        re_log::warn_once!(
+                            "Channel between ViewportBlueprint and Viewport is broken"
+                        );
                     }
                 }
 

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -13,7 +13,7 @@ use re_renderer::ScreenshotProcessor;
 use re_space_view::SpaceViewBlueprint;
 use re_ui::{Icon, ReUi};
 use re_viewer_context::{
-    AppOptions, ContainerId, Item, SpaceViewClassIdentifier, SpaceViewClassRegistry, SpaceViewId,
+    ContainerId, Item, SpaceViewClassIdentifier, SpaceViewClassRegistry, SpaceViewId,
     SpaceViewState, SystemExecutionOutput, ViewQuery, ViewerContext,
 };
 
@@ -122,9 +122,7 @@ pub enum TreeAction {
     SetDropTarget(ContainerId),
 }
 
-fn tree_simplification_option_for_app_options(
-    app_options: &AppOptions,
-) -> egui_tiles::SimplificationOptions {
+fn tree_simplification_options() -> egui_tiles::SimplificationOptions {
     egui_tiles::SimplificationOptions {
         prune_empty_tabs: false,
         all_panes_must_have_tabs: true,
@@ -527,7 +525,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
             // Simplify before we save the tree. Normally additional simplification will
             // happen on the next render loop, but that's too late -- unsimplified
             // changes will be baked into the tree.
-            let options = tree_simplification_option_for_app_options(ctx.app_options);
+            let options = tree_simplification_options();
             self.tree.simplify(&options);
 
             self.blueprint.save_tree_as_containers(&self.tree, ctx);
@@ -795,7 +793,7 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
     ///
     /// These options are applied on every frame by `egui_tiles`.
     fn simplification_options(&self) -> egui_tiles::SimplificationOptions {
-        tree_simplification_option_for_app_options(self.ctx.app_options)
+        tree_simplification_options()
     }
 
     // Callbacks:

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -1,9 +1,7 @@
 use egui::{Response, Ui};
-use itertools::Itertools;
 
 use re_entity_db::InstancePath;
-use re_log_types::{EntityPath, EntityPathRule};
-use re_space_view::DataQueryBlueprint;
+use re_log_types::EntityPathRule;
 use re_space_view::SpaceViewBlueprint;
 use re_space_view::SpaceViewName;
 use re_ui::{drag_and_drop::DropTarget, list_item::ListItem, ReUi};
@@ -11,7 +9,7 @@ use re_viewer_context::{
     ContainerId, DataQueryResult, DataResultNode, HoverHighlight, Item, SpaceViewId, ViewerContext,
 };
 
-use crate::{container::Contents, space_view_heuristics::default_created_space_views, Viewport};
+use crate::{container::Contents, Viewport};
 
 /// The style to use for displaying this space view name in the UI.
 pub fn space_view_name_style(name: &SpaceViewName) -> re_ui::LabelStyle {


### PR DESCRIPTION
### What

Actually flipping the switch to always use the new workflow. We still defaulted to the old 😱 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5141/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5141/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5141/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5141)
- [Docs preview](https://rerun.io/preview/3a988ed9e26ef4b81320e9cef7fa0a30ffde1cda/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3a988ed9e26ef4b81320e9cef7fa0a30ffde1cda/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)