### PR TITLE
More robust handling of maximum texture size for non-color data, slight perf improvements for large point clouds

### DIFF
--- a/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
+++ b/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
@@ -212,6 +212,12 @@ where
         Ok(())
     }
 
+    /// True if no elements have been pushed into the buffer so far.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.unwritten_element_range.start == 0
+    }
+
     /// The number of elements pushed into the buffer so far.
     #[inline]
     pub fn num_written(&self) -> usize {

--- a/crates/re_renderer/src/allocator/data_texture_source.rs
+++ b/crates/re_renderer/src/allocator/data_texture_source.rs
@@ -35,7 +35,6 @@ pub enum DataTextureSourceWriteError {
 /// This is implemented by dynamically allocating cpu-write-gpu-read buffers from the
 /// central [`super::CpuWriteGpuReadBelt`] and copying all of them to the texture in the end.
 pub struct DataTextureSource<'a, T: Pod + Send + Sync> {
-    // TODO(andreas): Rename to `DataTextureBuilder`?
     ctx: &'a RenderContext, // TODO(andreas): Don't dependency inject, layers on top of this can do that.
 
     /// Buffers that need to be transferred to the data texture in the end.
@@ -171,7 +170,7 @@ impl<'a, T: Pod + Send + Sync> DataTextureSource<'a, T> {
         let new_buffer_size = (num_elements - remaining_capacity)
             .max(last_buffer_size * 2)
             .next_multiple_of(max_data_texture_width(max_texture_dimension_2d) as usize)
-            .min(max_num_elements_per_data_texture(max_texture_dimension_2d) - self.len());
+            .min(max_num_elements_per_data_texture(max_texture_dimension_2d) - self.capacity());
 
         if new_buffer_size > 0 {
             self.buffers
@@ -292,7 +291,7 @@ impl<'a, T: Pod + Send + Sync> DataTextureSource<'a, T> {
         let texel_size_in_bytes = std::mem::size_of::<T>() as u32;
         let num_texels = self.len();
 
-        debug_assert!(num_texels < max_num_elements_per_data_texture(max_texture_dimension_2d));
+        debug_assert!(num_texels <= max_num_elements_per_data_texture(max_texture_dimension_2d));
 
         // Our data textures are usually accessed in a linear fashion, so ideally we'd be using a 1D texture.
         // However, 1D textures are very limited in size on many platforms, we have to use 2D textures instead.

--- a/crates/re_renderer/src/allocator/data_texture_source.rs
+++ b/crates/re_renderer/src/allocator/data_texture_source.rs
@@ -84,7 +84,7 @@ impl<'a, T: Pod + Send + Sync> DataTextureSource<'a, T> {
     pub fn is_empty(&self) -> bool {
         self.buffers
             .first()
-            .map_or(false, |first_buffer| first_buffer.is_empty())
+            .map_or(true, |first_buffer| first_buffer.is_empty())
     }
 
     /// The number of elements written so far.

--- a/crates/re_renderer/src/allocator/data_texture_source.rs
+++ b/crates/re_renderer/src/allocator/data_texture_source.rs
@@ -7,6 +7,22 @@ use crate::{
 
 use super::{CpuWriteGpuReadBuffer, CpuWriteGpuReadError};
 
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum DataTextureSourceWriteError {
+    #[error(
+        "Reached maximum number of elements for a data texture of {max_num_elements} elements.
+ Tried to add {num_elements_attempted_to_add} elements, but only added {num_elements_actually_added}."
+    )]
+    ReachedMaximumNumberOfElements {
+        max_num_elements: usize,
+        num_elements_attempted_to_add: usize,
+        num_elements_actually_added: usize,
+    },
+
+    #[error(transparent)]
+    CpuWriteGpuReadError(#[from] crate::CpuWriteGpuReadError),
+}
+
 /// Utility for writing data to a dynamically sized "data textures".
 ///
 /// For WebGL compatibility we sometimes have to use textures instead of buffers.
@@ -62,31 +78,6 @@ impl<'a, T: Pod + Send + Sync> DataTextureSource<'a, T> {
             buffers: Vec::new(),
             active_buffer_index: 0,
         }
-    }
-
-    /// Maximum width for data textures.
-    #[inline]
-    pub fn max_data_texture_width(device_limits: &wgpu::Limits) -> usize {
-        // We limit the data texture width to 16384 or whatever smaller value is supported but the device.
-        //
-        // If we make buffers always a multiple of this width, we can do all buffer copies in a single copy!
-        //
-        // But wait! If we're using this as the minimum buffer size, isn't that too big?
-        // 16384 * float4 (worst case) = 256KiB.
-        // Keep in mind that weaker hardware will have 8192 max width.
-        // Also note, that many of our textures use 4 & 8 byte formats.
-        // So while this is still a considerable amount of memory when used for very small data textures
-        // it's not as bad as it seems.
-        // Given how much it simplifies to keep buffers a multiple of the texture width,
-        // this seems to be a reasonable trade-off.
-        (device_limits.max_texture_dimension_2d as usize).min(16384)
-    }
-
-    /// Maximum number of elements that can be written to a single data texture.
-    pub fn max_num_elements(device_limits: &wgpu::Limits) -> usize {
-        let max_width = Self::max_data_texture_width(device_limits);
-        let max_height = device_limits.max_texture_dimension_2d as usize;
-        max_width * max_height
     }
 
     /// Whether no elements have been written at all.
@@ -155,51 +146,79 @@ impl<'a, T: Pod + Send + Sync> DataTextureSource<'a, T> {
 
     /// Ensures that there's space internally for at least `num_elements` more elements.
     ///
+    /// Returns the number of elements that are currently reserved.
+    /// This value is *smaller* than the requested number of elements if the maximum number of
+    /// elements that can be stored is reached, see [`max_num_elements_per_data_texture`].
+    ///
     /// Creating new buffers is a relatively expensive operation, so it's best to
     /// reserve gratuitously and often. Ideally, you know exactly how many elements you're going to write and reserve
     /// accordingly at the start.
     ///
     /// If there's no more space, a new buffer is allocated such that:
-    /// * have a total capacity for at least as many elements as requested
+    /// * have a total capacity for at least as many elements as requested, clamping total size to [`max_num_elements_per_data_texture`]
     /// * be at least double the size of the last buffer
     /// * keep it easy to copy to textures by always being a multiple of the maximum row size we use for data textures
     ///      -> this massively simplifies the buffer->texture copy logic!
-    pub fn reserve(&mut self, num_elements: usize) -> Result<(), CpuWriteGpuReadError> {
+    pub fn reserve(&mut self, num_elements: usize) -> Result<usize, CpuWriteGpuReadError> {
         let remaining_capacity = self.remaining_capacity();
         if remaining_capacity >= num_elements {
-            return Ok(());
+            return Ok(remaining_capacity);
         }
+
+        let max_texture_dimension_2d = self.ctx.device.limits().max_texture_dimension_2d;
 
         let last_buffer_size = self.buffers.last().map_or(0, |b| b.capacity());
         let new_buffer_size = (num_elements - remaining_capacity)
             .max(last_buffer_size * 2)
-            .next_multiple_of(Self::max_data_texture_width(&self.ctx.device.limits()));
+            .next_multiple_of(max_data_texture_width(max_texture_dimension_2d) as usize)
+            .min(max_num_elements_per_data_texture(max_texture_dimension_2d) - self.len());
 
-        self.buffers
-            .push(self.ctx.cpu_write_gpu_read_belt.lock().allocate(
-                &self.ctx.device,
-                &self.ctx.gpu_resources.buffers,
-                new_buffer_size,
-            )?);
+        if new_buffer_size > 0 {
+            self.buffers
+                .push(self.ctx.cpu_write_gpu_read_belt.lock().allocate(
+                    &self.ctx.device,
+                    &self.ctx.gpu_resources.buffers,
+                    new_buffer_size,
+                )?);
+        }
 
-        Ok(())
+        Ok(remaining_capacity + new_buffer_size)
+    }
+
+    fn error_on_clamped_write(
+        &self,
+        num_elements_attempted_to_add: usize,
+        num_elements_actually_added: usize,
+    ) -> Result<(), DataTextureSourceWriteError> {
+        if num_elements_actually_added < num_elements_attempted_to_add {
+            Err(
+                DataTextureSourceWriteError::ReachedMaximumNumberOfElements {
+                    max_num_elements: max_num_elements_per_data_texture(
+                        self.ctx.device.limits().max_texture_dimension_2d,
+                    ),
+                    num_elements_attempted_to_add,
+                    num_elements_actually_added,
+                },
+            )
+        } else {
+            Ok(())
+        }
     }
 
     /// Pushes a slice of elements into the data texture builder.
-    #[inline]
-    pub fn extend_from_slice(&mut self, elements: &[T]) -> Result<(), CpuWriteGpuReadError> {
+    pub fn extend_from_slice(&mut self, elements: &[T]) -> Result<(), DataTextureSourceWriteError> {
         if elements.is_empty() {
             return Ok(());
         }
 
         re_tracing::profile_function!();
 
-        self.reserve(elements.len())?;
+        let num_elements_available = self.reserve(elements.len())?;
+        let num_elements_actually_added = num_elements_available.min(elements.len());
 
-        let mut remaining_elements = elements;
-
+        let mut remaining_elements = &elements[..num_elements_actually_added];
         loop {
-            let result =
+            let write_result =
                 self.buffers[self.active_buffer_index].extend_from_slice(remaining_elements);
 
             // `extend_from_slice` is documented to write as many elements as possible, so we can just continue with the next buffer,
@@ -207,32 +226,36 @@ impl<'a, T: Pod + Send + Sync> DataTextureSource<'a, T> {
             if let Err(CpuWriteGpuReadError::BufferFull {
                 num_elements_actually_added,
                 ..
-            }) = result
+            }) = write_result
             {
                 remaining_elements = &remaining_elements[num_elements_actually_added..];
                 self.active_buffer_index += 1; // Due to the prior `reserve` call we know that there's more buffers!
             } else {
+                write_result?;
                 self.ensure_active_buffer_invariant_after_adding_elements();
-                return result;
+                return self.error_on_clamped_write(elements.len(), num_elements_actually_added);
             }
         }
     }
 
     /// Fills the buffer with n instances of an element.
-    #[inline]
-    pub fn add_n(&mut self, element: T, num_elements: usize) -> Result<(), CpuWriteGpuReadError> {
+    pub fn add_n(
+        &mut self,
+        element: T,
+        num_elements: usize,
+    ) -> Result<(), DataTextureSourceWriteError> {
         if num_elements == 0 {
             return Ok(());
         }
 
         re_tracing::profile_function!();
 
-        self.reserve(num_elements)?;
+        let num_elements_available = self.reserve(num_elements)?;
+        let num_elements_actually_added = num_elements_available.min(num_elements);
 
-        let mut num_elements_remaining = num_elements;
-
+        let mut num_elements_remaining = num_elements_actually_added;
         loop {
-            let result =
+            let write_result =
                 self.buffers[self.active_buffer_index].add_n(element, num_elements_remaining);
 
             // `fill_n` is documented to write as many elements as possible, so we can just continue with the next buffer,
@@ -240,29 +263,74 @@ impl<'a, T: Pod + Send + Sync> DataTextureSource<'a, T> {
             if let Err(CpuWriteGpuReadError::BufferFull {
                 num_elements_actually_added,
                 ..
-            }) = result
+            }) = write_result
             {
                 num_elements_remaining -= num_elements_actually_added;
                 self.active_buffer_index += 1; // Due to the prior `reserve` call we know that there's more buffers!
             } else {
+                write_result?;
                 self.ensure_active_buffer_invariant_after_adding_elements();
-                return result;
+                return self.error_on_clamped_write(num_elements, num_elements_actually_added);
             }
         }
     }
 
     #[allow(unused)] // TODO(andreas): soon!
     #[inline]
-    pub fn push(&mut self, element: T) -> Result<(), CpuWriteGpuReadError> {
-        self.reserve(1)?;
+    pub fn push(&mut self, element: T) -> Result<(), DataTextureSourceWriteError> {
+        if self.reserve(1)? < 1 {
+            return self.error_on_clamped_write(1, 0);
+        }
+
         self.buffers[self.active_buffer_index].push(element);
         self.ensure_active_buffer_invariant_after_adding_elements();
 
         Ok(())
     }
 
+    fn data_texture_size(&self, max_texture_dimension_2d: u32) -> wgpu::Extent3d {
+        let texel_size_in_bytes = std::mem::size_of::<T>() as u32;
+        let num_texels = self.len();
+
+        debug_assert!(num_texels < max_num_elements_per_data_texture(max_texture_dimension_2d));
+
+        // Our data textures are usually accessed in a linear fashion, so ideally we'd be using a 1D texture.
+        // However, 1D textures are very limited in size on many platforms, we have to use 2D textures instead.
+        // 2D textures perform a lot better when their dimensions are powers of two, so we'll strictly stick to that even
+        // when it seems to cause memory overhead.
+
+        // We fill row by row. With the power-of-two requirement, this is the optimal strategy:
+        // if there were a texture with less padding that uses half the width,
+        // then we'd need to increase the height. We can't increase without doubling it, thus creating a texture
+        // with the exact same mount of padding as before.
+        let max_data_texture_width = max_data_texture_width(max_texture_dimension_2d);
+        let width = if num_texels < max_data_texture_width as usize {
+            num_texels
+                .next_power_of_two()
+                // For too few number of written texels, or too small texels we might need to increase the size to stay
+                // above a row **byte** size of `wgpu::COPY_BYTES_PER_ROW_ALIGNMENT`.
+                // Note that this implies that for very large texels, we need less wide textures to stay above this limit.
+                // (width is in number of texels, but alignment cares about bytes!)
+                .next_multiple_of(
+                    (wgpu::COPY_BYTES_PER_ROW_ALIGNMENT / texel_size_in_bytes) as usize,
+                ) as u32
+        } else {
+            max_data_texture_width
+        };
+
+        let height = num_texels.div_ceil(width as usize);
+        debug_assert!(height <= max_texture_dimension_2d as usize); // Texel count should have been clamped accordingly already!
+
+        wgpu::Extent3d {
+            width,
+            height: height as u32,
+            depth_or_array_layers: 1,
+        }
+    }
+
     /// Schedules copies of all previous writes to this `DataTextureSource` to a `GpuTexture`.
     ///
+    /// The format *has* to be uncompressed, not a depth/stencil format and have the exact same block size of the size of type `T`.
     /// The resulting `GpuTexture` is ready to be bound as a data texture in a shader.
     pub fn finish(
         self,
@@ -271,20 +339,31 @@ impl<'a, T: Pod + Send + Sync> DataTextureSource<'a, T> {
     ) -> Result<GpuTexture, CpuWriteGpuReadError> {
         re_tracing::profile_function!();
 
-        let total_num_elements = self.len();
-
-        let texture_desc = data_texture_desc(
-            texture_label,
-            texture_format,
-            total_num_elements,
-            Self::max_data_texture_width(&self.ctx.device.limits()) as u32,
+        debug_assert!(!texture_format.has_depth_aspect());
+        debug_assert!(!texture_format.has_stencil_aspect());
+        debug_assert!(!texture_format.is_compressed());
+        debug_assert_eq!(
+            texture_format
+                .block_copy_size(None)
+                .expect("Depth/stencil formats are not supported as data textures"),
+            std::mem::size_of::<T>() as u32,
         );
-        let data_texture = self
-            .ctx
-            .gpu_resources
-            .textures
-            .alloc(&self.ctx.device, &texture_desc);
-        let texture_width = texture_desc.size.width as usize;
+
+        let texture_size =
+            self.data_texture_size(self.ctx.device.limits().max_texture_dimension_2d);
+        let data_texture = self.ctx.gpu_resources.textures.alloc(
+            &self.ctx.device,
+            &wgpu_resources::TextureDesc {
+                label: texture_label.into(),
+                size: texture_size,
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: texture_format,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            },
+        );
+        let texture_width = texture_size.width as usize;
 
         // Copy all buffers to the texture.
         let mut current_row = 0;
@@ -316,7 +395,7 @@ impl<'a, T: Pod + Send + Sync> DataTextureSource<'a, T> {
                 },
                 wgpu::Extent3d {
                     height: num_rows as u32,
-                    ..texture_desc.size
+                    ..texture_size
                 },
             )?;
 
@@ -327,6 +406,7 @@ impl<'a, T: Pod + Send + Sync> DataTextureSource<'a, T> {
     }
 }
 
+// TODO(andreas): This is now redundant to `DataTextureSource::data_texture_size`. Remove this once all line data has moved to `DataTextureSource`.
 /// Texture size for storing a given amount of data.
 ///
 /// For WebGL compatibility we sometimes have to use textures instead of buffers.
@@ -340,7 +420,6 @@ impl<'a, T: Pod + Send + Sync> DataTextureSource<'a, T> {
 /// row size in bytes is a multiple of `wgpu::COPY_BYTES_PER_ROW_ALIGNMENT`.
 /// This makes it a lot easier to copy data from a continuous buffer to the texture.
 /// If we wouldn't do that, we'd need to do a copy for each row in some cases.
-// TODO(andreas): everything should use `DataTextureSource` directly, then this function is no longer needed!
 pub fn data_texture_size(
     format: wgpu::TextureFormat,
     num_texels_written: usize,
@@ -411,4 +490,30 @@ pub fn data_texture_desc(
         format,
         usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
     }
+}
+
+/// Maximum width for data textures.
+#[inline]
+fn max_data_texture_width(max_texture_dimension_2d: u32) -> u32 {
+    // We limit the data texture width to 16384 or whatever smaller value is supported but the device.
+    //
+    // If we make buffers always a multiple of this width, we can do all buffer copies in a single copy!
+    //
+    // But wait! If we're using this as the minimum buffer size, isn't that too big?
+    // 16384 * float4 (worst case) = 256KiB.
+    // Keep in mind that weaker hardware will have 8192 max width.
+    // Also note, that many of our textures use 4 & 8 byte formats.
+    // So while this is still a considerable amount of memory when used for very small data textures
+    // it's not as bad as it seems.
+    // Given how much it simplifies to keep buffers a multiple of the texture width,
+    // this seems to be a reasonable trade-off.
+    (max_texture_dimension_2d).min(16384)
+}
+
+/// Maximum number of elements that can be written to a single data texture.
+#[inline]
+fn max_num_elements_per_data_texture(max_texture_dimension_2d: u32) -> usize {
+    let max_width = max_data_texture_width(max_texture_dimension_2d) as usize;
+    let max_height = max_texture_dimension_2d as usize;
+    max_width * max_height
 }

--- a/crates/re_renderer/src/allocator/mod.rs
+++ b/crates/re_renderer/src/allocator/mod.rs
@@ -11,10 +11,7 @@ mod uniform_buffer_fill;
 pub use cpu_write_gpu_read_belt::{
     CpuWriteGpuReadBelt, CpuWriteGpuReadBuffer, CpuWriteGpuReadError,
 };
-pub use data_texture_source::{
-    data_texture_desc, data_texture_size, data_texture_source_buffer_element_count,
-    DataTextureSource,
-};
+pub use data_texture_source::{data_texture_desc, data_texture_size, DataTextureSource};
 pub use gpu_readback_belt::{
     GpuReadbackBelt, GpuReadbackBuffer, GpuReadbackError, GpuReadbackIdentifier,
 };

--- a/crates/re_renderer/src/allocator/mod.rs
+++ b/crates/re_renderer/src/allocator/mod.rs
@@ -11,7 +11,7 @@ mod uniform_buffer_fill;
 pub use cpu_write_gpu_read_belt::{
     CpuWriteGpuReadBelt, CpuWriteGpuReadBuffer, CpuWriteGpuReadError,
 };
-pub use data_texture_source::{data_texture_desc, data_texture_size, DataTextureSource};
+pub use data_texture_source::{data_texture_desc, DataTextureSource};
 pub use gpu_readback_belt::{
     GpuReadbackBelt, GpuReadbackBuffer, GpuReadbackError, GpuReadbackIdentifier,
 };

--- a/crates/re_renderer/src/line_drawable_builder.rs
+++ b/crates/re_renderer/src/line_drawable_builder.rs
@@ -16,7 +16,7 @@ use crate::{
 /// TODO(andreas): We could make significant optimizations here by making this builder capable
 /// of writing to a GPU readable memory location for all its data.
 pub struct LineDrawableBuilder<'ctx> {
-    ctx: &'ctx crate::context::RenderContext,
+    ctx: &'ctx RenderContext,
 
     pub(crate) vertices: Vec<LineVertex>,
     pub(crate) batches: Vec<LineBatchInfo>,

--- a/crates/re_renderer/src/line_drawable_builder.rs
+++ b/crates/re_renderer/src/line_drawable_builder.rs
@@ -41,15 +41,19 @@ impl<'ctx> LineDrawableBuilder<'ctx> {
         }
     }
 
-    pub fn reserve_strips(&mut self, num_strips: usize) -> Result<(), CpuWriteGpuReadError> {
+    /// Returns number of strips that can be added without reallocation.
+    /// This may be smaller than the requested number if the maximum number of strips is reached.
+    pub fn reserve_strips(&mut self, num_strips: usize) -> Result<usize, CpuWriteGpuReadError> {
         self.strips.reserve(num_strips);
         self.picking_instance_ids_buffer.reserve(num_strips)
     }
 
+    /// Returns number of vertices that can be added without reallocation.
+    /// This may be smaller than the requested number if the maximum number of vertices is reached.
     #[allow(clippy::unnecessary_wraps)] // TODO(andreas): will be needed once vertices writes directly to GPU readable memory.
-    pub fn reserve_vertices(&mut self, num_vertices: usize) -> Result<(), CpuWriteGpuReadError> {
+    pub fn reserve_vertices(&mut self, num_vertices: usize) -> Result<usize, CpuWriteGpuReadError> {
         self.vertices.reserve(num_vertices);
-        Ok(())
+        Ok(self.vertices.capacity() - self.vertices.len())
     }
 
     /// Boosts the size of the points by the given amount of ui-points for the purpose of drawing outlines.

--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -184,7 +184,7 @@ impl<'a, 'ctx> PointCloudBatchBuilder<'a, 'ctx> {
         let colors = &colors[0..num_points.min(colors.len())];
         let picking_ids = &picking_ids[0..num_points.min(picking_ids.len())];
 
-        self.batch_mut().point_count += positions.len() as u32;
+        self.batch_mut().point_count += num_points as u32;
 
         {
             re_tracing::profile_scope!("positions & radii");
@@ -212,7 +212,7 @@ impl<'a, 'ctx> PointCloudBatchBuilder<'a, 'ctx> {
                 .ok_or_log_error();
             self.0
                 .color_buffer
-                .add_n(Color32::WHITE, positions.len().saturating_sub(colors.len()))
+                .add_n(Color32::WHITE, num_points.saturating_sub(colors.len()))
                 .ok_or_log_error();
         }
         {
@@ -226,9 +226,9 @@ impl<'a, 'ctx> PointCloudBatchBuilder<'a, 'ctx> {
                 .picking_instance_ids_buffer
                 .add_n(
                     PickingLayerInstanceId::default(),
-                    positions.len().saturating_sub(picking_ids.len()),
+                    num_points.saturating_sub(picking_ids.len()),
                 )
-                .ok_or_log_error(); // TODO: forward errors here and elsewhere?
+                .ok_or_log_error();
         }
 
         self

--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -40,10 +40,13 @@ impl<'ctx> PointCloudBuilder<'ctx> {
         }
     }
 
+    /// Returns number of points that can be added without reallocation.
+    /// This may be smaller than the requested number if the maximum number of strips is reached.
     pub fn reserve(
         &mut self,
         expected_number_of_additional_points: usize,
-    ) -> Result<(), CpuWriteGpuReadError> {
+    ) -> Result<usize, CpuWriteGpuReadError> {
+        // We know that the maximum number is independent of datatype, so we can use the same value for all.
         self.position_radius_buffer
             .reserve(expected_number_of_additional_points)?;
         self.color_buffer

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -171,7 +171,7 @@ impl PointCloudDrawData {
 
         let PointCloudBuilder {
             ctx,
-            vertices_buffer,
+            position_radius_buffer: vertices_buffer,
             color_buffer,
             picking_instance_ids_buffer,
             batches,

--- a/crates/re_renderer_examples/2d.rs
+++ b/crates/re_renderer_examples/2d.rs
@@ -175,7 +175,8 @@ impl framework::Example for Render2D {
         // Moving the windows to a high dpi screen makes the second one bigger.
         // Also, it looks different under perspective projection.
         // The third point is automatic thickness which is determined by the point renderer implementation.
-        let mut point_cloud_builder = PointCloudBuilder::new(re_ctx, 128);
+        let mut point_cloud_builder = PointCloudBuilder::new(re_ctx);
+        point_cloud_builder.reserve(128).unwrap();
         point_cloud_builder.batch("points").add_points_2d(
             &[
                 glam::vec3(500.0, 120.0, 0.0),
@@ -244,7 +245,7 @@ impl framework::Example for Render2D {
         }
 
         let line_strip_draw_data = line_strip_builder.into_draw_data().unwrap();
-        let point_draw_data = point_cloud_builder.into_draw_data(re_ctx).unwrap();
+        let point_draw_data = point_cloud_builder.into_draw_data().unwrap();
 
         let image_scale = 4.0;
         let rectangle_draw_data = RectangleDrawData::new(

--- a/crates/re_renderer_examples/depth_cloud.rs
+++ b/crates/re_renderer_examples/depth_cloud.rs
@@ -99,12 +99,11 @@ impl RenderDepthClouds {
                 })
                 .multiunzip();
 
-            let mut builder = PointCloudBuilder::new(re_ctx, points.len());
+            let mut builder = PointCloudBuilder::new(re_ctx);
             builder
                 .batch("backprojected point cloud")
                 .add_points(&points, &radii, &colors, &[]);
-
-            builder.into_draw_data(re_ctx).unwrap()
+            builder.into_draw_data().unwrap()
         };
 
         let mut view_builder = ViewBuilder::new(

--- a/crates/re_renderer_examples/multiview.rs
+++ b/crates/re_renderer_examples/multiview.rs
@@ -327,7 +327,7 @@ impl Example for Multiview {
         let skybox = GenericSkyboxDrawData::new(re_ctx);
         let lines = build_lines(re_ctx, seconds_since_startup);
 
-        let mut builder = PointCloudBuilder::new(re_ctx, self.random_points_positions.len());
+        let mut builder = PointCloudBuilder::new(re_ctx);
         builder
             .batch("Random Points")
             .world_from_obj(glam::Affine3A::from_rotation_x(seconds_since_startup))
@@ -338,7 +338,7 @@ impl Example for Multiview {
                 &[],
             );
 
-        let point_cloud = builder.into_draw_data(re_ctx).unwrap();
+        let point_cloud = builder.into_draw_data().unwrap();
         let meshes = build_mesh_instances(
             re_ctx,
             &self.model_mesh_instances,

--- a/crates/re_renderer_examples/picking.rs
+++ b/crates/re_renderer_examples/picking.rs
@@ -156,10 +156,10 @@ impl framework::Example for Picking {
             .schedule_picking_rect(re_ctx, picking_rect, READBACK_IDENTIFIER, (), false)
             .unwrap();
 
-        let mut point_builder = PointCloudBuilder::new(
-            re_ctx,
-            self.point_sets.iter().map(|set| set.positions.len()).sum(),
-        );
+        let mut point_builder = PointCloudBuilder::new(re_ctx);
+        point_builder
+            .reserve(self.point_sets.iter().map(|set| set.positions.len()).sum())
+            .unwrap();
         for (i, point_set) in self.point_sets.iter().enumerate() {
             point_builder
                 .batch(format!("Random Points {i}"))
@@ -171,7 +171,7 @@ impl framework::Example for Picking {
                     &point_set.picking_ids,
                 );
         }
-        view_builder.queue_draw(point_builder.into_draw_data(re_ctx).unwrap());
+        view_builder.queue_draw(point_builder.into_draw_data().unwrap());
 
         let instances = self
             .model_mesh_instances

--- a/crates/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points2d.rs
@@ -74,7 +74,7 @@ impl Points2DVisualizer {
 
     fn process_data(
         &mut self,
-        point_builder: &mut PointCloudBuilder,
+        point_builder: &mut PointCloudBuilder<'_>,
         line_builder: &mut LineDrawableBuilder<'_>,
         query: &ViewQuery<'_>,
         data: &Points2DComponentData<'_>,
@@ -259,7 +259,8 @@ impl VisualizerSystem for Points2DVisualizer {
             return Ok(Vec::new());
         }
 
-        let mut point_builder = PointCloudBuilder::new(ctx.render_ctx, num_points)
+        let mut point_builder = PointCloudBuilder::new(ctx.render_ctx);
+        point_builder
             .radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_POINT_OUTLINES);
 
         // We need lines from keypoints. The number of lines we'll have is harder to predict, so we'll go with the dynamic allocation approach.
@@ -315,7 +316,7 @@ impl VisualizerSystem for Points2DVisualizer {
         )?;
 
         Ok(vec![
-            point_builder.into_draw_data(ctx.render_ctx)?.into(),
+            point_builder.into_draw_data()?.into(),
             line_builder.into_draw_data()?.into(),
         ])
     }

--- a/crates/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points3d.rs
@@ -75,7 +75,7 @@ impl Points3DVisualizer {
 
     fn process_data(
         &mut self,
-        point_builder: &mut PointCloudBuilder,
+        point_builder: &mut PointCloudBuilder<'_>,
         line_builder: &mut LineDrawableBuilder<'_>,
         query: &ViewQuery<'_>,
         ent_path: &EntityPath,
@@ -200,7 +200,9 @@ impl VisualizerSystem for Points3DVisualizer {
             return Ok(Vec::new());
         }
 
-        let mut point_builder = PointCloudBuilder::new(ctx.render_ctx, num_points)
+        let mut point_builder = PointCloudBuilder::new(ctx.render_ctx);
+        point_builder.reserve(num_points)?;
+        point_builder
             .radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_POINT_OUTLINES);
 
         // We need lines from keypoints. The number of lines we'll have is harder to predict, so we'll go with the dynamic allocation approach.
@@ -256,7 +258,7 @@ impl VisualizerSystem for Points3DVisualizer {
         )?;
 
         Ok(vec![
-            point_builder.into_draw_data(ctx.render_ctx)?.into(),
+            point_builder.into_draw_data()?.into(),
             line_builder.into_draw_data()?.into(),
         ])
     }


### PR DESCRIPTION
 ### What

* Part of #1398
* Follow-up to #5207


Point cloud builder uses now `DataTextureSource` for all its data.

`DataTextureSource` is now better at dealing with the max texture size: data writes are clamped ahead of time, meaning we no longer reserve memory for data that we can't write into the texture upon `DataTexturesSource::finish`.
This bubbled up now since `PointCloudBuilder` so far used a vec for positions and checked that against the maximum. The changes here leave the check in place, but make `DataTextureSource` reserving & writing clamp to the maximum and deal with this robustly even if high level data structures (like `PointCloudBuilder`) fail to handle this.



Artificially limiting the data texture size to 256 * 256 looks like this:
<img width="1751" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/ff65944c-b499-4772-8993-9619daf8d6b0">

I tested performance before/after on these changes on two opf scenes on my mac to check for changes in perf and found the switch to using `DataTextureSource` for position/radius improved performance slightly:
* olympic (1.5mio points):  ~7.0ms ->  ~6.8ms
* rainwater (4.6mio points): ~17.1ms-> ~16.5ms
(numbers via performance metrics, release build)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5229/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5229/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5229/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5229)
- [Docs preview](https://rerun.io/preview/963956c93faa135571b48dc764f26ffea87e186b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/963956c93faa135571b48dc764f26ffea87e186b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)