### PR TITLE
Fix indeterministic redundancy check for space view spawning heuristic

### DIFF
--- a/crates/re_space_view_spatial/src/space_view_3d.rs
+++ b/crates/re_space_view_spatial/src/space_view_3d.rs
@@ -164,11 +164,17 @@ impl SpaceViewClass for SpatialSpaceView3D {
                     } else {
                         // Creates space views at each view coordinates if there's any.
                         // (yes, we do so even if they're empty at the moment!)
+                        //
+                        // An exception to this rule is not to create a view there if this is already _also_ a subspace root.
+                        // (e.g. this also has a camera or a `disconnect` logged there)
                         let mut roots = subspace
                             .heuristic_hints
                             .iter()
-                            .filter(|(_, hint)| hint.contains(HeuristicHints::ViewCoordinates3d))
-                            .map(|(root, _)| root.clone())
+                            .filter(|(path, hint)| {
+                                hint.contains(HeuristicHints::ViewCoordinates3d)
+                                    && !subspace.child_spaces.contains(path)
+                            })
+                            .map(|(path, _)| path.clone())
                             .collect::<Vec<_>>();
 
                         // If there's no view coordinates or there are still some entities not covered,

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -363,7 +363,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
                 })
                 .collect::<Vec<_>>();
 
-            // Remove all space views that redundant within the remaining recommendation.
+            // Remove all space views that are redundant within the remaining recommendation.
             // This n^2 loop should only run ever for frames that add new space views.
             let final_recommendations =
                 recommended_space_views


### PR DESCRIPTION
### What

* Fixes #5258

The mechanism we used for determining whether a "recommended" space view is redundant was flawed in several ways, causing it to be order hash map order dependent among other things.

Small improvement to 3d space view heuristic that stop it from considering subspaces with ViewCoordinates.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5266/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5266/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5266/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5266)
- [Docs preview](https://rerun.io/preview/8cce4d41110675bca314b675d962644ea0fdf394/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8cce4d41110675bca314b675d962644ea0fdf394/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)