### PR TITLE
Run C++/rust CI only on C++/rust changes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,21 @@ jobs:
     uses: ./.github/workflows/reusable_checks.yml
     with:
       CONCURRENCY: nightly
+    secrets: inherit
+
+  checks-cpp:
+    name: Checks
+    uses: ./.github/workflows/reusable_checks_cpp.yml
+    with:
+      CONCURRENCY: nightly
+      FULL: "true"
+    secrets: inherit
+
+  checks-rust:
+    name: Checks
+    uses: ./.github/workflows/reusable_checks_rust.yml
+    with:
+      CONCURRENCY: nightly
       ALL_CHECKS: true
     secrets: inherit
 

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -41,12 +41,13 @@ jobs:
 
   cpp-tests:
     name: "C++ tests"
+    if: needs.cpp-paths-filter.outputs.cpp_changes == 'true'
     # Wait for the cpp-paths-filter to be completed before starting.
     needs: cpp-paths-filter
     uses: ./.github/workflows/reusable_checks_cpp.yml
     with:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}
-      FULL: "${{ needs.cpp-paths-filter.outputs.cpp_changes }}"
+      FULL: "true"
     secrets: inherit
 
   min-wheel-build:

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -19,8 +19,23 @@ jobs:
     uses: ./.github/workflows/reusable_checks.yml
     with:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets: inherit
+
+  rust-paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      rust_changes: ${{ steps.filter.outputs.rust_changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            rust_changes:
+              - "**/*.rs"
+              - "**/*.toml"
 
   cpp-paths-filter:
     runs-on: ubuntu-latest
@@ -36,8 +51,18 @@ jobs:
           filters: |
             cpp_changes:
               - '**/*.hpp'
-              - '**/.cpp'
+              - '**/*.cpp'
               - '**/CMakeLists.txt'
+
+  rust-checks:
+    name: "Rust Checks"
+    if: github.event.pull_request.head.repo.owner.login == 'rerun-io' && needs.cpp-paths-filter.outputs.rust_changes == 'true'
+    # Wait for the rust-paths-filter to be completed before starting.
+    needs: rust-paths-filter
+    uses: ./.github/workflows/reusable_checks_rust.yml
+    with:
+      CONCURRENCY: pr-${{ github.event.pull_request.number }}
+    secrets: inherit
 
   cpp-tests:
     name: "C++ tests"

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -21,6 +21,13 @@ jobs:
       FULL: "true"
     secrets: inherit
 
+  rust_checks:
+    name: Checks
+    uses: ./.github/workflows/reusable_checks_rust.yml
+    with:
+      CONCURRENCY: push-${{ github.ref_name }}
+    secrets: inherit
+
   # Check that a CLEAN container with just `cargo` on it can build rerun:
   clean-build:
     name: cargo build on clean container

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -1,4 +1,4 @@
-name: "Checks: Lints, Tests, Docs"
+name: "General checks: Lints, Tests, Docs"
 
 on:
   workflow_call:
@@ -6,26 +6,6 @@ on:
       CONCURRENCY:
         required: true
         type: string
-      SAVE_PY_DOCS:
-        required: false
-        type: boolean
-        default: false
-      SAVE_PY_DOCS_AS:
-        required: false
-        type: string
-        default: ""
-      SAVE_RUST_DOCS:
-        required: false
-        type: boolean
-        default: false
-      PR_NUMBER:
-        required: false
-        type: string
-        default: ""
-      ALL_CHECKS:
-        required: false
-        type: boolean
-        default: false
 
 concurrency:
   group: ${{ inputs.CONCURRENCY }}-checks
@@ -154,100 +134,6 @@ jobs:
         run: |
           pixi run codegen --force --check
 
-  rs-lints:
-    name: Rust lints (fmt, check, cranky, tests, doc)
-    runs-on: ubuntu-latest-16-cores
-    container:
-      image: rerunio/ci_docker:0.11.0
-    env:
-      RUSTC_WRAPPER: "sccache"
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
-
-      - name: Set up Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          cache_key: "build-linux"
-          save_cache: true
-          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
-
-      # We need to build the web viewer for `rust_checks.py` to succeed.
-      - name: Build web-viewer (release)
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          # We build in release so that we can reuse the results for actual publishing, if necessary
-          args: --locked -p re_build_web_viewer -- --release
-
-      - name: Rust checks & tests
-        if: ${{ !inputs.ALL_CHECKS }}
-        run: ./scripts/ci/rust_checks.py --skip-check-individual-crates
-
-      - name: Rust all checks & tests
-        if: inputs.ALL_CHECKS
-        run: ./scripts/ci/rust_checks.py
-
-  # ---------------------------------------------------------------------------
-
-  rs-check-wasm:
-    name: Check Rust web build (wasm32 + wasm-bindgen)
-    runs-on: ubuntu-latest-16-cores
-    container:
-      image: rerunio/ci_docker:0.11.0
-    env:
-      RUSTC_WRAPPER: "sccache"
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
-
-      - name: Set up Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          cache_key: "build-web"
-          save_cache: true
-          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
-
-      - name: clippy check re_viewer wasm32
-        shell: bash
-        run: ./scripts/clippy_wasm.sh
-
-      - name: Check re_renderer examples wasm32
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --locked --target wasm32-unknown-unknown --target-dir target_wasm -p re_renderer --examples
-
-      - name: Build web-viewer (release)
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          # We build in release so that we can reuse the results for actual publishing, if necessary
-          args: --locked -p re_build_web_viewer -- --release
-
-  # ---------------------------------------------------------------------------
-
-  toml-lints:
-    name: Lint TOML files
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
-
-      - uses: prefix-dev/setup-pixi@v0.4.1
-        with:
-          pixi-version: v0.13.0
-
-      - name: Taplo check
-        shell: bash
-        run: |
-          pixi run lint-taplo
-
   # ---------------------------------------------------------------------------
 
   misc-rerun-lints:
@@ -309,23 +195,6 @@ jobs:
 
       - name: Check spelling of entire workspace
         uses: crate-ci/typos@v1.18.0
-
-  # ---------------------------------------------------------------------------
-
-  rs-cargo-deny:
-    name: Cargo Deny
-    runs-on: ubuntu-latest
-    container:
-      image: rerunio/ci_docker:0.11.0
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
-
-      - name: Cargo Deny
-        shell: bash
-        id: expected_version
-        run: ./scripts/ci/cargo_deny.sh
 
   # ---------------------------------------------------------------------------
 

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -329,21 +329,6 @@ jobs:
 
   # ---------------------------------------------------------------------------
 
-  cpp-formatting:
-    name: C++ formatting check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
-
-      - name: Run clang format on all relevant files
-        uses: jidicula/clang-format-action@v4.11.0
-        with:
-          clang-format-version: "16"
-          # Only check c/cpp/h/hpp (default checks also .proto and others)
-          include-regex: ^.*\.(c|cpp|h|hpp)$
-
   misc-formatting:
     name: Misc formatting
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable_checks_cpp.yml
+++ b/.github/workflows/reusable_checks_cpp.yml
@@ -91,3 +91,18 @@ jobs:
           ${{ matrix.extra_env_vars }} RERUN_WERROR=ON pixi run cpp-build-all
           ${{ matrix.extra_env_vars }} RERUN_WERROR=ON pixi run cpp-test
           ${{ matrix.additional_commands }}
+
+  cpp-formatting:
+    name: C++ formatting check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+
+      - name: Run clang format on all relevant files
+        uses: jidicula/clang-format-action@v4.11.0
+        with:
+          clang-format-version: "16"
+          # Only check c/cpp/h/hpp (default checks also .proto and others)
+          include-regex: ^.*\.(c|cpp|h|hpp)$

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -1,0 +1,147 @@
+name: "Rust & toml Checks: Lints, Tests, Docs"
+
+on:
+  workflow_call:
+    inputs:
+      CONCURRENCY:
+        required: true
+        type: string
+      ALL_CHECKS:
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ inputs.CONCURRENCY }}-checks
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.8"
+  # web_sys_unstable_apis is required to enable the web_sys clipboard API which egui_web uses
+  # https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Clipboard.html
+  # https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html
+  RUSTFLAGS: --cfg=web_sys_unstable_apis --deny warnings
+
+  # See https://github.com/ericseppanen/cargo-cranky/issues/8
+  RUSTDOCFLAGS: --deny warnings --deny rustdoc::missing_crate_level_docs
+
+  # See: https://github.com/marketplace/actions/sccache-action
+  SCCACHE_GHA_ENABLED: "false"
+
+permissions:
+  contents: "read"
+  id-token: "write"
+
+jobs:
+  # ---------------------------------------------------------------------------
+
+  rs-lints:
+    name: Rust lints (fmt, check, cranky, tests, doc)
+    runs-on: ubuntu-latest-16-cores
+    container:
+      image: rerunio/ci_docker:0.11.0
+    env:
+      RUSTC_WRAPPER: "sccache"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache_key: "build-linux"
+          save_cache: true
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+
+      # We need to build the web viewer for `rust_checks.py` to succeed.
+      - name: Build web-viewer (release)
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          # We build in release so that we can reuse the results for actual publishing, if necessary
+          args: --locked -p re_build_web_viewer -- --release
+
+      - name: Rust checks & tests
+        if: ${{ !inputs.ALL_CHECKS }}
+        run: ./scripts/ci/rust_checks.py --skip-check-individual-crates
+
+      - name: Rust all checks & tests
+        if: inputs.ALL_CHECKS
+        run: ./scripts/ci/rust_checks.py
+
+  # ---------------------------------------------------------------------------
+
+  rs-check-wasm:
+    name: Check Rust web build (wasm32 + wasm-bindgen)
+    runs-on: ubuntu-latest-16-cores
+    container:
+      image: rerunio/ci_docker:0.11.0
+    env:
+      RUSTC_WRAPPER: "sccache"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache_key: "build-web"
+          save_cache: true
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+
+      - name: clippy check re_viewer wasm32
+        shell: bash
+        run: ./scripts/clippy_wasm.sh
+
+      - name: Check re_renderer examples wasm32
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --locked --target wasm32-unknown-unknown --target-dir target_wasm -p re_renderer --examples
+
+      - name: Build web-viewer (release)
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          # We build in release so that we can reuse the results for actual publishing, if necessary
+          args: --locked -p re_build_web_viewer -- --release
+
+  # ---------------------------------------------------------------------------
+
+  toml-lints:
+    name: Lint TOML files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+
+      - uses: prefix-dev/setup-pixi@v0.4.1
+        with:
+          pixi-version: v0.13.0
+
+      - name: Taplo check
+        shell: bash
+        run: |
+          pixi run lint-taplo
+
+  # ---------------------------------------------------------------------------
+
+  rs-cargo-deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    container:
+      image: rerunio/ci_docker:0.11.0
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+
+      - name: Cargo Deny
+        shell: bash
+        id: expected_version
+        run: ./scripts/ci/cargo_deny.sh


### PR DESCRIPTION
### What

* Part of #5332

C++ had some of this already but this PR makes it more aggressive:
* don't run _any_ cpp checks if no cpp file was touched
* move C++ formatting checks to the cpp check workflow
* split out rust checks and for PRs only run them when rust or toml files were touched

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5333/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5333/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5333/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5333)
- [Docs preview](https://rerun.io/preview/ee71a7da27fbc49f343046003bcdb75e91ef5f9a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ee71a7da27fbc49f343046003bcdb75e91ef5f9a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)