### PR TITLE
Small release fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,7 +305,7 @@ jobs:
         run: |
           git fetch
           git checkout ${{ github.ref_name }}
-          git push --force origin refs/heads${{ github.ref_name }}:refs/heads/latest
+          git push --force origin refs/heads/${{ github.ref_name }}:refs/heads/latest
 
   github-release:
     name: "GitHub Release"
@@ -326,7 +326,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: ${{ needs.version.outputs.release-commit }}
           token: ${{ secrets.RERUN_BOT_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,31 +384,30 @@ jobs:
         with:
           python-version: 3.11
 
+      - uses: prefix-dev/setup-pixi@v0.4.1
+        with:
+          pixi-version: v0.13.0
+
       - name: Install dependencies
         shell: bash
         run: |
           python3 -m pip install -r scripts/ci/requirements-crates.txt
 
-      - name: Update version
-        id: update-version
-        shell: bash
-        run: |
-          python3 scripts/ci/crates.py version --bump auto
-          echo "version=$(python3 scripts/ci/crates.py get-version)" >> "$GITHUB_OUTPUT"
-
-      - uses: prefix-dev/setup-pixi@v0.4.1
-        with:
-          pixi-version: v0.13.0
-
-      - run: pixi run toml-fmt
-        shell: bash
-
       - name: Commit new version
         shell: bash
         run: |
+          # checkout + pull changes
           git config --global user.name "rerun-bot"
           git config --global user.email "bot@rerun.io"
-          git commit -am "Bump versions to ${{ steps.update-version.outputs.version }}"
+          git checkout ${{ github.ref_name }}
+          git pull --rebase
+
+          # bump version and commit it
+          python3 scripts/ci/crates.py version --bump auto
+          pixi run toml-fmt
+          version="$(python3 scripts/ci/crates.py get-version)"
+
+          git commit -am "Bump versions to $version"
           git push
 
   comment-artifact-links:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.version.outputs.release-commit }}
+          fetch-depth: 0
           token: ${{ secrets.RERUN_BOT_TOKEN }}
 
       - name: Release tag
@@ -334,7 +334,8 @@ jobs:
           GH_TOKEN: ${{ secrets.RERUN_BOT_TOKEN }}
         run: |
           version="${{ needs.version.outputs.final }}"
-          git tag $version
+          commit="${{ needs.version.outputs.release-commit }}"
+          git tag $version $commit
           git push origin $version
           gh release create $version --verify-tag --draft --title $version
 
@@ -372,7 +373,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ needs.version.outputs.release-commit }}
           token: ${{ secrets.RERUN_BOT_TOKEN }}
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
### What

A few jobs failed in the `0.13` release job: https://github.com/rerun-io/rerun/actions/runs/7873726829/job/21483717804

- `Update latest branch` failed due to a missing slash in the ref name that we're pushing as the `latest` branch
- `GitHub Release` could not determine branch name, because the job checked out
  a specific commit instead of the `release-0.13` branch.
  - This was done to try and ensure the correct commit is tagged, but it's not actually necessary,
    instead a specific commit is now tagged via the `git tag <name> <commit>` form of the command.
  - As a result, the release branch is now checked out in that job, so the `gh pr view` command can find it and correctly determine the PR number to which it should post the comment.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5179/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5179/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5179/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5179)
- [Docs preview](https://rerun.io/preview/30b2e6a0f0027f9db63a86164a7b0697102022d1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/30b2e6a0f0027f9db63a86164a7b0697102022d1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)