### PR TITLE
More context menu 3: add support for removing `DataResult` from a space view

### DIFF
--- a/tests/python/release_checklist/check_context_menu.py
+++ b/tests/python/release_checklist/check_context_menu.py
@@ -33,6 +33,7 @@ README = """
     - Move to new container
 * Right-click on a data result and check for the context menu content:
     - Hide (or Show, depending on visibility)
+    - Remove
 * Select a container and, in the Selection Panel, right click on either space view or container children:
     - The context menu action should be the same as before.
     - The selection state is not affected by the right-click.
@@ -62,6 +63,7 @@ README = """
 * Select a mix of containers, space views, and data results, and check for context menu content:
     - Hide All (if any are visible)
     - Show All (if any are hidden)
+    - Remove
 
 ### Invalid sub-container kind
 


### PR DESCRIPTION
### What

As the title says ☝🏻 

Will easily trigger:
- https://github.com/rerun-io/rerun/issues/5404
- https://github.com/rerun-io/rerun/issues/5406


<img width="321" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/e996ade1-2ad7-42a5-8b9a-852149d653a3">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5407/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5407/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5407/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5407)
- [Docs preview](https://rerun.io/preview/4a94ddc1c02addd3e7a45a9241dcf57eade1df91/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4a94ddc1c02addd3e7a45a9241dcf57eade1df91/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)