### PR TITLE
Fix missing error message when passing `from_parent` + rerun transform type to `rerun.Transform3D`

### DIFF
--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d_ext.py
@@ -68,6 +68,8 @@ class Transform3DExt:
                     raise ValueError("Rotation and mat3x3 parameters are mutually exclusive.")
                 if scale is not None and mat3x3 is not None:
                     raise ValueError("Scale and mat3x3 parameters are mutually exclusive.")
+                if from_parent is None:
+                    from_parent = False
 
                 if mat3x3 is not None:
                     self.__attrs_init__(

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d_ext.py
@@ -24,7 +24,7 @@ class Transform3DExt:
         rotation: Rotation3DLike | None = None,
         scale: Scale3DLike | None = None,
         mat3x3: Mat3x3Like | None = None,
-        from_parent: bool = False,
+        from_parent: bool | None = None,
     ):
         """
         Create a new instance of the Transform3D archetype.
@@ -54,7 +54,13 @@ class Transform3DExt:
 
         with catch_and_log_exceptions(context=self.__class__.__name__):
             if transform is not None:
-                if translation is not None or rotation is not None or scale is not None or mat3x3 is not None:
+                if (
+                    translation is not None
+                    or rotation is not None
+                    or scale is not None
+                    or mat3x3 is not None
+                    or from_parent is not None
+                ):
                     raise ValueError("If a transform is given, none of the other parameters can be set.")
                 self.__attrs_init__(transform=transform)
             else:

--- a/rerun_py/tests/unit/test_transform3d.py
+++ b/rerun_py/tests/unit/test_transform3d.py
@@ -272,6 +272,8 @@ def test_transform3d_invalid_parameter_combinations() -> None:
     with pytest.raises(ValueError):
         rr.Transform3D(transform=TranslationRotationScale3D(translation=[1, 2, 3]), scale=2)
     with pytest.raises(ValueError):
+        rr.Transform3D(transform=TranslationRotationScale3D(translation=[1, 2, 3]), from_parent=True)
+    with pytest.raises(ValueError):
         rr.Transform3D(
             transform=TranslationRotationScale3D(translation=[1, 2, 3]), rotation=rr.Quaternion(xyzw=[1, 2, 3, 4])
         )


### PR DESCRIPTION
### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5270/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5270/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5270/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5270)
- [Docs preview](https://rerun.io/preview/3124801766a07451a44456b871ca968d72fa9fdd/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3124801766a07451a44456b871ca968d72fa9fdd/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)