### PR TITLE
Change the pattern for relative imports in scoped components

### DIFF
--- a/crates/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/re_types_builder/src/codegen/python/mod.rs
@@ -1300,17 +1300,17 @@ fn quote_import_clauses_from_fqname(obj_scope: &Option<String>, fqname: &str) ->
         if from.starts_with("rerun.datatypes") {
             "from ... import datatypes".to_owned() // NOLINT
         } else if from.starts_with(format!("rerun.{scope}.datatypes").as_str()) {
-            format!("from ... import {scope}")
+            format!("from ...{scope} import datatypes as {scope}_datatypes")
         } else if from.starts_with("rerun.components") {
             "from ... import components".to_owned() // NOLINT
         } else if from.starts_with(format!("rerun.{scope}.components").as_str()) {
-            format!("from ... import {scope}")
+            format!("from ...{scope} import components as {scope}_components")
         } else if from.starts_with("rerun.archetypes") {
             // NOTE: This is assuming importing other archetypes is legal… which whether it is or
             // isn't for this code generator to say.
             "from ... import archetypes".to_owned() // NOLINT
         } else if from.starts_with(format!("rerun.{scope}.archetytpes").as_str()) {
-            "from .. import {scope}".to_owned()
+            format!("from ...{scope} import archetypes as {scope}_archetypes")
         } else if from.is_empty() {
             format!("from . import {class}")
         } else {
@@ -1523,9 +1523,9 @@ fn fqname_to_type(fqname: &str) -> String {
         ["rerun", "datatypes", name] => format!("datatypes.{name}"),
         ["rerun", "components", name] => format!("components.{name}"),
         ["rerun", "archetypes", name] => format!("archetypes.{name}"),
-        ["rerun", scope, "datatypes", name] => format!("{scope}.datatypes.{name}"),
-        ["rerun", scope, "components", name] => format!("{scope}.components.{name}"),
-        ["rerun", scope, "archetypes", name] => format!("{scope}.archetypes.{name}"),
+        ["rerun", scope, "datatypes", name] => format!("{scope}_datatypes.{name}"),
+        ["rerun", scope, "components", name] => format!("{scope}_components.{name}"),
+        ["rerun", scope, "archetypes", name] => format!("{scope}_archetypes.{name}"),
         _ => {
             panic!("Unexpected fqname: {fqname}");
         }
@@ -1594,7 +1594,7 @@ fn quote_arrow_support_from_obj(
     } else if obj.kind == ObjectKind::Component {
         if let Some(data_type) = obj.delegate_datatype(objects) {
             let scope = match data_type.scope() {
-                Some(scope) => format!("{scope}."),
+                Some(scope) => format!("{scope}_"),
                 None => String::new(),
             };
             let data_extension_type = format!("{scope}datatypes.{}Type", data_type.name);

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -63,6 +63,7 @@ __all__ = [
     "ViewCoordinates",
     "archetypes",
     "bindings",
+    "blueprint",
     "components",
     "connect",
     "datatypes",
@@ -181,7 +182,7 @@ from .time import (
 
 # Import experimental last
 from . import experimental  # isort: skip
-
+from . import blueprint
 
 # =====================================
 # UTILITIES

--- a/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from . import archetypes, components, datatypes
-
 __all__ = ["archetypes", "datatypes", "components"]
+
+from . import archetypes, components, datatypes

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/container_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/container_blueprint.py
@@ -9,8 +9,9 @@ from typing import Any
 
 from attrs import define, field
 
-from ... import blueprint, components, datatypes
+from ... import components, datatypes
 from ..._baseclasses import Archetype
+from ...blueprint import components as blueprint_components
 from ...error_utils import catch_and_log_exceptions
 
 __all__ = ["ContainerBlueprint"]
@@ -22,15 +23,15 @@ class ContainerBlueprint(Archetype):
 
     def __init__(
         self: Any,
-        container_kind: blueprint.components.ContainerKindLike,
+        container_kind: blueprint_components.ContainerKindLike,
         *,
         display_name: datatypes.Utf8Like | None = None,
-        contents: blueprint.components.IncludedContentsLike | None = None,
-        col_shares: blueprint.components.ColumnSharesLike | None = None,
-        row_shares: blueprint.components.RowSharesLike | None = None,
+        contents: blueprint_components.IncludedContentsLike | None = None,
+        col_shares: blueprint_components.ColumnSharesLike | None = None,
+        row_shares: blueprint_components.RowSharesLike | None = None,
         active_tab: datatypes.EntityPathLike | None = None,
-        visible: blueprint.components.VisibleLike | None = None,
-        grid_columns: blueprint.components.GridColumnsLike | None = None,
+        visible: blueprint_components.VisibleLike | None = None,
+        grid_columns: blueprint_components.GridColumnsLike | None = None,
     ):
         """
         Create a new instance of the ContainerBlueprint archetype.
@@ -107,9 +108,9 @@ class ContainerBlueprint(Archetype):
         inst.__attrs_clear__()
         return inst
 
-    container_kind: blueprint.components.ContainerKindBatch = field(
+    container_kind: blueprint_components.ContainerKindBatch = field(
         metadata={"component": "required"},
-        converter=blueprint.components.ContainerKindBatch._required,  # type: ignore[misc]
+        converter=blueprint_components.ContainerKindBatch._required,  # type: ignore[misc]
     )
     # The class of the view.
     #
@@ -124,19 +125,19 @@ class ContainerBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    contents: blueprint.components.IncludedContentsBatch | None = field(
+    contents: blueprint_components.IncludedContentsBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.IncludedContentsBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.IncludedContentsBatch._optional,  # type: ignore[misc]
     )
     # `ContainerIds`s or `SpaceViewId`s that are children of this container.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    col_shares: blueprint.components.ColumnSharesBatch | None = field(
+    col_shares: blueprint_components.ColumnSharesBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.ColumnSharesBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.ColumnSharesBatch._optional,  # type: ignore[misc]
     )
     # The layout shares of each column in the container.
     #
@@ -146,10 +147,10 @@ class ContainerBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    row_shares: blueprint.components.RowSharesBatch | None = field(
+    row_shares: blueprint_components.RowSharesBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.RowSharesBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.RowSharesBatch._optional,  # type: ignore[misc]
     )
     # The layout shares of each row of the container.
     #
@@ -159,10 +160,10 @@ class ContainerBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    active_tab: blueprint.components.ActiveTabBatch | None = field(
+    active_tab: blueprint_components.ActiveTabBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.ActiveTabBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.ActiveTabBatch._optional,  # type: ignore[misc]
     )
     # Which tab is active.
     #
@@ -170,10 +171,10 @@ class ContainerBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    visible: blueprint.components.VisibleBatch | None = field(
+    visible: blueprint_components.VisibleBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.VisibleBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.VisibleBatch._optional,  # type: ignore[misc]
     )
     # Whether this container is visible.
     #
@@ -181,10 +182,10 @@ class ContainerBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    grid_columns: blueprint.components.GridColumnsBatch | None = field(
+    grid_columns: blueprint_components.GridColumnsBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.GridColumnsBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.GridColumnsBatch._optional,  # type: ignore[misc]
     )
     # How many columns this grid should have.
     #

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/plot_legend.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/plot_legend.py
@@ -9,8 +9,8 @@ from typing import Any
 
 from attrs import define, field
 
-from ... import blueprint
 from ..._baseclasses import Archetype
+from ...blueprint import components as blueprint_components
 from ...error_utils import catch_and_log_exceptions
 
 __all__ = ["PlotLegend"]
@@ -23,8 +23,8 @@ class PlotLegend(Archetype):
     def __init__(
         self: Any,
         *,
-        corner: blueprint.components.Corner2DLike | None = None,
-        visible: blueprint.components.VisibleLike | None = None,
+        corner: blueprint_components.Corner2DLike | None = None,
+        visible: blueprint_components.VisibleLike | None = None,
     ):
         """
         Create a new instance of the PlotLegend archetype.
@@ -62,10 +62,10 @@ class PlotLegend(Archetype):
         inst.__attrs_clear__()
         return inst
 
-    corner: blueprint.components.Corner2DBatch | None = field(
+    corner: blueprint_components.Corner2DBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.Corner2DBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.Corner2DBatch._optional,  # type: ignore[misc]
     )
     # To what corner the legend is aligned.
     #
@@ -73,10 +73,10 @@ class PlotLegend(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    visible: blueprint.components.VisibleBatch | None = field(
+    visible: blueprint_components.VisibleBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.VisibleBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.VisibleBatch._optional,  # type: ignore[misc]
     )
     # Whether the legend is shown at all.
     #

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/scalar_axis.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/scalar_axis.py
@@ -9,8 +9,9 @@ from typing import Any
 
 from attrs import define, field
 
-from ... import blueprint, components
+from ... import components
 from ..._baseclasses import Archetype
+from ...blueprint import components as blueprint_components
 from ...error_utils import catch_and_log_exceptions
 
 __all__ = ["ScalarAxis"]
@@ -24,7 +25,7 @@ class ScalarAxis(Archetype):
         self: Any,
         *,
         range: components.Range1DLike | None = None,
-        lock_range_during_zoom: blueprint.components.LockRangeDuringZoomLike | None = None,
+        lock_range_during_zoom: blueprint_components.LockRangeDuringZoomLike | None = None,
     ):
         """
         Create a new instance of the ScalarAxis archetype.
@@ -71,10 +72,10 @@ class ScalarAxis(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    lock_range_during_zoom: blueprint.components.LockRangeDuringZoomBatch | None = field(
+    lock_range_during_zoom: blueprint_components.LockRangeDuringZoomBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.LockRangeDuringZoomBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.LockRangeDuringZoomBatch._optional,  # type: ignore[misc]
     )
     # Whether to lock the range of the axis during zoom.
     #

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_blueprint.py
@@ -9,8 +9,9 @@ from typing import Any
 
 from attrs import define, field
 
-from ... import blueprint, components, datatypes
+from ... import components, datatypes
 from ..._baseclasses import Archetype
+from ...blueprint import components as blueprint_components
 from ...error_utils import catch_and_log_exceptions
 
 __all__ = ["SpaceViewBlueprint"]
@@ -22,13 +23,13 @@ class SpaceViewBlueprint(Archetype):
 
     def __init__(
         self: Any,
-        class_identifier: blueprint.components.SpaceViewClassLike,
+        class_identifier: blueprint_components.SpaceViewClassLike,
         *,
         display_name: datatypes.Utf8Like | None = None,
         space_origin: datatypes.EntityPathLike | None = None,
-        entities_determined_by_user: blueprint.components.EntitiesDeterminedByUserLike | None = None,
-        contents: blueprint.components.IncludedQueriesLike | None = None,
-        visible: blueprint.components.VisibleLike | None = None,
+        entities_determined_by_user: blueprint_components.EntitiesDeterminedByUserLike | None = None,
+        contents: blueprint_components.IncludedQueriesLike | None = None,
+        visible: blueprint_components.VisibleLike | None = None,
     ):
         """
         Create a new instance of the SpaceViewBlueprint archetype.
@@ -89,9 +90,9 @@ class SpaceViewBlueprint(Archetype):
         inst.__attrs_clear__()
         return inst
 
-    class_identifier: blueprint.components.SpaceViewClassBatch = field(
+    class_identifier: blueprint_components.SpaceViewClassBatch = field(
         metadata={"component": "required"},
-        converter=blueprint.components.SpaceViewClassBatch._required,  # type: ignore[misc]
+        converter=blueprint_components.SpaceViewClassBatch._required,  # type: ignore[misc]
     )
     # The class of the view.
     #
@@ -106,10 +107,10 @@ class SpaceViewBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    space_origin: blueprint.components.SpaceViewOriginBatch | None = field(
+    space_origin: blueprint_components.SpaceViewOriginBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.SpaceViewOriginBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.SpaceViewOriginBatch._optional,  # type: ignore[misc]
     )
     # The "anchor point" of this space view.
     #
@@ -119,19 +120,19 @@ class SpaceViewBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    entities_determined_by_user: blueprint.components.EntitiesDeterminedByUserBatch | None = field(
+    entities_determined_by_user: blueprint_components.EntitiesDeterminedByUserBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.EntitiesDeterminedByUserBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.EntitiesDeterminedByUserBatch._optional,  # type: ignore[misc]
     )
     # True if the user is has added entities themselves. False otherwise.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    contents: blueprint.components.IncludedQueriesBatch | None = field(
+    contents: blueprint_components.IncludedQueriesBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.IncludedQueriesBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.IncludedQueriesBatch._optional,  # type: ignore[misc]
     )
     # `BlueprintId`s of the `DataQuery`s that make up this `SpaceView`.
     #
@@ -139,10 +140,10 @@ class SpaceViewBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    visible: blueprint.components.VisibleBatch | None = field(
+    visible: blueprint_components.VisibleBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.VisibleBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.VisibleBatch._optional,  # type: ignore[misc]
     )
     # Whether this space view is visible.
     #

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/viewport_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/viewport_blueprint.py
@@ -9,8 +9,9 @@ from typing import Any
 
 from attrs import define, field
 
-from ... import blueprint, datatypes
+from ... import datatypes
 from ..._baseclasses import Archetype
+from ...blueprint import components as blueprint_components
 from ...error_utils import catch_and_log_exceptions
 
 __all__ = ["ViewportBlueprint"]
@@ -22,13 +23,13 @@ class ViewportBlueprint(Archetype):
 
     def __init__(
         self: Any,
-        space_views: blueprint.components.IncludedSpaceViewsLike,
+        space_views: blueprint_components.IncludedSpaceViewsLike,
         *,
-        layout: blueprint.components.ViewportLayoutLike | None = None,
+        layout: blueprint_components.ViewportLayoutLike | None = None,
         root_container: datatypes.UuidLike | None = None,
         maximized: datatypes.UuidLike | None = None,
-        auto_layout: blueprint.components.AutoLayoutLike | None = None,
-        auto_space_views: blueprint.components.AutoSpaceViewsLike | None = None,
+        auto_layout: blueprint_components.AutoLayoutLike | None = None,
+        auto_space_views: blueprint_components.AutoSpaceViewsLike | None = None,
     ):
         """
         Create a new instance of the ViewportBlueprint archetype.
@@ -83,45 +84,45 @@ class ViewportBlueprint(Archetype):
         inst.__attrs_clear__()
         return inst
 
-    space_views: blueprint.components.IncludedSpaceViewsBatch = field(
+    space_views: blueprint_components.IncludedSpaceViewsBatch = field(
         metadata={"component": "required"},
-        converter=blueprint.components.IncludedSpaceViewsBatch._required,  # type: ignore[misc]
+        converter=blueprint_components.IncludedSpaceViewsBatch._required,  # type: ignore[misc]
     )
     # All of the space-views that belong to the viewport.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    layout: blueprint.components.ViewportLayoutBatch | None = field(
+    layout: blueprint_components.ViewportLayoutBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.ViewportLayoutBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.ViewportLayoutBatch._optional,  # type: ignore[misc]
     )
     # The layout of the space-views
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    root_container: blueprint.components.RootContainerBatch | None = field(
+    root_container: blueprint_components.RootContainerBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.RootContainerBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.RootContainerBatch._optional,  # type: ignore[misc]
     )
     # The layout of the space-views
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    maximized: blueprint.components.SpaceViewMaximizedBatch | None = field(
+    maximized: blueprint_components.SpaceViewMaximizedBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.SpaceViewMaximizedBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.SpaceViewMaximizedBatch._optional,  # type: ignore[misc]
     )
     # Show one tab as maximized?
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    auto_layout: blueprint.components.AutoLayoutBatch | None = field(
+    auto_layout: blueprint_components.AutoLayoutBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.AutoLayoutBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.AutoLayoutBatch._optional,  # type: ignore[misc]
     )
     # Whether the viewport layout is determined automatically.
     #
@@ -129,10 +130,10 @@ class ViewportBlueprint(Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    auto_space_views: blueprint.components.AutoSpaceViewsBatch | None = field(
+    auto_space_views: blueprint_components.AutoSpaceViewsBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=blueprint.components.AutoSpaceViewsBatch._optional,  # type: ignore[misc]
+        converter=blueprint_components.AutoSpaceViewsBatch._optional,  # type: ignore[misc]
     )
     # Whether or not space views should be created automatically.
     #


### PR DESCRIPTION
### What

This is a complex problem that probably warrants a different long-term solution, but this unblocks things for now.

The normal pattern of `from ...blueprint import components` created a potential conflict when an archetype used a mix of components from blueprint and core components.

The next fix we tried of just import `from ... import blueprint` appeared to work, but led to circular import errors on archetypes, since components would try to import blueprints which would include archetypes before components was initialized.

We now only import the direct packages we need from the scope, but introduce an alias `{scope}_{type}` to avoid the collision.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5322/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5322/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5322/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5322)
- [Docs preview](https://rerun.io/preview/92be21320f9b2c0726c86dc1f5ccacd4719e3624/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/92be21320f9b2c0726c86dc1f5ccacd4719e3624/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)