### PR TITLE
Remove Objectron from default examples

### DIFF
--- a/examples/python/objectron/README.md
+++ b/examples/python/objectron/README.md
@@ -4,7 +4,7 @@ tags = ["2D", "3D", "object-detection", "pinhole-camera"]
 description = "Example of using the Rerun SDK to log the Google Research Objectron dataset."
 thumbnail = "https://static.rerun.io/objectron/8ea3a37e6b4af2e06f8e2ea5e70c1951af67fea8/480w.png"
 thumbnail_dimensions = [480, 268]
-channel = "release"
+# channel = "release"  - Disabled because it sometimes have bad first-frame heuristics
 build_args = ["--frames=150"]
 -->
 


### PR DESCRIPTION
### What
The first-frame heuristics of objectron sometimes produce really bad results:

![image](https://github.com/rerun-io/rerun/assets/1148717/99561a46-38cd-4c4d-8a65-b793b1be79bf)

(top-right corner is a 3D view with 2D elements in it).

In the interest of getting a release out today, and not giving first users a bad impression, this PR removes Objectron from the example page. It is not a very pretty example anyway.

### Related issues
* https://github.com/rerun-io/rerun/issues/5156
* https://github.com/rerun-io/rerun/issues/5154

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5155/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5155/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5155/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5155)
- [Docs preview](https://rerun.io/preview/49097fb6d0b36ac10840101262e5a4b6abb87ca4/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/49097fb6d0b36ac10840101262e5a4b6abb87ca4/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)