### PR TITLE
Activate blueprint as soon as it has finished transmitting

### DIFF
--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -16,6 +16,9 @@ impl DataUi for LogMsg {
         match self {
             LogMsg::SetStoreInfo(msg) => msg.data_ui(ctx, ui, verbosity, query, store),
             LogMsg::ArrowMsg(_, msg) => msg.data_ui(ctx, ui, verbosity, query, store),
+            LogMsg::ActivateStore(store_id) => {
+                ui.label(format!("ActivateStore({store_id})"));
+            }
         }
     }
 }

--- a/crates/re_entity_db/src/entity_db.rs
+++ b/crates/re_entity_db/src/entity_db.rs
@@ -273,6 +273,10 @@ impl EntityDb {
                 let table = DataTable::from_arrow_msg(arrow_msg)?;
                 self.add_data_table(table)?;
             }
+
+            LogMsg::ActivateStore(_) => {
+                // Not for us to handle
+            }
         }
 
         Ok(())

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -218,13 +218,20 @@ pub enum LogMsg {
 
     /// Log an entity using an [`ArrowMsg`].
     ArrowMsg(StoreId, ArrowMsg),
+
+    /// Send after all messages in a blueprint to signal that the blueprint is complete.
+    ///
+    /// This is so that the viewer can wait with activating the blueprint until it is
+    /// fully transmitted. Showing a half-transmitted blueprint can cause confusion,
+    /// and also lead to problems with space-view heuristics.
+    ActivateStore(StoreId),
 }
 
 impl LogMsg {
     pub fn store_id(&self) -> &StoreId {
         match self {
             Self::SetStoreInfo(msg) => &msg.info.store_id,
-            Self::ArrowMsg(store_id, _) => store_id,
+            Self::ArrowMsg(store_id, _) | Self::ActivateStore(store_id) => store_id,
         }
     }
 
@@ -233,7 +240,7 @@ impl LogMsg {
             LogMsg::SetStoreInfo(store_info) => {
                 store_info.info.store_id = new_store_id;
             }
-            LogMsg::ArrowMsg(msg_store_id, _) => {
+            LogMsg::ArrowMsg(msg_store_id, _) | LogMsg::ActivateStore(msg_store_id) => {
                 *msg_store_id = new_store_id;
             }
         }

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -249,7 +249,7 @@ impl CongestionManager {
         #[allow(clippy::match_same_arms)]
         match msg {
             // we don't want to drop any of these
-            LogMsg::SetStoreInfo(_) => true,
+            LogMsg::SetStoreInfo(_) | LogMsg::ActivateStore(_) => true,
 
             LogMsg::ArrowMsg(_, arrow_msg) => self.should_send_time_point(&arrow_msg.timepoint_max),
         }

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -948,6 +948,7 @@ impl App {
                         // In that case, we want to make it the default.
                         // We wait with activaing blueprints until they are fully loaded,
                         // so that we don't run heuristics on half-loaded blueprints.
+                        // This is a fallback in case `LogMsg::ActivateStore` isn't sent (for whatever reason).
 
                         let blueprints = store_hub
                             .entity_dbs_from_channel_source(&channel_source)
@@ -997,21 +998,45 @@ impl App {
                 re_log::error_once!("Failed to add incoming msg: {err}");
             };
 
-            // Set the recording-id after potentially creating the store in the hub.
-            // This ordering is important because the `StoreHub` internally
-            // updates the app-id when changing the recording.
-            if let LogMsg::SetStoreInfo(msg) = &msg {
-                match msg.info.store_id.kind {
-                    StoreKind::Recording => {
-                        re_log::debug!("Opening a new recording: {:?}", msg.info);
-                        store_hub.set_recording_id(store_id.clone());
+            match &msg {
+                LogMsg::SetStoreInfo(_) => {
+                    // Set the recording-id after potentially creating the store in the hub.
+                    // This ordering is important because the `StoreHub` internally
+                    // updates the app-id when changing the recording.
+                    match store_id.kind {
+                        StoreKind::Recording => {
+                            re_log::debug!("Opening a new recording: {store_id}");
+                            store_hub.set_recording_id(store_id.clone());
+                        }
+                        StoreKind::Blueprint => {
+                            // We wait with activaing blueprints until they are fully loaded,
+                            // so that we don't run heuristics on half-loaded blueprints.
+                            // TODO(#5297): heed special "end-of-blueprint" message to activate blueprint.
+                            // Otherwise on a mixed connection (SDK sending both blueprint and recording)
+                            // the blueprint won't be activated until the whole _recording_ has finished loading.
+                        }
                     }
-                    StoreKind::Blueprint => {
-                        // We wait with activaing blueprints until they are fully loaded,
-                        // so that we don't run heuristics on half-loaded blueprints.
-                        // TODO(#5297): heed special "end-of-blueprint" message to activate blueprint.
-                        // Otherwise on a mixed connection (SDK sending both blueprint and recording)
-                        // the blueprint won't be activated until the whole _recording_ has finished loading.
+                }
+
+                LogMsg::ArrowMsg(_, _) => {
+                    // Andled by EntityDb::add
+                }
+
+                LogMsg::ActivateStore(store_id) => {
+                    match store_id.kind {
+                        StoreKind::Recording => {
+                            re_log::debug!("Opening a new recording: {store_id}");
+                            store_hub.set_recording_id(store_id.clone());
+                        }
+                        StoreKind::Blueprint => {
+                            re_log::debug!("Activating newly loaded blueprint");
+                            if let Some(info) = entity_db.store_info() {
+                                let app_id = info.application_id.clone();
+                                store_hub.set_blueprint_for_app_id(store_id.clone(), app_id);
+                            } else {
+                                re_log::warn!("Got ActivateStore message without first receiving a SetStoreInfo");
+                            }
+                        }
                     }
                 }
             }

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -532,6 +532,7 @@ impl PrintCommand {
                     let SetStoreInfo { row_id: _, info } = msg;
                     println!("{info:#?}");
                 }
+
                 LogMsg::ArrowMsg(_row_id, arrow_msg) => {
                     let mut table =
                         DataTable::from_arrow_msg(&arrow_msg).context("Decode arrow message")?;
@@ -556,6 +557,10 @@ impl PrintCommand {
                             re_format::format_bytes(table.heap_size_bytes() as _),
                         );
                     }
+                }
+
+                LogMsg::ActivateStore(store_id) => {
+                    println!("ActivateStore({store_id})");
                 }
             }
         }


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5297

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5529/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5529/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5529/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5529)
- [Docs preview](https://rerun.io/preview/d2d0b7e00a7ad3c8ef5ced1744605977f302760c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d2d0b7e00a7ad3c8ef5ced1744605977f302760c/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)