### PR TITLE
Add support for active_tab

### DIFF
--- a/rerun_py/rerun_sdk/rerun/blueprint/containers.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/containers.py
@@ -84,7 +84,7 @@ class Grid(Container):
 class Tabs(Container):
     """A tab container."""
 
-    def __init__(self, *contents: Container | SpaceView):
+    def __init__(self, *contents: Container | SpaceView, active_tab: Optional[int | str] = None):
         """
         Construct a new tab container.
 
@@ -92,6 +92,8 @@ class Tabs(Container):
         ----------
         *contents:
             All positional arguments are the contents of the container, which may be either other containers or space views.
+        active_tab:
+            The index or name of the active tab.
 
         """
-        super().__init__(*contents, kind=ContainerKind.Tabs)
+        super().__init__(*contents, kind=ContainerKind.Tabs, active_tab=active_tab)

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -65,6 +65,7 @@ def script_setup(
     args: Namespace,
     application_id: str,
     recording_id: str | UUID | None = None,
+    blueprint: rr.blueprint.Blueprint | None = None,
 ) -> RecordingStream:
     """
     Run common Rerun script setup actions. Connect to the viewer if necessary.
@@ -86,6 +87,8 @@ def script_setup(
         processes to log to the same Rerun instance (and be part of the same recording),
         you will need to manually assign them all the same recording_id.
         Any random UUIDv4 will work, or copy the recording id for the parent process.
+    blueprint : Optional[rr.blueprint.Blueprint]
+        An optional blueprint to use for the viewer.
 
     """
     rr.init(
@@ -106,11 +109,11 @@ def script_setup(
         # Send logging data to separate `rerun` process.
         # You can omit the argument to connect to the default address,
         # which is `127.0.0.1:9876`.
-        rec.connect(args.addr)  # type: ignore[attr-defined]
+        rec.connect(args.addr, blueprint=blueprint)  # type: ignore[attr-defined]
     elif args.save is not None:
         rec.save(args.save)  # type: ignore[attr-defined]
     elif not args.headless:
-        rec.spawn()  # type: ignore[attr-defined]
+        rec.spawn(blueprint=blueprint)  # type: ignore[attr-defined]
 
     return rec
 


### PR DESCRIPTION
### What
Referring to an object created in the same constructor is somewhat awkward.

Forcing users to create the object out-of-line so they can assign it to a variable and then refer to it is just a pain.
Specifying a name or index seems like a convenient middle ground.


Example
```python
            Tabs(
                BarChartView(name="Bar Chart", origin="/bar_chart", contents=["/bar_chart/**"]),
                TimeSeriesView(name="Curves", origin="/curves", contents=["/curves/**"]),
                TimeSeriesView(name="Trig", origin="/trig", contents=["/trig/**"]),
                TimeSeriesView(name="Classification", origin="/classification", contents=["/classification/**"]),
                active_tab="Curves",
            ),
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5499/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5499/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5499/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5499)
- [Docs preview](https://rerun.io/preview/4c45a10b77cb3dd4794ca2d2ac8267e3d9230606/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4c45a10b77cb3dd4794ca2d2ac8267e3d9230606/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)