### PR TITLE
Add `-g` option to `re_build_web_viewer` to keep debug symbols

### DIFF
--- a/crates/re_build_web_viewer/src/main.rs
+++ b/crates/re_build_web_viewer/src/main.rs
@@ -86,7 +86,7 @@ fn print_help() {
   --debug:    Build a debug binary
   --release:  Compile for release, and run wasm-opt.
               NOTE: --release also removes debug symbols which are otherwise useful for in-browser profiling.
-  -g:         Keep debug symboles, even in release builds.
+  -g:         Keep debug symbols, even in release builds.
               This gives better callstacks on panics, and also allows for in-browser profiling of the Wasm.
   -o, --out:  Set the output directory. This is a path relative to the cargo workspace root.
 "


### PR DESCRIPTION
This enables in-browser profiling of the web viewer, as well as better callstack.

Usage:

`cargo r -p re_build_web_viewer -- --release -g`


|                        | .wasm | zipped |
| ------------- | ------------- | ------------- |
| `--release`  | 19.2 MB  | 6.3 MB |
| `--release -g`  | 20.7 MB  | 6.6 MB |

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5500/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5500/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5500/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5500)
- [Docs preview](https://rerun.io/preview/806fb1cc339b0efe732650e49d447fabdd38d821/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/806fb1cc339b0efe732650e49d447fabdd38d821/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)