### PR TITLE
More context menu 2:  add support to show/hide `DataResult`s

### DIFF
--- a/crates/re_viewport/src/context_menu/actions.rs
+++ b/crates/re_viewport/src/context_menu/actions.rs
@@ -119,25 +119,26 @@ fn data_result_visible(
     space_view_id: &SpaceViewId,
     instance_path: &InstancePath,
 ) -> Option<bool> {
-    if instance_path.is_splat() {
-        if let Some(space_view) = ctx.viewport_blueprint.space_view(space_view_id) {
-            let query_result = ctx
-                .viewer_context
-                .lookup_query_result(space_view.query_id());
-            query_result
-                .tree
-                .lookup_result_by_path(&instance_path.entity_path)
-                .map(|data_result| {
-                    data_result
-                        .recursive_properties()
-                        .map_or(true, |prop| prop.visible)
+    instance_path
+        .is_splat()
+        .then(|| {
+            ctx.viewport_blueprint
+                .space_view(space_view_id)
+                .and_then(|space_view| {
+                    let query_result = ctx
+                        .viewer_context
+                        .lookup_query_result(space_view.query_id());
+                    query_result
+                        .tree
+                        .lookup_result_by_path(&instance_path.entity_path)
+                        .map(|data_result| {
+                            data_result
+                                .recursive_properties()
+                                .map_or(true, |prop| prop.visible)
+                        })
                 })
-        } else {
-            None
-        }
-    } else {
-        None
-    }
+        })
+        .flatten()
 }
 
 fn set_data_result_visible(

--- a/crates/re_viewport/src/context_menu/actions.rs
+++ b/crates/re_viewport/src/context_menu/actions.rs
@@ -1,3 +1,4 @@
+use re_entity_db::InstancePath;
 use re_log_types::{EntityPath, EntityPathFilter};
 use re_space_view::{DataQueryBlueprint, SpaceViewBlueprint};
 use re_viewer_context::{ContainerId, Item, SpaceViewClassIdentifier, SpaceViewId};
@@ -17,6 +18,9 @@ impl ContextMenuAction for ShowAction {
                 !ctx.viewport_blueprint
                     .is_contents_visible(&Contents::Container(*container_id))
                     && ctx.viewport_blueprint.root_container != Some(*container_id)
+            }
+            Item::DataResult(space_view_id, instance_path) => {
+                data_result_visible(ctx, space_view_id, instance_path).is_some_and(|vis| !vis)
             }
             _ => false,
         })
@@ -45,9 +49,16 @@ impl ContextMenuAction for ShowAction {
             true,
         );
     }
-}
 
-// ---
+    fn process_data_result(
+        &self,
+        ctx: &ContextMenuContext<'_>,
+        space_view_id: &SpaceViewId,
+        instance_path: &InstancePath,
+    ) {
+        set_data_result_visible(ctx, space_view_id, instance_path, true);
+    }
+}
 
 pub(super) struct HideAction;
 
@@ -61,6 +72,9 @@ impl ContextMenuAction for HideAction {
                 ctx.viewport_blueprint
                     .is_contents_visible(&Contents::Container(*container_id))
                     && ctx.viewport_blueprint.root_container != Some(*container_id)
+            }
+            Item::DataResult(space_view_id, instance_path) => {
+                data_result_visible(ctx, space_view_id, instance_path).unwrap_or(false)
             }
             _ => false,
         })
@@ -88,6 +102,66 @@ impl ContextMenuAction for HideAction {
             &Contents::SpaceView(*space_view_id),
             false,
         );
+    }
+
+    fn process_data_result(
+        &self,
+        ctx: &ContextMenuContext<'_>,
+        space_view_id: &SpaceViewId,
+        instance_path: &InstancePath,
+    ) {
+        set_data_result_visible(ctx, space_view_id, instance_path, false);
+    }
+}
+
+fn data_result_visible(
+    ctx: &ContextMenuContext<'_>,
+    space_view_id: &SpaceViewId,
+    instance_path: &InstancePath,
+) -> Option<bool> {
+    if instance_path.is_splat() {
+        if let Some(space_view) = ctx.viewport_blueprint.space_view(space_view_id) {
+            let query_result = ctx
+                .viewer_context
+                .lookup_query_result(space_view.query_id());
+            query_result
+                .tree
+                .lookup_result_by_path(&instance_path.entity_path)
+                .map(|data_result| {
+                    data_result
+                        .recursive_properties()
+                        .map_or(true, |prop| prop.visible)
+                })
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+fn set_data_result_visible(
+    ctx: &ContextMenuContext<'_>,
+    space_view_id: &SpaceViewId,
+    instance_path: &InstancePath,
+    visible: bool,
+) {
+    if let Some(space_view) = ctx.viewport_blueprint.space_view(space_view_id) {
+        let query_result = ctx
+            .viewer_context
+            .lookup_query_result(space_view.query_id());
+        if let Some(data_result) = query_result
+            .tree
+            .lookup_result_by_path(&instance_path.entity_path)
+        {
+            let mut recursive_properties = data_result
+                .recursive_properties()
+                .cloned()
+                .unwrap_or_default();
+            recursive_properties.visible = visible;
+
+            data_result.save_recursive_override(ctx.viewer_context, Some(recursive_properties));
+        }
     }
 }
 

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -290,7 +290,7 @@ impl Viewport<'_, '_> {
                 default_open,
                 |_, ui| {
                     // Always show the origin hierarchy first.
-                    Self::space_view_entity_hierarchy_ui(
+                    self.space_view_entity_hierarchy_ui(
                         ctx,
                         ui,
                         query_result,
@@ -323,7 +323,7 @@ impl Viewport<'_, '_> {
                         ui.label(egui::RichText::new("Projections:").italics());
 
                         for projection in projections {
-                            Self::space_view_entity_hierarchy_ui(
+                            self.space_view_entity_hierarchy_ui(
                                 ctx,
                                 ui,
                                 query_result,
@@ -365,7 +365,9 @@ impl Viewport<'_, '_> {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn space_view_entity_hierarchy_ui(
+        &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         query_result: &DataQueryResult,
@@ -491,7 +493,7 @@ impl Viewport<'_, '_> {
                                 continue;
                             };
 
-                            Self::space_view_entity_hierarchy_ui(
+                            self.space_view_entity_hierarchy_ui(
                                 ctx,
                                 ui,
                                 query_result,
@@ -517,6 +519,14 @@ impl Viewport<'_, '_> {
             let query = ctx.current_query();
             re_data_ui::item_ui::entity_hover_card_ui(ui, ctx, &query, store, entity_path);
         });
+
+        context_menu_ui_for_item(
+            ctx,
+            self.blueprint,
+            &item,
+            &response,
+            SelectionUpdateBehavior::UseSelection,
+        );
         ctx.select_hovered_on_click(&response, item);
     }
 

--- a/tests/python/release_checklist/check_context_menu.py
+++ b/tests/python/release_checklist/check_context_menu.py
@@ -13,7 +13,7 @@ README = """
 
 * Reset the blueprint.
 * Right-click on any space view and check for context menu content:
-    - Hide
+    - Hide (or Show, depending on visibility)
     - Remove
     - Clone
     - Move to new container
@@ -26,19 +26,17 @@ README = """
     - Add Space View
 * Add a container via the context menu, check the container appears at then end of the list.
 * Right-click on the container and check for context menu content:
-    - Hide
+    - Hide (or Show, depending on visibility)
     - Remove
     - Add Container
     - Add Space View
     - Move to new container
+* Right-click on a data result and check for the context menu content:
+    - Hide (or Show, depending on visibility)
 * Select a container and, in the Selection Panel, right click on either space view or container children:
     - The context menu action should be the same as before.
     - The selection state is not affected by the right-click.
 
-### Show/Hide
-
-* Hide a space view and check that its context menu shows "Show" instead of "Hide".
-* Select multiple space views with homogeneous or heterogeneous visibility states. Check that either or both of "Show All" and "Hide All" are showed as appropriate.
 
 ### Selection behavior
 
@@ -52,12 +50,18 @@ README = """
 ### Multi-selection checks
 
 * Select multiple space views, right-click, and check for context menu content:
-    - Hide
+    - Hide All (if any are visible)
+    - Show All (if any are hidden)
     - Remove
     - Move to new container
 * Same as above, but with only containers selected.
 * Same as above, but with both space views and containers selected.
-* Same as above, but with the viewport selected as well. The context menu should be identical, but none of its actions should apply to the viewport.
+* Same as above, but with the viewport selected as well, and check for context menu content. These should not affect the Viewport.
+    - Hide All (if any are visible)
+    - Show All (if any are hidden)
+* Select a mix of containers, space views, and data results, and check for context menu content:
+    - Hide All (if any are visible)
+    - Show All (if any are hidden)
 
 ### Invalid sub-container kind
 


### PR DESCRIPTION
### What

The `Hide` and `Show` actions now support `DataResult`s as well.

With that, it's easier than ever to run into:
- https://github.com/rerun-io/rerun/issues/5396
- #5310

<img width="313" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/d6ee0b27-3438-4c95-b60d-7ed95ca26061">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5397/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5397/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5397/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5397)
- [Docs preview](https://rerun.io/preview/5fb3cb84bb6be6f6b133dd82e2d2a19b9d9ce4a9/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5fb3cb84bb6be6f6b133dd82e2d2a19b9d9ce4a9/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)