### PR TITLE
Fix warnings when compiling with nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/crates/re_analytics/src/native/sink.rs
+++ b/crates/re_analytics/src/native/sink.rs
@@ -3,9 +3,6 @@ use std::sync::Arc;
 use super::AbortSignal;
 use crate::{Event, PostHogBatch, PostHogEvent};
 
-#[derive(Debug, Clone)]
-struct Url(String);
-
 #[derive(Default, Debug, Clone)]
 pub(crate) struct PostHogSink {}
 

--- a/crates/re_log_types/src/path/parse_path.rs
+++ b/crates/re_log_types/src/path/parse_path.rs
@@ -266,12 +266,12 @@ fn join(tokens: &[&str]) -> String {
     s
 }
 
-/// "/foo/bar" -> ["/", "foo", "/", "bar"]
+/// `"/foo/bar"` -> `["/", "foo", "/", "bar"]`
 fn tokenize_entity_path(path: &str) -> Vec<&str> {
     tokenize_by(path, &[b'/'])
 }
 
-/// "/foo/bar[#42]:Color" -> ["/", "foo", "/", "bar", "[", "#42:", "]", ":", "Color"]
+/// `"/foo/bar[#42]:Color"` -> `["/", "foo", "/", "bar", "[", "#42:", "]", ":", "Color"]`
 fn tokenize_data_path(path: &str) -> Vec<&str> {
     tokenize_by(path, &[b'/', b'[', b']', b':'])
 }

--- a/crates/re_memory/src/accounting_allocator.rs
+++ b/crates/re_memory/src/accounting_allocator.rs
@@ -31,7 +31,7 @@ thread_local! {
     ///
     /// Tracking an allocation (taking its backtrace etc) can itself create allocations.
     /// We don't want to track those allocations, or we will have infinite recursion.
-    static IS_THREAD_IN_ALLOCATION_TRACKER: std::cell::Cell<bool> = std::cell::Cell::new(false);
+    static IS_THREAD_IN_ALLOCATION_TRACKER: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/re_renderer/src/allocator/mod.rs
+++ b/crates/re_renderer/src/allocator/mod.rs
@@ -12,7 +12,6 @@ pub use cpu_write_gpu_read_belt::{
 };
 pub use gpu_readback_belt::{
     GpuReadbackBelt, GpuReadbackBuffer, GpuReadbackError, GpuReadbackIdentifier,
-    GpuReadbackUserDataStorage,
 };
 pub use uniform_buffer_fill::{
     create_and_fill_uniform_buffer, create_and_fill_uniform_buffer_batch,

--- a/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
+++ b/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
@@ -1,7 +1,5 @@
 use re_log::ResultExt;
 
-pub use super::cpu_write_gpu_read_belt::{CpuWriteGpuReadBelt, CpuWriteGpuReadBuffer};
-
 use crate::{wgpu_resources::BindGroupEntry, DebugLabel, RenderContext};
 
 struct UniformBufferAlignmentCheck<T> {

--- a/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
+++ b/crates/re_renderer/src/allocator/uniform_buffer_fill.rs
@@ -20,11 +20,11 @@ impl<T> UniformBufferAlignmentCheck<T> {
     /// Alternatively to enforcing this alignment on the type we could:
     /// * only align on the gpu buffer
     ///     -> causes more fine grained `copy_buffer_to_buffer` calls on the gpu encoder
-    /// * only align on the [`CpuWriteGpuReadBuffer`] & gpu buffer
-    ///     -> causes more complicated offset computation on [`CpuWriteGpuReadBuffer`] as well as either
+    /// * only align on the [`CpuWriteGpuReadBuffer`][crate::allocator::CpuWriteGpuReadBuffer] & gpu buffer
+    ///     -> causes more complicated offset computation on [`CpuWriteGpuReadBuffer`][crate::allocator::CpuWriteGpuReadBuffer] as well as either
     ///         holes at padding (-> undefined values & slow for write combined!) or complicated nulling of padding
     ///
-    /// About the [`bytemuck::Pod`] requirement (dragged in by [`CpuWriteGpuReadBuffer`]):
+    /// About the [`bytemuck::Pod`] requirement (dragged in by [`CpuWriteGpuReadBuffer`][crate::allocator::CpuWriteGpuReadBuffer]):
     /// [`bytemuck::Pod`] forces us to be explicit about padding as it doesn't allow invisible padding bytes!
     /// We could drop this and thus make it easier to define uniform buffer types.
     /// But this leads to more unsafe code, harder to avoid holes in write combined memory access

--- a/crates/re_renderer/src/wgpu_resources/mod.rs
+++ b/crates/re_renderer/src/wgpu_resources/mod.rs
@@ -13,17 +13,13 @@ pub use bind_group_layout_pool::{
 };
 
 mod bind_group_pool;
-pub use bind_group_pool::{
-    BindGroupDesc, BindGroupEntry, GpuBindGroup, GpuBindGroupHandle, GpuBindGroupPool,
-};
+pub use bind_group_pool::{BindGroupDesc, BindGroupEntry, GpuBindGroup, GpuBindGroupPool};
 
 mod buffer_pool;
-pub use buffer_pool::{BufferDesc, GpuBuffer, GpuBufferHandle, GpuBufferPool};
+pub use buffer_pool::{BufferDesc, GpuBuffer, GpuBufferPool};
 
 mod pipeline_layout_pool;
-pub use pipeline_layout_pool::{
-    GpuPipelineLayoutHandle, GpuPipelineLayoutPool, PipelineLayoutDesc,
-};
+pub use pipeline_layout_pool::{GpuPipelineLayoutPool, PipelineLayoutDesc};
 
 mod render_pipeline_pool;
 pub use render_pipeline_pool::{
@@ -38,16 +34,13 @@ mod shader_module_pool;
 pub use shader_module_pool::{GpuShaderModuleHandle, GpuShaderModulePool, ShaderModuleDesc};
 
 mod texture_pool;
-pub use texture_pool::{
-    GpuTexture, GpuTextureHandle, GpuTextureInternal, GpuTexturePool, TextureDesc,
-};
+pub use texture_pool::{GpuTexture, GpuTextureHandle, GpuTexturePool, TextureDesc};
 
 mod resource;
 pub use resource::PoolError;
 
 mod dynamic_resource_pool;
 mod static_resource_pool;
-pub use static_resource_pool::StaticResourcePoolAccessor;
 
 /// Collection of all wgpu resource pools.
 ///

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -286,9 +286,9 @@ pub fn create_labels(
     // Closest last (painters algorithm)
     labels.sort_by_key(|label| {
         if let UiLabelTarget::Position3D(pos) = label.target {
-            OrderedFloat::try_from(-ui_from_world_3d.transform_point3(pos).z).ok()
+            OrderedFloat::from(-ui_from_world_3d.transform_point3(pos).z)
         } else {
-            Default::default()
+            OrderedFloat::from(0.0)
         }
     });
 

--- a/crates/re_space_view_spatial/src/visualizers/images.rs
+++ b/crates/re_space_view_spatial/src/visualizers/images.rs
@@ -66,9 +66,7 @@ fn to_textured_rect(
 ) -> Option<re_renderer::renderer::TexturedRect> {
     re_tracing::profile_function!();
 
-    let Some([height, width, _]) = tensor.image_height_width_channels() else {
-        return None;
-    };
+    let [height, width, _] = tensor.image_height_width_channels()?;
 
     let debug_name = ent_path.to_string();
     let tensor_stats = ctx

--- a/crates/re_types/src/image.rs
+++ b/crates/re_types/src/image.rs
@@ -70,7 +70,7 @@ pub fn find_non_empty_dim_indices(shape: &[TensorDimension]) -> SmallVec<[usize;
 #[test]
 fn test_find_non_empty_dim_indices() {
     fn expect(shape: &[u64], expected: &[usize]) {
-        let dim = shape
+        let dim: Vec<_> = shape
             .iter()
             .map(|s| TensorDimension {
                 size: *s,

--- a/crates/re_types/src/image.rs
+++ b/crates/re_types/src/image.rs
@@ -20,7 +20,7 @@ where
 ///
 /// For instance: `[1, 640, 480, 3, 1]` would return `[1, 2, 3]`,
 /// the indices of the `[640, 480, 3]` dimensions.
-pub fn find_non_empty_dim_indices(shape: &Vec<TensorDimension>) -> SmallVec<[usize; 4]> {
+pub fn find_non_empty_dim_indices(shape: &[TensorDimension]) -> SmallVec<[usize; 4]> {
     match shape.len() {
         0 => return smallvec![],
         1 => return smallvec![0],

--- a/crates/re_types_builder/src/codegen/mod.rs
+++ b/crates/re_types_builder/src/codegen/mod.rs
@@ -39,7 +39,6 @@ mod docs;
 mod python;
 mod rust;
 
-pub use self::common::write_file;
 pub use self::cpp::CppCodeGenerator;
 pub use self::docs::DocsCodeGenerator;
 pub use self::python::PythonCodeGenerator;

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -53,7 +53,7 @@ fn guess_query_and_store_for_selected_entity<'a>(
     {
         (
             ctx.blueprint_cfg.time_ctrl.read().current_query(),
-            &ctx.store_context.blueprint.store(),
+            ctx.store_context.blueprint.store(),
         )
     } else {
         (

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -407,17 +407,9 @@ fn e2e_latency_ui(
     ui: &mut egui::Ui,
     store_context: Option<&StoreContext<'_>>,
 ) -> Option<egui::Response> {
-    let Some(store_context) = store_context else {
-        return None;
-    };
-
-    let Some(recording) = store_context.recording else {
-        return None;
-    };
-
-    let Some(e2e_latency_sec) = recording.ingestion_stats().current_e2e_latency_sec() else {
-        return None;
-    };
+    let store_context = store_context?;
+    let recording = store_context.recording?;
+    let e2e_latency_sec = recording.ingestion_stats().current_e2e_latency_sec()?;
 
     if e2e_latency_sec > 60.0 {
         return None; // Probably an old recording and not live data.

--- a/crates/re_viewer_context/src/clipboard.rs
+++ b/crates/re_viewer_context/src/clipboard.rs
@@ -32,7 +32,7 @@ impl Clipboard {
     pub fn with<R>(f: impl FnOnce(&mut Clipboard) -> R) -> R {
         use std::cell::RefCell;
         thread_local! {
-            static CLIPBOARD: RefCell<Option<Clipboard>> = RefCell::new(None);
+            static CLIPBOARD: RefCell<Option<Clipboard>> = const { RefCell::new(None) };
         }
 
         CLIPBOARD.with(|clipboard| {

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -234,9 +234,7 @@ impl ViewportBlueprint {
         space_view_id: &SpaceViewId,
         ctx: &ViewerContext<'_>,
     ) -> Option<SpaceViewId> {
-        let Some(space_view) = self.space_view(space_view_id) else {
-            return None;
-        };
+        let space_view = self.space_view(space_view_id)?;
 
         let new_space_view = space_view.duplicate(ctx.store_context.blueprint, ctx.blueprint_query);
         let new_space_view_id = new_space_view.id;
@@ -358,9 +356,7 @@ impl ViewportBlueprint {
             return Some(Contents::Container(*container_id));
         }
 
-        let Some(container) = self.container(container_id) else {
-            return None;
-        };
+        let container = self.container(container_id)?;
 
         for contents in &container.contents {
             if predicate(contents) {
@@ -412,9 +408,7 @@ impl ViewportBlueprint {
         contents: &Contents,
         container_id: &ContainerId,
     ) -> Option<(ContainerId, usize)> {
-        let Some(container) = self.container(container_id) else {
-            return None;
-        };
+        let container = self.container(container_id)?;
 
         for (pos, child_contents) in container.contents.iter().enumerate() {
             if child_contents == contents {

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -19,7 +19,7 @@ class Timing:
 
 
 def run_cargo(command: str, args: str) -> Timing:
-    cwd = f"cargo {command} {args}"
+    cwd = f"cargo {command} --quiet {args}"
     print(f"Running '{cwd}'")
     start = time.time()
     result = subprocess.call(cwd, shell=True)


### PR DESCRIPTION
### What
This allows us to compile with the nightly rust compiler without warnings, which is just a nice convenience.

It is especially nice for https://github.com/rerun-io/rerun/pull/4780 which relies on compiling with the nightly compiler.

Also fixes some new clippy warnings.

I needed to update `ahash` to compile on bleeding edge nightly.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5184/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5184/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5184/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5184)
- [Docs preview](https://rerun.io/preview/a43b20b9c39030cf6c06e62bdb2b3cc1a6e1e9e6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a43b20b9c39030cf6c06e62bdb2b3cc1a6e1e9e6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)