### PR TITLE
Remove gratuitous profiler scopes.

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -118,7 +118,7 @@ High-level documentation for rerun can be found at [http://rerun.io/docs](http:/
 ## Building for the Web
 
 If you want to build a standalone rerun executable that contains the web-viewer and a websocket server,
-you need to install install the `wasm32-unknown-unknown` rust target and ensure the `web_viewer` feature flag is set when building rerun.
+you need to install the `wasm32-unknown-unknown` rust target and ensure the `web_viewer` feature flag is set when building rerun.
 This is automatically done by this shortcut which builds & runs the web viewer:
 ```
 pixi run rerun-web

--- a/crates/re_query/src/query.rs
+++ b/crates/re_query/src/query.rs
@@ -106,8 +106,6 @@ pub fn query_archetype<A: Archetype>(
     query: &LatestAtQuery,
     ent_path: &EntityPath,
 ) -> crate::Result<ArchetypeView<A>> {
-    re_tracing::profile_function!();
-
     let required_components: Vec<_> = A::required_components()
         .iter()
         .map(|component| get_component_with_instances(store, query, ent_path, *component))

--- a/crates/re_query/src/query.rs
+++ b/crates/re_query/src/query.rs
@@ -106,6 +106,9 @@ pub fn query_archetype<A: Archetype>(
     query: &LatestAtQuery,
     ent_path: &EntityPath,
 ) -> crate::Result<ArchetypeView<A>> {
+    // Profiling this can be useful, but we have many queries of very small archetypes, adding a lot of profiling overhead.
+    //re_tracing::profile_function!();
+
     let required_components: Vec<_> = A::required_components()
         .iter()
         .map(|component| get_component_with_instances(store, query, ent_path, *component))

--- a/crates/re_query_cache/src/latest_at.rs
+++ b/crates/re_query_cache/src/latest_at.rs
@@ -175,8 +175,6 @@ macro_rules! impl_query_archetype_latest_at {
             ),
         {
             let iter_results = |timeless: bool, bucket: &crate::CacheBucket, f: &mut F| -> crate::Result<()> {
-                re_tracing::profile_scope!("iter");
-
                 let it = itertools::izip!(
                     bucket.iter_data_times(),
                     bucket.iter_pov_instance_keys(),

--- a/crates/re_query_cache/src/latest_at.rs
+++ b/crates/re_query_cache/src/latest_at.rs
@@ -175,6 +175,9 @@ macro_rules! impl_query_archetype_latest_at {
             ),
         {
             let iter_results = |timeless: bool, bucket: &crate::CacheBucket, f: &mut F| -> crate::Result<()> {
+                // Profiling this in isolation can be useful, but adds a lot of noise for small queries.
+                //re_tracing::profile_scope!("iter");
+
                 let it = itertools::izip!(
                     bucket.iter_data_times(),
                     bucket.iter_pov_instance_keys(),

--- a/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
@@ -89,6 +89,7 @@ pub fn color_tensor_to_gpu(
     let [height, width, depth] = texture_height_width_channels(tensor)?;
 
     let texture_handle = try_get_or_create_texture(render_ctx, texture_key, || {
+        // Profile creation of the texture, but not cache hits (those take close to no time, which would just add profiler overhead).
         re_tracing::profile_function!();
 
         let (data, format) = match (depth, &tensor.buffer) {

--- a/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
@@ -85,12 +85,12 @@ pub fn color_tensor_to_gpu(
     tensor: &DecodedTensor,
     tensor_stats: &TensorStats,
 ) -> anyhow::Result<ColormappedTexture> {
-    re_tracing::profile_function!();
-
     let texture_key = hash(tensor_data_row_id);
     let [height, width, depth] = texture_height_width_channels(tensor)?;
 
     let texture_handle = try_get_or_create_texture(render_ctx, texture_key, || {
+        re_tracing::profile_function!();
+
         let (data, format) = match (depth, &tensor.buffer) {
             (3, TensorBuffer::Nv12(buf) | TensorBuffer::Yuy2(buf)) => {
                 (cast_slice_to_cow(buf.as_slice()), TextureFormat::R8Uint)

--- a/crates/re_viewer_context/src/tensor/tensor_stats_cache.rs
+++ b/crates/re_viewer_context/src/tensor/tensor_stats_cache.rs
@@ -14,8 +14,6 @@ impl TensorStatsCache {
     /// NOTE: `TensorData` is never batched (they are mono-components),
     /// so we don't need the instance id here.
     pub fn entry(&mut self, key: RowId, tensor: &TensorData) -> TensorStats {
-        re_tracing::profile_function!();
-
         *self
             .0
             .entry(key)


### PR DESCRIPTION
### What

Removes a bunch of profiler scopes that were showing up a lot without taking time, adding to the huge profiler overhead in some scenes


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5272/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5272/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5272/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5272)
- [Docs preview](https://rerun.io/preview/5da957d4ab87c7460c52138b0bf1d16710be9344/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5da957d4ab87c7460c52138b0bf1d16710be9344/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)