### PR TITLE
add timezone option unix epoch

### DIFF
--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -318,12 +318,22 @@ fn options_menu_ui(
 
     ui.horizontal(|ui| {
         ui.label("Timezone:");
+    });
+    ui.horizontal(|ui| {
         re_ui
             .radio_value(ui, &mut app_options.time_zone, TimeZone::Utc, "UTC")
             .on_hover_text("Display timestamps in UTC");
         re_ui
             .radio_value(ui, &mut app_options.time_zone, TimeZone::Local, "Local")
             .on_hover_text("Display timestamps in the local timezone");
+        re_ui
+            .radio_value(
+                ui,
+                &mut app_options.time_zone,
+                TimeZone::UnixEpoch,
+                "Unix Epoch",
+            )
+            .on_hover_text("Display timestamps in seconds since unix epoch");
     });
 
     {


### PR DESCRIPTION
### What
Added a unix epoch timestamp display option, as mentioned in issue [4866](https://github.com/rerun-io/rerun/issues/4866)

<img width="1470" alt="Screenshot 2024-03-10 at 23 25 16-min" src="https://github.com/rerun-io/rerun/assets/21971561/c18ae1c1-9eb5-494a-bf30-78d2e0f7f363">

Not quite sure how compact time display should be handled: 

```diff
    /// Useful when showing dates/times on a timeline
    /// and you want it compact.
    ///
    /// Shows dates when zoomed out, shows times when zoomed in,
    /// shows relative millisecond when really zoomed in.
    pub fn format_time_compact(&self, time_zone_for_timestamps: TimeZone) -> String {
...
            if let Some(datetime) = self.to_datetime() {
                let is_whole_minute = ns % 60_000_000_000 == 0;
                let time_format = if self.is_exactly_midnight() {
                    "[year]-[month]-[day]"
                } else if is_whole_minute {
                    "[hour]:[minute]"
                } else {
-                    "[hour]:[minute]:[second]"
+                    Self::get_time_prefix(&time_zone_for_timestamps)
                };
                let parsed_format = time::format_description::parse(time_format).unwrap();

                return Self::time_string(datetime, &parsed_format, time_zone_for_timestamps);
            }
...
}
``` 

Should the `[hour]:[minute]` be changed as well when unix timestamp is chosen?

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
