### PR TITLE
Aggregate plots with duplicate time stamps

### DIFF
--- a/crates/re_space_view_time_series/src/aggregation.rs
+++ b/crates/re_space_view_time_series/src/aggregation.rs
@@ -6,6 +6,9 @@ pub struct AverageAggregator;
 
 impl AverageAggregator {
     /// `aggregation_factor`: the width of the aggregation window.
+    ///
+    /// Adjacent plot points may have the same `PlotPoint::time`,
+    /// if data was logged multiple times on the same time stamp.
     #[inline]
     pub fn aggregate(aggregation_factor: f64, points: &[PlotPoint]) -> Vec<PlotPoint> {
         let min_time = points.first().map_or(i64::MIN, |p| p.time);
@@ -91,13 +94,12 @@ pub enum MinMaxAggregator {
 }
 
 impl MinMaxAggregator {
+    /// Adjacent plot points may have the same `PlotPoint::time`,
+    /// if data was logged multiple times on the same time stamp.
     #[inline]
     pub fn aggregate(&self, aggregation_window_size: f64, points: &[PlotPoint]) -> Vec<PlotPoint> {
         // NOTE: `round()` since this can only handle discrete window sizes.
         let window_size = usize::max(1, aggregation_window_size.round() as usize);
-
-        // Keep in mind that adjacent plot points can have the same `PlotPoint::time`,
-        // if data was logged multiple times on the same time stamp.
 
         let min_time = points.first().map_or(i64::MIN, |p| p.time);
         let max_time = points.last().map_or(i64::MAX, |p| p.time);

--- a/crates/re_space_view_time_series/src/aggregation.rs
+++ b/crates/re_space_view_time_series/src/aggregation.rs
@@ -26,9 +26,7 @@ impl AverageAggregator {
             let mut acc = points[i + j].clone();
             j += 1;
 
-            while j < window_size
-                && i + j < points.len()
-                && are_aggregatable(&points[i], &points[i + j], window_size)
+            while i + j < points.len() && are_aggregatable(&points[i], &points[i + j], window_size)
             {
                 let point = &points[i + j];
 

--- a/crates/re_space_view_time_series/src/aggregation.rs
+++ b/crates/re_space_view_time_series/src/aggregation.rs
@@ -23,6 +23,7 @@ impl AverageAggregator {
 
         let mut i = 0;
         while i < points.len() {
+            // How many points to combine together this time.
             let mut j = 0;
 
             let mut ratio = 1.0;
@@ -112,6 +113,7 @@ impl MinMaxAggregator {
 
         let mut i = 0;
         while i < points.len() {
+            // How many points to combine together this time.
             let mut j = 0;
 
             let mut acc_min = points[i + j].clone();
@@ -148,11 +150,9 @@ impl MinMaxAggregator {
 
             match self {
                 MinMaxAggregator::MinMax => {
-                    if acc_min == acc_max {
-                        // Don't push the same point twice.
-                        aggregated.push(acc_min);
-                    } else {
-                        aggregated.push(acc_min);
+                    aggregated.push(acc_min);
+                    // Avoid pushing the same point twice.
+                    if j > 1 {
                         aggregated.push(acc_max);
                     }
                 }

--- a/crates/re_space_view_time_series/src/lib.rs
+++ b/crates/re_space_view_time_series/src/lib.rs
@@ -59,7 +59,7 @@ impl PartialEq for PlotPointAttrs {
 
 impl Eq for PlotPointAttrs {}
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 struct PlotPoint {
     time: i64,
     value: f64,


### PR DESCRIPTION
### What
If a user logs multiple scalars to an entity path during the same time sequence, the aggregator needs to kick. Now it does.

![image](https://github.com/rerun-io/rerun/assets/1148717/d641ee06-c2de-403c-9ed5-462123304ca4)
![image](https://github.com/rerun-io/rerun/assets/1148717/c4253038-8381-45f0-b8fa-26afcfc45433)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5161/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5161/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5161/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5161)
- [Docs preview](https://rerun.io/preview/c0a24a900fc3ef23e4629fae2ca6c7a87ca579bd/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c0a24a900fc3ef23e4629fae2ca6c7a87ca579bd/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)