### PR TITLE
Introduce basic support for $origin substitution in EntityPathFilter

### DIFF
--- a/crates/re_log_types/src/path/entity_path_filter.rs
+++ b/crates/re_log_types/src/path/entity_path_filter.rs
@@ -537,7 +537,9 @@ mod tests {
 
     #[test]
     fn test_entity_path_filter_subs() {
-        let subst_env = EntityPathSubs::new_with_origin(&EntityPath::from("/world"));
+        // Make sure we use a string longer than `$origin` here.
+        // We can't do in-place substitution.
+        let subst_env = EntityPathSubs::new_with_origin(&EntityPath::from("/annoyingly/long/path"));
 
         let filter = EntityPathFilter::parse_forgiving(
             r#"
@@ -551,12 +553,18 @@ mod tests {
 
         for (path, expected_effect) in [
             ("/unworldly", None),
-            ("/world", Some(RuleEffect::Exclude)),
-            ("/world/house", Some(RuleEffect::Include)),
-            ("/world/car", Some(RuleEffect::Exclude)),
-            ("/world/car/hood", Some(RuleEffect::Exclude)),
-            ("/world/car/driver", Some(RuleEffect::Include)),
-            ("/world/car/driver/head", Some(RuleEffect::Exclude)),
+            ("/annoyingly/long/path", Some(RuleEffect::Exclude)),
+            ("/annoyingly/long/path/house", Some(RuleEffect::Include)),
+            ("/annoyingly/long/path/car", Some(RuleEffect::Exclude)),
+            ("/annoyingly/long/path/car/hood", Some(RuleEffect::Exclude)),
+            (
+                "/annoyingly/long/path/car/driver",
+                Some(RuleEffect::Include),
+            ),
+            (
+                "/annoyingly/long/path/car/driver/head",
+                Some(RuleEffect::Exclude),
+            ),
         ] {
             assert_eq!(
                 filter.most_specific_match(&EntityPath::from(path)),

--- a/crates/re_log_types/src/path/mod.rs
+++ b/crates/re_log_types/src/path/mod.rs
@@ -14,7 +14,7 @@ mod parse_path;
 pub use component_path::ComponentPath;
 pub use data_path::DataPath;
 pub use entity_path::{EntityPath, EntityPathHash};
-pub use entity_path_filter::{EntityPathFilter, EntityPathRule, RuleEffect};
+pub use entity_path_filter::{EntityPathFilter, EntityPathRule, EntityPathSubs, RuleEffect};
 pub use entity_path_part::EntityPathPart;
 pub use parse_path::PathParseError;
 

--- a/crates/re_space_view/src/heuristics.rs
+++ b/crates/re_space_view/src/heuristics.rs
@@ -1,4 +1,3 @@
-use re_log_types::EntityPathFilter;
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, RecommendedSpaceView, SpaceViewClass,
     SpaceViewSpawnHeuristics, ViewerContext, VisualizerSystem,
@@ -44,10 +43,7 @@ where
             {
                 None
             } else {
-                Some(RecommendedSpaceView {
-                    root: entity.clone(),
-                    query_filter: EntityPathFilter::single_entity_filter(entity),
-                })
+                Some(RecommendedSpaceView::new_single_entity(entity.clone()))
             }
         })
         .collect();

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -165,8 +165,15 @@ impl SpaceViewBlueprint {
         let class_identifier: SpaceViewClassIdentifier = class_identifier.0.as_str().into();
         let display_name = display_name.map(|v| v.0.to_string());
 
-        let content =
-            SpaceViewContents::from_db_or_default(id, blueprint_db, query, class_identifier);
+        let space_env = std::iter::once(("origin".to_owned(), space_origin.to_string())).collect();
+
+        let content = SpaceViewContents::from_db_or_default(
+            id,
+            blueprint_db,
+            query,
+            class_identifier,
+            &space_env,
+        );
         let visible = visible.map_or(true, |v| v.0);
 
         Some(Self {
@@ -487,6 +494,8 @@ mod tests {
 
     #[test]
     fn test_entity_properties() {
+        let space_env = Default::default();
+
         let space_view_class_registry = SpaceViewClassRegistry::default();
         let mut recording = EntityDb::new(StoreId::random(re_log_types::StoreKind::Recording));
         let mut blueprint = EntityDb::new(StoreId::random(re_log_types::StoreKind::Blueprint));
@@ -512,6 +521,7 @@ mod tests {
                     + parent/skip/child1
                     + parent/skip/child2
                 ",
+                &space_env,
             ),
         );
 
@@ -779,6 +789,8 @@ mod tests {
 
     #[test]
     fn test_component_overrides() {
+        let space_env = Default::default();
+
         let space_view_class_registry = SpaceViewClassRegistry::default();
         let mut recording = EntityDb::new(StoreId::random(re_log_types::StoreKind::Recording));
         let mut visualizable_entities_per_visualizer =
@@ -813,7 +825,7 @@ mod tests {
         let space_view = SpaceViewBlueprint::new(
             "3D".into(),
             &EntityPath::root(),
-            EntityPathFilter::parse_forgiving("+ /**"),
+            EntityPathFilter::parse_forgiving("+ /**", &space_env),
         );
         let individual_override_root = space_view
             .contents

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -4,7 +4,7 @@ use re_entity_db::{EntityDb, EntityPath, EntityProperties, VisibleHistory};
 use re_entity_db::{EntityPropertiesComponent, EntityPropertyMap};
 
 use crate::SpaceViewContents;
-use re_log_types::{DataRow, RowId};
+use re_log_types::{DataRow, EntityPathSubs, RowId};
 use re_query::query_archetype;
 use re_types::blueprint::archetypes as blueprint_archetypes;
 use re_types::{
@@ -165,7 +165,7 @@ impl SpaceViewBlueprint {
         let class_identifier: SpaceViewClassIdentifier = class_identifier.0.as_str().into();
         let display_name = display_name.map(|v| v.0.to_string());
 
-        let space_env = std::iter::once(("origin".to_owned(), space_origin.to_string())).collect();
+        let space_env = EntityPathSubs::new_with_origin(&space_origin);
 
         let content = SpaceViewContents::from_db_or_default(
             id,

--- a/crates/re_space_view/src/space_view_contents.rs
+++ b/crates/re_space_view/src/space_view_contents.rs
@@ -6,7 +6,9 @@ use re_entity_db::{
     external::re_data_store::LatestAtQuery, EntityDb, EntityProperties, EntityPropertiesComponent,
     EntityPropertyMap, EntityTree,
 };
-use re_log_types::{path::RuleEffect, EntityPath, EntityPathFilter, EntityPathRule};
+use re_log_types::{
+    path::RuleEffect, EntityPath, EntityPathFilter, EntityPathRule, EntityPathSubs,
+};
 use re_types::{
     blueprint::{archetypes as blueprint_archetypes, components::QueryExpression},
     Archetype as _,
@@ -97,7 +99,7 @@ impl SpaceViewContents {
         blueprint_db: &EntityDb,
         query: &LatestAtQuery,
         space_view_class_identifier: SpaceViewClassIdentifier,
-        space_env: &HashMap<String, String>,
+        space_env: &EntityPathSubs,
     ) -> Self {
         let (contents, blueprint_entity_path) = query_space_view_sub_archetype::<
             blueprint_archetypes::SpaceViewContents,

--- a/crates/re_space_view/src/space_view_contents.rs
+++ b/crates/re_space_view/src/space_view_contents.rs
@@ -97,6 +97,7 @@ impl SpaceViewContents {
         blueprint_db: &EntityDb,
         query: &LatestAtQuery,
         space_view_class_identifier: SpaceViewClassIdentifier,
+        space_env: &HashMap<String, String>,
     ) -> Self {
         let (contents, blueprint_entity_path) = query_space_view_sub_archetype::<
             blueprint_archetypes::SpaceViewContents,
@@ -114,7 +115,7 @@ impl SpaceViewContents {
 
         let query = query.iter().map(|qe| qe.0.as_str());
 
-        let entity_path_filter = EntityPathFilter::from_query_expressions(query);
+        let entity_path_filter = EntityPathFilter::from_query_expressions(query, space_env);
 
         Self {
             blueprint_entity_path,
@@ -596,6 +597,8 @@ mod tests {
 
     #[test]
     fn test_query_results() {
+        let space_env = Default::default();
+
         let mut recording = EntityDb::new(StoreId::random(re_log_types::StoreKind::Recording));
         let blueprint = EntityDb::new(StoreId::random(re_log_types::StoreKind::Blueprint));
 
@@ -729,7 +732,7 @@ mod tests {
             let contents = SpaceViewContents::new(
                 SpaceViewId::random(),
                 "3D".into(),
-                EntityPathFilter::parse_forgiving(filter),
+                EntityPathFilter::parse_forgiving(filter, &space_env),
             );
 
             let query_result =

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -2,7 +2,7 @@ use ahash::HashSet;
 use nohash_hasher::{IntMap, IntSet};
 
 use re_entity_db::{EntityDb, EntityProperties, EntityTree};
-use re_log_types::{EntityPath, EntityPathFilter};
+use re_log_types::EntityPath;
 use re_types::{
     archetypes::{DepthImage, Image},
     Archetype, ComponentName,
@@ -387,10 +387,9 @@ fn recommended_space_views_with_image_splits(
         // If the root also had a visualizable entity, give it its own space.
         // TODO(jleibs): Maybe merge this entity into each child
         if entities.contains(recommended_root) {
-            recommended.push(RecommendedSpaceView {
-                root: recommended_root.clone(),
-                query_filter: EntityPathFilter::single_entity_filter(recommended_root),
-            });
+            recommended.push(RecommendedSpaceView::new_single_entity(
+                recommended_root.clone(),
+            ));
         }
 
         // And then recurse into the children
@@ -413,9 +412,6 @@ fn recommended_space_views_with_image_splits(
         }
     } else {
         // Otherwise we can use the space as it is
-        recommended.push(RecommendedSpaceView {
-            root: recommended_root.clone(),
-            query_filter: EntityPathFilter::subtree_entity_filter(recommended_root),
-        });
+        recommended.push(RecommendedSpaceView::new_subtree(recommended_root.clone()));
     }
 }

--- a/crates/re_space_view_text_log/src/space_view_class.rs
+++ b/crates/re_space_view_text_log/src/space_view_class.rs
@@ -2,7 +2,7 @@ use re_entity_db::EntityProperties;
 use std::collections::BTreeMap;
 
 use re_data_ui::item_ui;
-use re_log_types::{EntityPath, EntityPathFilter, TimePoint, Timeline};
+use re_log_types::{EntityPath, TimePoint, Timeline};
 use re_types::components::TextLogLevel;
 use re_viewer_context::{
     level_to_rich_text, IdentifiedViewSystem as _, RecommendedSpaceView, SpaceViewClass,
@@ -91,10 +91,7 @@ impl SpaceViewClass for TextSpaceView {
             SpaceViewSpawnHeuristics::default()
         } else {
             SpaceViewSpawnHeuristics {
-                recommended_space_views: vec![RecommendedSpaceView {
-                    root: EntityPath::root(),
-                    query_filter: EntityPathFilter::subtree_entity_filter(&EntityPath::root()),
-                }],
+                recommended_space_views: vec![RecommendedSpaceView::root()],
             }
         }
     }

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -4,7 +4,7 @@ use egui_plot::{Legend, Line, Plot, PlotPoint, Points};
 
 use re_data_store::TimeType;
 use re_format::next_grid_tick_magnitude_ns;
-use re_log_types::{EntityPath, EntityPathFilter, TimeZone};
+use re_log_types::{EntityPath, TimeZone};
 use re_space_view::{controls, query_space_view_sub_archetype_or_default};
 use re_types::blueprint::components::Corner2D;
 use re_types::components::Range1D;
@@ -223,10 +223,7 @@ It can greatly improve performance (and readability) in such situations as it pr
                 .any(|(_, subtree)| indicated_entities.contains(&subtree.path))
         {
             return SpaceViewSpawnHeuristics {
-                recommended_space_views: vec![RecommendedSpaceView {
-                    root: EntityPath::root(),
-                    query_filter: EntityPathFilter::subtree_entity_filter(&EntityPath::root()),
-                }],
+                recommended_space_views: vec![RecommendedSpaceView::root()],
             };
         }
 
@@ -242,10 +239,7 @@ It can greatly improve performance (and readability) in such situations as it pr
             .into_iter()
             .map(|path_part| {
                 let entity = EntityPath::new(vec![path_part.clone()]);
-                RecommendedSpaceView {
-                    query_filter: EntityPathFilter::subtree_entity_filter(&entity),
-                    root: entity,
-                }
+                RecommendedSpaceView::new_subtree(entity)
             })
             .collect();
 

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -1058,7 +1058,7 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
     }
 
     // Apply the edit.
-    let new_filter = EntityPathFilter::parse_forgiving(&filter_string);
+    let new_filter = EntityPathFilter::parse_forgiving(&filter_string, &Default::default());
     if &new_filter == filter {
         None // no change
     } else {

--- a/crates/re_viewer_context/src/space_view/spawn_heuristics.rs
+++ b/crates/re_viewer_context/src/space_view/spawn_heuristics.rs
@@ -1,9 +1,9 @@
 use re_log_types::{EntityPath, EntityPathFilter};
 
 /// Properties of a space view that as recommended to be spawned by default via space view spawn heuristics.
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, Clone)]
 pub struct RecommendedSpaceView {
-    pub root: EntityPath,
+    pub origin: EntityPath,
     pub query_filter: EntityPathFilter,
 }
 
@@ -16,4 +16,30 @@ pub struct RecommendedSpaceView {
 pub struct SpaceViewSpawnHeuristics {
     /// The recommended space views to spawn
     pub recommended_space_views: Vec<RecommendedSpaceView>,
+}
+
+impl RecommendedSpaceView {
+    #[inline]
+    pub fn new<'a>(origin: EntityPath, expressions: impl IntoIterator<Item = &'a str>) -> Self {
+        let space_env = std::iter::once(("origin".to_owned(), origin.to_string())).collect();
+        Self {
+            origin,
+            query_filter: EntityPathFilter::from_query_expressions(expressions, &space_env),
+        }
+    }
+
+    #[inline]
+    pub fn new_subtree(origin: EntityPath) -> Self {
+        Self::new(origin, std::iter::once("$origin/**"))
+    }
+
+    #[inline]
+    pub fn new_single_entity(origin: EntityPath) -> Self {
+        Self::new(origin, std::iter::once("$origin"))
+    }
+
+    #[inline]
+    pub fn root() -> Self {
+        Self::new_subtree(EntityPath::root())
+    }
 }

--- a/crates/re_viewer_context/src/space_view/spawn_heuristics.rs
+++ b/crates/re_viewer_context/src/space_view/spawn_heuristics.rs
@@ -1,4 +1,4 @@
-use re_log_types::{EntityPath, EntityPathFilter};
+use re_log_types::{EntityPath, EntityPathFilter, EntityPathSubs};
 
 /// Properties of a space view that as recommended to be spawned by default via space view spawn heuristics.
 #[derive(Hash, Debug, Clone)]
@@ -21,7 +21,7 @@ pub struct SpaceViewSpawnHeuristics {
 impl RecommendedSpaceView {
     #[inline]
     pub fn new<'a>(origin: EntityPath, expressions: impl IntoIterator<Item = &'a str>) -> Self {
-        let space_env = std::iter::once(("origin".to_owned(), origin.to_string())).collect();
+        let space_env = EntityPathSubs::new_with_origin(&origin);
         Self {
             origin,
             query_filter: EntityPathFilter::from_query_expressions(expressions, &space_env),

--- a/crates/re_viewport/src/add_space_view_or_container_modal.rs
+++ b/crates/re_viewport/src/add_space_view_or_container_modal.rs
@@ -4,10 +4,9 @@ use itertools::Itertools;
 
 use crate::container::blueprint_id_to_tile_id;
 use crate::{icon_for_container_kind, ViewportBlueprint};
-use re_log_types::EntityPath;
 use re_space_view::SpaceViewBlueprint;
 use re_ui::ReUi;
-use re_viewer_context::{ContainerId, ViewerContext};
+use re_viewer_context::{ContainerId, RecommendedSpaceView, ViewerContext};
 
 #[derive(Default)]
 pub struct AddSpaceViewOrContainerModal {
@@ -112,9 +111,7 @@ fn modal_ui(
         .space_view_class_registry
         .iter_registry()
         .sorted_by_key(|entry| entry.class.display_name())
-        .map(|entry| {
-            SpaceViewBlueprint::new(entry.identifier, &EntityPath::root(), Default::default())
-        })
+        .map(|entry| SpaceViewBlueprint::new(entry.identifier, RecommendedSpaceView::root()))
     {
         let icon = space_view.class(ctx.space_view_class_registry).icon();
         let title = space_view

--- a/crates/re_viewport/src/context_menu/actions/add_entities_to_new_space_view.rs
+++ b/crates/re_viewport/src/context_menu/actions/add_entities_to_new_space_view.rs
@@ -4,7 +4,7 @@ use nohash_hasher::IntSet;
 
 use re_log_types::{EntityPath, EntityPathFilter, EntityPathRule, RuleEffect};
 use re_space_view::{determine_visualizable_entities, SpaceViewBlueprint};
-use re_viewer_context::{Item, SpaceViewClassIdentifier};
+use re_viewer_context::{Item, RecommendedSpaceView, SpaceViewClassIdentifier};
 
 use crate::context_menu::{ContextMenuAction, ContextMenuContext};
 
@@ -149,15 +149,20 @@ fn create_space_view_for_selected_entities(
 
     let mut filter = EntityPathFilter::default();
 
-    for path in entities_of_interest {
-        filter.add_rule(RuleEffect::Include, EntityPathRule::including_subtree(path));
-    }
-
     let target_container_id = ctx
         .clicked_item_enclosing_container_id_and_position()
         .map(|(id, _)| id);
 
-    let space_view = SpaceViewBlueprint::new(identifier, &origin, filter);
+    // TODO(jleibs): Take the `$origin` into account here
+    for path in entities_of_interest {
+        filter.add_rule(RuleEffect::Include, EntityPathRule::including_subtree(path));
+    }
+    let recommended = RecommendedSpaceView {
+        origin,
+        query_filter: filter,
+    };
+
+    let space_view = SpaceViewBlueprint::new(identifier, recommended);
 
     let new_space_view = ctx.viewport_blueprint.add_space_views(
         std::iter::once(space_view),

--- a/crates/re_viewport/src/context_menu/actions/add_entities_to_new_space_view.rs
+++ b/crates/re_viewport/src/context_menu/actions/add_entities_to_new_space_view.rs
@@ -153,7 +153,9 @@ fn create_space_view_for_selected_entities(
         .clicked_item_enclosing_container_id_and_position()
         .map(|(id, _)| id);
 
-    // TODO(jleibs): Take the `$origin` into account here
+    // Note that these entity paths will always be absolute, rather than
+    // relative to the origin. This makes sense since if you create a view and
+    // then change the origin you likely wanted those entities to still be there.
     for path in entities_of_interest {
         filter.add_rule(RuleEffect::Include, EntityPathRule::including_subtree(path));
     }

--- a/crates/re_viewport/src/context_menu/actions/add_space_view.rs
+++ b/crates/re_viewport/src/context_menu/actions/add_space_view.rs
@@ -1,6 +1,5 @@
-use re_log_types::{EntityPath, EntityPathFilter};
 use re_space_view::SpaceViewBlueprint;
-use re_viewer_context::{ContainerId, Item, SpaceViewClassIdentifier};
+use re_viewer_context::{ContainerId, Item, RecommendedSpaceView, SpaceViewClassIdentifier};
 
 use crate::context_menu::{ContextMenuAction, ContextMenuContext};
 
@@ -21,8 +20,7 @@ impl ContextMenuAction for AddSpaceViewAction {
     }
 
     fn process_container(&self, ctx: &ContextMenuContext<'_>, container_id: &ContainerId) {
-        let space_view =
-            SpaceViewBlueprint::new(self.0, &EntityPath::root(), EntityPathFilter::default());
+        let space_view = SpaceViewBlueprint::new(self.0, RecommendedSpaceView::root());
 
         ctx.viewport_blueprint.add_space_views(
             std::iter::once(space_view),

--- a/crates/re_viewport/src/space_view_heuristics.rs
+++ b/crates/re_viewport/src/space_view_heuristics.rs
@@ -16,13 +16,7 @@ pub fn default_created_space_views(ctx: &ViewerContext<'_>) -> Vec<SpaceViewBlue
             spawn_heuristics
                 .recommended_space_views
                 .into_iter()
-                .map(move |recommendation| {
-                    SpaceViewBlueprint::new(
-                        entry.identifier,
-                        &recommendation.root,
-                        recommendation.query_filter,
-                    )
-                })
+                .map(|recommendation| SpaceViewBlueprint::new(entry.identifier, recommendation))
         })
         .collect()
 }

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -364,11 +364,7 @@ impl ViewportBlueprint {
 
             self.add_space_views(
                 final_recommendations.map(|recommendation| {
-                    SpaceViewBlueprint::new(
-                        class_id,
-                        &recommendation.root,
-                        recommendation.query_filter.clone(),
-                    )
+                    SpaceViewBlueprint::new(class_id, recommendation.clone())
                 }),
                 ctx,
                 None,

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -14,7 +14,8 @@ import random
 from math import cos, sin, tau
 
 import numpy as np
-import rerun as rr  # pip install rerun-sdk
+import rerun as rr
+import rerun.blueprint as rrb
 
 DESCRIPTION = """
 # Plots
@@ -126,7 +127,22 @@ def main() -> None:
     rr.script_add_args(parser)
     args = parser.parse_args()
 
-    rr.script_setup(args, "rerun_example_plot")
+    blueprint = rrb.Blueprint(
+        rrb.Horizontal(
+            rrb.Grid(
+                rrb.BarChartView(name="Bar Chart", origin="/bar_chart"),
+                rrb.TimeSeriesView(name="Curves", origin="/curves"),
+                rrb.TimeSeriesView(name="Trig", origin="/trig"),
+                rrb.TimeSeriesView(name="Classification", origin="/classification"),
+            ),
+            rrb.TextDocumentView(name="Description", origin="/description"),
+            column_shares=[2, 1],
+        ),
+        rrb.SelectionPanel(expanded=False),
+        rrb.TimePanel(expanded=False),
+    )
+
+    rr.script_setup(args, "rerun_example_plot", blueprint=blueprint)
 
     rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
     log_bar_chart()

--- a/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
@@ -2,7 +2,7 @@ use re_viewer::external::{
     egui,
     re_data_ui::{item_ui, DataUi},
     re_entity_db::{EntityProperties, InstancePath},
-    re_log_types::{EntityPath, EntityPathFilter},
+    re_log_types::EntityPath,
     re_ui,
     re_viewer_context::{
         HoverHighlight, IdentifiedViewSystem as _, Item, RecommendedSpaceView, SelectionHighlight,
@@ -115,10 +115,7 @@ impl SpaceViewClass for ColorCoordinatesSpaceView {
             SpaceViewSpawnHeuristics::default()
         } else {
             SpaceViewSpawnHeuristics {
-                recommended_space_views: vec![RecommendedSpaceView {
-                    root: EntityPath::root(),
-                    query_filter: EntityPathFilter::subtree_entity_filter(&EntityPath::root()),
-                }],
+                recommended_space_views: vec![RecommendedSpaceView::root()],
             }
         }
     }

--- a/rerun_py/rerun_sdk/rerun/blueprint/space_views.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/space_views.py
@@ -8,7 +8,11 @@ class BarChartView(SpaceView):
     """A bar chart view."""
 
     def __init__(
-        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
+        self,
+        *,
+        origin: EntityPathLike = "/",
+        contents: SpaceViewContentsLike = "$origin/**",
+        name: Utf8Like | None = None,
     ):
         """
         Construct a blueprint for a new bar chart view.
@@ -33,7 +37,11 @@ class Spatial2DView(SpaceView):
     """A Spatial 2D view."""
 
     def __init__(
-        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
+        self,
+        *,
+        origin: EntityPathLike = "/",
+        contents: SpaceViewContentsLike = "$origin/**",
+        name: Utf8Like | None = None,
     ):
         """
         Construct a blueprint for a new spatial 2D view.
@@ -58,7 +66,11 @@ class Spatial3DView(SpaceView):
     """A Spatial 3D view."""
 
     def __init__(
-        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
+        self,
+        *,
+        origin: EntityPathLike = "/",
+        contents: SpaceViewContentsLike = "$origin/**",
+        name: Utf8Like | None = None,
     ):
         """
         Construct a blueprint for a new spatial 3D view.
@@ -83,7 +95,11 @@ class TensorView(SpaceView):
     """A tensor view."""
 
     def __init__(
-        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
+        self,
+        *,
+        origin: EntityPathLike = "/",
+        contents: SpaceViewContentsLike = "$origin/**",
+        name: Utf8Like | None = None,
     ):
         """
         Construct a blueprint for a new tensor view.
@@ -108,7 +124,11 @@ class TextDocumentView(SpaceView):
     """A text document view."""
 
     def __init__(
-        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
+        self,
+        *,
+        origin: EntityPathLike = "/",
+        contents: SpaceViewContentsLike = "$origin/**",
+        name: Utf8Like | None = None,
     ):
         """
         Construct a blueprint for a new text document view.
@@ -133,7 +153,11 @@ class TextLogView(SpaceView):
     """A text log view."""
 
     def __init__(
-        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
+        self,
+        *,
+        origin: EntityPathLike = "/",
+        contents: SpaceViewContentsLike = "$origin/**",
+        name: Utf8Like | None = None,
     ):
         """
         Construct a blueprint for a new text log view.
@@ -158,7 +182,11 @@ class TimeSeriesView(SpaceView):
     """A time series view."""
 
     def __init__(
-        self, *, origin: EntityPathLike = "/", contents: SpaceViewContentsLike = "/**", name: Utf8Like | None = None
+        self,
+        *,
+        origin: EntityPathLike = "/",
+        contents: SpaceViewContentsLike = "$origin/**",
+        name: Utf8Like | None = None,
     ):
         """
         Construct a blueprint for a new time series view.


### PR DESCRIPTION
### What
 - Initial implementation of: https://github.com/rerun-io/rerun/issues/5288
 - Builds on top of: https://github.com/rerun-io/rerun/pull/5516

This is a very dumb first stab at doing variable substitution.
 - Rather than parse the string to extract potential `$vars` it uses the input environment and blindly tries to substitute all the vars it knows about (currently only `origin`).
 - The biggest downside of this is we get no feedback when a variable fails to substitute.
 - There's just enough future complexity handling edge-cases (e.g. mismatched `{`, variable-termination, nested substitutions, etc.) that it might be worth pulling in a proper utility library, though I don't know if there's an obvious rust ecosystem choice here.

Working through this uncovered some complexities regarding what we store in different parts of the blueprint.  For example, if we do the full substitution immediately when construction the EntityPathFilter, then we can't use that Filter to re-create the query with the variable substitutions.

Additionally, we need to know about these substitutions all the way back when evaluating whether we want to keep RecommendedSpaceViews because we need the substitutions applied to do the overlap-checking.

I suspect the direction we might want to go in is to split EntityPathFilter into a non-substituted representation, from which we can create a version that executes the substitutions, but I'm not yet sure what the storage should look like.  For example, do we just create full `EntityPath`s that contain EntityPathParts with "$origin" in them and then run the substitution on the EntityPath?

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5517/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5517/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5517/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5517)
- [Docs preview](https://rerun.io/preview/82c517d5786790176b78fdfbff4a5e261a25f7f0/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/82c517d5786790176b78fdfbff4a5e261a25f7f0/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)