### PR TITLE
Fix CI: bad `egui_tiles` commit and merge bug in #5369

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "egui_tiles"
 version = "0.7.2"
-source = "git+https://github.com/rerun-io/egui_tiles?rev=6147feb6f9e6a60e8f12872398d449baa6e0b2ec#6147feb6f9e6a60e8f12872398d449baa6e0b2ec"
+source = "git+https://github.com/rerun-io/egui_tiles?rev=5245a28df8a3a5befd0c55085de4f7044a6d831e#5245a28df8a3a5befd0c55085de4f7044a6d831e"
 dependencies = [
  "ahash",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,6 +301,6 @@ emath = { git = "https://github.com/emilk/egui.git", rev = "e29022efc4783fe06842
 # egui-wgpu = { path = "../../egui/crates/egui-wgpu" }
 # emath = { path = "../../egui/crates/emath" }
 
-egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "6147feb6f9e6a60e8f12872398d449baa6e0b2ec" } # main 2024-02-27, which works with egui master
+egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "5245a28df8a3a5befd0c55085de4f7044a6d831e" } # main 2024-02-27, which works with egui master
 
 # egui_commonmark = { git = "https://github.com/rerun-io/egui_commonmark", rev = "3d83a92f995a1d18ab1172d0b129d496e0eedaae" } # Update to egui 0.25 https://github.com/lampsitter/egui_commonmark/pull/27

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -1,6 +1,7 @@
 use egui::{Response, Ui};
 
 use itertools::Itertools;
+use re_entity_db::InstancePath;
 
 use re_log_types::EntityPath;
 use re_log_types::EntityPathRule;
@@ -376,8 +377,8 @@ impl Viewport<'_, '_> {
                 )
                 .clicked()
             {
-                ctx.selection_state().set_selection(Item::InstancePath(
-                    Some(space_view.id),
+                ctx.selection_state().set_selection(Item::DataResult(
+                    space_view.id,
                     InstancePath::entity_splat(entity_path.clone()),
                 ));
             }


### PR DESCRIPTION
### What

As the title says ☝🏻 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5373/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5373/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5373/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5373)
- [Docs preview](https://rerun.io/preview/4ce11b992b0951da9170518b8c3f5af2f65b8275/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4ce11b992b0951da9170518b8c3f5af2f65b8275/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)