### PR TITLE
Build CLI for Linux ARM64

### DIFF
--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -33,7 +33,7 @@ jobs:
     name: cargo build on clean container
     strategy:
       matrix:
-        os: [ubuntu-latest-16-cores, macos-latest, windows-latest-8-cores]
+        os: [ ubuntu-latest-16-cores, macos-latest, windows-latest-8-cores ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
     secrets: inherit
 
   deploy-docs:
-    needs: [checks, benches]
+    needs: [ checks, benches ]
     name: Deploy Docs
     uses: ./.github/workflows/reusable_deploy_docs.yml
     with:
@@ -79,7 +79,7 @@ jobs:
 
   upload-web:
     name: "Upload Web"
-    needs: [build-web]
+    needs: [ build-web ]
     uses: ./.github/workflows/reusable_upload_web.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}
@@ -87,7 +87,7 @@ jobs:
 
   build-examples:
     name: "Build Examples"
-    needs: [build-wheel-linux]
+    needs: [ build-wheel-linux ]
     uses: ./.github/workflows/reusable_build_examples.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}
@@ -97,7 +97,7 @@ jobs:
 
   track-sizes:
     name: "Track Sizes"
-    needs: [build-web, build-examples]
+    needs: [ build-web, build-examples ]
     uses: ./.github/workflows/reusable_track_size.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}
@@ -105,7 +105,7 @@ jobs:
 
   upload-examples:
     name: "Upload Examples"
-    needs: [build-examples]
+    needs: [ build-examples ]
     uses: ./.github/workflows/reusable_upload_examples.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}
@@ -115,7 +115,7 @@ jobs:
   # Build rerun_c library binaries:
 
   build-rerun_c-and-upload-linux-arm64:
-    needs: [checks]
+    needs: [ checks ]
     name: "Linux-Arm64: Build & Upload rerun_c"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
     with:
@@ -124,7 +124,7 @@ jobs:
     secrets: inherit
 
   build-rerun_c-and-upload-linux-x64:
-    needs: [checks]
+    needs: [ checks ]
     name: "Linux-x64: Build & Upload rerun_c"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
     with:
@@ -133,7 +133,7 @@ jobs:
     secrets: inherit
 
   build-rerun_c-and-upload-macos-x64:
-    needs: [checks]
+    needs: [ checks ]
     name: "Mac-Intel: Build & Upload rerun_c"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
     with:
@@ -142,7 +142,7 @@ jobs:
     secrets: inherit
 
   build-rerun_c-and-upload-macos-arm64:
-    needs: [checks]
+    needs: [ checks ]
     name: "Mac-Arm64: Build & Upload rerun_c"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
     with:
@@ -151,7 +151,7 @@ jobs:
     secrets: inherit
 
   build-rerun_c-and-upload-windows-x64:
-    needs: [checks]
+    needs: [ checks ]
     name: "Windows-x64: Build & Upload rerun_c"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
     with:
@@ -162,46 +162,55 @@ jobs:
   # -----------------------------------------------------------------------------------
   # Build rerun-cli (rerun binaries):
 
-  build-rerun-cli-and-upload-linux:
-    needs: [checks]
+  build-rerun-cli-and-upload-linux-arm64:
+    needs: [ checks ]
+    name: "Linux-arm64: Build & Upload rerun-cli"
+    uses: ./.github/workflows/reusable_build_and_upload_rerun_cli.yml
+    with:
+      CONCURRENCY: push-linux-arm64-${{ github.ref_name }}
+      PLATFORM: linux-arm64
+    secrets: inherit
+
+  build-rerun-cli-and-upload-linux-x64:
+    needs: [ checks ]
     name: "Linux-x64: Build & Upload rerun-cli"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_cli.yml
     with:
-      CONCURRENCY: push-linux-${{ github.ref_name }}
-      PLATFORM: linux
+      CONCURRENCY: push-linux-x64-${{ github.ref_name }}
+      PLATFORM: linux-x64
     secrets: inherit
 
-  build-rerun-cli-and-upload-macos-intel:
-    needs: [checks]
-    name: "Mac-Intel: Build & Upload rerun-cli"
+  build-rerun-cli-and-upload-macos-x64:
+    needs: [ checks ]
+    name: "Mac-x64: Build & Upload rerun-cli"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_cli.yml
     with:
-      CONCURRENCY: push-macos-intel-${{ github.ref_name }}
-      PLATFORM: macos-intel
+      CONCURRENCY: push-macos-x64-${{ github.ref_name }}
+      PLATFORM: macos-x64
     secrets: inherit
 
-  build-rerun-cli-and-upload-macos-arm:
-    needs: [checks]
-    name: "Mac-Arm: Build & Upload rerun-cli"
+  build-rerun-cli-and-upload-macos-arm64:
+    needs: [ checks ]
+    name: "Mac-arm64: Build & Upload rerun-cli"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_cli.yml
     with:
-      CONCURRENCY: push-macos-arm-${{ github.ref_name }}
-      PLATFORM: macos-arm
+      CONCURRENCY: push-macos-arm64-${{ github.ref_name }}
+      PLATFORM: macos-arm64
     secrets: inherit
 
-  build-rerun-cli-and-upload-windows:
-    needs: [checks]
+  build-rerun-cli-and-upload-windows-x64:
+    needs: [ checks ]
     name: "Windows-x64: Build & Upload rerun-cli"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_cli.yml
     with:
-      CONCURRENCY: push-windows-${{ github.ref_name }}
-      PLATFORM: windows
+      CONCURRENCY: push-windows-x64--${{ github.ref_name }}
+      PLATFORM: windows-x64
     secrets: inherit
 
   # -----------------------------------------------------------------------------------
 
   build-wheel-linux:
-    needs: [checks]
+    needs: [ checks ]
     name: "Linux: Build & Upload Wheels"
     uses: ./.github/workflows/reusable_build_and_upload_wheels.yml
     with:
@@ -212,7 +221,7 @@ jobs:
     secrets: inherit
 
   build-wheel-windows:
-    needs: [checks]
+    needs: [ checks ]
     name: "Windows: Build & Upload Wheels"
     uses: ./.github/workflows/reusable_build_and_upload_wheels.yml
     with:
@@ -223,7 +232,7 @@ jobs:
     secrets: inherit
 
   build-wheel-macos-arm:
-    needs: [checks]
+    needs: [ checks ]
     name: "Macos-Arm: Build & Upload Wheels"
     uses: ./.github/workflows/reusable_build_and_upload_wheels.yml
     with:
@@ -234,7 +243,7 @@ jobs:
     secrets: inherit
 
   build-wheel-macos-intel:
-    needs: [checks]
+    needs: [ checks ]
     name: "Macos-Intel: Build & Upload Wheels"
     uses: ./.github/workflows/reusable_build_and_upload_wheels.yml
     with:
@@ -245,7 +254,7 @@ jobs:
     secrets: inherit
 
   test-wheel-linux:
-    needs: [checks, build-wheel-linux]
+    needs: [ checks, build-wheel-linux ]
     name: "Linux: Test Wheels"
     uses: ./.github/workflows/reusable_test_wheels.yml
     with:
@@ -255,7 +264,7 @@ jobs:
     secrets: inherit
 
   test-wheel-windows:
-    needs: [checks, build-wheel-windows]
+    needs: [ checks, build-wheel-windows ]
     name: "Windows: Test Wheels"
     uses: ./.github/workflows/reusable_test_wheels.yml
     with:
@@ -305,10 +314,11 @@ jobs:
         build-rerun_c-and-upload-macos-x64,
         build-rerun_c-and-upload-macos-arm64,
         build-rerun_c-and-upload-windows-x64,
-        build-rerun-cli-and-upload-linux,
-        build-rerun-cli-and-upload-macos-intel,
-        build-rerun-cli-and-upload-macos-arm,
-        build-rerun-cli-and-upload-windows,
+        build-rerun-cli-and-upload-linux-x64,
+        build-rerun-cli-and-upload-linux-arm64,
+        build-rerun-cli-and-upload-macos-x64,
+        build-rerun-cli-and-upload-macos-arm64,
+        build-rerun-cli-and-upload-windows-x64,
         bundle-and-upload-rerun_cpp,
       ]
     runs-on: "ubuntu-latest"
@@ -371,7 +381,7 @@ jobs:
           replacesArtifacts: true
 
   sync-release-assets:
-    needs: [pre-release]
+    needs: [ pre-release ]
     name: "Sync pre-release assets & build.rerun.io"
     uses: ./.github/workflows/reusable_sync_release_assets.yml
     with:

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -33,7 +33,7 @@ jobs:
     name: cargo build on clean container
     strategy:
       matrix:
-        os: [ ubuntu-latest-16-cores, macos-latest, windows-latest-8-cores ]
+        os: [ubuntu-latest-16-cores, macos-latest, windows-latest-8-cores]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
     secrets: inherit
 
   deploy-docs:
-    needs: [ checks, benches ]
+    needs: [checks, benches]
     name: Deploy Docs
     uses: ./.github/workflows/reusable_deploy_docs.yml
     with:
@@ -79,7 +79,7 @@ jobs:
 
   upload-web:
     name: "Upload Web"
-    needs: [ build-web ]
+    needs: [build-web]
     uses: ./.github/workflows/reusable_upload_web.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}
@@ -87,7 +87,7 @@ jobs:
 
   build-examples:
     name: "Build Examples"
-    needs: [ build-wheel-linux ]
+    needs: [build-wheel-linux]
     uses: ./.github/workflows/reusable_build_examples.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}
@@ -97,7 +97,7 @@ jobs:
 
   track-sizes:
     name: "Track Sizes"
-    needs: [ build-web, build-examples ]
+    needs: [build-web, build-examples]
     uses: ./.github/workflows/reusable_track_size.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}
@@ -105,7 +105,7 @@ jobs:
 
   upload-examples:
     name: "Upload Examples"
-    needs: [ build-examples ]
+    needs: [build-examples]
     uses: ./.github/workflows/reusable_upload_examples.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}
@@ -115,7 +115,7 @@ jobs:
   # Build rerun_c library binaries:
 
   build-rerun_c-and-upload-linux-arm64:
-    needs: [ checks ]
+    needs: [checks]
     name: "Linux-Arm64: Build & Upload rerun_c"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
     with:
@@ -124,7 +124,7 @@ jobs:
     secrets: inherit
 
   build-rerun_c-and-upload-linux-x64:
-    needs: [ checks ]
+    needs: [checks]
     name: "Linux-x64: Build & Upload rerun_c"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
     with:
@@ -133,7 +133,7 @@ jobs:
     secrets: inherit
 
   build-rerun_c-and-upload-macos-x64:
-    needs: [ checks ]
+    needs: [checks]
     name: "Mac-Intel: Build & Upload rerun_c"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
     with:
@@ -142,7 +142,7 @@ jobs:
     secrets: inherit
 
   build-rerun_c-and-upload-macos-arm64:
-    needs: [ checks ]
+    needs: [checks]
     name: "Mac-Arm64: Build & Upload rerun_c"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
     with:
@@ -151,7 +151,7 @@ jobs:
     secrets: inherit
 
   build-rerun_c-and-upload-windows-x64:
-    needs: [ checks ]
+    needs: [checks]
     name: "Windows-x64: Build & Upload rerun_c"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
     with:
@@ -163,7 +163,7 @@ jobs:
   # Build rerun-cli (rerun binaries):
 
   build-rerun-cli-and-upload-linux-arm64:
-    needs: [ checks ]
+    needs: [checks]
     name: "Linux-arm64: Build & Upload rerun-cli"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_cli.yml
     with:
@@ -172,7 +172,7 @@ jobs:
     secrets: inherit
 
   build-rerun-cli-and-upload-linux-x64:
-    needs: [ checks ]
+    needs: [checks]
     name: "Linux-x64: Build & Upload rerun-cli"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_cli.yml
     with:
@@ -181,7 +181,7 @@ jobs:
     secrets: inherit
 
   build-rerun-cli-and-upload-macos-x64:
-    needs: [ checks ]
+    needs: [checks]
     name: "Mac-x64: Build & Upload rerun-cli"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_cli.yml
     with:
@@ -190,7 +190,7 @@ jobs:
     secrets: inherit
 
   build-rerun-cli-and-upload-macos-arm64:
-    needs: [ checks ]
+    needs: [checks]
     name: "Mac-arm64: Build & Upload rerun-cli"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_cli.yml
     with:
@@ -199,7 +199,7 @@ jobs:
     secrets: inherit
 
   build-rerun-cli-and-upload-windows-x64:
-    needs: [ checks ]
+    needs: [checks]
     name: "Windows-x64: Build & Upload rerun-cli"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_cli.yml
     with:
@@ -210,7 +210,7 @@ jobs:
   # -----------------------------------------------------------------------------------
 
   build-wheel-linux:
-    needs: [ checks ]
+    needs: [checks]
     name: "Linux: Build & Upload Wheels"
     uses: ./.github/workflows/reusable_build_and_upload_wheels.yml
     with:
@@ -221,7 +221,7 @@ jobs:
     secrets: inherit
 
   build-wheel-windows:
-    needs: [ checks ]
+    needs: [checks]
     name: "Windows: Build & Upload Wheels"
     uses: ./.github/workflows/reusable_build_and_upload_wheels.yml
     with:
@@ -232,7 +232,7 @@ jobs:
     secrets: inherit
 
   build-wheel-macos-arm:
-    needs: [ checks ]
+    needs: [checks]
     name: "Macos-Arm: Build & Upload Wheels"
     uses: ./.github/workflows/reusable_build_and_upload_wheels.yml
     with:
@@ -243,7 +243,7 @@ jobs:
     secrets: inherit
 
   build-wheel-macos-intel:
-    needs: [ checks ]
+    needs: [checks]
     name: "Macos-Intel: Build & Upload Wheels"
     uses: ./.github/workflows/reusable_build_and_upload_wheels.yml
     with:
@@ -254,7 +254,7 @@ jobs:
     secrets: inherit
 
   test-wheel-linux:
-    needs: [ checks, build-wheel-linux ]
+    needs: [checks, build-wheel-linux]
     name: "Linux: Test Wheels"
     uses: ./.github/workflows/reusable_test_wheels.yml
     with:
@@ -264,7 +264,7 @@ jobs:
     secrets: inherit
 
   test-wheel-windows:
-    needs: [ checks, build-wheel-windows ]
+    needs: [checks, build-wheel-windows]
     name: "Windows: Test Wheels"
     uses: ./.github/workflows/reusable_test_wheels.yml
     with:
@@ -381,7 +381,7 @@ jobs:
           replacesArtifacts: true
 
   sync-release-assets:
-    needs: [ pre-release ]
+    needs: [pre-release]
     name: "Sync pre-release assets & build.rerun.io"
     uses: ./.github/workflows/reusable_sync_release_assets.yml
     with:

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -203,7 +203,7 @@ jobs:
     name: "Windows-x64: Build & Upload rerun-cli"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_cli.yml
     with:
-      CONCURRENCY: push-windows-x64--${{ github.ref_name }}
+      CONCURRENCY: push-windows-x64-${{ github.ref_name }}
       PLATFORM: windows-x64
     secrets: inherit
 

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -39,6 +39,7 @@ on:
         required: false
         type: string
         default: "adhoc"
+        description: "Concurrency group to use"
 
 concurrency:
   group: ${{ inputs.CONCURRENCY }}-build-rerun_c
@@ -111,7 +112,7 @@ jobs:
 
   rs-build-rerun_c:
     name: Build rerun_c (${{ needs.set-config.outputs.RUNNER }})
-    needs: [set-config]
+    needs: [ set-config ]
     runs-on: ${{ needs.set-config.outputs.RUNNER }}
     container: ${{ fromJson(needs.set-config.outputs.CONTAINER) }}
     steps:

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -112,7 +112,7 @@ jobs:
 
   rs-build-rerun_c:
     name: Build rerun_c (${{ needs.set-config.outputs.RUNNER }})
-    needs: [ set-config ]
+    needs: [set-config]
     runs-on: ${{ needs.set-config.outputs.RUNNER }}
     container: ${{ fromJson(needs.set-config.outputs.CONTAINER) }}
     steps:

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -114,7 +114,7 @@ jobs:
   build-rerun-cli:
     name: Build rerun-cli (${{ needs.set-config.outputs.RUNNER }})
 
-    needs: [ set-config ]
+    needs: [set-config]
 
     runs-on: ${{ needs.set-config.outputs.RUNNER }}
     container: ${{ fromJson(needs.set-config.outputs.CONTAINER) }}

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -147,12 +147,12 @@ jobs:
           targets: ${{ needs.set-config.outputs.TARGET }}
 
       - uses: prefix-dev/setup-pixi@v0.4.1
-        if: ${{ inputs.PLATFORM != 'linux-arm64' }}  # TODO(5507): see below
+        if: ${{ inputs.PLATFORM != 'linux-arm64' }} # TODO(#5507): see below
         with:
           pixi-version: v0.13.0
 
       - name: Build web-viewer (release)
-        if: ${{ inputs.PLATFORM != 'linux-arm64' }}  # TODO(5507): see below
+        if: ${{ inputs.PLATFORM != 'linux-arm64' }} # TODO(#5507): see below
         shell: bash
         run: |
           pixi run cargo run --locked -p re_build_web_viewer -- --release

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -147,12 +147,22 @@ jobs:
           targets: ${{ needs.set-config.outputs.TARGET }}
 
       - uses: prefix-dev/setup-pixi@v0.4.1
+        if: ${{ inputs.PLATFORM != 'linux-arm64' }}
         with:
           pixi-version: v0.13.0
 
       - name: Build web-viewer (release)
+        if: ${{ inputs.PLATFORM != 'linux-arm64' }}
         shell: bash
         run: |
+          pixi run cargo run --locked -p re_build_web_viewer -- --release
+
+      # Many of our pixi dependencies are not available on linux-arm64, so we must bypass pixi for this build
+      - name: Build web-viewer (release, Linux ARM64)
+        if: ${{ inputs.PLATFORM == 'linux-arm64' }}
+        shell: bash
+        run: |
+          apt install binaryen
           pixi run cargo run --locked -p re_build_web_viewer -- --release
 
       # This does not run in the pixi environment, doing so

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -21,22 +21,25 @@ on:
   workflow_dispatch:
     inputs:
       ADHOC_NAME:
-        required: true
+        required: false
         type: string
+        default: ""
         description: "Name of the adhoc build, used for upload directory"
       PLATFORM:
         type: choice
         options:
-          - linux
-          - windows
-          - macos-arm
-          - macos-intel
+          - linux-arm64
+          - linux-x64
+          - windows-x64
+          - macos-arm64
+          - macos-x64
         description: "Platform to build for"
         required: true
       CONCURRENCY:
         required: false
         type: string
         default: "adhoc"
+        description: "Concurrency group to use"
 
 concurrency:
   group: ${{ inputs.CONCURRENCY }}-build-rerun-cli
@@ -71,25 +74,31 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.PLATFORM }}" in
-            linux)
+            linux-arm64)
+                runner="buildjet-8vcpu-ubuntu-2204-arm"
+                target="aarch64-unknown-linux-gnu"
+                container="null"
+                bin_name="rerun"
+                ;;
+            linux-x64)
               runner="ubuntu-latest-16-cores"
               target="x86_64-unknown-linux-gnu"
               container="{'image': 'rerunio/ci_docker:0.11.0'}"
               bin_name="rerun"
               ;;
-            windows)
+            windows-x64)
               runner="windows-latest-8-cores"
               target="x86_64-pc-windows-msvc"
               container="null"
               bin_name="rerun.exe"
               ;;
-            macos-arm)
+            macos-arm64)
               runner="macos-latest-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="aarch64-apple-darwin"
               container="null"
               bin_name="rerun"
               ;;
-            macos-intel)
+            macos-x64)
               runner="macos-latest-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="x86_64-apple-darwin"
               container="null"
@@ -105,7 +114,7 @@ jobs:
   build-rerun-cli:
     name: Build rerun-cli (${{ needs.set-config.outputs.RUNNER }})
 
-    needs: [set-config]
+    needs: [ set-config ]
 
     runs-on: ${{ needs.set-config.outputs.RUNNER }}
     container: ${{ fromJson(needs.set-config.outputs.CONTAINER) }}
@@ -147,7 +156,7 @@ jobs:
           pixi run cargo run --locked -p re_build_web_viewer -- --release
 
       # This does not run in the pixi environment, doing so
-      # causes it to select the wrong compiler on macos-arm
+      # causes it to select the wrong compiler on macos-arm64
       - name: Build rerun-cli
         shell: bash
         env:

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -147,17 +147,17 @@ jobs:
           targets: ${{ needs.set-config.outputs.TARGET }}
 
       - uses: prefix-dev/setup-pixi@v0.4.1
-        if: ${{ inputs.PLATFORM != 'linux-arm64' }}
+        if: ${{ inputs.PLATFORM != 'linux-arm64' }}  # TODO(5507): see below
         with:
           pixi-version: v0.13.0
 
       - name: Build web-viewer (release)
-        if: ${{ inputs.PLATFORM != 'linux-arm64' }}
+        if: ${{ inputs.PLATFORM != 'linux-arm64' }}  # TODO(5507): see below
         shell: bash
         run: |
           pixi run cargo run --locked -p re_build_web_viewer -- --release
 
-      # Many of our pixi dependencies are not available on linux-arm64, so we must bypass pixi for this build
+      # TODO(5507): supress this workaround when pixi dependencies are available on linux-arm64
       - name: Build web-viewer (release, Linux ARM64)
         if: ${{ inputs.PLATFORM == 'linux-arm64' }}
         shell: bash

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           pixi run cargo run --locked -p re_build_web_viewer -- --release
 
-      # TODO(5507): supress this workaround when pixi dependencies are available on linux-arm64
+      # TODO(#5507): supress this workaround when pixi dependencies are available on linux-arm64
       - name: Build web-viewer (release, Linux ARM64)
         if: ${{ inputs.PLATFORM == 'linux-arm64' }}
         shell: bash

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -163,7 +163,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get install binaryen
-          pixi run cargo run --locked -p re_build_web_viewer -- --release
+          cargo run --locked -p re_build_web_viewer -- --release
 
       # This does not run in the pixi environment, doing so
       # causes it to select the wrong compiler on macos-arm64

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -162,7 +162,7 @@ jobs:
         if: ${{ inputs.PLATFORM == 'linux-arm64' }}
         shell: bash
         run: |
-          apt install binaryen
+          sudo apt-get install binaryen
           pixi run cargo run --locked -p re_build_web_viewer -- --release
 
       # This does not run in the pixi environment, doing so

--- a/scripts/ci/sync_release_assets.py
+++ b/scripts/ci/sync_release_assets.py
@@ -96,19 +96,23 @@ def fetch_binary_assets(
         rerun_c_blobs = [
             (
                 f"rerun_c-{tag}-x86_64-pc-windows-msvc.lib",
-                f"commit/{commit_short}/rerun_c/windows/rerun_c.lib",
+                f"commit/{commit_short}/rerun_c/windows-x64/rerun_c.lib",
             ),
             (
                 f"librerun_c-{tag}-x86_64-unknown-linux-gnu.a",
-                f"commit/{commit_short}/rerun_c/linux/librerun_c.a",
+                f"commit/{commit_short}/rerun_c/linux-x64/librerun_c.a",
+            ),
+            (
+                f"librerun_c-{tag}-aarch64-unknown-linux-gnu.a",
+                f"commit/{commit_short}/rerun_c/linux-arm64/librerun_c.a",
             ),
             (
                 f"librerun_c-{tag}-aarch64-apple-darwin.a",
-                f"commit/{commit_short}/rerun_c/macos-arm/librerun_c.a",
+                f"commit/{commit_short}/rerun_c/macos-arm64/librerun_c.a",
             ),
             (
                 f"librerun_c-{tag}-x86_64-apple-darwin.a",
-                f"commit/{commit_short}/rerun_c/macos-intel/librerun_c.a",
+                f"commit/{commit_short}/rerun_c/macos-x64/librerun_c.a",
             ),
         ]
         for name, blob_url in rerun_c_blobs:
@@ -139,19 +143,23 @@ def fetch_binary_assets(
         rerun_cli_blobs = [
             (
                 f"rerun-cli-{tag}-x86_64-pc-windows-msvc.exe",
-                f"commit/{commit_short}/rerun-cli/windows/rerun.exe",
+                f"commit/{commit_short}/rerun-cli/windows-x64/rerun.exe",
             ),
             (
                 f"rerun-cli-{tag}-x86_64-unknown-linux-gnu",
-                f"commit/{commit_short}/rerun-cli/linux/rerun",
+                f"commit/{commit_short}/rerun-cli/linux-x64/rerun",
+            ),
+            (
+                f"rerun-cli-{tag}-aarch64-unknown-linux-gnu",
+                f"commit/{commit_short}/rerun-cli/linux-arm64/rerun",
             ),
             (
                 f"rerun-cli-{tag}-aarch64-apple-darwin",
-                f"commit/{commit_short}/rerun-cli/macos-arm/rerun",
+                f"commit/{commit_short}/rerun-cli/macos-arm64/rerun",
             ),
             (
                 f"rerun-cli-{tag}-x86_64-apple-darwin",
-                f"commit/{commit_short}/rerun-cli/macos-intel/rerun",
+                f"commit/{commit_short}/rerun-cli/macos-x64/rerun",
             ),
         ]
         for name, blob_url in rerun_cli_blobs:


### PR DESCRIPTION
### What

Add support for building a Linux ARM64 version of the CLI in our build system.

- Follow-up to https://github.com/rerun-io/rerun/pull/5489
- Part of #4136

This PR introduces ugly work-around to be cleaned when our pixi deps support linux-aarch64:
- https://github.com/rerun-io/rerun/issues/5507

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5503/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5503/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5503/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5503)
- [Docs preview](https://rerun.io/preview/65c8082ad0c5482bad9167e8620490494f80637e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/65c8082ad0c5482bad9167e8620490494f80637e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)