### PR TITLE
Remove recursive clear cascade debug assertion 

### DIFF
--- a/crates/re_entity_db/src/entity_db.rs
+++ b/crates/re_entity_db/src/entity_db.rs
@@ -340,7 +340,11 @@ impl EntityDb {
 
         // Clears don't affect `Clear` components themselves, therefore we cannot have recursive
         // cascades, thus this whole process must stabilize after one iteration.
-        debug_assert!(clear_cascade.is_empty());
+        if !clear_cascade.is_empty() {
+            re_log::debug!(
+                "recursive clear cascade detected -- might just have been logged this way"
+            );
+        }
 
         // We inform the stats last, since it measures e2e latency.
         self.stats.on_events(original_store_events);


### PR DESCRIPTION
While it should not happen because of the cascade itself, it can still happen if someone actually make it happen via log calls.

- Fixes https://github.com/rerun-io/rerun/issues/5428

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5430/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5430/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5430/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5430)
- [Docs preview](https://rerun.io/preview/d0511fb6224e3fbdd6a267a5aee0351402b62b82/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d0511fb6224e3fbdd6a267a5aee0351402b62b82/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)