### PR TITLE
Clickable path parts in selection-panel 

### DIFF
--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -67,6 +67,8 @@ pub fn entity_path_parts_buttons(
     entity_path: &EntityPath,
 ) -> egui::Response {
     ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 4.0;
+
         let mut accumulated = Vec::new();
         for part in entity_path.iter() {
             accumulated.push(part.clone());
@@ -158,6 +160,8 @@ pub fn instance_path_parts_buttons(
     instance_path: &InstancePath,
 ) -> egui::Response {
     ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 4.0;
+
         let mut accumulated = Vec::new();
         for part in instance_path.entity_path.iter() {
             accumulated.push(part.clone());

--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -57,6 +57,35 @@ pub fn entity_path_button(
     )
 }
 
+/// Show the different parts of an entity path and make them selectable.
+pub fn entity_path_parts_buttons(
+    ctx: &ViewerContext<'_>,
+    query: &re_data_store::LatestAtQuery,
+    store: &re_data_store::DataStore,
+    ui: &mut egui::Ui,
+    space_view_id: Option<SpaceViewId>,
+    entity_path: &EntityPath,
+) -> egui::Response {
+    ui.horizontal(|ui| {
+        let mut accumulated = Vec::new();
+        for part in entity_path.iter() {
+            accumulated.push(part.clone());
+
+            ui.strong("/");
+            entity_path_button_to(
+                ctx,
+                query,
+                store,
+                ui,
+                space_view_id,
+                &accumulated.clone().into(),
+                part.syntax_highlighted(ui.style()),
+            );
+        }
+    })
+    .response
+}
+
 /// Show an entity path and make it selectable.
 pub fn entity_path_button_to(
     ctx: &ViewerContext<'_>,
@@ -117,6 +146,48 @@ pub fn instance_path_button_to(
         });
 
     cursor_interact_with_selectable(ctx, response, item)
+}
+
+/// Show the different parts of an instance path and make them selectable.
+pub fn instance_path_parts_buttons(
+    ctx: &ViewerContext<'_>,
+    query: &re_data_store::LatestAtQuery,
+    store: &re_data_store::DataStore,
+    ui: &mut egui::Ui,
+    space_view_id: Option<SpaceViewId>,
+    instance_path: &InstancePath,
+) -> egui::Response {
+    ui.horizontal(|ui| {
+        let mut accumulated = Vec::new();
+        for part in instance_path.entity_path.iter() {
+            accumulated.push(part.clone());
+
+            ui.strong("/");
+            entity_path_button_to(
+                ctx,
+                query,
+                store,
+                ui,
+                space_view_id,
+                &accumulated.clone().into(),
+                part.syntax_highlighted(ui.style()),
+            );
+        }
+
+        if !instance_path.instance_key.is_splat() {
+            ui.strong("/");
+            instance_path_button_to(
+                ctx,
+                query,
+                store,
+                ui,
+                space_view_id,
+                instance_path,
+                instance_path.instance_key.syntax_highlighted(ui.style()),
+            );
+        }
+    })
+    .response
 }
 
 fn entity_tree_stats_ui(ui: &mut egui::Ui, timeline: &Timeline, tree: &EntityTree) {

--- a/crates/re_ui/src/syntax_highlighting.rs
+++ b/crates/re_ui/src/syntax_highlighting.rs
@@ -1,5 +1,5 @@
 use re_entity_db::InstancePath;
-use re_log_types::{EntityPath, EntityPathPart};
+use re_log_types::{external::re_types_core::components::InstanceKey, EntityPath, EntityPathPart};
 
 use egui::{text::LayoutJob, Color32, Style, TextFormat};
 
@@ -39,6 +39,14 @@ impl SyntaxHighlighting for EntityPathPart {
     }
 }
 
+impl SyntaxHighlighting for InstanceKey {
+    fn syntax_highlight_into(&self, style: &Style, job: &mut LayoutJob) {
+        job.append("[", 0.0, faint_text_format(style));
+        job.append(&self.to_string(), 0.0, text_format(style));
+        job.append("]", 0.0, faint_text_format(style));
+    }
+}
+
 impl SyntaxHighlighting for EntityPath {
     fn syntax_highlight_into(&self, style: &Style, job: &mut LayoutJob) {
         job.append("/", 0.0, faint_text_format(style));
@@ -56,9 +64,7 @@ impl SyntaxHighlighting for InstancePath {
     fn syntax_highlight_into(&self, style: &Style, job: &mut LayoutJob) {
         self.entity_path.syntax_highlight_into(style, job);
         if !self.instance_key.is_splat() {
-            job.append("[", 0.0, faint_text_format(style));
-            job.append(&self.instance_key.to_string(), 0.0, text_format(style));
-            job.append("]", 0.0, faint_text_format(style));
+            self.instance_key.syntax_highlight_into(style, job);
         }
     }
 }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -13,7 +13,6 @@ use re_types::{
 use re_types_core::components::InstanceKey;
 use re_ui::list_item::ListItem;
 use re_ui::ReUi;
-use re_ui::SyntaxHighlighting as _;
 use re_viewer_context::{
     blueprint_timepoint_for_writes, gpu_bridge::colormap_dropdown_button_ui, ContainerId,
     DataQueryId, HoverHighlight, Item, SpaceViewClass, SpaceViewClassIdentifier, SpaceViewId,
@@ -416,20 +415,23 @@ fn what_is_selected_ui(
                 "Entity instance"
             };
 
-            let name = instance_path.syntax_highlighted(ui.style());
+            let (query, store) =
+                guess_query_and_store_for_selected_entity(ctx, &instance_path.entity_path);
 
             if let Some(space_view_id) = space_view_id {
                 if let Some(space_view) = viewport.space_view(space_view_id) {
-                    item_title_ui(
-                        ctx.re_ui,
+                    item_ui::instance_path_parts_buttons(
+                        ctx,
+                        &query,
+                        store,
                         ui,
-                        name,
-                        None,
-                        &format!(
-                            "{typ} '{instance_path}' as shown in Space View {:?}",
-                            space_view.display_name
-                        ),
-                    );
+                        Some(*space_view_id),
+                        instance_path,
+                    )
+                    .on_hover_text(format!(
+                        "{typ} '{instance_path}' as shown in Space View {:?}",
+                        space_view.display_name
+                    ));
 
                     ui.horizontal(|ui| {
                         ui.label("in");
@@ -437,13 +439,8 @@ fn what_is_selected_ui(
                     });
                 }
             } else {
-                item_title_ui(
-                    ctx.re_ui,
-                    ui,
-                    name,
-                    None,
-                    &format!("{typ} '{instance_path}'"),
-                );
+                item_ui::instance_path_parts_buttons(ctx, &query, store, ui, None, instance_path)
+                    .on_hover_text(format!("{typ} '{instance_path}'"));
 
                 list_existing_data_blueprints(ui, ctx, &instance_path.entity_path, viewport);
             }


### PR DESCRIPTION
UPDATE: Cleaned it up with @abey79!

Just a proof-of-concept as I have no clue how to do things correctly and no time to dig right now.

But UX wise, man, it's _awesome_!


https://github.com/rerun-io/rerun/assets/2910679/2360e249-8ebd-4a33-a6dd-f732daddec92





### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5220/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5220/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5220/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5220)
- [Docs preview](https://rerun.io/preview/20ff5fb6a3b03e5aac404dcd31bd16546dc3a11c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/20ff5fb6a3b03e5aac404dcd31bd16546dc3a11c/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)