### PR TITLE
SDK `DataLoader`s 1: barebones Rust support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2968,6 +2968,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "log_file"
+version = "0.14.0-alpha.2"
+dependencies = [
+ "anyhow",
+ "clap",
+ "glam",
+ "rerun",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3952,15 +3962,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0"
+checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset 0.9.0",
  "parking_lot",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -3969,9 +3980,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be"
+checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -3979,9 +3990,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1"
+checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3989,9 +4000,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3"
+checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -4001,12 +4012,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f"
+checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn 2.0.48",
 ]
@@ -6144,9 +6156,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.13"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4616,6 +4616,7 @@ dependencies = [
  "rand",
  "re_build_info",
  "re_build_tools",
+ "re_data_source",
  "re_data_store",
  "re_log",
  "re_log_encoding",

--- a/crates/re_data_source/src/load_file.rs
+++ b/crates/re_data_source/src/load_file.rs
@@ -27,7 +27,7 @@ pub fn load_from_path(
     if !path.exists() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
-            "path does not exist: {path:?}",
+            format!("path does not exist: {path:?}"),
         )
         .into());
     }

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -312,6 +312,7 @@ pub enum FileSource {
     Cli,
     DragAndDrop,
     FileDialog,
+    Sdk,
 }
 
 /// The source of a recording or blueprint.
@@ -358,6 +359,7 @@ impl std::fmt::Display for StoreSource {
                 FileSource::Cli => write!(f, "File via CLI"),
                 FileSource::DragAndDrop => write!(f, "File via drag-and-drop"),
                 FileSource::FileDialog => write!(f, "File via file dialog"),
+                FileSource::Sdk => write!(f, "File via SDK"),
             },
             Self::Viewer => write!(f, "Viewer-generated"),
             Self::Other(string) => format!("{string:?}").fmt(f), // put it in quotes

--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -31,7 +31,6 @@ default = []
 ## However, when building from source in the repository, this feature adds quite a bit
 ## to the compile time since it requires compiling and bundling the viewer as wasm.
 web_viewer = [
-  "dep:re_smart_channel",
   "dep:re_web_viewer_server",
   "dep:re_ws_comms",
   "dep:anyhow",
@@ -42,11 +41,13 @@ web_viewer = [
 
 [dependencies]
 re_build_info.workspace = true
+re_data_source.workspace = true
 re_log_encoding = { workspace = true, features = ["encoder"] }
 re_log_types.workspace = true
 re_log.workspace = true
 re_memory.workspace = true
 re_sdk_comms = { workspace = true, features = ["client"] }
+re_smart_channel.workspace = true
 re_types_core.workspace = true
 
 ahash.workspace = true
@@ -58,7 +59,6 @@ thiserror.workspace = true
 
 # Optional dependencies
 
-re_smart_channel = { workspace = true, optional = true }
 re_ws_comms = { workspace = true, optional = true }
 re_web_viewer_server = { workspace = true, optional = true }
 

--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -21,6 +21,12 @@ all-features = true
 [features]
 default = []
 
+## Support for using Rerun's data-loaders directly from the SDK.
+##
+## See our `log_file` example and <https://www.rerun.io/docs/howto/open-any-file>
+## for more information.
+data_loaders = ["dep:re_data_source", "dep:re_smart_channel"]
+
 ## Support serving a web viewer over HTTP.
 ##
 ## Enabling this inflates the binary size quite a bit, since it embeds the viewer wasm.
@@ -31,6 +37,7 @@ default = []
 ## However, when building from source in the repository, this feature adds quite a bit
 ## to the compile time since it requires compiling and bundling the viewer as wasm.
 web_viewer = [
+  "dep:re_smart_channel",
   "dep:re_web_viewer_server",
   "dep:re_ws_comms",
   "dep:anyhow",
@@ -41,13 +48,11 @@ web_viewer = [
 
 [dependencies]
 re_build_info.workspace = true
-re_data_source.workspace = true
 re_log_encoding = { workspace = true, features = ["encoder"] }
 re_log_types.workspace = true
 re_log.workspace = true
 re_memory.workspace = true
 re_sdk_comms = { workspace = true, features = ["client"] }
-re_smart_channel.workspace = true
 re_types_core.workspace = true
 
 ahash.workspace = true
@@ -59,6 +64,8 @@ thiserror.workspace = true
 
 # Optional dependencies
 
+re_data_source = { workspace = true, optional = true }
+re_smart_channel = { workspace = true, optional = true }
 re_ws_comms = { workspace = true, optional = true }
 re_web_viewer_server = { workspace = true, optional = true }
 

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -81,7 +81,8 @@ pub enum RecordingStreamError {
     #[error(transparent)]
     DataReadError(#[from] re_log_types::DataReadError),
 
-    /// An error occurred when attempting to used a [`re_data_source::DataLoader`].
+    /// An error occurred while attempting to use a [`re_data_source::DataLoader`].
+    #[cfg(feature = "data_loaders")]
     #[error(transparent)]
     DataLoaderError(#[from] re_data_source::DataLoaderError),
 }
@@ -1023,6 +1024,7 @@ impl RecordingStream {
     /// streaming data in or all of them fail.
     ///
     /// See <https://www.rerun.io/docs/howto/open-any-file> for more information.
+    #[cfg(feature = "data_loaders")]
     pub fn log_file_from_path(
         &self,
         filepath: impl AsRef<std::path::Path>,
@@ -1038,6 +1040,7 @@ impl RecordingStream {
     /// streaming data in or all of them fail.
     ///
     /// See <https://www.rerun.io/docs/howto/open-any-file> for more information.
+    #[cfg(feature = "data_loaders")]
     pub fn log_file_from_contents(
         &self,
         filepath: impl AsRef<std::path::Path>,
@@ -1046,6 +1049,7 @@ impl RecordingStream {
         self.log_file(filepath, Some(contents))
     }
 
+    #[cfg(feature = "data_loaders")]
     fn log_file(
         &self,
         filepath: impl AsRef<std::path::Path>,

--- a/crates/re_viewer/src/viewer_analytics/event.rs
+++ b/crates/re_viewer/src/viewer_analytics/event.rs
@@ -66,6 +66,7 @@ pub fn open_recording(
                 re_log_types::FileSource::Cli => "file_cli".to_owned(),
                 re_log_types::FileSource::DragAndDrop => "file_drag_and_drop".to_owned(),
                 re_log_types::FileSource::FileDialog => "file_dialog".to_owned(),
+                re_log_types::FileSource::Sdk => "file_sdk".to_owned(),
             },
             S::Viewer => "viewer".to_owned(),
             S::Other(other) => other.clone(),

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -20,7 +20,7 @@ targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 
 [features]
-default = ["analytics", "demo", "glam", "image", "log", "sdk", "server"]
+default = ["analytics", "data_loaders", "demo", "glam", "image", "log", "sdk", "server"]
 
 ## Enable telemetry using our analytics SDK.
 analytics = [
@@ -32,6 +32,12 @@ analytics = [
 
 ## Integration with `clap`.
 clap = ["dep:clap", "dep:tokio"]
+
+## Support for using Rerun's data-loaders directly from the SDK.
+##
+## See our `log_file` example and <https://www.rerun.io/docs/howto/open-any-file>
+## for more information.
+data_loaders = ["re_sdk?/data_loaders"]
 
 ## Demo helpers for examples.
 demo = []

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -20,7 +20,16 @@ targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 
 [features]
-default = ["analytics", "data_loaders", "demo", "glam", "image", "log", "sdk", "server"]
+default = [
+  "analytics",
+  "data_loaders",
+  "demo",
+  "glam",
+  "image",
+  "log",
+  "sdk",
+  "server",
+]
 
 ## Enable telemetry using our analytics SDK.
 analytics = [

--- a/examples/rust/log_file/Cargo.toml
+++ b/examples/rust/log_file/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "log_file"
+version = "0.14.0-alpha.2"
+edition = "2021"
+rust-version = "1.74"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+rerun = { path = "../../../crates/rerun", features = ["web_viewer", "clap"] }
+
+anyhow = "1.0"
+clap = { version = "4.0", features = ["derive"] }
+glam = "0.22"

--- a/examples/rust/log_file/README.md
+++ b/examples/rust/log_file/README.md
@@ -1,0 +1,10 @@
+<!--[metadata]
+title = "Log file example"
+-->
+
+Demonstrates how to log any file from the SDK using the [`DataLoader`](https://www.rerun.io/docs/howto/open-any-file) machinery.
+
+Usage:
+```bash
+cargo run -p log_file -- examples/assets
+```

--- a/examples/rust/log_file/src/main.rs
+++ b/examples/rust/log_file/src/main.rs
@@ -1,0 +1,59 @@
+//! Demonstrates how to log any file from the SDK using the `DataLoader` machinery.
+//!
+//! See <https://www.rerun.io/docs/howto/open-any-file> for more information.
+//!
+//! Usage:
+//! ```
+//! cargo run -p log_file -- examples/assets
+//! ```
+
+use rerun::external::re_log;
+
+#[derive(Debug, clap::Parser)]
+#[clap(author, version, about)]
+struct Args {
+    #[command(flatten)]
+    rerun: rerun::clap::RerunArgs,
+
+    // Log the contents of the file directly (files only -- not supported by external loaders).
+    #[clap(long, default_value = "false")]
+    from_contents: bool,
+
+    /// The filepaths to be loaded and logged.
+    filepaths: Vec<std::path::PathBuf>,
+}
+
+fn main() -> anyhow::Result<()> {
+    re_log::setup_logging();
+
+    use clap::Parser as _;
+    let args = Args::parse();
+
+    let (rec, _serve_guard) = args.rerun.init("rerun_example_log_file")?;
+    run(&rec, &args)?;
+
+    Ok(())
+}
+
+fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
+    for filepath in &args.filepaths {
+        let filepath = filepath.as_path();
+
+        if !args.from_contents {
+            // Either log the file using its path…
+            rec.log_file_from_path(filepath)?;
+        } else {
+            // …or using its contents if you already have them loaded for some reason.
+            if filepath.is_file() {
+                let contents = std::fs::read(filepath)?;
+                rec.log_file_from_contents(filepath, std::borrow::Cow::Borrowed(&contents))?;
+            }
+        }
+    }
+
+    // TODO(cmc): This is required because the way we handle RecordingStream clones in subtly
+    // broken. That's outside the scope of this PR, I'll fix this in a follow-up.
+    rec.disconnect();
+
+    Ok(())
+}


### PR DESCRIPTION
Exposes raw `DataLoader`s to the Rust SDK through 2 new methods: `RecordingStream::log_file_from_path` & `RecordingStream::log_file_from_contents`.

Everything streams asynchronously, as expected.

There's no way to configure the behavior of the `DataLoader` at all, yet. That comes next.

```rust
rec.log_file_from_path(filepath)?;
```
![image](https://github.com/rerun-io/rerun/assets/2910679/fac1514a-a00b-40c3-8950-df076080e1fc)

This highlighted some brittleness on the shutdown path, see:
- #5335 

---

Part of series of PR to expose configurable `DataLoader`s to our SDKs:
- #5327 
- #5328 
- #5330
- #5337 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5327/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5327/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5327/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5327)
- [Docs preview](https://rerun.io/preview/9e28fc9254d11f6edcde4318b5e968f283e7a985/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/9e28fc9254d11f6edcde4318b5e968f283e7a985/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)