### PR TITLE
fix link to cpp example that linked to edit version of README.md

### DIFF
--- a/examples/cpp/eigen_opencv/README.md
+++ b/examples/cpp/eigen_opencv/README.md
@@ -6,10 +6,9 @@ thumbnail = "https://static.rerun.io/cpp-example-opencv-eigen/2fc6355fd87fbb4d07
 thumbnail_dimensions = [480, 267]
 -->
 
-
 This is a minimal CMake project that shows how to use Rerun in your code in conjunction with [Eigen](https://eigen.tuxfamily.org/) and [OpenCV](https://opencv.org/).
 
-You can find the example at <https://github.com/rerun-io/cpp-example-opencv-eigen/edit/main/README.md>.
+You can find the example at <https://github.com/rerun-io/cpp-example-opencv-eigen/blob/main/README.md>.
 
 <picture>
   <img src="https://static.rerun.io/cpp-example-opencv-eigen/2fc6355fd87fbb4d07cda384ee8805edb68b5e01/full.png" alt="">


### PR DESCRIPTION

### What

The link to the cpp-example-opencv-eigen repo linked to the edit view of README.md which requires permission to view.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
