### PR TITLE
Remove the check for WrongNumberOfInstances

### DIFF
--- a/crates/re_log_types/src/data_row.rs
+++ b/crates/re_log_types/src/data_row.rs
@@ -12,18 +12,6 @@ use crate::{DataCell, DataCellError, DataTable, EntityPath, NumInstances, TableI
 #[derive(thiserror::Error, Debug)]
 pub enum DataReadError {
     #[error(
-        "Each cell must contain either 0, 1 or `num_instances` instances, \
-        but cell '{component}' in '{entity_path}' holds {num_instances} instances \
-        (expected {expected_num_instances})"
-    )]
-    WrongNumberOfInstances {
-        entity_path: EntityPath,
-        component: ComponentName,
-        expected_num_instances: u32,
-        num_instances: u32,
-    },
-
-    #[error(
         "Same component type present multiple times within a single row: \
         '{component}' in '{entity_path}'"
     )]
@@ -388,19 +376,6 @@ impl DataRow {
                     entity_path,
                     component,
                 });
-            }
-
-            match cell.num_instances() {
-                0 | 1 => {}
-                n if n == num_instances => {}
-                n => {
-                    return Err(DataReadError::WrongNumberOfInstances {
-                        entity_path,
-                        component,
-                        expected_num_instances: num_instances,
-                        num_instances: n,
-                    })
-                }
             }
         }
 

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -968,8 +968,6 @@ impl RecordingStream {
     /// See `RecordingStream::set_time_*` family of methods for more information.
     ///
     /// The number of instances will be determined by the longest batch in the bundle.
-    /// All of the batches should have the same number of instances, or length 1 if the component is
-    /// a splat, or 0 if the component is being cleared.
     ///
     /// The entity path can either be a string
     /// (with special characters escaped, split on unescaped slashes)

--- a/crates/re_types_core/src/lib.rs
+++ b/crates/re_types_core/src/lib.rs
@@ -49,9 +49,6 @@ pub trait AsComponents {
     ///
     /// If not implemented, the number of instances will be determined by the longest
     /// batch in the bundle.
-    ///
-    /// Each batch returned by `as_component_batches` should have this number of elements,
-    /// or 1 in the case it is a splat, or 0 in the case that component is being cleared.
     #[inline]
     fn num_instances(&self) -> usize {
         self.as_component_batches()

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -482,10 +482,6 @@ namespace rerun {
         /// This is a more low-level API than `log`/`log_timeless\ and requires you to already serialize the data
         /// ahead of time.
         ///
-        /// The number of instances in each batch must either be equal to the maximum or:
-        /// - zero instances - implies a clear
-        /// - single instance (but other instances have more) - causes a splat
-        ///
         /// \param entity_path Path to the entity in the space hierarchy.
         /// \param timeless If true, the logged components will be timeless.
         /// Otherwise, the data will be timestamped automatically with `log_time` and `log_tick`.

--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -41,24 +41,9 @@ class AsComponents(Protocol):
         Returns an iterable of `ComponentBatchLike` objects.
 
         Each object in the iterable must adhere to the `ComponentBatchLike`
-        interface. All of the batches should have the same length as the value
-        returned by `num_instances`, or length 1 if the component is a splat.,
-        or 0 if the component is being cleared.
+        interface.
         """
         ...
-
-    # def num_instances(self) -> int | None:
-    #     """
-    #     (Optional) The number of instances in each batch.
-    #
-    #     If not implemented, the number of instances will be determined by the longest
-    #     batch in the bundle.
-    #
-    #     Each batch returned by `as_component_batches` should have this number of
-    #     elements, or 1 in the case it is a splat, or 0 in the case that
-    #     component is being cleared.
-    #     """
-    #     return None
 
 
 @define

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -186,10 +186,6 @@ def log_components(
     r"""
     Log an entity from a collection of `ComponentBatchLike` objects.
 
-    All of the batches should have the same length as the value of
-    `num_instances`, or length 1 if the component is a splat., or 0 if the
-    component is being cleared.
-
     See also: [`rerun.log`][].
 
     Parameters


### PR DESCRIPTION
### What
Also removed instances of the restriction in documentation.

I believe, in theory this means we can remove a bunch of places where we determine and pass around num_instances. However, doing that requires cleaning up the splat-determination logic and the special splat-instance-key-value, which I assume will come as part of:
 - https://github.com/rerun-io/rerun/issues/5303

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5399/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5399/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5399/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5399)
- [Docs preview](https://rerun.io/preview/140181bdafde95319a803565065aa3b5ed9efa63/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/140181bdafde95319a803565065aa3b5ed9efa63/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)