### PR TITLE
Remove now unnecessary unsafe Send/Sync impls for CpuWriteGpuReadBuffer

### DIFF
--- a/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
+++ b/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
@@ -61,14 +61,6 @@ pub struct CpuWriteGpuReadBuffer<T: bytemuck::Pod + Send + Sync> {
     _type: std::marker::PhantomData<T>,
 }
 
-#[allow(unsafe_code)]
-// SAFETY: TODO(gfx-rs/wgpu#4818): Upstream wgpu allows `wgpu::BufferViewMut` to be Send.
-unsafe impl<T> Send for CpuWriteGpuReadBuffer<T> where T: bytemuck::Pod + Send + Sync {}
-
-#[allow(unsafe_code)]
-// SAFETY: TODO(gfx-rs/wgpu#4818): Upstream wgpu allows `wgpu::BufferViewMut` to be Sync.
-unsafe impl<T> Sync for CpuWriteGpuReadBuffer<T> where T: bytemuck::Pod + Send + Sync {}
-
 impl<T> CpuWriteGpuReadBuffer<T>
 where
     T: bytemuck::Pod + Send + Sync,


### PR DESCRIPTION
### What

* This got fixed in https://github.com/gfx-rs/wgpu/pull/4818

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5225/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5225/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5225/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5225)
- [Docs preview](https://rerun.io/preview/db9b495d18aec9485ec24c85cf11506d58b0843d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/db9b495d18aec9485ec24c85cf11506d58b0843d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)