### PR TITLE
Fix `update_pr_body`'s handling of backticks

### DIFF
--- a/scripts/ci/update_pr_body.py
+++ b/scripts/ci/update_pr_body.py
@@ -35,9 +35,11 @@ CODE_BLOCK_PLACEHOLDER = "{CODE BLOCK PLACEHOLDER}"
 
 
 def index_code_block(lines: list[str]) -> tuple[bool, int, int]:
+    # Truncate the lines so we can find things like "```rust".
+    line_starts = [line[0:3] for line in lines]
     if "```" in lines:
-        opening_line = lines.index("```")
-        closing_line = lines.index("```", opening_line + 1)
+        opening_line = line_starts.index("```")
+        closing_line = line_starts.index("```", opening_line + 1)
         return True, opening_line, closing_line
     return False, 0, 0
 
@@ -48,7 +50,9 @@ def extract_code_blocks(lines: list[str]) -> list[list[str]]:
     code_blocks = []
     has_code_blocks = True
     while has_code_blocks:
-        if "```" in lines:
+        # Truncate the lines so we can find things like "```rust".
+        line_starts = [line[0:3] for line in lines]
+        if "```" in line_starts:
             block, op, cl = index_code_block(lines)
             if block:
                 code_blocks.append(lines[op : cl + 1])


### PR DESCRIPTION
- Fixes https://github.com/rerun-io/rerun/issues/5248

```rust
test
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5346/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5346/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5346/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5346)
- [Docs preview](https://rerun.io/preview/58dd8336e206675c7daff0052ac905b8644997ac/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/58dd8336e206675c7daff0052ac905b8644997ac/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)