### PR TITLE
Incremental logging example improvements + removed from manifest 

### DIFF
--- a/examples/cpp/incremental_logging/README.md
+++ b/examples/cpp/incremental_logging/README.md
@@ -4,7 +4,6 @@ tags = ["3D", "api-example"]
 description = "Showcases how to incrementally log data belonging to the same archetype."
 thumbnail = "https://static.rerun.io/incremental_logging/b7a2bd889b09c3840f56dc31bd6d677934ab3126/480w.png"
 thumbnail_dimensions = [480, 285]
-channel = "main"
 -->
 
 

--- a/examples/cpp/incremental_logging/main.cpp
+++ b/examples/cpp/incremental_logging/main.cpp
@@ -6,9 +6,48 @@
 #include <algorithm>
 #include <random>
 
+const char* README = R"(
+# Incremental Logging
+
+This example showcases how to incrementally log data belonging to the same archetype, and re-use some or all of it across frames.
+
+It was logged with the following code:
+```cpp
+std::vector<rerun::Color> colors(10, rerun::Color(255, 0, 0));
+std::vector<rerun::Radius> radii(10, rerun::Radius(0.1f));
+
+// Only log colors and radii once.
+rec.set_time_sequence("frame_nr", 0);
+rec.log("points", colors, radii);
+
+std::default_random_engine gen;
+std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);
+
+// Then log only the points themselves each frame.
+//
+// They will automatically re-use the colors and radii logged at the beginning.
+for (int i = 0; i < 10; ++i) {
+    rec.set_time_sequence("frame_nr", i);
+
+    std::vector<rerun::Position3D> points(10);
+    std::generate(points.begin(), points.end(), [&] {
+        return rerun::Position3D(dist_pos(gen), dist_pos(gen), dist_pos(gen));
+    });
+    rec.log("points", rerun::Points3D(points));
+}
+```
+
+Move the time cursor around, and notice how the colors and radii from frame 0 are still picked up by later frames, while the points themselves keep changing every frame.
+)";
+
 int main() {
     const auto rec = rerun::RecordingStream("rerun_example_incremental_logging");
     rec.spawn().exit_on_failure();
+
+    rec.log_timeless(
+        "readme",
+        rerun::TextDocument(README).with_media_type(rerun::components::MediaType::markdown())
+    );
 
     // TODO(#5264): just log one once clamp-to-edge semantics land.
     std::vector<rerun::Color> colors(10, rerun::Color(255, 0, 0));

--- a/examples/python/incremental_logging/README.md
+++ b/examples/python/incremental_logging/README.md
@@ -4,7 +4,6 @@ tags = ["3D", "api-example"]
 description = "Showcases how to incrementally log data belonging to the same archetype."
 thumbnail = "https://static.rerun.io/incremental_logging/b7a2bd889b09c3840f56dc31bd6d677934ab3126/480w.png"
 thumbnail_dimensions = [480, 301]
-channel = "main"
 -->
 
 

--- a/examples/python/incremental_logging/main.py
+++ b/examples/python/incremental_logging/main.py
@@ -12,7 +12,39 @@ parser = argparse.ArgumentParser(description="Showcases how to incrementally log
 rr.script_add_args(parser)
 args = parser.parse_args()
 
+
+README = """\
+# Incremental Logging
+
+This example showcases how to incrementally log data belonging to the same archetype, and re-use some or all of it across frames.
+
+It was logged with the following code:
+```python
+colors = rr.components.ColorBatch(np.repeat(0xFF0000FF, 10))
+radii = rr.components.RadiusBatch(np.repeat(0.1, 10))
+
+# Only log colors and radii once.
+rr.set_time_sequence("frame_nr", 0)
+rr.log_components("points", [colors, radii])
+
+rng = default_rng(12345)
+
+# Then log only the points themselves each frame.
+#
+# They will automatically re-use the colors and radii logged at the beginning.
+for i in range(10):
+    rr.set_time_sequence("frame_nr", i)
+    rr.log("points", rr.Points3D(rng.uniform(-5, 5, size=[10, 3])))
+```
+
+Move the time cursor around, and notice how the colors and radii from frame 0 are still picked up by later frames, while the points themselves keep changing every frame.
+"""
+
+# ---
+
 rr.script_setup(args, "rerun_example_incremental_logging")
+
+rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
 
 # TODO(#5264): just log one once clamp-to-edge semantics land.
 colors = rr.components.ColorBatch(np.repeat(0xFF0000FF, 10))

--- a/examples/rust/incremental_logging/README.md
+++ b/examples/rust/incremental_logging/README.md
@@ -4,7 +4,6 @@ tags = ["3D", "api-example"]
 description = "Showcases how to incrementally log data belonging to the same archetype."
 thumbnail = "https://static.rerun.io/incremental_logging/b7a2bd889b09c3840f56dc31bd6d677934ab3126/480w.png"
 thumbnail_dimensions = [480, 285]
-channel = "main"
 -->
 
 

--- a/examples/rust/incremental_logging/src/main.rs
+++ b/examples/rust/incremental_logging/src/main.rs
@@ -26,7 +26,41 @@ fn main() -> anyhow::Result<()> {
     run(&rec)
 }
 
+const README: &str = r#"
+# Incremental Logging
+
+This example showcases how to incrementally log data belonging to the same archetype, and re-use some or all of it across frames.
+
+It was logged with the following code:
+```rust
+let colors = [rerun::Color::from_rgb(255, 0, 0); 10];
+let radii = [rerun::Radius(0.1); 10];
+
+// Only log colors and radii once.
+rec.set_time_sequence("frame_nr", 0);
+rec.log_component_batches("points", false, /* timeless */ [&colors as &dyn rerun::ComponentBatch, &radii])?;
+
+let mut rng = rand::thread_rng();
+let dist = Uniform::new(-5., 5.);
+
+// Then log only the points themselves each frame.
+//
+// They will automatically re-use the colors and radii logged at the beginning.
+for i in 0..10 {
+    rec.set_time_sequence("frame_nr", i);
+    rec.log("points", &rerun::Points3D::new((0..10).map(|_| (rng.sample(dist), rng.sample(dist), rng.sample(dist)))))?;
+}
+```
+
+Move the time cursor around, and notice how the colors and radii from frame 0 are still picked up by later frames, while the points themselves keep changing every frame.
+"#;
+
 fn run(rec: &rerun::RecordingStream) -> anyhow::Result<()> {
+    rec.log_timeless(
+        "readme",
+        &rerun::TextDocument::new(README).with_media_type(rerun::MediaType::MARKDOWN),
+    )?;
+
     // TODO(#5264): just log one once clamp-to-edge semantics land.
     let colors = [rerun::Color::from_rgb(255, 0, 0); 10];
     let radii = [rerun::Radius(0.1); 10];


### PR DESCRIPTION
This example ended up in the manifest by mistake.

### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
