### PR TITLE
Increase the max WebSocket frame limit for the native client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "ewebsock"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7340666282406cb008c4d7206e6d7e157a82486afddd26deaad3ce9ebff3f238"
+checksum = "6177769715c6ec5a324acee995183b22721ea23c58e49af14a828eadec85d120"
 dependencies = [
  "document-features",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ document-features = "0.2.8"
 ehttp = "0.4.0"
 enumset = "1.0.12"
 env_logger = { version = "0.10", default-features = false }
-ewebsock = "0.4.0"
+ewebsock = "0.5.0"
 fixed = { version = "1.17", default-features = false }
 flatbuffers = "23.0"
 futures-channel = "0.3"

--- a/crates/re_ws_comms/src/client.rs
+++ b/crates/re_ws_comms/src/client.rs
@@ -10,8 +10,17 @@ pub fn viewer_to_server(
     url: String,
     on_binary_msg: impl Fn(Vec<u8>) -> ControlFlow<()> + Send + 'static,
 ) -> Result<()> {
+    let gigs = 1024 * 1024 * 1024;
+    let options = ewebsock::Options {
+        // This limits the size of one chunk of rerun log data when running a local websocket client.
+        // We set a very high limit, because we should be able to trust the server.
+        // See https://github.com/rerun-io/rerun/issues/5268 for more
+        max_incoming_frame_size: 2 * gigs,
+    };
+
     ewebsock::ws_receive(
         url.clone(),
+        options,
         Box::new(move |event: WsEvent| match event {
             WsEvent::Opened => {
                 re_log::info!("Connection to {url} established");


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/5268

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5282/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5282/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5282/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5282)
- [Docs preview](https://rerun.io/preview/d30ec257f0553f728aaf28fd500aa2a8633bd4c3/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d30ec257f0553f728aaf28fd500aa2a8633bd4c3/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)