### PR TITLE
Fix resetting vertical axis when using non-uniform zoom on Time Series

### DIFF
--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -380,6 +380,7 @@ It can greatly improve performance (and readability) in such situations as it pr
             .id(crate::plot_id(query.space_view_id))
             .auto_bounds([true, auto_y].into())
             .allow_zoom([true, !lock_y_during_zoom])
+            .allow_drag([true, !lock_y_during_zoom])
             .x_axis_formatter(move |time, _, _| {
                 format_time(
                     time_type,


### PR DESCRIPTION
### What

* Fixes #5180

@reviewer: Best to try it yourself, took a fair bit of time to get the desired behavior in (presumably) all cases.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5287/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5287/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5287/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5287)
- [Docs preview](https://rerun.io/preview/eae896267e1ef818093d1183f03f49c53d631490/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/eae896267e1ef818093d1183f03f49c53d631490/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)