### PR TITLE
More context menu 5: add context menu to streams tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4878,6 +4878,7 @@ dependencies = [
  "re_tracing",
  "re_ui",
  "re_viewer_context",
+ "re_viewport",
  "serde",
  "vec1",
 ]

--- a/crates/re_time_panel/Cargo.toml
+++ b/crates/re_time_panel/Cargo.toml
@@ -24,7 +24,7 @@ re_log_types.workspace = true
 re_tracing.workspace = true
 re_ui.workspace = true
 re_viewer_context.workspace = true
-re_viewport.workspace = true
+re_viewport.workspace = true       # TODO(#5421): remove this dependency in favor of re_viewpoert_blueprint when it exists
 
 egui.workspace = true
 itertools.workspace = true

--- a/crates/re_time_panel/Cargo.toml
+++ b/crates/re_time_panel/Cargo.toml
@@ -24,7 +24,7 @@ re_log_types.workspace = true
 re_tracing.workspace = true
 re_ui.workspace = true
 re_viewer_context.workspace = true
-re_viewport.workspace = true       # TODO(#5421): remove this dependency in favor of re_viewpoert_blueprint when it exists
+re_viewport.workspace = true       # TODO(#5421): remove this dependency in favor of re_viewport_blueprint when it exists
 
 egui.workspace = true
 itertools.workspace = true

--- a/crates/re_time_panel/Cargo.toml
+++ b/crates/re_time_panel/Cargo.toml
@@ -24,6 +24,7 @@ re_log_types.workspace = true
 re_tracing.workspace = true
 re_ui.workspace = true
 re_viewer_context.workspace = true
+re_viewport.workspace = true
 
 egui.workspace = true
 itertools.workspace = true

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -288,10 +288,18 @@ impl AppState {
         };
 
         if app_options.inspect_blueprint_timeline {
-            blueprint_panel.show_panel(&ctx, ctx.store_context.blueprint, blueprint_cfg, ui, true);
+            blueprint_panel.show_panel(
+                &ctx,
+                &viewport_blueprint,
+                ctx.store_context.blueprint,
+                blueprint_cfg,
+                ui,
+                true,
+            );
         }
         time_panel.show_panel(
             &ctx,
+            &viewport_blueprint,
             ctx.entity_db,
             ctx.rec_cfg,
             ui,

--- a/tests/python/release_checklist/check_context_menu_add_entity_to_new_space_view.py
+++ b/tests/python/release_checklist/check_context_menu_add_entity_to_new_space_view.py
@@ -11,11 +11,17 @@ import rerun as rr
 README = """
 # Context Menu - Add entity to new space view
 
+## Blueprint tree
+
 * Reset the blueprint.
 * Expend all space views and data result.
 * Right-click on the `boxes3d` entity and select "Add to new space view" -> "3D". Check a new space view is created _and selected_ with the boxes3d entity and origin set to root.
 * In each space view, right-click on the leaf entity, and check that "Add to new space view" recommends at least space views of the same kind.
 * Select both the `boxes3d` entity and the `text_logs` entity. Check no space view is recommended (except Dataframe if enabled).
+
+## Streams tree
+
+* Right-click on the `bars` entity and check that a Bar Plot space view can successfully be created.
 """
 
 


### PR DESCRIPTION
### What

The streams tree now supports context menu. Currently, the only available action is to create a space view with the selected entities.

Annoyingly, this PR introduces a dependency on `re_viewport` from `re_time_panel`. However, a refactor is in order and will enable a scope reduction for this new (otherwise inevitable) dependency:
- https://github.com/rerun-io/rerun/issues/5421

<img width="510" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/a5ec0e60-5a0e-47cb-9f19-94729d96b30e">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5422/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5422/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5422/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5422)
- [Docs preview](https://rerun.io/preview/a62b1d874cda0237e5a9599627d34c19c889df99/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a62b1d874cda0237e5a9599627d34c19c889df99/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)