### PR TITLE
Still process annotations without keypoint_ids

### DIFF
--- a/tests/python/release_checklist/check_annotations.py
+++ b/tests/python/release_checklist/check_annotations.py
@@ -20,8 +20,6 @@ The image should contain a red region and a green region.
 There should be 1 red rectangle and 1 green rectangle.
 
 Hover over each of the elements and confirm it shows the label as "red" or "green" as expected.
-
-
 """
 
 

--- a/tests/python/release_checklist/check_annotations.py
+++ b/tests/python/release_checklist/check_annotations.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import os
+from argparse import Namespace
+from uuid import uuid4
+
+import numpy as np
+import rerun as rr
+
+README = """
+# Annotations
+
+This checks whether annotations behave correctly
+
+### Actions
+
+There should be one space-view with an image and a batch of 2 rectangles.
+
+The image should contain a red region and a green region.
+There should be 1 red rectangle and 1 green rectangle.
+
+Hover over each of the elements and confirm it shows the label as "red" or "green" as expected.
+
+
+"""
+
+
+def log_readme() -> None:
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+
+
+def log_annotations() -> None:
+    # Log an annotation context to assign a label and color to each class
+    rr.log("/", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), timeless=True)
+
+    # Log a batch of 2 rectangles with different `class_ids`
+    rr.log("detections", rr.Boxes2D(mins=[[200, 50], [75, 150]], sizes=[[30, 30], [20, 20]], class_ids=[1, 2]))
+
+    # Create a simple segmentation image
+
+    image = np.zeros((200, 300), dtype=np.uint8)
+    image[50:100, 50:120] = 1
+    image[100:180, 130:280] = 2
+    rr.log("segmentation/image", rr.SegmentationImage(image))
+
+
+def run(args: Namespace) -> None:
+    # TODO(cmc): I have no idea why this works without specifying a `recording_id`, but
+    # I'm not gonna rely on it anyway.
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4())
+
+    log_readme()
+    log_annotations()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Interactive release checklist")
+    rr.script_add_args(parser)
+    args = parser.parse_args()
+    run(args)


### PR DESCRIPTION
### What
 - Resolves: https://github.com/rerun-io/rerun/issues/5147

process_annotation_and_keypoint_slices was early-exiting if we don't have keypoint_ids, which is actually almost all cases.
We can't even log Boxes with KeypointIds at the moment (though the idea of supporting it isn't unreasonable).

Properly handle missing keypoints in the shared `process_annotation_and_keypoint_slices` 

![image](https://github.com/rerun-io/rerun/assets/3312232/232925da-e3c6-4b7d-867b-a021c15e6277)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5149/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5149/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5149/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5149)
- [Docs preview](https://rerun.io/preview/09973f7bbf91efa258b765591a04763ae6b65aea/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/09973f7bbf91efa258b765591a04763ae6b65aea/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)