### PR TITLE
Fix cmake install not finding external arrow for dynamic arrow linking)

### DIFF
--- a/rerun_cpp/Config.cmake.in
+++ b/rerun_cpp/Config.cmake.in
@@ -31,7 +31,7 @@ if(@RERUN_DOWNLOAD_AND_BUILD_ARROW@ AND NOT @RERUN_ARROW_LINK_SHARED@)
     set_target_properties(arrow_targetBundledDeps PROPERTIES IMPORTED_LOCATION "${RERUN_LIB_DIR}/${RERUN_ARROW_DEPS_LIB_NAME}")
     target_link_libraries(rerun_arrow_target INTERFACE arrow_targetBundledDeps)
 else()
-    if(@RERUN_ARROW_LINK_SHARED@)
+    if(@RERUN_DOWNLOAD_AND_BUILD_ARROW@ AND @RERUN_ARROW_LINK_SHARED@)
         message(WARNING
             "Rerun got built with an automatically downloaded version of libArrow,"
             "but it was not bundled as part of the install since export of shared libArrow is not supported yet."
@@ -42,9 +42,8 @@ else()
     find_package(Arrow REQUIRED)
 
     message(STATUS "Rerun is using a system installed libArrow.")
-    option(RERUN_ARROW_LINK_SHARED "Link to the Arrow shared library" @RERUN_ARROW_LINK_SHARED_DEFAULT@)
 
-    if(RERUN_ARROW_LINK_SHARED)
+    if(@RERUN_ARROW_LINK_SHARED@)
         add_library(rerun_arrow_target ALIAS Arrow::arrow_shared)
     else()
         add_library(rerun_arrow_target ALIAS Arrow::arrow_static)


### PR DESCRIPTION
Before this PR, if `rerun_sdk` was build with `RERUN_DOWNLOAD_AND_BUILD_ARROW` set to `OFF` and `RERUN_ARROW_LINK_SHARED` set to `ON`, the downstream build of a package that uses `rerun_sdk` via `find_package(rerun_sdk)` had the following problems:
* A "Rerun got built with an automatically downloaded version of libArrow" warning was printed, even if rerun was built against a system version of arrow
* If the arrow system installation did not shipped `Arrow::arrow_static` (as it is the case for conda-forge, at least for the `libarrow` package), the CMake failed as the non-existent `Arrow::arrow_static` target was referenced.

These two problems are solved in these PR by:
* Only printing the "Rerun got built with an automatically downloaded version of libArrow" warning if `@RERUN_DOWNLOAD_AND_BUILD_ARROW@` is OFF
* Define the `rerun_arrow_target` target using the value of `RERUN_ARROW_LINK_SHARED` used when building rerun.



### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5375/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5375/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5375/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5375)
- [Docs preview](https://rerun.io/preview/f47c23fce28dc8ba70ffd4a39f27fbc4f556fdf1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f47c23fce28dc8ba70ffd4a39f27fbc4f556fdf1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)