### PR TITLE
SDK `DataLoader`s 5: customizable (external) loaders for Rust

### DIFF
--- a/crates/re_data_source/src/data_loader/loader_archetype.rs
+++ b/crates/re_data_source/src/data_loader/loader_archetype.rs
@@ -19,7 +19,7 @@ impl DataLoader for ArchetypeLoader {
     #[cfg(not(target_arch = "wasm32"))]
     fn load_from_path(
         &self,
-        store_id: re_log_types::StoreId,
+        settings: &crate::RecommendedLoadSettings,
         filepath: std::path::PathBuf,
         tx: std::sync::mpsc::Sender<LoadedData>,
     ) -> Result<(), crate::DataLoaderError> {
@@ -35,12 +35,12 @@ impl DataLoader for ArchetypeLoader {
             .with_context(|| format!("Failed to read file {filepath:?}"))?;
         let contents = std::borrow::Cow::Owned(contents);
 
-        self.load_from_file_contents(store_id, filepath, contents, tx)
+        self.load_from_file_contents(settings, filepath, contents, tx)
     }
 
     fn load_from_file_contents(
         &self,
-        _store_id: re_log_types::StoreId,
+        _settings: &crate::RecommendedLoadSettings,
         filepath: std::path::PathBuf,
         contents: std::borrow::Cow<'_, [u8]>,
         tx: std::sync::mpsc::Sender<LoadedData>,

--- a/crates/re_data_source/src/data_loader/loader_archetype.rs
+++ b/crates/re_data_source/src/data_loader/loader_archetype.rs
@@ -19,7 +19,7 @@ impl DataLoader for ArchetypeLoader {
     #[cfg(not(target_arch = "wasm32"))]
     fn load_from_path(
         &self,
-        settings: &crate::RecommendedLoadSettings,
+        settings: &crate::DataLoaderSettings,
         filepath: std::path::PathBuf,
         tx: std::sync::mpsc::Sender<LoadedData>,
     ) -> Result<(), crate::DataLoaderError> {
@@ -40,7 +40,7 @@ impl DataLoader for ArchetypeLoader {
 
     fn load_from_file_contents(
         &self,
-        _settings: &crate::RecommendedLoadSettings,
+        _settings: &crate::DataLoaderSettings,
         filepath: std::path::PathBuf,
         contents: std::borrow::Cow<'_, [u8]>,
         tx: std::sync::mpsc::Sender<LoadedData>,

--- a/crates/re_data_source/src/data_loader/loader_directory.rs
+++ b/crates/re_data_source/src/data_loader/loader_directory.rs
@@ -16,7 +16,7 @@ impl crate::DataLoader for DirectoryLoader {
     #[cfg(not(target_arch = "wasm32"))]
     fn load_from_path(
         &self,
-        store_id: re_log_types::StoreId,
+        settings: &crate::RecommendedLoadSettings,
         dirpath: std::path::PathBuf,
         tx: std::sync::mpsc::Sender<crate::LoadedData>,
     ) -> Result<(), crate::DataLoaderError> {
@@ -39,7 +39,7 @@ impl crate::DataLoader for DirectoryLoader {
 
             let filepath = entry.path();
             if filepath.is_file() {
-                let store_id = store_id.clone();
+                let settings = settings.clone();
                 let filepath = filepath.to_owned();
                 let tx = tx.clone();
 
@@ -51,7 +51,7 @@ impl crate::DataLoader for DirectoryLoader {
                 _ = std::thread::Builder::new()
                     .name(format!("load_dir_entry({filepath:?})"))
                     .spawn(move || {
-                        let data = match crate::load_file::load(&store_id, &filepath, None) {
+                        let data = match crate::load_file::load(&settings, &filepath, None) {
                             Ok(data) => data,
                             Err(err) => {
                                 re_log::error!(?filepath, %err, "Failed to load directory entry");
@@ -74,7 +74,7 @@ impl crate::DataLoader for DirectoryLoader {
     #[inline]
     fn load_from_file_contents(
         &self,
-        _store_id: re_log_types::StoreId,
+        _settings: &crate::RecommendedLoadSettings,
         path: std::path::PathBuf,
         _contents: std::borrow::Cow<'_, [u8]>,
         _tx: std::sync::mpsc::Sender<crate::LoadedData>,

--- a/crates/re_data_source/src/data_loader/loader_directory.rs
+++ b/crates/re_data_source/src/data_loader/loader_directory.rs
@@ -16,7 +16,7 @@ impl crate::DataLoader for DirectoryLoader {
     #[cfg(not(target_arch = "wasm32"))]
     fn load_from_path(
         &self,
-        settings: &crate::RecommendedLoadSettings,
+        settings: &crate::DataLoaderSettings,
         dirpath: std::path::PathBuf,
         tx: std::sync::mpsc::Sender<crate::LoadedData>,
     ) -> Result<(), crate::DataLoaderError> {
@@ -74,7 +74,7 @@ impl crate::DataLoader for DirectoryLoader {
     #[inline]
     fn load_from_file_contents(
         &self,
-        _settings: &crate::RecommendedLoadSettings,
+        _settings: &crate::DataLoaderSettings,
         path: std::path::PathBuf,
         _contents: std::borrow::Cow<'_, [u8]>,
         _tx: std::sync::mpsc::Sender<crate::LoadedData>,

--- a/crates/re_data_source/src/data_loader/loader_external.rs
+++ b/crates/re_data_source/src/data_loader/loader_external.rs
@@ -114,7 +114,7 @@ impl crate::DataLoader for ExternalLoader {
 
     fn load_from_path(
         &self,
-        settings: &crate::RecommendedLoadSettings,
+        settings: &crate::DataLoaderSettings,
         filepath: std::path::PathBuf,
         tx: std::sync::mpsc::Sender<crate::LoadedData>,
     ) -> Result<(), crate::DataLoaderError> {
@@ -278,7 +278,7 @@ impl crate::DataLoader for ExternalLoader {
     #[inline]
     fn load_from_file_contents(
         &self,
-        _settings: &crate::RecommendedLoadSettings,
+        _settings: &crate::DataLoaderSettings,
         path: std::path::PathBuf,
         _contents: std::borrow::Cow<'_, [u8]>,
         _tx: std::sync::mpsc::Sender<crate::LoadedData>,

--- a/crates/re_data_source/src/data_loader/loader_rrd.rs
+++ b/crates/re_data_source/src/data_loader/loader_rrd.rs
@@ -15,7 +15,7 @@ impl crate::DataLoader for RrdLoader {
     fn load_from_path(
         &self,
         // NOTE: The Store ID comes from the rrd file itself.
-        _store_id: re_log_types::StoreId,
+        _settings: &crate::RecommendedLoadSettings,
         filepath: std::path::PathBuf,
         tx: std::sync::mpsc::Sender<crate::LoadedData>,
     ) -> Result<(), crate::DataLoaderError> {
@@ -58,7 +58,7 @@ impl crate::DataLoader for RrdLoader {
     fn load_from_file_contents(
         &self,
         // NOTE: The Store ID comes from the rrd file itself.
-        _store_id: re_log_types::StoreId,
+        _settings: &crate::RecommendedLoadSettings,
         filepath: std::path::PathBuf,
         contents: std::borrow::Cow<'_, [u8]>,
         tx: std::sync::mpsc::Sender<crate::LoadedData>,

--- a/crates/re_data_source/src/data_loader/loader_rrd.rs
+++ b/crates/re_data_source/src/data_loader/loader_rrd.rs
@@ -15,7 +15,7 @@ impl crate::DataLoader for RrdLoader {
     fn load_from_path(
         &self,
         // NOTE: The Store ID comes from the rrd file itself.
-        _settings: &crate::RecommendedLoadSettings,
+        _settings: &crate::DataLoaderSettings,
         filepath: std::path::PathBuf,
         tx: std::sync::mpsc::Sender<crate::LoadedData>,
     ) -> Result<(), crate::DataLoaderError> {
@@ -58,7 +58,7 @@ impl crate::DataLoader for RrdLoader {
     fn load_from_file_contents(
         &self,
         // NOTE: The Store ID comes from the rrd file itself.
-        _settings: &crate::RecommendedLoadSettings,
+        _settings: &crate::DataLoaderSettings,
         filepath: std::path::PathBuf,
         contents: std::borrow::Cow<'_, [u8]>,
         tx: std::sync::mpsc::Sender<crate::LoadedData>,

--- a/crates/re_data_source/src/data_loader/mod.rs
+++ b/crates/re_data_source/src/data_loader/mod.rs
@@ -2,9 +2,105 @@ use std::sync::Arc;
 
 use once_cell::sync::Lazy;
 
-use re_log_types::{ArrowMsg, DataRow, LogMsg};
+use re_log_types::{ArrowMsg, DataRow, EntityPath, LogMsg, TimePoint};
 
 // ---
+
+/// Recommended settings for the [`DataLoader`].
+///
+/// The loader is free to ignore some or all of these.
+///
+/// External [`DataLoader`]s will be passed the the following CLI parameters:
+/// * `--recording-id <store_id>`
+/// * `--opened-recording-id <opened_store_id>` (if set)
+/// * `--entity-path-prefix <entity_path_prefix>` (if set)
+/// * `--timeless` (if `timepoint` is set to the timeless timepoint)
+/// * `--time <timeline1>=<time1> <timeline2>=<time2> ...` (if `timepoint` contains temporal data)
+/// * `--sequence <timeline1>=<seq1> <timeline2>=<seq2> ...` (if `timepoint` contains sequence data)
+#[derive(Debug, Clone)]
+pub struct RecommendedLoadSettings {
+    /// The recommended [`re_log_types::StoreId`] to log the data to, based on the surrounding context.
+    pub store_id: re_log_types::StoreId,
+
+    /// The [`re_log_types::StoreId`] that is currently opened in the viewer, if any.
+    ///
+    /// Log data to this recording if you want it to appear in a new recording shared by all
+    /// data-loaders for the current loading session.
+    //
+    // TODO: issue
+    pub opened_store_id: Option<re_log_types::StoreId>,
+
+    /// What should the entity paths be prefixed with?
+    pub entity_path_prefix: Option<EntityPath>,
+
+    /// At what time(s) should the data be logged to?
+    pub timepoint: Option<TimePoint>,
+}
+
+impl RecommendedLoadSettings {
+    #[inline]
+    pub fn recommended(store_id: impl Into<re_log_types::StoreId>) -> Self {
+        Self {
+            store_id: store_id.into(),
+            opened_store_id: Default::default(),
+            entity_path_prefix: Default::default(),
+            timepoint: Default::default(),
+        }
+    }
+
+    /// Generates CLI flags from these settings, for external data loaders.
+    pub fn to_cli_args(&self) -> Vec<String> {
+        let Self {
+            store_id,
+            opened_store_id,
+            entity_path_prefix,
+            timepoint,
+        } = self;
+
+        let mut args = Vec::new();
+
+        args.extend(["--recording-id".to_owned(), format!("{store_id}")]);
+
+        if let Some(opened_store_id) = opened_store_id {
+            args.extend([
+                "--opened-recording-id".to_owned(),
+                format!("{opened_store_id}"),
+            ]);
+        }
+
+        if let Some(entity_path_prefix) = entity_path_prefix {
+            args.extend([
+                "--entity-path-prefix".to_owned(),
+                format!("{entity_path_prefix}"),
+            ]);
+        }
+
+        if let Some(timepoint) = timepoint {
+            if timepoint.is_timeless() {
+                args.push("--timeless".to_owned());
+            }
+
+            for (timeline, time) in timepoint.iter() {
+                match timeline.typ() {
+                    re_log_types::TimeType::Time => {
+                        args.extend([
+                            "--time".to_owned(),
+                            format!("{}={}", timeline.name(), time.as_i64()),
+                        ]);
+                    }
+                    re_log_types::TimeType::Sequence => {
+                        args.extend([
+                            "--sequence".to_owned(),
+                            format!("{}={}", timeline.name(), time.as_i64()),
+                        ]);
+                    }
+                }
+            }
+        }
+
+        args
+    }
+}
 
 /// A [`DataLoader`] loads data from a file path and/or a file's contents.
 ///
@@ -90,7 +186,7 @@ pub trait DataLoader: Send + Sync {
     #[cfg(not(target_arch = "wasm32"))]
     fn load_from_path(
         &self,
-        store_id: re_log_types::StoreId,
+        settings: &RecommendedLoadSettings,
         path: std::path::PathBuf,
         tx: std::sync::mpsc::Sender<LoadedData>,
     ) -> Result<(), DataLoaderError>;
@@ -122,7 +218,7 @@ pub trait DataLoader: Send + Sync {
     /// with a [`DataLoaderError::Incompatible`] error.
     fn load_from_file_contents(
         &self,
-        store_id: re_log_types::StoreId,
+        settings: &RecommendedLoadSettings,
         filepath: std::path::PathBuf,
         contents: std::borrow::Cow<'_, [u8]>,
         tx: std::sync::mpsc::Sender<LoadedData>,

--- a/crates/re_data_source/src/data_loader/mod.rs
+++ b/crates/re_data_source/src/data_loader/mod.rs
@@ -10,7 +10,7 @@ use re_log_types::{ArrowMsg, DataRow, EntityPath, LogMsg, TimePoint};
 ///
 /// The loader is free to ignore some or all of these.
 ///
-/// External [`DataLoader`]s will be passed the the following CLI parameters:
+/// External [`DataLoader`]s will be passed the following CLI parameters:
 /// * `--recording-id <store_id>`
 /// * `--opened-recording-id <opened_store_id>` (if set)
 /// * `--entity-path-prefix <entity_path_prefix>` (if set)
@@ -27,7 +27,7 @@ pub struct RecommendedLoadSettings {
     /// Log data to this recording if you want it to appear in a new recording shared by all
     /// data-loaders for the current loading session.
     //
-    // TODO: issue
+    // TODO(#5350): actually support this
     pub opened_store_id: Option<re_log_types::StoreId>,
 
     /// What should the entity paths be prefixed with?

--- a/crates/re_data_source/src/data_loader/mod.rs
+++ b/crates/re_data_source/src/data_loader/mod.rs
@@ -18,7 +18,7 @@ use re_log_types::{ArrowMsg, DataRow, EntityPath, LogMsg, TimePoint};
 /// * `--time <timeline1>=<time1> <timeline2>=<time2> ...` (if `timepoint` contains temporal data)
 /// * `--sequence <timeline1>=<seq1> <timeline2>=<seq2> ...` (if `timepoint` contains sequence data)
 #[derive(Debug, Clone)]
-pub struct RecommendedLoadSettings {
+pub struct DataLoaderSettings {
     /// The recommended [`re_log_types::StoreId`] to log the data to, based on the surrounding context.
     pub store_id: re_log_types::StoreId,
 
@@ -37,7 +37,7 @@ pub struct RecommendedLoadSettings {
     pub timepoint: Option<TimePoint>,
 }
 
-impl RecommendedLoadSettings {
+impl DataLoaderSettings {
     #[inline]
     pub fn recommended(store_id: impl Into<re_log_types::StoreId>) -> Self {
         Self {
@@ -186,7 +186,7 @@ pub trait DataLoader: Send + Sync {
     #[cfg(not(target_arch = "wasm32"))]
     fn load_from_path(
         &self,
-        settings: &RecommendedLoadSettings,
+        settings: &DataLoaderSettings,
         path: std::path::PathBuf,
         tx: std::sync::mpsc::Sender<LoadedData>,
     ) -> Result<(), DataLoaderError>;
@@ -218,7 +218,7 @@ pub trait DataLoader: Send + Sync {
     /// with a [`DataLoaderError::Incompatible`] error.
     fn load_from_file_contents(
         &self,
-        settings: &RecommendedLoadSettings,
+        settings: &DataLoaderSettings,
         filepath: std::path::PathBuf,
         contents: std::borrow::Cow<'_, [u8]>,
         tx: std::sync::mpsc::Sender<LoadedData>,

--- a/crates/re_data_source/src/data_source.rs
+++ b/crates/re_data_source/src/data_source.rs
@@ -136,7 +136,7 @@ impl DataSource {
                 // or not.
                 let shared_store_id =
                     re_log_types::StoreId::random(re_log_types::StoreKind::Recording);
-                let settings = crate::RecommendedLoadSettings::recommended(shared_store_id);
+                let settings = crate::DataLoaderSettings::recommended(shared_store_id);
                 crate::load_from_path(&settings, file_source, &path, &tx)
                     .with_context(|| format!("{path:?}"))?;
 
@@ -160,7 +160,7 @@ impl DataSource {
                 // or not.
                 let shared_store_id =
                     re_log_types::StoreId::random(re_log_types::StoreKind::Recording);
-                let settings = crate::RecommendedLoadSettings::recommended(shared_store_id);
+                let settings = crate::DataLoaderSettings::recommended(shared_store_id);
                 crate::load_from_file_contents(
                     &settings,
                     file_source,

--- a/crates/re_data_source/src/data_source.rs
+++ b/crates/re_data_source/src/data_source.rs
@@ -134,8 +134,10 @@ impl DataSource {
                 // This `StoreId` will be communicated to all `DataLoader`s, which may or may not
                 // decide to use it depending on whether they want to share a common recording
                 // or not.
-                let store_id = re_log_types::StoreId::random(re_log_types::StoreKind::Recording);
-                crate::load_from_path(&store_id, file_source, &path, &tx)
+                let shared_store_id =
+                    re_log_types::StoreId::random(re_log_types::StoreKind::Recording);
+                let settings = crate::RecommendedLoadSettings::recommended(shared_store_id);
+                crate::load_from_path(&settings, file_source, &path, &tx)
                     .with_context(|| format!("{path:?}"))?;
 
                 if let Some(on_msg) = on_msg {
@@ -156,9 +158,11 @@ impl DataSource {
                 // This `StoreId` will be communicated to all `DataLoader`s, which may or may not
                 // decide to use it depending on whether they want to share a common recording
                 // or not.
-                let store_id = re_log_types::StoreId::random(re_log_types::StoreKind::Recording);
+                let shared_store_id =
+                    re_log_types::StoreId::random(re_log_types::StoreKind::Recording);
+                let settings = crate::RecommendedLoadSettings::recommended(shared_store_id);
                 crate::load_from_file_contents(
-                    &store_id,
+                    &settings,
                     file_source,
                     &std::path::PathBuf::from(file_contents.name),
                     std::borrow::Cow::Borrowed(&file_contents.bytes),

--- a/crates/re_data_source/src/lib.rs
+++ b/crates/re_data_source/src/lib.rs
@@ -16,7 +16,7 @@ mod load_stdin;
 
 pub use self::data_loader::{
     iter_loaders, register_custom_data_loader, ArchetypeLoader, DataLoader, DataLoaderError,
-    DirectoryLoader, LoadedData, RrdLoader,
+    DirectoryLoader, LoadedData, RecommendedLoadSettings, RrdLoader,
 };
 pub use self::data_source::DataSource;
 pub use self::load_file::{extension, load_from_file_contents};
@@ -24,8 +24,8 @@ pub use self::web_sockets::connect_to_ws_url;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use self::data_loader::{
-    iter_external_loaders, ExternalLoader, RecommendedLoadSettings,
-    EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE, EXTERNAL_DATA_LOADER_PREFIX,
+    iter_external_loaders, ExternalLoader, EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE,
+    EXTERNAL_DATA_LOADER_PREFIX,
 };
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/re_data_source/src/lib.rs
+++ b/crates/re_data_source/src/lib.rs
@@ -16,7 +16,7 @@ mod load_stdin;
 
 pub use self::data_loader::{
     iter_loaders, register_custom_data_loader, ArchetypeLoader, DataLoader, DataLoaderError,
-    DirectoryLoader, LoadedData, RecommendedLoadSettings, RrdLoader,
+    DirectoryLoader, LoadedData, DataLoaderSettings, RrdLoader,
 };
 pub use self::data_source::DataSource;
 pub use self::load_file::{extension, load_from_file_contents};

--- a/crates/re_data_source/src/lib.rs
+++ b/crates/re_data_source/src/lib.rs
@@ -24,8 +24,8 @@ pub use self::web_sockets::connect_to_ws_url;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use self::data_loader::{
-    iter_external_loaders, ExternalLoader, EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE,
-    EXTERNAL_DATA_LOADER_PREFIX,
+    iter_external_loaders, ExternalLoader, RecommendedLoadSettings,
+    EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE, EXTERNAL_DATA_LOADER_PREFIX,
 };
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/re_data_source/src/lib.rs
+++ b/crates/re_data_source/src/lib.rs
@@ -16,7 +16,7 @@ mod load_stdin;
 
 pub use self::data_loader::{
     iter_loaders, register_custom_data_loader, ArchetypeLoader, DataLoader, DataLoaderError,
-    DirectoryLoader, LoadedData, DataLoaderSettings, RrdLoader,
+    DataLoaderSettings, DirectoryLoader, LoadedData, RrdLoader,
 };
 pub use self::data_source::DataSource;
 pub use self::load_file::{extension, load_from_file_contents};

--- a/crates/re_data_source/src/load_file.rs
+++ b/crates/re_data_source/src/load_file.rs
@@ -36,7 +36,7 @@ pub fn load_from_path(
 
     let data = load(settings, path, None)?;
 
-    // TODO: there's probably gonna be issues with this though... maybe?
+    // TODO(cmc): should we always unconditionally set store info though?
     // If we reach this point, then at least one compatible `DataLoader` has been found.
     let store_info = prepare_store_info(&settings.store_id, file_source, path);
     if let Some(store_info) = store_info {
@@ -45,7 +45,6 @@ pub fn load_from_path(
         }
     }
 
-    // TODO: should we be using this one here?
     send(&settings.store_id, data, tx);
 
     Ok(())
@@ -73,6 +72,7 @@ pub fn load_from_file_contents(
 
     let data = load(settings, filepath, Some(contents))?;
 
+    // TODO(cmc): should we always unconditionally set store info though?
     // If we reach this point, then at least one compatible `DataLoader` has been found.
     let store_info = prepare_store_info(&settings.store_id, file_source, filepath);
     if let Some(store_info) = store_info {
@@ -81,7 +81,6 @@ pub fn load_from_file_contents(
         }
     }
 
-    // TODO: should we be using this one here?
     send(&settings.store_id, data, tx);
 
     Ok(())

--- a/crates/re_data_source/src/load_file.rs
+++ b/crates/re_data_source/src/load_file.rs
@@ -16,7 +16,7 @@ use crate::{DataLoaderError, LoadedData};
 /// (i.e. they're logged).
 #[cfg(not(target_arch = "wasm32"))]
 pub fn load_from_path(
-    settings: &crate::RecommendedLoadSettings,
+    settings: &crate::DataLoaderSettings,
     file_source: FileSource,
     path: &std::path::Path,
     // NOTE: This channel must be unbounded since we serialize all operations when running on wasm.
@@ -59,7 +59,7 @@ pub fn load_from_path(
 ///
 /// `path` is only used for informational purposes, no data is ever read from the filesystem.
 pub fn load_from_file_contents(
-    settings: &crate::RecommendedLoadSettings,
+    settings: &crate::DataLoaderSettings,
     file_source: FileSource,
     filepath: &std::path::Path,
     contents: std::borrow::Cow<'_, [u8]>,
@@ -139,7 +139,7 @@ pub(crate) fn prepare_store_info(
 /// [`DataLoaderError::Incompatible`] will be returned.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn load(
-    settings: &crate::RecommendedLoadSettings,
+    settings: &crate::DataLoaderSettings,
     path: &std::path::Path,
     contents: Option<std::borrow::Cow<'_, [u8]>>,
 ) -> Result<std::sync::mpsc::Receiver<LoadedData>, DataLoaderError> {
@@ -227,7 +227,7 @@ pub(crate) fn load(
 #[cfg(target_arch = "wasm32")]
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn load(
-    settings: &crate::RecommendedLoadSettings,
+    settings: &crate::DataLoaderSettings,
     path: &std::path::Path,
     contents: Option<std::borrow::Cow<'_, [u8]>>,
 ) -> Result<std::sync::mpsc::Receiver<LoadedData>, DataLoaderError> {

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -86,7 +86,7 @@ pub use re_types_core::{
 };
 
 #[cfg(feature = "data_loaders")]
-pub use re_data_source::{DataLoader, DataLoaderError, LoadedData, RecommendedLoadSettings};
+pub use re_data_source::{DataLoader, DataLoaderError, LoadedData, DataLoaderSettings};
 
 /// Methods for spawning the web viewer and streaming the SDK log stream to it.
 #[cfg(feature = "web_viewer")]

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -86,7 +86,7 @@ pub use re_types_core::{
 };
 
 #[cfg(feature = "data_loaders")]
-pub use re_data_source::{DataLoader, DataLoaderError, LoadedData, DataLoaderSettings};
+pub use re_data_source::{DataLoader, DataLoaderError, DataLoaderSettings, LoadedData};
 
 /// Methods for spawning the web viewer and streaming the SDK log stream to it.
 #[cfg(feature = "web_viewer")]

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -85,6 +85,9 @@ pub use re_types_core::{
     MaybeOwnedComponentBatch, NamedIndicatorComponent, SizeBytes,
 };
 
+#[cfg(feature = "data_loaders")]
+pub use re_data_source::{DataLoader, DataLoaderError, LoadedData, RecommendedLoadSettings};
+
 /// Methods for spawning the web viewer and streaming the SDK log stream to it.
 #[cfg(feature = "web_viewer")]
 pub mod web_viewer;
@@ -97,6 +100,9 @@ pub mod external {
 
     pub use re_log::external::*;
     pub use re_log_types::external::*;
+
+    #[cfg(feature = "data_loaders")]
+    pub use re_data_source;
 
     #[cfg(feature = "log")]
     pub use log;

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1095,7 +1095,7 @@ impl RecordingStream {
     #[cfg(feature = "data_loaders")]
     pub fn log_file_from_path(
         &self,
-        settings: &re_data_source::RecommendedLoadSettings,
+        settings: &re_data_source::DataLoaderSettings,
         filepath: impl AsRef<std::path::Path>,
     ) -> RecordingStreamResult<()> {
         self.log_file(settings, filepath, None)
@@ -1112,7 +1112,7 @@ impl RecordingStream {
     #[cfg(feature = "data_loaders")]
     pub fn log_file_from_contents(
         &self,
-        settings: &re_data_source::RecommendedLoadSettings,
+        settings: &re_data_source::DataLoaderSettings,
         filepath: impl AsRef<std::path::Path>,
         contents: std::borrow::Cow<'_, [u8]>,
     ) -> RecordingStreamResult<()> {
@@ -1122,7 +1122,7 @@ impl RecordingStream {
     #[cfg(feature = "data_loaders")]
     fn log_file(
         &self,
-        settings: &re_data_source::RecommendedLoadSettings,
+        settings: &re_data_source::DataLoaderSettings,
         filepath: impl AsRef<std::path::Path>,
         contents: Option<std::borrow::Cow<'_, [u8]>>,
     ) -> RecordingStreamResult<()> {

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1095,9 +1095,10 @@ impl RecordingStream {
     #[cfg(feature = "data_loaders")]
     pub fn log_file_from_path(
         &self,
+        settings: &re_data_source::RecommendedLoadSettings,
         filepath: impl AsRef<std::path::Path>,
     ) -> RecordingStreamResult<()> {
-        self.log_file(filepath, None)
+        self.log_file(settings, filepath, None)
     }
 
     /// Logs the given `contents` using all [`re_data_source::DataLoader`]s available.
@@ -1111,15 +1112,17 @@ impl RecordingStream {
     #[cfg(feature = "data_loaders")]
     pub fn log_file_from_contents(
         &self,
+        settings: &re_data_source::RecommendedLoadSettings,
         filepath: impl AsRef<std::path::Path>,
         contents: std::borrow::Cow<'_, [u8]>,
     ) -> RecordingStreamResult<()> {
-        self.log_file(filepath, Some(contents))
+        self.log_file(settings, filepath, Some(contents))
     }
 
     #[cfg(feature = "data_loaders")]
     fn log_file(
         &self,
+        settings: &re_data_source::RecommendedLoadSettings,
         filepath: impl AsRef<std::path::Path>,
         contents: Option<std::borrow::Cow<'_, [u8]>>,
     ) -> RecordingStreamResult<()> {
@@ -1131,27 +1134,16 @@ impl RecordingStream {
             re_smart_channel::SmartChannelSource::File(filepath.into()),
         );
 
-        let Some(store_id) = self.store_info().map(|info| info.store_id.clone()) else {
-            // There's no recording.
-            return Ok(());
-        };
-        // TODO
-        let settings = re_data_source::RecommendedLoadSettings::recommended(store_id);
         if let Some(contents) = contents {
             re_data_source::load_from_file_contents(
-                &settings,
+                settings,
                 re_log_types::FileSource::Sdk,
                 filepath,
                 contents,
                 &tx,
             )?;
         } else {
-            re_data_source::load_from_path(
-                &settings,
-                re_log_types::FileSource::Sdk,
-                filepath,
-                &tx,
-            )?;
+            re_data_source::load_from_path(settings, re_log_types::FileSource::Sdk, filepath, &tx)?;
         }
         drop(tx);
 

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1131,20 +1131,27 @@ impl RecordingStream {
             re_smart_channel::SmartChannelSource::File(filepath.into()),
         );
 
-        let Some(store_id) = &self.store_info().map(|info| info.store_id.clone()) else {
+        let Some(store_id) = self.store_info().map(|info| info.store_id.clone()) else {
             // There's no recording.
             return Ok(());
         };
+        // TODO
+        let settings = re_data_source::RecommendedLoadSettings::recommended(store_id);
         if let Some(contents) = contents {
             re_data_source::load_from_file_contents(
-                store_id,
+                &settings,
                 re_log_types::FileSource::Sdk,
                 filepath,
                 contents,
                 &tx,
             )?;
         } else {
-            re_data_source::load_from_path(store_id, re_log_types::FileSource::Sdk, filepath, &tx)?;
+            re_data_source::load_from_path(
+                &settings,
+                re_log_types::FileSource::Sdk,
+                filepath,
+                &tx,
+            )?;
         }
         drop(tx);
 

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -734,13 +734,26 @@ fn rr_log_file_from_path_impl(
 ) -> Result<(), CError> {
     let stream = recording_stream(stream)?;
 
+    let recording_id = stream
+        .store_info()
+        .ok_or_else(|| {
+            CError::new(
+                CErrorCode::RecordingStreamRuntimeFailure,
+                &format!("Couldn't load file {filepath:?}: no recording available"),
+            )
+        })?
+        .store_id;
+    let settings = re_sdk::DataLoaderSettings::recommended(recording_id);
+
     let filepath = filepath.as_str("filepath")?;
-    stream.log_file_from_path(filepath).map_err(|err| {
-        CError::new(
-            CErrorCode::RecordingStreamRuntimeFailure,
-            &format!("Couldn't load file {filepath:?}: {err}"),
-        )
-    })?;
+    stream
+        .log_file_from_path(&settings, filepath)
+        .map_err(|err| {
+            CError::new(
+                CErrorCode::RecordingStreamRuntimeFailure,
+                &format!("Couldn't load file {filepath:?}: {err}"),
+            )
+        })?;
 
     Ok(())
 }
@@ -766,11 +779,22 @@ fn rr_log_file_from_contents_impl(
 ) -> Result<(), CError> {
     let stream = recording_stream(stream)?;
 
+    let recording_id = stream
+        .store_info()
+        .ok_or_else(|| {
+            CError::new(
+                CErrorCode::RecordingStreamRuntimeFailure,
+                &format!("Couldn't load file {filepath:?}: no recording available"),
+            )
+        })?
+        .store_id;
+    let settings = re_sdk::DataLoaderSettings::recommended(recording_id);
+
     let filepath = filepath.as_str("filepath")?;
     let contents = contents.as_bytes("contents")?;
 
     stream
-        .log_file_from_contents(filepath, std::borrow::Cow::Borrowed(contents))
+        .log_file_from_contents(&settings, filepath, std::borrow::Cow::Borrowed(contents))
         .map_err(|err| {
             CError::new(
                 CErrorCode::RecordingStreamRuntimeFailure,

--- a/examples/python/requirements.txt
+++ b/examples/python/requirements.txt
@@ -15,6 +15,7 @@
 -r live_camera_edge_detection/requirements.txt
 -r live_depth_sensor/requirements.txt
 -r llm_embedding_ner/requirements.txt
+-r log_file/requirements.txt
 -r minimal/requirements.txt
 -r minimal_options/requirements.txt
 -r multiprocessing/requirements.txt

--- a/examples/rust/custom_data_loader/src/main.rs
+++ b/examples/rust/custom_data_loader/src/main.rs
@@ -36,7 +36,7 @@ impl re_data_source::DataLoader for HashLoader {
 
     fn load_from_path(
         &self,
-        _settings: &rerun::external::re_data_source::RecommendedLoadSettings,
+        _settings: &rerun::external::re_data_source::DataLoaderSettings,
         path: std::path::PathBuf,
         tx: std::sync::mpsc::Sender<re_data_source::LoadedData>,
     ) -> Result<(), re_data_source::DataLoaderError> {
@@ -49,7 +49,7 @@ impl re_data_source::DataLoader for HashLoader {
 
     fn load_from_file_contents(
         &self,
-        _settings: &rerun::external::re_data_source::RecommendedLoadSettings,
+        _settings: &rerun::external::re_data_source::DataLoaderSettings,
         filepath: std::path::PathBuf,
         contents: std::borrow::Cow<'_, [u8]>,
         tx: std::sync::mpsc::Sender<re_data_source::LoadedData>,

--- a/examples/rust/custom_data_loader/src/main.rs
+++ b/examples/rust/custom_data_loader/src/main.rs
@@ -36,7 +36,7 @@ impl re_data_source::DataLoader for HashLoader {
 
     fn load_from_path(
         &self,
-        _store_id: rerun::external::re_log_types::StoreId,
+        _settings: &rerun::external::re_data_source::RecommendedLoadSettings,
         path: std::path::PathBuf,
         tx: std::sync::mpsc::Sender<re_data_source::LoadedData>,
     ) -> Result<(), re_data_source::DataLoaderError> {
@@ -49,7 +49,7 @@ impl re_data_source::DataLoader for HashLoader {
 
     fn load_from_file_contents(
         &self,
-        _store_id: rerun::external::re_log_types::StoreId,
+        _settings: &rerun::external::re_data_source::RecommendedLoadSettings,
         filepath: std::path::PathBuf,
         contents: std::borrow::Cow<'_, [u8]>,
         tx: std::sync::mpsc::Sender<re_data_source::LoadedData>,

--- a/examples/rust/external_data_loader/src/main.rs
+++ b/examples/rust/external_data_loader/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> anyhow::Result<()> {
         rec.stdout()?
     };
 
-    // TODO: send APIs
+    // TODO(#3841): really need those send APIs
     rec.set_timepoint(timepoint_from_args(&args)?);
 
     let entity_path_prefix = args

--- a/examples/rust/external_data_loader/src/main.rs
+++ b/examples/rust/external_data_loader/src/main.rs
@@ -41,11 +41,11 @@ struct Args {
     #[argh(switch)]
     timeless: bool,
 
-    /// optional timestamps to log at (e.g. `--time sim_time=1709203426`) [repeatable]
+    /// optional timestamps to log at (e.g. `--time sim_time=1709203426`) (repeatable)
     #[argh(option)]
     time: Vec<String>,
 
-    /// optional sequences to log at (e.g. `--sequence sim_frame=42`) [repeatable]
+    /// optional sequences to log at (e.g. `--sequence sim_frame=42`) (repeatable)
     #[argh(option)]
     sequence: Vec<String>,
 }

--- a/examples/rust/external_data_loader/src/main.rs
+++ b/examples/rust/external_data_loader/src/main.rs
@@ -10,7 +10,7 @@ use rerun::{MediaType, EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE};
 // If you use it, the data will end up in the same recording as all other plugins interested in
 // that file, otherwise you can just create a dedicated recording for it. Or both.
 //
-// Check out `re_data_source::RecommendedLoadSettings` documentation for an exhaustive listing of
+// Check out `re_data_source::DataLoaderSettings` documentation for an exhaustive listing of
 // the available CLI parameters.
 
 /// This is an example executable data-loader plugin for the Rerun Viewer.
@@ -83,7 +83,8 @@ fn main() -> anyhow::Result<()> {
         rec.stdout()?
     };
 
-    // TODO(#3841): really need those send APIs
+    // TODO(#3841): In the future, we will introduce so-called stateless APIs that allow logging
+    // data at a specific timepoint without having to modify the global stateful clock.
     rec.set_timepoint(timepoint_from_args(&args)?);
 
     let entity_path_prefix = args

--- a/examples/rust/log_file/src/main.rs
+++ b/examples/rust/log_file/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> anyhow::Result<()> {
 
 fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
     let mut settings =
-        rerun::RecommendedLoadSettings::recommended(rec.store_info().unwrap().store_id);
+        rerun::DataLoaderSettings::recommended(rec.store_info().unwrap().store_id);
     settings.entity_path_prefix = Some("log_file_example".into());
 
     for filepath in &args.filepaths {

--- a/examples/rust/log_file/src/main.rs
+++ b/examples/rust/log_file/src/main.rs
@@ -36,17 +36,25 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
+    let mut settings =
+        rerun::RecommendedLoadSettings::recommended(rec.store_info().unwrap().store_id);
+    settings.entity_path_prefix = Some("log_file_example".into());
+
     for filepath in &args.filepaths {
         let filepath = filepath.as_path();
 
         if !args.from_contents {
             // Either log the file using its path…
-            rec.log_file_from_path(filepath)?;
+            rec.log_file_from_path(&settings, filepath)?;
         } else {
             // …or using its contents if you already have them loaded for some reason.
             if filepath.is_file() {
                 let contents = std::fs::read(filepath)?;
-                rec.log_file_from_contents(filepath, std::borrow::Cow::Borrowed(&contents))?;
+                rec.log_file_from_contents(
+                    &settings,
+                    filepath,
+                    std::borrow::Cow::Borrowed(&contents),
+                )?;
             }
         }
     }

--- a/examples/rust/log_file/src/main.rs
+++ b/examples/rust/log_file/src/main.rs
@@ -36,8 +36,7 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
-    let mut settings =
-        rerun::DataLoaderSettings::recommended(rec.store_info().unwrap().store_id);
+    let mut settings = rerun::DataLoaderSettings::recommended(rec.store_info().unwrap().store_id);
     settings.entity_path_prefix = Some("log_file_example".into());
 
     for filepath in &args.filepaths {

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -286,7 +286,7 @@ namespace rerun {
         rr_error status = {};
         rr_recording_stream_log_file_from_contents(
             _id,
-            detail::to_rr_string(std::string_view(filepath.c_str())),
+            detail::to_rr_string(filepath.string()),
             data,
             &status
         );

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -265,7 +265,7 @@ namespace rerun {
         rr_error status = {};
         rr_recording_stream_log_file_from_path(
             _id,
-            detail::to_rr_string(std::string_view(filepath.c_str())),
+            detail::to_rr_string(filepath.string()),
             &status
         );
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -978,8 +978,13 @@ fn log_file_from_path(
         return Ok(());
     };
 
+    let Some(recording_id) = recording.store_info().map(|info| info.store_id.clone()) else {
+        return Ok(());
+    };
+    let settings = rerun::DataLoaderSettings::recommended(recording_id);
+
     recording
-        .log_file_from_path(file_path)
+        .log_file_from_path(&settings, file_path)
         .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
 
     py.allow_threads(flush_garbage_queue);
@@ -1003,8 +1008,17 @@ fn log_file_from_contents(
         return Ok(());
     };
 
+    let Some(recording_id) = recording.store_info().map(|info| info.store_id.clone()) else {
+        return Ok(());
+    };
+    let settings = rerun::DataLoaderSettings::recommended(recording_id);
+
     recording
-        .log_file_from_contents(file_path, std::borrow::Cow::Borrowed(file_contents))
+        .log_file_from_contents(
+            &settings,
+            file_path,
+            std::borrow::Cow::Borrowed(file_contents),
+        )
         .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
 
     py.allow_threads(flush_garbage_queue);


### PR DESCRIPTION
Adds new `RecommendedLoadSettings` that gets passed to all `DataLoader`s -- builtin and external -- in order to customize their behaviors.

This includes:
- A recommended recording ID
- The ID of the currently opened recording in the viewer (not implemented)
  - Related: https://github.com/rerun-io/rerun/issues/5350
- A recommended entity path prefix
- A recommended timepoint

```bash
cargo r -p rerun-loader-rust-file -- run_wasm/src/main.rs  --recording-id this-one --entity-path-prefix a/b/c  --time sim_time=1000 --time wall_time=1709204046 --sequence sim_frame=42 | rerun -
```
![image](https://github.com/rerun-io/rerun/assets/2910679/631d9798-c198-4e86-b6f8-32d0b849e7b2)


Checks:
- [x] external loader ran manually (`loader | rerun`)
- [x] external loader via rerun (`rerun xxx.rs`)
- [x] log_file with external loader (`log_file xxx.rs`)

---

Part of series of PR to expose configurable `DataLoader`s to our SDKs:
- #5327 
- #5328 
- #5330
- #5337
- #5351
- #5355

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5327/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5327/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5327/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5327)
- [Docs preview](https://rerun.io/preview/b6cad12cb411149ce5836214026af2180c3c3c72/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b6cad12cb411149ce5836214026af2180c3c3c72/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)