### PR TITLE
Refactor the 2D heuristic again

### DIFF
--- a/crates/re_space_view_spatial/src/lib.rs
+++ b/crates/re_space_view_spatial/src/lib.rs
@@ -6,6 +6,7 @@ mod contexts;
 mod eye;
 mod heuristics;
 mod instance_hash_conversions;
+mod max_image_dimension_subscriber;
 mod mesh_cache;
 mod mesh_loader;
 mod picking;

--- a/crates/re_space_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/re_space_view_spatial/src/max_image_dimension_subscriber.rs
@@ -16,7 +16,7 @@ pub struct ImageDimensions {
 pub struct MaxImageDimensions(IntMap<EntityPath, ImageDimensions>);
 
 impl MaxImageDimensions {
-    /// Accesses the the image dimension information for a given store
+    /// Accesses the image dimension information for a given store
     pub fn access<T>(
         store_id: &StoreId,
         f: impl FnOnce(&IntMap<EntityPath, ImageDimensions>) -> T,

--- a/crates/re_space_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/re_space_view_spatial/src/max_image_dimension_subscriber.rs
@@ -1,0 +1,96 @@
+use ahash::HashMap;
+use nohash_hasher::IntMap;
+use once_cell::sync::OnceCell;
+use re_data_store::{StoreSubscriber, StoreSubscriberHandle};
+use re_log_types::{EntityPath, StoreId};
+use re_types::{components::TensorData, Loggable};
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ImageDimensions {
+    pub height: u64,
+    pub width: u64,
+    pub channels: u64,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct MaxImageDimensions(IntMap<EntityPath, ImageDimensions>);
+
+impl MaxImageDimensions {
+    /// Accesses the the image dimension information for a given store
+    pub fn access<T>(
+        store_id: &StoreId,
+        f: impl FnOnce(&IntMap<EntityPath, ImageDimensions>) -> T,
+    ) -> Option<T> {
+        re_data_store::DataStore::with_subscriber_once(
+            MaxImageDimensionSubscriber::subscription_handle(),
+            move |subscriber: &MaxImageDimensionSubscriber| {
+                subscriber.max_dimensions.get(store_id).map(|v| &v.0).map(f)
+            },
+        )
+        .flatten()
+    }
+}
+
+#[derive(Default)]
+struct MaxImageDimensionSubscriber {
+    max_dimensions: HashMap<StoreId, MaxImageDimensions>,
+}
+
+impl MaxImageDimensionSubscriber {
+    /// Accesses the global store subscriber.
+    ///
+    /// Lazily registers the subscriber if it hasn't been registered yet.
+    pub fn subscription_handle() -> StoreSubscriberHandle {
+        static SUBSCRIPTION: OnceCell<re_data_store::StoreSubscriberHandle> = OnceCell::new();
+        *SUBSCRIPTION.get_or_init(|| {
+            re_data_store::DataStore::register_subscriber(
+                Box::<MaxImageDimensionSubscriber>::default(),
+            )
+        })
+    }
+}
+
+impl StoreSubscriber for MaxImageDimensionSubscriber {
+    fn name(&self) -> String {
+        "MaxImageDimensionStoreSubscriber".to_owned()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn on_events(&mut self, events: &[re_data_store::StoreEvent]) {
+        re_tracing::profile_function!();
+
+        for event in events {
+            if event.diff.kind != re_data_store::StoreDiffKind::Addition {
+                // Max image dimensions are strictly additive
+                continue;
+            }
+
+            if let Some(cell) = event.diff.cells.get(&TensorData::name()) {
+                if let Ok(Some(tensor_data)) = cell.try_to_native_mono::<TensorData>() {
+                    if let Some([height, width, channels]) =
+                        tensor_data.image_height_width_channels()
+                    {
+                        let dimensions = self
+                            .max_dimensions
+                            .entry(event.store_id.clone())
+                            .or_default()
+                            .0
+                            .entry(event.diff.entity_path.clone())
+                            .or_default();
+
+                        dimensions.height = dimensions.height.max(height);
+                        dimensions.width = dimensions.width.max(width);
+                        dimensions.channels = dimensions.channels.max(channels);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -362,6 +362,17 @@ fn recommended_space_views_with_image_splits(
     // then split the space.
     if found_image_dimensions.len() > 1 || image_count > 1 || depth_count > 1 {
         // Otherwise, split the space and recurse
+
+        // If the root also had a visualizable entity, give it its own space.
+        // TODO(jleibs): Maybe merge this entity into each child
+        if entities.contains(recommended_root) {
+            recommended.push(RecommendedSpaceView {
+                root: recommended_root.clone(),
+                query_filter: EntityPathFilter::single_entity_filter(recommended_root),
+            });
+        }
+
+        // And then recurse into the children
         for child in subtree.children.values() {
             let sub_bucket: IntSet<_> = entities
                 .iter()
@@ -380,7 +391,7 @@ fn recommended_space_views_with_image_splits(
             }
         }
     } else {
-        // If there is only one image, or no images, then we can just use the space as is.
+        // Otherwise we can use the space as it is
         recommended.push(RecommendedSpaceView {
             root: recommended_root.clone(),
             query_filter: EntityPathFilter::subtree_entity_filter(recommended_root),


### PR DESCRIPTION
### What
 - Builds on top of https://github.com/rerun-io/rerun/pull/5164

Adds a store subscriber for tracking the dimensions of image entities.

Gets rid of the previous bucketing logic and replaces it with a new implementation that starts at the top of the subspace and incrementally splits when it finds conflicting image entities within the space.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5166/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5166/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5166/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5166)
- [Docs preview](https://rerun.io/preview/da9a0d206235016d14d9826e8c42ed8481d29643/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/da9a0d206235016d14d9826e8c42ed8481d29643/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)