### PR TITLE
Implement `enum` codegen for C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ function(rerun_strict_warning_settings target)
                 -Wno-unreachable-code-return # TODO(emilk): remove this exception - we only need this because of codegen
                 -Wno-unused-macros
                 -Wno-unsafe-buffer-usage # There's a few helper ctors that run into this.
+                -Wno-unknown-warning-option # Otherwise older clang will complain about `-Wno-unsafe-buffer-usage`
             )
         endif()
 

--- a/crates/re_types/definitions/rerun/datatypes/angle.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/angle.fbs
@@ -13,8 +13,8 @@ union Angle (
   "attr.rust.derive": "Copy, PartialEq"
 ) {
   /// \py 3D rotation angle in radians. Only one of `degrees` or `radians` should be set.
-  Radians: rerun.datatypes.Float32 (order: 100, transparent),
+  Radians: rerun.datatypes.Float32 (transparent),
 
   /// \py 3D rotation angle in degrees. Only one of `degrees` or `radians` should be set.
-  Degrees: rerun.datatypes.Float32 (order: 200, transparent),
+  Degrees: rerun.datatypes.Float32 (transparent),
 }

--- a/crates/re_types/definitions/rerun/datatypes/rotation3d.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/rotation3d.fbs
@@ -12,8 +12,8 @@ union Rotation3D (
   "attr.python.aliases": "Sequence[SupportsFloat]"
 ) {
   /// Rotation defined by a quaternion.
-  Quaternion: Quaternion (order: 100),
+  Quaternion: Quaternion,
 
   /// Rotation defined with an axis and an angle.
-  AxisAngle: RotationAxisAngle (order: 200),
+  AxisAngle: RotationAxisAngle,
 }

--- a/crates/re_types/definitions/rerun/datatypes/scale3d.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/scale3d.fbs
@@ -27,8 +27,8 @@ union Scale3D (
   "attr.rust.derive": "Copy, PartialEq"
 ) {
   /// Individual scaling factors for each axis, distorting the original object.
-  ThreeD: rerun.datatypes.Vec3D (order: 100),
+  ThreeD: rerun.datatypes.Vec3D,
 
   /// Uniform scaling factor along all axis.
-  Uniform: rerun.datatypes.Float32 (order: 200, transparent),
+  Uniform: rerun.datatypes.Float32 (transparent),
 }

--- a/crates/re_types/definitions/rerun/datatypes/tensor_buffer.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/tensor_buffer.fbs
@@ -70,48 +70,48 @@ union TensorBuffer (
   "attr.rust.derive_only": "Clone, PartialEq"
 ) {
   /// 8bit unsigned integer.
-  U8: U8Buffer (transparent, order:100),
+  U8: U8Buffer (transparent),
 
   /// 16bit unsigned integer.
-  U16: U16Buffer (transparent, order:200),
+  U16: U16Buffer (transparent),
 
   /// 32bit unsigned integer.
-  U32: U32Buffer (transparent, order:300),
+  U32: U32Buffer (transparent),
 
   /// 64bit unsigned integer.
-  U64: U64Buffer (transparent, order:400),
+  U64: U64Buffer (transparent),
 
   /// 8bit signed integer.
-  I8: I8Buffer (transparent, order:500),
+  I8: I8Buffer (transparent),
 
   /// 16bit signed integer.
-  I16: I16Buffer (transparent, order:600),
+  I16: I16Buffer (transparent),
 
   /// 32bit signed integer.
-  I32: I32Buffer (transparent, order:700),
+  I32: I32Buffer (transparent),
 
   /// 64bit signed integer.
-  I64: I64Buffer (transparent, order:800),
+  I64: I64Buffer (transparent),
 
   /// 16bit IEEE-754 floating point, also known as `half`.
-  F16: F16Buffer (transparent, order:900),
+  F16: F16Buffer (transparent),
 
   /// 32bit IEEE-754 floating point, also known as `float` or `single`.
-  F32: F32Buffer (transparent, order:1000),
+  F32: F32Buffer (transparent),
 
   /// 64bit IEEE-754 floating point, also known as `double`.
-  F64: F64Buffer (transparent, order:1200),
+  F64: F64Buffer (transparent),
 
   /// Raw bytes of a JPEG file.
-  JPEG: JPEGBuffer (transparent, order:1300),
+  JPEG: JPEGBuffer (transparent),
 
   /// NV12 is a YUV 4:2:0 chroma downsamples format with 8 bits per channel.
   ///
   /// First comes entire image in Y, followed by interleaved lines ordered as U0, V0, U1, V1, etc.
-  NV12: NV12Buffer (transparent, order:1400),
+  NV12: NV12Buffer (transparent),
 
   /// YUY2, also known as YUYV is a YUV 4:2:2 chrome downsampled format with 8 bits per channel.
   ///
   /// The order of the channels is Y0, U0, Y1, V0.
-  YUY2: YUY2Buffer (transparent, order:1500),
+  YUY2: YUY2Buffer (transparent),
 }

--- a/crates/re_types/definitions/rerun/datatypes/transform3d.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/transform3d.fbs
@@ -12,7 +12,7 @@ namespace rerun.datatypes;
 union Transform3D (
   "attr.rust.derive": "Copy, PartialEq"
 ) {
-  TranslationAndMat3x3: TranslationAndMat3x3 (order: 100),
-  TranslationRotationScale: TranslationRotationScale3D (order: 200),
+  TranslationAndMat3x3: TranslationAndMat3x3,
+  TranslationRotationScale: TranslationRotationScale3D,
   // TODO(andreas): Raw 4x4 matrix.
 }

--- a/crates/re_types/definitions/rerun/testing/datatypes/fuzzy.fbs
+++ b/crates/re_types/definitions/rerun/testing/datatypes/fuzzy.fbs
@@ -57,10 +57,10 @@ table AffixFuzzer2 (
 union AffixFuzzer3 (
   "attr.rust.derive": "PartialEq"
 ) {
-  degrees: FlattenedScalar (transparent, order: 100),
-  radians: FlattenedScalar (transparent, nullable, order: 101),
-  craziness: __AffixFuzzer1Vec (transparent, order: 102),
-  fixed_size_shenanigans: ArrayOfFloats (transparent, order: 103),
+  degrees: FlattenedScalar (transparent),
+  radians: FlattenedScalar (transparent, nullable),
+  craziness: __AffixFuzzer1Vec (transparent),
+  fixed_size_shenanigans: ArrayOfFloats (transparent),
 }
 
 table __AffixFuzzer3 (transparent, order: 0) {
@@ -74,9 +74,9 @@ table __AffixFuzzer3Vec (transparent, order: 0) {
 union AffixFuzzer4 (
   "attr.rust.derive": "PartialEq"
 ) {
-  single_required: __AffixFuzzer3 (transparent, order: 100),
-  many_required: __AffixFuzzer3Vec (transparent, order: 101),
-  many_optional: __AffixFuzzer3Vec (transparent, order: 102, nullable),
+  single_required: __AffixFuzzer3 (transparent),
+  many_required: __AffixFuzzer3Vec (transparent),
+  many_optional: __AffixFuzzer3Vec (transparent, nullable),
 }
 
 table AffixFuzzer5 (

--- a/crates/re_types_builder/src/bin/build_re_types.rs
+++ b/crates/re_types_builder/src/bin/build_re_types.rs
@@ -110,7 +110,7 @@ fn main() {
     let (report, reporter) = re_types_builder::report::init();
 
     let (objects, arrow_registry) =
-        re_types_builder::generate_lang_agnostic(definitions_dir_path, entrypoint_path);
+        re_types_builder::generate_lang_agnostic(&reporter, definitions_dir_path, entrypoint_path);
 
     re_tracing::profile_scope!("Language-specific code-gen");
     join!(

--- a/crates/re_types_builder/src/codegen/cpp/array_builder.rs
+++ b/crates/re_types_builder/src/codegen/cpp/array_builder.rs
@@ -1,7 +1,7 @@
 use proc_macro2::Ident;
 use quote::{format_ident, quote};
 
-use crate::{Object, ObjectSpecifics, Objects, Type};
+use crate::{Object, ObjectClass, Objects, Type};
 
 use super::forward_decl::{ForwardDecl, ForwardDecls};
 
@@ -98,9 +98,10 @@ pub fn arrow_array_builder_type_object(
     if obj.is_arrow_transparent() {
         arrow_array_builder_type_and_declaration(&obj.fields[0].typ, objects, declarations)
     } else {
-        let class_ident = match obj.specifics {
-            ObjectSpecifics::Struct => format_ident!("StructBuilder"),
-            ObjectSpecifics::Union { .. } => format_ident!("DenseUnionBuilder"),
+        let class_ident = match obj.class {
+            ObjectClass::Struct => format_ident!("StructBuilder"),
+            ObjectClass::Enum => format_ident!("SparseUnionBuilder"),
+            ObjectClass::Union => format_ident!("DenseUnionBuilder"),
         };
 
         declarations.insert("arrow", ForwardDecl::Class(class_ident.clone()));

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -381,6 +381,7 @@ struct QuotedObject {
 }
 
 impl QuotedObject {
+    #[allow(clippy::unnecessary_wraps)] // TODO(emilk): implement proper error handling instead of panicking
     pub fn new(
         objects: &Objects,
         obj: &Object,
@@ -399,15 +400,13 @@ impl QuotedObject {
                     Ok(Self::from_archetype(obj, hpp_includes, hpp_type_extensions))
                 }
             },
+            ObjectClass::Enum => Ok(Self::from_enum(objects, obj, hpp_includes)),
             ObjectClass::Union => Ok(Self::from_union(
                 objects,
                 obj,
                 hpp_includes,
                 hpp_type_extensions,
             )),
-            ObjectClass::Enum => {
-                anyhow::bail!("Enums are not implemented in C++")
-            }
         }
     }
 
@@ -1160,6 +1159,78 @@ impl QuotedObject {
 
         Self { hpp, cpp }
     }
+
+    // C-style enum
+    fn from_enum(objects: &Objects, obj: &Object, mut hpp_includes: Includes) -> QuotedObject {
+        // We use a simple `enum class`, which is a type-safe enum.
+        // They don't support methods, but we don't need them,
+        // since `Loggable` is implemented outside the type.
+
+        let namespace_ident = obj.namespace_ident();
+
+        let quoted_namespace = if let Some(scope) = obj.scope() {
+            let scope = format_ident!("{}", scope);
+            quote! { #scope::#namespace_ident}
+        } else {
+            quote! {#namespace_ident}
+        };
+
+        let type_ident = obj.ident();
+        let quoted_docs = quote_obj_docs(obj);
+        let deprecation_notice = quote_deprecation_notice(obj);
+
+        let mut cpp_includes = Includes::new(obj.fqname.clone(), obj.scope());
+        let mut hpp_declarations = ForwardDecls::default();
+
+        let field_declarations = obj
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(i, obj_field)| {
+                let docstring = quote_field_docs(obj_field);
+                let field_name = format_ident!("{}", obj_field.name);
+
+                // We assign the arrow type index to the enum fields to make encoding simpler and faster:
+                let arrow_type_index = proc_macro2::Literal::usize_unsuffixed(1 + i); // 0 is reserved for `_null_markers`
+
+                quote! {
+                    #NEWLINE_TOKEN
+                    #docstring
+                    #field_name = #arrow_type_index
+                }
+            })
+            .collect_vec();
+
+        let (hpp_loggable, cpp_loggable) = quote_loggable_hpp_and_cpp(
+            obj,
+            objects,
+            &mut hpp_includes,
+            &mut cpp_includes,
+            &mut hpp_declarations,
+        );
+
+        let hpp = quote! {
+            #hpp_includes
+
+            #hpp_declarations
+
+            namespace rerun::#quoted_namespace {
+                #quoted_docs
+                enum class #deprecation_notice #type_ident : uint8_t {
+                    #(#field_declarations,)*
+                };
+            }
+
+            #hpp_loggable
+        };
+        let cpp = quote! {
+            #cpp_includes
+
+            #cpp_loggable
+        };
+
+        Self { hpp, cpp }
+    }
 }
 
 fn single_field_constructor_methods(
@@ -1518,19 +1589,19 @@ fn quote_fill_arrow_array_builder(
         match obj.class {
             ObjectClass::Struct => {
                 let fill_fields = obj.fields.iter().enumerate().map(
-                |(field_index, field)| {
-                    let field_index = quote_integer(field_index);
-                    let field_builder = format_ident!("field_builder");
-                    let field_builder_type = arrow_array_builder_type(&field.typ, objects);
-                    let field_append = quote_append_field_to_builder(field, &field_builder, false, includes, objects);
-                    quote! {
-                        {
-                            auto #field_builder = static_cast<arrow::#field_builder_type*>(builder->field_builder(#field_index));
-                            #field_append
+                    |(field_index, field)| {
+                        let field_index = quote_integer(field_index);
+                        let field_builder = format_ident!("field_builder");
+                        let field_builder_type = arrow_array_builder_type(&field.typ, objects);
+                        let field_append = quote_append_field_to_builder(field, &field_builder, false, includes, objects);
+                        quote! {
+                            {
+                                auto #field_builder = static_cast<arrow::#field_builder_type*>(builder->field_builder(#field_index));
+                                #field_append
+                            }
                         }
-                    }
-                },
-            );
+                    },
+                );
 
                 quote! {
                     #parameter_check
@@ -1539,9 +1610,20 @@ fn quote_fill_arrow_array_builder(
                     ARROW_RETURN_NOT_OK(builder->AppendValues(static_cast<int64_t>(num_elements), nullptr));
                 }
             }
+
+            // C-style enum, encoded as a sparse arrow union
             ObjectClass::Enum => {
-                unimplemented!("enums in C++")
+                quote! {
+                    #parameter_check
+                    ARROW_RETURN_NOT_OK(#builder->Reserve(static_cast<int64_t>(num_elements)));
+                    for (size_t elem_idx = 0; elem_idx < num_elements; elem_idx += 1) {
+                        const auto variant = elements[elem_idx];
+                        ARROW_RETURN_NOT_OK(#builder->Append(static_cast<int8_t>(variant)));
+                    }
+                }
             }
+
+            // sum-type union, encoded as a dense arrow union
             ObjectClass::Union => {
                 let variant_builder = format_ident!("variant_builder");
 
@@ -2235,12 +2317,18 @@ fn quote_arrow_data_type(
                         quote!(arrow::struct_({ #(#quoted_fields,)* }))
                     }
                     ObjectClass::Enum => {
-                        unimplemented!("enums in C++")
+                        quote! {
+                            arrow::sparse_union({
+                                arrow::field("_null_markers", arrow::null(), true, nullptr),
+                                #(#quoted_fields,)*
+                            })
+                        }
                     }
                     ObjectClass::Union => {
                         quote! {
                             arrow::dense_union({
-                                arrow::field("_null_markers", arrow::null(), true, nullptr), #(#quoted_fields,)*
+                                arrow::field("_null_markers", arrow::null(), true, nullptr),
+                                #(#quoted_fields,)*
                             })
                         }
                     }

--- a/crates/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/re_types_builder/src/codegen/python/mod.rs
@@ -13,7 +13,7 @@ use crate::{
         StringExt as _,
     },
     format_path,
-    objects::ObjectType,
+    objects::ObjectClass,
     ArrowRegistry, CodeGenerator, Docs, ElementType, GeneratedFiles, Object, ObjectField,
     ObjectKind, Objects, Reporter, Type, ATTR_PYTHON_ALIASES, ATTR_PYTHON_ARRAY_ALIASES,
 };
@@ -427,14 +427,14 @@ impl PythonCodeGenerator {
                 code.push_unindented_text(format!("\n__all__ = [{manifest}]\n\n\n"), 0);
             }
 
-            let obj_code = match obj.typ() {
-                crate::objects::ObjectType::Struct => {
+            let obj_code = match obj.class {
+                crate::objects::ObjectClass::Struct => {
                     code_for_struct(reporter, arrow_registry, &ext_class, objects, obj)
                 }
-                crate::objects::ObjectType::Union => {
+                crate::objects::ObjectClass::Union => {
                     code_for_union(arrow_registry, &ext_class, objects, obj)
                 }
-                crate::objects::ObjectType::Enum => {
+                crate::objects::ObjectClass::Enum => {
                     reporter.error(
                         &obj.virtpath,
                         &obj.fqname,
@@ -761,7 +761,7 @@ fn code_for_union(
     objects: &Objects,
     obj: &Object,
 ) -> String {
-    assert_eq!(obj.typ(), ObjectType::Union);
+    assert_eq!(obj.class, ObjectClass::Union);
     assert_eq!(obj.kind, ObjectKind::Datatype);
 
     let Object {

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -22,7 +22,7 @@ use crate::{
         StringExt as _,
     },
     format_path,
-    objects::ObjectType,
+    objects::ObjectClass,
     ArrowRegistry, CodeGenerator, Docs, ElementType, Object, ObjectField, ObjectKind, Objects,
     Reporter, Type, ATTR_RERUN_COMPONENT_OPTIONAL, ATTR_RERUN_COMPONENT_RECOMMENDED,
     ATTR_RERUN_COMPONENT_REQUIRED, ATTR_RUST_CUSTOM_CLAUSE, ATTR_RUST_DERIVE,
@@ -181,10 +181,10 @@ fn generate_object_file(
     // inject some of our own when writing to file… while making sure that don't inject
     // random spacing into doc comments that look like code!
 
-    let quoted_obj = match obj.typ() {
-        crate::objects::ObjectType::Struct => quote_struct(reporter, arrow_registry, objects, obj),
-        crate::objects::ObjectType::Union => quote_union(reporter, arrow_registry, objects, obj),
-        crate::objects::ObjectType::Enum => quote_enum(reporter, arrow_registry, objects, obj),
+    let quoted_obj = match obj.class {
+        crate::objects::ObjectClass::Struct => quote_struct(reporter, arrow_registry, objects, obj),
+        crate::objects::ObjectClass::Union => quote_union(reporter, arrow_registry, objects, obj),
+        crate::objects::ObjectClass::Enum => quote_enum(reporter, arrow_registry, objects, obj),
     };
 
     let mut tokens = quoted_obj.into_iter();
@@ -454,7 +454,7 @@ fn quote_union(
     objects: &Objects,
     obj: &Object,
 ) -> TokenStream {
-    assert_eq!(obj.typ(), ObjectType::Union);
+    assert_eq!(obj.class, ObjectClass::Union);
 
     let Object { name, fields, .. } = obj;
 
@@ -553,7 +553,7 @@ fn quote_enum(
     objects: &Objects,
     obj: &Object,
 ) -> TokenStream {
-    assert_eq!(obj.typ(), ObjectType::Enum);
+    assert_eq!(obj.class, ObjectClass::Enum);
 
     let Object { name, fields, .. } = obj;
 

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -562,14 +562,17 @@ fn quote_enum(
     let quoted_doc = quote_obj_docs(reporter, obj);
     let quoted_custom_clause = quote_meta_clause_from_obj(obj, ATTR_RUST_CUSTOM_CLAUSE, "");
 
-    let quoted_fields = fields.iter().map(|obj_field| {
-        let name = format_ident!("{}", crate::to_pascal_case(&obj_field.name));
+    let quoted_fields = fields.iter().enumerate().map(|(i, field)| {
+        let name = format_ident!("{}", crate::to_pascal_case(&field.name));
 
-        let quoted_doc = quote_field_docs(reporter, obj_field);
+        let quoted_doc = quote_field_docs(reporter, field);
+
+        // We assign the arrow type index to the enum fields to make encoding simpler and faster:
+        let arrow_type_index = proc_macro2::Literal::usize_unsuffixed(1 + i); // 0 is reserved for `_null_markers`
 
         quote! {
             #quoted_doc
-            #name
+            #name = #arrow_type_index
         }
     });
 

--- a/crates/re_types_builder/src/codegen/rust/deserializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/deserializer.rs
@@ -1,5 +1,5 @@
 use arrow2::datatypes::DataType;
-use proc_macro2::TokenStream;
+use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
 
 use crate::{
@@ -227,10 +227,11 @@ pub fn quote_arrow_deserializer(
                 let obj_fqname = obj.fqname.as_str();
                 let quoted_obj_name = format_ident!("{}", obj.name);
                 let quoted_branches = obj.fields.iter().enumerate().map(|(typ, obj_field)| {
-                    let typ = typ as i8 + 1; // NOTE: +1 to account for `_null_markers` virtual arm
+                    let arrow_type_index = Literal::i8_unsuffixed(typ as i8 + 1); // 0 is reserved for `_null_markers`
+
                     let quoted_obj_field_type = format_ident!("{}", obj_field.pascal_case_name());
                     quote! {
-                        #typ => Ok(Some(#quoted_obj_name::#quoted_obj_field_type))
+                        #arrow_type_index => Ok(Some(#quoted_obj_name::#quoted_obj_field_type))
                     }
                 });
 

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -197,25 +197,14 @@ pub fn quote_arrow_serializer(
                         .collect();
                 };
 
-                let quoted_types = {
-                    let quoted_obj_name = format_ident!("{}", obj.name);
-                    let quoted_branches = obj.fields.iter().enumerate().map(|(i, obj_field)| {
-                        let i = 1 + i as i8; // NOTE: +1 to account for `nulls` virtual arm
-                        let quoted_obj_field_name =
-                            format_ident!("{}", obj_field.pascal_case_name());
-
-                        quote!(Some(#quoted_obj_name::#quoted_obj_field_name) => #i)
-                    });
-
-                    quote! {
-                        #data_src
-                            .iter()
-                            .map(|a| match a.as_deref() {
-                                None => 0,
-                                #(#quoted_branches,)*
-                            })
-                            .collect()
-                    }
+                let quoted_types = quote! {
+                    #data_src
+                        .iter()
+                        .map(|a| match a.as_deref() {
+                            None => 0,
+                            Some(value) => *value as i8,
+                        })
+                        .collect()
                 };
 
                 let num_variants = obj.fields.len();

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -243,6 +243,7 @@ pub fn compile_binary_schemas(
 /// - `include_dir_path`: path to the root directory of the fbs definition tree.
 /// - `entrypoint_path`: path to the root file of the fbs definition tree.
 pub fn generate_lang_agnostic(
+    reporter: &Reporter,
     include_dir_path: impl AsRef<Utf8Path>,
     entrypoint_path: impl AsRef<Utf8Path>,
 ) -> (Objects, ArrowRegistry) {
@@ -271,6 +272,7 @@ pub fn generate_lang_agnostic(
 
     // semantic pass: high level objects from low-level reflection data
     let mut objects = Objects::from_buf(
+        reporter,
         include_dir_path,
         sh.read_binary_file(tmp_path.join(binary_entrypoint_path))
             .unwrap()

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -153,7 +153,7 @@ pub use self::codegen::{
 };
 pub use self::format::{CodeFormatter, CppCodeFormatter, PythonCodeFormatter, RustCodeFormatter};
 pub use self::objects::{
-    Attributes, Docs, ElementType, Object, ObjectField, ObjectKind, ObjectSpecifics, Objects, Type,
+    Attributes, Docs, ElementType, Object, ObjectClass, ObjectField, ObjectKind, Objects, Type,
 };
 pub use self::report::{Report, Reporter};
 

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 
 use crate::{
     root_as_schema, FbsBaseType, FbsEnum, FbsEnumVal, FbsField, FbsKeyValue, FbsObject, FbsSchema,
-    FbsType, ATTR_RERUN_OVERRIDE_TYPE,
+    FbsType, Reporter, ATTR_RERUN_OVERRIDE_TYPE,
 };
 
 // ---
@@ -28,13 +28,21 @@ impl Objects {
     /// Runs the semantic pass on a serialized flatbuffers schema.
     ///
     /// The buffer must be a serialized [`FbsSchema`] (i.e. `.bfbs` data).
-    pub fn from_buf(include_dir_path: impl AsRef<Utf8Path>, buf: &[u8]) -> Self {
+    pub fn from_buf(
+        reporter: &Reporter,
+        include_dir_path: impl AsRef<Utf8Path>,
+        buf: &[u8],
+    ) -> Self {
         let schema = root_as_schema(buf).unwrap();
-        Self::from_raw_schema(include_dir_path, &schema)
+        Self::from_raw_schema(reporter, include_dir_path, &schema)
     }
 
     /// Runs the semantic pass on a deserialized flatbuffers [`FbsSchema`].
-    pub fn from_raw_schema(include_dir_path: impl AsRef<Utf8Path>, schema: &FbsSchema<'_>) -> Self {
+    pub fn from_raw_schema(
+        reporter: &Reporter,
+        include_dir_path: impl AsRef<Utf8Path>,
+        schema: &FbsSchema<'_>,
+    ) -> Self {
         let mut resolved_objs = BTreeMap::new();
         let mut resolved_enums = BTreeMap::new();
 
@@ -45,7 +53,8 @@ impl Objects {
 
         // resolve enums
         for enm in schema.enums() {
-            let resolved_enum = Object::from_raw_enum(include_dir_path, &enums, &objs, &enm);
+            let resolved_enum =
+                Object::from_raw_enum(reporter, include_dir_path, &enums, &objs, &enm);
             resolved_enums.insert(resolved_enum.fqname.clone(), resolved_enum);
         }
 
@@ -475,6 +484,8 @@ impl Object {
                     ObjectField::from_raw_object_field(include_dir_path, enums, objs, obj, &field)
                 })
                 .collect();
+
+            // The fields of a struct is completely arbitrary, so we use the `order` attribute to sort them.
             fields.sort_by_key(|field| field.order);
 
             // Make sure no two fields have the same order:
@@ -516,6 +527,7 @@ impl Object {
     /// Resolves a raw [`FbsEnum`] into a higher-level representation that can be easily
     /// interpreted and manipulated.
     pub fn from_raw_enum(
+        reporter: &Reporter,
         include_dir_path: impl AsRef<Utf8Path>,
         enums: &[FbsEnum<'_>],
         objs: &[FbsObject<'_>],
@@ -542,7 +554,7 @@ impl Object {
 
         let is_enum = enm.underlying_type().base_type() != FbsBaseType::UType;
 
-        let mut fields: Vec<_> = enm
+        let fields: Vec<_> = enm
             .values()
             .iter()
             // NOTE: `BaseType::None` is only used by internal flatbuffers fields, we don't care.
@@ -554,23 +566,9 @@ impl Object {
                         .is_some()
             })
             .map(|val| {
-                ObjectField::from_raw_enum_value(include_dir_path, enums, objs, enm, &val, is_enum)
+                ObjectField::from_raw_enum_value(reporter, include_dir_path, enums, objs, enm, &val)
             })
             .collect();
-
-        if !is_enum {
-            fields.sort_by_key(|field| field.order);
-
-            // Make sure no two fields have the same order:
-            for (a, b) in fields.iter().tuple_windows() {
-                assert!(
-                    a.order != b.order,
-                    "{name:?}: Fields {:?} and {:?} have the same order",
-                    a.name,
-                    b.name
-                );
-            }
-        }
 
         if kind == ObjectKind::Component {
             assert!(
@@ -753,7 +751,8 @@ pub struct ObjectField {
     /// The field's attributes.
     pub attrs: Attributes,
 
-    /// The field's `order` attribute's value, which is always mandatory.
+    /// The struct field's `order` attribute's value, which is mandatory for struct fields
+    /// (otherwise their order is undefined).
     pub order: u32,
 
     /// Whether the field is nullable.
@@ -820,12 +819,12 @@ impl ObjectField {
     }
 
     pub fn from_raw_enum_value(
+        reporter: &Reporter,
         include_dir_path: impl AsRef<Utf8Path>,
         enums: &[FbsEnum<'_>],
         objs: &[FbsObject<'_>],
         enm: &FbsEnum<'_>,
         val: &FbsEnumVal<'_>,
-        is_enum: bool,
     ) -> Self {
         let fqname = format!("{}#{}", enm.name(), val.name());
         let (pkg_name, name) = fqname
@@ -853,15 +852,17 @@ impl ObjectField {
             &attrs,
         );
 
-        let order = if is_enum {
-            0 // enum variants don't have/need order
-        } else {
-            attrs.get::<u32>(&fqname, crate::ATTR_ORDER)
-        };
-
         let is_nullable = attrs.has(crate::ATTR_NULLABLE);
         // TODO(cmc): not sure about this, but fbs unions are a bit weird that way
         let is_deprecated = false;
+
+        if attrs.has(crate::ATTR_ORDER) {
+            reporter.warn(
+                &virtpath,
+                &fqname,
+                "There is no need for an `order` attribute on enum/union variants",
+            );
+        }
 
         Self {
             virtpath,
@@ -872,7 +873,7 @@ impl ObjectField {
             docs,
             typ,
             attrs,
-            order,
+            order: 0, // no needed for enums
             is_nullable,
             is_deprecated,
             datatype: None,

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -697,7 +697,7 @@ pub fn is_testing_fqname(fqname: &str) -> bool {
 pub enum ObjectClass {
     Struct,
 
-    /// Dumn C-style enum.
+    /// Dumb C-style enum.
     ///
     /// Encoded as a sparse arrow union.
     ///

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -485,7 +485,8 @@ impl Object {
                 })
                 .collect();
 
-            // The fields of a struct is completely arbitrary, so we use the `order` attribute to sort them.
+            // The fields of a struct are reported in arbitrary order by flatbuffers,
+            // so we use the `order` attribute to sort them:
             fields.sort_by_key(|field| field.order);
 
             // Make sure no two fields have the same order:


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/3384

### Coming later
* Python
* Tests
* Switching to using `enum` for existing types

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5314/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5314/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5314/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5314)
- [Docs preview](https://rerun.io/preview/cdd09f81a3a8fa16c2dbbffca7403165bc907739/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/cdd09f81a3a8fa16c2dbbffca7403165bc907739/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)