### PR TITLE
Add STL mesh support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4577,6 +4577,7 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "thiserror",
+ "tinystl",
  "tobj",
  "type-map",
  "unindent",
@@ -6282,6 +6283,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
+]
+
+[[package]]
+name = "tinystl"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdbcdda2f86a57b89b5d9ac17cd4c9f3917ec8edcde403badf3d992d2947af2a"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,7 @@ thiserror = "1.0"
 time = { version = "0.3", default-features = false, features = [
   "wasm-bindgen",
 ] }
+tinystl = { version = "0.0.3", default-features = false }
 tinyvec = { version = "1.6", features = ["alloc", "rustc_1_55"] }
 tobj = "4.0"
 tokio = { version = "1.24", default-features = false }

--- a/crates/re_data_source/src/lib.rs
+++ b/crates/re_data_source/src/lib.rs
@@ -50,7 +50,7 @@ pub const SUPPORTED_IMAGE_EXTENSIONS: &[&str] = &[
     "pbm", "pgm", "png", "ppm", "tga", "tif", "tiff", "webp",
 ];
 
-pub const SUPPORTED_MESH_EXTENSIONS: &[&str] = &["glb", "gltf", "obj"];
+pub const SUPPORTED_MESH_EXTENSIONS: &[&str] = &["glb", "gltf", "obj", "stl"];
 
 // TODO(#4532): `.ply` data loader should support 2D point cloud & meshes
 pub const SUPPORTED_POINT_CLOUD_EXTENSIONS: &[&str] = &["ply"];

--- a/crates/re_renderer/Cargo.toml
+++ b/crates/re_renderer/Cargo.toml
@@ -24,7 +24,7 @@ targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 
 [features]
-default = ["import-obj", "import-gltf"]
+default = ["import-obj", "import-gltf", "import-stl"]
 
 ## Support for Arrow datatypes for end-to-end zero-copy.
 arrow = ["dep:arrow2"]
@@ -34,6 +34,9 @@ import-obj = ["dep:tobj"]
 
 ## Support importing .gltf and .glb files
 import-gltf = ["dep:gltf"]
+
+## Support importing binary & ascii .stl files
+import-stl = ["dep:tinystl"]
 
 ## Enable (de)serialization using serde.
 serde = ["dep:serde"]
@@ -73,6 +76,7 @@ wgpu-core.workspace = true                                           # Needed fo
 # optional
 arrow2 = { workspace = true, optional = true }
 gltf = { workspace = true, optional = true }
+tinystl = { workspace = true, features = ["bytemuck"], optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 tobj = { workspace = true, optional = true }
 

--- a/crates/re_renderer/src/importer/mod.rs
+++ b/crates/re_renderer/src/importer/mod.rs
@@ -4,6 +4,9 @@ pub mod obj;
 #[cfg(feature = "import-gltf")]
 pub mod gltf;
 
+#[cfg(feature = "import-stl")]
+pub mod stl;
+
 use macaw::Vec3Ext as _;
 
 use crate::renderer::MeshInstance;

--- a/crates/re_renderer/src/importer/stl.rs
+++ b/crates/re_renderer/src/importer/stl.rs
@@ -1,0 +1,105 @@
+use itertools::Itertools;
+use smallvec::smallvec;
+use tinystl::StlData;
+
+use crate::{mesh, renderer::MeshInstance, resource_managers::ResourceLifeTime, RenderContext};
+
+#[derive(thiserror::Error, Debug)]
+pub enum StlImportError {
+    #[error("Missing data in STL file.")]
+    MissingData,
+
+    #[error("Unexpected data in STL file at line {0}.")]
+    Unexpected(usize),
+
+    #[error("Failed to parse line {0} (usually due to a malformed vertex).")]
+    Parse(usize),
+
+    #[error("Failed to convert the number of triangles to a 32bit unsigned integer (as required by the STL specification).")]
+    TooManyFacets,
+
+    #[error("Failed to parse integer.")]
+    TryFromInt,
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    MeshError(#[from] mesh::MeshError),
+
+    #[error(transparent)]
+    ResourceManagerError(#[from] crate::resource_managers::ResourceManagerError),
+}
+
+/// Load a [STL .stl file](https://en.wikipedia.org/wiki/STL_(file_format)) into the mesh manager.
+pub fn load_stl_from_buffer(
+    buffer: &[u8],
+    ctx: &RenderContext,
+) -> Result<Vec<MeshInstance>, StlImportError> {
+    re_tracing::profile_function!();
+
+    let cursor = std::io::Cursor::new(buffer);
+    let stl_data =
+        StlData::read_buffer(std::io::BufReader::new(cursor)).map_err(|err| match err {
+            tinystl::Error::MissingData => StlImportError::MissingData,
+            tinystl::Error::Unexpected(line) => StlImportError::Unexpected(line),
+            tinystl::Error::Parse(line) => StlImportError::Parse(line),
+            tinystl::Error::TooManyFacets(_) => StlImportError::TooManyFacets,
+            tinystl::Error::TryFromInt(_) => StlImportError::TryFromInt,
+            tinystl::Error::Io(err) => err.into(),
+        })?;
+
+    let StlData {
+        name,
+        triangles,
+        normals,
+        ..
+    } = stl_data;
+
+    let num_vertices = triangles.len() * 3;
+
+    let material = mesh::Material {
+        label: "default material".into(),
+        index_range: 0..num_vertices as u32,
+        albedo: ctx.texture_manager_2d.white_texture_unorm_handle().clone(),
+        albedo_multiplier: crate::Rgba::WHITE,
+    };
+
+    let mesh = mesh::Mesh {
+        label: name.into(),
+        triangle_indices: (0..num_vertices as u32)
+            .tuples::<(_, _, _)>()
+            .map(glam::UVec3::from)
+            .collect::<Vec<_>>(),
+        vertex_positions: bytemuck::cast_slice(&triangles).to_vec(),
+
+        // Normals on STL are per triangle, not per vertex.
+        // Yes, this makes STL always look faceted.
+        vertex_normals: normals
+            .into_iter()
+            .flat_map(|n| {
+                let n = glam::Vec3::from_array(n);
+                [n, n, n]
+            })
+            .collect(),
+
+        // STL has neither colors nor texcoords.
+        vertex_colors: vec![crate::Rgba32Unmul::WHITE; num_vertices],
+        vertex_texcoords: vec![glam::Vec2::ZERO; num_vertices],
+
+        materials: smallvec![material],
+    };
+
+    mesh.sanity_check()?;
+
+    let gpu_mesh = ctx
+        .mesh_manager
+        .write()
+        .create(ctx, &mesh, ResourceLifeTime::LongLived)?;
+
+    Ok(vec![MeshInstance {
+        gpu_mesh,
+        mesh: Some(std::sync::Arc::new(mesh)),
+        ..Default::default()
+    }])
+}

--- a/crates/re_space_view_spatial/Cargo.toml
+++ b/crates/re_space_view_spatial/Cargo.toml
@@ -25,7 +25,11 @@ re_log_types.workspace = true
 re_log.workspace = true
 re_query.workspace = true
 re_query_cache.workspace = true
-re_renderer = { workspace = true, features = ["import-gltf", "import-obj"] }
+re_renderer = { workspace = true, features = [
+  "import-gltf",
+  "import-obj",
+  "import-stl",
+] }
 re_types = { workspace = true, features = ["ecolor", "glam", "image"] }
 re_tracing.workspace = true
 re_ui.workspace = true

--- a/crates/re_space_view_spatial/src/mesh_loader.rs
+++ b/crates/re_space_view_spatial/src/mesh_loader.rs
@@ -53,6 +53,7 @@ impl LoadedMesh {
                 ResourceLifeTime::LongLived,
                 render_ctx,
             )?,
+            MediaType::STL => re_renderer::importer::stl::load_stl_from_buffer(bytes, render_ctx)?,
             _ => anyhow::bail!("{media_type} files are not supported"),
         };
 

--- a/crates/re_types/definitions/rerun/archetypes/asset3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/asset3d.fbs
@@ -7,7 +7,7 @@ namespace rerun.archetypes;
 
 // ---
 
-/// A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
+/// A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, `.stl`, etc.).
 ///
 /// \py See also [`Mesh3D`][rerun.archetypes.Mesh3D].
 /// \rs See also [`Mesh3D`][crate::archetypes::Mesh3D].
@@ -28,7 +28,9 @@ table Asset3D (
   ///
   /// Supported values:
   /// * `model/gltf-binary`
+  /// * `model/gltf+json`
   /// * `model/obj` (.mtl material files are not supported yet, references are silently ignored)
+  /// * `model/stl`
   ///
   /// If omitted, the viewer will try to guess from the data blob.
   /// If it cannot guess, it won't be able to render the asset.

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -34,7 +34,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// fn main() -> anyhow::Result<()> {
 ///     let args = std::env::args().collect::<Vec<_>>();
 ///     let Some(path) = args.get(1) else {
-///         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj]>", args[0]);
+///         anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj|stl]>", args[0]);
 ///     };
 ///
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d").spawn()?;

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -21,7 +21,7 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Archetype**: A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
+/// **Archetype**: A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, `.stl`, etc.).
 ///
 /// See also [`Mesh3D`][crate::archetypes::Mesh3D].
 ///
@@ -63,7 +63,9 @@ pub struct Asset3D {
     ///
     /// Supported values:
     /// * `model/gltf-binary`
+    /// * `model/gltf+json`
     /// * `model/obj` (.mtl material files are not supported yet, references are silently ignored)
+    /// * `model/stl`
     ///
     /// If omitted, the viewer will try to guess from the data blob.
     /// If it cannot guess, it won't be able to render the asset.

--- a/docs/code-examples/all/asset3d_simple.cpp
+++ b/docs/code-examples/all/asset3d_simple.cpp
@@ -8,7 +8,7 @@
 
 int main(int argc, char* argv[]) {
     if (argc < 2) {
-        std::cerr << "Usage: " << argv[0] << " <path_to_asset.[gltf|glb|obj]>" << std::endl;
+        std::cerr << "Usage: " << argv[0] << " <path_to_asset.[gltf|glb|obj|stl]>" << std::endl;
         return 1;
     }
 

--- a/docs/code-examples/all/asset3d_simple.py
+++ b/docs/code-examples/all/asset3d_simple.py
@@ -4,7 +4,7 @@ import sys
 import rerun as rr
 
 if len(sys.argv) < 2:
-    print(f"Usage: {sys.argv[0]} <path_to_asset.[gltf|glb|obj]>")
+    print(f"Usage: {sys.argv[0]} <path_to_asset.[gltf|glb|obj|stl]>")
     sys.exit(1)
 
 rr.init("rerun_example_asset3d", spawn=True)

--- a/docs/code-examples/all/asset3d_simple.rs
+++ b/docs/code-examples/all/asset3d_simple.rs
@@ -5,7 +5,7 @@ use rerun::external::anyhow;
 fn main() -> anyhow::Result<()> {
     let args = std::env::args().collect::<Vec<_>>();
     let Some(path) = args.get(1) else {
-        anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj]>", args[0]);
+        anyhow::bail!("Usage: {} <path_to_asset.[gltf|glb|obj|stl]>", args[0]);
     };
 
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d").spawn()?;

--- a/docs/content/reference/types/archetypes/asset3d.md
+++ b/docs/content/reference/types/archetypes/asset3d.md
@@ -2,7 +2,7 @@
 title: "Asset3D"
 ---
 
-A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
+A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, `.stl`, etc.).
 
 ## Components
 

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -324,6 +324,7 @@
     "stacklevel",
     "startswith",
     "staticmethod",
+    "Stereolithography",
     "struct",
     "Struct",
     "structs",

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -19,7 +19,7 @@
 #include <vector>
 
 namespace rerun::archetypes {
-    /// **Archetype**: A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
+    /// **Archetype**: A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, `.stl`, etc.).
     ///
     /// ## Example
     ///
@@ -56,7 +56,9 @@ namespace rerun::archetypes {
         ///
         /// Supported values:
         /// * `model/gltf-binary`
+        /// * `model/gltf+json`
         /// * `model/obj` (.mtl material files are not supported yet, references are silently ignored)
+        /// * `model/stl`
         ///
         /// If omitted, the viewer will try to guess from the data blob.
         /// If it cannot guess, it won't be able to render the asset.
@@ -111,7 +113,9 @@ namespace rerun::archetypes {
         ///
         /// Supported values:
         /// * `model/gltf-binary`
+        /// * `model/gltf+json`
         /// * `model/obj` (.mtl material files are not supported yet, references are silently ignored)
+        /// * `model/stl`
         ///
         /// If omitted, the viewer will try to guess from the data blob.
         /// If it cannot guess, it won't be able to render the asset.

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -35,7 +35,7 @@ namespace rerun::archetypes {
     ///
     /// int main(int argc, char* argv[]) {
     ///     if (argc <2) {
-    ///         std::cerr <<"Usage: " <<argv[0] <<" <path_to_asset.[gltf|glb|obj]>" <<std::endl;
+    ///         std::cerr <<"Usage: " <<argv[0] <<" <path_to_asset.[gltf|glb|obj|stl]>" <<std::endl;
     ///         return 1;
     ///     }
     ///

--- a/rerun_cpp/src/rerun/archetypes/asset3d_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d_ext.cpp
@@ -77,6 +77,8 @@ namespace rerun::archetypes {
             return rerun::components::MediaType::gltf();
         } else if (ext == ".obj") {
             return rerun::components::MediaType::obj();
+        } else if (ext == ".stl") {
+            return rerun::components::MediaType::stl();
         } else {
             return std::nullopt;
         }

--- a/rerun_cpp/src/rerun/components/media_type.hpp
+++ b/rerun_cpp/src/rerun/components/media_type.hpp
@@ -46,21 +46,29 @@ namespace rerun::components {
             return "text/markdown";
         }
 
-        /// `glTF`(https://en.wikipedia.org/wiki/GlTF): `model/gltf+json`.
+        /// [`glTF`](https://en.wikipedia.org/wiki/GlTF): `model/gltf+json`.
         ///
         /// <https://www.iana.org/assignments/media-types/model/gltf+json>
         static MediaType gltf() {
             return "model/gltf+json";
         }
 
-        /// Binary `glTF`(https://en.wikipedia.org/wiki/GlTF): `model/gltf-binary`.
+        /// [Binary `glTF`](https://en.wikipedia.org/wiki/GlTF): `model/gltf-binary`.
         ///
         /// <https://www.iana.org/assignments/media-types/model/gltf-binary>
         static MediaType glb() {
             return "model/gltf-binary";
         }
 
-        /// [Wavefront .obj](https://en.wikipedia.org/wiki/Wavefront_.obj_file): `model/obj`.
+        /// [Stereolithography Model `stl`](https://en.wikipedia.org/wiki/STL_(file_format)): `model/stl`.
+        ///
+        /// Either binary or ASCII.
+        /// <https://www.iana.org/assignments/media-types/model/stl>
+        static MediaType stl() {
+            return "model/stl";
+        }
+
+        /// [Wavefront `obj`](https://en.wikipedia.org/wiki/Wavefront_.obj_file): `model/obj`.
         ///
         /// <https://www.iana.org/assignments/media-types/model/obj>
         static MediaType obj() {

--- a/rerun_cpp/src/rerun/components/media_type.hpp
+++ b/rerun_cpp/src/rerun/components/media_type.hpp
@@ -60,19 +60,19 @@ namespace rerun::components {
             return "model/gltf-binary";
         }
 
+        /// [Wavefront `obj`](https://en.wikipedia.org/wiki/Wavefront_.obj_file): `model/obj`.
+        ///
+        /// <https://www.iana.org/assignments/media-types/model/obj>
+        static MediaType obj() {
+            return "model/obj";
+        }
+
         /// [Stereolithography Model `stl`](https://en.wikipedia.org/wiki/STL_(file_format)): `model/stl`.
         ///
         /// Either binary or ASCII.
         /// <https://www.iana.org/assignments/media-types/model/stl>
         static MediaType stl() {
             return "model/stl";
-        }
-
-        /// [Wavefront `obj`](https://en.wikipedia.org/wiki/Wavefront_.obj_file): `model/obj`.
-        ///
-        /// <https://www.iana.org/assignments/media-types/model/obj>
-        static MediaType obj() {
-            return "model/obj";
         }
 
       public:

--- a/rerun_cpp/src/rerun/components/media_type_ext.cpp
+++ b/rerun_cpp/src/rerun/components/media_type_ext.cpp
@@ -32,25 +32,33 @@ namespace rerun {
                 return "text/markdown";
             }
 
-            /// `glTF`(https://en.wikipedia.org/wiki/GlTF): `model/gltf+json`.
+            /// [`glTF`](https://en.wikipedia.org/wiki/GlTF): `model/gltf+json`.
             ///
             /// <https://www.iana.org/assignments/media-types/model/gltf+json>
             static MediaType gltf() {
                 return "model/gltf+json";
             }
 
-            /// Binary `glTF`(https://en.wikipedia.org/wiki/GlTF): `model/gltf-binary`.
+            /// [Binary `glTF`](https://en.wikipedia.org/wiki/GlTF): `model/gltf-binary`.
             ///
             /// <https://www.iana.org/assignments/media-types/model/gltf-binary>
             static MediaType glb() {
                 return "model/gltf-binary";
             }
 
-            /// [Wavefront .obj](https://en.wikipedia.org/wiki/Wavefront_.obj_file): `model/obj`.
+            /// [Wavefront `obj`](https://en.wikipedia.org/wiki/Wavefront_.obj_file): `model/obj`.
             ///
             /// <https://www.iana.org/assignments/media-types/model/obj>
             static MediaType obj() {
                 return "model/obj";
+            }
+
+            /// [Stereolithography Model `stl`](https://en.wikipedia.org/wiki/STL_(file_format)): `model/stl`.
+            ///
+            /// Either binary or ASCII.
+            /// <https://www.iana.org/assignments/media-types/model/stl>
+            static MediaType stl() {
+                return "model/stl";
             }
 
             // </CODEGEN_COPY_TO_HEADER>

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -30,7 +30,7 @@ class Asset3D(Asset3DExt, Archetype):
     import rerun as rr
 
     if len(sys.argv) < 2:
-        print(f"Usage: {sys.argv[0]} <path_to_asset.[gltf|glb|obj]>")
+        print(f"Usage: {sys.argv[0]} <path_to_asset.[gltf|glb|obj|stl]>")
         sys.exit(1)
 
     rr.init("rerun_example_asset3d", spawn=True)

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -17,7 +17,7 @@ __all__ = ["Asset3D"]
 @define(str=False, repr=False, init=False)
 class Asset3D(Asset3DExt, Archetype):
     """
-    **Archetype**: A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, etc.).
+    **Archetype**: A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, `.stl`, etc.).
 
     See also [`Mesh3D`][rerun.archetypes.Mesh3D].
 
@@ -83,7 +83,9 @@ class Asset3D(Asset3DExt, Archetype):
     #
     # Supported values:
     # * `model/gltf-binary`
+    # * `model/gltf+json`
     # * `model/obj` (.mtl material files are not supported yet, references are silently ignored)
+    # * `model/stl`
     #
     # If omitted, the viewer will try to guess from the data blob.
     # If it cannot guess, it won't be able to render the asset.

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d_ext.py
@@ -20,6 +20,8 @@ def guess_media_type(path: str | pathlib.Path) -> MediaType | None:
         return MediaType.GLTF
     elif ext == ".obj":
         return MediaType.OBJ
+    elif ext == ".stl":
+        return MediaType.STL
     else:
         return None
 
@@ -53,7 +55,9 @@ class Asset3DExt:
 
             For instance:
              * `model/gltf-binary`
+             * `model/gltf+json`
              * `model/obj`
+             * `model/stl`
 
             If omitted, it will be guessed from the `path` (if any),
             or the viewer will try to guess from the contents (magic header).

--- a/rerun_py/rerun_sdk/rerun/components/media_type_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/media_type_ext.py
@@ -41,6 +41,14 @@ class MediaTypeExt:
     <https://www.iana.org/assignments/media-types/model/obj>
     """
 
+    STL: MediaType = None  # type: ignore[assignment]
+    """
+    [Stereolithography Model `stl`](https://en.wikipedia.org/wiki/STL_(file_format)): `model/stl`.
+    Either binary or ASCII.
+
+    <https://www.iana.org/assignments/media-types/model/stl>
+    """
+
     @staticmethod
     def deferred_patch_class(cls: Any) -> None:
         cls.TEXT = cls("text/plain")
@@ -48,3 +56,4 @@ class MediaTypeExt:
         cls.GLB = cls("model/gltf-binary")
         cls.GLTF = cls("model/gltf+json")
         cls.OBJ = cls("model/obj")
+        cls.STL = cls("model/stl")


### PR DESCRIPTION
### What

Allows to log stl through `Asset3D` or load it directly into the viewer via drag/drop or the CLI

https://github.com/rerun-io/rerun/assets/1220815/b3050b4d-8115-47fd-abb2-7f03285d322f


To test that the api works I ran
`python ./docs/code-examples/all/asset3d_simple.py ../buckle.stl` with [this](https://github.com/rerun-io/rerun/files/14351841/buckle.stl.zip) file. 


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5244/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5244/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5244/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5244)
- [Docs preview](https://rerun.io/preview/648d891e1f1f8ec715aacbb123a71792224e5ac1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/648d891e1f1f8ec715aacbb123a71792224e5ac1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)