### PR TITLE
Use the same icon for recordings everywhere

### DIFF
--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -182,8 +182,10 @@ fn recording_ui(
                 ui.visuals().widgets.noninteractive.fg_stroke.color
             };
 
-            ui.painter()
-                .circle(rect.center(), 4.0, color, egui::Stroke::NONE);
+            re_ui::icons::STORE
+                .as_image()
+                .tint(color)
+                .paint_at(ui, rect);
         })
         .with_buttons(|re_ui, ui| {
             // Close-button:


### PR DESCRIPTION
### What

<img width="360" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/3202ac5b-bfca-49bb-b446-1363b84c2a0f">

<br/>
<br/>

-> use the same icon as the one introduced by #4761:

<img width="426" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/fa711a4c-b7e8-4810-ba41-6d0225d77fed">




### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5246/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5246/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5246/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5246)
- [Docs preview](https://rerun.io/preview/7d6649d2c5395bc6e5f789409733e374adafb8ec/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7d6649d2c5395bc6e5f789409733e374adafb8ec/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)