### PR TITLE
All python components that wrap a bool now implement __bool__

### DIFF
--- a/crates/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/re_types_builder/src/codegen/python/mod.rs
@@ -633,6 +633,20 @@ fn code_for_struct(
         code.push_indented(1, quote_init_method(reporter, obj, ext_class, objects), 2);
     }
 
+    // Generate __bool__ operator if this is a single field struct with a bool field.
+    if fields.len() == 1 && fields[0].typ == Type::Bool {
+        code.push_indented(
+            1,
+            format!(
+                "def __bool__(self) -> bool:
+    return self.{}
+",
+                fields[0].name
+            ),
+            2,
+        );
+    }
+
     if obj.kind == ObjectKind::Archetype {
         code.push_indented(1, quote_clear_methods(obj), 2);
     }

--- a/crates/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/re_types_builder/src/codegen/python/mod.rs
@@ -736,7 +736,11 @@ fn code_for_struct(
 
         if *kind == ObjectKind::Archetype {
             code.push_indented(1, "__str__ = Archetype.__str__", 1);
-            code.push_indented(1, "__repr__ = Archetype.__repr__", 1);
+            code.push_indented(
+                1,
+                "__repr__ = Archetype.__repr__ # type: ignore[assignment] ",
+                1,
+            );
         }
 
         code.push_indented(1, quote_array_method_from_obj(ext_class, objects, obj), 1);

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -527,8 +527,9 @@ def _register_on_fork() -> None:
     try:
         import os
 
-        os.register_at_fork(after_in_child=cleanup_if_forked_child)
+        os.register_at_fork(after_in_child=cleanup_if_forked_child) # type: ignore[attr-defined]
     except AttributeError:
+        # not defined on all OSes
         pass
 
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -99,4 +99,4 @@ class AnnotationContext(Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
@@ -141,4 +141,4 @@ class Arrows2D(Arrows2DExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
@@ -141,4 +141,4 @@ class Arrows3D(Arrows3DExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -105,4 +105,4 @@ class Asset3D(Asset3DExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -96,4 +96,4 @@ class BarChart(BarChartExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -144,4 +144,4 @@ class Boxes2D(Boxes2DExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -148,4 +148,4 @@ class Boxes3D(Boxes3DExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -81,4 +81,4 @@ class Clear(ClearExt, Archetype):
         converter=components.ClearIsRecursiveBatch._required,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -142,4 +142,4 @@ class DepthImage(DepthImageExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
@@ -72,4 +72,4 @@ class DisconnectedSpace(DisconnectedSpaceExt, Archetype):
         converter=components.DisconnectedSpaceBatch._required,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -115,4 +115,4 @@ class Image(ImageExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -194,4 +194,4 @@ class LineStrips2D(Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -187,4 +187,4 @@ class LineStrips3D(Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -165,4 +165,4 @@ class Mesh3D(Mesh3DExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
@@ -142,4 +142,4 @@ class Pinhole(PinholeExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -158,4 +158,4 @@ class Points2D(Points2DExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -143,4 +143,4 @@ class Points3D(Points3DExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
@@ -97,4 +97,4 @@ class Scalar(Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -119,4 +119,4 @@ class SegmentationImage(SegmentationImageExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
@@ -136,4 +136,4 @@ class SeriesLine(Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
@@ -167,4 +167,4 @@ class SeriesPoint(Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -69,4 +69,4 @@ class Tensor(TensorExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -150,4 +150,4 @@ class TextDocument(Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -124,4 +124,4 @@ class TextLog(Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/time_series_scalar.py
@@ -215,4 +215,4 @@ class TimeSeriesScalar(Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -82,4 +82,4 @@ class Transform3D(Transform3DExt, Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -85,7 +85,7 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
         converter=components.ViewCoordinatesBatch._required,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]
 
 
 ViewCoordinatesExt.deferred_patch_class(ViewCoordinates)

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/container_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/container_blueprint.py
@@ -196,4 +196,4 @@ class ContainerBlueprint(Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/plot_legend.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/plot_legend.py
@@ -85,4 +85,4 @@ class PlotLegend(Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/scalar_axis.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/scalar_axis.py
@@ -82,4 +82,4 @@ class ScalarAxis(Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_blueprint.py
@@ -152,4 +152,4 @@ class SpaceViewBlueprint(Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/viewport_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/viewport_blueprint.py
@@ -128,4 +128,4 @@ class ViewportBlueprint(Archetype):
     # (Docstring intentionally commented out to hide this field from the docs)
 
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/auto_layout.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/auto_layout.py
@@ -30,6 +30,9 @@ class AutoLayout(AutoLayoutExt):
         # You can define your own __init__ function as a member of AutoLayoutExt in auto_layout_ext.py
         self.__attrs_init__(auto_layout=auto_layout)
 
+    def __bool__(self) -> bool:
+        return self.auto_layout
+
     auto_layout: bool = field(converter=bool)
 
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/auto_space_views.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/auto_space_views.py
@@ -36,6 +36,9 @@ class AutoSpaceViews(AutoSpaceViewsExt):
         # You can define your own __init__ function as a member of AutoSpaceViewsExt in auto_space_views_ext.py
         self.__attrs_init__(auto_space_views=auto_space_views)
 
+    def __bool__(self) -> bool:
+        return self.auto_space_views
+
     auto_space_views: bool = field(converter=bool)
 
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/entities_determined_by_user.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/entities_determined_by_user.py
@@ -31,6 +31,9 @@ class EntitiesDeterminedByUser:
         # You can define your own __init__ function as a member of EntitiesDeterminedByUserExt in entities_determined_by_user_ext.py
         self.__attrs_init__(value=value)
 
+    def __bool__(self) -> bool:
+        return self.value
+
     value: bool = field(converter=bool)
 
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/lock_range_during_zoom.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/lock_range_during_zoom.py
@@ -35,6 +35,9 @@ class LockRangeDuringZoom:
         # You can define your own __init__ function as a member of LockRangeDuringZoomExt in lock_range_during_zoom_ext.py
         self.__attrs_init__(lock_range=lock_range)
 
+    def __bool__(self) -> bool:
+        return self.lock_range
+
     lock_range: bool = field(converter=bool)
 
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/panel_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/panel_view.py
@@ -29,6 +29,9 @@ class PanelView:
         # You can define your own __init__ function as a member of PanelViewExt in panel_view_ext.py
         self.__attrs_init__(is_expanded=is_expanded)
 
+    def __bool__(self) -> bool:
+        return self.is_expanded
+
     is_expanded: bool = field(converter=bool)
 
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visible.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visible.py
@@ -25,6 +25,9 @@ class Visible:
         # You can define your own __init__ function as a member of VisibleExt in visible_ext.py
         self.__attrs_init__(visible=visible)
 
+    def __bool__(self) -> bool:
+        return self.visible
+
     visible: bool = field(converter=bool)
 
 

--- a/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
+++ b/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
@@ -42,6 +42,9 @@ class ClearIsRecursive(ClearIsRecursiveExt):
         # You can define your own __init__ function as a member of ClearIsRecursiveExt in clear_is_recursive_ext.py
         self.__attrs_init__(recursive=recursive)
 
+    def __bool__(self) -> bool:
+        return self.recursive
+
     recursive: bool = field(converter=bool)
     # If true, also clears all recursive children entities.
     #

--- a/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
@@ -37,6 +37,9 @@ class DisconnectedSpace(DisconnectedSpaceExt):
 
     # __init__ can be found in disconnected_space_ext.py
 
+    def __bool__(self) -> bool:
+        return self.is_disconnected
+
     is_disconnected: bool = field(converter=bool)
     # Whether the entity path at which this is logged is disconnected from its parent.
     #

--- a/rerun_py/rerun_sdk/rerun/components/scalar_scattering.py
+++ b/rerun_py/rerun_sdk/rerun/components/scalar_scattering.py
@@ -34,6 +34,9 @@ class ScalarScattering(ScalarScatteringExt):
         # You can define your own __init__ function as a member of ScalarScatteringExt in scalar_scattering_ext.py
         self.__attrs_init__(scattered=scattered)
 
+    def __bool__(self) -> bool:
+        return self.scattered
+
     scattered: bool = field(converter=bool)
 
 

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -197,4 +197,4 @@ class AffixFuzzer1(Archetype):
         converter=components.AffixFuzzer22Batch._required,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -176,4 +176,4 @@ class AffixFuzzer2(Archetype):
         converter=components.AffixFuzzer22Batch._required,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -188,4 +188,4 @@ class AffixFuzzer3(Archetype):
         converter=components.AffixFuzzer18Batch._optional,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -188,4 +188,4 @@ class AffixFuzzer4(Archetype):
         converter=components.AffixFuzzer18Batch._optional,  # type: ignore[misc]
     )
     __str__ = Archetype.__str__
-    __repr__ = Archetype.__repr__
+    __repr__ = Archetype.__repr__  # type: ignore[assignment]

--- a/rerun_py/tests/unit/test_clear.py
+++ b/rerun_py/tests/unit/test_clear.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import numpy as np
 import rerun as rr
-from rerun.components import ClearIsRecursiveBatch
+from rerun.components import ClearIsRecursive, ClearIsRecursiveBatch
 
 
 def test_clear() -> None:
@@ -17,6 +18,15 @@ def test_clear() -> None:
 def test_clear_factory_methods() -> None:
     assert rr.Clear(recursive=True) == rr.Clear.recursive()
     assert rr.Clear(recursive=False) == rr.Clear.flat()
+
+
+def test_truthiness() -> None:
+    assert ClearIsRecursive(recursive=True)
+    assert not ClearIsRecursive(recursive=False)
+    assert np.array_equal(
+        np.array([ClearIsRecursive(recursive=True), ClearIsRecursive(recursive=False)], dtype=np.bool_),
+        np.array([True, False], dtype=np.bool_)
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What

This fixes unexpected errors with python truthiness.

plus some mypy linting fixes for issues I encountered when running `pixi run lint-py-mypy` on windows

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
