### PR TITLE
Use `DataTextureSource` for lines

### DIFF
--- a/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
+++ b/crates/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
@@ -241,6 +241,7 @@ where
     /// (taking into account required padding as specified by [`wgpu::COPY_BYTES_PER_ROW_ALIGNMENT`])
     ///
     /// Fails if the buffer size is not sufficient to fill the entire texture.
+    #[allow(unused)]
     pub fn copy_to_texture2d_entire_first_layer(
         self,
         encoder: &mut wgpu::CommandEncoder,

--- a/crates/re_renderer/src/allocator/mod.rs
+++ b/crates/re_renderer/src/allocator/mod.rs
@@ -11,7 +11,7 @@ mod uniform_buffer_fill;
 pub use cpu_write_gpu_read_belt::{
     CpuWriteGpuReadBelt, CpuWriteGpuReadBuffer, CpuWriteGpuReadError,
 };
-pub use data_texture_source::{data_texture_desc, DataTextureSource};
+pub use data_texture_source::{DataTextureSource, DataTextureSourceWriteError};
 pub use gpu_readback_belt::{
     GpuReadbackBelt, GpuReadbackBuffer, GpuReadbackError, GpuReadbackIdentifier,
 };

--- a/crates/re_renderer/src/line_drawable_builder.rs
+++ b/crates/re_renderer/src/line_drawable_builder.rs
@@ -560,5 +560,9 @@ impl<'a, 'ctx> Drop for LineStripBuilder<'a, 'ctx> {
             .strips_buffer
             .add_n(self.strip, self.num_strips_added)
             .ok_or_log_error_once();
+
+        debug_assert!(
+            self.builder.strips_buffer.len() == self.builder.picking_instance_ids_buffer.len()
+        );
     }
 }

--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -6,8 +6,8 @@ use crate::{
     allocator::DataTextureSource,
     draw_phases::PickingLayerObjectId,
     renderer::{
-        PointCloudBatchFlags, PointCloudBatchInfo, PointCloudDrawData, PointCloudDrawDataError,
-        PositionRadius,
+        gpu_data::PositionRadius, PointCloudBatchFlags, PointCloudBatchInfo, PointCloudDrawData,
+        PointCloudDrawDataError,
     },
     Color32, CpuWriteGpuReadError, DebugLabel, DepthOffset, OutlineMaskPreference,
     PickingLayerInstanceId, RenderContext, Size,

--- a/crates/re_renderer/src/renderer/mod.rs
+++ b/crates/re_renderer/src/renderer/mod.rs
@@ -2,15 +2,11 @@ mod generic_skybox;
 pub use generic_skybox::GenericSkyboxDrawData;
 
 mod lines;
-pub use lines::{
-    gpu_data::LineVertex, LineBatchInfo, LineDrawData, LineDrawDataError, LineStripFlags,
-    LineStripInfo,
-};
+pub use lines::{LineBatchInfo, LineDrawData, LineDrawDataError, LineStripFlags};
 
 mod point_cloud;
 pub use point_cloud::{
     PointCloudBatchFlags, PointCloudBatchInfo, PointCloudDrawData, PointCloudDrawDataError,
-    PositionRadius,
 };
 
 mod depth_cloud;
@@ -34,6 +30,11 @@ pub(crate) use compositor::CompositorDrawData;
 
 mod debug_overlay;
 pub use debug_overlay::{DebugOverlayDrawData, DebugOverlayError, DebugOverlayRenderer};
+
+pub mod gpu_data {
+    pub use super::lines::gpu_data::{LineStripInfo, LineVertex};
+    pub use super::point_cloud::gpu_data::PositionRadius;
+}
 
 use crate::{
     context::RenderContext,

--- a/crates/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/re_renderer/src/renderer/point_cloud.rs
@@ -52,7 +52,7 @@ bitflags! {
     }
 }
 
-mod gpu_data {
+pub mod gpu_data {
     use crate::{draw_phases::PickingLayerObjectId, wgpu_buffer_types, Size};
 
     // Don't use `wgsl_buffer_types` since this data doesn't go into a buffer, so alignment rules don't apply like on buffers..
@@ -150,8 +150,6 @@ pub struct PointCloudBatchInfo {
     /// Depth offset applied after projection.
     pub depth_offset: DepthOffset,
 }
-
-pub use gpu_data::PositionRadius;
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum PointCloudDrawDataError {


### PR DESCRIPTION
### What

* Fixes #1398 
* Follow-up of #5229
   * same changelog applies which is why I left it out: again this makes handling of 

I tried a scene with a very large number of line strips and the performance is about the same before after, hard to judge though since before perf was not very stable and both before/after we have a huge profiler overhead - there's some low hanging fruit in better batching how we add batches of line strips, but I left this intentionally out of this pr.

Similar to the previous PR I also artificially lowered the data size texture limit to check that the error messages and truncating of lines works gracefully.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5240/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5240/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5240/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5240)
- [Docs preview](https://rerun.io/preview/6d57ed6f6cfce86d82218a33994437fd4fdb637e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/6d57ed6f6cfce86d82218a33994437fd4fdb637e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)