### PR TITLE
SDK `DataLoader`s 2: barebones Python support

### DIFF
--- a/examples/python/log_file/README.md
+++ b/examples/python/log_file/README.md
@@ -1,0 +1,11 @@
+<!--[metadata]
+title = "Log file example"
+-->
+
+Demonstrates how to log any file from the SDK using the [`DataLoader`](https://www.rerun.io/docs/howto/open-any-file) machinery.
+
+Usage:
+```bash
+python examples/python/log_file/main.py examples/assets
+```
+

--- a/examples/python/log_file/main.py
+++ b/examples/python/log_file/main.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+Demonstrates how to log any file from the SDK using the `DataLoader` machinery.
+
+See <https://www.rerun.io/docs/howto/open-any-file> for more information.
+
+Usage:
+```
+python examples/python/log_file/main.py -- examples/assets
+```
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import rerun as rr  # pip install rerun-sdk
+
+parser = argparse.ArgumentParser(
+    description="Demonstrates how to log any file from the SDK using the `DataLoader` machinery."
+)
+rr.script_add_args(parser)
+parser.add_argument(
+    "--from-contents",
+    action="store_true",
+    default=False,
+    help="Log the contents of the file directly (files only -- not supported by external loaders).",
+)
+parser.add_argument("filepaths", nargs="+", type=Path, help="The filepaths to be loaded and logged.")
+args = parser.parse_args()
+
+rr.script_setup(args, "rerun_example_log_file")
+
+for filepath in args.filepaths:
+    if not args.from_contents:
+        # Either log the file using its path…
+        rr.log_file_from_path(filepath)
+    else:
+        # …or using its contents if you already have them loaded for some reason.
+        try:
+            with open(filepath, "rb") as file:
+                rr.log_file_from_contents(filepath, file.read())
+        except Exception:
+            pass
+
+rr.script_teardown(args)

--- a/examples/python/log_file/requirements.txt
+++ b/examples/python/log_file/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+rerun-sdk

--- a/examples/python/log_file/requirements.txt
+++ b/examples/python/log_file/requirements.txt
@@ -1,2 +1,1 @@
-numpy
 rerun-sdk

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -41,7 +41,13 @@ re_error.workspace = true
 re_log.workspace = true
 re_log_types.workspace = true
 re_memory.workspace = true
-rerun = { workspace = true, features = ["analytics", "data_loaders", "run", "server", "sdk"] }
+rerun = { workspace = true, features = [
+  "analytics",
+  "data_loaders",
+  "run",
+  "server",
+  "sdk",
+] }
 re_web_viewer_server = { workspace = true, optional = true }
 re_ws_comms = { workspace = true, optional = true }
 

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -41,7 +41,7 @@ re_error.workspace = true
 re_log.workspace = true
 re_log_types.workspace = true
 re_memory.workspace = true
-rerun = { workspace = true, features = ["analytics", "run", "server", "sdk"] }
+rerun = { workspace = true, features = ["analytics", "data_loaders", "run", "server", "sdk"] }
 re_web_viewer_server = { workspace = true, optional = true }
 re_ws_comms = { workspace = true, optional = true }
 

--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -94,6 +94,8 @@ SECTION_TABLE: Final[list[Section]] = [
         title="Logging functions",
         func_list=[
             "log",
+            "log_file_from_path",
+            "log_file_from_contents",
         ],
     ),
     Section(

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -77,8 +77,10 @@ __all__ = [
     "get_recording_id",
     "get_thread_local_data_recording",
     "is_enabled",
-    "log_components",
     "log",
+    "log_components",
+    "log_file_from_contents",
+    "log_file_from_path",
     "memory_recording",
     "new_entity_path",
     "reset_time",
@@ -105,6 +107,8 @@ from ._log import (
     escape_entity_path_part,
     log,
     log_components,
+    log_file_from_contents,
+    log_file_from_path,
     new_entity_path,
 )
 from .any_value import AnyValues

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -290,11 +290,11 @@ def log_file_from_path(
     recording: RecordingStream | None = None,
 ) -> None:
     r"""
-    Logs the file at the given `path` using all `re_data_source::DataLoader`s available.
+    Logs the file at the given `path` using all `DataLoader`s available.
 
     A single `path` might be handled by more than one loader.
 
-    This method blocks until either at least one `re_data_source::DataLoader` starts
+    This method blocks until either at least one `DataLoader` starts
     streaming data in or all of them fail.
 
     See <https://www.rerun.io/docs/howto/open-any-file> for more information.
@@ -322,11 +322,11 @@ def log_file_from_contents(
     recording: RecordingStream | None = None,
 ) -> None:
     r"""
-    Logs the given `file_contents` using all `crate::DataLoader`s available.
+    Logs the given `file_contents` using all `DataLoader`s available.
 
     A single `path` might be handled by more than one loader.
 
-    This method blocks until either at least one `re_data_source::DataLoader` starts
+    This method blocks until either at least one `DataLoader` starts
     streaming data in or all of them fail.
 
     See <https://www.rerun.io/docs/howto/open-any-file> for more information.

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Iterable
 
 import pyarrow as pa
@@ -280,6 +281,72 @@ def log_components(
         timeless=timeless,
         recording=recording,
     )
+
+
+@catch_and_log_exceptions()
+def log_file_from_path(
+    file_path: str | Path,
+    *,
+    recording: RecordingStream | None = None,
+) -> None:
+    r"""
+    Logs the file at the given `path` using all `re_data_source::DataLoader`s available.
+
+    A single `path` might be handled by more than one loader.
+
+    This method blocks until either at least one `re_data_source::DataLoader` starts
+    streaming data in or all of them fail.
+
+    See <https://www.rerun.io/docs/howto/open-any-file> for more information.
+
+    Parameters
+    ----------
+    file_path:
+        Path to the file to be logged.
+
+    recording:
+        Specifies the [`rerun.RecordingStream`][] to use. If left unspecified,
+        defaults to the current active data recording, if there is one. See
+        also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
+
+    """
+
+    bindings.log_file_from_path(Path(file_path), recording=recording)
+
+
+@catch_and_log_exceptions()
+def log_file_from_contents(
+    file_path: str | Path,
+    file_contents: bytes,
+    *,
+    recording: RecordingStream | None = None,
+) -> None:
+    r"""
+    Logs the given `file_contents` using all `crate::DataLoader`s available.
+
+    A single `path` might be handled by more than one loader.
+
+    This method blocks until either at least one `re_data_source::DataLoader` starts
+    streaming data in or all of them fail.
+
+    See <https://www.rerun.io/docs/howto/open-any-file> for more information.
+
+    Parameters
+    ----------
+    file_path:
+        Path to the file that the `file_contents` belong to.
+
+    file_contents:
+        Contents to be logged.
+
+    recording:
+        Specifies the [`rerun.RecordingStream`][] to use. If left unspecified,
+        defaults to the current active data recording, if there is one. See
+        also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
+
+    """
+
+    bindings.log_file_from_contents(Path(file_path), file_contents, recording=recording)
 
 
 def escape_entity_path_part(part: str) -> str:


### PR DESCRIPTION
Exposes raw `DataLoader`s to the Python SDK through 2 new methods: `RecordingStream.log_file_from_path` & `RecordingStream.log_file_from_contents`.

Everything streams asynchronously, as expected.

There's no way to configure the behavior of the `DataLoader` at all, yet. That comes next.

```python
rr.log_file_from_path(filepath)
```
![image](https://github.com/rerun-io/rerun/assets/2910679/0fe2d39c-f069-44a6-b836-e31001b3adaa)


---

Part of series of PR to expose configurable `DataLoader`s to our SDKs:
- #5327 
- #5328 
- #5330
- #5337
- #5351
- #5355

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5327/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5327/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5327/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5327)
- [Docs preview](https://rerun.io/preview/786e77f5b3a5acc818ff712bf4abc72c6b44e529/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/786e77f5b3a5acc818ff712bf4abc72c6b44e529/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)