### PR TITLE
Add the remaining space views and name them consistently

### DIFF
--- a/examples/python/blueprint/main.py
+++ b/examples/python/blueprint/main.py
@@ -6,7 +6,7 @@ import argparse
 
 import numpy as np
 import rerun as rr  # pip install rerun-sdk
-from rerun.blueprint import Blueprint, BlueprintPanel, Grid, SelectionPanel, Spatial2D, TimePanel, Viewport
+from rerun.blueprint import Blueprint, BlueprintPanel, Grid, SelectionPanel, Spatial2DView, TimePanel, Viewport
 
 
 def main() -> None:
@@ -28,8 +28,8 @@ def main() -> None:
         blueprint = Blueprint(
             Viewport(
                 Grid(
-                    Spatial2D(name="Rect 0", origin="/", contents=["image", "rect/0"]),
-                    Spatial2D(name="Rect 1", origin="/", contents=["image", "rect/1"]),
+                    Spatial2DView(name="Rect 0", origin="/", contents=["image", "rect/0"]),
+                    Spatial2DView(name="Rect 1", origin="/", contents=["image", "rect/1"]),
                 ),
                 auto_space_views=args.auto_space_views,
             ),

--- a/examples/python/blueprint/main.py
+++ b/examples/python/blueprint/main.py
@@ -6,7 +6,7 @@ import argparse
 
 import numpy as np
 import rerun as rr  # pip install rerun-sdk
-from rerun.blueprint.api import Blueprint, BlueprintPanel, Grid, SelectionPanel, Spatial2D, TimePanel, Viewport
+from rerun.blueprint import Blueprint, BlueprintPanel, Grid, SelectionPanel, Spatial2D, TimePanel, Viewport
 
 
 def main() -> None:

--- a/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
@@ -23,13 +23,9 @@ from .api import (
     Blueprint,
     BlueprintLike,
     BlueprintPanel,
-    Grid,
-    Horizontal,
     SelectionPanel,
-    Spatial2D,
-    Spatial3D,
-    Tabs,
     TimePanel,
-    Vertical,
     Viewport,
 )
+from .containers import Grid, Horizontal, Vertical
+from .space_views import Spatial2D, Spatial3D

--- a/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 __all__ = [
     "archetypes",
+    "BarChartView",
     "Blueprint",
     "BlueprintLike",
     "BlueprintPanel",
@@ -10,10 +11,14 @@ __all__ = [
     "Grid",
     "Horizontal",
     "SelectionPanel",
-    "Spatial2D",
-    "Spatial3D",
+    "Spatial2DView",
+    "Spatial3DView",
     "Tabs",
+    "TensorView",
+    "TextDocumentView",
+    "TextLogView",
     "TimePanel",
+    "TimeSeriesView",
     "Vertical",
     "Viewport",
 ]
@@ -28,4 +33,12 @@ from .api import (
     Viewport,
 )
 from .containers import Grid, Horizontal, Vertical
-from .space_views import Spatial2D, Spatial3D
+from .space_views import (
+    BarChartView,
+    Spatial2DView,
+    Spatial3DView,
+    TensorView,
+    TextDocumentView,
+    TextLogView,
+    TimeSeriesView,
+)

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -11,7 +11,7 @@ from ..recording import MemoryRecording
 from ..recording_stream import RecordingStream
 from .archetypes import ContainerBlueprint, PanelBlueprint, SpaceViewBlueprint, SpaceViewContents, ViewportBlueprint
 from .components import ColumnShareArrayLike, RowShareArrayLike
-from .components.container_kind import ContainerKind, ContainerKindLike
+from .components.container_kind import ContainerKindLike
 
 SpaceViewContentsLike = Union[str, Sequence[str], Utf8Like, SpaceViewContents]
 
@@ -70,6 +70,8 @@ class SpaceView:
 
     def to_viewport(self) -> Viewport:
         """Convert this space view to a viewport."""
+        from .containers import Grid
+
         return Viewport(Grid(self))
 
     def to_blueprint(self) -> Blueprint:
@@ -110,56 +112,6 @@ class SpaceView:
         # TODO(jleibs): This goes away when we get rid of `space_views` from the viewport and just use
         # the entity-path lookup instead.
         return [self.id.bytes]
-
-
-class Spatial3D(SpaceView):
-    """A Spatial 3D space view."""
-
-    def __init__(
-        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
-    ):
-        """
-        Construct a blueprint for a new 3D space view.
-
-        Parameters
-        ----------
-        origin
-            The `EntityPath` to use as the origin of this space view. All other entities will be transformed
-            to be displayed relative to this origin.
-        contents
-            The contents of the space view. Most commonly specified as a query expression. The individual
-            sub-expressions must either be newline separate, or provided as a list of strings.
-            See: [rerun.blueprint.components.QueryExpression][].
-        name
-            The name of the space view.
-
-        """
-        super().__init__(class_identifier="3D", origin=origin, contents=contents, name=name)
-
-
-class Spatial2D(SpaceView):
-    """A Spatial 2D space view."""
-
-    def __init__(
-        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
-    ):
-        """
-        Construct a blueprint for a new 2D space view.
-
-        Parameters
-        ----------
-        origin
-            The `EntityPath` to use as the origin of this space view. All other entities will be transformed
-            to be displayed relative to this origin.
-        contents
-            The contents of the space view. Most commonly specified as a query expression. The individual
-            sub-expressions must either be newline separate, or provided as a list of strings.
-            See: [rerun.blueprint.components.QueryExpression][].
-        name
-            The name of the space view.
-
-        """
-        super().__init__(class_identifier="2D", origin=origin, contents=contents, name=name)
 
 
 class Container:
@@ -250,96 +202,6 @@ class Container:
         # TODO(jleibs): This goes away when we get rid of `space_views` from the viewport and just use
         # the entity-path lookup instead.
         return itertools.chain.from_iterable(sub._iter_space_views() for sub in self.contents)
-
-
-class Horizontal(Container):
-    """A horizontal container."""
-
-    def __init__(self, *contents: Container | SpaceView, column_shares: Optional[ColumnShareArrayLike] = None):
-        """
-        Construct a new horizontal container.
-
-        Parameters
-        ----------
-        *contents:
-            All positional arguments are the contents of the container, which may be either other containers or space views.
-        column_shares
-            The layout shares of the columns in the container. The share is used to determine what fraction of the total width each
-            column should take up. The column with index `i` will take up the fraction `shares[i] / total_shares`.
-
-        """
-        super().__init__(*contents, kind=ContainerKind.Horizontal, column_shares=column_shares)
-
-
-class Vertical(Container):
-    """A vertical container."""
-
-    def __init__(self, *contents: Container | SpaceView, row_shares: Optional[RowShareArrayLike] = None):
-        """
-        Construct a new vertical container.
-
-        Parameters
-        ----------
-        *contents:
-            All positional arguments are the contents of the container, which may be either other containers or space views.
-        row_shares
-            The layout shares of the rows in the container. The share is used to determine what fraction of the total height each
-            row should take up. The ros with index `i` will take up the fraction `shares[i] / total_shares`.
-
-        """
-        super().__init__(*contents, kind=ContainerKind.Vertical, row_shares=row_shares)
-
-
-class Grid(Container):
-    """A grid container."""
-
-    def __init__(
-        self,
-        *contents: Container | SpaceView,
-        column_shares: Optional[ColumnShareArrayLike] = None,
-        row_shares: Optional[RowShareArrayLike] = None,
-        grid_columns: Optional[int] = None,
-    ):
-        """
-        Construct a new grid container.
-
-        Parameters
-        ----------
-        *contents:
-            All positional arguments are the contents of the container, which may be either other containers or space views.
-        column_shares
-            The layout shares of the columns in the container. The share is used to determine what fraction of the total width each
-            column should take up. The column with index `i` will take up the fraction `shares[i] / total_shares`.
-        row_shares
-            The layout shares of the rows in the container. The share is used to determine what fraction of the total height each
-            row should take up. The ros with index `i` will take up the fraction `shares[i] / total_shares`.
-        grid_columns
-            The number of columns in the grid.
-
-        """
-        super().__init__(
-            *contents,
-            kind=ContainerKind.Grid,
-            column_shares=column_shares,
-            row_shares=row_shares,
-            grid_columns=grid_columns,
-        )
-
-
-class Tabs(Container):
-    """A tab container."""
-
-    def __init__(self, *contents: Container | SpaceView):
-        """
-        Construct a new tab container.
-
-        Parameters
-        ----------
-        *contents:
-            All positional arguments are the contents of the container, which may be either other containers or space views.
-
-        """
-        super().__init__(*contents, kind=ContainerKind.Tabs)
 
 
 class Viewport:

--- a/rerun_py/rerun_sdk/rerun/blueprint/containers.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/containers.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from .api import Container, SpaceView
+from .components import ColumnShareArrayLike, RowShareArrayLike
+from .components.container_kind import ContainerKind
+
+
+class Horizontal(Container):
+    """A horizontal container."""
+
+    def __init__(self, *contents: Container | SpaceView, column_shares: Optional[ColumnShareArrayLike] = None):
+        """
+        Construct a new horizontal container.
+
+        Parameters
+        ----------
+        *contents:
+            All positional arguments are the contents of the container, which may be either other containers or space views.
+        column_shares
+            The layout shares of the columns in the container. The share is used to determine what fraction of the total width each
+            column should take up. The column with index `i` will take up the fraction `shares[i] / total_shares`.
+
+        """
+        super().__init__(*contents, kind=ContainerKind.Horizontal, column_shares=column_shares)
+
+
+class Vertical(Container):
+    """A vertical container."""
+
+    def __init__(self, *contents: Container | SpaceView, row_shares: Optional[RowShareArrayLike] = None):
+        """
+        Construct a new vertical container.
+
+        Parameters
+        ----------
+        *contents:
+            All positional arguments are the contents of the container, which may be either other containers or space views.
+        row_shares
+            The layout shares of the rows in the container. The share is used to determine what fraction of the total height each
+            row should take up. The ros with index `i` will take up the fraction `shares[i] / total_shares`.
+
+        """
+        super().__init__(*contents, kind=ContainerKind.Vertical, row_shares=row_shares)
+
+
+class Grid(Container):
+    """A grid container."""
+
+    def __init__(
+        self,
+        *contents: Container | SpaceView,
+        column_shares: Optional[ColumnShareArrayLike] = None,
+        row_shares: Optional[RowShareArrayLike] = None,
+        grid_columns: Optional[int] = None,
+    ):
+        """
+        Construct a new grid container.
+
+        Parameters
+        ----------
+        *contents:
+            All positional arguments are the contents of the container, which may be either other containers or space views.
+        column_shares
+            The layout shares of the columns in the container. The share is used to determine what fraction of the total width each
+            column should take up. The column with index `i` will take up the fraction `shares[i] / total_shares`.
+        row_shares
+            The layout shares of the rows in the container. The share is used to determine what fraction of the total height each
+            row should take up. The ros with index `i` will take up the fraction `shares[i] / total_shares`.
+        grid_columns
+            The number of columns in the grid.
+
+        """
+        super().__init__(
+            *contents,
+            kind=ContainerKind.Grid,
+            column_shares=column_shares,
+            row_shares=row_shares,
+            grid_columns=grid_columns,
+        )
+
+
+class Tabs(Container):
+    """A tab container."""
+
+    def __init__(self, *contents: Container | SpaceView):
+        """
+        Construct a new tab container.
+
+        Parameters
+        ----------
+        *contents:
+            All positional arguments are the contents of the container, which may be either other containers or space views.
+
+        """
+        super().__init__(*contents, kind=ContainerKind.Tabs)

--- a/rerun_py/rerun_sdk/rerun/blueprint/space_views.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/space_views.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from ..datatypes import EntityPathLike, Utf8Like
+from .api import SpaceView, SpaceViewContentsLike
+
+
+class Spatial3D(SpaceView):
+    """A Spatial 3D space view."""
+
+    def __init__(
+        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
+    ):
+        """
+        Construct a blueprint for a new 3D space view.
+
+        Parameters
+        ----------
+        origin
+            The `EntityPath` to use as the origin of this space view. All other entities will be transformed
+            to be displayed relative to this origin.
+        contents
+            The contents of the space view. Most commonly specified as a query expression. The individual
+            sub-expressions must either be newline separate, or provided as a list of strings.
+            See: [rerun.blueprint.components.QueryExpression][].
+        name
+            The name of the space view.
+
+        """
+        super().__init__(class_identifier="3D", origin=origin, contents=contents, name=name)
+
+
+class Spatial2D(SpaceView):
+    """A Spatial 2D space view."""
+
+    def __init__(
+        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
+    ):
+        """
+        Construct a blueprint for a new 2D space view.
+
+        Parameters
+        ----------
+        origin
+            The `EntityPath` to use as the origin of this space view. All other entities will be transformed
+            to be displayed relative to this origin.
+        contents
+            The contents of the space view. Most commonly specified as a query expression. The individual
+            sub-expressions must either be newline separate, or provided as a list of strings.
+            See: [rerun.blueprint.components.QueryExpression][].
+        name
+            The name of the space view.
+
+        """
+        super().__init__(class_identifier="2D", origin=origin, contents=contents, name=name)

--- a/rerun_py/rerun_sdk/rerun/blueprint/space_views.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/space_views.py
@@ -4,51 +4,176 @@ from ..datatypes import EntityPathLike, Utf8Like
 from .api import SpaceView, SpaceViewContentsLike
 
 
-class Spatial3D(SpaceView):
-    """A Spatial 3D space view."""
+class BarChartView(SpaceView):
+    """A bar chart view."""
 
     def __init__(
         self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
     ):
         """
-        Construct a blueprint for a new 3D space view.
+        Construct a blueprint for a new bar chart view.
 
         Parameters
         ----------
         origin
-            The `EntityPath` to use as the origin of this space view. All other entities will be transformed
+            The `EntityPath` to use as the origin of this view. All other entities will be transformed
             to be displayed relative to this origin.
         contents
-            The contents of the space view. Most commonly specified as a query expression. The individual
+            The contents of the view. Most commonly specified as a query expression. The individual
             sub-expressions must either be newline separate, or provided as a list of strings.
             See: [rerun.blueprint.components.QueryExpression][].
         name
-            The name of the space view.
+            The name of the view.
+
+        """
+        super().__init__(class_identifier="Bar Chart", origin=origin, contents=contents, name=name)
+
+
+class Spatial2DView(SpaceView):
+    """A Spatial 2D view."""
+
+    def __init__(
+        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
+    ):
+        """
+        Construct a blueprint for a new spatial 2D view.
+
+        Parameters
+        ----------
+        origin
+            The `EntityPath` to use as the origin of this view. All other entities will be transformed
+            to be displayed relative to this origin.
+        contents
+            The contents of the view. Most commonly specified as a query expression. The individual
+            sub-expressions must either be newline separate, or provided as a list of strings.
+            See: [rerun.blueprint.components.QueryExpression][].
+        name
+            The name of the view.
+
+        """
+        super().__init__(class_identifier="2D", origin=origin, contents=contents, name=name)
+
+
+class Spatial3DView(SpaceView):
+    """A Spatial 3D view."""
+
+    def __init__(
+        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
+    ):
+        """
+        Construct a blueprint for a new spatial 3D view.
+
+        Parameters
+        ----------
+        origin
+            The `EntityPath` to use as the origin of this view. All other entities will be transformed
+            to be displayed relative to this origin.
+        contents
+            The contents of the view. Most commonly specified as a query expression. The individual
+            sub-expressions must either be newline separate, or provided as a list of strings.
+            See: [rerun.blueprint.components.QueryExpression][].
+        name
+            The name of the view.
 
         """
         super().__init__(class_identifier="3D", origin=origin, contents=contents, name=name)
 
 
-class Spatial2D(SpaceView):
-    """A Spatial 2D space view."""
+class TensorView(SpaceView):
+    """A tensor view."""
 
     def __init__(
         self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
     ):
         """
-        Construct a blueprint for a new 2D space view.
+        Construct a blueprint for a new tensor view.
 
         Parameters
         ----------
         origin
-            The `EntityPath` to use as the origin of this space view. All other entities will be transformed
+            The `EntityPath` to use as the origin of this view. All other entities will be transformed
             to be displayed relative to this origin.
         contents
-            The contents of the space view. Most commonly specified as a query expression. The individual
+            The contents of the view. Most commonly specified as a query expression. The individual
             sub-expressions must either be newline separate, or provided as a list of strings.
             See: [rerun.blueprint.components.QueryExpression][].
         name
-            The name of the space view.
+            The name of the view.
 
         """
-        super().__init__(class_identifier="2D", origin=origin, contents=contents, name=name)
+        super().__init__(class_identifier="Tensor", origin=origin, contents=contents, name=name)
+
+
+class TextDocumentView(SpaceView):
+    """A text document view."""
+
+    def __init__(
+        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
+    ):
+        """
+        Construct a blueprint for a new text document view.
+
+        Parameters
+        ----------
+        origin
+            The `EntityPath` to use as the origin of this view. All other entities will be transformed
+            to be displayed relative to this origin.
+        contents
+            The contents of the view. Most commonly specified as a query expression. The individual
+            sub-expressions must either be newline separate, or provided as a list of strings.
+            See: [rerun.blueprint.components.QueryExpression][].
+        name
+            The name of the view.
+
+        """
+        super().__init__(class_identifier="Text Document", origin=origin, contents=contents, name=name)
+
+
+class TextLogView(SpaceView):
+    """A text log view."""
+
+    def __init__(
+        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
+    ):
+        """
+        Construct a blueprint for a new text log view.
+
+        Parameters
+        ----------
+        origin
+            The `EntityPath` to use as the origin of this view. All other entities will be transformed
+            to be displayed relative to this origin.
+        contents
+            The contents of the view. Most commonly specified as a query expression. The individual
+            sub-expressions must either be newline separate, or provided as a list of strings.
+            See: [rerun.blueprint.components.QueryExpression][].
+        name
+            The name of the view.
+
+        """
+        super().__init__(class_identifier="TextLog", origin=origin, contents=contents, name=name)
+
+
+class TimeSeriesView(SpaceView):
+    """A time series view."""
+
+    def __init__(
+        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
+    ):
+        """
+        Construct a blueprint for a new time series view.
+
+        Parameters
+        ----------
+        origin
+            The `EntityPath` to use as the origin of this view. All other entities will be transformed
+            to be displayed relative to this origin.
+        contents
+            The contents of the view. Most commonly specified as a query expression. The individual
+            sub-expressions must either be newline separate, or provided as a list of strings.
+            See: [rerun.blueprint.components.QueryExpression][].
+        name
+            The name of the view.
+
+        """
+        super().__init__(class_identifier="Time Series", origin=origin, contents=contents, name=name)

--- a/tests/python/blueprint/main.py
+++ b/tests/python/blueprint/main.py
@@ -2,23 +2,33 @@ from __future__ import annotations
 
 import rerun as rr
 from numpy.random import default_rng
-from rerun.blueprint import Blueprint, Grid, Horizontal, Spatial2D, Spatial3D, Tabs, TimePanel, Vertical, Viewport
+from rerun.blueprint import (
+    Blueprint,
+    Grid,
+    Horizontal,
+    Spatial2DView,
+    Spatial3DView,
+    Tabs,
+    TimePanel,
+    Vertical,
+    Viewport,
+)
 
 if __name__ == "__main__":
     blueprint = Blueprint(
         Viewport(
             Vertical(
-                Spatial3D(origin="/test1"),
+                Spatial3DView(origin="/test1"),
                 Horizontal(
                     Tabs(
-                        Spatial3D(origin="/test1"),
-                        Spatial2D(origin="/test2"),
+                        Spatial3DView(origin="/test1"),
+                        Spatial2DView(origin="/test2"),
                     ),
                     Grid(
-                        Spatial3D(origin="/test1"),
-                        Spatial2D(origin="/test2"),
-                        Spatial3D(origin="/test1"),
-                        Spatial2D(origin="/test2"),
+                        Spatial3DView(origin="/test1"),
+                        Spatial2DView(origin="/test2"),
+                        Spatial3DView(origin="/test1"),
+                        Spatial2DView(origin="/test2"),
                         grid_columns=3,
                         column_shares=[1, 1, 1],
                     ),

--- a/tests/python/blueprint/main.py
+++ b/tests/python/blueprint/main.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import rerun as rr
 from numpy.random import default_rng
-from rerun.blueprint import Blueprint, Grid, Horizontal, Spatial2D, Spatial3D, Tabs, Vertical, Viewport
-from rerun.blueprint.api import TimePanel
+from rerun.blueprint import Blueprint, Grid, Horizontal, Spatial2D, Spatial3D, Tabs, TimePanel, Vertical, Viewport
 
 if __name__ == "__main__":
     blueprint = Blueprint(


### PR DESCRIPTION
### What
Just lots of boiler plate with some name changes.

Also split the apy.py file into a few sub-modules because it was getting large.

All SpaceViews now end in View.
 - Spatial2DView
 - Spatial3DView
 - BarChartView
 - TensorView
 - TextDocumentView
 - TextLogView
 - TimeSeriesView

Testing it out on the plots example:
![image](https://github.com/rerun-io/rerun/assets/3312232/97890949-de50-464e-b640-014f151177b5)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5498/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5498/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5498/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5498)
- [Docs preview](https://rerun.io/preview/bcbce7510db61092c96237a2668518ba564f0227/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bcbce7510db61092c96237a2668518ba564f0227/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)