### PR TITLE
Convert the SpaceViewArchetype to use QueryExpression as a batch

### DIFF
--- a/crates/re_space_view/src/space_view_contents.rs
+++ b/crates/re_space_view/src/space_view_contents.rs
@@ -112,7 +112,9 @@ impl SpaceViewContents {
             Default::default()
         });
 
-        let entity_path_filter = EntityPathFilter::parse_forgiving(query.0.as_str());
+        let query = query.iter().map(|qe| qe.0.as_str());
+
+        let entity_path_filter = EntityPathFilter::from_query_expressions(query);
 
         Self {
             blueprint_entity_path,
@@ -130,7 +132,9 @@ impl SpaceViewContents {
     pub fn save_to_blueprint_store(&self, ctx: &ViewerContext<'_>) {
         ctx.save_blueprint_archetype(
             self.blueprint_entity_path.clone(),
-            &blueprint_archetypes::SpaceViewContents::new(self.entity_path_filter.formatted()),
+            &blueprint_archetypes::SpaceViewContents::new(
+                self.entity_path_filter.iter_expressions(),
+            ),
         );
     }
 
@@ -145,7 +149,10 @@ impl SpaceViewContents {
 
         ctx.save_blueprint_component(
             &self.blueprint_entity_path,
-            &QueryExpression(new_entity_path_filter.formatted().into()),
+            &new_entity_path_filter
+                .iter_expressions()
+                .map(|s| QueryExpression(s.into()))
+                .collect::<Vec<_>>(),
         );
     }
 

--- a/crates/re_types/definitions/rerun/blueprint/archetypes/space_view_contents.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/archetypes/space_view_contents.fbs
@@ -26,7 +26,7 @@ namespace rerun.blueprint.archetypes;
 /// Other uses of `*` are not (yet) supported.
 ///
 /// Internally, `EntityPathFilter` sorts the rule by entity path, with recursive coming before non-recursive.
-/// This means the last matching rule is also the most specific one.  For instance:
+/// This means the last matching rule is also the most specific one. For instance:
 /// ```diff
 /// + /world/**
 /// - /world

--- a/crates/re_types/definitions/rerun/blueprint/archetypes/space_view_contents.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/archetypes/space_view_contents.fbs
@@ -8,6 +8,38 @@ namespace rerun.blueprint.archetypes;
 // ---
 
 /// The contents of a `SpaceView`.
+///
+/// The contents are found by combining a collection of `QueryExpression`s.
+///
+/// ```diff
+/// + /world/**           # add everything…
+/// - /world/roads/**     # …but remove all roads…
+/// + /world/roads/main   # …but show main road
+/// ```
+///
+/// If there is multiple matching rules, the most specific rule wins.
+/// If there are multiple rules of the same specificity, the last one wins.
+/// If no rules match, the path is excluded.
+///
+/// The `/**` suffix matches the whole subtree, i.e. self and any child, recursively
+/// (`/world/**` matches both `/world` and `/world/car/driver`).
+/// Other uses of `*` are not (yet) supported.
+///
+/// Internally, `EntityPathFilter` sorts the rule by entity path, with recursive coming before non-recursive.
+/// This means the last matching rule is also the most specific one.  For instance:
+/// ```diff
+/// + /world/**
+/// - /world
+/// - /world/car/**
+/// + /world/car/driver
+/// ```
+///
+/// The last rule matching `/world/car/driver` is `+ /world/car/driver`, so it is included.
+/// The last rule matching `/world/car/hood` is `- /world/car/**`, so it is excluded.
+/// The last rule matching `/world` is `- /world`, so it is excluded.
+/// The last rule matching `/world/house` is `+ /world/**`, so it is included.
+///
+/// Unstable. Used for the ongoing blueprint experimentations.
 table SpaceViewContents (
     "attr.rerun.scope": "blueprint",
     "attr.rust.derive": "Default"
@@ -17,5 +49,5 @@ table SpaceViewContents (
     /// The `QueryExpression` that populates the contents for the `SpaceView`.
     ///
     /// They determine which entities are part of the spaceview.
-    query: rerun.blueprint.components.QueryExpression ("attr.rerun.component_required", order: 1000);
+    query: [rerun.blueprint.components.QueryExpression] ("attr.rerun.component_required", order: 1000);
 }

--- a/crates/re_types/definitions/rerun/blueprint/components/query_expression.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/query_expression.fbs
@@ -8,39 +8,16 @@ include "rerun/attributes.fbs";
 namespace rerun.blueprint.components;
 
 // ---
-/// A way to filter a set of `EntityPath`s.
+/// An individual `QueryExpression` used to filter a set of `EntityPath`s.
 ///
-/// This implements as simple set of include/exclude rules:
+/// Each expression is either an inclusion or an exclusion expression.
+/// Inclusions start with an optional `+` and exclusions must start with a `-`.
 ///
-/// ```diff
-/// + /world/**           # add everything…
-/// - /world/roads/**     # …but remove all roads…
-/// + /world/roads/main   # …but show main road
-/// ```
-///
-/// If there is multiple matching rules, the most specific rule wins.
-/// If there are multiple rules of the same specificity, the last one wins.
-/// If no rules match, the path is excluded.
+/// Multiple expressions are combined together as part of `SpaceViewContents`.
 ///
 /// The `/**` suffix matches the whole subtree, i.e. self and any child, recursively
 /// (`/world/**` matches both `/world` and `/world/car/driver`).
 /// Other uses of `*` are not (yet) supported.
-///
-/// Internally, `EntityPathFilter` sorts the rule by entity path, with recursive coming before non-recursive.
-/// This means the last matching rule is also the most specific one.
-/// For instance:
-///
-/// ```diff
-/// + /world/**
-/// - /world
-/// - /world/car/**
-/// + /world/car/driver
-/// ```
-///
-/// The last rule matching `/world/car/driver` is `+ /world/car/driver`, so it is included.
-/// The last rule matching `/world/car/hood` is `- /world/car/**`, so it is excluded.
-/// The last rule matching `/world` is `- /world`, so it is excluded.
-/// The last rule matching `/world/house` is `+ /world/**`, so it is included.
 ///
 /// Unstable. Used for the ongoing blueprint experimentations.
 table QueryExpression (

--- a/crates/re_types/src/blueprint/archetypes/space_view_contents.rs
+++ b/crates/re_types/src/blueprint/archetypes/space_view_contents.rs
@@ -40,7 +40,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// Other uses of `*` are not (yet) supported.
 ///
 /// Internally, `EntityPathFilter` sorts the rule by entity path, with recursive coming before non-recursive.
-/// This means the last matching rule is also the most specific one.  For instance:
+/// This means the last matching rule is also the most specific one. For instance:
 /// ```diff
 /// + /world/**
 /// - /world

--- a/crates/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/re_types/src/blueprint/components/query_expression.rs
@@ -21,39 +21,16 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Component**: A way to filter a set of `EntityPath`s.
+/// **Component**: An individual `QueryExpression` used to filter a set of `EntityPath`s.
 ///
-/// This implements as simple set of include/exclude rules:
+/// Each expression is either an inclusion or an exclusion expression.
+/// Inclusions start with an optional `+` and exclusions must start with a `-`.
 ///
-/// ```diff
-/// + /world/**           # add everything…
-/// - /world/roads/**     # …but remove all roads…
-/// + /world/roads/main   # …but show main road
-/// ```
-///
-/// If there is multiple matching rules, the most specific rule wins.
-/// If there are multiple rules of the same specificity, the last one wins.
-/// If no rules match, the path is excluded.
+/// Multiple expressions are combined together as part of `SpaceViewContents`.
 ///
 /// The `/**` suffix matches the whole subtree, i.e. self and any child, recursively
 /// (`/world/**` matches both `/world` and `/world/car/driver`).
 /// Other uses of `*` are not (yet) supported.
-///
-/// Internally, `EntityPathFilter` sorts the rule by entity path, with recursive coming before non-recursive.
-/// This means the last matching rule is also the most specific one.
-/// For instance:
-///
-/// ```diff
-/// + /world/**
-/// - /world
-/// - /world/car/**
-/// + /world/car/driver
-/// ```
-///
-/// The last rule matching `/world/car/driver` is `+ /world/car/driver`, so it is included.
-/// The last rule matching `/world/car/hood` is `- /world/car/**`, so it is excluded.
-/// The last rule matching `/world` is `- /world`, so it is excluded.
-/// The last rule matching `/world/house` is `+ /world/**`, so it is included.
 ///
 /// Unstable. Used for the ongoing blueprint experimentations.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]

--- a/rerun_cpp/src/rerun/blueprint/archetypes/space_view_contents.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/space_view_contents.hpp
@@ -33,7 +33,7 @@ namespace rerun::blueprint::archetypes {
     /// Other uses of `*` are not (yet) supported.
     ///
     /// Internally, `EntityPathFilter` sorts the rule by entity path, with recursive coming before non-recursive.
-    /// This means the last matching rule is also the most specific one.  For instance:
+    /// This means the last matching rule is also the most specific one. For instance:
     /// ```diff
     /// + /world/**
     /// - /world

--- a/rerun_cpp/src/rerun/blueprint/components/query_expression.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/query_expression.hpp
@@ -18,39 +18,16 @@ namespace arrow {
 } // namespace arrow
 
 namespace rerun::blueprint::components {
-    /// **Component**: A way to filter a set of `EntityPath`s.
+    /// **Component**: An individual `QueryExpression` used to filter a set of `EntityPath`s.
     ///
-    /// This implements as simple set of include/exclude rules:
+    /// Each expression is either an inclusion or an exclusion expression.
+    /// Inclusions start with an optional `+` and exclusions must start with a `-`.
     ///
-    /// ```diff
-    /// + /world/**           # add everything…
-    /// - /world/roads/**     # …but remove all roads…
-    /// + /world/roads/main   # …but show main road
-    /// ```
-    ///
-    /// If there is multiple matching rules, the most specific rule wins.
-    /// If there are multiple rules of the same specificity, the last one wins.
-    /// If no rules match, the path is excluded.
+    /// Multiple expressions are combined together as part of `SpaceViewContents`.
     ///
     /// The `/**` suffix matches the whole subtree, i.e. self and any child, recursively
     /// (`/world/**` matches both `/world` and `/world/car/driver`).
     /// Other uses of `*` are not (yet) supported.
-    ///
-    /// Internally, `EntityPathFilter` sorts the rule by entity path, with recursive coming before non-recursive.
-    /// This means the last matching rule is also the most specific one.
-    /// For instance:
-    ///
-    /// ```diff
-    /// + /world/**
-    /// - /world
-    /// - /world/car/**
-    /// + /world/car/driver
-    /// ```
-    ///
-    /// The last rule matching `/world/car/driver` is `+ /world/car/driver`, so it is included.
-    /// The last rule matching `/world/car/hood` is `- /world/car/**`, so it is excluded.
-    /// The last rule matching `/world` is `- /world`, so it is excluded.
-    /// The last rule matching `/world/house` is `+ /world/**`, so it is included.
     ///
     /// Unstable. Used for the ongoing blueprint experimentations.
     struct QueryExpression {

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 import itertools
 import uuid
-from typing import Iterable, Optional, Sequence, Union
+from typing import Iterable, Optional, Union
 
 import rerun_bindings as bindings
 
-from ..datatypes import EntityPathLike, Utf8Like
+from ..datatypes import EntityPathLike, Utf8ArrayLike, Utf8Like
 from ..recording import MemoryRecording
 from ..recording_stream import RecordingStream
 from .archetypes import ContainerBlueprint, PanelBlueprint, SpaceViewBlueprint, SpaceViewContents, ViewportBlueprint
 from .components import ColumnShareArrayLike, RowShareArrayLike
 from .components.container_kind import ContainerKindLike
 
-SpaceViewContentsLike = Union[str, Sequence[str], Utf8Like, SpaceViewContents]
+SpaceViewContentsLike = Union[Utf8ArrayLike, SpaceViewContents]
 
 
 class SpaceView:
@@ -80,21 +80,11 @@ class SpaceView:
 
     def _log_to_stream(self, stream: RecordingStream) -> None:
         """Internal method to convert to an archetype and log to the stream."""
-        # Handle the cases for SpaceViewContentsLike
-        # TODO(#5483): Move this into a QueryExpressionExt class.
-        # This is a little bit tricky since QueryExpression is a delegating component for Utf8,
-        # and delegating components make extending things in this way a bit more complicated.
-        if isinstance(self.contents, str):
-            # str
-            contents = SpaceViewContents(query=self.contents)
-        elif isinstance(self.contents, Sequence) and len(self.contents) > 0 and isinstance(self.contents[0], str):
-            # list[str]
-            contents = SpaceViewContents(query="\n".join(self.contents))
-        elif isinstance(self.contents, SpaceViewContents):
-            # SpaceViewContents
+        if isinstance(self.contents, SpaceViewContents):
+            # If contents is already a SpaceViewContents, we can just use it directly
             contents = self.contents
         else:
-            # Anything else we let SpaceViewContents handle
+            # Otherwise we delegate to the SpaceViewContents constructor
             contents = SpaceViewContents(query=self.contents)  # type: ignore[arg-type]
 
         stream.log(self.blueprint_path() + "/SpaceViewContents", contents)  # type: ignore[attr-defined]

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_contents.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_contents.py
@@ -39,7 +39,7 @@ class SpaceViewContents(Archetype):
     Other uses of `*` are not (yet) supported.
 
     Internally, `EntityPathFilter` sorts the rule by entity path, with recursive coming before non-recursive.
-    This means the last matching rule is also the most specific one.  For instance:
+    This means the last matching rule is also the most specific one. For instance:
     ```diff
     + /world/**
     - /world

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_contents.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_contents.py
@@ -19,9 +19,43 @@ __all__ = ["SpaceViewContents"]
 
 @define(str=False, repr=False, init=False)
 class SpaceViewContents(Archetype):
-    """**Archetype**: The contents of a `SpaceView`."""
+    """
+    **Archetype**: The contents of a `SpaceView`.
 
-    def __init__(self: Any, query: datatypes.Utf8Like):
+    The contents are found by combining a collection of `QueryExpression`s.
+
+    ```diff
+    + /world/**           # add everything…
+    - /world/roads/**     # …but remove all roads…
+    + /world/roads/main   # …but show main road
+    ```
+
+    If there is multiple matching rules, the most specific rule wins.
+    If there are multiple rules of the same specificity, the last one wins.
+    If no rules match, the path is excluded.
+
+    The `/**` suffix matches the whole subtree, i.e. self and any child, recursively
+    (`/world/**` matches both `/world` and `/world/car/driver`).
+    Other uses of `*` are not (yet) supported.
+
+    Internally, `EntityPathFilter` sorts the rule by entity path, with recursive coming before non-recursive.
+    This means the last matching rule is also the most specific one.  For instance:
+    ```diff
+    + /world/**
+    - /world
+    - /world/car/**
+    + /world/car/driver
+    ```
+
+    The last rule matching `/world/car/driver` is `+ /world/car/driver`, so it is included.
+    The last rule matching `/world/car/hood` is `- /world/car/**`, so it is excluded.
+    The last rule matching `/world` is `- /world`, so it is excluded.
+    The last rule matching `/world/house` is `+ /world/**`, so it is included.
+
+    Unstable. Used for the ongoing blueprint experimentations.
+    """
+
+    def __init__(self: Any, query: datatypes.Utf8ArrayLike):
         """
         Create a new instance of the SpaceViewContents archetype.
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/query_expression.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/query_expression.py
@@ -13,39 +13,16 @@ __all__ = ["QueryExpression", "QueryExpressionBatch", "QueryExpressionType"]
 
 class QueryExpression(datatypes.Utf8):
     """
-    **Component**: A way to filter a set of `EntityPath`s.
+    **Component**: An individual `QueryExpression` used to filter a set of `EntityPath`s.
 
-    This implements as simple set of include/exclude rules:
+    Each expression is either an inclusion or an exclusion expression.
+    Inclusions start with an optional `+` and exclusions must start with a `-`.
 
-    ```diff
-    + /world/**           # add everything…
-    - /world/roads/**     # …but remove all roads…
-    + /world/roads/main   # …but show main road
-    ```
-
-    If there is multiple matching rules, the most specific rule wins.
-    If there are multiple rules of the same specificity, the last one wins.
-    If no rules match, the path is excluded.
+    Multiple expressions are combined together as part of `SpaceViewContents`.
 
     The `/**` suffix matches the whole subtree, i.e. self and any child, recursively
     (`/world/**` matches both `/world` and `/world/car/driver`).
     Other uses of `*` are not (yet) supported.
-
-    Internally, `EntityPathFilter` sorts the rule by entity path, with recursive coming before non-recursive.
-    This means the last matching rule is also the most specific one.
-    For instance:
-
-    ```diff
-    + /world/**
-    - /world
-    - /world/car/**
-    + /world/car/driver
-    ```
-
-    The last rule matching `/world/car/driver` is `+ /world/car/driver`, so it is included.
-    The last rule matching `/world/car/hood` is `- /world/car/**`, so it is excluded.
-    The last rule matching `/world` is `- /world`, so it is excluded.
-    The last rule matching `/world/house` is `+ /world/**`, so it is included.
 
     Unstable. Used for the ongoing blueprint experimentations.
     """

--- a/rerun_py/tests/unit/test_space_view_contents.py
+++ b/rerun_py/tests/unit/test_space_view_contents.py
@@ -5,11 +5,20 @@ from typing import cast
 
 from rerun.blueprint.archetypes.space_view_contents import SpaceViewContents
 from rerun.blueprint.components.query_expression import QueryExpression, QueryExpressionBatch
-from rerun.datatypes.utf8 import Utf8Like
+from rerun.datatypes.utf8 import Utf8ArrayLike
 
 
 def test_space_view_contents() -> None:
-    query_array = ["+ /**\n- /robot", QueryExpression("+ /**\n- /robot")]
+    query_array = [
+        [
+            "+ /**",
+            "- /robot",
+        ],
+        [
+            QueryExpression("+ /**"),
+            QueryExpression("- /robot"),
+        ],
+    ]
 
     all_arrays = itertools.zip_longest(
         query_array,
@@ -19,7 +28,7 @@ def test_space_view_contents() -> None:
         # query = query if query is not None else query_array[-1]
 
         # mypy can't track types properly through itertools zip so re-cast
-        query = cast(Utf8Like, query)
+        query = cast(Utf8ArrayLike, query)
 
         print(
             "rr.SpaceViewContents(\n",
@@ -29,7 +38,6 @@ def test_space_view_contents() -> None:
         arch = SpaceViewContents(
             query,
         )
-        print(f"{arch}\n")
 
         # Equality checks on some of these are a bit silly, but at least they test out that the serialization code runs without problems.
-        assert arch.query == QueryExpressionBatch("+ /**\n- /robot")
+        assert arch.query == QueryExpressionBatch(["+ /**", "- /robot"])


### PR DESCRIPTION
### What
Working with lists of query expressions is generally much more ergonomic than wrangling newline separated strings in the blueprint APIs.

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
