### PR TITLE
Fix example --help texts for some python examples

### DIFF
--- a/examples/python/car/main.py
+++ b/examples/python/car/main.py
@@ -255,7 +255,9 @@ def generate_car_data(num_frames: int) -> Iterator[SampleFrame]:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")
+    parser = argparse.ArgumentParser(
+        description="A very simple 2D car is drawn using OpenCV, and a depth image is simulated and logged as a point cloud."
+    )
     rr.script_add_args(parser)
     args = parser.parse_args()
 

--- a/examples/python/dicom_mri/main.py
+++ b/examples/python/dicom_mri/main.py
@@ -95,7 +95,7 @@ def ensure_dataset_downloaded() -> Iterable[Path]:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")
+    parser = argparse.ArgumentParser(description="Example using MRI scan data in the DICOM format.")
     rr.script_add_args(parser)
     args = parser.parse_args()
     rr.script_setup(args, "rerun_example_dicom_mri")

--- a/examples/python/minimal_options/main.py
+++ b/examples/python/minimal_options/main.py
@@ -7,7 +7,9 @@ import argparse
 import numpy as np
 import rerun as rr  # pip install rerun-sdk
 
-parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")
+parser = argparse.ArgumentParser(
+    description="Demonstrates the most barebone usage of the Rerun SDK, with standard options."
+)
 rr.script_add_args(parser)
 args = parser.parse_args()
 

--- a/examples/python/multithreading/main.py
+++ b/examples/python/multithreading/main.py
@@ -20,7 +20,7 @@ def rect_logger(path: str, color: npt.NDArray[np.float32]) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")
+    parser = argparse.ArgumentParser(description="Demonstration of using rerun from multiple threads.")
     rr.script_add_args(parser)
     args = parser.parse_args()
 

--- a/examples/python/multithreading/main.py
+++ b/examples/python/multithreading/main.py
@@ -20,7 +20,7 @@ def rect_logger(path: str, color: npt.NDArray[np.float32]) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Demonstration of using rerun from multiple threads.")
+    parser = argparse.ArgumentParser(description="Demonstration of using Rerun from multiple threads.")
     rr.script_add_args(parser)
     args = parser.parse_args()
 

--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -193,7 +193,9 @@ def main() -> None:
     logging.getLogger().addHandler(rr.LoggingHandler())
     logging.getLogger().setLevel("INFO")
 
-    parser = argparse.ArgumentParser(description="Uses the MediaPipe Face Detection to track a human pose in video.")
+    parser = argparse.ArgumentParser(
+        description="Load an Open Photogrammetry Format (OPF) project and display the cameras and point cloud."
+    )
     parser.add_argument(
         "--dataset",
         choices=DATASETS.keys(),

--- a/examples/python/rgbd/main.py
+++ b/examples/python/rgbd/main.py
@@ -145,7 +145,7 @@ def download_progress(url: str, dst: Path) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")
+    parser = argparse.ArgumentParser(description="Example using an example depth dataset from NYU.")
     parser.add_argument(
         "--recording",
         type=str,


### PR DESCRIPTION
### What

Noticed that the opf text was wrong and then fixed up a few more.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5194/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5194/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5194/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5194)
- [Docs preview](https://rerun.io/preview/3c595af18d87a790ab56c8725d0b66f17fe4f4e2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3c595af18d87a790ab56c8725d0b66f17fe4f4e2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)