### PR TITLE
Add RERUN_INSTALL_RERUN_C CMake option to disable installation of rerun_c library

### DIFF
--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -129,7 +129,7 @@ install(DIRECTORY "${RERUN_CPP_SOURCE_DIR}/" TYPE INCLUDE FILES_MATCHING PATTERN
 option(RERUN_INSTALL_RERUN_C "Install rerun_c file." ON)
 # if rerun_sdk is a static library it is compulsory to install rerun_c
 get_target_property(rerun_sdk_TYPE rerun_sdk TYPE)
-if(rerun_sdk_TYPE STREQUAL "STATIC_LIBRARY")
+if(rerun_sdk_TYPE STREQUAL "STATIC_LIBRARY" AND NOT RERUN_INSTALL_RERUN_C)
     message(FATAL_ERROR "It is not possible to disable RERUN_INSTALL_RERUN_C option if rerun_sdk is compiled as static library.")
 endif()
 

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -123,13 +123,22 @@ install(TARGETS rerun_sdk
     INCLUDES DESTINATION include
 )
 
-# Add all headers to the install.
-install(DIRECTORY "${RERUN_CPP_SOURCE_DIR}/" TYPE INCLUDE FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h")
+# Add all C++ headers to the install.
+install(DIRECTORY "${RERUN_CPP_SOURCE_DIR}/" TYPE INCLUDE FILES_MATCHING PATTERN "*.hpp")
 
-# Add rerun_c to the lib folder.
-# CMake doesn't allow installing imported targets which is why we need to add this as a file.
-get_target_property(RERUN_C_LIB_LOCATION rerun_c IMPORTED_LOCATION)
-install(FILES ${RERUN_C_LIB_LOCATION} DESTINATION lib)
+option(RERUN_INSTALL_RERUN_C "Install rerun_c file." ON)
+# if rerun_sdk is a static library it is compulsory to install rerun_c
+get_target_property(rerun_sdk_TYPE rerun_sdk TYPE)
+if(rerun_sdk_TYPE STREQUAL "STATIC_LIBRARY")
+    message(FATAL_ERROR "It is not possible to disable RERUN_INSTALL_RERUN_C option if rerun_sdk is compiled as static library.")
+endif()
+
+if(RERUN_INSTALL_RERUN_C)
+    # CMake doesn't allow installing imported targets which is why we need to add this as a file.
+    get_target_property(RERUN_C_LIB_LOCATION rerun_c IMPORTED_LOCATION)
+    install(DIRECTORY "${RERUN_CPP_SOURCE_DIR}/" TYPE INCLUDE FILES_MATCHING PATTERN "*.h")
+    install(FILES ${RERUN_C_LIB_LOCATION} DESTINATION lib)
+endif()
 
 # Similarly, we bundle the arrow library that was used during the build.
 # For the moment we only support this when building with the downloaded, static libarrow.

--- a/rerun_cpp/Config.cmake.in
+++ b/rerun_cpp/Config.cmake.in
@@ -4,16 +4,18 @@ include("${CMAKE_CURRENT_LIST_DIR}/rerun_sdkTargets.cmake")
 
 set(RERUN_LIB_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-# Setup `rerun_c` (imported libraries can't be exported!)
-add_library(rerun_c STATIC IMPORTED GLOBAL)
-get_filename_component(RERUN_C_LIB_NAME "@RERUN_C_LIB_LOCATION@" NAME)
-set_target_properties(rerun_c PROPERTIES IMPORTED_LOCATION "${RERUN_LIB_DIR}/${RERUN_C_LIB_NAME}")
-if(APPLE)
-    target_link_libraries(rerun_c INTERFACE "-framework CoreFoundation" "-framework IOKit")
-elseif(UNIX) # if(LINUX) # CMake 3.25
-    target_link_libraries(rerun_c INTERFACE "-lm -ldl -pthread")
-elseif(WIN32)
-    target_link_libraries(rerun_c INTERFACE ws2_32.dll Bcrypt.dll Userenv.dll ntdll.dll)
+if(@RERUN_INSTALL_RERUN_C@)
+    # Setup `rerun_c` (imported libraries can't be exported!)
+    add_library(rerun_c STATIC IMPORTED GLOBAL)
+    get_filename_component(RERUN_C_LIB_NAME "@RERUN_C_LIB_LOCATION@" NAME)
+    set_target_properties(rerun_c PROPERTIES IMPORTED_LOCATION "${RERUN_LIB_DIR}/${RERUN_C_LIB_NAME}")
+    if(APPLE)
+        target_link_libraries(rerun_c INTERFACE "-framework CoreFoundation" "-framework IOKit")
+    elseif(UNIX) # if(LINUX) # CMake 3.25
+        target_link_libraries(rerun_c INTERFACE "-lm -ldl -pthread")
+    elseif(WIN32)
+        target_link_libraries(rerun_c INTERFACE ws2_32.dll Bcrypt.dll Userenv.dll ntdll.dll)
+    endif()
 endif()
 
 # Setup `rerun_arrow_target` (imported libraries can't be exported and package dependencies need to be re-declared)


### PR DESCRIPTION
When building the C++ SDK with the `BUILD_SHARED_LIBS` option set to `ON`, it is not compulsory to also install the `rerun_c` static library. This PR adds a CMake option `RERUN_INSTALL_RERUN_C` (enabled by default), that can be disabled when `rerun_sdk` is not compiled as static library. 

This is useful when packaging the rerun C++ SDK if you want to avoid to also install the rerun_c static library (related to https://github.com/rerun-io/rerun/issues/4579).

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5374/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5374/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5374/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5374)
- [Docs preview](https://rerun.io/preview/538c4c8eaad0963eaa2a6915c1179106d5acc111/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/538c4c8eaad0963eaa2a6915c1179106d5acc111/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)