### PR TITLE
Make pinhole.hpp robust against min/max preprocessor macros (typically from windows.h)

### DIFF
--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -153,7 +153,8 @@ namespace rerun::archetypes {
         /// Assumes the principal point to be in the middle of the sensor.
         static Pinhole from_fov_and_aspect_ratio(float fov_y, float aspect_ratio) {
             const float EPSILON = std::numeric_limits<float>::epsilon();
-            const float focal_length_y = 0.5f / std::tan(std::max(fov_y * 0.5f, EPSILON));
+            // `max` has explicit template args to avoid preprocessor replacement when <windows.h> is included without NOMINMAX.
+            const float focal_length_y = 0.5f / std::tan(std::max<float>(fov_y * 0.5f, EPSILON));
             return from_focal_length_and_resolution(
                 {focal_length_y, focal_length_y},
                 {aspect_ratio, 1.0}

--- a/rerun_cpp/src/rerun/archetypes/pinhole_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole_ext.cpp
@@ -36,7 +36,8 @@ namespace rerun {
         /// Assumes the principal point to be in the middle of the sensor.
         static Pinhole from_fov_and_aspect_ratio(float fov_y, float aspect_ratio) {
             const float EPSILON = std::numeric_limits<float>::epsilon();
-            const float focal_length_y = 0.5f / std::tan(std::max(fov_y * 0.5f, EPSILON));
+            // `max` has explicit template args to avoid preprocessor replacement when <windows.h> is included without NOMINMAX.
+            const float focal_length_y = 0.5f / std::tan(std::max<float>(fov_y * 0.5f, EPSILON));
             return from_focal_length_and_resolution(
                 {focal_length_y, focal_length_y},
                 {aspect_ratio, 1.0}

--- a/rerun_cpp/tests/windows_min_max_robustness.cpp
+++ b/rerun_cpp/tests/windows_min_max_robustness.cpp
@@ -1,0 +1,10 @@
+
+// `<windows.h>` by default defined min and max as macros, which can cause issues with std::min and std::max.
+// This can be easily turned off by the user with `#define NOMINMAX` before including `<windows.h>`.
+// However, users might not know about this or forget about it and we want to be robust against it.
+//
+// This test checks that rerun.h is robust against this issue by explicitly setting `min`/`max` macros and including rerun.hpp.
+#define min(a, b) (this does not compile)
+#define max(a, b) (this does not compile)
+
+#include <rerun.hpp>


### PR DESCRIPTION
### What

And add a test to ensure we don't run into this again!

* Fixes #5414

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5432/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5432/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5432/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5432)
- [Docs preview](https://rerun.io/preview/13b23da339babe01018016fb651da7d8f02e549c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/13b23da339babe01018016fb651da7d8f02e549c/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)