### PR TITLE
Update wgpu to 0.19.3

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,7 +14,6 @@ IS_IN_RERUN_WORKSPACE = "yes"
 
 # web_sys_unstable_apis is required to enable the web_sys clipboard API which egui_web uses,
 # https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Clipboard.html
-# as well as WebGPU apis.
 # https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html
 [target.wasm32-unknown-unknown]
 rustflags = ["--cfg=web_sys_unstable_apis"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7074,9 +7074,9 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "wgpu"
-version = "0.19.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe9a310dcf2e6b85f00c46059aaeaf4184caa8e29a1ecd4b7a704c3482332d"
+checksum = "a4b1213b52478a7631d6e387543ed8f642bc02c578ef4e3b49aca2a29a7df0cb"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -7099,9 +7099,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.19.0"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b15e451d4060ada0d99a64df44e4d590213496da7c4f245572d51071e8e30ed"
+checksum = "f9f6b033c2f00ae0bc8ea872c5989777c60bc241aac4e58b24774faa8b391f78"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -7125,9 +7125,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.19.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bb47856236bfafc0bc591a925eb036ac19cd987624a447ff353e7a7e7e6f72"
+checksum = "49f972c280505ab52ffe17e94a7413d9d54b58af0114ab226b9fc4999a47082e"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -7149,6 +7149,7 @@ dependencies = [
  "log",
  "metal",
  "naga",
+ "ndk-sys",
  "objc",
  "once_cell",
  "parking_lot",
@@ -7166,9 +7167,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.19.0"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "895fcbeb772bfb049eb80b2d6e47f6c9af235284e9703c96fc0218a42ffd5af2"
+checksum = "b671ff9fb03f78b46ff176494ee1ebe7d603393f42664be55b64dc8d53969805"
 dependencies = [
  "bitflags 2.4.1",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,8 +231,7 @@ walkdir = "2.0"
 wasm-bindgen = "0.2.89"
 wasm-bindgen-cli-support = "0.2.89"
 wasm-bindgen-futures = "0.4.33"
-# web-sys 0.3.68 contains breaking API changes in an unstable API used by wgpu
-web-sys = "=0.3.67"
+web-sys = "0.3"
 web-time = "0.2.0"
 webbrowser = "0.8"
 winit = { version = "0.29.9", default-features = false }


### PR DESCRIPTION
### What

WebGPU APIs are now vendored inside of wgpu, meaning the only reason we still need unstable web-sys is clipboard support in egui.

[Changelog 0.19.3](https://github.com/gfx-rs/wgpu/releases/tag/v0.19.3)
[Changelog 0.19.2](https://github.com/gfx-rs/wgpu/releases/tag/v0.19.2)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5409/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5409/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5409/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5409)
- [Docs preview](https://rerun.io/preview/ce6d4fab8a0dfa8f465a68180a7dacc2187af736/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ce6d4fab8a0dfa8f465a68180a7dacc2187af736/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)