### PR TITLE
Fix incorrect minimum supported rust version mentioned in docs and examples

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -3,7 +3,7 @@
 # -----------------------------------------------------------------------------
 # Section identical to the main scripts/clippy_wasm/clippy.toml:
 
-msrv = "1.72"
+msrv = "1.74"
 
 allow-unwrap-in-tests = true
 

--- a/crates/re_viewer/data/quick_start_guides/rust_connect.md
+++ b/crates/re_viewer/data/quick_start_guides/rust_connect.md
@@ -10,7 +10,7 @@ Let's try it out in a brand-new Rust project:
 cargo init cube && cd cube && cargo add rerun --features native_viewer
 ```
 
-Note that the Rerun SDK requires a working installation of Rust 1.72+.
+Note that the Rerun SDK requires a working installation of Rust 1.74+.
 
 ## Logging your own data
 

--- a/crates/re_viewer/data/quick_start_guides/rust_spawn.md
+++ b/crates/re_viewer/data/quick_start_guides/rust_spawn.md
@@ -10,7 +10,7 @@ Let's try it out in a brand-new Rust project:
 cargo init cube && cd cube && cargo add rerun
 ```
 
-Note that the Rerun SDK requires a working installation of Rust 1.72+.
+Note that the Rerun SDK requires a working installation of Rust 1.74+.
 
 ## Logging your own data
 

--- a/docs/content/getting-started/installing-viewer.md
+++ b/docs/content/getting-started/installing-viewer.md
@@ -9,7 +9,7 @@ Generally, you should make sure that your SDK version matches the version of the
 There are many ways to install the viewer. Please pick whatever works best for your setup:
 
 * `cargo binstall rerun-cli` - download binaries via [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall)
-* `cargo install rerun-cli` - build it from source (this requires Rust 1.72+)
+* `cargo install rerun-cli` - build it from source (this requires Rust 1.74+)
 * Download it from the [GitHub Release artifacts](https://github.com/rerun-io/rerun/releases/latest/)
 * Together with the Rerun [Python SDK](python.md):
   * `pip3 install rerun-sdk` - download it via pip

--- a/docs/content/getting-started/rust.md
+++ b/docs/content/getting-started/rust.md
@@ -4,7 +4,7 @@ order: 3
 ---
 
 ## Setup
-The Rerun SDK for Rust requires a working installation of Rust 1.72+.
+The Rerun SDK for Rust requires a working installation of Rust 1.74+.
 
 After you have [installed the viewer](installing-viewer.md) you can simply add [the rerun crate](https://crates.io/crates/rerun) to your project with `cargo add rerun`.
 

--- a/examples/rust/clock/Cargo.toml
+++ b/examples/rust/clock/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clock"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/custom_data_loader/Cargo.toml
+++ b/examples/rust/custom_data_loader/Cargo.toml
@@ -2,7 +2,7 @@
 name = "custom_data_loader"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/custom_space_view/Cargo.toml
+++ b/examples/rust/custom_space_view/Cargo.toml
@@ -2,7 +2,7 @@
 name = "custom_space_view"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/custom_store_subscriber/Cargo.toml
+++ b/examples/rust/custom_store_subscriber/Cargo.toml
@@ -2,7 +2,7 @@
 name = "custom_store_subscriber"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/dna/Cargo.toml
+++ b/examples/rust/dna/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dna"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/extend_viewer_ui/Cargo.toml
+++ b/examples/rust/extend_viewer_ui/Cargo.toml
@@ -2,7 +2,7 @@
 name = "extend_viewer_ui"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/external_data_loader/Cargo.toml
+++ b/examples/rust/external_data_loader/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rerun-loader-rust-file"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/minimal/Cargo.toml
+++ b/examples/rust/minimal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "minimal"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/minimal_options/Cargo.toml
+++ b/examples/rust/minimal_options/Cargo.toml
@@ -2,7 +2,7 @@
 name = "minimal_options"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/minimal_serve/Cargo.toml
+++ b/examples/rust/minimal_serve/Cargo.toml
@@ -2,7 +2,7 @@
 name = "minimal_serve"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/objectron/Cargo.toml
+++ b/examples/rust/objectron/Cargo.toml
@@ -2,7 +2,7 @@
 name = "objectron"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/raw_mesh/Cargo.toml
+++ b/examples/rust/raw_mesh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "raw_mesh"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/shared_recording/Cargo.toml
+++ b/examples/rust/shared_recording/Cargo.toml
@@ -2,7 +2,7 @@
 name = "shared_recording"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/spawn_viewer/Cargo.toml
+++ b/examples/rust/spawn_viewer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "spawn_viewer"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/stdio/Cargo.toml
+++ b/examples/rust/stdio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stdio"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/examples/rust/template/Cargo.toml
+++ b/examples/rust/template/Cargo.toml
@@ -2,7 +2,7 @@
 name = "template"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/rerun_py/README.md
+++ b/rerun_py/README.md
@@ -151,10 +151,10 @@ You can run with `RUST_LOG=debug` to get more output out of the rerun SDK.
 If you are using an Apple-silicon Mac, make sure `rustc -vV` outputs `host: aarch64-apple-darwin`. If not, this should fix it:
 
 ``` sh
-rustup set default-host aarch64-apple-darwin && rustup install 1.72
+rustup set default-host aarch64-apple-darwin && rustup install 1.74
 ```
 
 If you want to switch back, this is how:
 ``` sh
-rustup set default-host x86_64-apple-darwin && rustup install 1.72
+rustup set default-host x86_64-apple-darwin && rustup install 1.74
 ```

--- a/scripts/clippy_wasm/clippy.toml
+++ b/scripts/clippy_wasm/clippy.toml
@@ -6,7 +6,7 @@
 # -----------------------------------------------------------------------------
 # Section identical to the main clippy.toml:
 
-msrv = "1.72"
+msrv = "1.74"
 
 allow-unwrap-in-tests = true
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -516,7 +516,7 @@ def test_lint_workspace_deps() -> None:
         name = "clock"
         version = "0.6.0-alpha.0"
         edition = "2021"
-        rust-version = "1.72"
+        rust-version = "1.74"
         license = "MIT OR Apache-2.0"
         publish = false
 

--- a/tests/rust/plot_dashboard_stress/Cargo.toml
+++ b/tests/rust/plot_dashboard_stress/Cargo.toml
@@ -2,7 +2,7 @@
 name = "plot_dashboard_stress"
 version = "0.14.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 publish = false
 


### PR DESCRIPTION
### What

The last rust update in 
* https://github.com/rerun-io/rerun/pull/4390

didn't catch a whole bunch of places.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5195/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5195/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5195/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5195)
- [Docs preview](https://rerun.io/preview/7ac1616173ee2d5da35c31ea3617e3146e2f6a2e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7ac1616173ee2d5da35c31ea3617e3146e2f6a2e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)