### PR TITLE
Implement recursive component overrides

### DIFF
--- a/crates/re_space_view/src/data_query.rs
+++ b/crates/re_space_view/src/data_query.rs
@@ -1,10 +1,17 @@
+use ahash::HashMap;
+
 use re_entity_db::{external::re_data_store::LatestAtQuery, EntityProperties, EntityPropertyMap};
+use re_log_types::{EntityPath, StoreKind};
+use re_types::ComponentName;
 use re_viewer_context::{DataQueryResult, PerVisualizer, StoreContext, VisualizableEntities};
 
 pub struct EntityOverrideContext {
     pub root: EntityProperties,
     pub individual: EntityPropertyMap,
     pub recursive: EntityPropertyMap,
+
+    /// Base component overrides that are inherited by all entities.
+    pub root_component_overrides: HashMap<ComponentName, (StoreKind, EntityPath)>,
 }
 
 /// Trait for resolving properties needed by most implementations of [`DataQuery`]

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -450,12 +450,16 @@ impl SpaceViewBlueprint {
 mod tests {
     use crate::data_query::{DataQuery, PropertyResolver};
     use re_entity_db::EntityDb;
-    use re_log_types::{DataCell, DataRow, EntityPathFilter, RowId, StoreId, TimePoint};
-    use re_types::archetypes::Points3D;
+    use re_log_types::{
+        example_components::{MyColor, MyLabel, MyPoint},
+        DataCell, DataRow, EntityPathFilter, RowId, StoreId, StoreKind, TimePoint,
+    };
+    use re_types::{archetypes::Points3D, ComponentBatch, ComponentName, Loggable as _};
     use re_viewer_context::{
         blueprint_timeline, IndicatedEntities, PerVisualizer, SpaceViewClassRegistry, StoreContext,
         VisualizableEntities,
     };
+    use std::collections::HashMap;
 
     use super::*;
 
@@ -474,7 +478,7 @@ mod tests {
     }
 
     #[test]
-    fn test_overrides() {
+    fn test_entity_properties() {
         let space_view_class_registry = SpaceViewClassRegistry::default();
         let mut recording = EntityDb::new(StoreId::random(re_log_types::StoreKind::Recording));
         let mut blueprint = EntityDb::new(StoreId::random(re_log_types::StoreKind::Blueprint));
@@ -756,6 +760,291 @@ mod tests {
                 child2.accumulated_properties().visible_history.nanos,
                 VisibleHistory::OFF
             );
+        }
+    }
+
+    #[test]
+    fn test_component_overrides() {
+        let space_view_class_registry = SpaceViewClassRegistry::default();
+        let mut recording = EntityDb::new(StoreId::random(re_log_types::StoreKind::Recording));
+        let mut visualizable_entities_per_visualizer =
+            PerVisualizer::<VisualizableEntities>::default();
+
+        // Set up a store DB with some entities.
+        {
+            let entity_paths: Vec<EntityPath> =
+                ["parent", "parent/skipped/grandchild", "parent/child"]
+                    .into_iter()
+                    .map(Into::into)
+                    .collect();
+            for entity_path in &entity_paths {
+                let row = DataRow::from_component_batches(
+                    RowId::new(),
+                    TimePoint::timeless(),
+                    entity_path.clone(),
+                    [&[MyPoint::new(1.0, 2.0)] as _],
+                )
+                .unwrap();
+                recording.add_data_row(row).unwrap();
+            }
+
+            // All of them are visualizable with some arbitrary visualizer.
+            visualizable_entities_per_visualizer
+                .0
+                .entry("Points3D".into())
+                .or_insert_with(|| VisualizableEntities(entity_paths.into_iter().collect()));
+        }
+
+        // Basic blueprint - a single space view that queries everything.
+        let space_view = SpaceViewBlueprint::new(
+            "3D".into(),
+            &EntityPath::root(),
+            EntityPathFilter::parse_forgiving("+ /**"),
+        );
+        let individual_override_root = space_view
+            .contents
+            .blueprint_entity_path
+            .join(&DataResult::INDIVIDUAL_OVERRIDES_PREFIX.into());
+        let recursive_override_root = space_view
+            .contents
+            .blueprint_entity_path
+            .join(&DataResult::RECURSIVE_OVERRIDES_PREFIX.into());
+
+        // Things needed to resolve properties:
+        let auto_properties = EntityPropertyMap::default();
+        let indicated_entities_per_visualizer = PerVisualizer::<IndicatedEntities>::default(); // Don't care about indicated entities.
+        let resolver = space_view.contents.build_resolver(
+            &space_view_class_registry,
+            &space_view,
+            &auto_properties,
+            &visualizable_entities_per_visualizer,
+            &indicated_entities_per_visualizer,
+        );
+
+        struct Scenario {
+            recursive_overrides: Vec<(EntityPath, Box<dyn ComponentBatch>)>,
+            individual_overrides: Vec<(EntityPath, Box<dyn ComponentBatch>)>,
+            expected_overrides: HashMap<EntityPath, HashMap<ComponentName, EntityPath>>,
+        }
+
+        let scenarios: Vec<Scenario> = vec![
+            // No overrides.
+            Scenario {
+                recursive_overrides: Vec::new(),
+                individual_overrides: Vec::new(),
+                expected_overrides: HashMap::default(),
+            },
+            // Recursive override at parent entity.
+            Scenario {
+                recursive_overrides: vec![(
+                    "parent".into(),
+                    Box::new(MyLabel("parent_override".to_owned())),
+                )],
+                individual_overrides: Vec::new(),
+                expected_overrides: HashMap::from([
+                    (
+                        "parent".into(),
+                        HashMap::from([(
+                            MyLabel::name(),
+                            recursive_override_root.join(&"parent".into()),
+                        )]),
+                    ),
+                    (
+                        "parent/skipped".into(),
+                        HashMap::from([(
+                            MyLabel::name(),
+                            recursive_override_root.join(&"parent".into()),
+                        )]),
+                    ),
+                    (
+                        "parent/skipped/grandchild".into(),
+                        HashMap::from([(
+                            MyLabel::name(),
+                            recursive_override_root.join(&"parent".into()),
+                        )]),
+                    ),
+                    (
+                        "parent/child".into(),
+                        HashMap::from([(
+                            MyLabel::name(),
+                            recursive_override_root.join(&"parent".into()),
+                        )]),
+                    ),
+                ]),
+            },
+            // Set a single individual.
+            Scenario {
+                recursive_overrides: Vec::new(),
+                individual_overrides: vec![(
+                    "parent".into(),
+                    Box::new(MyLabel("parent_individual".to_owned())),
+                )],
+                expected_overrides: HashMap::from([(
+                    "parent".into(),
+                    HashMap::from([(
+                        MyLabel::name(),
+                        individual_override_root.join(&"parent".into()),
+                    )]),
+                )]),
+            },
+            // Recursive override, partially shadowed by individual.
+            Scenario {
+                recursive_overrides: vec![
+                    (
+                        "parent/skipped".into(),
+                        Box::new(MyLabel("parent_individual".to_owned())),
+                    ),
+                    (
+                        "parent/skipped".into(),
+                        Box::new(MyColor::from_rgb(0, 1, 2)),
+                    ),
+                ],
+                individual_overrides: vec![(
+                    "parent/skipped/grandchild".into(),
+                    Box::new(MyColor::from_rgb(1, 2, 3)),
+                )],
+                expected_overrides: HashMap::from([
+                    (
+                        "parent/skipped".into(),
+                        HashMap::from([
+                            (
+                                MyLabel::name(),
+                                recursive_override_root.join(&"parent/skipped".into()),
+                            ),
+                            (
+                                MyColor::name(),
+                                recursive_override_root.join(&"parent/skipped".into()),
+                            ),
+                        ]),
+                    ),
+                    (
+                        "parent/skipped/grandchild".into(),
+                        HashMap::from([
+                            (
+                                MyLabel::name(),
+                                recursive_override_root.join(&"parent/skipped".into()),
+                            ),
+                            (
+                                MyColor::name(),
+                                individual_override_root.join(&"parent/skipped/grandchild".into()),
+                            ),
+                        ]),
+                    ),
+                ]),
+            },
+            // Recursive override, partially shadowed by another recursive override.
+            Scenario {
+                recursive_overrides: vec![
+                    (
+                        "parent/skipped".into(),
+                        Box::new(MyLabel("parent_individual".to_owned())),
+                    ),
+                    (
+                        "parent/skipped".into(),
+                        Box::new(MyColor::from_rgb(0, 1, 2)),
+                    ),
+                    (
+                        "parent/skipped/grandchild".into(),
+                        Box::new(MyColor::from_rgb(3, 2, 1)),
+                    ),
+                ],
+                individual_overrides: Vec::new(),
+                expected_overrides: HashMap::from([
+                    (
+                        "parent/skipped".into(),
+                        HashMap::from([
+                            (
+                                MyLabel::name(),
+                                recursive_override_root.join(&"parent/skipped".into()),
+                            ),
+                            (
+                                MyColor::name(),
+                                recursive_override_root.join(&"parent/skipped".into()),
+                            ),
+                        ]),
+                    ),
+                    (
+                        "parent/skipped/grandchild".into(),
+                        HashMap::from([
+                            (
+                                MyLabel::name(),
+                                recursive_override_root.join(&"parent/skipped".into()),
+                            ),
+                            (
+                                MyColor::name(),
+                                recursive_override_root.join(&"parent/skipped/grandchild".into()),
+                            ),
+                        ]),
+                    ),
+                ]),
+            },
+        ];
+
+        for (
+            i,
+            Scenario {
+                recursive_overrides,
+                individual_overrides,
+                expected_overrides,
+            },
+        ) in scenarios.into_iter().enumerate()
+        {
+            let mut blueprint = EntityDb::new(StoreId::random(re_log_types::StoreKind::Blueprint));
+            let mut add_to_blueprint = |path: &EntityPath, batch: &dyn ComponentBatch| {
+                let row = DataRow::from_component_batches(
+                    RowId::new(),
+                    TimePoint::timeless(),
+                    path.clone(),
+                    std::iter::once(batch),
+                )
+                .unwrap();
+                blueprint.add_data_row(row).unwrap();
+            };
+
+            // log individual and override components as instructed.
+            for (entity_path, batch) in recursive_overrides {
+                add_to_blueprint(&recursive_override_root.join(&entity_path), batch.as_ref());
+            }
+            for (entity_path, batch) in individual_overrides {
+                add_to_blueprint(&individual_override_root.join(&entity_path), batch.as_ref());
+            }
+
+            // Set up a store query and update the overrides.
+            let ctx = StoreContext {
+                blueprint: &blueprint,
+                recording: Some(&recording),
+                all_recordings: vec![],
+            };
+            let mut query_result = space_view
+                .contents
+                .execute_query(&ctx, &visualizable_entities_per_visualizer);
+            let blueprint_query = LatestAtQuery::latest(blueprint_timeline());
+            resolver.update_overrides(&ctx, &blueprint_query, &mut query_result);
+
+            // Extract component overrides for testing.
+            let mut visited: HashMap<EntityPath, HashMap<ComponentName, EntityPath>> =
+                HashMap::default();
+            query_result.tree.visit(&mut |node| {
+                let result = &node.data_result;
+                if let Some(property_overrides) = &result.property_overrides {
+                    if !property_overrides.component_overrides.is_empty() {
+                        visited.insert(
+                            result.entity_path.clone(),
+                            property_overrides
+                                .component_overrides
+                                .iter()
+                                .map(|(component_name, (store_kind, path))| {
+                                    assert_eq!(store_kind, &StoreKind::Blueprint);
+                                    (*component_name, path.clone())
+                                })
+                                .collect(),
+                        );
+                    }
+                }
+                true
+            });
+
+            assert_eq!(visited, expected_overrides, "Scenario {i}");
         }
     }
 }

--- a/crates/re_viewer_context/src/space_view/view_query.rs
+++ b/crates/re_viewer_context/src/space_view/view_query.rs
@@ -33,7 +33,7 @@ pub struct PropertyOverrides {
     // TODO(jleibs): Consider something like `tinymap` for this.
     pub component_overrides: HashMap<ComponentName, (StoreKind, EntityPath)>,
 
-    /// `EntityPath` in the Blueprint store where updated overrides should be written back\
+    /// `EntityPath` in the Blueprint store where updated overrides should be written back
     /// for properties that apply recursively.
     pub recursive_override_path: EntityPath,
 


### PR DESCRIPTION
### What

* First bits of #5463

10% impl 90% test code! (unfortunately a fair portion of that is boilerplate)

Additionally, also takes into account "root property overrides": visual time range on space view is right now implemented via a special hook that passes root `EntityProperties` in. We need/want the same for component overrides and that's exactly what's happening here as well. Unfortunately, that part isn't covered by unit testing, but it's fairly straight forward so I'm not too worried.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5481/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5481/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5481/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5481)
- [Docs preview](https://rerun.io/preview/2ae6d25785a5275e2fc721691cd3850e4096a9f4/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2ae6d25785a5275e2fc721691cd3850e4096a9f4/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)