### PR TITLE
Context menu 3: add "Move to new container" context menu action

### DIFF
--- a/crates/re_viewport/src/context_menu.rs
+++ b/crates/re_viewport/src/context_menu.rs
@@ -42,18 +42,19 @@ fn context_menu_items_for_selection_summary(
 ) -> Vec<Box<dyn ContextMenuItem>> {
     match selection_summary {
         SelectionSummary::SingleContainerItem(container_id) => {
-            let mut items = vec![];
+            // We want all the actions available for collections of contents…
+            let mut items = context_menu_items_for_selection_summary(
+                ctx,
+                viewport_blueprint,
+                item,
+                SelectionSummary::ContentsItems(vec![Contents::Container(container_id)]),
+            );
 
-            // only show/hide and remove if it's not the root container
-            if Some(container_id) != viewport_blueprint.root_container {
-                let contents = Rc::new(vec![Contents::Container(container_id)]);
-                items.extend([
-                    ContentVisibilityToggle::item(viewport_blueprint, contents.clone()),
-                    ContentRemove::item(contents),
-                    Separator::item(),
-                ]);
+            if !items.is_empty() {
+                items.push(Separator::item());
             }
 
+            // …plus some more that apply to single container only.
             items.extend([
                 SubMenu::item(
                     "Add Container",

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -523,7 +523,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
                         new_container_tile_id,
                         target_container_tile_id,
                         target_position_in_container,
-                        true,
+                        true, // reflow grid if needed
                     );
 
                     for (pos, content) in contents_to_move.into_iter().enumerate() {
@@ -531,7 +531,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
                             content.as_tile_id(),
                             new_container_tile_id,
                             pos,
-                            true,
+                            true, // reflow grid if needed
                         );
                     }
 

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -460,6 +460,22 @@ impl ViewportBlueprint {
         });
     }
 
+    /// Move some [`Contents`] to a newly created container of the given kind.
+    pub fn move_contents_to_new_container(
+        &self,
+        contents: Vec<Contents>,
+        new_container_kind: egui_tiles::ContainerKind,
+        target_container: ContainerId,
+        target_position_in_container: usize,
+    ) {
+        self.send_tree_action(TreeAction::MoveContentsToNewContainer {
+            contents_to_move: contents,
+            new_container_kind,
+            target_container,
+            target_position_in_container,
+        });
+    }
+
     /// Make sure the tab corresponding to this space view is focused.
     pub fn focus_tab(&self, space_view_id: SpaceViewId) {
         self.send_tree_action(TreeAction::FocusTab(space_view_id));

--- a/tests/python/release_checklist/check_context_menu.py
+++ b/tests/python/release_checklist/check_context_menu.py
@@ -15,6 +15,7 @@ README = """
 * Right-click on any space view and check for context menu content:
     - Hide
     - Remove
+    - Move to new container
 * Check both work as expected.
 * Right-click on the viewport and check for context menu content:
     - Add Container
@@ -23,6 +24,7 @@ README = """
 * Right-click on the container and check for context menu content:
     - Hide
     - Remove
+    - Move to new container
     - Add Container
     - Add Space View
 
@@ -41,9 +43,17 @@ README = """
 * Select multiple space views, right-click, and check for context menu content:
     - Hide
     - Remove
+    - Move to new container
 * Same as above, but with only containers selected.
 * Same as above, but with both space views and containers selected.
 * Same as above, but with the viewport selected as well. The context menu should be identical, but none of its actions should apply to the viewport.
+
+### Invalid sub-container kind
+
+* Single-select a horizontal container, check that it disallow adding an horizontal container inside it.
+* Same for a vertical container.
+* Single select a space view inside a horizontal container, check that it disallow moving to a new horizontal container.
+* Same for a space view inside a vertical container.
 """
 
 


### PR DESCRIPTION
### What

* Follow-up to #5205
* Part of #4823

![Export-1708013884748](https://github.com/rerun-io/rerun/assets/49431240/c3e6485a-48c6-4f38-b5c2-907f4c546346)

<br/>
<br/>

This PR adds a new "Move to new container" context menu action, that applies when one or more space views and/or containers are selected. The new container is created at the location of the clicked item, and all the selected items are moved into it.

**Note**: one very often runs into this while using this feature:
- https://github.com/rerun-io/rerun/issues/5208

TODO in future PR:
- additional actions
- entity level manipulations
- use ListItem instead of label/WidgetText
- better folder structure
- release checklist update

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5210/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5210/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5210/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5210)
- [Docs preview](https://rerun.io/preview/d842739a5e559177ddc2b0f682b58df6a40076b3/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d842739a5e559177ddc2b0f682b58df6a40076b3/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)