### PR TITLE
Allow rerun_py to be built without the viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5354,8 +5354,6 @@ dependencies = [
  "re_log",
  "re_log_types",
  "re_memory",
- "re_viewer",
- "re_viewport",
  "re_web_viewer_server",
  "re_ws_comms",
  "rerun",

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -51,10 +51,6 @@ rerun = { workspace = true, features = [
 re_web_viewer_server = { workspace = true, optional = true }
 re_ws_comms = { workspace = true, optional = true }
 
-# TODO(jleibs): Dependency on re_viewer and re_viewport should go away as part of https://github.com/rerun-io/rerun/issues/2089
-re_viewer.workspace = true
-re_viewport.workspace = true
-
 arrow2 = { workspace = true, features = ["io_ipc", "io_print"] }
 crossbeam.workspace = true
 document-features.workspace = true


### PR DESCRIPTION
### What
- Builds on top of: https://github.com/rerun-io/rerun/pull/5484

- Resolves: https://github.com/rerun-io/rerun/issues/2089
  - Specifically the part about the bridge dep on re_viewer. The rest of the decoupling has already been done.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5485/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5485/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5485/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5485)
- [Docs preview](https://rerun.io/preview/5189590ca4dc0282a6b1c814200db8434ab7004e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5189590ca4dc0282a6b1c814200db8434ab7004e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)