### PR TITLE
Fix crates.py retry delay parsing

### DIFF
--- a/scripts/ci/crates.py
+++ b/scripts/ci/crates.py
@@ -438,7 +438,7 @@ def publish_crate(crate: Crate, token: str, version: str, env: dict[str, Any]) -
             error_message = e.stdout.decode("utf-8").strip()
             # if we get a 429, parse the retry delay from it
             # for any other error, retry after 6 seconds
-            retry_delay = 1 + parse_retry_delay_secs(error_message) or 5.0
+            retry_delay = 1 + (parse_retry_delay_secs(error_message) or 5.0)
             if retry_attempts > 0:
                 print(f"{R}Failed to publish{X} {B}{name}{X}, retrying in {retry_delay} seconds…")
                 retry_attempts -= 1


### PR DESCRIPTION
### What



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5386/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5386/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5386/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5386)
- [Docs preview](https://rerun.io/preview/782b8e91be5420931dee3d10b3e026b37b9d4c09/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/782b8e91be5420931dee3d10b3e026b37b9d4c09/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)