### PR TITLE
Fix (log only) error on quickly resizing the viewer

### DIFF
--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -499,6 +499,11 @@ impl ViewBuilder {
         }
     }
 
+    /// Resolution in pixels as configured on view builder creation.
+    pub fn resolution_in_pixel(&self) -> [u32; 2] {
+        self.setup.resolution_in_pixel
+    }
+
     fn draw_phase<'a>(
         &'a self,
         renderers: &Renderers,
@@ -787,18 +792,8 @@ impl ViewBuilder {
         ctx: &RenderContext,
         render_pipelines: &'a GpuRenderPipelinePoolAccessor<'a>,
         pass: &mut wgpu::RenderPass<'a>,
-        screen_position: glam::Vec2,
     ) {
         re_tracing::profile_function!();
-
-        pass.set_viewport(
-            screen_position.x,
-            screen_position.y,
-            self.setup.resolution_in_pixel[0] as f32,
-            self.setup.resolution_in_pixel[1] as f32,
-            0.0,
-            1.0,
-        );
 
         pass.set_bind_group(0, &self.setup.bind_group_0, &[]);
         self.draw_phase(

--- a/crates/re_renderer_examples/framework.rs
+++ b/crates/re_renderer_examples/framework.rs
@@ -132,8 +132,7 @@ impl<E: Example + 'static> Application<E> {
                 &wgpu::DeviceDescriptor {
                     label: None,
                     required_features: wgpu::Features::empty(),
-                    required_limits: wgpu::Limits::downlevel_webgl2_defaults()
-                        .using_resolution(adapter.limits()),
+                    required_limits: device_caps.limits(),
                 },
                 None,
             )

--- a/crates/re_renderer_examples/framework.rs
+++ b/crates/re_renderer_examples/framework.rs
@@ -294,11 +294,18 @@ impl<E: Example + 'static> Application<E> {
                             );
 
                             for draw_result in &draw_results {
+                                composite_pass.set_viewport(
+                                    draw_result.target_location.x,
+                                    draw_result.target_location.y,
+                                    draw_result.view_builder.resolution_in_pixel()[0] as f32,
+                                    draw_result.view_builder.resolution_in_pixel()[1] as f32,
+                                    0.0,
+                                    1.0,
+                                );
                                 draw_result.view_builder.composite(
                                     &self.re_ctx,
                                     &render_pipelines,
                                     &mut composite_pass,
-                                    draw_result.target_location,
                                 );
                             }
                         };

--- a/crates/re_viewer_context/src/gpu_bridge/re_renderer_callback.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/re_renderer_callback.rs
@@ -78,7 +78,7 @@ impl egui_wgpu::CallbackTrait for ReRendererCallback {
 
     fn paint<'a>(
         &'a self,
-        info: egui::PaintCallbackInfo,
+        _info: egui::PaintCallbackInfo,
         render_pass: &mut wgpu::RenderPass<'a>,
         paint_callback_resources: &'a egui_wgpu::CallbackResources,
     ) {
@@ -97,10 +97,7 @@ impl egui_wgpu::CallbackTrait for ReRendererCallback {
             return;
         };
 
-        let screen_position = (info.viewport.min.to_vec2() * info.pixels_per_point).round();
-        let screen_position = glam::vec2(screen_position.x, screen_position.y);
-
         self.view_builder
-            .composite(ctx, render_pipelines, render_pass, screen_position);
+            .composite(ctx, render_pipelines, render_pass);
     }
 }


### PR DESCRIPTION
### What

* Fixes #4455

Got a good repro of this on my windows machine by using the screenshot action on a low-dpi screen (screenshot action will do a quick resize on native) while having the pose tracking example open.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5189/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5189/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5189/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5189)
- [Docs preview](https://rerun.io/preview/f54be52f2819874bcec35e91db189eb369a007af/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f54be52f2819874bcec35e91db189eb369a007af/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)