### PR TITLE
Lock the web-sys version to 0.3.67

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,7 +231,8 @@ walkdir = "2.0"
 wasm-bindgen = "0.2.89"
 wasm-bindgen-cli-support = "0.2.89"
 wasm-bindgen-futures = "0.4.33"
-web-sys = "0.3.61"
+# web-sys 0.3.68 contains breaking API changes in an unstable API used by wgpu
+web-sys = "=0.3.67"
 web-time = "0.2.0"
 webbrowser = "0.8"
 winit = { version = "0.29.9", default-features = false }


### PR DESCRIPTION
### What
When investigating the doc build issues I noticed that 0.3.68 is going to cause a build failure:

```
  Compiling rust to wasm in /home/jleibs/rerun/target_wasm…
  /home/jleibs/rerun> CARGO_ENCODED_RUSTFLAGS="--cfg=web_sys_unstable_apis" RUSTFLAGS="--cfg=web_sys_unstable_apis" "cargo" "build" "--quiet" "--package" "re_viewer" "--lib" "--target" "wasm32-unknown-unknown" "--target-dir" "/home/jleibs/rerun/target_wasm" "--no-default-features" "--features=analytics"
  error[E0061]: this function takes 1 argument but 3 arguments were supplied
     --> /home/jleibs/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-0.19.1/src/backend/webgpu.rs:375:22
      |
  375 |     let mut mapped = web_sys::GpuDepthStencilState::new(
      |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  376 |         map_compare_function(desc.depth_compare),
      |         ---------------------------------------- unexpected argument of type `GpuCompareFunction`
  377 |         desc.depth_write_enabled,
      |         ------------------------ unexpected argument of type `bool`
      |
  note: associated function defined here
     --> /home/jleibs/.cargo/registry/src/index.crates.io-6f17d22bba15001f/web-sys-0.3.68/src/features/gen_GpuDepthStencilState.rs:27:12
      |
  27  |     pub fn new(format: GpuTextureFormat) -> Self {
      |            ^^^
  help: remove the extra arguments
      |
  376 -         map_compare_function(desc.depth_compare),
  376 +         map_texture_format(desc.format),
      |

  error[E0061]: this function takes 1 argument but 2 arguments were supplied
      --> /home/jleibs/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-0.19.1/src/backend/webgpu.rs:1693:13
       |
  1693 |             web_sys::GpuVertexState::new(desc.vertex.entry_point, &module.0);
       |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -------------------------
       |                                          |
       |                                          unexpected argument of type `&str`
       |                                          help: remove the extra argument
       |
  note: associated function defined here
      --> /home/jleibs/.cargo/registry/src/index.crates.io-6f17d22bba15001f/web-sys-0.3.68/src/features/gen_GpuVertexState.rs:27:12
       |
  27   |     pub fn new(module: &GpuShaderModule) -> Self {
       |            ^^^

  error[E0061]: this function takes 2 arguments but 3 arguments were supplied
      --> /home/jleibs/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-0.19.1/src/backend/webgpu.rs:1768:17
       |
  1768 |                 web_sys::GpuFragmentState::new(frag.entry_point, &module.0, &targets);
       |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ----------------             -------- unexpected argument of type `&js_sys::Array`
       |                                                |
       |                                                expected `&GpuShaderModule`, found `&str`
       |
       = note: expected reference `&GpuShaderModule`
                  found reference `&str`
  note: associated function defined here
      --> /home/jleibs/.cargo/registry/src/index.crates.io-6f17d22bba15001f/web-sys-0.3.68/src/features/gen_GpuFragmentState.rs:27:12
       |
  27   |     pub fn new(module: &GpuShaderModule, targets: &::wasm_bindgen::JsValue) -> Self {
       |            ^^^
  help: remove the extra argument
       |
  1768 -                 web_sys::GpuFragmentState::new(frag.entry_point, &module.0, &targets);
  1768 +                 web_sys::GpuFragmentState::new(/* &GpuShaderModule */, &module.0);
       |

  error[E0061]: this function takes 1 argument but 2 arguments were supplied
      --> /home/jleibs/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-0.19.1/src/backend/webgpu.rs:1793:13
       |
  1793 |             web_sys::GpuProgrammableStage::new(desc.entry_point, &shader_module.0);
       |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ------------------
       |                                                |
       |                                                unexpected argument of type `&str`
       |                                                help: remove the extra argument
       |
  note: associated function defined here
      --> /home/jleibs/.cargo/registry/src/index.crates.io-6f17d22bba15001f/web-sys-0.3.68/src/features/gen_GpuProgrammableStage.rs:27:12
       |
  27   |     pub fn new(module: &GpuShaderModule) -> Self {
       |            ^^^

  error[E0599]: no method named `write_timestamp` found for struct `GpuCommandEncoder` in the current scope
      --> /home/jleibs/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-0.19.1/src/backend/webgpu.rs:2505:14
       |
  2503 | /         encoder_data
  2504 | |             .0
  2505 | |             .write_timestamp(&query_set_data.0, query_index);
       | |             -^^^^^^^^^^^^^^^ method not found in `GpuCommandEncoder`
       | |_____________|
       | 
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5211/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5211/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5211/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5211)
- [Docs preview](https://rerun.io/preview/41fc46af69131e3c2800c9fd6a9b2f4e009cc438/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/41fc46af69131e3c2800c9fd6a9b2f4e009cc438/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)