### PR TITLE
Fix using `rerun` crate as a dependency on CI

### DIFF
--- a/crates/re_build_examples/src/manifest.rs
+++ b/crates/re_build_examples/src/manifest.rs
@@ -92,9 +92,9 @@ fn get_base_url(build_env: Environment) -> anyhow::Result<String> {
     // In the CondaBuild environment we can't trust the git_branch name -- if it exists
     // at all it's going to be the feedstock branch-name, not our Rerun branch. However
     // conda should ONLY be building released versions, so we want to version the manifest.
-    let versioned_manifest = matches!(build_env, Environment::CondaBuild) || {
+    let versioned_manifest = build_env == Environment::CondaBuild || {
         let branch = re_build_tools::git_branch()?;
-        if branch == "main" || !re_build_tools::is_on_ci() {
+        if branch == "main" || build_env != Environment::RerunCI {
             // on `main` and local builds, use `version/main`
             // this will point to data uploaded by `.github/workflows/reusable_upload_examples.yml`
             // on every commit to the `main` branch

--- a/crates/re_build_tools/src/lib.rs
+++ b/crates/re_build_tools/src/lib.rs
@@ -58,7 +58,7 @@ pub(crate) fn should_output_cargo_build_instructions() -> bool {
 // ------------------
 
 /// Where is this `build.rs` build script running?
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Environment {
     /// We are running `cargo publish` (via `scripts/ci/crates.py`); _probably_ on CI.
     PublishingCrates,

--- a/crates/re_build_tools/src/rebuild_detector.rs
+++ b/crates/re_build_tools/src/rebuild_detector.rs
@@ -20,7 +20,7 @@ fn should_run() -> bool {
         Environment::PublishingCrates | Environment::CondaBuild => false,
 
         // Dependencies shouldn't change on CI, but who knows 🤷‍♂️
-        Environment::CI => true,
+        Environment::RerunCI => true,
 
         // Yes - this is what we want tracking for.
         Environment::DeveloperInWorkspace => true,

--- a/crates/re_renderer/build.rs
+++ b/crates/re_renderer/build.rs
@@ -110,7 +110,7 @@ fn should_run() -> bool {
         Environment::PublishingCrates => false,
 
         // The code we're generating here is actual source code that gets committed into the repository.
-        Environment::CI | Environment::CondaBuild => false,
+        Environment::RerunCI | Environment::CondaBuild => false,
 
         Environment::DeveloperInWorkspace => true,
 

--- a/crates/re_types_builder/build.rs
+++ b/crates/re_types_builder/build.rs
@@ -22,7 +22,7 @@ fn should_run() -> bool {
         Environment::PublishingCrates => false,
 
         // The code we're generating here is actual source code that gets committed into the repository.
-        Environment::CI | Environment::CondaBuild => false,
+        Environment::RerunCI | Environment::CondaBuild => false,
 
         Environment::DeveloperInWorkspace => {
             // This `build.rs` depends on having `flatc` installed,

--- a/crates/re_web_viewer_server/build.rs
+++ b/crates/re_web_viewer_server/build.rs
@@ -18,7 +18,7 @@ fn should_run() -> bool {
         Environment::PublishingCrates => false,
 
         // TODO(emilk): only build the web viewer explicitly on CI
-        Environment::CI | Environment::CondaBuild => true,
+        Environment::RerunCI | Environment::CondaBuild => true,
 
         Environment::DeveloperInWorkspace => true,
 

--- a/examples/rust/objectron/build.rs
+++ b/examples/rust/objectron/build.rs
@@ -12,7 +12,7 @@ fn should_run() -> bool {
 
         // No need to run this on CI (which means setting up `protoc` etc)
         // since the code is committed anyway.
-        Environment::CI | Environment::CondaBuild => false,
+        Environment::RerunCI | Environment::CondaBuild => false,
 
         // Sure - let's keep it up-to-date.
         Environment::DeveloperInWorkspace => true,


### PR DESCRIPTION
Our complex `buid.rs` scripts come to bite us again

* Closes https://github.com/rerun-io/rerun/issues/5168

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5170/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5170/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5170/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5170)
- [Docs preview](https://rerun.io/preview/3bebf6d5b54bbd4a0f616cba19ea16892e703378/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3bebf6d5b54bbd4a0f616cba19ea16892e703378/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)