### PR TITLE
Do not implicitly build web viewer on CI

### DIFF
--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -197,11 +197,12 @@ jobs:
           command: check
           args: --locked --target wasm32-unknown-unknown --target-dir target_wasm -p re_renderer --examples
 
-      - name: Build web-viewer (debug)
+      - name: Build web-viewer (release)
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --locked -p re_build_web_viewer -- --debug
+          # We build in release so that we can reuse the results for actual publishing, if necessary
+          args: --locked -p re_build_web_viewer -- --release
 
   toml-lints:
     name: Lint TOML files

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           pixi-version: v0.13.0
 
-      - name: Build web-viewer
+      - name: Build web-viewer (release)
         shell: bash
         run: |
           pixi run cargo run --locked -p re_build_web_viewer -- --release

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -174,6 +174,14 @@ jobs:
           workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
+      # We need to build the web viewer for `rust_checks.py` to succeed.
+      - name: Build web-viewer (release)
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          # We build in release so that we can reuse the results for actual publishing, if necessary
+          args: --locked -p re_build_web_viewer -- --release
+
       - name: Rust checks & tests
         if: ${{ !inputs.ALL_CHECKS }}
         run: ./scripts/ci/rust_checks.py --skip-check-individual-crates

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -214,11 +214,12 @@ jobs:
           command: check
           args: --locked --target wasm32-unknown-unknown --target-dir target_wasm -p re_renderer --examples
 
-      - name: Build web-viewer (debug)
+      - name: Build web-viewer (release)
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --locked -p re_build_web_viewer -- --debug
+          # We build in release so that we can reuse the results for actual publishing, if necessary
+          args: --locked -p re_build_web_viewer -- --release
 
   # ---------------------------------------------------------------------------
 

--- a/.github/workflows/reusable_publish_web.yml
+++ b/.github/workflows/reusable_publish_web.yml
@@ -105,7 +105,7 @@ jobs:
           pixi run which rerun
           pixi run rerun --version
 
-      - name: Build app.rerun.io
+      - name: Build web-viewer (release)
         shell: bash
         run: |
           pixi run cargo run --locked -p re_build_web_viewer -- --release

--- a/.github/workflows/reusable_release_crates.yml
+++ b/.github/workflows/reusable_release_crates.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           pixi-version: v0.13.0
 
-      - name: Build web-viewer
+      - name: Build web-viewer (release)
         shell: bash
         run: |
           pixi run cargo run --locked -p re_build_web_viewer -- --release

--- a/crates/re_web_viewer_server/build.rs
+++ b/crates/re_web_viewer_server/build.rs
@@ -20,8 +20,9 @@ fn should_run() -> bool {
         // We build the web viewer in an explicit, separate step.
         Environment::RerunCI => false,
 
-        // TODO(emilk): build the web viewer as an explicit step instead
-        Environment::CondaBuild => true,
+        // We build the web-viewer as an explicit step:
+        // https://github.com/conda-forge/rerun-sdk-feedstock/blob/8a63484685d6697c638c0d45b78396f049d10ce7/recipe/build.sh#L18
+        Environment::CondaBuild => false,
 
         // If a developer is iterating on the viewer, they don't want to manually recompile it.
         Environment::DeveloperInWorkspace => true,

--- a/crates/re_web_viewer_server/build.rs
+++ b/crates/re_web_viewer_server/build.rs
@@ -17,9 +17,13 @@ fn should_run() -> bool {
         // We should build the web viewer before starting crate publishing
         Environment::PublishingCrates => false,
 
-        // TODO(emilk): only build the web viewer explicitly on CI
-        Environment::RerunCI | Environment::CondaBuild => true,
+        // We build the web viewer in an explicit, separate step.
+        Environment::RerunCI => false,
 
+        // TODO(emilk): build the web viewer as an explicit step instead
+        Environment::CondaBuild => true,
+
+        // If a developer is iterating on the viewer, they don't want to manually recompile it.
         Environment::DeveloperInWorkspace => true,
 
         // Definitely not

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -19,7 +19,7 @@ class Timing:
 
 
 def run_cargo(command: str, args: str) -> Timing:
-    cwd = f"cargo {command} {args}"
+    cwd = f"cargo {command} --quiet {args}"
     print(f"Running '{cwd}'")
     start = time.time()
     result = subprocess.call(cwd, shell=True)


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5171

Explicit is better than implicit

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5172/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5172/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5172/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5172)
- [Docs preview](https://rerun.io/preview/2062863d4c35a8d370e6920a81a6ed27a79c8bad/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2062863d4c35a8d370e6920a81a6ed27a79c8bad/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)