### PR TITLE
Download `librerun` artifacts using GCS APIs directly

### DIFF
--- a/scripts/ci/bundle_and_upload_rerun_cpp.py
+++ b/scripts/ci/bundle_and_upload_rerun_cpp.py
@@ -26,6 +26,9 @@ def run(
 def download_rerun_c(target_dir: str, git_hash: str, platform_filter: str = None) -> None:
     logging.info("Downloading rerun_c…")
 
+    gcs = storage.Client("rerun-open")
+    bucket = gcs.bucket("rerun-builds")
+
     os.mkdir(target_dir)
 
     # See reusable_build_and_upload_rerun_c.yml for available libraries.
@@ -39,8 +42,10 @@ def download_rerun_c(target_dir: str, git_hash: str, platform_filter: str = None
         if platform_filter is not None and src.startswith(platform_filter) is False:
             continue
 
-        url = f"https://build.rerun.io/commit/{git_hash}/rerun_c/{src}"
-        run(["curl", "-L", "-o", f"{target_dir}/{dst}", url])
+        blob = bucket.get_blob(f"commit/{git_hash}/rerun_c/{src}")
+        with open(f"{target_dir}/{dst}", 'wb') as f:
+            logging.info(f"Copying {blob.path} to {target_dir}/{dst}")
+            blob.download_to_file(f)
 
 
 def upload_rerun_cpp_sdk(rerun_zip: str, git_hash: str) -> None:


### PR DESCRIPTION
Testing locally -- seems to work :shrug: 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5158/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5158/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5158/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5158)
- [Docs preview](https://rerun.io/preview/05fbe43a19de5530928ed648c85bd3eb52157739/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/05fbe43a19de5530928ed648c85bd3eb52157739/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)