### PR TITLE
Fix broken doctests

### DIFF
--- a/crates/re_space_view_time_series/src/util.rs
+++ b/crates/re_space_view_time_series/src/util.rs
@@ -287,7 +287,7 @@ fn add_series_runs(
 /// The identity `x.next_up() == -(-x).next_down()` holds for all non-NaN `x`. When `x`
 /// is finite `x == x.next_up().next_down()` also holds.
 ///
-/// ```rust
+/// ```ignore
 /// #![feature(float_next_up_down)]
 /// // f64::EPSILON is the difference between 1.0 and the next number up.
 /// assert_eq!(1.0f64.next_up(), 1.0 + f64::EPSILON);

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -202,7 +202,6 @@ use camino::{Utf8Path, Utf8PathBuf};
 /// - `include_dir_path`: path to the root directory of the fbs definition tree.
 /// - `output_dir_path`: output directory, where the binary schemas will be stored.
 /// - `entrypoint_path`: path to the root file of the fbs definition tree.
-/// ```
 pub fn compile_binary_schemas(
     include_dir_path: impl AsRef<Utf8Path>,
     output_dir_path: impl AsRef<Utf8Path>,
@@ -426,7 +425,6 @@ fn generate_code(
 /// Panics on error.
 ///
 /// - `output_path`: path to the root of the output.
-/// ```
 pub fn generate_cpp_code(
     reporter: &Reporter,
     output_path: impl AsRef<Utf8Path>,
@@ -460,7 +458,6 @@ pub fn generate_cpp_code(
 /// If `check` is true, this will run a comparison check instead of writing files to disk.
 ///
 /// Panics on error.
-/// ```
 pub fn generate_rust_code(
     reporter: &Reporter,
     workspace_path: impl Into<Utf8PathBuf>,
@@ -491,7 +488,6 @@ pub fn generate_rust_code(
 /// Panics on error.
 ///
 /// - `output_pkg_path`: path to the root of the output package.
-/// ```
 pub fn generate_python_code(
     reporter: &Reporter,
     output_pkg_path: impl AsRef<Utf8Path>,

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -202,14 +202,6 @@ use camino::{Utf8Path, Utf8PathBuf};
 /// - `include_dir_path`: path to the root directory of the fbs definition tree.
 /// - `output_dir_path`: output directory, where the binary schemas will be stored.
 /// - `entrypoint_path`: path to the root file of the fbs definition tree.
-///
-/// E.g.:
-/// ```no_run
-/// re_types_builder::compile_binary_schemas(
-///     "definitions/",
-///     "out/",
-///     "definitions/rerun/archetypes.fbs",
-/// );
 /// ```
 pub fn compile_binary_schemas(
     include_dir_path: impl AsRef<Utf8Path>,
@@ -434,22 +426,6 @@ fn generate_code(
 /// Panics on error.
 ///
 /// - `output_path`: path to the root of the output.
-///
-/// E.g.:
-/// ```no_run
-/// let (objects, arrow_registry) = re_types_builder::generate_lang_agnostic(
-///     "./definitions",
-///     "./definitions/rerun/archetypes.fbs",
-/// );
-/// # let reporter = re_types_builder::report::init().1;
-/// # let check = false;
-/// re_types_builder::generate_cpp_code(
-///     &reporter,
-///     ".",
-///     &objects,
-///     &arrow_registry,
-///     check,
-/// );
 /// ```
 pub fn generate_cpp_code(
     reporter: &Reporter,
@@ -484,22 +460,6 @@ pub fn generate_cpp_code(
 /// If `check` is true, this will run a comparison check instead of writing files to disk.
 ///
 /// Panics on error.
-///
-/// E.g.:
-/// ```no_run
-/// let (objects, arrow_registry) = re_types_builder::generate_lang_agnostic(
-///     "./definitions",
-///     "./definitions/rerun/archetypes.fbs",
-/// );
-/// # let reporter = re_types_builder::report::init().1;
-/// # let check = false;
-/// re_types_builder::generate_rust_code(
-///     &reporter,
-///     ".",
-///     &objects,
-///     &arrow_registry,
-///     check,
-/// );
 /// ```
 pub fn generate_rust_code(
     reporter: &Reporter,
@@ -531,23 +491,6 @@ pub fn generate_rust_code(
 /// Panics on error.
 ///
 /// - `output_pkg_path`: path to the root of the output package.
-///
-/// E.g.:
-/// ```no_run
-/// let (objects, arrow_registry) = re_types_builder::generate_lang_agnostic(
-///     "./definitions",
-///     "./definitions/rerun/archetypes.fbs",
-/// );
-/// # let reporter = re_types_builder::report::init().1;
-/// # let check = false;
-/// re_types_builder::generate_python_code(
-///     &reporter,
-///     "./rerun_py/rerun_sdk",
-///     "./rerun_py/tests",
-///     &objects,
-///     &arrow_registry,
-///     check,
-/// );
 /// ```
 pub fn generate_python_code(
     reporter: &Reporter,


### PR DESCRIPTION
`cargo test --quiet --doc --all-features` was failing locally (does this not run on CI? I guess that's for the best...).

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5339/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5339/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5339/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5339)
- [Docs preview](https://rerun.io/preview/5baa53a7bf26940244ed79a33c777237b325e68b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5baa53a7bf26940244ed79a33c777237b325e68b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)