### PR TITLE
Focus on current bounding-box when resetting camera-eye on a 3D space view (double click it)

### DIFF
--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -145,7 +145,7 @@ impl SpatialSpaceViewState {
                         .clicked()
                     {
                         self.bounding_boxes.accumulated = self.bounding_boxes.current;
-                        self.state_3d.reset_camera(&self.bounding_boxes.accumulated, scene_view_coordinates);
+                        self.state_3d.reset_camera(&self.bounding_boxes, scene_view_coordinates);
                     }
                     let mut spin = self.state_3d.spin();
                     if re_ui.checkbox(ui, &mut spin, "Spin")

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -92,12 +92,13 @@ fn ease_out(t: f32) -> f32 {
 impl View3DState {
     pub fn reset_camera(
         &mut self,
-        scene_bbox: &BoundingBox,
+        scene_bbox: &SceneBoundingBoxes,
         scene_view_coordinates: Option<ViewCoordinates>,
     ) {
-        // Mark as interaction since we want to stop doing any automatic interpolation even after a
+        // Mark as interaction since we want to stop doing any automatic interpolations,
+        // even if this is caused by a full reset.
         self.last_eye_interaction = Some(Instant::now());
-        self.interpolate_to_orbit_eye(default_eye(scene_bbox, scene_view_coordinates));
+        self.interpolate_to_orbit_eye(default_eye(&scene_bbox.current, scene_view_coordinates));
         self.tracked_entity = None;
         self.camera_before_tracked_entity = None;
     }
@@ -548,7 +549,7 @@ pub fn view_3d(
                 if space_view_id == &query.space_view_id {
                     state
                         .state_3d
-                        .reset_camera(&state.bounding_boxes.current, scene_view_coordinates);
+                        .reset_camera(&state.bounding_boxes, scene_view_coordinates);
                 }
                 None
             }

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -92,10 +92,12 @@ fn ease_out(t: f32) -> f32 {
 impl View3DState {
     pub fn reset_camera(
         &mut self,
-        scene_bbox_accum: &BoundingBox,
+        scene_bbox: &BoundingBox,
         scene_view_coordinates: Option<ViewCoordinates>,
     ) {
-        self.interpolate_to_orbit_eye(default_eye(scene_bbox_accum, scene_view_coordinates));
+        // Mark as interaction since we want to stop doing any automatic interpolation even after a
+        self.last_eye_interaction = Some(Instant::now());
+        self.interpolate_to_orbit_eye(default_eye(scene_bbox, scene_view_coordinates));
         self.tracked_entity = None;
         self.camera_before_tracked_entity = None;
     }
@@ -546,7 +548,7 @@ pub fn view_3d(
                 if space_view_id == &query.space_view_id {
                     state
                         .state_3d
-                        .reset_camera(&state.bounding_boxes.accumulated, scene_view_coordinates);
+                        .reset_camera(&state.bounding_boxes.current, scene_view_coordinates);
                 }
                 None
             }


### PR DESCRIPTION
### What

* Fixes #5204

Bit back and forth on this: Originally also wanted to track the non-accumulated bounding box when data comes in, but for many scenes this gets too awkward.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5209/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5209/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5209/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5209)
- [Docs preview](https://rerun.io/preview/9a4526d29f61a77f2d9c1e87d61bb86b38392dff/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/9a4526d29f61a77f2d9c1e87d61bb86b38392dff/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)