### PR TITLE
Emilk/save blueprint

### DIFF
--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -553,6 +553,7 @@ mod tests {
         // No overrides set. Everybody has default values.
         {
             let ctx = StoreContext {
+                app_id: re_log_types::ApplicationId::unknown(),
                 blueprint: &blueprint,
                 recording: Some(&recording),
                 all_recordings: vec![],
@@ -595,6 +596,7 @@ mod tests {
         // Parent is not visible, but children are
         {
             let ctx = StoreContext {
+                app_id: re_log_types::ApplicationId::unknown(),
                 blueprint: &blueprint,
                 recording: Some(&recording),
                 all_recordings: vec![],
@@ -643,6 +645,7 @@ mod tests {
         // Nobody is visible
         {
             let ctx = StoreContext {
+                app_id: re_log_types::ApplicationId::unknown(),
                 blueprint: &blueprint,
                 recording: Some(&recording),
                 all_recordings: vec![],
@@ -673,6 +676,7 @@ mod tests {
         {
             let root = space_view.root_data_result(
                 &StoreContext {
+                    app_id: re_log_types::ApplicationId::unknown(),
                     blueprint: &blueprint,
                     recording: Some(&recording),
                     all_recordings: vec![],
@@ -693,6 +697,7 @@ mod tests {
         // Everyone has visible history
         {
             let ctx = StoreContext {
+                app_id: re_log_types::ApplicationId::unknown(),
                 blueprint: &blueprint,
                 recording: Some(&recording),
                 all_recordings: vec![],
@@ -734,6 +739,7 @@ mod tests {
         // Child2 has its own visible history
         {
             let ctx = StoreContext {
+                app_id: re_log_types::ApplicationId::unknown(),
                 blueprint: &blueprint,
                 recording: Some(&recording),
                 all_recordings: vec![],

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -16,6 +16,7 @@ pub enum UICommand {
     Open,
     SaveRecording,
     SaveRecordingSelection,
+    SaveBlueprint,
     CloseCurrentRecording,
     #[cfg(not(target_arch = "wasm32"))]
     Quit,
@@ -99,6 +100,8 @@ impl UICommand {
                 "Save recording (current time selection only)…",
                 "Save data for the current loop selection to a Rerun data file (.rrd)",
             ),
+
+            Self::SaveBlueprint => ("Save blueprint…", "Save the current viewer setup as a Rerun blueprint file (.blueprint)"),
 
             Self::Open => ("Open…", "Open any supported files (.rrd, images, meshes, …)"),
 
@@ -245,6 +248,7 @@ impl UICommand {
         match self {
             Self::SaveRecording => Some(cmd(Key::S)),
             Self::SaveRecordingSelection => Some(cmd_alt(Key::S)),
+            Self::SaveBlueprint => None,
             Self::Open => Some(cmd(Key::O)),
             Self::CloseCurrentRecording => None,
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1568,10 +1568,10 @@ fn save_entity_db(
                     return;
                 }
             };
-            if let Err(err) = app
-                .background_tasks
-                .spawn_file_saver(move || crate::saving::encode_to_file(&path, messages.iter()))
-            {
+            if let Err(err) = app.background_tasks.spawn_file_saver(move || {
+                crate::saving::encode_to_file(&path, messages.iter())?;
+                Ok(path)
+            }) {
                 // NOTE: Can only happen if saving through the command palette.
                 re_log::error!("File saving failed: {err}");
             }

--- a/crates/re_viewer/src/background_tasks.rs
+++ b/crates/re_viewer/src/background_tasks.rs
@@ -44,10 +44,9 @@ impl BackgroundTasks {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn spawn_file_saver<F, T>(&mut self, f: F) -> anyhow::Result<()>
+    pub fn spawn_file_saver<F>(&mut self, f: F) -> anyhow::Result<()>
     where
-        F: FnOnce() -> T + Send + 'static,
-        T: Send + 'static,
+        F: FnOnce() -> anyhow::Result<PathBuf> + Send + 'static,
     {
         self.spawn_threaded_promise(FILE_SAVER_PROMISE, f)
     }

--- a/crates/re_viewer/src/saving.rs
+++ b/crates/re_viewer/src/saving.rs
@@ -1,10 +1,8 @@
-#[cfg(not(target_arch = "wasm32"))]
 use re_log_types::ApplicationId;
 
-#[cfg(not(target_arch = "wasm32"))]
 /// Convert to lowercase and replace any character that is not a fairly common
 /// filename character with '-'
-fn sanitize_app_id(app_id: &ApplicationId) -> String {
+pub fn sanitize_app_id(app_id: &ApplicationId) -> String {
     let output = app_id.0.to_lowercase();
     output.replace(
         |c: char| !matches!(c, '0'..='9' | 'a'..='z' | '.' | '_' | '+' | '(' | ')' | '[' | ']'),
@@ -12,10 +10,10 @@ fn sanitize_app_id(app_id: &ApplicationId) -> String {
     )
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 /// Determine the default path for a blueprint based on its `ApplicationId`
 /// This path should be deterministic and unique.
 // TODO(#2579): Implement equivalent for web
+#[cfg(not(target_arch = "wasm32"))]
 pub fn default_blueprint_path(app_id: &ApplicationId) -> anyhow::Result<std::path::PathBuf> {
     use anyhow::Context;
 

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -40,6 +40,8 @@ impl App {
 
             self.save_buttons_ui(ui, _store_context);
 
+            UICommand::SaveBlueprint.menu_button_ui(ui, &self.command_sender);
+
             UICommand::CloseCurrentRecording.menu_button_ui(ui, &self.command_sender);
 
             ui.add_space(SPACING);
@@ -165,13 +167,13 @@ impl App {
 
         let file_save_in_progress = self.background_tasks.is_file_save_in_progress();
 
-        let save_button = UICommand::SaveRecording.menu_button(ui.ctx());
+        let save_recording_button = UICommand::SaveRecording.menu_button(ui.ctx());
         let save_selection_button = UICommand::SaveRecordingSelection.menu_button(ui.ctx());
 
         if file_save_in_progress {
             ui.add_enabled_ui(false, |ui| {
                 ui.horizontal(|ui| {
-                    ui.add(save_button);
+                    ui.add(save_recording_button);
                     ui.spinner();
                 });
                 ui.horizontal(|ui| {
@@ -185,7 +187,7 @@ impl App {
                 .map_or(false, |recording| !recording.is_empty());
             ui.add_enabled_ui(entity_db_is_nonempty, |ui| {
                 if ui
-                    .add(save_button)
+                    .add(save_recording_button)
                     .on_hover_text("Save all data to a Rerun data file (.rrd)")
                     .clicked()
                 {

--- a/crates/re_viewer_context/src/store_context.rs
+++ b/crates/re_viewer_context/src/store_context.rs
@@ -1,7 +1,9 @@
 use re_entity_db::EntityDb;
+use re_log_types::ApplicationId;
 
 /// The current Blueprint and Recording being displayed by the viewer
 pub struct StoreContext<'a> {
+    pub app_id: ApplicationId,
     pub blueprint: &'a EntityDb,
     pub recording: Option<&'a EntityDb>,
     pub all_recordings: Vec<&'a EntityDb>,


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/5294

This adds a command for saving the currently active `.blueprint` file to disk.

![image](https://github.com/rerun-io/rerun/assets/1148717/706006f1-e440-4402-a73d-b78e4c24a936)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
