### PR TITLE
Add first person 3D eye-camera

### DIFF
--- a/crates/re_space_view_spatial/src/eye.rs
+++ b/crates/re_space_view_spatial/src/eye.rs
@@ -173,7 +173,7 @@ pub struct ViewEye {
     /// Center of orbit, or camera position in first person mode.
     center: Vec3,
 
-    /// Ignored for [`EyeControl::FirstPerson`],
+    /// Ignored for [`EyeMode::FirstPerson`],
     /// but kept for if/when the user switches to orbital mode.
     orbit_radius: f32,
 

--- a/crates/re_space_view_spatial/src/eye.rs
+++ b/crates/re_space_view_spatial/src/eye.rs
@@ -149,7 +149,7 @@ impl Eye {
 
 // ----------------------------------------------------------------------------
 
-/// The mode of an [`OrbitEye`].
+/// The mode of an [`ViewEye`].
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub enum EyeMode {
     FirstPerson,
@@ -166,7 +166,7 @@ pub enum EyeMode {
 ///
 /// Note: we use "eye" so we don't confuse this with logged camera.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OrbitEye {
+pub struct ViewEye {
     /// First person or orbital?
     pub mode: EyeMode,
 
@@ -197,7 +197,7 @@ pub struct OrbitEye {
     pub velocity: Vec3,
 }
 
-impl OrbitEye {
+impl ViewEye {
     /// Avoids zentith/nadir singularity.
     const MAX_PITCH: f32 = 0.99 * 0.25 * std::f32::consts::TAU;
 
@@ -207,7 +207,7 @@ impl OrbitEye {
         world_from_view_rot: Quat,
         eye_up: Vec3,
     ) -> Self {
-        OrbitEye {
+        ViewEye {
             mode: EyeMode::Orbital,
             center: orbit_center,
             orbit_radius,
@@ -238,7 +238,7 @@ impl OrbitEye {
         }
     }
 
-    /// Create an [`OrbitEye`] from a [`Eye`].
+    /// Create an [`ViewEye`] from a [`Eye`].
     pub fn copy_from_eye(&mut self, eye: &Eye) {
         match self.mode {
             EyeMode::FirstPerson => {

--- a/crates/re_space_view_spatial/src/eye.rs
+++ b/crates/re_space_view_spatial/src/eye.rs
@@ -391,7 +391,10 @@ impl ViewEye {
             } else if response.dragged_by(ROTATE3D_BUTTON) {
                 self.rotate(response.drag_delta());
             } else if response.dragged_by(DRAG_PAN3D_BUTTON) {
-                let delta_in_view = 0.001 * speed * response.drag_delta(); // TODO(emilk): take fov and screen size into account?
+                // The pan speed is selected to make the panning feel natural for orbit mode,
+                // but it should probably take FOV and screen size into account
+                let pan_speed = 0.001 * speed;
+                let delta_in_view = pan_speed * response.drag_delta();
 
                 self.translate(delta_in_view);
             }

--- a/crates/re_space_view_spatial/src/eye.rs
+++ b/crates/re_space_view_spatial/src/eye.rs
@@ -359,7 +359,7 @@ impl ViewEye {
         bounding_boxes: &SceneBoundingBoxes,
     ) -> bool {
         let mut speed = match self.mode {
-            EyeMode::FirstPerson => 0.1 * bounding_boxes.accumulated.size().length(), // TODO(emilk): user controlled speed
+            EyeMode::FirstPerson => 0.1 * bounding_boxes.current.size().length(), // TODO(emilk): user controlled speed
             EyeMode::Orbital => self.orbit_radius,
         };
 

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -171,10 +171,10 @@ impl SpatialSpaceViewState {
                         });
 
                         if let Some(eye) = &self.state_3d.view_eye {
-                            if eye.eye_up != glam::Vec3::ZERO {
+                            if let Some(eye_up) = eye.eye_up() {
                                 ui.label(format!(
                                     "Current camera-eye up-axis is {}",
-                                    format_vector(eye.eye_up)
+                                    format_vector(eye_up)
                                 ));
                             }
                         }
@@ -248,10 +248,11 @@ impl SpatialSpaceViewState {
 
         if let Some(eye) = &mut self.state_3d.view_eye {
             ui.horizontal(|ui| {
-                let mode = &mut eye.mode;
+                let mut mode = eye.mode();
                 ui.label("Mode:");
-                ui.selectable_value(mode, EyeMode::FirstPerson, "First Person");
-                ui.selectable_value(mode, EyeMode::Orbital, "Orbital");
+                ui.selectable_value(&mut mode, EyeMode::FirstPerson, "First Person");
+                ui.selectable_value(&mut mode, EyeMode::Orbital, "Orbital");
+                eye.set_mode(mode);
             });
         }
     }

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -249,7 +249,6 @@ impl SpatialSpaceViewState {
         if let Some(eye) = &mut self.state_3d.view_eye {
             ui.horizontal(|ui| {
                 let mut mode = eye.mode();
-                ui.label("Mode:");
                 ui.selectable_value(&mut mode, EyeMode::FirstPerson, "First Person");
                 ui.selectable_value(&mut mode, EyeMode::Orbital, "Orbital");
                 eye.set_mode(mode);

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -146,7 +146,7 @@ impl SpatialSpaceViewState {
                     .on_hover_text("The virtual camera which controls what is shown on screen");
                 ui.vertical(|ui| {
                     if spatial_kind == SpatialSpaceViewKind::ThreeD {
-                        self.eye_3d_ui(re_ui, ui, scene_view_coordinates);
+                        self.view_eye_ui(re_ui, ui, scene_view_coordinates);
                     }
                 });
                 ui.end_row();
@@ -216,7 +216,8 @@ impl SpatialSpaceViewState {
             });
     }
 
-    fn eye_3d_ui(
+    // Say the name out loud. It is fun!
+    fn view_eye_ui(
         &mut self,
         re_ui: &re_ui::ReUi,
         ui: &mut egui::Ui,

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -16,7 +16,6 @@ use re_viewer_context::{
 };
 
 use super::{eye::Eye, ui_2d::View2DState, ui_3d::View3DState};
-use crate::heuristics::auto_size_world_heuristic;
 use crate::scene_bounding_boxes::SceneBoundingBoxes;
 use crate::{
     contexts::{AnnotationSceneContext, NonInteractiveEntities},
@@ -24,6 +23,7 @@ use crate::{
     view_kind::SpatialSpaceViewKind,
     visualizers::{CamerasVisualizer, ImageVisualizer, UiLabel, UiLabelTarget},
 };
+use crate::{eye::EyeMode, heuristics::auto_size_world_heuristic};
 
 /// Default auto point radius in UI points.
 const AUTO_POINT_RADIUS: f32 = 1.5;
@@ -103,110 +103,156 @@ impl SpatialSpaceViewState {
             .query_latest_component::<ViewCoordinates>(space_origin, &ctx.current_query())
             .map(|c| c.value);
 
-        ctx.re_ui.selection_grid(ui, "spatial_settings_ui")
+        ctx.re_ui
+            .selection_grid(ui, "spatial_settings_ui")
             .show(ui, |ui| {
-            let auto_size_world = auto_size_world_heuristic(&self.bounding_boxes.accumulated, self.scene_num_primitives);
+                let auto_size_world = auto_size_world_heuristic(
+                    &self.bounding_boxes.accumulated,
+                    self.scene_num_primitives,
+                );
 
-            ctx.re_ui.grid_left_hand_label(ui, "Default size");
-            ui.vertical(|ui| {
-                ui.horizontal(|ui| {
-                    ui.push_id("points", |ui| {
-                        size_ui(
-                            ui,
-                            2.0,
-                            auto_size_world,
-                            &mut self.auto_size_config.point_radius,
-                        );
+                ctx.re_ui.grid_left_hand_label(ui, "Default size");
+                ui.vertical(|ui| {
+                    ui.horizontal(|ui| {
+                        ui.push_id("points", |ui| {
+                            size_ui(
+                                ui,
+                                2.0,
+                                auto_size_world,
+                                &mut self.auto_size_config.point_radius,
+                            );
+                        });
+                        ui.label("Point radius")
+                            .on_hover_text("Point radius used whenever not explicitly specified");
                     });
-                    ui.label("Point radius")
-                    .on_hover_text("Point radius used whenever not explicitly specified");
-                });
-                ui.horizontal(|ui| {
-                    ui.push_id("lines", |ui| {
-                        size_ui(
-                            ui,
-                            1.5,
-                            auto_size_world,
-                            &mut self.auto_size_config.line_radius,
-                        );
-                        ui.label("Line radius")
-                            .on_hover_text("Line radius used whenever not explicitly specified");
+                    ui.horizontal(|ui| {
+                        ui.push_id("lines", |ui| {
+                            size_ui(
+                                ui,
+                                1.5,
+                                auto_size_world,
+                                &mut self.auto_size_config.line_radius,
+                            );
+                            ui.label("Line radius").on_hover_text(
+                                "Line radius used whenever not explicitly specified",
+                            );
+                        });
                     });
-                });
-            });
-            ui.end_row();
-
-            ctx.re_ui.grid_left_hand_label(ui, "Camera")
-                .on_hover_text("The virtual camera which controls what is shown on screen");
-            ui.vertical(|ui| {
-                if spatial_kind == SpatialSpaceViewKind::ThreeD {
-                    if ui.button("Reset").on_hover_text(
-                        "Resets camera position & orientation.\nYou can also double-click the 3D view.")
-                        .clicked()
-                    {
-                        self.bounding_boxes.accumulated = self.bounding_boxes.current;
-                        self.state_3d.reset_camera(&self.bounding_boxes, scene_view_coordinates);
-                    }
-                    let mut spin = self.state_3d.spin();
-                    if re_ui.checkbox(ui, &mut spin, "Spin")
-                        .on_hover_text("Spin camera around the orbit center").changed() {
-                        self.state_3d.set_spin(spin);
-                    }
-                }
-            });
-            ui.end_row();
-
-            if spatial_kind == SpatialSpaceViewKind::ThreeD {
-                ctx.re_ui.grid_left_hand_label(ui, "Coordinates")
-                    .on_hover_text("The world coordinate system used for this view");
-                ui.vertical(|ui|{
-                    let up_description = if let Some(scene_up) = scene_view_coordinates.and_then(|vc| vc.up()) {
-                        format!("Scene up is {scene_up}")
-                    } else {
-                        "Scene up is unspecified".to_owned()
-                    };
-                    ui.label(up_description).on_hover_ui(|ui| {
-                        re_ui::markdown_ui(ui, egui::Id::new("view_coordinates_tooltip"), "Set with `rerun.ViewCoordinates`.");
-                    });
-
-                    if let Some(eye) = &self.state_3d.orbit_eye {
-                        if eye.eye_up != glam::Vec3::ZERO {
-                            ui.label(format!("Current camera-eye up-axis is {}", format_vector(eye.eye_up)));
-                        }
-                    }
-
-                    re_ui.checkbox(ui, &mut self.state_3d.show_axes, "Show origin axes").on_hover_text("Show X-Y-Z axes");
-                    re_ui.checkbox(ui, &mut self.state_3d.show_bbox, "Show bounding box").on_hover_text("Show the current scene bounding box");
-                    re_ui.checkbox(ui, &mut self.state_3d.show_accumulated_bbox, "Show accumulated bounding box").on_hover_text("Show bounding box accumulated over all rendered frames");
                 });
                 ui.end_row();
-            }
 
-            ctx.re_ui.grid_left_hand_label(ui, "Bounding box")
-                .on_hover_text("The bounding box encompassing all Entities in the view right now");
-            ui.vertical(|ui| {
-                ui.style_mut().wrap = Some(false);
-                let BoundingBox { min, max } = self.bounding_boxes.current;
-                ui.label(format!(
-                    "x [{} - {}]",
-                    format_f32(min.x),
-                    format_f32(max.x),
-                ));
-                ui.label(format!(
-                    "y [{} - {}]",
-                    format_f32(min.y),
-                    format_f32(max.y),
-                ));
+                ctx.re_ui
+                    .grid_left_hand_label(ui, "Camera")
+                    .on_hover_text("The virtual camera which controls what is shown on screen");
+                ui.vertical(|ui| {
+                    if spatial_kind == SpatialSpaceViewKind::ThreeD {
+                        self.eye_3d_ui(re_ui, ui, scene_view_coordinates);
+                    }
+                });
+                ui.end_row();
+
                 if spatial_kind == SpatialSpaceViewKind::ThreeD {
-                    ui.label(format!(
-                        "z [{} - {}]",
-                        format_f32(min.z),
-                        format_f32(max.z),
-                    ));
+                    ctx.re_ui
+                        .grid_left_hand_label(ui, "Coordinates")
+                        .on_hover_text("The world coordinate system used for this view");
+                    ui.vertical(|ui| {
+                        let up_description =
+                            if let Some(scene_up) = scene_view_coordinates.and_then(|vc| vc.up()) {
+                                format!("Scene up is {scene_up}")
+                            } else {
+                                "Scene up is unspecified".to_owned()
+                            };
+                        ui.label(up_description).on_hover_ui(|ui| {
+                            re_ui::markdown_ui(
+                                ui,
+                                egui::Id::new("view_coordinates_tooltip"),
+                                "Set with `rerun.ViewCoordinates`.",
+                            );
+                        });
+
+                        if let Some(eye) = &self.state_3d.orbit_eye {
+                            if eye.eye_up != glam::Vec3::ZERO {
+                                ui.label(format!(
+                                    "Current camera-eye up-axis is {}",
+                                    format_vector(eye.eye_up)
+                                ));
+                            }
+                        }
+
+                        re_ui
+                            .checkbox(ui, &mut self.state_3d.show_axes, "Show origin axes")
+                            .on_hover_text("Show X-Y-Z axes");
+                        re_ui
+                            .checkbox(ui, &mut self.state_3d.show_bbox, "Show bounding box")
+                            .on_hover_text("Show the current scene bounding box");
+                        re_ui
+                            .checkbox(
+                                ui,
+                                &mut self.state_3d.show_accumulated_bbox,
+                                "Show accumulated bounding box",
+                            )
+                            .on_hover_text(
+                                "Show bounding box accumulated over all rendered frames",
+                            );
+                    });
+                    ui.end_row();
                 }
+
+                ctx.re_ui
+                    .grid_left_hand_label(ui, "Bounding box")
+                    .on_hover_text(
+                        "The bounding box encompassing all Entities in the view right now",
+                    );
+                ui.vertical(|ui| {
+                    ui.style_mut().wrap = Some(false);
+                    let BoundingBox { min, max } = self.bounding_boxes.current;
+                    ui.label(format!("x [{} - {}]", format_f32(min.x), format_f32(max.x),));
+                    ui.label(format!("y [{} - {}]", format_f32(min.y), format_f32(max.y),));
+                    if spatial_kind == SpatialSpaceViewKind::ThreeD {
+                        ui.label(format!("z [{} - {}]", format_f32(min.z), format_f32(max.z),));
+                    }
+                });
+                ui.end_row();
             });
-            ui.end_row();
-        });
+    }
+
+    fn eye_3d_ui(
+        &mut self,
+        re_ui: &re_ui::ReUi,
+        ui: &mut egui::Ui,
+        scene_view_coordinates: Option<ViewCoordinates>,
+    ) {
+        if ui
+            .button("Reset")
+            .on_hover_text(
+                "Resets camera position & orientation.\nYou can also double-click the 3D view.",
+            )
+            .clicked()
+        {
+            self.bounding_boxes.accumulated = self.bounding_boxes.current;
+            self.state_3d
+                .reset_camera(&self.bounding_boxes, scene_view_coordinates);
+        }
+
+        {
+            let mut spin = self.state_3d.spin();
+            if re_ui
+                .checkbox(ui, &mut spin, "Spin")
+                .on_hover_text("Spin camera around the orbit center")
+                .changed()
+            {
+                self.state_3d.set_spin(spin);
+            }
+        }
+
+        if let Some(eye) = &mut self.state_3d.orbit_eye {
+            ui.horizontal(|ui| {
+                let mode = &mut eye.mode;
+                ui.label("Mode:");
+                ui.selectable_value(mode, EyeMode::FirstPerson, "First Person");
+                ui.selectable_value(mode, EyeMode::Orbital, "Orbital");
+            });
+        }
     }
 }
 

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -170,7 +170,7 @@ impl SpatialSpaceViewState {
                             );
                         });
 
-                        if let Some(eye) = &self.state_3d.orbit_eye {
+                        if let Some(eye) = &self.state_3d.view_eye {
                             if eye.eye_up != glam::Vec3::ZERO {
                                 ui.label(format!(
                                     "Current camera-eye up-axis is {}",
@@ -245,7 +245,7 @@ impl SpatialSpaceViewState {
             }
         }
 
-        if let Some(eye) = &mut self.state_3d.orbit_eye {
+        if let Some(eye) = &mut self.state_3d.view_eye {
             ui.horizontal(|ui| {
                 let mode = &mut eye.mode;
                 ui.label("Mode:");

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -648,7 +648,7 @@ pub fn view_3d(
             });
     }
 
-    show_view_eye_center(
+    show_orbit_eye_center(
         ui.ctx(),
         &mut state.state_3d,
         &mut line_builder,
@@ -681,7 +681,7 @@ pub fn view_3d(
 }
 
 /// Show center of orbit camera when interacting with camera (it's quite helpful).
-fn show_view_eye_center(
+fn show_orbit_eye_center(
     egui_ctx: &egui::Context,
     state_3d: &mut View3DState,
     line_builder: &mut LineDrawableBuilder<'_>,


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/1879

This adds a first-person mode to the eye-camera, selectable in the selection panel.

https://github.com/rerun-io/rerun/assets/1148717/545783a0-70ea-47f6-b314-ea4a34e8569e

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5249/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5249/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5249/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5249)
- [Docs preview](https://rerun.io/preview/bac481f20acaca68b9701efa59ab1628dccab35f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bac481f20acaca68b9701efa59ab1628dccab35f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)