### PR TITLE
Fix `cargo doc` on CI

### DIFF
--- a/crates/re_web_viewer_server/Cargo.toml
+++ b/crates/re_web_viewer_server/Cargo.toml
@@ -30,6 +30,15 @@ all-features = true
 
 
 [features]
+## ONLY FOR CI!
+##
+## When set, the crate builds despite the `.wasm` being missing, but will panic at runtime.
+## For instance: when the CI builds the docs for all crates, it uses `--all-features`, which means
+## it can build the docs for this crate without having to build the web-viewer first.
+##
+## When not set, you must build the `.wasm` before building the crate, using `cargo run -p re_build_web_viewer`.
+__ci = []
+
 ## Enable telemetry using our analytics SDK.
 analytics = ["dep:re_analytics"]
 


### PR DESCRIPTION
This PR ensures we can run `cargo doc --all-features` without having to first build the web viewer.

I accidentally broke this in
https://github.com/rerun-io/rerun/pull/5252

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5281/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5281/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5281/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5281)
- [Docs preview](https://rerun.io/preview/e7e6bb2b3664fdca59a6d74e78545c3d8e044bb7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e7e6bb2b3664fdca59a6d74e78545c3d8e044bb7/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)