### PR TITLE
Add `workflow_dispatch` to reusable_build_and_upload_wheels.yml

### DIFF
--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -22,6 +22,41 @@ on:
         type: string
         default: ""
 
+  workflow_dispatch:
+    inputs:
+      PLATFORM:
+        type: choice
+        options:
+          - linux-arm64
+          - linux-x64
+          - windows-x64
+          - macos-arm64
+          - macos-x64
+        description: "Platform to build for"
+        required: true
+      MODE:
+        type: choice
+        required: false
+        options:
+          - pypi
+          - pr
+        description: "The build mode (`pypi` includes the web viewer, `pr` does not)"
+      CONCURRENCY:
+        required: false
+        type: string
+        default: "adhoc"
+        description: "Concurrency group to use"
+      WHEEL_ARTIFACT_NAME:
+        required: false
+        type: string
+        default: ""
+        description: "If set, will be saved under that name in the workflow artifacts"
+      RELEASE_COMMIT:
+        required: false
+        type: string
+        default: ""
+        description: "Release commit"
+
 concurrency:
   group: ${{ inputs.CONCURRENCY }}-build-wheels
   cancel-in-progress: true


### PR DESCRIPTION
### What

I need that to test https://github.com/rerun-io/rerun/pull/5511

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
