### PR TITLE
Rename `.blueprint` extension to `.rbl`

### DIFF
--- a/crates/re_log_encoding/src/decoder/mod.rs
+++ b/crates/re_log_encoding/src/decoder/mod.rs
@@ -22,7 +22,7 @@ pub enum VersionPolicy {
 
     /// Return [`DecodeError::IncompatibleRerunVersion`] if the versions aren't compatible.
     ///
-    /// We usually use this for tests, and for loading `.blueprint` files.
+    /// We usually use this for tests, and for loading `.rbl` blueprint files.
     Error,
 }
 

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -101,7 +101,7 @@ impl UICommand {
                 "Save data for the current loop selection to a Rerun data file (.rrd)",
             ),
 
-            Self::SaveBlueprint => ("Save blueprint…", "Save the current viewer setup as a Rerun blueprint file (.blueprint)"),
+            Self::SaveBlueprint => ("Save blueprint…", "Save the current viewer setup as a Rerun blueprint file (.rbl)"),
 
             Self::Open => ("Open…", "Open any supported files (.rrd, images, meshes, …)"),
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1541,7 +1541,7 @@ fn save_blueprint(app: &mut App, store_context: Option<&StoreContext<'_>>) {
     let entity_db = store_context.blueprint;
 
     let file_name = format!(
-        "{}.blueprint",
+        "{}.rbl",
         crate::saving::sanitize_app_id(&store_context.app_id)
     );
     let title = "Save blueprint";

--- a/crates/re_viewer/src/saving.rs
+++ b/crates/re_viewer/src/saving.rs
@@ -37,7 +37,7 @@ pub fn default_blueprint_path(app_id: &ApplicationId) -> anyhow::Result<std::pat
     const MAX_PATH: usize = 255;
     let directory_part_length = blueprint_dir.as_os_str().len();
     let hash_part_length = 16 + 1;
-    let extension_part_length = ".blueprint".len();
+    let extension_part_length = ".rbl".len();
     let total_reserved_length = directory_part_length + hash_part_length + extension_part_length;
     if total_reserved_length > MAX_PATH {
         anyhow::bail!(
@@ -56,7 +56,7 @@ pub fn default_blueprint_path(app_id: &ApplicationId) -> anyhow::Result<std::pat
         sanitized_app_id = format!("{sanitized_app_id}-{hash:x}");
     }
 
-    Ok(blueprint_dir.join(format!("{sanitized_app_id}.blueprint")))
+    Ok(blueprint_dir.join(format!("{sanitized_app_id}.rbl")))
 }
 
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
### What
Three letters is common. You can read it as "Rerun Blueprint Layout" or maybe "Rerun BLuprint". Can be pronounced as "rebel"

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5506/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5506/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5506/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5506)
- [Docs preview](https://rerun.io/preview/d8af706a0b2ee89c43bfd2ccbc2de9779b9b5e14/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d8af706a0b2ee89c43bfd2ccbc2de9779b9b5e14/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)