### PR TITLE
Fix broken link in the installing-viewer documentation

### DIFF
--- a/docs/content/getting-started/installing-viewer.md
+++ b/docs/content/getting-started/installing-viewer.md
@@ -25,4 +25,4 @@ The Rerun Viewer has built-in support for opening many kinds of files, and can b
 To start getting your own data logged & visualized in the viewer check one of the respective getting started guides:
 * [Python](python.md)
 * [C++](cpp.md)
-* [Rust](python.md)
+* [Rust](rust.md)


### PR DESCRIPTION
Fix of missing rust link

<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5236/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5236/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5236/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5236)
- [Docs preview](https://rerun.io/preview/d87083a7b45ad02af9869c3557d1fbaf996911ee/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d87083a7b45ad02af9869c3557d1fbaf996911ee/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)