### PR TITLE
Fix crash from removing SpaceViewContents due to double-clear

### DIFF
--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -297,7 +297,6 @@ impl SpaceViewBlueprint {
     pub fn clear(&self, ctx: &ViewerContext<'_>) {
         let clear = Clear::recursive();
         ctx.save_blueprint_component(&self.entity_path(), &clear.is_recursive);
-        self.contents.clear(ctx);
     }
 
     #[inline]

--- a/crates/re_space_view/src/space_view_contents.rs
+++ b/crates/re_space_view/src/space_view_contents.rs
@@ -14,7 +14,7 @@ use re_types::{
     },
     Archetype as _,
 };
-use re_types_core::{archetypes::Clear, components::VisualizerOverrides, ComponentName};
+use re_types_core::{components::VisualizerOverrides, ComponentName};
 use re_viewer_context::{
     DataQueryResult, DataResult, DataResultHandle, DataResultNode, DataResultTree,
     IndicatedEntities, PerVisualizer, PropertyOverrides, SpaceViewClassIdentifier, SpaceViewId,
@@ -166,11 +166,6 @@ impl SpaceViewContents {
                 &EntitiesDeterminedByUser(true),
             );
         }
-    }
-
-    pub fn clear(&self, ctx: &ViewerContext<'_>) {
-        let clear = Clear::recursive();
-        ctx.save_blueprint_component(&self.blueprint_entity_path, &clear.is_recursive);
     }
 
     pub fn build_resolver<'a>(


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/5426

SpaceViewContents are now nested under SpaceView.  This means the clear from SpaceView will already clear the contained SpaceViewContents (and any other sub-archetypes).

It appears if we sequentially issue 2 recursive clears that overlap in the hierarchy this causes a crash:
 - https://github.com/rerun-io/rerun/issues/5428

This simply removes the explicit clear we previously had since it's no longer necessary, which **avoids** the crash on this viewer behavior, but doesn't actually address the underlying separate issue.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5427/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5427/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5427/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5427)
- [Docs preview](https://rerun.io/preview/8cb0b9b66fdda2484e3148c38dbca98e99643cec/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8cb0b9b66fdda2484e3148c38dbca98e99643cec/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)