### PR TITLE
Fix spurious bullets in entity names in the "Add/remove entities" modal

### DIFF
--- a/crates/re_viewport/src/space_view_entity_picker.rs
+++ b/crates/re_viewport/src/space_view_entity_picker.rs
@@ -90,7 +90,7 @@ fn add_entities_tree_ui(
         add_entities_line_ui(
             ctx,
             ui,
-            &format!("🔹 {name}"),
+            name,
             tree,
             space_view,
             query_result,


### PR DESCRIPTION
### What

Fix an oversight from:
- #5318

<img width="512" alt="Screenshot 2024-02-28 at 17 14 45" src="https://github.com/rerun-io/rerun/assets/2624717/8c96768b-c6c5-4f26-b608-3c2ef3f36eb9">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5341/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5341/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5341/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5341)
- [Docs preview](https://rerun.io/preview/f963e4b35b0b5886ac875c4d0d8a2e4c4be5b496/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f963e4b35b0b5886ac875c4d0d8a2e4c4be5b496/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)