### PR TITLE
Add missing python docs for `disable_timeline` & `reset_time`

### DIFF
--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -92,7 +92,19 @@ SECTION_TABLE: Final[list[Section]] = [
     ),
     Section(
         title="Logging functions",
-        func_list=["log", "set_time_sequence", "set_time_seconds", "set_time_nanos"],
+        func_list=[
+            "log",
+        ],
+    ),
+    Section(
+        title="Timeline functions",
+        func_list=[
+            "set_time_sequence",
+            "set_time_seconds",
+            "set_time_nanos",
+            "disable_timeline",
+            "reset_time",
+        ],
     ),
     ################################################################################
     # These sections don't have tables, but generate pages containing all the archetypes, components, datatypes


### PR DESCRIPTION
### What

* Fixes #5255

<img width="867" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/3863cf76-5983-408f-aa08-6a591b1d763f">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5269/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5269/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5269/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5269)
- [Docs preview](https://rerun.io/preview/d897164010027b66072c9bd38e3ec445692b137b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d897164010027b66072c9bd38e3ec445692b137b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)