### PR TITLE
Fix `ListItem` indentation so icons are properly aligned

### DIFF
--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -848,7 +848,8 @@ impl ReUi {
     ///
     /// See [`ReUi::paint_collapsing_triangle`] for actually drawing the triangle.
     pub fn collapsing_triangle_size() -> egui::Vec2 {
-        egui::Vec2::splat(8.0)
+        // Required for the hierarchical lists to appear less busy by virtue of a better alignment
+        Self::small_icon_size()
     }
 
     /// Paint a collapsing triangle with rounded corners.
@@ -862,7 +863,7 @@ impl ReUi {
     ) {
         let visuals = ui.style().interact(response);
 
-        let extent = rect.size().min_elem();
+        static TRIANGLE_SIZE: f32 = 8.0;
 
         // Normalized in [0, 1]^2 space.
         // Note on how these coords have been computed: https://github.com/rerun-io/rerun/pull/2920
@@ -885,7 +886,7 @@ impl ReUi {
         use std::f32::consts::TAU;
         let rotation = Rot2::from_angle(egui::remap(openness, 0.0..=1.0, 0.0..=TAU / 4.0));
         for p in &mut points {
-            *p = rect.center() + rotation * (*p - pos2(0.5, 0.5)) * extent;
+            *p = rect.center() + rotation * (*p - pos2(0.5, 0.5)) * TRIANGLE_SIZE;
         }
 
         ui.painter().add(Shape::convex_polygon(

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -337,7 +337,7 @@ impl<'a> ListItem<'a> {
 
     fn ui(mut self, ui: &mut Ui, id: Option<egui::Id>) -> ListItemResponse {
         let collapse_extra = if self.collapse_openness.is_some() {
-            ReUi::collapsing_triangle_size().x + ReUi::text_to_icon_padding()
+            ReUi::collapsing_triangle_area().x + ReUi::text_to_icon_padding()
         } else {
             0.0
         };
@@ -439,16 +439,21 @@ impl<'a> ListItem<'a> {
             if let Some(openness) = self.collapse_openness {
                 let triangle_pos = ui.painter().round_pos_to_pixels(egui::pos2(
                     rect.min.x,
-                    rect.center().y - 0.5 * ReUi::collapsing_triangle_size().y,
+                    rect.center().y - 0.5 * ReUi::collapsing_triangle_area().y,
                 ));
                 let triangle_rect =
-                    egui::Rect::from_min_size(triangle_pos, ReUi::collapsing_triangle_size());
+                    egui::Rect::from_min_size(triangle_pos, ReUi::collapsing_triangle_area());
                 let triangle_response = ui.interact(
                     triangle_rect.expand(3.0), // make it easier to click
                     id.unwrap_or(ui.id()).with("collapsing_triangle"),
                     egui::Sense::click(),
                 );
-                ReUi::paint_collapsing_triangle(ui, openness, triangle_rect, &triangle_response);
+                ReUi::paint_collapsing_triangle(
+                    ui,
+                    openness,
+                    triangle_rect.center(),
+                    &triangle_response,
+                );
                 collapse_response = Some(triangle_response);
             }
 

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -322,8 +322,12 @@ impl<'a> ListItem<'a> {
             state.toggle(ui);
         }
 
-        let body_response =
-            state.show_body_indented(&response.response, ui, |ui| add_body(re_ui, ui));
+        let body_response = ui
+            .scope(|ui| {
+                ui.spacing_mut().indent = ReUi::small_icon_size().x + ReUi::text_to_icon_padding();
+                state.show_body_indented(&response.response, ui, |ui| add_body(re_ui, ui))
+            })
+            .inner;
 
         ShowCollapsingResponse {
             item_response: response.response,


### PR DESCRIPTION
### What

Make everything in list items all aligned and tidy:

<img width="199" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/ba319c87-4c0b-4b14-9b02-9d23bd8eb764">

<br/><br/>

Before/after:

<img width="252" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/5a740368-9d00-42de-8001-d4bdd7291d89">
<img width="198" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/488c361c-c05c-4646-8ffa-7520ae6cd16c">


cc @martenbjork 


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5340/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5340/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5340/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5340)
- [Docs preview](https://rerun.io/preview/d8cb174b34943bc04511ecb2ef8310130dcf5af2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d8cb174b34943bc04511ecb2ef8310130dcf5af2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)