### PR TITLE
Save recordings from web viewer

### DIFF
--- a/crates/re_data_store/src/store_read.rs
+++ b/crates/re_data_store/src/store_read.rs
@@ -397,6 +397,7 @@ impl DataStore {
 
     /// Sort all unsorted indices in the store.
     pub fn sort_indices_if_needed(&self) {
+        re_tracing::profile_function!();
         for index in self.tables.values() {
             index.sort_indices_if_needed();
         }

--- a/crates/re_log_encoding/src/encoder.rs
+++ b/crates/re_log_encoding/src/encoder.rs
@@ -125,15 +125,3 @@ pub fn encode<'a>(
     }
     Ok(())
 }
-
-pub fn encode_owned(
-    options: EncodingOptions,
-    messages: impl Iterator<Item = LogMsg>,
-    write: impl std::io::Write,
-) -> Result<(), EncodeError> {
-    let mut encoder = Encoder::new(options, write)?;
-    for message in messages {
-        encoder.append(&message)?;
-    }
-    Ok(())
-}

--- a/crates/re_log_encoding/src/encoder.rs
+++ b/crates/re_log_encoding/src/encoder.rs
@@ -75,6 +75,8 @@ impl<W: std::io::Write> Encoder<W> {
     }
 
     pub fn append(&mut self, message: &LogMsg) -> Result<(), EncodeError> {
+        re_tracing::profile_function!();
+
         self.uncompressed.clear();
         rmp_serde::encode::write_named(&mut self.uncompressed, message)?;
 
@@ -119,9 +121,23 @@ pub fn encode<'a>(
     messages: impl Iterator<Item = &'a LogMsg>,
     write: &mut impl std::io::Write,
 ) -> Result<(), EncodeError> {
+    re_tracing::profile_function!();
     let mut encoder = Encoder::new(options, write)?;
     for message in messages {
         encoder.append(message)?;
     }
     Ok(())
+}
+
+pub fn encode_as_bytes<'a>(
+    options: EncodingOptions,
+    messages: impl Iterator<Item = &'a LogMsg>,
+) -> Result<Vec<u8>, EncodeError> {
+    re_tracing::profile_function!();
+    let mut bytes: Vec<u8> = vec![];
+    let mut encoder = Encoder::new(options, &mut bytes)?;
+    for message in messages {
+        encoder.append(message)?;
+    }
+    Ok(bytes)
 }

--- a/crates/re_log_encoding/src/lib.rs
+++ b/crates/re_log_encoding/src/lib.rs
@@ -3,7 +3,6 @@
 #[cfg(feature = "decoder")]
 pub mod decoder;
 #[cfg(feature = "encoder")]
-#[cfg(not(target_arch = "wasm32"))] // we do no yet support encoding LogMsgs in the browser
 pub mod encoder;
 
 #[cfg(feature = "encoder")]
@@ -121,7 +120,6 @@ impl FileHeader {
     pub const SIZE: usize = 12;
 
     #[cfg(feature = "encoder")]
-    #[cfg(not(target_arch = "wasm32"))] // we do no yet support encoding LogMsgs in the browser
     pub fn encode(&self, write: &mut impl std::io::Write) -> Result<(), encoder::EncodeError> {
         write
             .write_all(&self.magic)
@@ -165,7 +163,6 @@ impl MessageHeader {
     pub const SIZE: usize = 8;
 
     #[cfg(feature = "encoder")]
-    #[cfg(not(target_arch = "wasm32"))] // we do no yet support encoding LogMsgs in the browser
     pub fn encode(&self, write: &mut impl std::io::Write) -> Result<(), encoder::EncodeError> {
         write
             .write_all(&self.compressed_len.to_le_bytes())

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -541,8 +541,8 @@ impl ExampleApp {
 }
 
 fn file_menu(ui: &mut egui::Ui, command_sender: &CommandSender) {
-    UICommand::Save.menu_button_ui(ui, command_sender);
-    UICommand::SaveSelection.menu_button_ui(ui, command_sender);
+    UICommand::SaveRecording.menu_button_ui(ui, command_sender);
+    UICommand::SaveRecordingSelection.menu_button_ui(ui, command_sender);
     UICommand::Open.menu_button_ui(ui, command_sender);
     UICommand::Quit.menu_button_ui(ui, command_sender);
 }

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -96,7 +96,7 @@ impl UICommand {
             Self::SaveRecording => ("Save recording…", "Save all data to a Rerun data file (.rrd)"),
 
             Self::SaveRecordingSelection => (
-                "Save recording loop selection…",
+                "Save recording (current time selection only)…",
                 "Save data for the current loop selection to a Rerun data file (.rrd)",
             ),
 

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -14,10 +14,8 @@ pub trait UICommandSender {
 pub enum UICommand {
     // Listed in the order they show up in the command palette by default!
     Open,
-    #[cfg(not(target_arch = "wasm32"))]
-    Save,
-    #[cfg(not(target_arch = "wasm32"))]
-    SaveSelection,
+    SaveRecording,
+    SaveRecordingSelection,
     CloseCurrentRecording,
     #[cfg(not(target_arch = "wasm32"))]
     Quit,
@@ -95,12 +93,10 @@ impl UICommand {
 
     pub fn text_and_tooltip(self) -> (&'static str, &'static str) {
         match self {
-            #[cfg(not(target_arch = "wasm32"))]
-            Self::Save => ("Save…", "Save all data to a Rerun data file (.rrd)"),
+            Self::SaveRecording => ("Save recording…", "Save all data to a Rerun data file (.rrd)"),
 
-            #[cfg(not(target_arch = "wasm32"))]
-            Self::SaveSelection => (
-                "Save loop selection…",
+            Self::SaveRecordingSelection => (
+                "Save recording loop selection…",
                 "Save data for the current loop selection to a Rerun data file (.rrd)",
             ),
 
@@ -238,7 +234,6 @@ impl UICommand {
             KeyboardShortcut::new(Modifiers::COMMAND, key)
         }
 
-        #[cfg(not(target_arch = "wasm32"))]
         fn cmd_alt(key: Key) -> KeyboardShortcut {
             KeyboardShortcut::new(Modifiers::COMMAND.plus(Modifiers::ALT), key)
         }
@@ -248,10 +243,8 @@ impl UICommand {
         }
 
         match self {
-            #[cfg(not(target_arch = "wasm32"))]
-            Self::Save => Some(cmd(Key::S)),
-            #[cfg(not(target_arch = "wasm32"))]
-            Self::SaveSelection => Some(cmd_alt(Key::S)),
+            Self::SaveRecording => Some(cmd(Key::S)),
+            Self::SaveRecordingSelection => Some(cmd_alt(Key::S)),
             Self::Open => Some(cmd(Key::O)),
             Self::CloseCurrentRecording => None,
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1502,7 +1502,7 @@ async fn async_open_rrd_dialog() -> Vec<re_data_source::FileContents> {
 
 #[allow(clippy::needless_pass_by_ref_mut)]
 fn save(
-    #[allow(unused_variables)] app: &mut App,
+    #[allow(unused_variables)] app: &mut App, // only used on native
     store_context: Option<&StoreContext<'_>>,
     loop_selection: Option<(re_entity_db::Timeline, re_log_types::TimeRangeF)>,
 ) {

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -10,10 +10,7 @@ use re_query_cache::CachesStats;
 use re_viewer_context::{AppOptions, StoreContext};
 
 #[cfg(not(target_arch = "wasm32"))]
-use crate::{
-    loading::load_blueprint_file,
-    saving::{default_blueprint_path, save_database_to_file},
-};
+use crate::{loading::load_blueprint_file, saving::default_blueprint_path};
 
 /// Interface for accessing all blueprints and recordings
 ///
@@ -342,10 +339,13 @@ impl StoreHub {
                     {
                         let blueprint_path = default_blueprint_path(app_id)?;
                         re_log::debug_once!("Saving blueprint for {app_id} to {blueprint_path:?}");
+
+                        let messages = blueprint.to_messages(None)?;
+
                         // TODO(jleibs): Should we push this into a background thread? Blueprints should generally
                         // be small & fast to save, but maybe not once we start adding big pieces of user data?
-                        let file_saver = save_database_to_file(blueprint, blueprint_path, None)?;
-                        file_saver()?;
+                        crate::saving::encode_to_file(&blueprint_path, messages.iter())?;
+
                         self.blueprint_last_save
                             .insert(blueprint_id.clone(), blueprint.generation());
                     }

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -38,14 +38,14 @@ impl App {
 
             UICommand::Open.menu_button_ui(ui, &self.command_sender);
 
+            self.save_buttons_ui(ui, _store_context);
+
+            UICommand::CloseCurrentRecording.menu_button_ui(ui, &self.command_sender);
+
+            ui.add_space(SPACING);
+
             #[cfg(not(target_arch = "wasm32"))]
             {
-                self.save_buttons_ui(ui, _store_context);
-
-                UICommand::CloseCurrentRecording.menu_button_ui(ui, &self.command_sender);
-
-                ui.add_space(SPACING);
-
                 // On the web the browser controls the zoom
                 let zoom_factor = ui.ctx().zoom_factor();
                 ui.weak(format!("Current zoom: {:.0}%", zoom_factor * 100.0))
@@ -160,15 +160,13 @@ impl App {
         }
     }
 
-    // TODO(emilk): support saving data on web
-    #[cfg(not(target_arch = "wasm32"))]
     fn save_buttons_ui(&mut self, ui: &mut egui::Ui, store_view: Option<&StoreContext<'_>>) {
         use re_ui::UICommandSender;
 
         let file_save_in_progress = self.background_tasks.is_file_save_in_progress();
 
-        let save_button = UICommand::Save.menu_button(ui.ctx());
-        let save_selection_button = UICommand::SaveSelection.menu_button(ui.ctx());
+        let save_button = UICommand::SaveRecording.menu_button(ui.ctx());
+        let save_selection_button = UICommand::SaveRecordingSelection.menu_button(ui.ctx());
 
         if file_save_in_progress {
             ui.add_enabled_ui(false, |ui| {
@@ -192,7 +190,7 @@ impl App {
                     .clicked()
                 {
                     ui.close_menu();
-                    self.command_sender.send_ui(UICommand::Save);
+                    self.command_sender.send_ui(UICommand::SaveRecording);
                 }
 
                 // We need to know the loop selection _before_ we can even display the
@@ -209,7 +207,8 @@ impl App {
                     .clicked()
                 {
                     ui.close_menu();
-                    self.command_sender.send_ui(UICommand::SaveSelection);
+                    self.command_sender
+                        .send_ui(UICommand::SaveRecordingSelection);
                 }
             });
         }

--- a/scripts/ci/compare.py
+++ b/scripts/ci/compare.py
@@ -116,7 +116,9 @@ def compare(
                 unit = get_unit(min(previous_bytes, current_bytes))
                 div = get_divisor(unit)
 
-            if previous == 0:
+            if previous == current:
+                change_pct = 0  # e.g. both are zero
+            elif previous == 0:
                 change_pct = 100
             else:
                 change_pct = 100 * (current - previous) / previous


### PR DESCRIPTION
### What
You can now save recordings from the web viewer. The UI is admittedly pretty ugly (we use [rfd](https://github.com/PolyMeilex/rfd)), but it works.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://githubcom/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5488/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5488/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5488/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5488)
- [Docs preview](https://rerun.io/preview/ebf6bf5a428eeabe6b61d1bfe9a5f2c578775bcd/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ebf6bf5a428eeabe6b61d1bfe9a5f2c578775bcd/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)