### PR TITLE
Fix missing redraw upon resetting blueprint

### DIFF
--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -375,6 +375,7 @@ impl App {
                 // at the beginning of the next frame.
                 re_log::debug!("Reset blueprint");
                 store_hub.clear_current_blueprint();
+                egui_ctx.request_repaint(); // Many changes take a frame delay to show up.
             }
             SystemCommand::UpdateBlueprint(blueprint_id, updates) => {
                 // We only want to update the blueprint if the "inspect blueprint timeline" mode is

--- a/examples/python/rrt-star/README.md
+++ b/examples/python/rrt-star/README.md
@@ -3,7 +3,7 @@ title = "RRT*"
 tags = ["2D"]
 description = "Visualization of the path finding algorithm RRT* in a simple environment."
 thumbnail= "https://static.rerun.io/rrt-star/4d4684a24eab7d5def5768b7c1685d8b1cb2c010/full.png"
-thumbnail_dimensions = [480, 360]
+thumbnail_dimensions = [1496, 840]
 -->
 
 <picture>


### PR DESCRIPTION
### What

Previously, many parts of the viewer only refresh after moving the cursor. Just clicking the reset button and not moving the mouse left things in an odd state.

Can't screenshot since pressing the screenshot shortcut causes a redraw :)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5262/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5262/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5262/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5262)
- [Docs preview](https://rerun.io/preview/642d07a4d446ee3fed0f7cd885bd00a11f143a67/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/642d07a4d446ee3fed0f7cd885bd00a11f143a67/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)