### PR TITLE
New 2d heuristic -- split any bucket with more than 1 image

### DIFF
--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -346,7 +346,7 @@ fn add_recommended_space_views_for_bucket(
     // Alternatively we want to split this bucket into a group for each child-space.
     let Some(subtree) = tree.subtree(&root) else {
         if cfg!(debug_assertions) {
-            re_log::warn_once!("Ancestor of entity not found in entity tree.")
+            re_log::warn_once!("Ancestor of entity not found in entity tree.");
         }
         return;
     };

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -197,7 +197,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
                         for bucket_entities in
                             bucket_images_in_subspace(ctx, subspace, image_entities)
                         {
-                            add_recommended_space_views_for_bucket(
+                            add_recommended_space_views_for_image_bucket(
                                 ctx,
                                 &bucket_entities,
                                 &mut recommended_space_views,
@@ -316,7 +316,8 @@ fn count_non_nested_entities_with_component(
     }
 }
 
-fn add_recommended_space_views_for_bucket(
+/// Given a bucket of image entities.
+fn add_recommended_space_views_for_image_bucket(
     ctx: &ViewerContext<'_>,
     entity_bucket: &IntSet<EntityPath>,
     recommended: &mut Vec<RecommendedSpaceView>,
@@ -377,7 +378,7 @@ fn add_recommended_space_views_for_bucket(
             .collect();
 
         if !sub_bucket.is_empty() {
-            add_recommended_space_views_for_bucket(ctx, &sub_bucket, recommended);
+            add_recommended_space_views_for_image_bucket(ctx, &sub_bucket, recommended);
         }
     }
 }

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -303,11 +303,8 @@ fn count_non_nested_entities_with_component(
     component_name: &ComponentName,
 ) -> usize {
     if entity_bucket.contains(&subtree.path) {
-        if subtree.entity.components.contains_key(component_name) {
-            1
-        } else {
-            0
-        }
+        // bool true -> 1
+        subtree.entity.components.contains_key(component_name) as usize
     } else if !entity_bucket
         .iter()
         .any(|e| e.is_descendant_of(&subtree.path))
@@ -318,7 +315,6 @@ fn count_non_nested_entities_with_component(
             .children
             .values()
             .map(|child| {
-                // TODO(jleibs): Early terminate if know the subtree has nothing from the bucket
                 count_non_nested_entities_with_component(entity_bucket, child, component_name)
             })
             .sum()

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -292,6 +292,12 @@ impl SpaceViewClass for SpatialSpaceView2D {
     }
 }
 
+/// Count how many occurrences of the given component are in
+/// the intersection of the subtree and the entity bucket,
+/// but stops recursion if there is a hit.
+///
+/// * So if the subtree root is in the bucket: return 1 if it has the component, 0 otherwise.
+/// * If not: recurse on children and sum the results.
 fn count_non_nested_entities_with_component(
     entity_bucket: &IntSet<EntityPath>,
     subtree: &EntityTree,
@@ -304,7 +310,7 @@ fn count_non_nested_entities_with_component(
         .iter()
         .any(|e| e.is_descendant_of(&subtree.path))
     {
-        0
+        0 // early-out optimization
     } else {
         subtree
             .children

--- a/tests/python/release_checklist/check_2d_heuristics.py
+++ b/tests/python/release_checklist/check_2d_heuristics.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+from argparse import Namespace
+from uuid import uuid4
+
+import numpy as np
+import rerun as rr
+
+README = """
+# 2D Heuristics
+
+This checks whether the heuristics do the right thing with images.
+
+Reset the blueprint to make sure you are viewing new heuristics and not a cached blueprint.
+
+### Action
+You should see 4 space-views. Depending on timing you may end up with a 5th space-view at the root.
+This should go away when you reset.
+
+The four remaining space-views should be:
+ - `image1` with a red square
+ - `image2` with a green square
+ - `image3` with a blue square and overlapping green square (rendered teal)
+ - `segmented` with a red square and overlapping green square (rendered yellow)
+"""
+
+
+def log_image(path: str, height: int, width: int, color: tuple[int, int, int]) -> None:
+    image = np.zeros((height, width, 3), dtype=np.uint8)
+    image[:, :, :] = color
+    rr.log(path, rr.Image(image))
+
+
+def log_image_nested(path: str, height: int, width: int, color: tuple[int, int, int]) -> None:
+    image = np.zeros((height, width, 3), dtype=np.uint8)
+    image[int(height / 4) : int(height - height / 4), int(width / 4) : int(width - width / 4), :] = color
+    rr.log(path, rr.Image(image))
+
+
+def log_annotation_context() -> None:
+    rr.log("/", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), timeless=True)
+
+
+def log_segmentation(path: str, height: int, width: int, class_id: int) -> None:
+    image = np.zeros((height, width, 1), dtype=np.uint8)
+    image[int(height / 4) : int(height - height / 4), int(width / 4) : int(width - width / 4), 0] = class_id
+    rr.log(path, rr.SegmentationImage(image))
+
+
+def log_readme() -> None:
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+
+
+def log_images() -> None:
+    log_annotation_context()
+    log_image("image1", 20, 30, (255, 0, 0))
+    log_image("image2", 20, 30, (0, 255, 0))
+    log_image("image3", 20, 30, (0, 0, 255))
+    log_image_nested("image3/nested", 20, 30, (0, 255, 0))
+    log_image("segmented/image4", 20, 30, (255, 0, 0))
+    log_segmentation("segmented/seg", 20, 30, 2)
+
+
+def run(args: Namespace) -> None:
+    # TODO(cmc): I have no idea why this works without specifying a `recording_id`, but
+    # I'm not gonna rely on it anyway.
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4())
+
+    log_readme()
+    log_images()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Interactive release checklist")
+    rr.script_add_args(parser)
+    args = parser.parse_args()
+    run(args)


### PR DESCRIPTION
### What
 - Resolves: https://github.com/rerun-io/rerun/issues/5145

I decided that if images are **nested** then we should still stack them when bucketed.
However, if multiple images are logged as **siblings** (or other non-nested hierarchies), they should get their own reviews.

The basic logic is as follows:
 - Bucket the images.
 - If the root of the bucket is an image (i.e. the contents are **nested** image) then use it.
 - Otherwise, check to see if there is more than 1 non-nested image or non-nested depth-image. (We allow multiple segmentation images to layer). If there aren't we return it.
 - If yes, then split the bucket and recurse.

![image](https://github.com/rerun-io/rerun/assets/3312232/2549f031-0e43-4b13-a51e-4b6bbed2b272)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5148/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5148/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5148/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

### Extra checklist
* [x] Reset viewer and test all nightly examples

- [PR Build Summary](https://build.rerun.io/pr/5148)
- [Docs preview](https://rerun.io/preview/b6b855478dda18f83afde6724bdeb915936a2751/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b6b855478dda18f83afde6724bdeb915936a2751/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)