### PR TITLE
Fix `spawn` starting the viewer even if logging is disabled

### DIFF
--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -231,6 +231,10 @@ def spawn(
 
     """
 
+    if not bindings.is_enabled():
+        logging.warning("Rerun is disabled - spawn() call ignored.")
+        return
+
     import os
     import subprocess
     import sys


### PR DESCRIPTION
### What

* Fixes #5261

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5284/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5284/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5284/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5284)
- [Docs preview](https://rerun.io/preview/c659f5a29d6a439bcf11756099e7e9338561774a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c659f5a29d6a439bcf11756099e7e9338561774a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)