### PR TITLE
Remove groups from blueprint

### DIFF
--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -5,9 +5,7 @@
 use re_entity_db::{EntityTree, InstancePath};
 use re_log_types::{ComponentPath, EntityPath, TimeInt, Timeline};
 use re_ui::SyntaxHighlighting;
-use re_viewer_context::{
-    DataQueryId, HoverHighlight, Item, SpaceViewId, UiVerbosity, ViewerContext,
-};
+use re_viewer_context::{HoverHighlight, Item, SpaceViewId, UiVerbosity, ViewerContext};
 
 use super::DataUi;
 
@@ -30,9 +28,6 @@ use super::DataUi;
 //         }
 //         Item::InstancePath(space_view_id, instance_path) => {
 //             instance_path_button_to(ctx, ui, *space_view_id, instance_path, text)
-//         }
-//         Item::DataBlueprintGroup(space_view_id, group_handle) => {
-//             data_blueprint_group_button_to(ctx, ui, text, *space_view_id, *group_handle)
 //         }
 //     }
 // }
@@ -308,28 +303,6 @@ pub fn component_path_button_to(
         ctx.selection().contains_item(&item),
         re_ui::LabelStyle::Normal,
     );
-    cursor_interact_with_selectable(ctx, response, item)
-}
-
-pub fn data_blueprint_group_button_to(
-    ctx: &ViewerContext<'_>,
-    ui: &mut egui::Ui,
-    text: impl Into<egui::WidgetText>,
-    space_view_id: SpaceViewId,
-    query_id: DataQueryId,
-    entity_path: EntityPath,
-) -> egui::Response {
-    let item = Item::DataBlueprintGroup(space_view_id, query_id, entity_path);
-    let response = ctx
-        .re_ui
-        .selectable_label_with_icon(
-            ui,
-            &re_ui::icons::GROUP,
-            text,
-            ctx.selection().contains_item(&item),
-            re_ui::LabelStyle::Normal,
-        )
-        .on_hover_text("Group");
     cursor_interact_with_selectable(ctx, response, item)
 }
 

--- a/crates/re_space_view/src/data_query.rs
+++ b/crates/re_space_view/src/data_query.rs
@@ -4,7 +4,7 @@ use re_viewer_context::{DataQueryResult, PerVisualizer, StoreContext, Visualizab
 pub struct EntityOverrideContext {
     pub root: EntityProperties,
     pub individual: EntityPropertyMap,
-    pub group: EntityPropertyMap,
+    pub recursive: EntityPropertyMap,
 }
 
 /// Trait for resolving properties needed by most implementations of [`DataQuery`]

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -543,8 +543,9 @@ impl DataQueryPropertyResolver<'_> {
                 }
 
                 node.data_result.property_overrides = Some(PropertyOverrides {
-                    individual_properties: individual_properties.cloned(),
                     accumulated_properties,
+                    individual_properties: individual_properties.cloned(),
+                    recursive_properties: recursive_properties.cloned(),
                     component_overrides,
                     recursive_override_path,
                     individual_override_path,

--- a/crates/re_space_view/src/data_query_blueprint.rs
+++ b/crates/re_space_view/src/data_query_blueprint.rs
@@ -477,7 +477,6 @@ impl DataQueryPropertyResolver<'_> {
                 let individual_properties = override_context
                     .individual
                     .get_opt(&node.data_result.entity_path);
-
                 let accumulated_properties =
                     if let Some(individual_override) = individual_properties {
                         accumulated_recursive_properties.with_child(individual_override)
@@ -519,6 +518,7 @@ impl DataQueryPropertyResolver<'_> {
                             );
                     }
                 }
+
                 let mut component_overrides: HashMap<ComponentName, (StoreKind, EntityPath)> =
                     Default::default();
 
@@ -544,7 +544,7 @@ impl DataQueryPropertyResolver<'_> {
 
                 node.data_result.property_overrides = Some(PropertyOverrides {
                     individual_properties: individual_properties.cloned(),
-                    accumulated_properties: accumulated_properties.clone(),
+                    accumulated_properties,
                     component_overrides,
                     recursive_override_path,
                     individual_override_path,

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -479,6 +479,7 @@ impl SpaceViewBlueprint {
             property_overrides: Some(PropertyOverrides {
                 accumulated_properties,
                 individual_properties,
+                recursive_properties: Default::default(),
                 component_overrides: Default::default(),
                 recursive_override_path: entity_path.clone(),
                 individual_override_path: entity_path,

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -475,13 +475,13 @@ impl SpaceViewBlueprint {
         DataResult {
             entity_path: entity_path.clone(),
             visualizers: Default::default(),
-            is_group: true,
             direct_included: true,
             property_overrides: Some(PropertyOverrides {
                 accumulated_properties,
                 individual_properties,
                 component_overrides: Default::default(),
-                override_path: entity_path,
+                recursive_override_path: entity_path.clone(),
+                individual_override_path: entity_path,
             }),
         }
     }
@@ -642,15 +642,15 @@ mod tests {
 
             let parent = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent"), false)
+                .lookup_result_by_path(&EntityPath::from("parent"))
                 .unwrap();
             let child1 = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent/skip/child1"), false)
+                .lookup_result_by_path(&EntityPath::from("parent/skip/child1"))
                 .unwrap();
             let child2 = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent/skip/child2"), false)
+                .lookup_result_by_path(&EntityPath::from("parent/skip/child2"))
                 .unwrap();
 
             for result in [parent, child1, child2] {
@@ -660,11 +660,15 @@ mod tests {
                 );
             }
 
-            // Now, override visibility on parent but not group
+            // Now, override visibility on parent individually.
             let mut overrides = parent.individual_properties().cloned().unwrap_or_default();
             overrides.visible = false;
 
-            save_override(overrides, parent.override_path().unwrap(), &mut blueprint);
+            save_override(
+                overrides,
+                parent.individual_override_path().unwrap(),
+                &mut blueprint,
+            );
         }
 
         // Parent is not visible, but children are
@@ -680,19 +684,19 @@ mod tests {
 
             let parent_group = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent"), true)
+                .lookup_result_by_path(&EntityPath::from("parent"))
                 .unwrap();
             let parent = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent"), false)
+                .lookup_result_by_path(&EntityPath::from("parent"))
                 .unwrap();
             let child1 = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent/skip/child1"), false)
+                .lookup_result_by_path(&EntityPath::from("parent/skip/child1"))
                 .unwrap();
             let child2 = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent/skip/child2"), false)
+                .lookup_result_by_path(&EntityPath::from("parent/skip/child2"))
                 .unwrap();
 
             assert!(!parent.accumulated_properties().visible);
@@ -701,7 +705,7 @@ mod tests {
                 assert!(result.accumulated_properties().visible);
             }
 
-            // Override visibility on parent group
+            // Override visibility on parent recursively.
             let mut overrides = parent_group
                 .individual_properties()
                 .cloned()
@@ -710,7 +714,7 @@ mod tests {
 
             save_override(
                 overrides,
-                parent_group.override_path().unwrap(),
+                parent_group.recursive_override_path().unwrap(),
                 &mut blueprint,
             );
         }
@@ -728,15 +732,15 @@ mod tests {
 
             let parent = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent"), false)
+                .lookup_result_by_path(&EntityPath::from("parent"))
                 .unwrap();
             let child1 = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent/skip/child1"), false)
+                .lookup_result_by_path(&EntityPath::from("parent/skip/child1"))
                 .unwrap();
             let child2 = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent/skip/child2"), false)
+                .lookup_result_by_path(&EntityPath::from("parent/skip/child2"))
                 .unwrap();
 
             for result in [parent, child1, child2] {
@@ -758,7 +762,11 @@ mod tests {
             overrides.visible_history.enabled = true;
             overrides.visible_history.nanos = VisibleHistory::ALL;
 
-            save_override(overrides, root.override_path().unwrap(), &mut blueprint);
+            save_override(
+                overrides,
+                root.recursive_override_path().unwrap(),
+                &mut blueprint,
+            );
         }
 
         // Everyone has visible history
@@ -773,15 +781,15 @@ mod tests {
 
             let parent = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent"), false)
+                .lookup_result_by_path(&EntityPath::from("parent"))
                 .unwrap();
             let child1 = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent/skip/child1"), false)
+                .lookup_result_by_path(&EntityPath::from("parent/skip/child1"))
                 .unwrap();
             let child2 = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent/skip/child2"), false)
+                .lookup_result_by_path(&EntityPath::from("parent/skip/child2"))
                 .unwrap();
 
             for result in [parent, child1, child2] {
@@ -795,7 +803,11 @@ mod tests {
             let mut overrides = child2.individual_properties().cloned().unwrap_or_default();
             overrides.visible_history.enabled = true;
 
-            save_override(overrides, child2.override_path().unwrap(), &mut blueprint);
+            save_override(
+                overrides,
+                child2.individual_override_path().unwrap(),
+                &mut blueprint,
+            );
         }
 
         // Child2 has its own visible history
@@ -811,15 +823,15 @@ mod tests {
 
             let parent = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent"), false)
+                .lookup_result_by_path(&EntityPath::from("parent"))
                 .unwrap();
             let child1 = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent/skip/child1"), false)
+                .lookup_result_by_path(&EntityPath::from("parent/skip/child1"))
                 .unwrap();
             let child2 = query_result
                 .tree
-                .lookup_result_by_path_and_group(&EntityPath::from("parent/skip/child2"), false)
+                .lookup_result_by_path(&EntityPath::from("parent/skip/child2"))
                 .unwrap();
 
             for result in [parent, child1] {

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -550,7 +550,7 @@ pub fn view_3d(
     // Track focused entity if any.
     if let Some(focused_item) = ctx.focused_item {
         let focused_entity = match focused_item {
-            Item::StoreId(_) | Item::DataBlueprintGroup(_, _, _) | Item::Container(_) => None,
+            Item::StoreId(_) | Item::Container(_) => None,
 
             Item::SpaceView(space_view_id) => {
                 if space_view_id == &query.space_view_id {

--- a/crates/re_viewer/src/ui/override_ui.rs
+++ b/crates/re_viewer/src/ui/override_ui.rs
@@ -38,7 +38,7 @@ pub fn override_ui(
     let query_result = ctx.lookup_query_result(space_view.query_id());
     let Some(data_result) = query_result
         .tree
-        .lookup_result_by_path_and_group(entity_path, false)
+        .lookup_result_by_path(entity_path)
         .cloned()
     else {
         ui.label(ctx.re_ui.error_text("Entity not found in view."));
@@ -125,7 +125,7 @@ pub fn override_ui(
                             // not exist in the recording store.
                             ctx.save_empty_blueprint_component_name(
                                 ctx.store_context.blueprint.store(),
-                                &overrides.override_path,
+                                &overrides.individual_override_path,
                                 *component_name,
                             );
                         }
@@ -166,7 +166,7 @@ pub fn override_ui(
                                 &query,
                                 store,
                                 entity_path,
-                                &overrides.override_path,
+                                &overrides.individual_override_path,
                                 &component_data,
                                 instance_key,
                             );
@@ -214,7 +214,7 @@ pub fn add_new_override(
                     }
                     // If we don't have an override_path we can't set up an initial override
                     // this shouldn't happen if the `DataResult` is valid.
-                    let Some(override_path) = data_result.override_path() else {
+                    let Some(override_path) = data_result.individual_override_path() else {
                         if cfg!(debug_assertions) {
                             re_log::error!("No override path for: {}", component);
                         }
@@ -327,14 +327,14 @@ pub fn override_visualizer_ui(
         let query_result = ctx.lookup_query_result(space_view.query_id());
         let Some(data_result) = query_result
             .tree
-            .lookup_result_by_path_and_group(entity_path, false)
+            .lookup_result_by_path(entity_path)
             .cloned()
         else {
             ui.label(ctx.re_ui.error_text("Entity not found in view."));
             return;
         };
 
-        let Some(override_path) = data_result.override_path() else {
+        let Some(override_path) = data_result.individual_override_path() else {
             if cfg!(debug_assertions) {
                 re_log::error!("No override path for entity: {}", data_result.entity_path);
             }
@@ -402,7 +402,7 @@ pub fn add_new_visualizer(
 ) {
     // If we don't have an override_path we can't set up an initial override
     // this shouldn't happen if the `DataResult` is valid.
-    let Some(override_path) = data_result.override_path() else {
+    let Some(override_path) = data_result.individual_override_path() else {
         if cfg!(debug_assertions) {
             re_log::error!("No override path for entity: {}", data_result.entity_path);
         }

--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -191,7 +191,6 @@ fn item_to_string(blueprint: &ViewportBlueprint, item: &Item) -> String {
             }
         }
         Item::InstancePath(_, entity_path) => entity_path.to_string(),
-        Item::DataBlueprintGroup(_sid, _qid, entity_path) => entity_path.to_string(),
         Item::ComponentPath(path) => {
             format!("{}:{}", path.entity_path, path.component_name.short_name(),)
         }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -907,7 +907,7 @@ fn blueprint_ui_for_space_view(
                 &mut props,
             );
 
-        root_data_result.save_override(Some(props), ctx);
+        root_data_result.save_recursive_override(Some(props), ctx);
     }
 }
 
@@ -924,12 +924,11 @@ fn blueprint_ui_for_instance_path(
                 // splat - the whole entity
                 let space_view_class = *space_view.class_identifier();
                 let entity_path = &instance_path.entity_path;
-                let as_group = false;
 
                 let query_result = ctx.lookup_query_result(space_view.query_id());
                 if let Some(data_result) = query_result
                     .tree
-                    .lookup_result_by_path_and_group(entity_path, as_group)
+                    .lookup_result_by_path(entity_path)
                     .cloned()
                 {
                     let mut props = data_result
@@ -944,7 +943,7 @@ fn blueprint_ui_for_instance_path(
                         &mut props,
                         data_result.accumulated_properties(),
                     );
-                    data_result.save_override(Some(props), ctx);
+                    data_result.save_recursive_override(Some(props), ctx);
                 }
             }
         }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -881,10 +881,7 @@ fn blueprint_ui_for_space_view(
         // Space View don't inherit properties.
         let root_data_result = space_view.root_data_result(ctx.store_context, ctx.blueprint_query);
 
-        let mut props = root_data_result
-            .individual_properties()
-            .cloned()
-            .unwrap_or_default();
+        let mut props = root_data_result.accumulated_properties().clone();
 
         visible_history_ui(
             ctx,
@@ -931,10 +928,7 @@ fn blueprint_ui_for_instance_path(
                     .lookup_result_by_path(entity_path)
                     .cloned()
                 {
-                    let mut props = data_result
-                        .individual_properties()
-                        .cloned()
-                        .unwrap_or_default();
+                    let mut props = data_result.accumulated_properties().clone();
                     entity_props_ui(
                         ctx,
                         ui,

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -881,7 +881,10 @@ fn blueprint_ui_for_space_view(
         // Space View don't inherit properties.
         let root_data_result = space_view.root_data_result(ctx.store_context, ctx.blueprint_query);
 
-        let mut props = root_data_result.accumulated_properties().clone();
+        let mut props = root_data_result
+            .individual_properties()
+            .cloned()
+            .unwrap_or_default();
 
         visible_history_ui(
             ctx,
@@ -904,7 +907,7 @@ fn blueprint_ui_for_space_view(
                 &mut props,
             );
 
-        root_data_result.save_recursive_override(Some(props), ctx);
+        root_data_result.save_individual_override(Some(props), ctx);
     }
 }
 
@@ -928,7 +931,11 @@ fn blueprint_ui_for_instance_path(
                     .lookup_result_by_path(entity_path)
                     .cloned()
                 {
-                    let mut props = data_result.accumulated_properties().clone();
+                    let mut props = data_result
+                        .individual_properties()
+                        .cloned()
+                        .unwrap_or_default();
+
                     entity_props_ui(
                         ctx,
                         ui,
@@ -937,7 +944,7 @@ fn blueprint_ui_for_instance_path(
                         &mut props,
                         data_result.accumulated_properties(),
                     );
-                    data_result.save_recursive_override(Some(props), ctx);
+                    data_result.save_individual_override(Some(props), ctx);
                 }
             }
         }

--- a/crates/re_viewer_context/src/item.rs
+++ b/crates/re_viewer_context/src/item.rs
@@ -1,7 +1,7 @@
 use re_entity_db::InstancePath;
 use re_log_types::{ComponentPath, DataPath, EntityPath};
 
-use crate::{ContainerId, DataQueryId, SpaceViewId};
+use crate::{ContainerId, SpaceViewId};
 
 /// One "thing" in the UI.
 ///
@@ -13,7 +13,6 @@ pub enum Item {
     ComponentPath(ComponentPath),
     SpaceView(SpaceViewId),
     InstancePath(Option<SpaceViewId>, InstancePath),
-    DataBlueprintGroup(SpaceViewId, DataQueryId, EntityPath),
     Container(ContainerId),
 }
 
@@ -23,7 +22,6 @@ impl Item {
             Item::ComponentPath(component_path) => Some(&component_path.entity_path),
             Item::SpaceView(_) | Item::Container(_) | Item::StoreId(_) => None,
             Item::InstancePath(_, instance_path) => Some(&instance_path.entity_path),
-            Item::DataBlueprintGroup(_, _, entity_path) => Some(entity_path),
         }
     }
 }
@@ -96,9 +94,6 @@ impl std::fmt::Debug for Item {
             Item::ComponentPath(s) => s.fmt(f),
             Item::SpaceView(s) => write!(f, "{s:?}"),
             Item::InstancePath(sid, path) => write!(f, "({sid:?}, {path})"),
-            Item::DataBlueprintGroup(sid, qid, entity_path) => {
-                write!(f, "({sid:?}, {qid:?}, {entity_path:?})")
-            }
             Item::Container(tile_id) => write!(f, "(tile: {tile_id:?})"),
         }
     }
@@ -124,7 +119,6 @@ impl Item {
             }
             Item::ComponentPath(_) => "Entity Component",
             Item::SpaceView(_) => "Space View",
-            Item::DataBlueprintGroup(_, _, _) => "Group",
             Item::Container(_) => "Container",
         }
     }
@@ -142,11 +136,9 @@ pub fn resolve_mono_instance_path_item(
             *space_view,
             resolve_mono_instance_path(query, store, instance),
         ),
-        Item::StoreId(_)
-        | Item::ComponentPath(_)
-        | Item::SpaceView(_)
-        | Item::DataBlueprintGroup(_, _, _)
-        | Item::Container(_) => item.clone(),
+        Item::StoreId(_) | Item::ComponentPath(_) | Item::SpaceView(_) | Item::Container(_) => {
+            item.clone()
+        }
     }
 }
 

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -74,11 +74,6 @@ pub mod external {
 
 // ---------------------------------------------------------------------------
 
-slotmap::new_key_type! {
-    /// Identifier for a blueprint group.
-    pub struct DataBlueprintGroupHandle;
-}
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum NeedsRepaint {
     Yes,

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -321,16 +321,10 @@ impl ApplicationSelectionState {
             .hovered_previous_frame
             .iter_items()
             .any(|current| match current {
-                Item::StoreId(_)
-                | Item::SpaceView(_)
-                | Item::DataBlueprintGroup(_, _, _)
-                | Item::Container(_) => current == test,
+                Item::StoreId(_) | Item::SpaceView(_) | Item::Container(_) => current == test,
 
                 Item::ComponentPath(component_path) => match test {
-                    Item::StoreId(_)
-                    | Item::SpaceView(_)
-                    | Item::DataBlueprintGroup(_, _, _)
-                    | Item::Container(_) => false,
+                    Item::StoreId(_) | Item::SpaceView(_) | Item::Container(_) => false,
 
                     Item::ComponentPath(test_component_path) => {
                         test_component_path == component_path

--- a/crates/re_viewer_context/src/space_view/view_query.rs
+++ b/crates/re_viewer_context/src/space_view/view_query.rs
@@ -30,10 +30,12 @@ pub struct PropertyOverrides {
     // TODO(jleibs): Consider something like `tinymap` for this.
     pub component_overrides: HashMap<ComponentName, (StoreKind, EntityPath)>,
 
-    /// `EntityPath` in the Blueprint store where updated overrides should be written back for properties that apply recursively.
+    /// `EntityPath` in the Blueprint store where updated overrides should be written back\
+    /// for properties that apply recursively.
     pub recursive_override_path: EntityPath,
 
-    /// `EntityPath` in the Blueprint store where updated overrides should be written back for properties that apply recursively.
+    /// `EntityPath` in the Blueprint store where updated overrides should be written back
+    /// for properties that apply to the individual entity only.
     pub individual_override_path: EntityPath,
 }
 
@@ -91,7 +93,7 @@ impl DataResult {
     /// TODO(andreas): This does NOT handle the case when individual properties need clearing to achieve the desired property result.
     pub fn save_recursive_override(
         &self,
-        props: Option<EntityProperties>,
+        new_accumulated_props: Option<EntityProperties>,
         ctx: &ViewerContext<'_>,
     ) {
         // TODO(jleibs): Make it impossible for this to happen with different type structure
@@ -110,7 +112,7 @@ impl DataResult {
             return;
         };
 
-        let cell = match props {
+        let cell = match new_accumulated_props {
             None => {
                 re_log::debug!("Clearing {:?}", override_path);
 

--- a/crates/re_viewport/src/space_view_highlights.rs
+++ b/crates/re_viewport/src/space_view_highlights.rs
@@ -33,36 +33,6 @@ pub fn highlights_for_space_view(
         match current_selection {
             Item::StoreId(_) | Item::SpaceView(_) | Item::Container(_) => {}
 
-            Item::DataBlueprintGroup(group_space_view_id, query_id, group_entity_path) => {
-                // Unlike for selected objects/data we are more picky for data blueprints with our hover highlights
-                // since they are truly local to a space view.
-                if *group_space_view_id == space_view_id {
-                    // Everything in the same group should receive the same selection outline.
-                    // (Due to the way outline masks work in re_renderer, we can't leave the hover channel empty)
-                    let selection_mask = next_selection_mask();
-
-                    let query_result = ctx.lookup_query_result(*query_id).clone();
-
-                    query_result
-                        .tree
-                        .visit_group(group_entity_path, &mut |handle| {
-                            if let Some(result) = query_result.tree.lookup_result(handle) {
-                                let entity_hash = result.entity_path.hash();
-                                let instance = result.entity_path.clone().into();
-
-                                highlighted_entity_paths
-                                    .entry(entity_hash)
-                                    .or_default()
-                                    .add_selection(&instance, SelectionHighlight::SiblingSelection);
-                                outlines_masks
-                                    .entry(entity_hash)
-                                    .or_default()
-                                    .add(&instance, selection_mask);
-                            }
-                        });
-                }
-            }
-
             Item::ComponentPath(component_path) => {
                 let entity_hash = component_path.entity_path.hash();
                 let instance = component_path.entity_path.clone().into();
@@ -107,33 +77,6 @@ pub fn highlights_for_space_view(
     for current_hover in ctx.selection_state().hovered().iter_items() {
         match current_hover {
             Item::StoreId(_) | Item::SpaceView(_) | Item::Container(_) => {}
-
-            Item::DataBlueprintGroup(group_space_view_id, query_id, group_entity_path) => {
-                // Unlike for selected objects/data we are more picky for data blueprints with our hover highlights
-                // since they are truly local to a space view.
-                if *group_space_view_id == space_view_id {
-                    // Everything in the same group should receive the same hover outline.
-                    let hover_mask = next_hover_mask();
-
-                    let query_result = ctx.lookup_query_result(*query_id).clone();
-
-                    query_result
-                        .tree
-                        .visit_group(group_entity_path, &mut |handle| {
-                            if let Some(result) = query_result.tree.lookup_result(handle) {
-                                let instance = result.entity_path.clone().into();
-                                highlighted_entity_paths
-                                    .entry(result.entity_path.hash())
-                                    .or_default()
-                                    .add_hover(&instance, HoverHighlight::Hovered);
-                                outlines_masks
-                                    .entry(result.entity_path.hash())
-                                    .or_default()
-                                    .add(&instance, hover_mask);
-                            }
-                        });
-                }
-            }
 
             Item::ComponentPath(component_path) => {
                 let entity_hash = component_path.entity_path.hash();

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -267,10 +267,6 @@ impl ViewportBlueprint {
                 .map(|space_view_id| self.space_view(&space_view_id).is_some())
                 .unwrap_or(true),
             Item::SpaceView(space_view_id) => self.space_view(space_view_id).is_some(),
-            Item::DataBlueprintGroup(space_view_id, query_id, _entity_path) => self
-                .space_views
-                .get(space_view_id)
-                .map_or(false, |sv| sv.queries.iter().any(|q| q.id == *query_id)),
             Item::Container(container_id) => self.container(container_id).is_some(),
         }
     }

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -618,11 +618,7 @@ impl ViewportBlueprint {
             .iter()
             .filter_map(|(space_view_id, space_view)| {
                 let query_result = ctx.lookup_query_result(space_view.query_id());
-                if query_result
-                    .tree
-                    .lookup_result_by_path_and_group(path, false)
-                    .is_some()
-                {
+                if query_result.tree.lookup_result_by_path(path).is_some() {
                     Some(*space_view_id)
                 } else {
                     None

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -317,15 +317,10 @@ impl Viewport<'_, '_> {
             let data_result = &child_node.data_result;
             let entity_path = &child_node.data_result.entity_path;
 
-            let item = if data_result.is_group {
-                // If we can't find a group_handle for some reason, use the default, null handle.
-                Item::DataBlueprintGroup(space_view.id, query_result.id, entity_path.clone())
-            } else {
-                Item::InstancePath(
-                    Some(space_view.id),
-                    InstancePath::entity_splat(entity_path.clone()),
-                )
-            };
+            let item = Item::InstancePath(
+                Some(space_view.id),
+                InstancePath::entity_splat(entity_path.clone()),
+            );
 
             let is_selected = ctx.selection().contains_item(&item);
 


### PR DESCRIPTION
### What

* Fixes  #4441

Ui changes were almost trivial, all the devil in the details is which exact property overrides are shown and edited where, mostly by virtue of that never showing up because of groups

Today, we have two kinds of overrides: `individual` & `recursive` which together get `accumulated`. The rule for `accumulated` is to combine for each entity all of it's parent `recursive` item with its single local `individual` one. Note that combination rules are a bit strange at times and have no concept of "this was not edited", e.g. a thing is visible if both parties are visible with no regard to whether any of the sources has actually been set (no tri-state as would be mandated by upcoming property overrides!)

Before, any edit on a group edited `recursive` and any edit on an entity path edited `individual`. Easy!
**Now** we'd arguably always like to edit `recursive` but if we were not to show `accumulated` things get extremely messy as you're not editing what you see.
So instead for now I went the path that visibility edits on the blueprint panel edit `recursive` and indicate `accumulated` visibility by greying out - the eye icons however are strictly following `recursive`. Everything on the selection panel both shows and edits `individual`.
This way we don't run into strange cases where looking at a thing gives us edits (like showing `accumulated` but editing something else would cause continuous edits without effect!) but it's overall a pretty bad scheme.

@abey79 and me discussed this situation for a bit and concluded what we'll have to embrace the null-state (often less correct dubbed tri-state: null, visible, invisible) given by component overrides one way or the other, especially to support cases like having visible objects with a parent that inherits invisible otherwise. While there's still many open questions, I believe that we should have null-states everywhere with a simple inheritance scheme of "inherit until non-null is found". The elegance in that is that "accumulated == override if override set" - to cement that I'd propose to drop `individual` for the forseeable future.
The tricky thing with this is that each ui element needs to present "not set" in some way and allow to reset it.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5326/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5326/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5326/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5326)
- [Docs preview](https://rerun.io/preview/f47b335da2320d5bc807c222b26c42f3c3f11a02/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f47b335da2320d5bc807c222b26c42f3c3f11a02/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)