### PR TITLE
Python: fix error message mentioning `TranslationRotationScale` instead of `TranslationRotationScale3D`

### DIFF
--- a/rerun_py/rerun_sdk/rerun/datatypes/transform3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/transform3d_ext.py
@@ -45,7 +45,7 @@ class Transform3DExt:
         else:
             raise ValueError(
                 f"unknown transform 3d value: {data} (expected `Transform3D`, `TranslationAndMat3x3`, or "
-                "`TranslationRotationScale`"
+                "`TranslationRotationScale3D`"
             )
 
         storage = build_dense_union(data_type, discriminant, transform_repr)


### PR DESCRIPTION
The following message is shown in case of using an invalid Type for transformation.
```
RerunWarning: OutOfTreeTransform3DBatch: ValueError(unknown transform 3d value: Scale3D(inner=0.1) (expected `Transform3D`, `TranslationAndMat3x3`, or `TranslationRotationScale`)
```

If you then try to use `TranslationRotationScale` the following shown up
```
 AttributeError: module 'rerun' has no attribute `TranslationRotationScale`. Did you mean: `TranslationRotationScale3D`?
```

So we are here updating the ValueError message to show directly the valid TransformType: `TranslationRotationScale3D`

<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5190/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5190/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5190/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5190)
- [Docs preview](https://rerun.io/preview/7021bc09b24a1c53c4a60fab870ef5e791d9235e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7021bc09b24a1c53c4a60fab870ef5e791d9235e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)