### PR TITLE
Only compute store/caching stats when the memory panel is opened

### DIFF
--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -412,6 +412,8 @@ impl StoreHub {
     // TODO(jleibs): We probably want stats for all recordings, not just
     // the currently selected recording.
     pub fn stats(&self, detailed_cache_stats: bool) -> StoreHubStats {
+        re_tracing::profile_function!();
+
         // If we have an app-id, then use it to look up the blueprint.
         let blueprint = self
             .selected_application_id


### PR DESCRIPTION
Computing stats for the store and caches is a very costly process.

We do so every frame because the memory panel's data gets updated whether it is opened or not, so that the memory graphs are not missing any data when you _eventually_ open it.

In the case of the store, we've added a lot of complexity a long time ago to make that process fast enough (although in a big enough scene, it will still take a non-trivial amount of time).
I've recently gone through the process of adding the same kind of complexity to the caches, but it gets absolutely insane -- so insane that it's just not worth it.

So, instead of making the caches even more complicated than they already are just so the memory panel can get updated in the background, we've decided to just _not_ updated the mempanel stats when it's hidden.

Before:
![image](https://github.com/rerun-io/rerun/assets/2910679/432515df-728d-4ba8-87be-a9545dc3a0b1)


After (mempanel opened):
![image](https://github.com/rerun-io/rerun/assets/2910679/0d1253c4-c3b6-4254-8555-c85c58994a8b)


After (mempanel hidden):
![image](https://github.com/rerun-io/rerun/assets/2910679/3bcd8757-a5dd-40e5-ade6-69f08f6ddada)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5274/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5274/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5274/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5274)
- [Docs preview](https://rerun.io/preview/678312328257b8c29d802aee693e630850fcd741/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/678312328257b8c29d802aee693e630850fcd741/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)