### PR TITLE
Allow hiding/showing entity subtrees under shown/hidden parent tree

### DIFF
--- a/crates/re_entity_db/src/entity_properties.rs
+++ b/crates/re_entity_db/src/entity_properties.rs
@@ -94,7 +94,6 @@ impl FromIterator<(EntityPath, EntityProperties)> for EntityPropertyMap {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct EntityProperties {
-    pub visible: bool,
     pub visible_history: re_query::ExtraQueryHistory,
     pub interactive: bool,
 
@@ -144,7 +143,6 @@ pub struct EntityProperties {
 impl Default for EntityProperties {
     fn default() -> Self {
         Self {
-            visible: true,
             visible_history: re_query::ExtraQueryHistory::default(),
             interactive: true,
             color_mapper: EditableAutoValue::default(),
@@ -166,7 +164,6 @@ impl EntityProperties {
     /// Multiply/and these together.
     pub fn with_child(&self, child: &Self) -> Self {
         Self {
-            visible: self.visible && child.visible,
             visible_history: self.visible_history.with_child(&child.visible_history),
             interactive: self.interactive && child.interactive,
 
@@ -211,7 +208,6 @@ impl EntityProperties {
     /// loaded from the Blueprint store where the Auto values are not up-to-date.
     pub fn merge_with(&self, other: &Self) -> Self {
         Self {
-            visible: other.visible,
             visible_history: self.visible_history.with_child(&other.visible_history),
             interactive: other.interactive,
 
@@ -250,7 +246,6 @@ impl EntityProperties {
     /// Determine whether this `EntityProperty` has user-edits relative to another `EntityProperty`
     pub fn has_edits(&self, other: &Self) -> bool {
         let Self {
-            visible,
             visible_history,
             interactive,
             color_mapper,
@@ -265,8 +260,7 @@ impl EntityProperties {
             time_series_aggregator,
         } = self;
 
-        visible != &other.visible
-            || visible_history != &other.visible_history
+        visible_history != &other.visible_history
             || interactive != &other.interactive
             || color_mapper.has_edits(&other.color_mapper)
             || pinhole_image_plane_distance.has_edits(&other.pinhole_image_plane_distance)

--- a/crates/re_space_view/src/data_query.rs
+++ b/crates/re_space_view/src/data_query.rs
@@ -1,9 +1,10 @@
 use nohash_hasher::IntMap;
 
 use re_entity_db::{external::re_data_store::LatestAtQuery, EntityProperties, EntityPropertyMap};
-use re_log_types::{EntityPath, StoreKind};
 use re_types::ComponentName;
-use re_viewer_context::{DataQueryResult, PerVisualizer, StoreContext, VisualizableEntities};
+use re_viewer_context::{
+    DataQueryResult, OverridePath, PerVisualizer, StoreContext, VisualizableEntities,
+};
 
 pub struct EntityOverrideContext {
     pub root: EntityProperties,
@@ -11,7 +12,7 @@ pub struct EntityOverrideContext {
     pub recursive: EntityPropertyMap,
 
     /// Base component overrides that are inherited by all entities.
-    pub root_component_overrides: IntMap<ComponentName, (StoreKind, EntityPath)>,
+    pub root_component_overrides: IntMap<ComponentName, OverridePath>,
 }
 
 /// Trait for resolving properties needed by most implementations of [`DataQuery`]

--- a/crates/re_space_view/src/data_query.rs
+++ b/crates/re_space_view/src/data_query.rs
@@ -1,4 +1,4 @@
-use ahash::HashMap;
+use nohash_hasher::IntMap;
 
 use re_entity_db::{external::re_data_store::LatestAtQuery, EntityProperties, EntityPropertyMap};
 use re_log_types::{EntityPath, StoreKind};
@@ -11,7 +11,7 @@ pub struct EntityOverrideContext {
     pub recursive: EntityPropertyMap,
 
     /// Base component overrides that are inherited by all entities.
-    pub root_component_overrides: HashMap<ComponentName, (StoreKind, EntityPath)>,
+    pub root_component_overrides: IntMap<ComponentName, (StoreKind, EntityPath)>,
 }
 
 /// Trait for resolving properties needed by most implementations of [`DataQuery`]

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -485,7 +485,6 @@ mod tests {
         store.add_data_row(row).unwrap();
     }
 
-    #[cfg(feature = "TODO")] // TODO:
     #[test]
     fn test_entity_properties() {
         let space_view_class_registry = SpaceViewClassRegistry::default();
@@ -582,9 +581,9 @@ mod tests {
                 );
             }
 
-            // Now, override visibility on parent individually.
+            // Now, override interactive on parent individually.
             let mut overrides = parent.individual_properties().cloned().unwrap_or_default();
-            overrides.visible = false;
+            overrides.interactive = false;
 
             save_override(
                 overrides,
@@ -593,7 +592,7 @@ mod tests {
             );
         }
 
-        // Parent is not visible, but children are
+        // Parent is not interactive, but children are
         {
             let ctx = StoreContext {
                 blueprint: &blueprint,
@@ -621,18 +620,18 @@ mod tests {
                 .lookup_result_by_path(&EntityPath::from("parent/skip/child2"))
                 .unwrap();
 
-            assert!(!parent.accumulated_properties().visible);
+            assert!(!parent.accumulated_properties().interactive);
 
             for result in [child1, child2] {
-                assert!(result.accumulated_properties().visible);
+                assert!(result.accumulated_properties().interactive);
             }
 
-            // Override visibility on parent recursively.
+            // Override interactivity on parent recursively.
             let mut overrides = parent_group
                 .individual_properties()
                 .cloned()
                 .unwrap_or_default();
-            overrides.visible = false;
+            overrides.interactive = false;
 
             save_override(
                 overrides,
@@ -641,7 +640,7 @@ mod tests {
             );
         }
 
-        // Nobody is visible
+        // Nobody is interactive
         {
             let ctx = StoreContext {
                 blueprint: &blueprint,
@@ -666,11 +665,11 @@ mod tests {
                 .unwrap();
 
             for result in [parent, child1, child2] {
-                assert!(!result.accumulated_properties().visible);
+                assert!(!result.accumulated_properties().interactive);
             }
         }
 
-        // Override visible range on root
+        // Override interactive range on root
         {
             let root = space_view.root_data_result(
                 &StoreContext {
@@ -691,7 +690,7 @@ mod tests {
             );
         }
 
-        // Everyone has visible history
+        // Everyone has interactive history
         {
             let ctx = StoreContext {
                 blueprint: &blueprint,
@@ -732,7 +731,7 @@ mod tests {
             );
         }
 
-        // Child2 has its own visible history
+        // Child2 has its own interactive history
         {
             let ctx = StoreContext {
                 blueprint: &blueprint,

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -485,6 +485,7 @@ mod tests {
         store.add_data_row(row).unwrap();
     }
 
+    #[cfg(feature = "TODO")] // TODO:
     #[test]
     fn test_entity_properties() {
         let space_view_class_registry = SpaceViewClassRegistry::default();

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -446,7 +446,7 @@ impl SpaceViewBlueprint {
                 accumulated_properties,
                 individual_properties,
                 recursive_properties: Default::default(),
-                component_overrides: Default::default(),
+                resolved_component_overrides: Default::default(),
                 recursive_override_path: entity_path.clone(),
                 individual_override_path: entity_path,
             }),
@@ -1035,11 +1035,11 @@ mod tests {
             query_result.tree.visit(&mut |node| {
                 let result = &node.data_result;
                 if let Some(property_overrides) = &result.property_overrides {
-                    if !property_overrides.component_overrides.is_empty() {
+                    if !property_overrides.resolved_component_overrides.is_empty() {
                         visited.insert(
                             result.entity_path.clone(),
                             property_overrides
-                                .component_overrides
+                                .resolved_component_overrides
                                 .iter()
                                 .map(|(component_name, (store_kind, path))| {
                                     assert_eq!(store_kind, &StoreKind::Blueprint);

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -464,8 +464,8 @@ mod tests {
     };
     use re_types::{archetypes::Points3D, ComponentBatch, ComponentName, Loggable as _};
     use re_viewer_context::{
-        blueprint_timeline, IndicatedEntities, PerVisualizer, SpaceViewClassRegistry, StoreContext,
-        VisualizableEntities,
+        blueprint_timeline, IndicatedEntities, OverridePath, PerVisualizer, SpaceViewClassRegistry,
+        StoreContext, VisualizableEntities,
     };
     use std::collections::HashMap;
 
@@ -1041,7 +1041,7 @@ mod tests {
                             property_overrides
                                 .resolved_component_overrides
                                 .iter()
-                                .map(|(component_name, (store_kind, path))| {
+                                .map(|(component_name, OverridePath { store_kind, path })| {
                                     assert_eq!(store_kind, &StoreKind::Blueprint);
                                     (*component_name, path.clone())
                                 })

--- a/crates/re_space_view/src/space_view_contents.rs
+++ b/crates/re_space_view/src/space_view_contents.rs
@@ -1,4 +1,4 @@
-use ahash::HashMap;
+use nohash_hasher::IntMap;
 use slotmap::SlotMap;
 use smallvec::SmallVec;
 
@@ -340,7 +340,7 @@ impl DataQueryPropertyResolver<'_> {
             .space_view
             .root_data_result(ctx, query)
             .property_overrides
-            .map(|p| (p.accumulated_properties, p.component_overrides))
+            .map(|p| (p.accumulated_properties, p.resolved_component_overrides))
             .unwrap_or_default();
 
         for prefix in &self.default_stack {
@@ -416,7 +416,7 @@ impl DataQueryPropertyResolver<'_> {
         query_result: &mut DataQueryResult,
         override_context: &EntityOverrideContext,
         accumulated: &EntityProperties,
-        recursive_property_overrides: &HashMap<ComponentName, (StoreKind, EntityPath)>,
+        recursive_property_overrides: &IntMap<ComponentName, (StoreKind, EntityPath)>,
         handle: DataResultHandle,
     ) {
         if let Some((child_handles, accumulated, recursive_property_overrides)) =
@@ -527,7 +527,7 @@ impl DataQueryPropertyResolver<'_> {
                     accumulated_properties,
                     individual_properties: individual_properties.cloned(),
                     recursive_properties: recursive_properties.cloned(),
-                    component_overrides,
+                    resolved_component_overrides: component_overrides,
                     recursive_override_path,
                     individual_override_path,
                 });

--- a/crates/re_space_view_bar_chart/src/visualizer_system.rs
+++ b/crates/re_space_view_bar_chart/src/visualizer_system.rs
@@ -50,7 +50,7 @@ impl VisualizerSystem for BarChartVisualizerSystem {
 
         let store = ctx.entity_db.store();
 
-        for data_result in query.iter_visible_data_results(Self::identifier()) {
+        for data_result in query.iter_visible_data_results(ctx, Self::identifier()) {
             let query = LatestAtQuery::new(query.timeline, query.latest_at);
             let tensor = store.query_latest_component::<re_types::components::TensorData>(
                 &data_result.entity_path,

--- a/crates/re_space_view_dataframe/src/space_view_class.rs
+++ b/crates/re_space_view_dataframe/src/space_view_class.rs
@@ -81,7 +81,7 @@ impl SpaceViewClass for DataframeSpaceView {
         // These are the entity paths whose content we must display.
         let sorted_entity_paths: BTreeSet<_> = query
             .iter_all_data_results()
-            .filter(|data_result| data_result.accumulated_properties().visible)
+            .filter(|data_result| data_result.is_visible(ctx))
             .map(|data_result| &data_result.entity_path)
             .cloned()
             .collect();

--- a/crates/re_space_view_spatial/src/contexts/depth_offsets.rs
+++ b/crates/re_space_view_spatial/src/contexts/depth_offsets.rs
@@ -48,7 +48,7 @@ impl ViewContextSystem for EntityDepthOffsets {
 
         // Use a BTreeSet for entity hashes to get a stable order.
         let mut entities_per_draw_order = BTreeMap::<DrawOrder, BTreeSet<DrawOrderTarget>>::new();
-        for data_result in query.iter_visible_data_results(Self::identifier()) {
+        for data_result in query.iter_visible_data_results(ctx, Self::identifier()) {
             if let Some(draw_order) = store
                 .query_latest_component::<DrawOrder>(&data_result.entity_path, &ctx.current_query())
             {

--- a/crates/re_space_view_spatial/src/visualizers/cameras.rs
+++ b/crates/re_space_view_spatial/src/visualizers/cameras.rs
@@ -213,7 +213,7 @@ impl VisualizerSystem for CamerasVisualizer {
         let mut line_builder = re_renderer::LineDrawableBuilder::new(ctx.render_ctx);
         line_builder.radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES);
 
-        for data_result in query.iter_visible_data_results(Self::identifier()) {
+        for data_result in query.iter_visible_data_results(ctx, Self::identifier()) {
             let time_query = re_data_store::LatestAtQuery::new(query.timeline, query.latest_at);
 
             if let Some(pinhole) = query_pinhole(store, &time_query, &data_result.entity_path) {

--- a/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
@@ -42,7 +42,7 @@ where
     let annotations = view_ctx.get::<AnnotationSceneContext>()?;
     let counter = view_ctx.get::<PrimitiveCounter>()?;
 
-    for data_result in query.iter_visible_data_results(System::identifier()) {
+    for data_result in query.iter_visible_data_results(ctx, System::identifier()) {
         // The transform that considers pinholes only makes sense if this is a 3D space-view
         let world_from_entity =
             if view_ctx.space_view_class_identifier() == SpatialSpaceView3D::identifier() {
@@ -151,7 +151,7 @@ macro_rules! impl_process_archetype {
             let annotations = view_ctx.get::<AnnotationSceneContext>()?;
             let counter = view_ctx.get::<PrimitiveCounter>()?;
 
-            for data_result in query.iter_visible_data_results(S::identifier()) {
+            for data_result in query.iter_visible_data_results(ctx, S::identifier()) {
                 // The transform that considers pinholes only makes sense if this is a 3D space-view
                 let world_from_entity = if view_ctx.space_view_class_identifier() == SpatialSpaceView3D::identifier() {
                     transforms.reference_from_entity(&data_result.entity_path)
@@ -256,7 +256,7 @@ pub fn count_instances_in_archetype_views<
 
     let mut num_instances = 0;
 
-    for data_result in query.iter_visible_data_results(System::identifier()) {
+    for data_result in query.iter_visible_data_results(ctx, System::identifier()) {
         match query_archetype_with_history::<A, N>(
             ctx.entity_db.store(),
             &query.timeline,

--- a/crates/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -61,7 +61,7 @@ impl VisualizerSystem for Transform3DArrowsVisualizer {
         let mut line_builder = re_renderer::LineDrawableBuilder::new(ctx.render_ctx);
         line_builder.radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES);
 
-        for data_result in query.iter_visible_data_results(Self::identifier()) {
+        for data_result in query.iter_visible_data_results(ctx, Self::identifier()) {
             if !*data_result.accumulated_properties().transform_3d_visible {
                 continue;
             }

--- a/crates/re_space_view_tensor/src/visualizer_system.rs
+++ b/crates/re_space_view_tensor/src/visualizer_system.rs
@@ -48,7 +48,7 @@ impl VisualizerSystem for TensorSystem {
         re_tracing::profile_function!();
 
         let store = ctx.entity_db.store();
-        for data_result in query.iter_visible_data_results(Self::identifier()) {
+        for data_result in query.iter_visible_data_results(ctx, Self::identifier()) {
             let timeline_query = LatestAtQuery::new(query.timeline, query.latest_at);
 
             if let Some(tensor) = store

--- a/crates/re_space_view_text_document/src/visualizer_system.rs
+++ b/crates/re_space_view_text_document/src/visualizer_system.rs
@@ -44,7 +44,7 @@ impl VisualizerSystem for TextDocumentSystem {
 
         let timeline_query = LatestAtQuery::new(query.timeline, query.latest_at);
 
-        for data_result in query.iter_visible_data_results(Self::identifier()) {
+        for data_result in query.iter_visible_data_results(ctx, Self::identifier()) {
             // TODO(#3320): this match can go away once the issue is resolved
             match query_archetype::<archetypes::TextDocument>(
                 store,

--- a/crates/re_space_view_text_log/src/visualizer_system.rs
+++ b/crates/re_space_view_text_log/src/visualizer_system.rs
@@ -53,7 +53,7 @@ impl VisualizerSystem for TextLogSystem {
         let query_caches = ctx.entity_db.query_caches();
         let store = ctx.entity_db.store();
 
-        for data_result in query.iter_visible_data_results(Self::identifier()) {
+        for data_result in query.iter_visible_data_results(ctx, Self::identifier()) {
             re_tracing::profile_scope!("primary", &data_result.entity_path.to_string());
 
             // We want everything, for all times:

--- a/crates/re_space_view_time_series/src/legacy_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/legacy_visualizer_system.rs
@@ -10,7 +10,7 @@ use re_viewer_context::{
 };
 
 use crate::{
-    overrides::{initial_override_color, lookup_override},
+    overrides::initial_override_color,
     util::{determine_plot_bounds_and_time_per_pixel, determine_time_range, points_to_series},
     PlotPoint, PlotPointAttrs, PlotSeries, PlotSeriesKind, ScatterAttrs,
 };
@@ -111,11 +111,14 @@ impl LegacyTimeSeriesSystem {
 
             const DEFAULT_RADIUS: f32 = 0.75;
 
-            let override_color = lookup_override::<Color>(data_result, ctx).map(|c| c.to_array());
-            let override_label = lookup_override::<Text>(data_result, ctx).map(|t| t.0);
-            let override_scattered =
-                lookup_override::<ScalarScattering>(data_result, ctx).map(|s| s.0);
-            let override_radius = lookup_override::<Radius>(data_result, ctx).map(|r| r.0);
+            let override_color = data_result
+                .lookup_override::<Color>(ctx)
+                .map(|c| c.to_array());
+            let override_label = data_result.lookup_override::<Text>(ctx).map(|t| t.0);
+            let override_scattered = data_result
+                .lookup_override::<ScalarScattering>(ctx)
+                .map(|s| s.0);
+            let override_radius = data_result.lookup_override::<Radius>(ctx).map(|r| r.0);
 
             // All the default values for a `PlotPoint`, accounting for both overrides and default
             // values.

--- a/crates/re_space_view_time_series/src/legacy_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/legacy_visualizer_system.rs
@@ -57,7 +57,7 @@ impl VisualizerSystem for LegacyTimeSeriesSystem {
             ctx,
             &query.latest_at_query(),
             query
-                .iter_visible_data_results(Self::identifier())
+                .iter_visible_data_results(ctx, Self::identifier())
                 .map(|data| &data.entity_path),
         );
 
@@ -102,7 +102,7 @@ impl LegacyTimeSeriesSystem {
         let (plot_bounds, time_per_pixel) = determine_plot_bounds_and_time_per_pixel(ctx, query);
 
         // TODO(cmc): this should be thread-pooled in case there are a gazillon series in the same plot…
-        for data_result in query.iter_visible_data_results(Self::identifier()) {
+        for data_result in query.iter_visible_data_results(ctx, Self::identifier()) {
             let annotations = self.annotation_map.find(&data_result.entity_path);
             let annotation_info = annotations
                 .resolved_class_description(None)

--- a/crates/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/line_visualizer_system.rs
@@ -56,7 +56,7 @@ impl VisualizerSystem for SeriesLineSystem {
             ctx,
             &query.latest_at_query(),
             query
-                .iter_visible_data_results(Self::identifier())
+                .iter_visible_data_results(ctx, Self::identifier())
                 .map(|data| &data.entity_path),
         );
 
@@ -98,7 +98,7 @@ impl SeriesLineSystem {
 
         let (plot_bounds, time_per_pixel) = determine_plot_bounds_and_time_per_pixel(ctx, query);
 
-        let data_results = query.iter_visible_data_results(Self::identifier());
+        let data_results = query.iter_visible_data_results(ctx, Self::identifier());
 
         let parallel_loading = false; // TODO(emilk): enable parallel loading when it is faster, because right now it is often slower.
         if parallel_loading {

--- a/crates/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/line_visualizer_system.rs
@@ -15,7 +15,7 @@ use crate::overrides::initial_override_color;
 use crate::util::{
     determine_plot_bounds_and_time_per_pixel, determine_time_range, points_to_series,
 };
-use crate::{overrides::lookup_override, PlotPoint, PlotPointAttrs, PlotSeries, PlotSeriesKind};
+use crate::{PlotPoint, PlotPointAttrs, PlotSeries, PlotSeriesKind};
 
 /// The system for rendering [`SeriesLine`] archetypes.
 #[derive(Default, Debug)]
@@ -162,9 +162,11 @@ fn load_series(
         .resolved_class_description(None)
         .annotation_info();
     let default_color = DefaultColor::EntityPath(&data_result.entity_path);
-    let override_color = lookup_override::<Color>(data_result, ctx).map(|c| c.to_array());
-    let override_series_name = lookup_override::<Name>(data_result, ctx).map(|t| t.0);
-    let override_stroke_width = lookup_override::<StrokeWidth>(data_result, ctx).map(|r| r.0);
+    let override_color = data_result
+        .lookup_override::<Color>(ctx)
+        .map(|c| c.to_array());
+    let override_series_name = data_result.lookup_override::<Name>(ctx).map(|t| t.0);
+    let override_stroke_width = data_result.lookup_override::<StrokeWidth>(ctx).map(|r| r.0);
 
     // All the default values for a `PlotPoint`, accounting for both overrides and default
     // values.

--- a/crates/re_space_view_time_series/src/overrides.rs
+++ b/crates/re_space_view_time_series/src/overrides.rs
@@ -1,28 +1,6 @@
-use re_log_types::{EntityPath, StoreKind};
-use re_types::{components::Color, Component};
-use re_viewer_context::{DefaultColor, ResolvedAnnotationInfo, ViewerContext};
-
-pub fn lookup_override<C: Component>(
-    data_result: &re_viewer_context::DataResult,
-    ctx: &ViewerContext<'_>,
-) -> Option<C> {
-    data_result
-        .property_overrides
-        .as_ref()
-        .and_then(|p| p.component_overrides.get(&C::name()))
-        .and_then(|(store_kind, path)| match store_kind {
-            StoreKind::Blueprint => ctx
-                .store_context
-                .blueprint
-                .store()
-                .query_latest_component::<C>(path, ctx.blueprint_query),
-            StoreKind::Recording => ctx
-                .entity_db
-                .store()
-                .query_latest_component::<C>(path, &ctx.current_query()),
-        })
-        .map(|c| c.value)
-}
+use re_log_types::EntityPath;
+use re_types::components::Color;
+use re_viewer_context::{DefaultColor, ResolvedAnnotationInfo};
 
 pub fn initial_override_color(entity_path: &EntityPath) -> Color {
     let default_color = DefaultColor::EntityPath(entity_path);

--- a/crates/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/point_visualizer_system.rs
@@ -60,7 +60,7 @@ impl VisualizerSystem for SeriesPointSystem {
             ctx,
             &query.latest_at_query(),
             query
-                .iter_visible_data_results(Self::identifier())
+                .iter_visible_data_results(ctx, Self::identifier())
                 .map(|data| &data.entity_path),
         );
 
@@ -106,7 +106,7 @@ impl SeriesPointSystem {
         let (plot_bounds, time_per_pixel) = determine_plot_bounds_and_time_per_pixel(ctx, query);
 
         // TODO(cmc): this should be thread-pooled in case there are a gazillon series in the same plot…
-        for data_result in query.iter_visible_data_results(Self::identifier()) {
+        for data_result in query.iter_visible_data_results(ctx, Self::identifier()) {
             let annotations = self.annotation_map.find(&data_result.entity_path);
             let annotation_info = annotations
                 .resolved_class_description(None)

--- a/crates/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/point_visualizer_system.rs
@@ -16,7 +16,7 @@ use crate::util::{
     determine_plot_bounds_and_time_per_pixel, determine_time_range, points_to_series,
 };
 use crate::ScatterAttrs;
-use crate::{overrides::lookup_override, PlotPoint, PlotPointAttrs, PlotSeries, PlotSeriesKind};
+use crate::{PlotPoint, PlotPointAttrs, PlotSeries, PlotSeriesKind};
 
 /// The system for rendering [`SeriesPoint`] archetypes.
 #[derive(Default, Debug)]
@@ -113,10 +113,12 @@ impl SeriesPointSystem {
                 .annotation_info();
             let default_color = DefaultColor::EntityPath(&data_result.entity_path);
 
-            let override_color = lookup_override::<Color>(data_result, ctx).map(|c| c.to_array());
-            let override_series_name = lookup_override::<Name>(data_result, ctx).map(|t| t.0);
-            let override_marker_size = lookup_override::<MarkerSize>(data_result, ctx).map(|r| r.0);
-            let override_marker = lookup_override::<MarkerShape>(data_result, ctx);
+            let override_color = data_result
+                .lookup_override::<Color>(ctx)
+                .map(|c| c.to_array());
+            let override_series_name = data_result.lookup_override::<Name>(ctx).map(|t| t.0);
+            let override_marker_size = data_result.lookup_override::<MarkerSize>(ctx).map(|r| r.0);
+            let override_marker = data_result.lookup_override::<MarkerShape>(ctx);
 
             // All the default values for a `PlotPoint`, accounting for both overrides and default
             // values.

--- a/crates/re_types/definitions/rerun/blueprint/components/visible.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/visible.fbs
@@ -14,7 +14,7 @@ struct Visible (
     "attr.arrow.transparent",
     "attr.rerun.scope": "blueprint",
     "attr.python.aliases": "bool",
-    "attr.rust.derive": "Copy, Default, PartialEq, Eq, PartialOrd, Ord",
+    "attr.rust.derive": "Copy, PartialEq, Eq, PartialOrd, Ord",
     "attr.rust.repr": "transparent",
     "attr.rust.tuple_struct"
 ) {

--- a/crates/re_types/src/blueprint/components/mod.rs
+++ b/crates/re_types/src/blueprint/components/mod.rs
@@ -13,6 +13,7 @@ mod space_view_class;
 mod space_view_origin;
 mod viewer_recommendation_hash;
 mod visible;
+mod visible_ext;
 
 pub use self::active_tab::ActiveTab;
 pub use self::background3d_kind::Background3DKind;

--- a/crates/re_types/src/blueprint/components/visible.rs
+++ b/crates/re_types/src/blueprint/components/visible.rs
@@ -22,7 +22,7 @@ use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Whether the container, space view, entity or instance is currently visible.
-#[derive(Clone, Debug, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Visible(pub bool);
 

--- a/crates/re_types/src/blueprint/components/visible_ext.rs
+++ b/crates/re_types/src/blueprint/components/visible_ext.rs
@@ -1,0 +1,7 @@
+use super::Visible;
+
+impl Default for Visible {
+    fn default() -> Self {
+        Self(true)
+    }
+}

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -65,7 +65,7 @@ pub enum LabelStyle {
 use crate::list_item::ListItem;
 use egui::emath::{Rangef, Rot2};
 use egui::epaint::util::FloatOrd;
-use egui::{pos2, Align2, CollapsingResponse, Color32, Mesh, NumExt, Rect, Shape, Vec2};
+use egui::{pos2, Align2, CollapsingResponse, Color32, Mesh, NumExt, Rect, Shape, Vec2, Widget};
 
 #[derive(Clone)]
 pub struct ReUi {
@@ -432,13 +432,26 @@ impl ReUi {
         selected: &mut bool,
         text: impl Into<egui::WidgetText>,
     ) -> egui::Response {
+        self.checkbox_indeterminate(ui, selected, text, false)
+    }
+
+    #[allow(clippy::unused_self)]
+    pub fn checkbox_indeterminate(
+        &self,
+        ui: &mut egui::Ui,
+        selected: &mut bool,
+        text: impl Into<egui::WidgetText>,
+        indeterminate: bool,
+    ) -> egui::Response {
         ui.scope(|ui| {
             ui.visuals_mut().widgets.hovered.expansion = 0.0;
             ui.visuals_mut().widgets.active.expansion = 0.0;
             ui.visuals_mut().widgets.open.expansion = 0.0;
 
             // NOLINT
-            ui.checkbox(selected, text)
+            egui::Checkbox::new(selected, text)
+                .indeterminate(indeterminate)
+                .ui(ui)
         })
         .inner
     }

--- a/crates/re_viewer/src/ui/override_ui.rs
+++ b/crates/re_viewer/src/ui/override_ui.rs
@@ -13,8 +13,8 @@ use re_types_core::{
     ComponentName,
 };
 use re_viewer_context::{
-    blueprint_timepoint_for_writes, DataResult, SystemCommand, SystemCommandSender as _,
-    UiVerbosity, ViewSystemIdentifier, ViewerContext,
+    blueprint_timepoint_for_writes, DataResult, OverridePath, SystemCommand,
+    SystemCommandSender as _, UiVerbosity, ViewSystemIdentifier, ViewerContext,
 };
 
 pub fn override_ui(
@@ -111,7 +111,7 @@ pub fn override_ui(
             re_ui::ReUi::setup_table_body(&mut body);
             let row_height = re_ui::ReUi::table_line_height();
             body.rows(row_height, components.len(), |mut row| {
-                if let Some((component_name, (store_kind, entity_path))) =
+                if let Some((component_name, OverridePath { store_kind, path })) =
                     components.get(row.index())
                 {
                     // Remove button
@@ -142,19 +142,11 @@ pub fn override_ui(
                             StoreKind::Blueprint => {
                                 let store = ctx.store_context.blueprint.store();
                                 let query = ctx.blueprint_query;
-                                get_component_with_instances(
-                                    store,
-                                    query,
-                                    entity_path,
-                                    *component_name,
-                                )
+                                get_component_with_instances(store, query, path, *component_name)
                             }
-                            StoreKind::Recording => get_component_with_instances(
-                                store,
-                                &query,
-                                entity_path,
-                                *component_name,
-                            ),
+                            StoreKind::Recording => {
+                                get_component_with_instances(store, &query, path, *component_name)
+                            }
                         };
 
                         if let Some((_, _, component_data)) = component_data {
@@ -164,7 +156,7 @@ pub fn override_ui(
                                 UiVerbosity::Small,
                                 &query,
                                 store,
-                                entity_path,
+                                path,
                                 &overrides.individual_override_path,
                                 &component_data,
                                 instance_key,

--- a/crates/re_viewer/src/ui/override_ui.rs
+++ b/crates/re_viewer/src/ui/override_ui.rs
@@ -48,7 +48,7 @@ pub fn override_ui(
     let active_overrides: BTreeSet<ComponentName> = data_result
         .property_overrides
         .as_ref()
-        .map(|props| props.component_overrides.keys().cloned().collect())
+        .map(|props| props.resolved_component_overrides.keys().cloned().collect())
         .unwrap_or_default();
 
     let view_systems = ctx
@@ -95,7 +95,7 @@ pub fn override_ui(
     };
 
     let components: Vec<_> = overrides
-        .component_overrides
+        .resolved_component_overrides
         .into_iter()
         .sorted_by_key(|(c, _)| *c)
         .filter(|(c, _)| component_to_vis.contains_key(c) && is_component_visible_in_ui(c))

--- a/crates/re_viewer/src/ui/override_ui.rs
+++ b/crates/re_viewer/src/ui/override_ui.rs
@@ -124,7 +124,6 @@ pub fn override_ui(
                             // Note: need to use the blueprint store since the data might
                             // not exist in the recording store.
                             ctx.save_empty_blueprint_component_name(
-                                ctx.store_context.blueprint.store(),
                                 &overrides.individual_override_path,
                                 *component_name,
                             );

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -1074,7 +1074,8 @@ fn entity_props_ui(
     resolved_entity_props: &EntityProperties,
 ) {
     let re_ui = ctx.re_ui;
-    re_ui.checkbox(ui, &mut entity_props.visible, "Visible");
+    // TODO:
+    //re_ui.checkbox(ui, &mut entity_props.visible, "Visible");
     re_ui
         .checkbox(ui, &mut entity_props.interactive, "Interactive")
         .on_hover_text("If disabled, the entity will not react to any mouse interaction");

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -17,8 +17,8 @@ use re_types::{
 use re_ui::list_item::ListItem;
 use re_ui::{ReUi, SyntaxHighlighting as _};
 use re_viewer_context::{
-    gpu_bridge::colormap_dropdown_button_ui, ContainerId, HoverHighlight, Item, SpaceViewClass,
-    SpaceViewClassIdentifier, SpaceViewId, UiVerbosity, ViewerContext,
+    gpu_bridge::colormap_dropdown_button_ui, ContainerId, DataQueryResult, HoverHighlight, Item,
+    SpaceViewClass, SpaceViewClassIdentifier, SpaceViewId, UiVerbosity, ViewerContext,
 };
 use re_viewport::{
     context_menu_ui_for_item, icon_for_container_kind, space_view_name_style, Contents,
@@ -911,8 +911,9 @@ fn blueprint_ui_for_data_result(
                 entity_props_ui(
                     ctx,
                     ui,
+                    ctx.lookup_query_result(*space_view_id),
                     &space_view_class,
-                    Some(entity_path),
+                    entity_path,
                     &mut props,
                     data_result.accumulated_properties(),
                 );
@@ -1068,14 +1069,55 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
 fn entity_props_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
+    query_result: &DataQueryResult,
     space_view_class: &SpaceViewClassIdentifier,
-    entity_path: Option<&EntityPath>,
+    entity_path: &EntityPath,
     entity_props: &mut EntityProperties,
     resolved_entity_props: &EntityProperties,
 ) {
+    use re_types::blueprint::components::Visible;
+    use re_types::Loggable as _;
+
     let re_ui = ctx.re_ui;
-    // TODO:
-    //re_ui.checkbox(ui, &mut entity_props.visible, "Visible");
+    let Some(data_result) = query_result.tree.lookup_result_by_path(entity_path) else {
+        return;
+    };
+
+    {
+        let visible_before = data_result.lookup_override_or_default::<Visible>(ctx);
+        let mut visible = visible_before;
+
+        let override_source =
+            data_result.component_override_source(&query_result.tree, &Visible::name());
+        let is_inherited =
+            override_source.is_some() && override_source.as_ref() != Some(entity_path);
+        let visible_response =
+            re_ui.checkbox_indeterminate(ui, &mut visible.0, "Visible", is_inherited);
+
+        if let (true, Some(override_source)) = (is_inherited, override_source) {
+            visible_response.on_hover_ui(|ui| {
+                ui.horizontal(|ui| {
+                    ui.label("Inherited from:");
+                    item_ui::entity_path_button(
+                        ctx,
+                        &ctx.current_query(),
+                        ctx.entity_db.store(),
+                        ui,
+                        None,
+                        &override_source,
+                    );
+                });
+            });
+        }
+        if visible_before != visible {
+            data_result.save_recursive_override_or_clear_if_redundant(
+                ctx,
+                &query_result.tree,
+                &visible,
+            );
+        }
+    }
+
     re_ui
         .checkbox(ui, &mut entity_props.interactive, "Interactive")
         .on_hover_text("If disabled, the entity will not react to any mouse interaction");
@@ -1085,7 +1127,7 @@ fn entity_props_ui(
         ui,
         space_view_class,
         false,
-        entity_path,
+        Some(entity_path),
         &mut entity_props.visible_history,
         &resolved_entity_props.visible_history,
     );
@@ -1095,11 +1137,9 @@ fn entity_props_ui(
         .show(ui, |ui| {
             // TODO(wumpf): It would be nice to only show pinhole & depth properties in the context of a 3D view.
             // if *view_state.state_spatial.nav_mode.get() == SpatialNavigationMode::ThreeD {
-            if let Some(entity_path) = entity_path {
-                pinhole_props_ui(ctx, ui, entity_path, entity_props);
-                depth_props_ui(ctx, ui, entity_path, entity_props);
-                transform3d_visualization_ui(ctx, ui, entity_path, entity_props);
-            }
+            pinhole_props_ui(ctx, ui, entity_path, entity_props);
+            depth_props_ui(ctx, ui, entity_path, entity_props);
+            transform3d_visualization_ui(ctx, ui, entity_path, entity_props);
         });
 }
 

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -1091,24 +1091,14 @@ fn entity_props_ui(
             data_result.component_override_source(&query_result.tree, &Visible::name());
         let is_inherited =
             override_source.is_some() && override_source.as_ref() != Some(entity_path);
-        let visible_response =
-            re_ui.checkbox_indeterminate(ui, &mut visible.0, "Visible", is_inherited);
 
-        if let (true, Some(override_source)) = (is_inherited, override_source) {
-            visible_response.on_hover_ui(|ui| {
-                ui.horizontal(|ui| {
-                    ui.label("Inherited from:");
-                    item_ui::entity_path_button(
-                        ctx,
-                        &ctx.current_query(),
-                        ctx.entity_db.store(),
-                        ui,
-                        None,
-                        &override_source,
-                    );
-                });
-            });
-        }
+        ui.horizontal(|ui| {
+            re_ui.checkbox(ui, &mut visible.0, "Visible");
+            if is_inherited {
+                ui.label("(inherited)");
+            }
+        });
+
         if visible_before != visible {
             data_result.save_recursive_override_or_clear_if_redundant(
                 ctx,

--- a/crates/re_viewer_context/src/blueprint_helpers.rs
+++ b/crates/re_viewer_context/src/blueprint_helpers.rs
@@ -59,7 +59,7 @@ impl ViewerContext<'_> {
         let num_instances = components.num_instances() as u32;
         let timepoint = blueprint_timepoint_for_writes();
 
-        re_log::debug!(
+        re_log::trace!(
             "Writing {} components of type {:?} to {:?}",
             num_instances,
             components.name(),

--- a/crates/re_viewer_context/src/blueprint_helpers.rs
+++ b/crates/re_viewer_context/src/blueprint_helpers.rs
@@ -59,6 +59,13 @@ impl ViewerContext<'_> {
         let num_instances = components.num_instances() as u32;
         let timepoint = blueprint_timepoint_for_writes();
 
+        re_log::debug!(
+            "Writing {} components of type {:?} to {:?}",
+            num_instances,
+            components.name(),
+            entity_path
+        );
+
         let data_row_result = if num_instances == 1 {
             let mut splat_cell: DataCell = [InstanceKey::SPLAT].into();
             splat_cell.compute_size_bytes();
@@ -105,11 +112,11 @@ impl ViewerContext<'_> {
     /// Helper to save a component to the blueprint store.
     pub fn save_empty_blueprint_component_name(
         &self,
-        store: &re_data_store::DataStore,
         entity_path: &EntityPath,
         component_name: ComponentName,
     ) {
-        let Some(datatype) = store.lookup_datatype(&component_name) else {
+        let blueprint = &self.store_context.blueprint;
+        let Some(datatype) = blueprint.store().lookup_datatype(&component_name) else {
             re_log::error_once!(
                 "Tried to clear a component with unknown type: {}",
                 component_name
@@ -130,7 +137,7 @@ impl ViewerContext<'_> {
             Ok(row) => self
                 .command_sender
                 .send_system(SystemCommand::UpdateBlueprint(
-                    self.store_context.blueprint.store_id().clone(),
+                    blueprint.store_id().clone(),
                     vec![row],
                 )),
             Err(err) => {

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -45,14 +45,15 @@ pub use selection_state::{
     Selection, SelectionHighlight,
 };
 pub use space_view::{
-    DataResult, IdentifiedViewSystem, PerSystemDataResults, PerSystemEntities, PropertyOverrides,
-    RecommendedSpaceView, SmallVisualizerSet, SpaceViewClass, SpaceViewClassIdentifier,
-    SpaceViewClassLayoutPriority, SpaceViewClassRegistry, SpaceViewClassRegistryError,
-    SpaceViewEntityHighlight, SpaceViewHighlights, SpaceViewOutlineMasks, SpaceViewSpawnHeuristics,
-    SpaceViewState, SpaceViewStateExt, SpaceViewSystemExecutionError, SpaceViewSystemRegistrator,
-    SystemExecutionOutput, ViewContextCollection, ViewContextSystem, ViewQuery,
-    ViewSystemIdentifier, VisualizableFilterContext, VisualizerAdditionalApplicabilityFilter,
-    VisualizerCollection, VisualizerQueryInfo, VisualizerSystem,
+    DataResult, IdentifiedViewSystem, OverridePath, PerSystemDataResults, PerSystemEntities,
+    PropertyOverrides, RecommendedSpaceView, SmallVisualizerSet, SpaceViewClass,
+    SpaceViewClassIdentifier, SpaceViewClassLayoutPriority, SpaceViewClassRegistry,
+    SpaceViewClassRegistryError, SpaceViewEntityHighlight, SpaceViewHighlights,
+    SpaceViewOutlineMasks, SpaceViewSpawnHeuristics, SpaceViewState, SpaceViewStateExt,
+    SpaceViewSystemExecutionError, SpaceViewSystemRegistrator, SystemExecutionOutput,
+    ViewContextCollection, ViewContextSystem, ViewQuery, ViewSystemIdentifier,
+    VisualizableFilterContext, VisualizerAdditionalApplicabilityFilter, VisualizerCollection,
+    VisualizerQueryInfo, VisualizerSystem,
 };
 pub use store_context::StoreContext;
 pub use tensor::{TensorDecodeCache, TensorStats, TensorStatsCache};

--- a/crates/re_viewer_context/src/space_view/mod.rs
+++ b/crates/re_viewer_context/src/space_view/mod.rs
@@ -29,7 +29,8 @@ pub use spawn_heuristics::{RecommendedSpaceView, SpaceViewSpawnHeuristics};
 pub use system_execution_output::SystemExecutionOutput;
 pub use view_context_system::{ViewContextCollection, ViewContextSystem};
 pub use view_query::{
-    DataResult, PerSystemDataResults, PropertyOverrides, SmallVisualizerSet, ViewQuery,
+    DataResult, OverridePath, PerSystemDataResults, PropertyOverrides, SmallVisualizerSet,
+    ViewQuery,
 };
 pub use visualizer_entity_subscriber::VisualizerAdditionalApplicabilityFilter;
 pub use visualizer_system::{VisualizerCollection, VisualizerQueryInfo, VisualizerSystem};

--- a/crates/re_viewer_context/src/space_view/view_query.rs
+++ b/crates/re_viewer_context/src/space_view/view_query.rs
@@ -98,7 +98,7 @@ impl DataResult {
     }
 
     /// Saves a recursive override OR clears both (!) individual & recursive overrides if the override is due to a parent recursive override or a default value.
-    // TODO(andreas/jleibs): Does not take individual overrides into account yet.
+    // TODO(andreas): Does not take individual overrides into account yet.
     // TODO(andreas): This should have a unit test, but the delayed override write makes it hard to test.
     pub fn save_recursive_override_or_clear_if_redundant<C: re_types::Component + Eq + Default>(
         &self,

--- a/crates/re_viewer_context/src/space_view/view_query.rs
+++ b/crates/re_viewer_context/src/space_view/view_query.rs
@@ -214,6 +214,24 @@ impl DataResult {
             .as_ref()
             .and_then(|p| p.individual_properties.as_ref())
     }
+
+    pub fn lookup_override<C: re_types::Component>(&self, ctx: &ViewerContext<'_>) -> Option<C> {
+        self.property_overrides
+            .as_ref()
+            .and_then(|p| p.component_overrides.get(&C::name()))
+            .and_then(|(store_kind, path)| match store_kind {
+                StoreKind::Blueprint => ctx
+                    .store_context
+                    .blueprint
+                    .store()
+                    .query_latest_component::<C>(path, ctx.blueprint_query),
+                StoreKind::Recording => ctx
+                    .entity_db
+                    .store()
+                    .query_latest_component::<C>(path, &ctx.current_query()),
+            })
+            .map(|c| c.value)
+    }
 }
 
 pub type PerSystemDataResults<'a> = BTreeMap<ViewSystemIdentifier, Vec<&'a DataResult>>;

--- a/crates/re_viewport/src/context_menu/actions/show_hide.rs
+++ b/crates/re_viewport/src/context_menu/actions/show_hide.rs
@@ -136,18 +136,18 @@ fn set_data_result_visible(
     instance_path: &InstancePath,
     visible: bool,
 ) {
-    let query_result = ctx.viewer_context.lookup_query_result(*space_view_id);
-    if let Some(data_result) = query_result
-        .tree
-        .lookup_result_by_path(&instance_path.entity_path)
-    {
-        // TODO:
-        // let mut recursive_properties = data_result
-        //     .recursive_properties()
-        //     .cloned()
-        //     .unwrap_or_default();
-        // recursive_properties.visible = visible;
-
-        // data_result.save_recursive_override(ctx.viewer_context, Some(recursive_properties));
+    if let Some(query_result) = ctx.viewer_context.query_results.get(space_view_id) {
+        if let Some(data_result) = query_result
+            .tree
+            .lookup_result_by_path(&instance_path.entity_path)
+        {
+            data_result.save_recursive_override_or_clear_if_redundant(
+                ctx.viewer_context,
+                &query_result.tree,
+                &re_types::blueprint::components::Visible(visible),
+            );
+        }
+    } else {
+        re_log::error!("No query available for space view {:?}", space_view_id);
     }
 }

--- a/crates/re_viewport/src/context_menu/actions/show_hide.rs
+++ b/crates/re_viewport/src/context_menu/actions/show_hide.rs
@@ -125,11 +125,7 @@ fn data_result_visible(
             query_result
                 .tree
                 .lookup_result_by_path(&instance_path.entity_path)
-                .map(|data_result| {
-                    data_result
-                        .recursive_properties()
-                        .map_or(true, |prop| prop.visible)
-                })
+                .map(|data_result| data_result.is_visible(ctx.viewer_context))
         })
         .flatten()
 }
@@ -145,12 +141,13 @@ fn set_data_result_visible(
         .tree
         .lookup_result_by_path(&instance_path.entity_path)
     {
-        let mut recursive_properties = data_result
-            .recursive_properties()
-            .cloned()
-            .unwrap_or_default();
-        recursive_properties.visible = visible;
+        // TODO:
+        // let mut recursive_properties = data_result
+        //     .recursive_properties()
+        //     .cloned()
+        //     .unwrap_or_default();
+        // recursive_properties.visible = visible;
 
-        data_result.save_recursive_override(ctx.viewer_context, Some(recursive_properties));
+        // data_result.save_recursive_override(ctx.viewer_context, Some(recursive_properties));
     }
 }

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -408,8 +408,7 @@ impl Viewport<'_, '_> {
         let is_item_hovered =
             ctx.selection_state().highlight_for_ui_element(&item) == HoverHighlight::Hovered;
 
-        let visible =
-            data_result_node.map_or(false, |n| n.data_result.accumulated_properties().visible);
+        let visible = data_result_node.map_or(false, |n| n.data_result.is_visible(ctx));
         let mut recursive_properties = data_result_node
             .and_then(|n| n.data_result.recursive_properties())
             .cloned()
@@ -442,12 +441,13 @@ impl Viewport<'_, '_> {
             .subdued(subdued)
             .force_hovered(is_item_hovered)
             .with_buttons(|re_ui: &_, ui: &mut egui::Ui| {
-                let vis_response = visibility_button_ui(
-                    re_ui,
-                    ui,
-                    space_view_visible,
-                    &mut recursive_properties.visible,
-                );
+                // TODO:
+                // let vis_response = visibility_button_ui(
+                //     re_ui,
+                //     ui,
+                //     space_view_visible,
+                //     &mut recursive_properties.visible,
+                // );
 
                 let response = remove_button_ui(
                     re_ui,
@@ -461,7 +461,7 @@ impl Viewport<'_, '_> {
                     );
                 }
 
-                response | vis_response
+                response // | vis_response // TODO:
             });
 
         // If there's any children on the data result nodes, show them, otherwise we're good with this list item as is.

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -6,6 +6,7 @@ use re_entity_db::InstancePath;
 use re_log_types::EntityPath;
 use re_log_types::EntityPathRule;
 use re_space_view::{SpaceViewBlueprint, SpaceViewName};
+use re_types::blueprint::components::Visible;
 use re_ui::{drag_and_drop::DropTarget, list_item::ListItem, ReUi};
 use re_viewer_context::{CollapseScope, DataResultTree};
 use re_viewer_context::{
@@ -409,10 +410,6 @@ impl Viewport<'_, '_> {
             ctx.selection_state().highlight_for_ui_element(&item) == HoverHighlight::Hovered;
 
         let visible = data_result_node.map_or(false, |n| n.data_result.is_visible(ctx));
-        let mut recursive_properties = data_result_node
-            .and_then(|n| n.data_result.recursive_properties())
-            .cloned()
-            .unwrap_or_default();
 
         let item_label = if entity_path.is_root() {
             "/ (root)".to_owned()
@@ -441,13 +438,20 @@ impl Viewport<'_, '_> {
             .subdued(subdued)
             .force_hovered(is_item_hovered)
             .with_buttons(|re_ui: &_, ui: &mut egui::Ui| {
-                // TODO:
-                // let vis_response = visibility_button_ui(
-                //     re_ui,
-                //     ui,
-                //     space_view_visible,
-                //     &mut recursive_properties.visible,
-                // );
+                let mut visible_after = visible;
+                let vis_response =
+                    visibility_button_ui(re_ui, ui, space_view_visible, &mut visible_after);
+                if visible_after != visible {
+                    if let Some(data_result_node) = data_result_node {
+                        data_result_node
+                            .data_result
+                            .save_recursive_override_or_clear_if_redundant(
+                                ctx,
+                                &query_result.tree,
+                                &Visible(visible_after),
+                            );
+                    }
+                }
 
                 let response = remove_button_ui(
                     re_ui,
@@ -461,7 +465,7 @@ impl Viewport<'_, '_> {
                     );
                 }
 
-                response // | vis_response // TODO:
+                response | vis_response
             });
 
         // If there's any children on the data result nodes, show them, otherwise we're good with this list item as is.
@@ -471,7 +475,7 @@ impl Viewport<'_, '_> {
             let default_open = entity_path.starts_with(&space_view.space_origin)
                 && Self::default_open_for_data_result(node);
 
-            let response = list_item
+            list_item
                 .show_collapsing(
                     ui,
                     CollapseScope::BlueprintTree
@@ -504,12 +508,7 @@ impl Viewport<'_, '_> {
                         }
                     },
                 )
-                .item_response;
-
-            node.data_result
-                .save_recursive_override(ctx, Some(recursive_properties));
-
-            response
+                .item_response
         } else {
             list_item.show(ui)
         };

--- a/examples/rust/custom_space_view/src/color_coordinates_visualizer_system.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_visualizer_system.rs
@@ -54,7 +54,7 @@ impl VisualizerSystem for InstanceColorSystem {
         _view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         // For each entity in the space view that should be displayed with the `InstanceColorSystem`…
-        for data_result in query.iter_visible_data_results(Self::identifier()) {
+        for data_result in query.iter_visible_data_results(ctx, Self::identifier()) {
             // …gather all colors and their instance ids.
             if let Ok(arch_view) = query_archetype::<ColorArchetype>(
                 ctx.entity_db.store(),


### PR DESCRIPTION
### What

* Fixes #5464
    * using the design we agreed upon that doesn't use tristate buttons in the blueprint panel
* Next step on #5463
* Fixes #5396
* Fixes #3194 

The title describes the main effect this has on what Rerun can do compared to the previous release. But the real star of the show is that visible is now a component, not part of `EntityProperties`.

@ reviewer: Please take your time and explore the behavior both on blueprint panel and selection panel, there's a surprising amount of nuance in here.
For instance there's extra logic for allowing you to go back to a clean slate with ui interactions - for instance hiding & unhiding an item that doesn't receive any parent overrides will remove the visibility override completely as the default value for visibility is 'true'.


You can now hide/show under a shown/hidden parent tree:

https://github.com/rerun-io/rerun/assets/1220815/f412cac5-2db6-43d0-9b02-d2269cb60824

We're able to keep track of where an override comes from, this is exposed in the selection panels' tooltip:
![image](https://github.com/rerun-io/rerun/assets/1220815/ef7794ac-07c8-4930-ba92-11a45f91f6fe)



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5508/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5508/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5508/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5508)
- [Docs preview](https://rerun.io/preview/a09f77a2233fd101a4c5a94703f7726a920a18c6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a09f77a2233fd101a4c5a94703f7726a920a18c6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)