### PR TITLE
Add experimental setting flag to always enable visualizer selection

### DIFF
--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -390,6 +390,14 @@ fn experimental_feature_ui(
             "Plots: query clamping",
         )
         .on_hover_text("Toggle query clamping for the plot visualizers.");
+
+    re_ui
+        .checkbox(
+            ui,
+            &mut app_options.experimental_visualizer_selection,
+            "Visualizer selection for all views",
+        )
+        .on_hover_text("Enables explicit visualizer selection for all views, not just Time Series where it's default enabled.");
 }
 
 #[cfg(debug_assertions)]

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -186,7 +186,9 @@ impl SelectionPanel {
                             // TODO(jleibs): Overrides still require special handling inside the visualizers.
                             // For now, only show the override section for TimeSeries until support is implemented
                             // generically.
-                            if space_view.class_identifier() == TimeSeriesSpaceView::IDENTIFIER {
+                            if space_view.class_identifier() == TimeSeriesSpaceView::IDENTIFIER
+                                || ctx.app_options.experimental_visualizer_selection
+                            {
                                 ctx.re_ui
                                     .large_collapsing_header(ui, "Visualizers", true, |ui| {
                                         override_visualizer_ui(ctx, space_view, instance_path, ui);

--- a/crates/re_viewer_context/src/app_options.rs
+++ b/crates/re_viewer_context/src/app_options.rs
@@ -22,6 +22,9 @@ pub struct AppOptions {
     /// Toggle query clamping for the plot visualizers.
     pub experimental_plot_query_clamping: bool,
 
+    /// Toggle explicit visualizer selection for all views.
+    pub experimental_visualizer_selection: bool,
+
     /// Displays an overlay for debugging picking.
     pub show_picking_debug_overlay: bool,
 
@@ -52,6 +55,8 @@ impl Default for AppOptions {
             experimental_entity_filter_editor: false,
 
             experimental_plot_query_clamping: false,
+
+            experimental_visualizer_selection: false,
 
             show_picking_debug_overlay: false,
 


### PR DESCRIPTION
### What

Currently, we show visualizer overrides only in the time series view since we haven't tested this mechanism all that much. And it's true, stuff behind is is somewhat brittle! So this PR allows you to test it by adding a new experimental flag!

This is what I wanted to get, but it requires some more work unfortunately:
![image](https://github.com/rerun-io/rerun/assets/1220815/26e479fd-3787-4997-b127-3fe2e07a352f)

Things missing for the demonstrated usecase:
* Image visualizer has this snippet to protect against showing both a depth and image texture. 
```
        // If this isn't an image, return
        // TODO(jleibs): The ArchetypeView should probably do this for us.
        if !ctx.entity_db.store().entity_has_component(
            &ctx.current_query().timeline,
            ent_path,
            &Image::indicator().name(),
        ) {
            return Ok(());
        }
```
    * Really what we need to do here is to split up the image visualizer into several. We can do this now! It's a similar problem like the one we solved in time series view
* 2D view freaks out when the origin is not set to world/Lantern because 2D view takes great interest in 3D transforms that confuse the hell out of it 


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5215/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5215/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5215/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5215)
- [Docs preview](https://rerun.io/preview/bd311af7f51ec3aadf89f5dd18ddc92ab3df9695/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bd311af7f51ec3aadf89f5dd18ddc92ab3df9695/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)