### PR TITLE
Add feature-flagged parallel loading of time series plots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4832,6 +4832,7 @@ dependencies = [
  "egui_plot",
  "itertools 0.12.0",
  "parking_lot",
+ "rayon",
  "re_data_store",
  "re_format",
  "re_log",

--- a/crates/re_space_view_time_series/Cargo.toml
+++ b/crates/re_space_view_time_series/Cargo.toml
@@ -33,3 +33,4 @@ egui.workspace = true
 egui_plot.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
+rayon.workspace = true

--- a/crates/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/line_visualizer_system.rs
@@ -166,6 +166,9 @@ fn load_series(
     let override_color = lookup_override::<Color>(data_result, ctx).map(|c| c.to_array());
     let override_series_name = lookup_override::<Name>(data_result, ctx).map(|t| t.0);
     let override_stroke_width = lookup_override::<StrokeWidth>(data_result, ctx).map(|r| r.0);
+
+    // All the default values for a `PlotPoint`, accounting for both overrides and default
+    // values.
     let default_point = PlotPoint {
         time: 0,
         value: 0.0,
@@ -176,7 +179,9 @@ fn load_series(
             kind: PlotSeriesKind::Continuous,
         },
     };
+
     let mut points = Vec::new();
+
     let time_range = determine_time_range(
         query,
         data_result,
@@ -267,6 +272,11 @@ fn load_series(
             },
         )?;
     }
+
+    // Check for an explicit label if any.
+    // We're using a separate latest-at query for this since the semantics for labels changing over time are a
+    // a bit unclear.
+    // Sidestepping the cache here shouldn't be a problem since we do so only once per entity.
     let series_name = if let Some(override_name) = override_series_name {
         Some(override_name)
     } else {
@@ -275,6 +285,8 @@ fn load_series(
             .query_latest_component::<Name>(&data_result.entity_path, &ctx.current_query())
             .map(|name| name.value.0)
     };
+
+    // Now convert the `PlotPoints` into `Vec<PlotSeries>`
     points_to_series(
         data_result,
         time_per_pixel,

--- a/crates/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/line_visualizer_system.rs
@@ -98,15 +98,14 @@ impl SeriesLineSystem {
 
         let (plot_bounds, time_per_pixel) = determine_plot_bounds_and_time_per_pixel(ctx, query);
 
-        let data_results = query
-            .iter_visible_data_results(Self::identifier())
-            .collect_vec();
+        let data_results = query.iter_visible_data_results(Self::identifier());
 
         if false {
             // TODO(emilk): enable parallel loading when it is faster, because right now it is often slower.
             use rayon::prelude::*;
             re_tracing::profile_wait!("load_series");
             for one_series in data_results
+                .collect_vec()
                 .par_iter()
                 .map(|data_result| -> Result<Vec<PlotSeries>, QueryError> {
                     let annotations = self.annotation_map.find(&data_result.entity_path);

--- a/crates/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/line_visualizer_system.rs
@@ -96,156 +96,166 @@ impl SeriesLineSystem {
     ) -> Result<(), QueryError> {
         re_tracing::profile_function!();
 
-        let query_caches = ctx.entity_db.query_caches();
-        let store = ctx.entity_db.store();
-
         let (plot_bounds, time_per_pixel) = determine_plot_bounds_and_time_per_pixel(ctx, query);
 
         // TODO(cmc): this should be thread-pooled in case there are a gazillon series in the same plot…
         for data_result in query.iter_visible_data_results(Self::identifier()) {
             let annotations = self.annotation_map.find(&data_result.entity_path);
-            let annotation_info = annotations
-                .resolved_class_description(None)
-                .annotation_info();
-            let default_color = DefaultColor::EntityPath(&data_result.entity_path);
+            let all_series = &mut self.all_series;
 
-            let override_color = lookup_override::<Color>(data_result, ctx).map(|c| c.to_array());
-            let override_series_name = lookup_override::<Name>(data_result, ctx).map(|t| t.0);
-            let override_stroke_width =
-                lookup_override::<StrokeWidth>(data_result, ctx).map(|r| r.0);
-
-            // All the default values for a `PlotPoint`, accounting for both overrides and default
-            // values.
-            let default_point = PlotPoint {
-                time: 0,
-                value: 0.0,
-                attrs: PlotPointAttrs {
-                    label: None,
-                    color: annotation_info.color(override_color, default_color),
-                    marker_size: override_stroke_width.unwrap_or(DEFAULT_STROKE_WIDTH),
-                    kind: PlotSeriesKind::Continuous,
-                },
-            };
-
-            let mut points = Vec::new();
-
-            let time_range = determine_time_range(
+            load_series(
+                ctx,
                 query,
-                data_result,
                 plot_bounds,
-                ctx.app_options.experimental_plot_query_clamping,
-            );
-
-            {
-                re_tracing::profile_scope!("primary", &data_result.entity_path.to_string());
-
-                let entity_path = &data_result.entity_path;
-                let query = re_data_store::RangeQuery::new(query.timeline, time_range);
-
-                // TODO(jleibs): need to do a "joined" archetype query
-                // The `Scalar` archetype queries for `MarkerShape` & `MarkerSize` in the point visualizer,
-                // and so it must do so here also.
-                // See https://github.com/rerun-io/rerun/pull/5029
-                query_caches.query_archetype_range_pov1_comp4::<
-                    archetypes::Scalar,
-                    Scalar,
-                    Color,
-                    StrokeWidth,
-                    MarkerSize, // unused
-                    MarkerShape, // unused
-                    _,
-                >(
-                    store,
-                    &query,
-                    entity_path,
-                    |_timeless, entry_range, (times, _, scalars, colors, stroke_widths, _, _)| {
-                        let times = times.range(entry_range.clone()).map(|(time, _)| time.as_i64());
-                        // Allocate all points.
-                        points = times.map(|time| PlotPoint {
-                            time,
-                            ..default_point.clone()
-                        }).collect_vec();
-
-                        // Fill in values.
-                        for (i, scalar) in scalars.range(entry_range.clone()).enumerate() {
-                            if scalar.len() > 1 {
-                                re_log::warn_once!("found a scalar batch in {entity_path:?} -- those have no effect");
-                            } else if scalar.is_empty() {
-                                points[i].attrs.kind = PlotSeriesKind::Clear;
-                            } else {
-                                points[i].value = scalar.first().map_or(0.0, |s| s.0);
-                            }
-                        }
-
-                        // Make it as clear as possible to the optimizer that some parameters
-                        // go completely unused as soon as overrides have been defined.
-
-                        // Fill in colors -- if available _and_ not overridden.
-                        if override_color.is_none() {
-                            if let Some(colors) = colors {
-                                for (i, color) in colors.range(entry_range.clone()).enumerate() {
-                                    if i >= points.len() {
-                                        re_log::debug_once!("more color attributes than points in {entity_path:?} -- this points to a bug in the query cache");
-                                        break;
-                                    }
-                                    if let Some(color) = color.first().copied().flatten().map(|c| {
-                                        let [r,g,b,a] = c.to_array();
-                                        if a == 255 {
-                                            // Common-case optimization
-                                            re_renderer::Color32::from_rgb(r, g, b)
-                                        } else {
-                                            re_renderer::Color32::from_rgba_unmultiplied(r, g, b, a)
-                                        }
-                                    }) {
-                                        points[i].attrs.color = color;
-                                    }
-                                }
-                            }
-                        }
-
-                        // Fill in radii -- if available _and_ not overridden.
-                        if override_stroke_width.is_none() {
-                            if let Some(stroke_widths) = stroke_widths {
-                                for (i, stroke_width) in stroke_widths.range(entry_range.clone()).enumerate() {
-                                    if i >= stroke_widths.num_entries() {
-                                        re_log::debug_once!("more stroke width attributes than points in {entity_path:?} -- this points to a bug in the query cache");
-                                        break;
-                                    }
-                                    if let Some(stroke_width) = stroke_width.first().copied().flatten().map(|r| r.0) {
-                                        points[i].attrs.marker_size = stroke_width;
-                                    }
-                                }
-                            }
-                        }
-                    },
-                )?;
-            }
-
-            // Check for an explicit label if any.
-            // We're using a separate latest-at query for this since the semantics for labels changing over time are a
-            // a bit unclear.
-            // Sidestepping the cache here shouldn't be a problem since we do so only once per entity.
-            let series_name = if let Some(override_name) = override_series_name {
-                Some(override_name)
-            } else {
-                ctx.entity_db
-                    .store()
-                    .query_latest_component::<Name>(&data_result.entity_path, &ctx.current_query())
-                    .map(|name| name.value.0)
-            };
-
-            // Now convert the `PlotPoints` into `Vec<PlotSeries>`
-            points_to_series(
-                data_result,
                 time_per_pixel,
-                points,
-                store,
-                query,
-                series_name,
-                &mut self.all_series,
-            );
+                &annotations,
+                data_result,
+                all_series,
+            )?;
         }
 
         Ok(())
     }
+}
+
+fn load_series(
+    ctx: &ViewerContext<'_>,
+    query: &ViewQuery<'_>,
+    plot_bounds: Option<egui_plot::PlotBounds>,
+    time_per_pixel: f64,
+    annotations: &re_viewer_context::Annotations,
+    data_result: &re_viewer_context::DataResult,
+    all_series: &mut Vec<PlotSeries>,
+) -> Result<(), QueryError> {
+    re_tracing::profile_function!();
+
+    let store = ctx.entity_db.store();
+    let query_caches = ctx.entity_db.query_caches();
+
+    let annotation_info = annotations
+        .resolved_class_description(None)
+        .annotation_info();
+    let default_color = DefaultColor::EntityPath(&data_result.entity_path);
+    let override_color = lookup_override::<Color>(data_result, ctx).map(|c| c.to_array());
+    let override_series_name = lookup_override::<Name>(data_result, ctx).map(|t| t.0);
+    let override_stroke_width = lookup_override::<StrokeWidth>(data_result, ctx).map(|r| r.0);
+    let default_point = PlotPoint {
+        time: 0,
+        value: 0.0,
+        attrs: PlotPointAttrs {
+            label: None,
+            color: annotation_info.color(override_color, default_color),
+            marker_size: override_stroke_width.unwrap_or(DEFAULT_STROKE_WIDTH),
+            kind: PlotSeriesKind::Continuous,
+        },
+    };
+    let mut points = Vec::new();
+    let time_range = determine_time_range(
+        query,
+        data_result,
+        plot_bounds,
+        ctx.app_options.experimental_plot_query_clamping,
+    );
+    {
+        re_tracing::profile_scope!("primary", &data_result.entity_path.to_string());
+
+        let entity_path = &data_result.entity_path;
+        let query = re_data_store::RangeQuery::new(query.timeline, time_range);
+
+        // TODO(jleibs): need to do a "joined" archetype query
+        // The `Scalar` archetype queries for `MarkerShape` & `MarkerSize` in the point visualizer,
+        // and so it must do so here also.
+        // See https://github.com/rerun-io/rerun/pull/5029
+        query_caches.query_archetype_range_pov1_comp4::<
+            archetypes::Scalar,
+            Scalar,
+            Color,
+            StrokeWidth,
+            MarkerSize, // unused
+            MarkerShape, // unused
+            _,
+        >(
+            store,
+            &query,
+            entity_path,
+            |_timeless, entry_range, (times, _, scalars, colors, stroke_widths, _, _)| {
+                let times = times.range(entry_range.clone()).map(|(time, _)| time.as_i64());
+                // Allocate all points.
+                points = times.map(|time| PlotPoint {
+                    time,
+                    ..default_point.clone()
+                }).collect_vec();
+
+                // Fill in values.
+                for (i, scalar) in scalars.range(entry_range.clone()).enumerate() {
+                    if scalar.len() > 1 {
+                        re_log::warn_once!("found a scalar batch in {entity_path:?} -- those have no effect");
+                    } else if scalar.is_empty() {
+                        points[i].attrs.kind = PlotSeriesKind::Clear;
+                    } else {
+                        points[i].value = scalar.first().map_or(0.0, |s| s.0);
+                    }
+                }
+
+                // Make it as clear as possible to the optimizer that some parameters
+                // go completely unused as soon as overrides have been defined.
+
+                // Fill in colors -- if available _and_ not overridden.
+                if override_color.is_none() {
+                    if let Some(colors) = colors {
+                        for (i, color) in colors.range(entry_range.clone()).enumerate() {
+                            if i >= points.len() {
+                                re_log::debug_once!("more color attributes than points in {entity_path:?} -- this points to a bug in the query cache");
+                                break;
+                            }
+                            if let Some(color) = color.first().copied().flatten().map(|c| {
+                                let [r,g,b,a] = c.to_array();
+                                if a == 255 {
+                                    // Common-case optimization
+                                    re_renderer::Color32::from_rgb(r, g, b)
+                                } else {
+                                    re_renderer::Color32::from_rgba_unmultiplied(r, g, b, a)
+                                }
+                            }) {
+                                points[i].attrs.color = color;
+                            }
+                        }
+                    }
+                }
+
+                // Fill in radii -- if available _and_ not overridden.
+                if override_stroke_width.is_none() {
+                    if let Some(stroke_widths) = stroke_widths {
+                        for (i, stroke_width) in stroke_widths.range(entry_range.clone()).enumerate() {
+                            if i >= stroke_widths.num_entries() {
+                                re_log::debug_once!("more stroke width attributes than points in {entity_path:?} -- this points to a bug in the query cache");
+                                break;
+                            }
+                            if let Some(stroke_width) = stroke_width.first().copied().flatten().map(|r| r.0) {
+                                points[i].attrs.marker_size = stroke_width;
+                            }
+                        }
+                    }
+                }
+            },
+        )?;
+    }
+    let series_name = if let Some(override_name) = override_series_name {
+        Some(override_name)
+    } else {
+        ctx.entity_db
+            .store()
+            .query_latest_component::<Name>(&data_result.entity_path, &ctx.current_query())
+            .map(|name| name.value.0)
+    };
+    points_to_series(
+        data_result,
+        time_per_pixel,
+        points,
+        store,
+        query,
+        series_name,
+        all_series,
+    );
+    Ok(())
 }

--- a/crates/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/line_visualizer_system.rs
@@ -100,8 +100,8 @@ impl SeriesLineSystem {
 
         let data_results = query.iter_visible_data_results(Self::identifier());
 
-        if false {
-            // TODO(emilk): enable parallel loading when it is faster, because right now it is often slower.
+        let parallel_loading = false; // TODO(emilk): enable parallel loading when it is faster, because right now it is often slower.
+        if parallel_loading {
             use rayon::prelude::*;
             re_tracing::profile_wait!("load_series");
             for one_series in data_results


### PR DESCRIPTION
### What
Test: `cargo r -p plot_dashboard_stress -- --num-series-per-plot 1000 --num-points-per-series 1000`

For some reason rayon just makes this slower, probably due to some lock contention, even when the data is fully loaded and the caches should be read-only.

### Results (serial):
![image](https://github.com/rerun-io/rerun/assets/1148717/183c1131-130f-471a-a188-004d71f2110e)

### Results (parallel):
![image](https://github.com/rerun-io/rerun/assets/1148717/cf58d483-e2cb-43cf-8799-f74340cd1190)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5185/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5185/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5185/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5185)
- [Docs preview](https://rerun.io/preview/a73747471eeb46ad00003b21fdd8b446579dc0c2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a73747471eeb46ad00003b21fdd8b446579dc0c2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)