### PR TITLE
Fix size comparison (red CI)

### DIFF
--- a/scripts/ci/compare.py
+++ b/scripts/ci/compare.py
@@ -116,7 +116,11 @@ def compare(
                 unit = get_unit(min(previous_bytes, current_bytes))
                 div = get_divisor(unit)
 
-            change_pct = ((current - previous) / previous) * 100
+            if previous == 0:
+                change_pct = 100
+            else:
+                change_pct = 100 * (current - previous) / previous
+
             if abs(change_pct) >= threshold_pct:
                 if unit in DIVISORS:
                     change = f"{change_pct:+.2f}%"


### PR DESCRIPTION
### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5474/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5474/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5474/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5474)
- [Docs preview](https://rerun.io/preview/1f43b69488e8e24931db53dbd1abbf78aaa2b731/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/1f43b69488e8e24931db53dbd1abbf78aaa2b731/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)