### PR TITLE
Update to egui 0.26.1 and fix top-bar interaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,9 +1558,9 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "ecolor"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a0e42e2b3d0f663e100f5c10710ffdb9748f7e7565305ecc09044d59e0fbd"
+checksum = "9c912193fa5698d4fbc857b831fb96b42215dcf565e06012993a65901299a21f"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1568,9 +1568,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2230537c7ee42c4c329461bad5933e91a8f938a9314645961e12e57080478731"
+checksum = "f31ff7b8ea429daa1370069cdca84cce0bc8e4358068fc50daef5e07b7e84481"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1604,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493685c2ca33e06b5ad45ae304b13bc084c395f422268bff1377633552f69ac"
+checksum = "abecd396ede556116fceaa0098a1c9278ef526119c5097311eac4bcf57484c52"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1621,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "094ce3408f61ead0747b506aeb9e3fa9adbd5d937096a26dfbee24387bce8b3a"
+checksum = "5c3b9dafdf68e57b0553205fa32bb111d84573de58410cd5fa448dc716e1d597"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1640,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85f8f89d6a937535e164a5bd6e31719fd7db01bc188d7b59425414b160a2ee1"
+checksum = "d0ef887214f5b65883cd1c85b0a5335e06f2876446c67fb64939c1ef0be518e0"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1670,9 +1670,9 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34bb4782902b4c314ab3bef2dd8a23c634df2e88978fa358cd2c09fb60bab172"
+checksum = "011213c1c95821080d1ea7a28cb2928f89df4d794a4c5f0ed034958966c58860"
 dependencies = [
  "egui",
  "ehttp",
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b8d8d33da3d2ae4db39b30ddcbc5f31e9b0d74e65dc028cf711e94b68ec4d6"
+checksum = "95307de94643fc205543c4145f2ce254685f6a6ead906393e3996ede9a67b87f"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1705,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "egui_plot"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c9fb26a588e070434a0b23783d8fc22a4c359ac5177401c9029add9dd2685f7"
+checksum = "6073f45dcd97a48366b2ae93d8a55f6b74aa5e92a502fe089982857d03750ba2"
 dependencies = [
  "egui",
 ]
@@ -1749,9 +1749,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "emath"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba2475f57a416ce2a05e557f3d18e465c7aef23f3f6da2252b428eaaaaa6a65"
+checksum = "2386663fafbd043f2cd14f0ded4702deb9348fb7e7bacba9c9087a31b17487f1"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1851,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823734a8b7e81302a5f1a8ba041ab4ed7805a43d8dfec4dac0c72b933699bbc"
+checksum = "36ac8c9ca960f0263856a7fbc90d7ad41280e8865a7cd3c64d3daec016bd7115"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,15 +74,15 @@ re_ws_comms = { path = "crates/re_ws_comms", version = "=0.13.0-alpha.3", defaul
 rerun = { path = "crates/rerun", version = "=0.13.0-alpha.3", default-features = false }
 
 # egui-crates:
-ecolor = "0.26.0"
-eframe = { version = "0.26.0", default-features = false, features = [
+ecolor = "0.26.1"
+eframe = { version = "0.26.1", default-features = false, features = [
   "accesskit",
   "default_fonts",
   "puffin",
   "wayland",
   "x11",
 ] }
-egui = { version = "0.26.0", features = [
+egui = { version = "0.26.1", features = [
   "callstack",
   "extra_debug_asserts",
   "log",
@@ -90,11 +90,11 @@ egui = { version = "0.26.0", features = [
   "rayon",
 ] }
 egui_commonmark = { version = "0.12", default-features = false }
-egui_extras = { version = "0.26.0", features = ["http", "image", "puffin"] }
-egui_plot = "0.26.0"
+egui_extras = { version = "0.26.1", features = ["http", "image", "puffin"] }
+egui_plot = "0.26.1"
 egui_tiles = "0.7.2"
-egui-wgpu = "0.26.0"
-emath = "0.26.0"
+egui-wgpu = "0.26.1"
+emath = "0.26.1"
 
 # All of our direct external dependencies should be found here:
 ahash = "0.8"

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -485,19 +485,15 @@ impl ExampleApp {
             .frame(self.re_ui.top_panel_frame())
             .exact_height(top_bar_style.height)
             .show(egui_ctx, |ui| {
-                let _response = egui::menu::bar(ui, |ui| {
-                    ui.set_height(top_bar_style.height);
-                    ui.add_space(top_bar_style.indent);
-
-                    ui.menu_button("File", |ui| file_menu(ui, &self.command_sender));
-
-                    self.top_bar_ui(ui);
-                })
-                .response;
-
                 #[cfg(not(target_arch = "wasm32"))]
                 if !re_ui::NATIVE_WINDOW_BAR {
-                    let title_bar_response = _response.interact(egui::Sense::click());
+                    // Interact with background first, so that buttons in the top bar gets input priority
+                    // (last added widget has priority for input).
+                    let title_bar_response = ui.interact(
+                        ui.max_rect(),
+                        ui.id().with("background"),
+                        egui::Sense::click(),
+                    );
                     if title_bar_response.double_clicked() {
                         let maximized = ui.input(|i| i.viewport().maximized.unwrap_or(false));
                         ui.ctx()
@@ -506,6 +502,15 @@ impl ExampleApp {
                         ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
                     }
                 }
+
+                egui::menu::bar(ui, |ui| {
+                    ui.set_height(top_bar_style.height);
+                    ui.add_space(top_bar_style.indent);
+
+                    ui.menu_button("File", |ui| file_menu(ui, &self.command_sender));
+
+                    self.top_bar_ui(ui);
+                });
             });
     }
 

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -25,7 +25,26 @@ pub fn top_panel(
         .frame(app.re_ui().top_panel_frame())
         .exact_height(top_bar_style.height)
         .show_inside(ui, |ui| {
-            let _response = egui::menu::bar(ui, |ui| {
+            // React to dragging and double-clicking the top bar:
+            #[cfg(not(target_arch = "wasm32"))]
+            if !re_ui::NATIVE_WINDOW_BAR {
+                // Interact with background first, so that buttons in the top bar gets input priority
+                // (last added widget has priority for input).
+                let title_bar_response = ui.interact(
+                    ui.max_rect(),
+                    ui.id().with("background"),
+                    egui::Sense::click(),
+                );
+                if title_bar_response.double_clicked() {
+                    let maximized = ui.input(|i| i.viewport().maximized.unwrap_or(false));
+                    ui.ctx()
+                        .send_viewport_cmd(egui::ViewportCommand::Maximized(!maximized));
+                } else if title_bar_response.is_pointer_button_down_on() {
+                    ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
+                }
+            }
+
+            egui::menu::bar(ui, |ui| {
                 ui.set_height(top_bar_style.height);
                 ui.add_space(top_bar_style.indent);
 
@@ -37,21 +56,7 @@ pub fn top_panel(
                     ui,
                     gpu_resource_stats,
                 );
-            })
-            .response;
-
-            // React to dragging and double-clicking the top bar:
-            #[cfg(not(target_arch = "wasm32"))]
-            if !re_ui::NATIVE_WINDOW_BAR {
-                let title_bar_response = _response.interact(egui::Sense::click());
-                if title_bar_response.double_clicked() {
-                    let maximized = ui.input(|i| i.viewport().maximized.unwrap_or(false));
-                    ui.ctx()
-                        .send_viewport_cmd(egui::ViewportCommand::Maximized(!maximized));
-                } else if title_bar_response.is_pointer_button_down_on() {
-                    ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
-                }
-            }
+            });
         });
 }
 


### PR DESCRIPTION
### What
We were doing it wrong, and I don't quite understand why it worked before.

But the bug surfaced in egui 0.26.1.

It is not obvious if `response.interact` should create a new interaction now (covering existing stuff) or retrospectively inject itself before the things added as children to it. I'll have to think through and specify this for egui 0.27.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5176/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5176/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5176/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5176)
- [Docs preview](https://rerun.io/preview/65ac8e7408098e69932e481a52671269d9756b45/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/65ac8e7408098e69932e481a52671269d9756b45/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)