### PR TITLE
`ListItem`'s collapsing triangle is now styled consistently with the rest of the item

### DIFF
--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -819,7 +819,7 @@ impl ReUi {
                     ui,
                     openness,
                     icon_rect.center(),
-                    &ui.style().interact(&icon_response),
+                    ui.style().interact(&icon_response),
                 );
 
                 let visuals = ui.style().interact(&header_response);

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -705,7 +705,12 @@ impl ReUi {
                 );
 
                 let icon_response = header_response.clone().with_new_rect(icon_rect);
-                Self::paint_collapsing_triangle(ui, openness, icon_rect.center(), &icon_response);
+                Self::paint_collapsing_triangle(
+                    ui,
+                    openness,
+                    icon_rect.center(),
+                    ui.style().interact(&icon_response),
+                );
             }
 
             ui.painter().galley(text_pos, galley, visuals.text_color());
@@ -810,7 +815,12 @@ impl ReUi {
                     egui::Vec2::splat(icon_width),
                 );
                 let icon_response = header_response.clone().with_new_rect(icon_rect);
-                Self::paint_collapsing_triangle(ui, openness, icon_rect.center(), &icon_response);
+                Self::paint_collapsing_triangle(
+                    ui,
+                    openness,
+                    icon_rect.center(),
+                    &ui.style().interact(&icon_response),
+                );
 
                 let visuals = ui.style().interact(&header_response);
 
@@ -862,10 +872,8 @@ impl ReUi {
         ui: &egui::Ui,
         openness: f32,
         center: egui::Pos2,
-        response: &egui::Response,
+        visuals: &egui::style::WidgetVisuals,
     ) {
-        let visuals = ui.style().interact(response);
-
         // This value is hard coded because, from a UI perspective, the size of the triangle is
         // given and fixed, and shouldn't vary based on the area it's in.
         static TRIANGLE_SIZE: f32 = 8.0;

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -448,12 +448,7 @@ impl<'a> ListItem<'a> {
                     id.unwrap_or(ui.id()).with("collapsing_triangle"),
                     egui::Sense::click(),
                 );
-                ReUi::paint_collapsing_triangle(
-                    ui,
-                    openness,
-                    triangle_rect.center(),
-                    &triangle_response,
-                );
+                ReUi::paint_collapsing_triangle(ui, openness, triangle_rect.center(), &visuals);
                 collapse_response = Some(triangle_response);
             }
 


### PR DESCRIPTION
### What

Another quick one, pointed out by @martenbjork 

Before/after:

<img width="205" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/60c82813-73a2-4346-8cda-25ec0e46be05">
<img width="169" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/4e2dbc7d-4b27-4d09-8acb-3b6d6c7248bd">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5354/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5354/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5354/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5354)
- [Docs preview](https://rerun.io/preview/31718db9b02b276ea61277b151b13a3ba1fd2dd0/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/31718db9b02b276ea61277b151b13a3ba1fd2dd0/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)