### PR TITLE
Update docs to not mention `WINIT_UNIX_BACKEND`

### DIFF
--- a/docs/content/getting-started/troubleshooting.md
+++ b/docs/content/getting-started/troubleshooting.md
@@ -51,7 +51,7 @@ sudo apt-get -y install \
 ```
 
 [TODO(#1250)](https://github.com/rerun-io/rerun/issues/1250): Running with the wayland window manager
-sometimes causes Rerun to crash. Try setting `WINIT_UNIX_BACKEND=x11` as a workaround.
+sometimes causes Rerun to crash. Try unsetting the wayland display (`unset WAYLAND_DISPLAY` or `WAYLAND_DISPLAY= `) as a workaround.
 
 ## Startup issues
 If Rerun is having trouble starting, you can try resetting its memory with:

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -350,6 +350,7 @@
     "uncollapsed",
     "unmultiplied",
     "Unorm",
+    "unsetting",
     "upcasting",
     "upsampling",
     "upvote",


### PR DESCRIPTION
`winit` 0.29 has silently removed support for `WINIT_UNIX_BACKEND`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5191/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5191/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5191/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5191)
- [Docs preview](https://rerun.io/preview/cce9ad1b0a7f62ff171a8874bfb0064b41db7d52/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/cce9ad1b0a7f62ff171a8874bfb0064b41db7d52/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)