### PR TITLE
Key-less datamodel 1: scrap `InstanceKey` from public logging APIs

### DIFF
--- a/crates/re_space_view_spatial/src/mesh_loader.rs
+++ b/crates/re_space_view_spatial/src/mesh_loader.rs
@@ -102,7 +102,6 @@ impl LoadedMesh {
             vertex_texcoords,
             mesh_material,
             class_ids: _,
-            instance_keys: _,
             albedo_texture,
         } = mesh3d;
 

--- a/crates/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/re_space_view_spatial/src/visualizers/meshes.rs
@@ -98,7 +98,6 @@ impl Mesh3DVisualizer {
                 mesh_material: arch_view.raw_optional_mono_component::<Material>()?,
                 albedo_texture: arch_view.raw_optional_mono_component::<TensorData>()?,
                 class_ids: None,
-                instance_keys: None,
             }
         };
 

--- a/crates/re_types/definitions/rerun/archetypes/arrows2d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/arrows2d.fbs
@@ -47,7 +47,4 @@ table Arrows2D (
   ///
   /// The class ID provides colors and labels if not specified explicitly.
   class_ids: [rerun.components.ClassId] ("attr.rerun.component_optional", nullable, order: 3300);
-
-  /// Unique identifiers for each individual point in the batch.
-  instance_keys: [rerun.components.InstanceKey] ("attr.rerun.component_optional", nullable, order: 3400);
 }

--- a/crates/re_types/definitions/rerun/archetypes/arrows3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/arrows3d.fbs
@@ -47,7 +47,4 @@ table Arrows3D (
   ///
   /// The class ID provides colors and labels if not specified explicitly.
   class_ids: [rerun.components.ClassId] ("attr.rerun.component_optional", nullable, order: 3300);
-
-  /// Unique identifiers for each individual point in the batch.
-  instance_keys: [rerun.components.InstanceKey] ("attr.rerun.component_optional", nullable, order: 3400);
 }

--- a/crates/re_types/definitions/rerun/archetypes/boxes2d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/boxes2d.fbs
@@ -53,7 +53,4 @@ table Boxes2D (
   ///
   /// The class ID provides colors and labels if not specified explicitly.
   class_ids: [rerun.components.ClassId] ("attr.rerun.component_optional", nullable, order: 3200);
-
-  /// Unique identifiers for each individual boxes in the batch.
-  instance_keys: [rerun.components.InstanceKey] ("attr.rerun.component_optional", nullable, order: 3400);
 }

--- a/crates/re_types/definitions/rerun/archetypes/boxes3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/boxes3d.fbs
@@ -46,7 +46,4 @@ table Boxes3D (
   ///
   /// The class ID provides colors and labels if not specified explicitly.
   class_ids: [rerun.components.ClassId] ("attr.rerun.component_optional", nullable, order: 3200);
-
-  /// Unique identifiers for each individual boxes in the batch.
-  instance_keys: [rerun.components.InstanceKey] ("attr.rerun.component_optional", nullable, order: 3300);
 }

--- a/crates/re_types/definitions/rerun/archetypes/line_strips2d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/line_strips2d.fbs
@@ -42,7 +42,4 @@ table LineStrips2D (
   ///
   /// The class ID provides colors and labels if not specified explicitly.
   class_ids: [rerun.components.ClassId] ("attr.rerun.component_optional", nullable, order: 3200);
-
-  /// Unique identifiers for each individual line strip in the batch.
-  instance_keys: [rerun.components.InstanceKey] ("attr.rerun.component_optional", nullable, order: 3400);
 }

--- a/crates/re_types/definitions/rerun/archetypes/line_strips3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/line_strips3d.fbs
@@ -37,7 +37,4 @@ table LineStrips3D (
   ///
   /// The class ID provides colors and labels if not specified explicitly.
   class_ids: [rerun.components.ClassId] ("attr.rerun.component_optional", nullable, order: 3200);
-
-  /// Unique identifiers for each individual line strip in the batch.
-  instance_keys: [rerun.components.InstanceKey] ("attr.rerun.component_optional", nullable, order: 3400);
 }

--- a/crates/re_types/definitions/rerun/archetypes/mesh3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/mesh3d.fbs
@@ -58,7 +58,4 @@ table Mesh3D (
   ///
   /// The class ID provides colors and labels if not specified explicitly.
   class_ids: [rerun.components.ClassId] ("attr.rerun.component_optional", nullable, order: 3500);
-
-  /// Unique identifiers for each individual vertex in the mesh.
-  instance_keys: [rerun.components.InstanceKey] ("attr.rerun.component_optional", nullable, order: 3600);
 }

--- a/crates/re_types/definitions/rerun/archetypes/points2d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/points2d.fbs
@@ -56,7 +56,4 @@ table Points2D (
   /// E.g. the classification might be 'Person' and the keypoints refer to joints on a
   /// detected skeleton.
   keypoint_ids: [rerun.components.KeypointId] ("attr.rerun.component_optional", nullable, order: 3300);
-
-  /// Unique identifiers for each individual point in the batch.
-  instance_keys: [rerun.components.InstanceKey] ("attr.rerun.component_optional", nullable, order: 3400);
 }

--- a/crates/re_types/definitions/rerun/archetypes/points3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/points3d.fbs
@@ -49,7 +49,4 @@ table Points3D (
   /// E.g. the classification might be 'Person' and the keypoints refer to joints on a
   /// detected skeleton.
   keypoint_ids: [rerun.components.KeypointId] ("attr.rerun.component_optional", nullable, order: 3300);
-
-  /// Unique identifiers for each individual point in the batch.
-  instance_keys: [rerun.components.InstanceKey] ("attr.rerun.component_optional", nullable, order: 3400);
 }

--- a/crates/re_types/src/archetypes/arrows2d.rs
+++ b/crates/re_types/src/archetypes/arrows2d.rs
@@ -77,9 +77,6 @@ pub struct Arrows2D {
     ///
     /// The class ID provides colors and labels if not specified explicitly.
     pub class_ids: Option<Vec<crate::components::ClassId>>,
-
-    /// Unique identifiers for each individual point in the batch.
-    pub instance_keys: Option<Vec<crate::components::InstanceKey>>,
 }
 
 impl ::re_types_core::SizeBytes for Arrows2D {
@@ -91,7 +88,6 @@ impl ::re_types_core::SizeBytes for Arrows2D {
             + self.colors.heap_size_bytes()
             + self.labels.heap_size_bytes()
             + self.class_ids.heap_size_bytes()
-            + self.instance_keys.heap_size_bytes()
     }
 
     #[inline]
@@ -102,7 +98,6 @@ impl ::re_types_core::SizeBytes for Arrows2D {
             && <Option<Vec<crate::components::Color>>>::is_pod()
             && <Option<Vec<crate::components::Text>>>::is_pod()
             && <Option<Vec<crate::components::ClassId>>>::is_pod()
-            && <Option<Vec<crate::components::InstanceKey>>>::is_pod()
     }
 }
 
@@ -265,19 +260,6 @@ impl ::re_types_core::Archetype for Arrows2D {
         } else {
             None
         };
-        let instance_keys = if let Some(array) = arrays_by_name.get("rerun.components.InstanceKey")
-        {
-            Some({
-                <crate::components::InstanceKey>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Arrows2D#instance_keys")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.Arrows2D#instance_keys")?
-            })
-        } else {
-            None
-        };
         Ok(Self {
             vectors,
             origins,
@@ -285,7 +267,6 @@ impl ::re_types_core::Archetype for Arrows2D {
             colors,
             labels,
             class_ids,
-            instance_keys,
         })
     }
 }
@@ -312,9 +293,6 @@ impl ::re_types_core::AsComponents for Arrows2D {
             self.class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.instance_keys
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()
@@ -338,7 +316,6 @@ impl Arrows2D {
             colors: None,
             labels: None,
             class_ids: None,
-            instance_keys: None,
         }
     }
 
@@ -384,15 +361,6 @@ impl Arrows2D {
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
-        self
-    }
-
-    #[inline]
-    pub fn with_instance_keys(
-        mut self,
-        instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,
-    ) -> Self {
-        self.instance_keys = Some(instance_keys.into_iter().map(Into::into).collect());
         self
     }
 }

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -90,9 +90,6 @@ pub struct Arrows3D {
     ///
     /// The class ID provides colors and labels if not specified explicitly.
     pub class_ids: Option<Vec<crate::components::ClassId>>,
-
-    /// Unique identifiers for each individual point in the batch.
-    pub instance_keys: Option<Vec<crate::components::InstanceKey>>,
 }
 
 impl ::re_types_core::SizeBytes for Arrows3D {
@@ -104,7 +101,6 @@ impl ::re_types_core::SizeBytes for Arrows3D {
             + self.colors.heap_size_bytes()
             + self.labels.heap_size_bytes()
             + self.class_ids.heap_size_bytes()
-            + self.instance_keys.heap_size_bytes()
     }
 
     #[inline]
@@ -115,7 +111,6 @@ impl ::re_types_core::SizeBytes for Arrows3D {
             && <Option<Vec<crate::components::Color>>>::is_pod()
             && <Option<Vec<crate::components::Text>>>::is_pod()
             && <Option<Vec<crate::components::ClassId>>>::is_pod()
-            && <Option<Vec<crate::components::InstanceKey>>>::is_pod()
     }
 }
 
@@ -278,19 +273,6 @@ impl ::re_types_core::Archetype for Arrows3D {
         } else {
             None
         };
-        let instance_keys = if let Some(array) = arrays_by_name.get("rerun.components.InstanceKey")
-        {
-            Some({
-                <crate::components::InstanceKey>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Arrows3D#instance_keys")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.Arrows3D#instance_keys")?
-            })
-        } else {
-            None
-        };
         Ok(Self {
             vectors,
             origins,
@@ -298,7 +280,6 @@ impl ::re_types_core::Archetype for Arrows3D {
             colors,
             labels,
             class_ids,
-            instance_keys,
         })
     }
 }
@@ -325,9 +306,6 @@ impl ::re_types_core::AsComponents for Arrows3D {
             self.class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.instance_keys
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()
@@ -351,7 +329,6 @@ impl Arrows3D {
             colors: None,
             labels: None,
             class_ids: None,
-            instance_keys: None,
         }
     }
 
@@ -397,15 +374,6 @@ impl Arrows3D {
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
-        self
-    }
-
-    #[inline]
-    pub fn with_instance_keys(
-        mut self,
-        instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,
-    ) -> Self {
-        self.instance_keys = Some(instance_keys.into_iter().map(Into::into).collect());
         self
     }
 }

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -78,9 +78,6 @@ pub struct Boxes2D {
     ///
     /// The class ID provides colors and labels if not specified explicitly.
     pub class_ids: Option<Vec<crate::components::ClassId>>,
-
-    /// Unique identifiers for each individual boxes in the batch.
-    pub instance_keys: Option<Vec<crate::components::InstanceKey>>,
 }
 
 impl ::re_types_core::SizeBytes for Boxes2D {
@@ -93,7 +90,6 @@ impl ::re_types_core::SizeBytes for Boxes2D {
             + self.labels.heap_size_bytes()
             + self.draw_order.heap_size_bytes()
             + self.class_ids.heap_size_bytes()
-            + self.instance_keys.heap_size_bytes()
     }
 
     #[inline]
@@ -105,7 +101,6 @@ impl ::re_types_core::SizeBytes for Boxes2D {
             && <Option<Vec<crate::components::Text>>>::is_pod()
             && <Option<crate::components::DrawOrder>>::is_pod()
             && <Option<Vec<crate::components::ClassId>>>::is_pod()
-            && <Option<Vec<crate::components::InstanceKey>>>::is_pod()
     }
 }
 
@@ -279,19 +274,6 @@ impl ::re_types_core::Archetype for Boxes2D {
         } else {
             None
         };
-        let instance_keys = if let Some(array) = arrays_by_name.get("rerun.components.InstanceKey")
-        {
-            Some({
-                <crate::components::InstanceKey>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Boxes2D#instance_keys")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.Boxes2D#instance_keys")?
-            })
-        } else {
-            None
-        };
         Ok(Self {
             half_sizes,
             centers,
@@ -300,7 +282,6 @@ impl ::re_types_core::Archetype for Boxes2D {
             labels,
             draw_order,
             class_ids,
-            instance_keys,
         })
     }
 }
@@ -330,9 +311,6 @@ impl ::re_types_core::AsComponents for Boxes2D {
             self.class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.instance_keys
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()
@@ -357,7 +335,6 @@ impl Boxes2D {
             labels: None,
             draw_order: None,
             class_ids: None,
-            instance_keys: None,
         }
     }
 
@@ -409,15 +386,6 @@ impl Boxes2D {
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
-        self
-    }
-
-    #[inline]
-    pub fn with_instance_keys(
-        mut self,
-        instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,
-    ) -> Self {
-        self.instance_keys = Some(instance_keys.into_iter().map(Into::into).collect());
         self
     }
 }

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -84,9 +84,6 @@ pub struct Boxes3D {
     ///
     /// The class ID provides colors and labels if not specified explicitly.
     pub class_ids: Option<Vec<crate::components::ClassId>>,
-
-    /// Unique identifiers for each individual boxes in the batch.
-    pub instance_keys: Option<Vec<crate::components::InstanceKey>>,
 }
 
 impl ::re_types_core::SizeBytes for Boxes3D {
@@ -99,7 +96,6 @@ impl ::re_types_core::SizeBytes for Boxes3D {
             + self.radii.heap_size_bytes()
             + self.labels.heap_size_bytes()
             + self.class_ids.heap_size_bytes()
-            + self.instance_keys.heap_size_bytes()
     }
 
     #[inline]
@@ -111,7 +107,6 @@ impl ::re_types_core::SizeBytes for Boxes3D {
             && <Option<Vec<crate::components::Radius>>>::is_pod()
             && <Option<Vec<crate::components::Text>>>::is_pod()
             && <Option<Vec<crate::components::ClassId>>>::is_pod()
-            && <Option<Vec<crate::components::InstanceKey>>>::is_pod()
     }
 }
 
@@ -288,19 +283,6 @@ impl ::re_types_core::Archetype for Boxes3D {
         } else {
             None
         };
-        let instance_keys = if let Some(array) = arrays_by_name.get("rerun.components.InstanceKey")
-        {
-            Some({
-                <crate::components::InstanceKey>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Boxes3D#instance_keys")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.Boxes3D#instance_keys")?
-            })
-        } else {
-            None
-        };
         Ok(Self {
             half_sizes,
             centers,
@@ -309,7 +291,6 @@ impl ::re_types_core::Archetype for Boxes3D {
             radii,
             labels,
             class_ids,
-            instance_keys,
         })
     }
 }
@@ -339,9 +320,6 @@ impl ::re_types_core::AsComponents for Boxes3D {
             self.class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.instance_keys
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()
@@ -366,7 +344,6 @@ impl Boxes3D {
             radii: None,
             labels: None,
             class_ids: None,
-            instance_keys: None,
         }
     }
 
@@ -421,15 +398,6 @@ impl Boxes3D {
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
-        self
-    }
-
-    #[inline]
-    pub fn with_instance_keys(
-        mut self,
-        instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,
-    ) -> Self {
-        self.instance_keys = Some(instance_keys.into_iter().map(Into::into).collect());
         self
     }
 }

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -82,9 +82,6 @@ pub struct LineStrips2D {
     ///
     /// The class ID provides colors and labels if not specified explicitly.
     pub class_ids: Option<Vec<crate::components::ClassId>>,
-
-    /// Unique identifiers for each individual line strip in the batch.
-    pub instance_keys: Option<Vec<crate::components::InstanceKey>>,
 }
 
 impl ::re_types_core::SizeBytes for LineStrips2D {
@@ -96,7 +93,6 @@ impl ::re_types_core::SizeBytes for LineStrips2D {
             + self.labels.heap_size_bytes()
             + self.draw_order.heap_size_bytes()
             + self.class_ids.heap_size_bytes()
-            + self.instance_keys.heap_size_bytes()
     }
 
     #[inline]
@@ -107,7 +103,6 @@ impl ::re_types_core::SizeBytes for LineStrips2D {
             && <Option<Vec<crate::components::Text>>>::is_pod()
             && <Option<crate::components::DrawOrder>>::is_pod()
             && <Option<Vec<crate::components::ClassId>>>::is_pod()
-            && <Option<Vec<crate::components::InstanceKey>>>::is_pod()
     }
 }
 
@@ -267,19 +262,6 @@ impl ::re_types_core::Archetype for LineStrips2D {
         } else {
             None
         };
-        let instance_keys = if let Some(array) = arrays_by_name.get("rerun.components.InstanceKey")
-        {
-            Some({
-                <crate::components::InstanceKey>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.LineStrips2D#instance_keys")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.LineStrips2D#instance_keys")?
-            })
-        } else {
-            None
-        };
         Ok(Self {
             strips,
             radii,
@@ -287,7 +269,6 @@ impl ::re_types_core::Archetype for LineStrips2D {
             labels,
             draw_order,
             class_ids,
-            instance_keys,
         })
     }
 }
@@ -314,9 +295,6 @@ impl ::re_types_core::AsComponents for LineStrips2D {
             self.class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.instance_keys
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()
@@ -340,7 +318,6 @@ impl LineStrips2D {
             labels: None,
             draw_order: None,
             class_ids: None,
-            instance_keys: None,
         }
     }
 
@@ -383,15 +360,6 @@ impl LineStrips2D {
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
-        self
-    }
-
-    #[inline]
-    pub fn with_instance_keys(
-        mut self,
-        instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,
-    ) -> Self {
-        self.instance_keys = Some(instance_keys.into_iter().map(Into::into).collect());
         self
     }
 }

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -79,9 +79,6 @@ pub struct LineStrips3D {
     ///
     /// The class ID provides colors and labels if not specified explicitly.
     pub class_ids: Option<Vec<crate::components::ClassId>>,
-
-    /// Unique identifiers for each individual line strip in the batch.
-    pub instance_keys: Option<Vec<crate::components::InstanceKey>>,
 }
 
 impl ::re_types_core::SizeBytes for LineStrips3D {
@@ -92,7 +89,6 @@ impl ::re_types_core::SizeBytes for LineStrips3D {
             + self.colors.heap_size_bytes()
             + self.labels.heap_size_bytes()
             + self.class_ids.heap_size_bytes()
-            + self.instance_keys.heap_size_bytes()
     }
 
     #[inline]
@@ -102,7 +98,6 @@ impl ::re_types_core::SizeBytes for LineStrips3D {
             && <Option<Vec<crate::components::Color>>>::is_pod()
             && <Option<Vec<crate::components::Text>>>::is_pod()
             && <Option<Vec<crate::components::ClassId>>>::is_pod()
-            && <Option<Vec<crate::components::InstanceKey>>>::is_pod()
     }
 }
 
@@ -251,26 +246,12 @@ impl ::re_types_core::Archetype for LineStrips3D {
         } else {
             None
         };
-        let instance_keys = if let Some(array) = arrays_by_name.get("rerun.components.InstanceKey")
-        {
-            Some({
-                <crate::components::InstanceKey>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.LineStrips3D#instance_keys")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.LineStrips3D#instance_keys")?
-            })
-        } else {
-            None
-        };
         Ok(Self {
             strips,
             radii,
             colors,
             labels,
             class_ids,
-            instance_keys,
         })
     }
 }
@@ -292,9 +273,6 @@ impl ::re_types_core::AsComponents for LineStrips3D {
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
             self.class_ids
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.instance_keys
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
         ]
@@ -319,7 +297,6 @@ impl LineStrips3D {
             colors: None,
             labels: None,
             class_ids: None,
-            instance_keys: None,
         }
     }
 
@@ -356,15 +333,6 @@ impl LineStrips3D {
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
-        self
-    }
-
-    #[inline]
-    pub fn with_instance_keys(
-        mut self,
-        instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,
-    ) -> Self {
-        self.instance_keys = Some(instance_keys.into_iter().map(Into::into).collect());
         self
     }
 }

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -87,9 +87,6 @@ pub struct Mesh3D {
     ///
     /// The class ID provides colors and labels if not specified explicitly.
     pub class_ids: Option<Vec<crate::components::ClassId>>,
-
-    /// Unique identifiers for each individual vertex in the mesh.
-    pub instance_keys: Option<Vec<crate::components::InstanceKey>>,
 }
 
 impl ::re_types_core::SizeBytes for Mesh3D {
@@ -103,7 +100,6 @@ impl ::re_types_core::SizeBytes for Mesh3D {
             + self.mesh_material.heap_size_bytes()
             + self.albedo_texture.heap_size_bytes()
             + self.class_ids.heap_size_bytes()
-            + self.instance_keys.heap_size_bytes()
     }
 
     #[inline]
@@ -116,7 +112,6 @@ impl ::re_types_core::SizeBytes for Mesh3D {
             && <Option<crate::components::Material>>::is_pod()
             && <Option<crate::components::TensorData>>::is_pod()
             && <Option<Vec<crate::components::ClassId>>>::is_pod()
-            && <Option<Vec<crate::components::InstanceKey>>>::is_pod()
     }
 }
 
@@ -301,19 +296,6 @@ impl ::re_types_core::Archetype for Mesh3D {
         } else {
             None
         };
-        let instance_keys = if let Some(array) = arrays_by_name.get("rerun.components.InstanceKey")
-        {
-            Some({
-                <crate::components::InstanceKey>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Mesh3D#instance_keys")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.Mesh3D#instance_keys")?
-            })
-        } else {
-            None
-        };
         Ok(Self {
             vertex_positions,
             mesh_properties,
@@ -323,7 +305,6 @@ impl ::re_types_core::Archetype for Mesh3D {
             mesh_material,
             albedo_texture,
             class_ids,
-            instance_keys,
         })
     }
 }
@@ -356,9 +337,6 @@ impl ::re_types_core::AsComponents for Mesh3D {
             self.class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.instance_keys
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()
@@ -384,7 +362,6 @@ impl Mesh3D {
             mesh_material: None,
             albedo_texture: None,
             class_ids: None,
-            instance_keys: None,
         }
     }
 
@@ -448,15 +425,6 @@ impl Mesh3D {
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
-        self
-    }
-
-    #[inline]
-    pub fn with_instance_keys(
-        mut self,
-        instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,
-    ) -> Self {
-        self.instance_keys = Some(instance_keys.into_iter().map(Into::into).collect());
         self
     }
 }

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -90,9 +90,6 @@ pub struct Points2D {
     /// E.g. the classification might be 'Person' and the keypoints refer to joints on a
     /// detected skeleton.
     pub keypoint_ids: Option<Vec<crate::components::KeypointId>>,
-
-    /// Unique identifiers for each individual point in the batch.
-    pub instance_keys: Option<Vec<crate::components::InstanceKey>>,
 }
 
 impl ::re_types_core::SizeBytes for Points2D {
@@ -105,7 +102,6 @@ impl ::re_types_core::SizeBytes for Points2D {
             + self.draw_order.heap_size_bytes()
             + self.class_ids.heap_size_bytes()
             + self.keypoint_ids.heap_size_bytes()
-            + self.instance_keys.heap_size_bytes()
     }
 
     #[inline]
@@ -117,7 +113,6 @@ impl ::re_types_core::SizeBytes for Points2D {
             && <Option<crate::components::DrawOrder>>::is_pod()
             && <Option<Vec<crate::components::ClassId>>>::is_pod()
             && <Option<Vec<crate::components::KeypointId>>>::is_pod()
-            && <Option<Vec<crate::components::InstanceKey>>>::is_pod()
     }
 }
 
@@ -291,19 +286,6 @@ impl ::re_types_core::Archetype for Points2D {
         } else {
             None
         };
-        let instance_keys = if let Some(array) = arrays_by_name.get("rerun.components.InstanceKey")
-        {
-            Some({
-                <crate::components::InstanceKey>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Points2D#instance_keys")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.Points2D#instance_keys")?
-            })
-        } else {
-            None
-        };
         Ok(Self {
             positions,
             radii,
@@ -312,7 +294,6 @@ impl ::re_types_core::Archetype for Points2D {
             draw_order,
             class_ids,
             keypoint_ids,
-            instance_keys,
         })
     }
 }
@@ -342,9 +323,6 @@ impl ::re_types_core::AsComponents for Points2D {
             self.keypoint_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.instance_keys
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()
@@ -369,7 +347,6 @@ impl Points2D {
             draw_order: None,
             class_ids: None,
             keypoint_ids: None,
-            instance_keys: None,
         }
     }
 
@@ -421,15 +398,6 @@ impl Points2D {
         keypoint_ids: impl IntoIterator<Item = impl Into<crate::components::KeypointId>>,
     ) -> Self {
         self.keypoint_ids = Some(keypoint_ids.into_iter().map(Into::into).collect());
-        self
-    }
-
-    #[inline]
-    pub fn with_instance_keys(
-        mut self,
-        instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,
-    ) -> Self {
-        self.instance_keys = Some(instance_keys.into_iter().map(Into::into).collect());
         self
     }
 }

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -84,9 +84,6 @@ pub struct Points3D {
     /// E.g. the classification might be 'Person' and the keypoints refer to joints on a
     /// detected skeleton.
     pub keypoint_ids: Option<Vec<crate::components::KeypointId>>,
-
-    /// Unique identifiers for each individual point in the batch.
-    pub instance_keys: Option<Vec<crate::components::InstanceKey>>,
 }
 
 impl ::re_types_core::SizeBytes for Points3D {
@@ -98,7 +95,6 @@ impl ::re_types_core::SizeBytes for Points3D {
             + self.labels.heap_size_bytes()
             + self.class_ids.heap_size_bytes()
             + self.keypoint_ids.heap_size_bytes()
-            + self.instance_keys.heap_size_bytes()
     }
 
     #[inline]
@@ -109,7 +105,6 @@ impl ::re_types_core::SizeBytes for Points3D {
             && <Option<Vec<crate::components::Text>>>::is_pod()
             && <Option<Vec<crate::components::ClassId>>>::is_pod()
             && <Option<Vec<crate::components::KeypointId>>>::is_pod()
-            && <Option<Vec<crate::components::InstanceKey>>>::is_pod()
     }
 }
 
@@ -272,19 +267,6 @@ impl ::re_types_core::Archetype for Points3D {
         } else {
             None
         };
-        let instance_keys = if let Some(array) = arrays_by_name.get("rerun.components.InstanceKey")
-        {
-            Some({
-                <crate::components::InstanceKey>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Points3D#instance_keys")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.Points3D#instance_keys")?
-            })
-        } else {
-            None
-        };
         Ok(Self {
             positions,
             radii,
@@ -292,7 +274,6 @@ impl ::re_types_core::Archetype for Points3D {
             labels,
             class_ids,
             keypoint_ids,
-            instance_keys,
         })
     }
 }
@@ -319,9 +300,6 @@ impl ::re_types_core::AsComponents for Points3D {
             self.keypoint_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.instance_keys
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
         ]
         .into_iter()
         .flatten()
@@ -345,7 +323,6 @@ impl Points3D {
             labels: None,
             class_ids: None,
             keypoint_ids: None,
-            instance_keys: None,
         }
     }
 
@@ -391,15 +368,6 @@ impl Points3D {
         keypoint_ids: impl IntoIterator<Item = impl Into<crate::components::KeypointId>>,
     ) -> Self {
         self.keypoint_ids = Some(keypoint_ids.into_iter().map(Into::into).collect());
-        self
-    }
-
-    #[inline]
-    pub fn with_instance_keys(
-        mut self,
-        instance_keys: impl IntoIterator<Item = impl Into<crate::components::InstanceKey>>,
-    ) -> Self {
-        self.instance_keys = Some(instance_keys.into_iter().map(Into::into).collect());
         self
     }
 }

--- a/crates/re_types/tests/arrows3d.rs
+++ b/crates/re_types/tests/arrows3d.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use re_types::{
     archetypes::Arrows3D,
-    components::{ClassId, Color, InstanceKey, Position3D, Radius, Vector3D},
+    components::{ClassId, Color, Position3D, Radius, Vector3D},
     datatypes::Vec3D,
     Archetype as _, AsComponents as _,
 };
@@ -34,10 +34,6 @@ fn roundtrip() {
             ClassId::from(126), //
             ClassId::from(127), //
         ]),
-        instance_keys: Some(vec![
-            InstanceKey(u64::MAX - 1), //
-            InstanceKey(u64::MAX),
-        ]),
     };
 
     let arch = Arrows3D::from_vectors([[1.0, 2.0, 3.0], [10.0, 20.0, 30.0]])
@@ -45,8 +41,7 @@ fn roundtrip() {
         .with_radii([1.0, 10.0])
         .with_colors([0xAA0000CC, 0x00BB00DD])
         .with_labels(["hello", "friend"])
-        .with_class_ids([126, 127])
-        .with_instance_keys([u64::MAX - 1, u64::MAX]);
+        .with_class_ids([126, 127]);
     similar_asserts::assert_eq!(expected, arch);
 
     let expected_extensions: HashMap<_, _> = [
@@ -55,7 +50,6 @@ fn roundtrip() {
         ("colors", vec!["rerun.components.Color"]),
         ("labels", vec!["rerun.components.Text"]),
         ("class_ids", vec!["rerun.components.ClassId"]),
-        ("instance_keys", vec!["rerun.components.InstanceKey"]),
     ]
     .into();
 

--- a/crates/re_types/tests/box2d.rs
+++ b/crates/re_types/tests/box2d.rs
@@ -30,10 +30,6 @@ fn roundtrip() {
             components::ClassId::from(126), //
             components::ClassId::from(127), //
         ]),
-        instance_keys: Some(vec![
-            components::InstanceKey(u64::MAX - 1), //
-            components::InstanceKey(u64::MAX),
-        ]),
     };
 
     let arch = Boxes2D::from_half_sizes([(1.0, 2.0), (3.0, 4.0)])
@@ -42,8 +38,7 @@ fn roundtrip() {
         .with_radii([42.0, 43.0])
         .with_labels(["hello", "friend"])
         .with_draw_order(300.0)
-        .with_class_ids([126, 127])
-        .with_instance_keys([u64::MAX - 1, u64::MAX]);
+        .with_class_ids([126, 127]);
     similar_asserts::assert_eq!(expected, arch);
 
     let expected_extensions: HashMap<_, _> = [
@@ -54,7 +49,6 @@ fn roundtrip() {
         ("labels", vec!["rerun.components.Label"]),
         ("draw_order", vec!["rerun.components.DrawOrder"]),
         ("class_ids", vec!["rerun.components.ClassId"]),
-        ("instance_keys", vec!["rerun.components.InstanceKey"]),
     ]
     .into();
 

--- a/crates/re_types/tests/box3d.rs
+++ b/crates/re_types/tests/box3d.rs
@@ -36,10 +36,6 @@ fn roundtrip() {
             components::ClassId::from(126), //
             components::ClassId::from(127), //
         ]),
-        instance_keys: Some(vec![
-            components::InstanceKey(u64::MAX - 1), //
-            components::InstanceKey(u64::MAX),
-        ]),
     };
 
     let arch = Boxes3D::from_half_sizes([(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)])
@@ -54,8 +50,7 @@ fn roundtrip() {
         .with_colors([0xAA0000CC, 0x00BB00DD])
         .with_radii([42.0, 43.0])
         .with_labels(["hello", "friend"])
-        .with_class_ids([126, 127])
-        .with_instance_keys([u64::MAX - 1, u64::MAX]);
+        .with_class_ids([126, 127]);
     similar_asserts::assert_eq!(expected, arch);
 
     let expected_extensions: HashMap<_, _> = [
@@ -66,7 +61,6 @@ fn roundtrip() {
         ("labels", vec!["rerun.components.Label"]),
         ("draw_order", vec!["rerun.components.DrawOrder"]),
         ("class_ids", vec!["rerun.components.ClassId"]),
-        ("instance_keys", vec!["rerun.components.InstanceKey"]),
     ]
     .into();
 

--- a/crates/re_types/tests/line_strips2d.rs
+++ b/crates/re_types/tests/line_strips2d.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use re_types::{
     archetypes::LineStrips2D,
-    components::{ClassId, Color, DrawOrder, InstanceKey, LineStrip2D, Radius},
+    components::{ClassId, Color, DrawOrder, LineStrip2D, Radius},
     Archetype as _, AsComponents as _,
 };
 
@@ -31,10 +31,6 @@ fn roundtrip() {
             ClassId::from(126), //
             ClassId::from(127), //
         ]),
-        instance_keys: Some(vec![
-            InstanceKey(u64::MAX - 1), //
-            InstanceKey(u64::MAX),
-        ]),
     };
 
     #[rustfmt::skip]
@@ -47,8 +43,7 @@ fn roundtrip() {
         .with_colors([0xAA0000CC, 0x00BB00DD])
         .with_labels(["hello", "friend"])
         .with_draw_order(300.0)
-        .with_class_ids([126, 127])
-        .with_instance_keys([u64::MAX - 1, u64::MAX]);
+        .with_class_ids([126, 127]);
     similar_asserts::assert_eq!(expected, arch);
 
     let expected_extensions: HashMap<_, _> = [
@@ -59,7 +54,6 @@ fn roundtrip() {
         ("draw_order", vec!["rerun.components.DrawOrder"]),
         ("class_ids", vec!["rerun.components.ClassId"]),
         ("keypoint_ids", vec!["rerun.components.KeypointId"]),
-        ("instance_keys", vec!["rerun.components.InstanceKey"]),
     ]
     .into();
 

--- a/crates/re_types/tests/line_strips3d.rs
+++ b/crates/re_types/tests/line_strips3d.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use re_types::{
     archetypes::LineStrips3D,
-    components::{ClassId, Color, InstanceKey, LineStrip3D, Radius},
+    components::{ClassId, Color, LineStrip3D, Radius},
     Archetype as _, AsComponents as _,
 };
 
@@ -30,10 +30,6 @@ fn roundtrip() {
             ClassId::from(126), //
             ClassId::from(127), //
         ]),
-        instance_keys: Some(vec![
-            InstanceKey(u64::MAX - 1), //
-            InstanceKey(u64::MAX),
-        ]),
     };
 
     #[rustfmt::skip]
@@ -45,8 +41,7 @@ fn roundtrip() {
         .with_radii([42.0, 43.0])
         .with_colors([0xAA0000CC, 0x00BB00DD])
         .with_labels(["hello", "friend"])
-        .with_class_ids([126, 127])
-        .with_instance_keys([u64::MAX - 1, u64::MAX]);
+        .with_class_ids([126, 127]);
     similar_asserts::assert_eq!(expected, arch);
 
     let expected_extensions: HashMap<_, _> = [
@@ -57,7 +52,6 @@ fn roundtrip() {
         ("draw_order", vec!["rerun.components.DrawOrder"]),
         ("class_ids", vec!["rerun.components.ClassId"]),
         ("keypoint_ids", vec!["rerun.components.KeypointId"]),
-        ("instance_keys", vec!["rerun.components.InstanceKey"]),
     ]
     .into();
 

--- a/crates/re_types/tests/mesh3d.rs
+++ b/crates/re_types/tests/mesh3d.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use re_types::{
     archetypes::Mesh3D,
-    components::{ClassId, InstanceKey, Position3D, Texcoord2D, Vector3D},
+    components::{ClassId, Position3D, Texcoord2D, Vector3D},
     datatypes::{
         Material, MeshProperties, Rgba32, TensorBuffer, TensorData, TensorDimension, Vec2D, Vec3D,
     },
@@ -60,10 +60,6 @@ fn roundtrip() {
             ClassId::from(126), //
             ClassId::from(127), //
         ]),
-        instance_keys: Some(vec![
-            InstanceKey(u64::MAX - 1), //
-            InstanceKey(u64::MAX),
-        ]),
     };
 
     let arch = Mesh3D::new([[1.0, 2.0, 3.0], [10.0, 20.0, 30.0]])
@@ -76,13 +72,11 @@ fn roundtrip() {
         .with_vertex_texcoords([[0.0, 1.0], [2.0, 3.0]])
         .with_mesh_material(Material::from_albedo_factor(0xEE112233))
         .with_class_ids([126, 127])
-        .with_instance_keys([u64::MAX - 1, u64::MAX])
         .with_albedo_texture(tensor_data);
     similar_asserts::assert_eq!(expected, arch);
 
     let expected_extensions: HashMap<_, _> = [
-        ("class_ids", vec!["rerun.components.ClassId"]),
-        ("instance_keys", vec!["rerun.components.InstanceKey"]),
+        ("class_ids", vec!["rerun.components.ClassId"]), //
     ]
     .into();
 

--- a/crates/re_types/tests/points2d.rs
+++ b/crates/re_types/tests/points2d.rs
@@ -30,10 +30,6 @@ fn roundtrip() {
             components::KeypointId::from(2), //
             components::KeypointId::from(3), //
         ]),
-        instance_keys: Some(vec![
-            components::InstanceKey(u64::MAX - 1), //
-            components::InstanceKey(u64::MAX),
-        ]),
     };
 
     let arch = Points2D::new([(1.0, 2.0), (3.0, 4.0)])
@@ -42,8 +38,7 @@ fn roundtrip() {
         .with_labels(["hello", "friend"])
         .with_draw_order(300.0)
         .with_class_ids([126, 127])
-        .with_keypoint_ids([2, 3])
-        .with_instance_keys([u64::MAX - 1, u64::MAX]);
+        .with_keypoint_ids([2, 3]);
     similar_asserts::assert_eq!(expected, arch);
 
     let expected_extensions: HashMap<_, _> = [
@@ -54,7 +49,6 @@ fn roundtrip() {
         ("draw_order", vec!["rerun.components.DrawOrder"]),
         ("class_ids", vec!["rerun.components.ClassId"]),
         ("keypoint_ids", vec!["rerun.components.KeypointId"]),
-        ("instance_keys", vec!["rerun.components.InstanceKey"]),
     ]
     .into();
 

--- a/crates/re_types/tests/points3d.rs
+++ b/crates/re_types/tests/points3d.rs
@@ -29,10 +29,6 @@ fn roundtrip() {
             components::KeypointId::from(2), //
             components::KeypointId::from(3), //
         ]),
-        instance_keys: Some(vec![
-            components::InstanceKey(u64::MAX - 1), //
-            components::InstanceKey(u64::MAX),
-        ]),
     };
 
     let arch = Points3D::new([(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)])
@@ -40,8 +36,7 @@ fn roundtrip() {
         .with_colors([0xAA0000CC, 0x00BB00DD])
         .with_labels(["hello", "friend"])
         .with_class_ids([126, 127])
-        .with_keypoint_ids([2, 3])
-        .with_instance_keys([u64::MAX - 1, u64::MAX]);
+        .with_keypoint_ids([2, 3]);
     similar_asserts::assert_eq!(expected, arch);
 
     let expected_extensions: HashMap<_, _> = [
@@ -51,7 +46,6 @@ fn roundtrip() {
         ("labels", vec!["rerun.components.Text"]),
         ("class_ids", vec!["rerun.components.ClassId"]),
         ("keypoint_ids", vec!["rerun.components.KeypointId"]),
-        ("instance_keys", vec!["rerun.components.InstanceKey"]),
     ]
     .into();
 

--- a/docs/content/reference/types/archetypes/arrows2d.md
+++ b/docs/content/reference/types/archetypes/arrows2d.md
@@ -10,7 +10,7 @@ title: "Arrows2D"
 
 **Recommended**: [`Position2D`](../components/position2d.md)
 
-**Optional**: [`Radius`](../components/radius.md), [`Color`](../components/color.md), [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
+**Optional**: [`Radius`](../components/radius.md), [`Color`](../components/color.md), [`Text`](../components/text.md), [`ClassId`](../components/class_id.md)
 
 ## Links
  * 🌊 [C++ API docs for `Arrows2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Arrows2D.html)

--- a/docs/content/reference/types/archetypes/arrows3d.md
+++ b/docs/content/reference/types/archetypes/arrows3d.md
@@ -10,7 +10,7 @@ title: "Arrows3D"
 
 **Recommended**: [`Position3D`](../components/position3d.md)
 
-**Optional**: [`Radius`](../components/radius.md), [`Color`](../components/color.md), [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
+**Optional**: [`Radius`](../components/radius.md), [`Color`](../components/color.md), [`Text`](../components/text.md), [`ClassId`](../components/class_id.md)
 
 ## Links
  * 🌊 [C++ API docs for `Arrows3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Arrows3D.html)

--- a/docs/content/reference/types/archetypes/boxes2d.md
+++ b/docs/content/reference/types/archetypes/boxes2d.md
@@ -10,7 +10,7 @@ title: "Boxes2D"
 
 **Recommended**: [`Position2D`](../components/position2d.md), [`Color`](../components/color.md)
 
-**Optional**: [`Radius`](../components/radius.md), [`Text`](../components/text.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
+**Optional**: [`Radius`](../components/radius.md), [`Text`](../components/text.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md)
 
 ## Links
  * 🌊 [C++ API docs for `Boxes2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Boxes2D.html)

--- a/docs/content/reference/types/archetypes/boxes3d.md
+++ b/docs/content/reference/types/archetypes/boxes3d.md
@@ -10,7 +10,7 @@ title: "Boxes3D"
 
 **Recommended**: [`Position3D`](../components/position3d.md), [`Rotation3D`](../components/rotation3d.md), [`Color`](../components/color.md)
 
-**Optional**: [`Radius`](../components/radius.md), [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
+**Optional**: [`Radius`](../components/radius.md), [`Text`](../components/text.md), [`ClassId`](../components/class_id.md)
 
 ## Links
  * 🌊 [C++ API docs for `Boxes3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Boxes3D.html)

--- a/docs/content/reference/types/archetypes/line_strips2d.md
+++ b/docs/content/reference/types/archetypes/line_strips2d.md
@@ -10,7 +10,7 @@ title: "LineStrips2D"
 
 **Recommended**: [`Radius`](../components/radius.md), [`Color`](../components/color.md)
 
-**Optional**: [`Text`](../components/text.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
+**Optional**: [`Text`](../components/text.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md)
 
 ## Links
  * 🌊 [C++ API docs for `LineStrips2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1LineStrips2D.html)

--- a/docs/content/reference/types/archetypes/line_strips3d.md
+++ b/docs/content/reference/types/archetypes/line_strips3d.md
@@ -10,7 +10,7 @@ title: "LineStrips3D"
 
 **Recommended**: [`Radius`](../components/radius.md), [`Color`](../components/color.md)
 
-**Optional**: [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
+**Optional**: [`Text`](../components/text.md), [`ClassId`](../components/class_id.md)
 
 ## Links
  * 🌊 [C++ API docs for `LineStrips3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1LineStrips3D.html)

--- a/docs/content/reference/types/archetypes/mesh3d.md
+++ b/docs/content/reference/types/archetypes/mesh3d.md
@@ -10,7 +10,7 @@ A 3D triangle mesh as specified by its per-mesh and per-vertex properties.
 
 **Recommended**: [`MeshProperties`](../components/mesh_properties.md), [`Vector3D`](../components/vector3d.md)
 
-**Optional**: [`Color`](../components/color.md), [`Texcoord2D`](../components/texcoord2d.md), [`Material`](../components/material.md), [`TensorData`](../components/tensor_data.md), [`ClassId`](../components/class_id.md), [`InstanceKey`](../components/instance_key.md)
+**Optional**: [`Color`](../components/color.md), [`Texcoord2D`](../components/texcoord2d.md), [`Material`](../components/material.md), [`TensorData`](../components/tensor_data.md), [`ClassId`](../components/class_id.md)
 
 ## Links
  * 🌊 [C++ API docs for `Mesh3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Mesh3D.html)

--- a/docs/content/reference/types/archetypes/points2d.md
+++ b/docs/content/reference/types/archetypes/points2d.md
@@ -10,7 +10,7 @@ A 2D point cloud with positions and optional colors, radii, labels, etc.
 
 **Recommended**: [`Radius`](../components/radius.md), [`Color`](../components/color.md)
 
-**Optional**: [`Text`](../components/text.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md), [`KeypointId`](../components/keypoint_id.md), [`InstanceKey`](../components/instance_key.md)
+**Optional**: [`Text`](../components/text.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md), [`KeypointId`](../components/keypoint_id.md)
 
 ## Links
  * 🌊 [C++ API docs for `Points2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Points2D.html)

--- a/docs/content/reference/types/archetypes/points3d.md
+++ b/docs/content/reference/types/archetypes/points3d.md
@@ -10,7 +10,7 @@ A 3D point cloud with positions and optional colors, radii, labels, etc.
 
 **Recommended**: [`Radius`](../components/radius.md), [`Color`](../components/color.md)
 
-**Optional**: [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`KeypointId`](../components/keypoint_id.md), [`InstanceKey`](../components/instance_key.md)
+**Optional**: [`Text`](../components/text.md), [`ClassId`](../components/class_id.md), [`KeypointId`](../components/keypoint_id.md)
 
 ## Links
  * 🌊 [C++ API docs for `Points3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Points3D.html)

--- a/docs/content/reference/types/components/instance_key.md
+++ b/docs/content/reference/types/components/instance_key.md
@@ -14,14 +14,3 @@ A unique numeric identifier for each individual instance within a batch.
  * 🦀 [Rust API docs for `InstanceKey`](https://docs.rs/rerun/latest/rerun/components/struct.InstanceKey.html)
 
 
-## Used by
-
-* [`Arrows2D`](../archetypes/arrows2d.md)
-* [`Arrows3D`](../archetypes/arrows3d.md)
-* [`Boxes2D`](../archetypes/boxes2d.md)
-* [`Boxes3D`](../archetypes/boxes3d.md)
-* [`LineStrips2D`](../archetypes/line_strips2d.md)
-* [`LineStrips3D`](../archetypes/line_strips3d.md)
-* [`Mesh3D`](../archetypes/mesh3d.md)
-* [`Points2D`](../archetypes/points2d.md)
-* [`Points3D`](../archetypes/points3d.md)

--- a/examples/python/objectron/main.py
+++ b/examples/python/objectron/main.py
@@ -161,8 +161,7 @@ def log_point_cloud(point_cloud: ARPointCloud) -> None:
     """Logs a point cloud from an `ARFrame` using the Rerun SDK."""
 
     positions = np.array([[p.x, p.y, p.z] for p in point_cloud.point]).astype(np.float32)
-    identifiers = point_cloud.identifier
-    rr.log("world/points", rr.Points3D(positions, instance_keys=identifiers, colors=[255, 255, 255, 255]))
+    rr.log("world/points", rr.Points3D(positions, colors=[255, 255, 255, 255]))
 
 
 def log_annotated_bboxes(bboxes: Iterable[Object]) -> None:

--- a/rerun_cpp/src/rerun/archetypes/arrows2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows2d.cpp
@@ -14,7 +14,7 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<DataCell> cells;
-        cells.reserve(8);
+        cells.reserve(7);
 
         {
             auto result = DataCell::from_loggable(archetype.vectors);
@@ -43,11 +43,6 @@ namespace rerun {
         }
         if (archetype.class_ids.has_value()) {
             auto result = DataCell::from_loggable(archetype.class_ids.value());
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
-        }
-        if (archetype.instance_keys.has_value()) {
-            auto result = DataCell::from_loggable(archetype.instance_keys.value());
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/arrows2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows2d.hpp
@@ -7,7 +7,6 @@
 #include "../compiler_utils.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
-#include "../components/instance_key.hpp"
 #include "../components/position2d.hpp"
 #include "../components/radius.hpp"
 #include "../components/text.hpp"
@@ -72,9 +71,6 @@ namespace rerun::archetypes {
         /// The class ID provides colors and labels if not specified explicitly.
         std::optional<Collection<rerun::components::ClassId>> class_ids;
 
-        /// Unique identifiers for each individual point in the batch.
-        std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
-
       public:
         static constexpr const char IndicatorComponentName[] = "rerun.components.Arrows2DIndicator";
 
@@ -133,13 +129,6 @@ namespace rerun::archetypes {
         /// The class ID provides colors and labels if not specified explicitly.
         Arrows2D with_class_ids(Collection<rerun::components::ClassId> _class_ids) && {
             class_ids = std::move(_class_ids);
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
-        }
-
-        /// Unique identifiers for each individual point in the batch.
-        Arrows2D with_instance_keys(Collection<rerun::components::InstanceKey> _instance_keys) && {
-            instance_keys = std::move(_instance_keys);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -14,7 +14,7 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<DataCell> cells;
-        cells.reserve(8);
+        cells.reserve(7);
 
         {
             auto result = DataCell::from_loggable(archetype.vectors);
@@ -43,11 +43,6 @@ namespace rerun {
         }
         if (archetype.class_ids.has_value()) {
             auto result = DataCell::from_loggable(archetype.class_ids.value());
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
-        }
-        if (archetype.instance_keys.has_value()) {
-            auto result = DataCell::from_loggable(archetype.instance_keys.value());
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -7,7 +7,6 @@
 #include "../compiler_utils.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
-#include "../components/instance_key.hpp"
 #include "../components/position3d.hpp"
 #include "../components/radius.hpp"
 #include "../components/text.hpp"
@@ -88,9 +87,6 @@ namespace rerun::archetypes {
         /// The class ID provides colors and labels if not specified explicitly.
         std::optional<Collection<rerun::components::ClassId>> class_ids;
 
-        /// Unique identifiers for each individual point in the batch.
-        std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
-
       public:
         static constexpr const char IndicatorComponentName[] = "rerun.components.Arrows3DIndicator";
 
@@ -150,13 +146,6 @@ namespace rerun::archetypes {
         /// The class ID provides colors and labels if not specified explicitly.
         Arrows3D with_class_ids(Collection<rerun::components::ClassId> _class_ids) && {
             class_ids = std::move(_class_ids);
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
-        }
-
-        /// Unique identifiers for each individual point in the batch.
-        Arrows3D with_instance_keys(Collection<rerun::components::InstanceKey> _instance_keys) && {
-            instance_keys = std::move(_instance_keys);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
@@ -14,7 +14,7 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<DataCell> cells;
-        cells.reserve(9);
+        cells.reserve(8);
 
         {
             auto result = DataCell::from_loggable(archetype.half_sizes);
@@ -48,11 +48,6 @@ namespace rerun {
         }
         if (archetype.class_ids.has_value()) {
             auto result = DataCell::from_loggable(archetype.class_ids.value());
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
-        }
-        if (archetype.instance_keys.has_value()) {
-            auto result = DataCell::from_loggable(archetype.instance_keys.value());
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -9,7 +9,6 @@
 #include "../components/color.hpp"
 #include "../components/draw_order.hpp"
 #include "../components/half_sizes2d.hpp"
-#include "../components/instance_key.hpp"
 #include "../components/position2d.hpp"
 #include "../components/radius.hpp"
 #include "../components/text.hpp"
@@ -70,9 +69,6 @@ namespace rerun::archetypes {
         ///
         /// The class ID provides colors and labels if not specified explicitly.
         std::optional<Collection<rerun::components::ClassId>> class_ids;
-
-        /// Unique identifiers for each individual boxes in the batch.
-        std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
 
       public:
         static constexpr const char IndicatorComponentName[] = "rerun.components.Boxes2DIndicator";
@@ -177,13 +173,6 @@ namespace rerun::archetypes {
         /// The class ID provides colors and labels if not specified explicitly.
         Boxes2D with_class_ids(Collection<rerun::components::ClassId> _class_ids) && {
             class_ids = std::move(_class_ids);
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
-        }
-
-        /// Unique identifiers for each individual boxes in the batch.
-        Boxes2D with_instance_keys(Collection<rerun::components::InstanceKey> _instance_keys) && {
-            instance_keys = std::move(_instance_keys);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
@@ -14,7 +14,7 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<DataCell> cells;
-        cells.reserve(9);
+        cells.reserve(8);
 
         {
             auto result = DataCell::from_loggable(archetype.half_sizes);
@@ -48,11 +48,6 @@ namespace rerun {
         }
         if (archetype.class_ids.has_value()) {
             auto result = DataCell::from_loggable(archetype.class_ids.value());
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
-        }
-        if (archetype.instance_keys.has_value()) {
-            auto result = DataCell::from_loggable(archetype.instance_keys.value());
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -8,7 +8,6 @@
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/half_sizes3d.hpp"
-#include "../components/instance_key.hpp"
 #include "../components/position3d.hpp"
 #include "../components/radius.hpp"
 #include "../components/rotation3d.hpp"
@@ -81,9 +80,6 @@ namespace rerun::archetypes {
         ///
         /// The class ID provides colors and labels if not specified explicitly.
         std::optional<Collection<rerun::components::ClassId>> class_ids;
-
-        /// Unique identifiers for each individual boxes in the batch.
-        std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
 
       public:
         static constexpr const char IndicatorComponentName[] = "rerun.components.Boxes3DIndicator";
@@ -186,13 +182,6 @@ namespace rerun::archetypes {
         /// The class ID provides colors and labels if not specified explicitly.
         Boxes3D with_class_ids(Collection<rerun::components::ClassId> _class_ids) && {
             class_ids = std::move(_class_ids);
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
-        }
-
-        /// Unique identifiers for each individual boxes in the batch.
-        Boxes3D with_instance_keys(Collection<rerun::components::InstanceKey> _instance_keys) && {
-            instance_keys = std::move(_instance_keys);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -14,7 +14,7 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<DataCell> cells;
-        cells.reserve(8);
+        cells.reserve(7);
 
         {
             auto result = DataCell::from_loggable(archetype.strips);
@@ -43,11 +43,6 @@ namespace rerun {
         }
         if (archetype.class_ids.has_value()) {
             auto result = DataCell::from_loggable(archetype.class_ids.value());
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
-        }
-        if (archetype.instance_keys.has_value()) {
-            auto result = DataCell::from_loggable(archetype.instance_keys.value());
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -8,7 +8,6 @@
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/draw_order.hpp"
-#include "../components/instance_key.hpp"
 #include "../components/line_strip2d.hpp"
 #include "../components/radius.hpp"
 #include "../components/text.hpp"
@@ -76,9 +75,6 @@ namespace rerun::archetypes {
         /// The class ID provides colors and labels if not specified explicitly.
         std::optional<Collection<rerun::components::ClassId>> class_ids;
 
-        /// Unique identifiers for each individual line strip in the batch.
-        std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
-
       public:
         static constexpr const char IndicatorComponentName[] =
             "rerun.components.LineStrips2DIndicator";
@@ -128,14 +124,6 @@ namespace rerun::archetypes {
         /// The class ID provides colors and labels if not specified explicitly.
         LineStrips2D with_class_ids(Collection<rerun::components::ClassId> _class_ids) && {
             class_ids = std::move(_class_ids);
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
-        }
-
-        /// Unique identifiers for each individual line strip in the batch.
-        LineStrips2D with_instance_keys(Collection<rerun::components::InstanceKey> _instance_keys
-        ) && {
-            instance_keys = std::move(_instance_keys);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -14,7 +14,7 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<DataCell> cells;
-        cells.reserve(7);
+        cells.reserve(6);
 
         {
             auto result = DataCell::from_loggable(archetype.strips);
@@ -38,11 +38,6 @@ namespace rerun {
         }
         if (archetype.class_ids.has_value()) {
             auto result = DataCell::from_loggable(archetype.class_ids.value());
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
-        }
-        if (archetype.instance_keys.has_value()) {
-            auto result = DataCell::from_loggable(archetype.instance_keys.value());
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -7,7 +7,6 @@
 #include "../compiler_utils.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
-#include "../components/instance_key.hpp"
 #include "../components/line_strip3d.hpp"
 #include "../components/radius.hpp"
 #include "../components/text.hpp"
@@ -80,9 +79,6 @@ namespace rerun::archetypes {
         /// The class ID provides colors and labels if not specified explicitly.
         std::optional<Collection<rerun::components::ClassId>> class_ids;
 
-        /// Unique identifiers for each individual line strip in the batch.
-        std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
-
       public:
         static constexpr const char IndicatorComponentName[] =
             "rerun.components.LineStrips3DIndicator";
@@ -123,14 +119,6 @@ namespace rerun::archetypes {
         /// The class ID provides colors and labels if not specified explicitly.
         LineStrips3D with_class_ids(Collection<rerun::components::ClassId> _class_ids) && {
             class_ids = std::move(_class_ids);
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
-        }
-
-        /// Unique identifiers for each individual line strip in the batch.
-        LineStrips3D with_instance_keys(Collection<rerun::components::InstanceKey> _instance_keys
-        ) && {
-            instance_keys = std::move(_instance_keys);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
@@ -14,7 +14,7 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<DataCell> cells;
-        cells.reserve(10);
+        cells.reserve(9);
 
         {
             auto result = DataCell::from_loggable(archetype.vertex_positions);
@@ -53,11 +53,6 @@ namespace rerun {
         }
         if (archetype.class_ids.has_value()) {
             auto result = DataCell::from_loggable(archetype.class_ids.value());
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
-        }
-        if (archetype.instance_keys.has_value()) {
-            auto result = DataCell::from_loggable(archetype.instance_keys.value());
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -7,7 +7,6 @@
 #include "../compiler_utils.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
-#include "../components/instance_key.hpp"
 #include "../components/material.hpp"
 #include "../components/mesh_properties.hpp"
 #include "../components/position3d.hpp"
@@ -96,9 +95,6 @@ namespace rerun::archetypes {
         /// The class ID provides colors and labels if not specified explicitly.
         std::optional<Collection<rerun::components::ClassId>> class_ids;
 
-        /// Unique identifiers for each individual vertex in the mesh.
-        std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
-
       public:
         static constexpr const char IndicatorComponentName[] = "rerun.components.Mesh3DIndicator";
 
@@ -166,13 +162,6 @@ namespace rerun::archetypes {
         /// The class ID provides colors and labels if not specified explicitly.
         Mesh3D with_class_ids(Collection<rerun::components::ClassId> _class_ids) && {
             class_ids = std::move(_class_ids);
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
-        }
-
-        /// Unique identifiers for each individual vertex in the mesh.
-        Mesh3D with_instance_keys(Collection<rerun::components::InstanceKey> _instance_keys) && {
-            instance_keys = std::move(_instance_keys);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -14,7 +14,7 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<DataCell> cells;
-        cells.reserve(9);
+        cells.reserve(8);
 
         {
             auto result = DataCell::from_loggable(archetype.positions);
@@ -48,11 +48,6 @@ namespace rerun {
         }
         if (archetype.keypoint_ids.has_value()) {
             auto result = DataCell::from_loggable(archetype.keypoint_ids.value());
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
-        }
-        if (archetype.instance_keys.has_value()) {
-            auto result = DataCell::from_loggable(archetype.instance_keys.value());
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -8,7 +8,6 @@
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
 #include "../components/draw_order.hpp"
-#include "../components/instance_key.hpp"
 #include "../components/keypoint_id.hpp"
 #include "../components/position2d.hpp"
 #include "../components/radius.hpp"
@@ -101,9 +100,6 @@ namespace rerun::archetypes {
         /// detected skeleton.
         std::optional<Collection<rerun::components::KeypointId>> keypoint_ids;
 
-        /// Unique identifiers for each individual point in the batch.
-        std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
-
       public:
         static constexpr const char IndicatorComponentName[] = "rerun.components.Points2DIndicator";
 
@@ -166,13 +162,6 @@ namespace rerun::archetypes {
         /// detected skeleton.
         Points2D with_keypoint_ids(Collection<rerun::components::KeypointId> _keypoint_ids) && {
             keypoint_ids = std::move(_keypoint_ids);
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
-        }
-
-        /// Unique identifiers for each individual point in the batch.
-        Points2D with_instance_keys(Collection<rerun::components::InstanceKey> _instance_keys) && {
-            instance_keys = std::move(_instance_keys);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -14,7 +14,7 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<DataCell> cells;
-        cells.reserve(8);
+        cells.reserve(7);
 
         {
             auto result = DataCell::from_loggable(archetype.positions);
@@ -43,11 +43,6 @@ namespace rerun {
         }
         if (archetype.keypoint_ids.has_value()) {
             auto result = DataCell::from_loggable(archetype.keypoint_ids.value());
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
-        }
-        if (archetype.instance_keys.has_value()) {
-            auto result = DataCell::from_loggable(archetype.instance_keys.value());
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -7,7 +7,6 @@
 #include "../compiler_utils.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
-#include "../components/instance_key.hpp"
 #include "../components/keypoint_id.hpp"
 #include "../components/position3d.hpp"
 #include "../components/radius.hpp"
@@ -92,9 +91,6 @@ namespace rerun::archetypes {
         /// detected skeleton.
         std::optional<Collection<rerun::components::KeypointId>> keypoint_ids;
 
-        /// Unique identifiers for each individual point in the batch.
-        std::optional<Collection<rerun::components::InstanceKey>> instance_keys;
-
       public:
         static constexpr const char IndicatorComponentName[] = "rerun.components.Points3DIndicator";
 
@@ -148,13 +144,6 @@ namespace rerun::archetypes {
         /// detected skeleton.
         Points3D with_keypoint_ids(Collection<rerun::components::KeypointId> _keypoint_ids) && {
             keypoint_ids = std::move(_keypoint_ids);
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
-        }
-
-        /// Unique identifiers for each individual point in the batch.
-        Points3D with_instance_keys(Collection<rerun::components::InstanceKey> _instance_keys) && {
-            instance_keys = std::move(_instance_keys);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -268,7 +268,7 @@ typedef struct rr_error {
 ///
 /// This should match the string returned by `rr_version_string`.
 /// If not, the SDK's binary and the C header are out of sync.
-#define RERUN_SDK_HEADER_VERSION "0.15.0-alpha.1+dev"
+#define RERUN_SDK_HEADER_VERSION "0.15.0-alpha.2"
 
 /// Returns a human-readable version string of the Rerun C SDK.
 ///

--- a/rerun_cpp/tests/archetypes/arrows3d.cpp
+++ b/rerun_cpp/tests/archetypes/arrows3d.cpp
@@ -17,8 +17,7 @@ SCENARIO(
                                 .with_radii({1.0, 10.0})
                                 .with_colors({{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}})
                                 .with_labels({"hello", "friend"})
-                                .with_class_ids({126, 127})
-                                .with_instance_keys({123ull, 124ull});
+                                .with_class_ids({126, 127});
 
         Arrows3D from_manual;
         from_manual.vectors = {{1.0, 2.0, 3.0}, {10.0, 20.0, 30.0}};
@@ -27,7 +26,6 @@ SCENARIO(
         from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
         from_manual.labels = {"hello", "friend"};
         from_manual.class_ids = {126, 127};
-        from_manual.instance_keys = {123ull, 124ull};
 
         test_compare_archetype_serialization(from_manual, from_builder);
     }

--- a/rerun_cpp/tests/archetypes/boxes2d.cpp
+++ b/rerun_cpp/tests/archetypes/boxes2d.cpp
@@ -18,8 +18,7 @@ SCENARIO(
                                 .with_labels({"hello", "friend"})
                                 .with_radii({0.1f, 1.0f})
                                 .with_draw_order(300.0f)
-                                .with_class_ids({126, 127})
-                                .with_instance_keys({66, 666});
+                                .with_class_ids({126, 127});
 
         Boxes2D from_manual;
         from_manual.half_sizes = {{10.f, 9.f}, {5.f, -5.f}};
@@ -29,7 +28,6 @@ SCENARIO(
         from_manual.radii = {0.1f, 1.0f};
         from_manual.draw_order = 300.0f;
         from_manual.class_ids = {126, 127};
-        from_manual.instance_keys = {66ull, 666ull};
 
         test_compare_archetype_serialization(from_manual, from_builder);
     }

--- a/rerun_cpp/tests/archetypes/boxes3d.cpp
+++ b/rerun_cpp/tests/archetypes/boxes3d.cpp
@@ -22,8 +22,7 @@ SCENARIO(
                                 .with_colors({0xAA0000CC, 0x00BB00DD})
                                 .with_labels({"hello", "friend"})
                                 .with_radii({0.1f, 1.0f})
-                                .with_class_ids({126, 127})
-                                .with_instance_keys({66, 666});
+                                .with_class_ids({126, 127});
 
         Boxes3D from_manual;
         from_manual.half_sizes = {{10.f, 9.f, 8.f}, {5.f, -5.f, 5.f}};
@@ -36,7 +35,6 @@ SCENARIO(
         from_manual.labels = {"hello", "friend"};
         from_manual.radii = {0.1f, 1.0f};
         from_manual.class_ids = {126, 127};
-        from_manual.instance_keys = {66ull, 666ull};
 
         test_compare_archetype_serialization(from_manual, from_builder);
     }

--- a/rerun_cpp/tests/archetypes/lines_strips2d.cpp
+++ b/rerun_cpp/tests/archetypes/lines_strips2d.cpp
@@ -21,7 +21,6 @@ SCENARIO(
                 .with_colors({{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}})
                 .with_labels({"hello", "friend"})
                 .with_class_ids({126, 127})
-                .with_instance_keys({123ull, 124ull})
                 .with_draw_order(123);
 
         LineStrips2D from_manual;
@@ -33,7 +32,6 @@ SCENARIO(
         from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
         from_manual.labels = {"hello", "friend"};
         from_manual.class_ids = {126, 127};
-        from_manual.instance_keys = {123ull, 124ull};
         from_manual.draw_order = 123.0f;
 
         test_compare_archetype_serialization(from_manual, from_builder);

--- a/rerun_cpp/tests/archetypes/lines_strips3d.cpp
+++ b/rerun_cpp/tests/archetypes/lines_strips3d.cpp
@@ -20,8 +20,7 @@ SCENARIO(
                 .with_radii({1.0, 10.0})
                 .with_colors({{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}})
                 .with_labels({"hello", "friend"})
-                .with_class_ids({126, 127})
-                .with_instance_keys({123ull, 124ull});
+                .with_class_ids({126, 127});
 
         LineStrips3D from_manual;
         from_manual.strips = {
@@ -32,7 +31,6 @@ SCENARIO(
         from_manual.colors = {{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}};
         from_manual.labels = {"hello", "friend"};
         from_manual.class_ids = {126, 127};
-        from_manual.instance_keys = {123ull, 124ull};
 
         test_compare_archetype_serialization(from_manual, from_builder);
     }

--- a/rerun_cpp/tests/archetypes/mesh3d.cpp
+++ b/rerun_cpp/tests/archetypes/mesh3d.cpp
@@ -19,8 +19,7 @@ SCENARIO(
                 .with_vertex_colors({{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}})
                 .with_mesh_properties(MeshProperties::from_triangle_indices({1, 2, 3, 4, 5, 6}))
                 .with_mesh_material(Material::from_albedo_factor(0xEE112233))
-                .with_class_ids({126, 127})
-                .with_instance_keys({123ull, 124ull});
+                .with_class_ids({126, 127});
 
         rerun::datatypes::MeshProperties mesh_properties_inner_manual;
         mesh_properties_inner_manual.indices = {1, 2, 3, 4, 5, 6};
@@ -41,7 +40,6 @@ SCENARIO(
         from_manual.mesh_properties = {mesh_properties_manual};
         from_manual.mesh_material = {mesh_material_manual};
         from_manual.class_ids = {126, 127};
-        from_manual.instance_keys = {123ull, 124ull};
 
         test_compare_archetype_serialization(from_manual, from_builder);
     }

--- a/rerun_cpp/tests/archetypes/points2d.cpp
+++ b/rerun_cpp/tests/archetypes/points2d.cpp
@@ -17,8 +17,7 @@ SCENARIO(
                                 .with_colors({{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}})
                                 .with_labels({"hello", "friend"})
                                 .with_class_ids({126, 127})
-                                .with_keypoint_ids({1, 2})
-                                .with_instance_keys({123ull, 124ull});
+                                .with_keypoint_ids({1, 2});
 
         Points2D from_manual;
         from_manual.positions = {{1.0, 2.0}, {10.0, 20.0}};
@@ -27,7 +26,6 @@ SCENARIO(
         from_manual.labels = {"hello", "friend"};
         from_manual.keypoint_ids = {1, 2};
         from_manual.class_ids = {126, 127};
-        from_manual.instance_keys = {123ull, 124ull};
 
         test_compare_archetype_serialization(from_manual, from_builder);
     }

--- a/rerun_cpp/tests/archetypes/points3d.cpp
+++ b/rerun_cpp/tests/archetypes/points3d.cpp
@@ -17,8 +17,7 @@ SCENARIO(
                                 .with_colors({{0xAA, 0x00, 0x00, 0xCC}, {0x00, 0xBB, 0x00, 0xDD}})
                                 .with_labels({"hello", "friend"})
                                 .with_class_ids({126, 127})
-                                .with_keypoint_ids({1, 2})
-                                .with_instance_keys({123ull, 124ull});
+                                .with_keypoint_ids({1, 2});
 
         Points3D from_manual;
         from_manual.positions = {{1.0, 2.0, 3.0}, {10.0, 20.0, 30.0}};
@@ -27,7 +26,6 @@ SCENARIO(
         from_manual.labels = {"hello", "friend"};
         from_manual.keypoint_ids = {1, 2};
         from_manual.class_ids = {126, 127};
-        from_manual.instance_keys = {123ull, 124ull};
 
         test_compare_archetype_serialization(from_manual, from_builder);
     }

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
@@ -61,7 +61,6 @@ class Arrows2D(Arrows2DExt, Archetype):
             colors=None,  # type: ignore[arg-type]
             labels=None,  # type: ignore[arg-type]
             class_ids=None,  # type: ignore[arg-type]
-            instance_keys=None,  # type: ignore[arg-type]
         )
 
     @classmethod
@@ -128,15 +127,6 @@ class Arrows2D(Arrows2DExt, Archetype):
     # Optional class Ids for the points.
     #
     # The class ID provides colors and labels if not specified explicitly.
-    #
-    # (Docstring intentionally commented out to hide this field from the docs)
-
-    instance_keys: components.InstanceKeyBatch | None = field(
-        metadata={"component": "optional"},
-        default=None,
-        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
-    )
-    # Unique identifiers for each individual point in the batch.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows2d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows2d_ext.py
@@ -18,7 +18,6 @@ class Arrows2DExt:
         colors: datatypes.Rgba32ArrayLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
-        instance_keys: components.InstanceKeyArrayLike | None = None,
     ) -> None:
         """
         Create a new instance of the Arrows2D archetype.
@@ -44,8 +43,6 @@ class Arrows2DExt:
             Optional class Ids for the points.
 
             The class ID provides colors and labels if not specified explicitly.
-        instance_keys:
-            Unique identifiers for each individual point in the batch.
 
         """
 
@@ -59,7 +56,6 @@ class Arrows2DExt:
                 colors=colors,
                 labels=labels,
                 class_ids=class_ids,
-                instance_keys=instance_keys,
             )
             return
         self.__attrs_clear__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
@@ -61,7 +61,6 @@ class Arrows3D(Arrows3DExt, Archetype):
             colors=None,  # type: ignore[arg-type]
             labels=None,  # type: ignore[arg-type]
             class_ids=None,  # type: ignore[arg-type]
-            instance_keys=None,  # type: ignore[arg-type]
         )
 
     @classmethod
@@ -128,15 +127,6 @@ class Arrows3D(Arrows3DExt, Archetype):
     # Optional class Ids for the points.
     #
     # The class ID provides colors and labels if not specified explicitly.
-    #
-    # (Docstring intentionally commented out to hide this field from the docs)
-
-    instance_keys: components.InstanceKeyBatch | None = field(
-        metadata={"component": "optional"},
-        default=None,
-        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
-    )
-    # Unique identifiers for each individual point in the batch.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d_ext.py
@@ -18,7 +18,6 @@ class Arrows3DExt:
         colors: datatypes.Rgba32ArrayLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
-        instance_keys: components.InstanceKeyArrayLike | None = None,
     ) -> None:
         """
         Create a new instance of the Arrows3D archetype.
@@ -44,8 +43,6 @@ class Arrows3DExt:
             Optional class Ids for the points.
 
             The class ID provides colors and labels if not specified explicitly.
-        instance_keys:
-            Unique identifiers for each individual point in the batch.
 
         """
 
@@ -59,7 +56,6 @@ class Arrows3DExt:
                 colors=colors,
                 labels=labels,
                 class_ids=class_ids,
-                instance_keys=instance_keys,
             )
             return
         self.__attrs_clear__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -56,7 +56,6 @@ class Boxes2D(Boxes2DExt, Archetype):
             labels=None,  # type: ignore[arg-type]
             draw_order=None,  # type: ignore[arg-type]
             class_ids=None,  # type: ignore[arg-type]
-            instance_keys=None,  # type: ignore[arg-type]
         )
 
     @classmethod
@@ -131,15 +130,6 @@ class Boxes2D(Boxes2DExt, Archetype):
     # Optional `ClassId`s for the boxes.
     #
     # The class ID provides colors and labels if not specified explicitly.
-    #
-    # (Docstring intentionally commented out to hide this field from the docs)
-
-    instance_keys: components.InstanceKeyBatch | None = field(
-        metadata={"component": "optional"},
-        default=None,
-        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
-    )
-    # Unique identifiers for each individual boxes in the batch.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d_ext.py
@@ -49,7 +49,6 @@ class Boxes2DExt:
         labels: datatypes.Utf8ArrayLike | None = None,
         draw_order: components.DrawOrderLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
-        instance_keys: components.InstanceKeyArrayLike | None = None,
     ) -> None:
         """
         Create a new instance of the Boxes2D archetype.
@@ -89,8 +88,6 @@ class Boxes2DExt:
             Optional `ClassId`s for the boxes.
 
             The class ID provides colors and labels if not specified explicitly.
-        instance_keys:
-            Unique identifiers for each individual boxes in the batch.
 
         """
 
@@ -169,7 +166,6 @@ class Boxes2DExt:
                 labels=labels,
                 draw_order=draw_order,
                 class_ids=class_ids,
-                instance_keys=instance_keys,
             )
             return
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -68,7 +68,6 @@ class Boxes3D(Boxes3DExt, Archetype):
             radii=None,  # type: ignore[arg-type]
             labels=None,  # type: ignore[arg-type]
             class_ids=None,  # type: ignore[arg-type]
-            instance_keys=None,  # type: ignore[arg-type]
         )
 
     @classmethod
@@ -135,15 +134,6 @@ class Boxes3D(Boxes3DExt, Archetype):
     # Optional `ClassId`s for the boxes.
     #
     # The class ID provides colors and labels if not specified explicitly.
-    #
-    # (Docstring intentionally commented out to hide this field from the docs)
-
-    instance_keys: components.InstanceKeyBatch | None = field(
-        metadata={"component": "optional"},
-        default=None,
-        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
-    )
-    # Unique identifiers for each individual boxes in the batch.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d_ext.py
@@ -23,7 +23,6 @@ class Boxes3DExt:
         radii: components.RadiusArrayLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
-        instance_keys: components.InstanceKeyArrayLike | None = None,
     ) -> None:
         """
         Create a new instance of the Boxes3D archetype.
@@ -52,8 +51,6 @@ class Boxes3DExt:
             Optional `ClassId`s for the boxes.
 
             The class ID provides colors and labels if not specified explicitly.
-        instance_keys:
-            Unique identifiers for each individual boxes in the batch.
 
         """
 
@@ -86,7 +83,6 @@ class Boxes3DExt:
                 radii=radii,
                 labels=labels,
                 class_ids=class_ids,
-                instance_keys=instance_keys,
             )
             return
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -66,7 +66,6 @@ class LineStrips2D(Archetype):
         labels: datatypes.Utf8ArrayLike | None = None,
         draw_order: components.DrawOrderLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
-        instance_keys: components.InstanceKeyArrayLike | None = None,
     ):
         """
         Create a new instance of the LineStrips2D archetype.
@@ -89,21 +88,13 @@ class LineStrips2D(Archetype):
             Optional `ClassId`s for the lines.
 
             The class ID provides colors and labels if not specified explicitly.
-        instance_keys:
-            Unique identifiers for each individual line strip in the batch.
 
         """
 
         # You can define your own __init__ function as a member of LineStrips2DExt in line_strips2d_ext.py
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(
-                strips=strips,
-                radii=radii,
-                colors=colors,
-                labels=labels,
-                draw_order=draw_order,
-                class_ids=class_ids,
-                instance_keys=instance_keys,
+                strips=strips, radii=radii, colors=colors, labels=labels, draw_order=draw_order, class_ids=class_ids
             )
             return
         self.__attrs_clear__()
@@ -117,7 +108,6 @@ class LineStrips2D(Archetype):
             labels=None,  # type: ignore[arg-type]
             draw_order=None,  # type: ignore[arg-type]
             class_ids=None,  # type: ignore[arg-type]
-            instance_keys=None,  # type: ignore[arg-type]
         )
 
     @classmethod
@@ -181,15 +171,6 @@ class LineStrips2D(Archetype):
     # Optional `ClassId`s for the lines.
     #
     # The class ID provides colors and labels if not specified explicitly.
-    #
-    # (Docstring intentionally commented out to hide this field from the docs)
-
-    instance_keys: components.InstanceKeyBatch | None = field(
-        metadata={"component": "optional"},
-        default=None,
-        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
-    )
-    # Unique identifiers for each individual line strip in the batch.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -76,7 +76,6 @@ class LineStrips3D(Archetype):
         colors: datatypes.Rgba32ArrayLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
-        instance_keys: components.InstanceKeyArrayLike | None = None,
     ):
         """
         Create a new instance of the LineStrips3D archetype.
@@ -95,21 +94,12 @@ class LineStrips3D(Archetype):
             Optional `ClassId`s for the lines.
 
             The class ID provides colors and labels if not specified explicitly.
-        instance_keys:
-            Unique identifiers for each individual line strip in the batch.
 
         """
 
         # You can define your own __init__ function as a member of LineStrips3DExt in line_strips3d_ext.py
         with catch_and_log_exceptions(context=self.__class__.__name__):
-            self.__attrs_init__(
-                strips=strips,
-                radii=radii,
-                colors=colors,
-                labels=labels,
-                class_ids=class_ids,
-                instance_keys=instance_keys,
-            )
+            self.__attrs_init__(strips=strips, radii=radii, colors=colors, labels=labels, class_ids=class_ids)
             return
         self.__attrs_clear__()
 
@@ -121,7 +111,6 @@ class LineStrips3D(Archetype):
             colors=None,  # type: ignore[arg-type]
             labels=None,  # type: ignore[arg-type]
             class_ids=None,  # type: ignore[arg-type]
-            instance_keys=None,  # type: ignore[arg-type]
         )
 
     @classmethod
@@ -174,15 +163,6 @@ class LineStrips3D(Archetype):
     # Optional `ClassId`s for the lines.
     #
     # The class ID provides colors and labels if not specified explicitly.
-    #
-    # (Docstring intentionally commented out to hide this field from the docs)
-
-    instance_keys: components.InstanceKeyBatch | None = field(
-        metadata={"component": "optional"},
-        default=None,
-        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
-    )
-    # Unique identifiers for each individual line strip in the batch.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -64,7 +64,6 @@ class Mesh3D(Mesh3DExt, Archetype):
             mesh_material=None,  # type: ignore[arg-type]
             albedo_texture=None,  # type: ignore[arg-type]
             class_ids=None,  # type: ignore[arg-type]
-            instance_keys=None,  # type: ignore[arg-type]
         )
 
     @classmethod
@@ -152,15 +151,6 @@ class Mesh3D(Mesh3DExt, Archetype):
     # Optional class Ids for the vertices.
     #
     # The class ID provides colors and labels if not specified explicitly.
-    #
-    # (Docstring intentionally commented out to hide this field from the docs)
-
-    instance_keys: components.InstanceKeyBatch | None = field(
-        metadata={"component": "optional"},
-        default=None,
-        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
-    )
-    # Unique identifiers for each individual vertex in the mesh.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d_ext.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import numpy.typing as npt
 
-from .. import components, datatypes
+from .. import datatypes
 from ..error_utils import catch_and_log_exceptions
 
 
@@ -23,7 +23,6 @@ class Mesh3DExt:
         albedo_texture: datatypes.TensorDataLike | None = None,
         mesh_material: datatypes.MaterialLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
-        instance_keys: components.InstanceKeyArrayLike | None = None,
     ):
         """
         Create a new instance of the Mesh3D archetype.
@@ -57,8 +56,6 @@ class Mesh3DExt:
         class_ids:
             Optional class Ids for the vertices.
             The class ID provides colors and labels if not specified explicitly.
-        instance_keys:
-            Unique identifiers for each individual vertex in the mesh.
 
         """
         with catch_and_log_exceptions(context=self.__class__.__name__):
@@ -77,7 +74,6 @@ class Mesh3DExt:
                 albedo_texture=albedo_texture,
                 mesh_material=mesh_material,
                 class_ids=class_ids,
-                instance_keys=instance_keys,
             )
             return
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -62,7 +62,6 @@ class Points2D(Points2DExt, Archetype):
             draw_order=None,  # type: ignore[arg-type]
             class_ids=None,  # type: ignore[arg-type]
             keypoint_ids=None,  # type: ignore[arg-type]
-            instance_keys=None,  # type: ignore[arg-type]
         )
 
     @classmethod
@@ -145,15 +144,6 @@ class Points2D(Points2DExt, Archetype):
     # with `class_id`).
     # E.g. the classification might be 'Person' and the keypoints refer to joints on a
     # detected skeleton.
-    #
-    # (Docstring intentionally commented out to hide this field from the docs)
-
-    instance_keys: components.InstanceKeyBatch | None = field(
-        metadata={"component": "optional"},
-        default=None,
-        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
-    )
-    # Unique identifiers for each individual point in the batch.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d_ext.py
@@ -19,7 +19,6 @@ class Points2DExt:
         draw_order: components.DrawOrderLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
         keypoint_ids: datatypes.KeypointIdArrayLike | None = None,
-        instance_keys: components.InstanceKeyArrayLike | None = None,
     ):
         """
         Create a new instance of the Points2D archetype.
@@ -53,8 +52,6 @@ class Points2DExt:
              with `class_id`).
              E.g. the classification might be 'Person' and the keypoints refer to joints on a
              detected skeleton.
-        instance_keys:
-             Unique identifiers for each individual point in the batch.
 
         """
 
@@ -70,7 +67,6 @@ class Points2DExt:
                 draw_order=draw_order,
                 class_ids=class_ids,
                 keypoint_ids=keypoint_ids,
-                instance_keys=instance_keys,
             )
             return
         self.__attrs_clear__()

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -58,7 +58,6 @@ class Points3D(Points3DExt, Archetype):
             labels=None,  # type: ignore[arg-type]
             class_ids=None,  # type: ignore[arg-type]
             keypoint_ids=None,  # type: ignore[arg-type]
-            instance_keys=None,  # type: ignore[arg-type]
         )
 
     @classmethod
@@ -130,15 +129,6 @@ class Points3D(Points3DExt, Archetype):
     # with `class_id`).
     # E.g. the classification might be 'Person' and the keypoints refer to joints on a
     # detected skeleton.
-    #
-    # (Docstring intentionally commented out to hide this field from the docs)
-
-    instance_keys: components.InstanceKeyBatch | None = field(
-        metadata={"component": "optional"},
-        default=None,
-        converter=components.InstanceKeyBatch._optional,  # type: ignore[misc]
-    )
-    # Unique identifiers for each individual point in the batch.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d_ext.py
@@ -18,7 +18,6 @@ class Points3DExt:
         labels: datatypes.Utf8ArrayLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
         keypoint_ids: datatypes.KeypointIdArrayLike | None = None,
-        instance_keys: components.InstanceKeyArrayLike | None = None,
     ):
         """
         Create a new instance of the Points3D archetype.
@@ -49,8 +48,6 @@ class Points3DExt:
              with `class_id`).
              E.g. the classification might be 'Person' and the keypoints refer to joints on a
              detected skeleton.
-        instance_keys:
-             Unique identifiers for each individual point in the batch.
 
         """
 
@@ -65,7 +62,6 @@ class Points3DExt:
                 labels=labels,
                 class_ids=class_ids,
                 keypoint_ids=keypoint_ids,
-                instance_keys=instance_keys,
             )
             return
         self.__attrs_clear__()

--- a/rerun_py/tests/unit/common_arrays.py
+++ b/rerun_py/tests/unit/common_arrays.py
@@ -12,8 +12,6 @@ from rerun.components import (
     DrawOrder,
     DrawOrderBatch,
     DrawOrderLike,
-    InstanceKey,
-    InstanceKeyBatch,
     KeypointId,
     KeypointIdBatch,
     Radius,
@@ -436,23 +434,6 @@ keypoint_ids_arrays = [
 def keypoint_ids_expected(obj: Any) -> Any:
     expected = none_empty_or_value(obj, [2, 3])
     return KeypointIdBatch._optional(expected)
-
-
-instance_keys_arrays = [
-    [],
-    np.array([]),
-    # InstanceKeyArrayLike: Sequence[InstanceKeyLike]: int
-    [U64_MAX_MINUS_1, U64_MAX],
-    # InstanceKeyArrayLike: Sequence[InstanceKeyLike]: InstanceKey
-    [InstanceKey(U64_MAX_MINUS_1), InstanceKey(U64_MAX)],
-    # InstanceKeyArrayLike: np.NDArray[np.uint64]
-    np.array([U64_MAX_MINUS_1, U64_MAX], dtype=np.uint64),
-]
-
-
-def instance_keys_expected(obj: Any) -> Any:
-    expected = none_empty_or_value(obj, [U64_MAX_MINUS_1, U64_MAX])
-    return InstanceKeyBatch._optional(expected)
 
 
 uuid_bytes0 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]

--- a/rerun_py/tests/unit/test_arrows3d.py
+++ b/rerun_py/tests/unit/test_arrows3d.py
@@ -4,7 +4,7 @@ import itertools
 from typing import Optional, cast
 
 import rerun as rr
-from rerun.components import InstanceKeyArrayLike, Position3DBatch, RadiusArrayLike, Vector3DBatch
+from rerun.components import Position3DBatch, RadiusArrayLike, Vector3DBatch
 from rerun.datatypes import ClassIdArrayLike, Rgba32ArrayLike, Utf8ArrayLike, Vec3DArrayLike
 
 from .common_arrays import (
@@ -12,8 +12,6 @@ from .common_arrays import (
     class_ids_expected,
     colors_arrays,
     colors_expected,
-    instance_keys_arrays,
-    instance_keys_expected,
     labels_arrays,
     labels_expected,
     radii_arrays,
@@ -34,10 +32,9 @@ def test_arrows3d() -> None:
         colors_arrays,
         labels_arrays,
         class_ids_arrays,
-        instance_keys_arrays,
     )
 
-    for vectors, origins, radii, colors, labels, class_ids, instance_keys in all_arrays:
+    for vectors, origins, radii, colors, labels, class_ids in all_arrays:
         vectors = vectors if vectors is not None else vectors_arrays[-1]
         origins = origins if origins is not None else origins_arrays[-1]
 
@@ -48,7 +45,6 @@ def test_arrows3d() -> None:
         colors = cast(Optional[Rgba32ArrayLike], colors)
         labels = cast(Optional[Utf8ArrayLike], labels)
         class_ids = cast(Optional[ClassIdArrayLike], class_ids)
-        instance_keys = cast(Optional[InstanceKeyArrayLike], instance_keys)
 
         print(
             f"E: rr.Arrows3D(\n"
@@ -58,7 +54,6 @@ def test_arrows3d() -> None:
             f"    colors={colors!r}\n"
             f"    labels={labels!r}\n"
             f"    class_ids={class_ids!r}\n"
-            f"    instance_keys={instance_keys!r}\n"
             f")"
         )
         arch = rr.Arrows3D(
@@ -68,7 +63,6 @@ def test_arrows3d() -> None:
             colors=colors,
             labels=labels,
             class_ids=class_ids,
-            instance_keys=instance_keys,
         )
         print(f"A: {arch}\n")
 
@@ -78,7 +72,6 @@ def test_arrows3d() -> None:
         assert arch.colors == colors_expected(colors)
         assert arch.labels == labels_expected(labels)
         assert arch.class_ids == class_ids_expected(class_ids)
-        assert arch.instance_keys == instance_keys_expected(instance_keys)
 
 
 if __name__ == "__main__":

--- a/rerun_py/tests/unit/test_box2d.py
+++ b/rerun_py/tests/unit/test_box2d.py
@@ -11,7 +11,6 @@ import torch
 from rerun.components import (
     DrawOrderLike,
     HalfSizes2DBatch,
-    InstanceKeyArrayLike,
     Position2DBatch,
     RadiusArrayLike,
 )
@@ -24,8 +23,6 @@ from .common_arrays import (
     colors_expected,
     draw_order_expected,
     draw_orders,
-    instance_keys_arrays,
-    instance_keys_expected,
     labels_arrays,
     labels_expected,
     radii_arrays,
@@ -54,10 +51,9 @@ def test_boxes2d() -> None:
         labels_arrays,
         draw_orders,
         class_ids_arrays,
-        instance_keys_arrays,
     )
 
-    for half_sizes, centers, colors, radii, labels, draw_order, class_ids, instance_keys in all_arrays:
+    for half_sizes, centers, colors, radii, labels, draw_order, class_ids in all_arrays:
         half_sizes = half_sizes if half_sizes is not None else half_sizes_arrays[-1]
 
         # make Pyright happy as it's apparently not able to track typing info trough zip_longest
@@ -68,7 +64,6 @@ def test_boxes2d() -> None:
         labels = cast(Optional[Utf8ArrayLike], labels)
         draw_order = cast(Optional[DrawOrderLike], draw_order)
         class_ids = cast(Optional[ClassIdArrayLike], class_ids)
-        instance_keys = cast(Optional[InstanceKeyArrayLike], instance_keys)
 
         print(
             f"rr.Boxes2D(\n"
@@ -79,7 +74,6 @@ def test_boxes2d() -> None:
             f"    labels={labels!r}\n"
             f"    draw_order={draw_order!r}\n"
             f"    class_ids={class_ids!r}\n"
-            f"    instance_keys={instance_keys!r}\n"
             f")"
         )
         arch = rr.Boxes2D(
@@ -90,7 +84,6 @@ def test_boxes2d() -> None:
             labels=labels,
             draw_order=draw_order,
             class_ids=class_ids,
-            instance_keys=instance_keys,
         )
         print(f"{arch}\n")
 
@@ -101,7 +94,6 @@ def test_boxes2d() -> None:
         assert arch.labels == labels_expected(labels)
         assert arch.draw_order == draw_order_expected(draw_order)
         assert arch.class_ids == class_ids_expected(class_ids)
-        assert arch.instance_keys == instance_keys_expected(instance_keys)
 
 
 def test_with_sizes() -> None:

--- a/rerun_py/tests/unit/test_box3d.py
+++ b/rerun_py/tests/unit/test_box3d.py
@@ -4,7 +4,7 @@ import itertools
 from typing import Optional, cast
 
 import rerun as rr
-from rerun.components import HalfSizes3DBatch, InstanceKeyArrayLike, Position3DBatch, RadiusArrayLike, Rotation3DBatch
+from rerun.components import HalfSizes3DBatch, Position3DBatch, RadiusArrayLike, Rotation3DBatch
 from rerun.datatypes import ClassIdArrayLike, Rgba32ArrayLike, Rotation3DArrayLike, Utf8ArrayLike
 from rerun.datatypes.vec3d import Vec3DArrayLike
 
@@ -14,8 +14,6 @@ from .common_arrays import (
     colors_arrays,
     colors_expected,
     expected_rotations,
-    instance_keys_arrays,
-    instance_keys_expected,
     labels_arrays,
     labels_expected,
     radii_arrays,
@@ -45,10 +43,9 @@ def test_boxes3d() -> None:
         radii_arrays,
         labels_arrays,
         class_ids_arrays,
-        instance_keys_arrays,
     )
 
-    for half_sizes, centers, rotations, colors, radii, labels, class_ids, instance_keys in all_arrays:
+    for half_sizes, centers, rotations, colors, radii, labels, class_ids in all_arrays:
         half_sizes = half_sizes if half_sizes is not None else half_sizes_arrays[-1]
 
         # make Pyright happy as it's apparently not able to track typing info trough zip_longest
@@ -59,7 +56,6 @@ def test_boxes3d() -> None:
         colors = cast(Optional[Rgba32ArrayLike], colors)
         labels = cast(Optional[Utf8ArrayLike], labels)
         class_ids = cast(Optional[ClassIdArrayLike], class_ids)
-        instance_keys = cast(Optional[InstanceKeyArrayLike], instance_keys)
 
         print(
             f"rr.Boxes3D(\n"
@@ -70,7 +66,6 @@ def test_boxes3d() -> None:
             f"    colors={colors!r}\n"
             f"    labels={labels!r}\n"
             f"    class_ids={class_ids!r}\n"
-            f"    instance_keys={instance_keys!r}\n"
             f")"
         )
         arch = rr.Boxes3D(
@@ -81,7 +76,6 @@ def test_boxes3d() -> None:
             colors=colors,
             labels=labels,
             class_ids=class_ids,
-            instance_keys=instance_keys,
         )
         print(f"{arch}\n")
 
@@ -92,7 +86,6 @@ def test_boxes3d() -> None:
         assert arch.radii == radii_expected(radii)
         assert arch.labels == labels_expected(labels)
         assert arch.class_ids == class_ids_expected(class_ids)
-        assert arch.instance_keys == instance_keys_expected(instance_keys)
 
 
 def test_with_sizes() -> None:

--- a/rerun_py/tests/unit/test_line_strips2d.py
+++ b/rerun_py/tests/unit/test_line_strips2d.py
@@ -9,7 +9,6 @@ import rerun as rr
 import torch
 from rerun.components import (
     DrawOrderLike,
-    InstanceKeyArrayLike,
     LineStrip2DArrayLike,
     LineStrip2DBatch,
     RadiusArrayLike,
@@ -23,8 +22,6 @@ from .common_arrays import (
     colors_expected,
     draw_order_expected,
     draw_orders,
-    instance_keys_arrays,
-    instance_keys_expected,
     labels_arrays,
     labels_expected,
     none_empty_or_value,
@@ -79,10 +76,9 @@ def test_line_strips2d() -> None:
         labels_arrays,
         draw_orders,
         class_ids_arrays,
-        instance_keys_arrays,
     )
 
-    for strips, radii, colors, labels, draw_order, class_ids, instance_keys in all_arrays:
+    for strips, radii, colors, labels, draw_order, class_ids in all_arrays:
         strips = strips if strips is not None else strips_arrays[-1]
 
         # make Pyright happy as it's apparently not able to track typing info trough zip_longest
@@ -92,7 +88,6 @@ def test_line_strips2d() -> None:
         labels = cast(Optional[Utf8ArrayLike], labels)
         draw_order = cast(Optional[DrawOrderLike], draw_order)
         class_ids = cast(Optional[ClassIdArrayLike], class_ids)
-        instance_keys = cast(Optional[InstanceKeyArrayLike], instance_keys)
 
         print(
             f"rr.LineStrips2D(\n"
@@ -102,7 +97,6 @@ def test_line_strips2d() -> None:
             f"    labels={labels!r}\n"
             f"    draw_order={draw_order!r}\n"
             f"    class_ids={class_ids!r}\n"
-            f"    instance_keys={instance_keys!r}\n"
             f")"
         )
         arch = rr.LineStrips2D(
@@ -112,7 +106,6 @@ def test_line_strips2d() -> None:
             labels=labels,
             draw_order=draw_order,
             class_ids=class_ids,
-            instance_keys=instance_keys,
         )
         print(f"{arch}\n")
 
@@ -122,7 +115,6 @@ def test_line_strips2d() -> None:
         assert arch.labels == labels_expected(labels)
         assert arch.draw_order == draw_order_expected(draw_order)
         assert arch.class_ids == class_ids_expected(class_ids)
-        assert arch.instance_keys == instance_keys_expected(instance_keys)
 
 
 @pytest.mark.parametrize(

--- a/rerun_py/tests/unit/test_line_strips3d.py
+++ b/rerun_py/tests/unit/test_line_strips3d.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 import rerun as rr
 import torch
-from rerun.components.instance_key import InstanceKeyArrayLike
 from rerun.components.line_strip3d import LineStrip3DArrayLike, LineStrip3DBatch
 from rerun.components.radius import RadiusArrayLike
 from rerun.datatypes import Vec3D
@@ -20,8 +19,6 @@ from .common_arrays import (
     class_ids_expected,
     colors_arrays,
     colors_expected,
-    instance_keys_arrays,
-    instance_keys_expected,
     labels_arrays,
     labels_expected,
     none_empty_or_value,
@@ -78,10 +75,9 @@ def test_line_strips3d() -> None:
         colors_arrays,
         labels_arrays,
         class_ids_arrays,
-        instance_keys_arrays,
     )
 
-    for strips, radii, colors, labels, class_ids, instance_keys in all_arrays:
+    for strips, radii, colors, labels, class_ids in all_arrays:
         strips = strips if strips is not None else strips_arrays[-1]
 
         # make Pyright happy as it's apparently not able to track typing info trough zip_longest
@@ -90,7 +86,6 @@ def test_line_strips3d() -> None:
         colors = cast(Optional[Rgba32ArrayLike], colors)
         labels = cast(Optional[Utf8ArrayLike], labels)
         class_ids = cast(Optional[ClassIdArrayLike], class_ids)
-        instance_keys = cast(Optional[InstanceKeyArrayLike], instance_keys)
 
         print(
             f"rr.LineStrips3D(\n"
@@ -99,7 +94,6 @@ def test_line_strips3d() -> None:
             f"    colors={colors!r}\n"
             f"    labels={labels!r}\n"
             f"    class_ids={class_ids!r}\n"
-            f"    instance_keys={instance_keys!r}\n"
             f")"
         )
         arch = rr.LineStrips3D(
@@ -108,7 +102,6 @@ def test_line_strips3d() -> None:
             colors=colors,
             labels=labels,
             class_ids=class_ids,
-            instance_keys=instance_keys,
         )
         print(f"{arch}\n")
 
@@ -117,7 +110,6 @@ def test_line_strips3d() -> None:
         assert arch.colors == colors_expected(colors)
         assert arch.labels == labels_expected(labels)
         assert arch.class_ids == class_ids_expected(class_ids)
-        assert arch.instance_keys == instance_keys_expected(instance_keys)
 
 
 @pytest.mark.parametrize(

--- a/rerun_py/tests/unit/test_mesh3d.py
+++ b/rerun_py/tests/unit/test_mesh3d.py
@@ -4,7 +4,7 @@ import itertools
 from typing import Any, Optional, cast
 
 import rerun as rr
-from rerun.components import InstanceKeyArrayLike, MaterialBatch, MeshPropertiesBatch, Position3DBatch, Vector3DBatch
+from rerun.components import MaterialBatch, MeshPropertiesBatch, Position3DBatch, Vector3DBatch
 from rerun.components.texcoord2d import Texcoord2DBatch
 from rerun.datatypes import (
     ClassIdArrayLike,
@@ -22,8 +22,6 @@ from .common_arrays import (
     class_ids_expected,
     colors_arrays,
     colors_expected,
-    instance_keys_arrays,
-    instance_keys_expected,
     none_empty_or_value,
     vec2ds_arrays,
     vec2ds_expected,
@@ -69,7 +67,6 @@ def test_mesh3d() -> None:
         mesh_properties_objects,
         mesh_materials,
         class_ids_arrays,
-        instance_keys_arrays,
     )
 
     for (
@@ -80,7 +77,6 @@ def test_mesh3d() -> None:
         mesh_properties,
         mesh_material,
         class_ids,
-        instance_keys,
     ) in all_arrays:
         vertex_positions = vertex_positions if vertex_positions is not None else vertex_positions_arrays[-1]
 
@@ -92,7 +88,6 @@ def test_mesh3d() -> None:
         mesh_properties = cast(Optional[MeshPropertiesLike], mesh_properties)
         mesh_material = cast(Optional[MaterialLike], mesh_material)
         class_ids = cast(Optional[ClassIdArrayLike], class_ids)
-        instance_keys = cast(Optional[InstanceKeyArrayLike], instance_keys)
 
         print(
             f"E: rr.Mesh3D(\n"
@@ -103,7 +98,6 @@ def test_mesh3d() -> None:
             f"    mesh_properties={mesh_properties_objects}\n"
             f"    mesh_material={mesh_material}\n"
             f"    class_ids={class_ids}\n"
-            f"    instance_keys={instance_keys}\n"
             f")"
         )
         arch = rr.Mesh3D(
@@ -114,7 +108,6 @@ def test_mesh3d() -> None:
             mesh_properties=mesh_properties,
             mesh_material=mesh_material,
             class_ids=class_ids,
-            instance_keys=instance_keys,
         )
         print(f"A: {arch}\n")
 
@@ -125,7 +118,6 @@ def test_mesh3d() -> None:
         assert arch.mesh_properties == mesh_properties_expected(mesh_properties)
         assert arch.mesh_material == mesh_material_expected(mesh_material)
         assert arch.class_ids == class_ids_expected(class_ids)
-        assert arch.instance_keys == instance_keys_expected(instance_keys)
 
 
 def test_nullable_albedo_factor() -> None:

--- a/rerun_py/tests/unit/test_points2d.py
+++ b/rerun_py/tests/unit/test_points2d.py
@@ -10,7 +10,6 @@ from rerun.components import (
     Color,
     ColorBatch,
     DrawOrderLike,
-    InstanceKeyArrayLike,
     Position2DBatch,
     RadiusArrayLike,
 )
@@ -23,8 +22,6 @@ from .common_arrays import (
     colors_expected,
     draw_order_expected,
     draw_orders,
-    instance_keys_arrays,
-    instance_keys_expected,
     keypoint_ids_arrays,
     keypoint_ids_expected,
     labels_arrays,
@@ -49,10 +46,9 @@ def test_points2d() -> None:
         draw_orders,
         class_ids_arrays,
         keypoint_ids_arrays,
-        instance_keys_arrays,
     )
 
-    for positions, radii, colors, labels, draw_order, class_ids, keypoint_ids, instance_keys in all_arrays:
+    for positions, radii, colors, labels, draw_order, class_ids, keypoint_ids in all_arrays:
         positions = positions if positions is not None else positions_arrays[-1]
 
         # make Pyright happy as it's apparently not able to track typing info trough zip_longest
@@ -63,7 +59,6 @@ def test_points2d() -> None:
         draw_order = cast(Optional[DrawOrderLike], draw_order)
         class_ids = cast(Optional[ClassIdArrayLike], class_ids)
         keypoint_ids = cast(Optional[KeypointIdArrayLike], keypoint_ids)
-        instance_keys = cast(Optional[InstanceKeyArrayLike], instance_keys)
 
         print(
             f"rr.Points2D(\n"
@@ -74,7 +69,6 @@ def test_points2d() -> None:
             f"    draw_order={draw_order!r}\n"
             f"    class_ids={class_ids!r}\n"
             f"    keypoint_ids={keypoint_ids!r}\n"
-            f"    instance_keys={instance_keys!r}\n"
             f")"
         )
         arch = rr.Points2D(
@@ -85,7 +79,6 @@ def test_points2d() -> None:
             draw_order=draw_order,
             class_ids=class_ids,
             keypoint_ids=keypoint_ids,
-            instance_keys=instance_keys,
         )
         print(f"{arch}\n")
 
@@ -96,7 +89,6 @@ def test_points2d() -> None:
         assert arch.draw_order == draw_order_expected(draw_order)
         assert arch.class_ids == class_ids_expected(class_ids)
         assert arch.keypoint_ids == keypoint_ids_expected(keypoint_ids)
-        assert arch.instance_keys == instance_keys_expected(instance_keys)
 
 
 @pytest.mark.parametrize(

--- a/rerun_py/tests/unit/test_points3d.py
+++ b/rerun_py/tests/unit/test_points3d.py
@@ -9,7 +9,6 @@ import rerun as rr
 from rerun.components import (
     Color,
     ColorBatch,
-    InstanceKeyArrayLike,
     Position3DBatch,
     RadiusArrayLike,
 )
@@ -20,8 +19,6 @@ from .common_arrays import (
     class_ids_expected,
     colors_arrays,
     colors_expected,
-    instance_keys_arrays,
-    instance_keys_expected,
     keypoint_ids_arrays,
     keypoint_ids_expected,
     labels_arrays,
@@ -45,10 +42,9 @@ def test_points3d() -> None:
         labels_arrays,
         class_ids_arrays,
         keypoint_ids_arrays,
-        instance_keys_arrays,
     )
 
-    for positions, radii, colors, labels, class_ids, keypoint_ids, instance_keys in all_arrays:
+    for positions, radii, colors, labels, class_ids, keypoint_ids in all_arrays:
         positions = positions if positions is not None else positions_arrays[-1]
 
         # make Pyright happy as it's apparently not able to track typing info trough zip_longest
@@ -58,7 +54,6 @@ def test_points3d() -> None:
         labels = cast(Optional[Utf8ArrayLike], labels)
         class_ids = cast(Optional[ClassIdArrayLike], class_ids)
         keypoint_ids = cast(Optional[KeypointIdArrayLike], keypoint_ids)
-        instance_keys = cast(Optional[InstanceKeyArrayLike], instance_keys)
 
         print(
             f"rr.Points3D(\n"
@@ -68,7 +63,6 @@ def test_points3d() -> None:
             f"    labels={labels!r}\n"
             f"    class_ids={class_ids!r}\n"
             f"    keypoint_ids={keypoint_ids!r}\n"
-            f"    instance_keys={instance_keys!r}\n"
             f")"
         )
         arch = rr.Points3D(
@@ -78,7 +72,6 @@ def test_points3d() -> None:
             labels=labels,
             class_ids=class_ids,
             keypoint_ids=keypoint_ids,
-            instance_keys=instance_keys,
         )
         print(f"{arch}\n")
 
@@ -88,7 +81,6 @@ def test_points3d() -> None:
         assert arch.labels == labels_expected(labels)
         assert arch.class_ids == class_ids_expected(class_ids)
         assert arch.keypoint_ids == keypoint_ids_expected(keypoint_ids)
-        assert arch.instance_keys == instance_keys_expected(instance_keys)
 
 
 @pytest.mark.parametrize(

--- a/tests/cpp/roundtrips/arrows2d/main.cpp
+++ b/tests/cpp/roundtrips/arrows2d/main.cpp
@@ -13,6 +13,5 @@ int main(int, char** argv) {
             .with_colors({0xAA0000CC, 0x00BB00DD})
             .with_labels({"hello", "friend"})
             .with_class_ids({126, 127})
-            .with_instance_keys({66, 666})
     );
 }

--- a/tests/cpp/roundtrips/arrows3d/main.cpp
+++ b/tests/cpp/roundtrips/arrows3d/main.cpp
@@ -13,6 +13,5 @@ int main(int, char** argv) {
             .with_colors({0xAA0000CC, 0x00BB00DD})
             .with_labels({"hello", "friend"})
             .with_class_ids({126, 127})
-            .with_instance_keys({66, 666})
     );
 }

--- a/tests/cpp/roundtrips/boxes2d/main.cpp
+++ b/tests/cpp/roundtrips/boxes2d/main.cpp
@@ -14,6 +14,5 @@ int main(int, char** argv) {
             .with_radii({0.1f, 1.0f})
             .with_draw_order(300.0)
             .with_class_ids({126, 127})
-            .with_instance_keys({66, 666})
     );
 }

--- a/tests/cpp/roundtrips/boxes3d/main.cpp
+++ b/tests/cpp/roundtrips/boxes3d/main.cpp
@@ -21,6 +21,5 @@ int main(int, char** argv) {
             .with_labels({"hello", "friend"})
             .with_radii({0.1f, 0.01f})
             .with_class_ids({126, 127})
-            .with_instance_keys({66, 666})
     );
 }

--- a/tests/cpp/roundtrips/line_strips2d/main.cpp
+++ b/tests/cpp/roundtrips/line_strips2d/main.cpp
@@ -15,7 +15,6 @@ int main(int, char** argv) {
             .with_labels({"hello", "friend"})
             .with_draw_order(300.0)
             .with_class_ids({126, 127})
-            .with_instance_keys({66, 666})
     );
 
     // Hack to establish 2d view bounds

--- a/tests/cpp/roundtrips/line_strips3d/main.cpp
+++ b/tests/cpp/roundtrips/line_strips3d/main.cpp
@@ -15,6 +15,5 @@ int main(int, char** argv) {
             .with_colors({0xAA0000CC, 0x00BB00DD})
             .with_labels({"hello", "friend"})
             .with_class_ids({126, 127})
-            .with_instance_keys({66, 666})
     );
 }

--- a/tests/cpp/roundtrips/points2d/main.cpp
+++ b/tests/cpp/roundtrips/points2d/main.cpp
@@ -15,7 +15,6 @@ int main(int, char** argv) {
             .with_draw_order(300.0)
             .with_class_ids({126, 127})
             .with_keypoint_ids({2, 3})
-            .with_instance_keys({66, 666})
     );
 
     // Hack to establish 2d view bounds

--- a/tests/cpp/roundtrips/points3d/main.cpp
+++ b/tests/cpp/roundtrips/points3d/main.cpp
@@ -13,6 +13,5 @@ int main(int, char** argv) {
             .with_labels({"hello", "friend"})
             .with_class_ids({126, 127})
             .with_keypoint_ids({2, 3})
-            .with_instance_keys({66, 666})
     );
 }

--- a/tests/python/roundtrips/arrows2d/main.py
+++ b/tests/python/roundtrips/arrows2d/main.py
@@ -23,7 +23,6 @@ def main() -> None:
     )
     labels = ["hello", "friend"]
     class_ids = np.array([126, 127], dtype=np.uint64)
-    instance_keys = np.array([66, 666], dtype=np.uint64)
 
     arrows2d = rr.Arrows2D(
         vectors=vectors,
@@ -32,7 +31,6 @@ def main() -> None:
         colors=colors,
         labels=labels,
         class_ids=class_ids,
-        instance_keys=instance_keys,
     )
 
     parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")

--- a/tests/python/roundtrips/arrows3d/main.py
+++ b/tests/python/roundtrips/arrows3d/main.py
@@ -23,7 +23,6 @@ def main() -> None:
     )
     labels = ["hello", "friend"]
     class_ids = np.array([126, 127], dtype=np.uint64)
-    instance_keys = np.array([66, 666], dtype=np.uint64)
 
     arrows3d = rr.Arrows3D(
         vectors=vectors,
@@ -32,7 +31,6 @@ def main() -> None:
         colors=colors,
         labels=labels,
         class_ids=class_ids,
-        instance_keys=instance_keys,
     )
 
     parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")

--- a/tests/python/roundtrips/boxes2d/main.py
+++ b/tests/python/roundtrips/boxes2d/main.py
@@ -24,7 +24,6 @@ def main() -> None:
     labels = ["hello", "friend"]
     draw_order = 300
     class_ids = np.array([126, 127], dtype=np.uint64)
-    instance_keys = np.array([66, 666], dtype=np.uint64)
 
     boxes2d = rr.Boxes2D(
         half_sizes=half_sizes,
@@ -34,7 +33,6 @@ def main() -> None:
         radii=radii,
         draw_order=draw_order,
         class_ids=class_ids,
-        instance_keys=instance_keys,
     )
 
     parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")

--- a/tests/python/roundtrips/boxes3d/main.py
+++ b/tests/python/roundtrips/boxes3d/main.py
@@ -25,7 +25,6 @@ def main() -> None:
     radii = np.array([0.1, 0.01], dtype=np.float32)
     labels = ["hello", "friend"]
     class_ids = np.array([126, 127], dtype=np.uint64)
-    instance_keys = np.array([66, 666], dtype=np.uint64)
 
     boxes3d = rr.Boxes3D(
         half_sizes=half_sizes,
@@ -35,7 +34,6 @@ def main() -> None:
         labels=labels,
         radii=radii,
         class_ids=class_ids,
-        instance_keys=instance_keys,
     )
 
     parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")

--- a/tests/python/roundtrips/line_strips2d/main.py
+++ b/tests/python/roundtrips/line_strips2d/main.py
@@ -23,7 +23,6 @@ def main() -> None:
     labels = ["hello", "friend"]
     draw_order = 300
     class_ids = np.array([126, 127], dtype=np.uint64)
-    instance_keys = np.array([66, 666], dtype=np.uint64)
 
     line_strips2d = rr.LineStrips2D(
         points,
@@ -32,7 +31,6 @@ def main() -> None:
         labels=labels,
         draw_order=draw_order,
         class_ids=class_ids,
-        instance_keys=instance_keys,
     )
 
     parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")

--- a/tests/python/roundtrips/line_strips3d/main.py
+++ b/tests/python/roundtrips/line_strips3d/main.py
@@ -22,7 +22,6 @@ def main() -> None:
     )
     labels = ["hello", "friend"]
     class_ids = np.array([126, 127], dtype=np.uint64)
-    instance_keys = np.array([66, 666], dtype=np.uint64)
 
     line_strips3d = rr.LineStrips3D(
         points,
@@ -30,7 +29,6 @@ def main() -> None:
         colors=colors,
         labels=labels,
         class_ids=class_ids,
-        instance_keys=instance_keys,
     )
 
     parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")

--- a/tests/python/roundtrips/points2d/main.py
+++ b/tests/python/roundtrips/points2d/main.py
@@ -24,7 +24,6 @@ def main() -> None:
     draw_order = 300
     class_ids = np.array([126, 127], dtype=np.uint64)
     keypoint_ids = np.array([2, 3], dtype=np.uint64)
-    instance_keys = np.array([66, 666], dtype=np.uint64)
 
     points2d = rr.Points2D(
         points,
@@ -34,7 +33,6 @@ def main() -> None:
         draw_order=draw_order,
         class_ids=class_ids,
         keypoint_ids=keypoint_ids,
-        instance_keys=instance_keys,
     )
 
     parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")

--- a/tests/python/roundtrips/points3d/main.py
+++ b/tests/python/roundtrips/points3d/main.py
@@ -23,7 +23,6 @@ def main() -> None:
     labels = ["hello", "friend"]
     class_ids = np.array([126, 127], dtype=np.uint64)
     keypoint_ids = np.array([2, 3], dtype=np.uint64)
-    instance_keys = np.array([66, 666], dtype=np.uint64)
 
     points3d = rr.Points3D(
         points,
@@ -32,7 +31,6 @@ def main() -> None:
         labels=labels,
         class_ids=class_ids,
         keypoint_ids=keypoint_ids,
-        instance_keys=instance_keys,
     )
 
     parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")

--- a/tests/rust/roundtrips/arrows2d/src/main.rs
+++ b/tests/rust/roundtrips/arrows2d/src/main.rs
@@ -17,8 +17,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
             .with_radii([0.1, 1.0])
             .with_colors([0xAA0000CC, 0x00BB00DD])
             .with_labels(["hello", "friend"])
-            .with_class_ids([126, 127])
-            .with_instance_keys([66, 666]),
+            .with_class_ids([126, 127]),
     )
     .map_err(Into::into)
 }

--- a/tests/rust/roundtrips/arrows3d/src/main.rs
+++ b/tests/rust/roundtrips/arrows3d/src/main.rs
@@ -17,8 +17,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
             .with_radii([0.1, 1.0])
             .with_colors([0xAA0000CC, 0x00BB00DD])
             .with_labels(["hello", "friend"])
-            .with_class_ids([126, 127])
-            .with_instance_keys([66, 666]),
+            .with_class_ids([126, 127]),
     )
     .map_err(Into::into)
 }

--- a/tests/rust/roundtrips/boxes2d/src/main.rs
+++ b/tests/rust/roundtrips/boxes2d/src/main.rs
@@ -18,8 +18,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
             .with_labels(["hello", "friend"])
             .with_radii([0.1, 1.0])
             .with_draw_order(300.0)
-            .with_class_ids([126, 127])
-            .with_instance_keys([66, 666]),
+            .with_class_ids([126, 127]),
     )?;
 
     Ok(())

--- a/tests/rust/roundtrips/boxes3d/src/main.rs
+++ b/tests/rust/roundtrips/boxes3d/src/main.rs
@@ -27,8 +27,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
             .with_colors([0xAA0000CC, 0x00BB00DD])
             .with_labels(["hello", "friend"])
             .with_radii([0.1, 0.01])
-            .with_class_ids([126, 127])
-            .with_instance_keys([66, 666]),
+            .with_class_ids([126, 127]),
     )?;
 
     Ok(())

--- a/tests/rust/roundtrips/line_strips2d/src/main.rs
+++ b/tests/rust/roundtrips/line_strips2d/src/main.rs
@@ -21,8 +21,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
             .with_colors([0xAA0000CC, 0x00BB00DD])
             .with_labels(["hello", "friend"])
             .with_draw_order(300.0)
-            .with_class_ids([126, 127])
-            .with_instance_keys([66, 666]),
+            .with_class_ids([126, 127]),
     )?;
 
     // Hack to establish 2d view bounds

--- a/tests/rust/roundtrips/line_strips3d/src/main.rs
+++ b/tests/rust/roundtrips/line_strips3d/src/main.rs
@@ -17,8 +17,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
             .with_radii([0.42, 0.43])
             .with_colors([0xAA0000CC, 0x00BB00DD])
             .with_labels(["hello", "friend"])
-            .with_class_ids([126, 127])
-            .with_instance_keys([66, 666]),
+            .with_class_ids([126, 127]),
     )
     .map_err(Into::into)
 }

--- a/tests/rust/roundtrips/points2d/src/main.rs
+++ b/tests/rust/roundtrips/points2d/src/main.rs
@@ -21,8 +21,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
             .with_labels(["hello", "friend"])
             .with_draw_order(300.0)
             .with_class_ids([126, 127])
-            .with_keypoint_ids([2, 3])
-            .with_instance_keys([66, 666]),
+            .with_keypoint_ids([2, 3]),
     )?;
 
     // Hack to establish 2d view bounds

--- a/tests/rust/roundtrips/points3d/src/main.rs
+++ b/tests/rust/roundtrips/points3d/src/main.rs
@@ -17,8 +17,7 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
             .with_colors([0xAA0000CC, 0x00BB00DD])
             .with_labels(["hello", "friend"])
             .with_class_ids([126, 127])
-            .with_keypoint_ids([2, 3])
-            .with_instance_keys([66, 666]),
+            .with_keypoint_ids([2, 3]),
     )
     .map_err(Into::into)
 }


### PR DESCRIPTION
This just removes `InstanceKey`s from the archetypes where they were exposed, and updates all tests/examples/APIs/etc accordingly.

Nothing else changes. Internally, everything is still driven by autogenerated instance keys.

The `num_instances` field and the associated log-time check ("0, 1, or N?") are still there.

---

Part of a series of PR to migrate to a key-less, PoV-less, component-based (as opposed to archetype-based) query model:
-  #5395

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5395/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5395/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5395/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5395)
- [Docs preview](https://rerun.io/preview/bd2dda5c89e65a5ed1ffee6e1129c990eda8e8f1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bd2dda5c89e65a5ed1ffee6e1129c990eda8e8f1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)