### PR TITLE
Static data 2: static-aware Python SDK

### DIFF
--- a/crates/re_query_cache/tests/latest_at.rs
+++ b/crates/re_query_cache/tests/latest_at.rs
@@ -314,7 +314,7 @@ fn invalidation() {
 
 // Test the following scenario:
 // ```py
-// rr.log("points", rr.Points3D([1, 2, 3]), timeless=True)
+// rr.log("points", rr.Points3D([1, 2, 3]), static=True)
 //
 // # Do first query here: LatestAt(+inf)
 // # Expected: points=[[1,2,3]] colors=[]

--- a/crates/re_query_cache/tests/range.rs
+++ b/crates/re_query_cache/tests/range.rs
@@ -439,7 +439,7 @@ fn invalidation() {
 
 // Test the following scenario:
 // ```py
-// rr.log("points", rr.Points3D([1, 2, 3]), timeless=True)
+// rr.log("points", rr.Points3D([1, 2, 3]), static=True)
 //
 // # Do first query here: LatestAt(+inf)
 // # Expected: points=[[1,2,3]] colors=[]

--- a/docs/content/concepts/spaces-and-transforms.md
+++ b/docs/content/concepts/spaces-and-transforms.md
@@ -110,7 +110,7 @@ Note that none of the names in the paths are special.
 
 You can use [`rr.ViewCoordinates`](https://ref.rerun.io/docs/python/stable/common/archetypes/#rerun.archetypes.ViewCoordinates) to set your preferred view coordinate systems, giving semantic meaning to the XYZ axes of the space.
 
-For 3D spaces it can be used to log what the up-axis is in your coordinate system. This will help Rerun set a good default view of your 3D scene, as well as make the virtual eye interactions more natural. This can be done with `rr.log("world", rr.ViewCoordinates(up="+Z"), timeless=True)`.
+For 3D spaces it can be used to log what the up-axis is in your coordinate system. This will help Rerun set a good default view of your 3D scene, as well as make the virtual eye interactions more natural. This can be done with `rr.log("world", rr.ViewCoordinates(up="+Z"), static=True)`.
 
 You can also use this `log_view_coordinates` for pinhole entities, but it is encouraged that you instead use [`rr.log(…, rr.Pinhole(camera_xyz=…))`](https://ref.rerun.io/docs/python/stable/common/archetypes/#rerun.archetypes.Pinhole) for this. The default coordinate system for pinhole entities is `RDF` (X=Right, Y=Down, Z=Forward).
 

--- a/docs/content/concepts/timelines.md
+++ b/docs/content/concepts/timelines.md
@@ -31,7 +31,7 @@ An _event_ refer to an instance of logging one or more component batches to one 
 ## Timeless data
 
 The [`rr.log()`](https://ref.rerun.io/docs/python/stable/common/logging_functions/#rerun.log) function has a `timeless=False` default argument.
-If `timeless=True` is used instead, the entity become *timeless*. Timeless entities belong to all timelines (existing ones, and ones not yet created) and are shown leftmost in the time panel in the viewer.
+If `static=True` is used instead, the entity become *timeless*. Timeless entities belong to all timelines (existing ones, and ones not yet created) and are shown leftmost in the time panel in the viewer.
 This is useful for entities that aren't part of normal data capture, but set the scene for how they are shown.
 For instance, if you are logging cars on a street, perhaps you want to always show a street mesh as part of the scenery, and for that it makes sense for that data to be timeless.
 

--- a/docs/content/concepts/timelines.md
+++ b/docs/content/concepts/timelines.md
@@ -28,11 +28,11 @@ An _event_ refer to an instance of logging one or more component batches to one 
 </picture>
 
 
-## Timeless data
+## Static data
 
-The [`rr.log()`](https://ref.rerun.io/docs/python/stable/common/logging_functions/#rerun.log) function has a `timeless=False` default argument.
-If `static=True` is used instead, the entity become *timeless*. Timeless entities belong to all timelines (existing ones, and ones not yet created) and are shown leftmost in the time panel in the viewer.
-This is useful for entities that aren't part of normal data capture, but set the scene for how they are shown.
-For instance, if you are logging cars on a street, perhaps you want to always show a street mesh as part of the scenery, and for that it makes sense for that data to be timeless.
+The [`rr.log()`](https://ref.rerun.io/docs/python/stable/common/logging_functions/#rerun.log) function has a `static=False` default argument.
+If `static=True` is used instead, the data logged becomes *static*. Static data belongs to all timelines (existing ones, and ones not yet created) and shadows any temporal data of the same type on the same entity.
+This is useful for data that isn't part of normal data capture, but sets the scene for how it should be shown.
+For instance, if you are logging cars on a street, perhaps you want to always show a street mesh as part of the scenery, and for that it makes sense for that data to be static.
 
-Similarly, [coordinate systems](spaces-and-transforms.md) or [annotation context](annotation-context.md) are typically timeless.
+Similarly, [coordinate systems](spaces-and-transforms.md) or [annotation context](annotation-context.md) are typically static.

--- a/docs/content/howto/ros2-nav-turtlebot.md
+++ b/docs/content/howto/ros2-nav-turtlebot.md
@@ -421,7 +421,7 @@ def urdf_callback(self, urdf_msg: String) -> None:
     rerun_urdf.log_scene(scene=scaled,
                          node=urdf.base_link,
                          path="map/robot/urdf",
-                         timeless=True)
+                         static=True)
 ```
 
 Back in `rerun_urdf.log_scene` all the code is doing is recursively walking through

--- a/docs/content/reference/data-loaders/overview.md
+++ b/docs/content/reference/data-loaders/overview.md
@@ -62,9 +62,9 @@ When the viewer and/or SDK executes an external loader, it will pass to it a set
 
     Recommended prefix to prepend to all entity paths.
 
-* `--timeless` (optional)
+* `--static` (optional)
 
-    The data is expected to be logged timelessly.
+    The data is expected to be logged as static.
 
 * `--time <timeline1>=<time1> <timeline2>=<time2> …` (optional)
 

--- a/docs/snippets/all/annotation-context/example.py
+++ b/docs/snippets/all/annotation-context/example.py
@@ -9,7 +9,7 @@ rr.log(
             rr.AnnotationInfo(id=1, label="Person", color=(255, 0, 0)),
         ],
     ),
-    timeless=True,
+    static=True,
 )
 
 # Annotation context with simple keypoints & keypoint connections.
@@ -20,5 +20,5 @@ rr.log(
         keypoint_annotations=[rr.AnnotationInfo(id=i, color=(0, 255 / 9 * i, 0)) for i in range(10)],
         keypoint_connections=[(i, i + 1) for i in range(9)],
     ),
-    timeless=True,
+    static=True,
 )

--- a/docs/snippets/all/annotation_context_connections.py
+++ b/docs/snippets/all/annotation_context_connections.py
@@ -21,7 +21,7 @@ rr.log(
             )
         ]
     ),
-    timeless=True,
+    static=True,
 )
 
 rr.log(

--- a/docs/snippets/all/annotation_context_rects.py
+++ b/docs/snippets/all/annotation_context_rects.py
@@ -3,7 +3,7 @@ import rerun as rr
 rr.init("rerun_example_annotation_context_rects", spawn=True)
 
 # Log an annotation context to assign a label and color to each class
-rr.log("/", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), timeless=True)
+rr.log("/", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), static=True)
 
 # Log a batch of 2 rectangles with different `class_ids`
 rr.log("detections", rr.Boxes2D(mins=[[-2, -2], [0, 0]], sizes=[[3, 3], [2, 2]], class_ids=[1, 2]))

--- a/docs/snippets/all/annotation_context_segmentation.py
+++ b/docs/snippets/all/annotation_context_segmentation.py
@@ -11,6 +11,6 @@ image[50:100, 50:120] = 1
 image[100:180, 130:280] = 2
 
 # Log an annotation context to assign a label and color to each class
-rr.log("segmentation", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), timeless=True)
+rr.log("segmentation", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), static=True)
 
 rr.log("segmentation/image", rr.SegmentationImage(image))

--- a/docs/snippets/all/asset3d_out_of_tree.py
+++ b/docs/snippets/all/asset3d_out_of_tree.py
@@ -12,7 +12,7 @@ if len(sys.argv) < 2:
 
 rr.init("rerun_example_asset3d_out_of_tree", spawn=True)
 
-rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)  # Set an up-axis
+rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)  # Set an up-axis
 
 rr.set_time_sequence("frame", 0)
 rr.log("world/asset", rr.Asset3D(path=sys.argv[1]))

--- a/docs/snippets/all/asset3d_simple.py
+++ b/docs/snippets/all/asset3d_simple.py
@@ -9,5 +9,5 @@ if len(sys.argv) < 2:
 
 rr.init("rerun_example_asset3d", spawn=True)
 
-rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)  # Set an up-axis
+rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)  # Set an up-axis
 rr.log("world/asset", rr.Asset3D(path=sys.argv[1]))

--- a/docs/snippets/all/scalar_multiple_plots.py
+++ b/docs/snippets/all/scalar_multiple_plots.py
@@ -11,10 +11,10 @@ lcg_state = np.int64(0)
 # Set up plot styling:
 # They are logged timeless as they don't change over time and apply to all timelines.
 # Log two lines series under a shared root so that they show in the same plot by default.
-rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)"), timeless=True)
-rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)"), timeless=True)
+rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)"), static=True)
+rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)"), static=True)
 # Log scattered points under a different root so that they show in a different plot by default.
-rr.log("scatter/lcg", rr.SeriesPoint(), timeless=True)
+rr.log("scatter/lcg", rr.SeriesPoint(), static=True)
 
 # Log the data on a timeline called "step".
 for t in range(0, int(tau * 2 * 100.0)):

--- a/docs/snippets/all/scalar_multiple_plots.py
+++ b/docs/snippets/all/scalar_multiple_plots.py
@@ -9,7 +9,7 @@ rr.init("rerun_example_scalar_multiple_plots", spawn=True)
 lcg_state = np.int64(0)
 
 # Set up plot styling:
-# They are logged timeless as they don't change over time and apply to all timelines.
+# They are logged statically as they don't change over time and apply to all timelines.
 # Log two lines series under a shared root so that they show in the same plot by default.
 rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)"), static=True)
 rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)"), static=True)

--- a/docs/snippets/all/scalar_multiple_plots.py
+++ b/docs/snippets/all/scalar_multiple_plots.py
@@ -9,7 +9,7 @@ rr.init("rerun_example_scalar_multiple_plots", spawn=True)
 lcg_state = np.int64(0)
 
 # Set up plot styling:
-# They are logged statically as they don't change over time and apply to all timelines.
+# They are logged as static as they don't change over time and apply to all timelines.
 # Log two lines series under a shared root so that they show in the same plot by default.
 rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)"), static=True)
 rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)"), static=True)

--- a/docs/snippets/all/segmentation_image_simple.py
+++ b/docs/snippets/all/segmentation_image_simple.py
@@ -11,6 +11,6 @@ image[4:8, 6:12] = 2
 rr.init("rerun_example_segmentation_image", spawn=True)
 
 # Assign a label and color to each class
-rr.log("/", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), timeless=True)
+rr.log("/", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), static=True)
 
 rr.log("image", rr.SegmentationImage(image))

--- a/docs/snippets/all/series_line_style.py
+++ b/docs/snippets/all/series_line_style.py
@@ -9,8 +9,8 @@ rr.init("rerun_example_series_line_style", spawn=True)
 # Set up plot styling:
 # They are logged timeless as they don't change over time and apply to all timelines.
 # Log two lines series under a shared root so that they show in the same plot by default.
-rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)", width=2), timeless=True)
-rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)", width=4), timeless=True)
+rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)", width=2), static=True)
+rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)", width=4), static=True)
 
 # Log the data on a timeline called "step".
 for t in range(0, int(tau * 2 * 100.0)):

--- a/docs/snippets/all/series_line_style.py
+++ b/docs/snippets/all/series_line_style.py
@@ -7,7 +7,7 @@ import rerun as rr
 rr.init("rerun_example_series_line_style", spawn=True)
 
 # Set up plot styling:
-# They are logged timeless as they don't change over time and apply to all timelines.
+# They are logged statically as they don't change over time and apply to all timelines.
 # Log two lines series under a shared root so that they show in the same plot by default.
 rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)", width=2), static=True)
 rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)", width=4), static=True)

--- a/docs/snippets/all/series_line_style.py
+++ b/docs/snippets/all/series_line_style.py
@@ -7,7 +7,7 @@ import rerun as rr
 rr.init("rerun_example_series_line_style", spawn=True)
 
 # Set up plot styling:
-# They are logged statically as they don't change over time and apply to all timelines.
+# They are logged as static as they don't change over time and apply to all timelines.
 # Log two lines series under a shared root so that they show in the same plot by default.
 rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)", width=2), static=True)
 rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)", width=4), static=True)

--- a/docs/snippets/all/series_point_style.py
+++ b/docs/snippets/all/series_point_style.py
@@ -17,7 +17,7 @@ rr.log(
         marker="circle",
         marker_size=4,
     ),
-    timeless=True,
+    static=True,
 )
 rr.log(
     "trig/cos",
@@ -27,7 +27,7 @@ rr.log(
         marker="cross",
         marker_size=2,
     ),
-    timeless=True,
+    static=True,
 )
 
 # Log the data on a timeline called "step".

--- a/docs/snippets/all/series_point_style.py
+++ b/docs/snippets/all/series_point_style.py
@@ -7,7 +7,7 @@ import rerun as rr
 rr.init("rerun_example_series_point_style", spawn=True)
 
 # Set up plot styling:
-# They are logged timeless as they don't change over time and apply to all timelines.
+# They are logged statically as they don't change over time and apply to all timelines.
 # Log two point series under a shared root so that they show in the same plot by default.
 rr.log(
     "trig/sin",

--- a/docs/snippets/all/series_point_style.py
+++ b/docs/snippets/all/series_point_style.py
@@ -7,7 +7,7 @@ import rerun as rr
 rr.init("rerun_example_series_point_style", spawn=True)
 
 # Set up plot styling:
-# They are logged statically as they don't change over time and apply to all timelines.
+# They are logged as static as they don't change over time and apply to all timelines.
 # Log two point series under a shared root so that they show in the same plot by default.
 rr.log(
     "trig/sin",

--- a/docs/snippets/all/view_coordinates_simple.py
+++ b/docs/snippets/all/view_coordinates_simple.py
@@ -4,7 +4,7 @@ import rerun as rr
 
 rr.init("rerun_example_view_coordinates", spawn=True)
 
-rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)  # Set an up-axis
+rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)  # Set an up-axis
 rr.log(
     "world/xyz",
     rr.Arrows3D(

--- a/examples/python/arkit_scenes/main.py
+++ b/examples/python/arkit_scenes/main.py
@@ -73,7 +73,7 @@ rr.log(
     static=True,
 )
 ```
-Here, the mesh is logged to the [world/mesh entity](recording://world/mesh) and is marked as timeless, since it does not
+Here, the mesh is logged to the [world/mesh entity](recording://world/mesh) and is marked as static, since it does not
 change in the context of this visualization.
 
 ### 3D bounding boxes

--- a/examples/python/arkit_scenes/main.py
+++ b/examples/python/arkit_scenes/main.py
@@ -70,7 +70,7 @@ rr.log(
         vertex_colors=mesh.visual.vertex_colors,
         indices=mesh.faces,
     ),
-    timeless=True,
+    static=True,
 )
 ```
 Here, the mesh is logged to the [world/mesh entity](recording://world/mesh) and is marked as timeless, since it does not
@@ -121,7 +121,7 @@ def log_annotated_bboxes(annotation: dict[str, Any]) -> None:
                 rotations=rr.Quaternion(xyzw=rot.as_quat()),
                 labels=label,
             ),
-            timeless=True,
+            static=True,
         )
 
 
@@ -213,7 +213,7 @@ def log_arkit(recording_path: Path, include_highres: bool) -> None:
     None
 
     """
-    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), static=True)
 
     video_id = recording_path.stem
     lowres_image_dir = recording_path / "lowres_wide"
@@ -242,7 +242,7 @@ def log_arkit(recording_path: Path, include_highres: bool) -> None:
         timestamp = f"{round(float(timestamp), 3):.3f}"
         camera_from_world_dict[timestamp] = camera_from_world
 
-    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)
+    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
     ply_path = recording_path / f"{recording_path.stem}_3dod_mesh.ply"
     print(f"Loading {ply_path}…")
     assert os.path.isfile(ply_path), f"Failed to find {ply_path}"
@@ -255,7 +255,7 @@ def log_arkit(recording_path: Path, include_highres: bool) -> None:
             vertex_colors=mesh.visual.vertex_colors,
             indices=mesh.faces,
         ),
-        timeless=True,
+        static=True,
     )
 
     # load the obb annotations and log them in the world frame

--- a/examples/python/clock/main.py
+++ b/examples/python/clock/main.py
@@ -30,12 +30,12 @@ def log_clock(steps: int) -> None:
             0.0,
         )
 
-    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Y_UP, timeless=True)
+    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Y_UP, static=True)
 
     rr.log(
         "world/frame",
         rr.Boxes3D(half_sizes=[LENGTH_S, LENGTH_S, 1.0], centers=[0.0, 0.0, 0.0]),
-        timeless=True,
+        static=True,
     )
 
     for step in range(steps):

--- a/examples/python/controlnet/main.py
+++ b/examples/python/controlnet/main.py
@@ -74,8 +74,8 @@ def run_canny_controlnet(image_path: str, prompt: str, negative_prompt: str) -> 
     canny_image = np.concatenate([canny_image, canny_image, canny_image], axis=2)
     canny_image = PIL.Image.fromarray(canny_image)
 
-    rr.log("input/raw", rr.Image(image), timeless=True)
-    rr.log("input/canny", rr.Image(canny_image), timeless=True)
+    rr.log("input/raw", rr.Image(image), static=True)
+    rr.log("input/canny", rr.Image(canny_image), static=True)
 
     controlnet = ControlNetModel.from_pretrained(
         "diffusers/controlnet-canny-sdxl-1.0",
@@ -95,8 +95,8 @@ def run_canny_controlnet(image_path: str, prompt: str, negative_prompt: str) -> 
 
     pipeline.enable_model_cpu_offload()
 
-    rr.log("positive_prompt", rr.TextDocument(prompt), timeless=True)
-    rr.log("negative_prompt", rr.TextDocument(negative_prompt), timeless=True)
+    rr.log("positive_prompt", rr.TextDocument(prompt), static=True)
+    rr.log("negative_prompt", rr.TextDocument(negative_prompt), static=True)
 
     images = pipeline(
         prompt,

--- a/examples/python/detect_and_track_objects/main.py
+++ b/examples/python/detect_and_track_objects/main.py
@@ -62,7 +62,7 @@ contains the id for each pixel. It is logged to the [segmentation entity](record
 
 The color and label for each class is determined by the
 [rr.AnnotationContext archetype](https://www.rerun.io/docs/reference/types/archetypes/annotation_context) which is
-logged to the root entity using `rr.log("/", …, timeless=True` as it should apply to the whole sequence and all
+logged to the root entity using `rr.log("/", …, static=True` as it should apply to the whole sequence and all
 entities that have a class id.
 
 ### Detections
@@ -369,7 +369,7 @@ def track_objects(video_path: str, *, max_frame_count: int | None) -> None:
     class_descriptions = [
         rr.AnnotationInfo(id=cat["id"], color=cat["color"], label=cat["name"]) for cat in coco_categories
     ]
-    rr.log("/", rr.AnnotationContext(class_descriptions), timeless=True)
+    rr.log("/", rr.AnnotationContext(class_descriptions), static=True)
 
     detector = Detector(coco_categories=coco_categories)
 
@@ -460,7 +460,7 @@ def main() -> None:
 
     setup_logging()
 
-    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), static=True)
 
     video_path: str = args.video_path
     if not video_path:

--- a/examples/python/dicom_mri/main.py
+++ b/examples/python/dicom_mri/main.py
@@ -71,7 +71,7 @@ def list_dicom_files(dir: Path) -> Iterable[Path]:
 
 
 def read_and_log_dicom_dataset(dicom_files: Iterable[Path]) -> None:
-    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), static=True)
 
     voxels_volume, _ = extract_voxel_data(dicom_files)
 

--- a/examples/python/dna/main.py
+++ b/examples/python/dna/main.py
@@ -47,7 +47,7 @@ the Blueprint settings on the right-hand side. You will see one static frame (i.
 
 
 def log_data() -> None:
-    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), static=True)
 
     rr.set_time_seconds("stable_time", 0)
 

--- a/examples/python/external_data_loader/main.py
+++ b/examples/python/external_data_loader/main.py
@@ -34,9 +34,8 @@ parser.add_argument("filepath", type=str)
 parser.add_argument("--application-id", type=str, help="optional recommended ID for the application")
 parser.add_argument("--recording-id", type=str, help="optional recommended ID for the recording")
 parser.add_argument("--entity-path-prefix", type=str, help="optional prefix for all entity paths")
-parser.add_argument(
-    "--timeless", action="store_true", default=False, help="optionally mark data to be logged as timeless"
-)
+parser.add_argument("--timeless", action="store_true", default=False, help="deprecated: alias for `--static`")
+parser.add_argument("--static", action="store_true", default=False, help="optionally mark data to be logged as static")
 parser.add_argument(
     "--time",
     type=str,
@@ -77,7 +76,9 @@ def main() -> None:
     with open(args.filepath) as file:
         body = file.read()
         text = f"""## Some Python code\n```python\n{body}\n```\n"""
-        rr.log(entity_path, rr.TextDocument(text, media_type=rr.MediaType.MARKDOWN), timeless=args.timeless)
+        rr.log(
+            entity_path, rr.TextDocument(text, media_type=rr.MediaType.MARKDOWN), static=args.static or args.timeless
+        )
 
 
 def set_time_from_args() -> None:

--- a/examples/python/face_tracking/main.py
+++ b/examples/python/face_tracking/main.py
@@ -120,7 +120,7 @@ class FaceDetectorLogger:
             rr.ClassDescription(
                 info=rr.AnnotationInfo(id=0), keypoint_connections=[(0, 1), (1, 2), (2, 0), (2, 3), (0, 4), (1, 5)]
             ),
-            timeless=True,
+            static=True,
         )
 
     def detect_and_log(self, image: npt.NDArray[np.uint8], frame_time_nano: int) -> None:
@@ -223,11 +223,11 @@ class FaceLandmarkerLogger:
                 )
             )
 
-        rr.log("video/landmarker", rr.AnnotationContext(class_descriptions), timeless=True)
-        rr.log("reconstruction", rr.AnnotationContext(class_descriptions), timeless=True)
+        rr.log("video/landmarker", rr.AnnotationContext(class_descriptions), static=True)
+        rr.log("reconstruction", rr.AnnotationContext(class_descriptions), static=True)
 
         # properly align the 3D face in the viewer
-        rr.log("reconstruction", rr.ViewCoordinates.RDF, timeless=True)
+        rr.log("reconstruction", rr.ViewCoordinates.RDF, static=True)
 
     def detect_and_log(self, image: npt.NDArray[np.uint8], frame_time_nano: int) -> None:
         height, width, _ = image.shape

--- a/examples/python/gesture_detection/README.md
+++ b/examples/python/gesture_detection/README.md
@@ -58,7 +58,7 @@ Meanwhile, the 3D points allows the creation of a 3D model of the hand for a mor
 
 The 2D and 3D points are logged through a combination of two archetypes.
 For the 2D points, the Points2D and LineStrips2D archetypes are utilized. These archetypes help visualize the points and connect them with lines, respectively.
-As for the 3D points, the logging process involves two steps. First, a timeless [`ClassDescription`](https://www.rerun.io/docs/reference/types/datatypes/class_description) is logged, that contains the information which maps keypoint ids to labels and how to connect
+As for the 3D points, the logging process involves two steps. First, a static [`ClassDescription`](https://www.rerun.io/docs/reference/types/datatypes/class_description) is logged, that contains the information which maps keypoint ids to labels and how to connect
 the keypoints. Defining these connections automatically renders lines between them. Mediapipe provides the `HAND_CONNECTIONS` variable which contains the list of `(from, to)` landmark indices that define the connections.
 Second, the actual keypoint positions are logged in 3D [`Points3D`](https://www.rerun.io/docs/reference/types/archetypes/points3d) archetype.
 
@@ -73,10 +73,10 @@ rr.log(
             keypoint_connections=mp.solutions.hands.HAND_CONNECTIONS,
         )
     ),
-    timeless=True,
+    static=True,
 )
 
-rr.log("Hand3D", rr.ViewCoordinates.LEFT_HAND_Y_DOWN, timeless=True)
+rr.log("Hand3D", rr.ViewCoordinates.LEFT_HAND_Y_DOWN, static=True)
 ```
 
 ### 2D Points

--- a/examples/python/gesture_detection/main.py
+++ b/examples/python/gesture_detection/main.py
@@ -86,9 +86,9 @@ class GestureDetectorLogger:
                     keypoint_connections=mp.solutions.hands.HAND_CONNECTIONS,
                 )
             ),
-            timeless=True,
+            static=True,
         )
-        rr.log("hand3d", rr.ViewCoordinates.LEFT_HAND_Y_DOWN, timeless=True)
+        rr.log("hand3d", rr.ViewCoordinates.LEFT_HAND_Y_DOWN, static=True)
 
     @staticmethod
     def convert_landmarks_to_image_coordinates(

--- a/examples/python/human_pose_tracking/README.md
+++ b/examples/python/human_pose_tracking/README.md
@@ -60,7 +60,7 @@ image itself is logged as an
 [`SegmentationImage`](https://www.rerun.io/docs/reference/types/archetypes/segmentation_image) and
 contains the id for each pixel. The color is determined by the
 [`AnnotationContext`](https://www.rerun.io/docs/reference/types/archetypes/annotation_context) which is
-logged with `timeless=True` as it should apply to the whole sequence.
+logged with `static=True` as it should apply to the whole sequence.
 
 ### Label mapping
 
@@ -73,7 +73,7 @@ rr.log(
                 rr.AnnotationInfo(id=1, label="Person", color=(0, 0, 0)),
             ]
         ),
-        timeless=True,
+        static=True,
     )
 ```
 
@@ -111,7 +111,7 @@ rr.log(
             keypoint_connections=mp_pose.POSE_CONNECTIONS,
         )
     ),
-    timeless=True,
+    static=True,
 )
 ```
 

--- a/examples/python/human_pose_tracking/main.py
+++ b/examples/python/human_pose_tracking/main.py
@@ -41,7 +41,7 @@ image itself is logged as an
 [rr.SegmentationImage archetype](https://www.rerun.io/docs/reference/types/archetypes/segmentation_image) and
 contains the id for each pixel. The color is determined by the
 [rr.AnnotationContext archetype](https://www.rerun.io/docs/reference/types/archetypes/annotation_context) which is
-logged with `rr.log(…, timeless=True` as it should apply to the whole sequence.
+logged with `rr.log(…, static=True` as it should apply to the whole sequence.
 
 ### Skeletons
 The [2D](recording://video/pose/points) and [3D skeletons](recording://person/pose/points) are also logged through a
@@ -63,7 +63,7 @@ nd 3D as [rr.Points2D](https://www.rerun.io/docs/reference/types/archetypes/poin
 def track_pose(video_path: str, *, segment: bool, max_frame_count: int | None) -> None:
     mp_pose = mp.solutions.pose
 
-    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), static=True)
 
     rr.log(
         "/",
@@ -74,7 +74,7 @@ def track_pose(video_path: str, *, segment: bool, max_frame_count: int | None) -
                 keypoint_connections=mp_pose.POSE_CONNECTIONS,
             )
         ),
-        timeless=True,
+        static=True,
     )
     # Use a separate annotation context for the segmentation mask.
     rr.log(
@@ -85,9 +85,9 @@ def track_pose(video_path: str, *, segment: bool, max_frame_count: int | None) -
                 rr.AnnotationInfo(id=1, label="Person", color=(0, 0, 0)),
             ]
         ),
-        timeless=True,
+        static=True,
     )
-    rr.log("person", rr.ViewCoordinates.RIGHT_HAND_Y_DOWN, timeless=True)
+    rr.log("person", rr.ViewCoordinates.RIGHT_HAND_Y_DOWN, static=True)
 
     with closing(VideoSource(video_path)) as video_source, mp_pose.Pose(enable_segmentation=segment) as pose:
         for idx, bgr_frame in enumerate(video_source.stream_bgr()):

--- a/examples/python/human_pose_tracking/main.py
+++ b/examples/python/human_pose_tracking/main.py
@@ -47,7 +47,7 @@ logged with `rr.log(…, static=True` as it should apply to the whole sequence.
 The [2D](recording://video/pose/points) and [3D skeletons](recording://person/pose/points) are also logged through a
 similar combination of two entities.
 
-First, a timeless
+First, a static
 [rr.ClassDescription](https://www.rerun.io/docs/reference/types/datatypes/class_description) is logged (note, that
 this is equivalent to logging an
 [rr.AnnotationContext archetype](https://www.rerun.io/docs/reference/types/archetypes/annotation_context) as in the

--- a/examples/python/incremental_logging/main.py
+++ b/examples/python/incremental_logging/main.py
@@ -44,7 +44,7 @@ Move the time cursor around, and notice how the colors and radii from frame 0 ar
 
 rr.script_setup(args, "rerun_example_incremental_logging")
 
-rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 # TODO(#5264): just log one once clamp-to-edge semantics land.
 colors = rr.components.ColorBatch(np.repeat(0xFF0000FF, 10))
@@ -53,8 +53,8 @@ radii = rr.components.RadiusBatch(np.repeat(0.1, 10))
 # Only log colors and radii once.
 rr.set_time_sequence("frame_nr", 0)
 rr.log_components("points", [colors, radii])
-# Logging timelessly would also work.
-# rr.log_components("points", [colors, radii], timeless=True)
+# Logging statically would also work.
+# rr.log_components("points", [colors, radii], static=True)
 
 rng = default_rng(12345)
 

--- a/examples/python/incremental_logging/main.py
+++ b/examples/python/incremental_logging/main.py
@@ -53,7 +53,7 @@ radii = rr.components.RadiusBatch(np.repeat(0.1, 10))
 # Only log colors and radii once.
 rr.set_time_sequence("frame_nr", 0)
 rr.log_components("points", [colors, radii])
-# Logging statically would also work.
+# Logging as static would also work.
 # rr.log_components("points", [colors, radii], static=True)
 
 rng = default_rng(12345)

--- a/examples/python/lidar/main.py
+++ b/examples/python/lidar/main.py
@@ -52,7 +52,7 @@ def log_nuscenes_lidar(root_dir: pathlib.Path, dataset_version: str, scene_name:
 
     scene = next(s for s in nusc.scene if s["name"] == scene_name)
 
-    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)
+    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
 
     first_sample = nusc.get("sample", scene["first_sample_token"])
     current_lidar_token = first_sample["data"]["LIDAR_TOP"]

--- a/examples/python/live_depth_sensor/main.py
+++ b/examples/python/live_depth_sensor/main.py
@@ -11,7 +11,7 @@ import rerun as rr  # pip install rerun-sdk
 
 def run_realsense(num_frames: int | None) -> None:
     # Visualize the data as RDF
-    rr.log("realsense", rr.ViewCoordinates.RDF, timeless=True)
+    rr.log("realsense", rr.ViewCoordinates.RDF, static=True)
 
     # Open the pipe
     pipe = rs.pipeline()
@@ -31,7 +31,7 @@ def run_realsense(num_frames: int | None) -> None:
             focal_length=[depth_intr.fx, depth_intr.fy],
             principal_point=[depth_intr.ppx, depth_intr.ppy],
         ),
-        timeless=True,
+        static=True,
     )
 
     # Get and log color extrinsics
@@ -45,7 +45,7 @@ def run_realsense(num_frames: int | None) -> None:
             mat3x3=np.reshape(rgb_from_depth.rotation, (3, 3)),
             from_parent=True,
         ),
-        timeless=True,
+        static=True,
     )
 
     # Get and log color intrinsics
@@ -58,7 +58,7 @@ def run_realsense(num_frames: int | None) -> None:
             focal_length=[rgb_intr.fx, rgb_intr.fy],
             principal_point=[rgb_intr.ppx, rgb_intr.ppy],
         ),
-        timeless=True,
+        static=True,
     )
 
     # Read frames in a loop

--- a/examples/python/nuscenes/main.py
+++ b/examples/python/nuscenes/main.py
@@ -73,7 +73,7 @@ def log_nuscenes(nusc: nuscenes.NuScenes, scene_name: str, max_time_sec: float) 
 
     scene = next(s for s in nusc.scene if s["name"] == scene_name)
 
-    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)
+    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
 
     first_sample_token = scene["first_sample_token"]
     first_sample = nusc.get("sample", scene["first_sample_token"])
@@ -200,7 +200,7 @@ def log_annotations(first_sample_token: str, nusc: nuscenes.NuScenes, max_timest
 
     # skipping for now since labels take too much space in 3D view (see https://github.com/rerun-io/rerun/issues/4451)
     # annotation_context = [(i, label) for label, i in label2id.items()]
-    # rr.log("world/anns", rr.AnnotationContext(annotation_context), timeless=True)
+    # rr.log("world/anns", rr.AnnotationContext(annotation_context), static=True)
 
 
 def log_sensor_calibration(sample_data: dict[str, Any], nusc: nuscenes.NuScenes) -> None:
@@ -216,7 +216,7 @@ def log_sensor_calibration(sample_data: dict[str, Any], nusc: nuscenes.NuScenes)
             rotation=rr.Quaternion(xyzw=rotation_xyzw),
             from_parent=False,
         ),
-        timeless=True,
+        static=True,
     )
     if len(calibrated_sensor["camera_intrinsic"]) != 0:
         rr.log(
@@ -226,7 +226,7 @@ def log_sensor_calibration(sample_data: dict[str, Any], nusc: nuscenes.NuScenes)
                 width=sample_data["width"],
                 height=sample_data["height"],
             ),
-            timeless=True,
+            static=True,
         )
 
 

--- a/examples/python/objectron/main.py
+++ b/examples/python/objectron/main.py
@@ -105,7 +105,7 @@ def read_annotations(dirpath: Path) -> Sequence:
 def log_ar_frames(samples: Iterable[SampleARFrame], seq: Sequence) -> None:
     """Logs a stream of `ARFrame` samples and their annotations with the Rerun SDK."""
 
-    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Y_UP, timeless=True)
+    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Y_UP, static=True)
 
     log_annotated_bboxes(seq.objects)
 
@@ -179,7 +179,7 @@ def log_annotated_bboxes(bboxes: Iterable[Object]) -> None:
                 colors=[160, 230, 130, 255],
                 labels=bbox.category,
             ),
-            timeless=True,
+            static=True,
         )
 
 

--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -113,7 +113,7 @@ class OPFProject:
     def log_point_cloud(self) -> None:
         """Log the project's point cloud."""
         points = self.project.point_cloud_objs[0].nodes[0]
-        rr.log("world/points", rr.Points3D(points.position, colors=points.color), timeless=True)
+        rr.log("world/points", rr.Points3D(points.position, colors=points.color), static=True)
 
     def log_calibrated_cameras(self, jpeg_quality: int | None) -> None:
         """
@@ -227,7 +227,7 @@ def main() -> None:
 
     # display everything in Rerun
     rr.script_setup(args, "rerun_example_open_photogrammetry_format")
-    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)
+    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
     project.log_point_cloud()
     project.log_calibrated_cameras(jpeg_quality=args.jpeg_quality)
     rr.script_teardown(args)

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -39,7 +39,7 @@ Additionally, the plots are styled using the
 archetypes respectively.
 
 For the [parabola](recording://curves/parabola) the radius and color is changed over time,
-the other plots use timeless for their styling properties where possible.
+the other plots use static for their styling properties where possible.
 
 [sin](recording://trig/sin) and [cos](recording://trig/cos) are logged with the same parent entity (i.e.,
 `trig/{cos,sin}`) which will put them in the same view by default.

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -63,7 +63,7 @@ def log_bar_chart() -> None:
 
 def log_parabola() -> None:
     # Name never changes, log it only once.
-    rr.log("curves/parabola", rr.SeriesLine(name="f(t) = (0.01t - 3)³ + 1"), timeless=True)
+    rr.log("curves/parabola", rr.SeriesLine(name="f(t) = (0.01t - 3)³ + 1"), static=True)
 
     # Log a parabola as a time series
     for t in range(0, 1000, 10):
@@ -85,9 +85,9 @@ def log_parabola() -> None:
 
 
 def log_trig() -> None:
-    # Styling doesn't change over time, log it once with timeless=True.
-    rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)"), timeless=True)
-    rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)"), timeless=True)
+    # Styling doesn't change over time, log it once with static=True.
+    rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)"), static=True)
+    rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)"), static=True)
 
     for t in range(0, int(tau * 2 * 100.0)):
         rr.set_time_sequence("frame_nr", t)
@@ -101,7 +101,7 @@ def log_trig() -> None:
 
 def log_classification() -> None:
     # Log components that don't change only once:
-    rr.log("classification/line", rr.SeriesLine(color=[255, 255, 0], width=3.0), timeless=True)
+    rr.log("classification/line", rr.SeriesLine(color=[255, 255, 0], width=3.0), static=True)
 
     for t in range(0, 1000, 2):
         rr.set_time_sequence("frame_nr", t)
@@ -144,7 +144,7 @@ def main() -> None:
 
     rr.script_setup(args, "rerun_example_plot", default_blueprint=blueprint)
 
-    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), static=True)
     log_bar_chart()
     log_parabola()
     log_trig()

--- a/examples/python/raw_mesh/main.py
+++ b/examples/python/raw_mesh/main.py
@@ -129,7 +129,7 @@ def main() -> None:
     root = next(iter(scene.graph.nodes))
 
     # glTF always uses a right-handed coordinate system when +Y is up and meshes face +Z.
-    rr.log(root, rr.ViewCoordinates.RUB, timeless=True)
+    rr.log(root, rr.ViewCoordinates.RUB, static=True)
     log_scene(scene, root)
 
     rr.script_teardown(args)

--- a/examples/python/rgbd/main.py
+++ b/examples/python/rgbd/main.py
@@ -53,7 +53,7 @@ def read_depth_image(buf: bytes) -> npt.NDArray[Any]:
 
 
 def log_nyud_data(recording_path: Path, subset_idx: int, frames: int) -> None:
-    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Y_DOWN, timeless=True)
+    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Y_DOWN, static=True)
 
     with zipfile.ZipFile(recording_path, "r") as archive:
         archive_dirs = [f.filename for f in archive.filelist if f.is_dir()]

--- a/examples/python/ros_node/main.py
+++ b/examples/python/ros_node/main.py
@@ -85,7 +85,7 @@ class TurtleSubscriber(Node):  # type: ignore[misc]
         rr.log(
             "map/box",
             rr.Boxes3D(half_sizes=[3, 3, 1], centers=[0, 0, 1], colors=[255, 255, 255, 255]),
-            timeless=True,
+            static=True,
         )
 
         # Subscriptions
@@ -264,7 +264,7 @@ class TurtleSubscriber(Node):  # type: ignore[misc]
         urdf.scene.graph.update(frame_to="camera_link", matrix=orig.dot(scale))
         scaled = urdf.scene.scaled(1.0)
 
-        rerun_urdf.log_scene(scene=scaled, node=urdf.base_link, path="map/robot/urdf", timeless=True)
+        rerun_urdf.log_scene(scene=scaled, node=urdf.base_link, path="map/robot/urdf", static=True)
 
 
 def main() -> None:

--- a/examples/python/ros_node/rerun_urdf.py
+++ b/examples/python/ros_node/rerun_urdf.py
@@ -27,7 +27,7 @@ def load_urdf_from_msg(msg: String) -> URDF:
     return URDF.load(f, filename_handler=ament_locate_package)
 
 
-def log_scene(scene: trimesh.Scene, node: str, path: str | None = None, timeless: bool = False) -> None:
+def log_scene(scene: trimesh.Scene, node: str, path: str | None = None, static: bool = False) -> None:
     """Log a trimesh scene to rerun."""
     path = path + "/" + node if path else node
 
@@ -46,7 +46,7 @@ def log_scene(scene: trimesh.Scene, node: str, path: str | None = None, timeless
                     translation=world_from_mesh[3, 0:3],
                     mat3x3=world_from_mesh[0:3, 0:3],
                 ),
-                timeless=timeless,
+                static=static,
             )
 
         # Log this node's mesh, if it has one.
@@ -82,9 +82,9 @@ def log_scene(scene: trimesh.Scene, node: str, path: str | None = None, timeless
                     vertex_normals=mesh.vertex_normals,
                     mesh_material=rr.Material(albedo_factor=albedo_factor),
                 ),
-                timeless=timeless,
+                static=static,
             )
 
     if children:
         for child in children:
-            log_scene(scene, child, path, timeless)
+            log_scene(scene, child, path, static)

--- a/examples/python/signed_distance_fields/main.py
+++ b/examples/python/signed_distance_fields/main.py
@@ -100,7 +100,7 @@ def log_mesh(path: Path, mesh: Trimesh) -> None:
 
 def log_sampled_sdf(points: npt.NDArray[np.float32], sdf: npt.NDArray[np.float32]) -> None:
     rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
-    rr.log("world/sdf", rr.AnnotationContext([(0, "inside", (255, 0, 0)), (1, "outside", (0, 255, 0))]), timeless=False)
+    rr.log("world/sdf", rr.AnnotationContext([(0, "inside", (255, 0, 0)), (1, "outside", (0, 255, 0))]), static=False)
     rr.log("world/sdf/points", rr.Points3D(points, class_ids=np.array(sdf > 0, dtype=np.uint8)))
 
     outside = points[sdf > 0]

--- a/examples/python/signed_distance_fields/main.py
+++ b/examples/python/signed_distance_fields/main.py
@@ -99,7 +99,7 @@ def log_mesh(path: Path, mesh: Trimesh) -> None:
 
 
 def log_sampled_sdf(points: npt.NDArray[np.float32], sdf: npt.NDArray[np.float32]) -> None:
-    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)
+    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
     rr.log("world/sdf", rr.AnnotationContext([(0, "inside", (255, 0, 0)), (1, "outside", (0, 255, 0))]), timeless=False)
     rr.log("world/sdf/points", rr.Points3D(points, class_ids=np.array(sdf > 0, dtype=np.uint8)))
 

--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -133,9 +133,9 @@ def read_and_log_sparse_reconstruction(dataset_path: Path, filter_output: bool, 
         # Filter out noisy points
         points3D = {id: point for id, point in points3D.items() if point.rgb.any() and len(point.image_ids) > 4}
 
-    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
-    rr.log("/", rr.ViewCoordinates.RIGHT_HAND_Y_DOWN, timeless=True)
-    rr.log("plot/avg_reproj_err", rr.SeriesLine(color=[240, 45, 58]), timeless=True)
+    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), static=True)
+    rr.log("/", rr.ViewCoordinates.RIGHT_HAND_Y_DOWN, static=True)
+    rr.log("plot/avg_reproj_err", rr.SeriesLine(color=[240, 45, 58]), static=True)
 
     # Iterate through images (video frames) logging data related to each frame.
     for image in sorted(images.values(), key=lambda im: im.name):  # type: ignore[no-any-return]
@@ -181,7 +181,7 @@ def read_and_log_sparse_reconstruction(dataset_path: Path, filter_output: bool, 
         rr.log(
             "camera", rr.Transform3D(translation=image.tvec, rotation=rr.Quaternion(xyzw=quat_xyzw), from_parent=True)
         )
-        rr.log("camera", rr.ViewCoordinates.RDF, timeless=True)  # X=Right, Y=Down, Z=Forward
+        rr.log("camera", rr.ViewCoordinates.RDF, static=True)  # X=Right, Y=Down, Z=Forward
 
         # Log camera intrinsics
         assert camera.model == "PINHOLE"

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -60,6 +60,7 @@ def log(
     entity: AsComponents | Iterable[ComponentBatchLike],
     *extra: AsComponents | Iterable[ComponentBatchLike],
     timeless: bool = False,
+    static: bool = False,
     recording: RecordingStream | None = None,
     strict: bool | None = None,
 ) -> None:
@@ -113,24 +114,45 @@ def log(
 
     entity:
         Anything that implements the [`rerun.AsComponents`][] interface, usually an archetype.
+
     *extra:
-        An arbitrary number of additional component bundles implementing the [`rerun.AsComponents`][] interface, that are logged to the same entity path.
+        An arbitrary number of additional component bundles implementing the [`rerun.AsComponents`][]
+        interface, that are logged to the same entity path.
+
     timeless:
-        If true, the logged components will be timeless.
+        Deprecated. Refer to `static` instead.
+
+    static:
+        If true, the components will be logged as static data.
+
+        Static data has no time associated with it, exists on all timelines, and unconditionally shadows
+        any temporal data of the same type.
 
         Otherwise, the data will be timestamped automatically with `log_time` and `log_tick`.
         Additional timelines set by [`rerun.set_time_sequence`][], [`rerun.set_time_seconds`][] or
         [`rerun.set_time_nanos`][] will also be included.
+
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
         If left unspecified, defaults to the current active data recording, if there is one.
         See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
+
     strict:
         If True, raise exceptions on non-loggable data.
         If False, warn on non-loggable data.
         if None, use the global default from `rerun.strict_mode()`
 
     """
+
+    if timeless is True:
+        import warnings
+
+        warnings.warn(
+            message=("`timeless` is deprecated as an argument to `log`; prefer `static` instead"),
+            category=DeprecationWarning,
+        )
+        static = True
+
     # TODO(jleibs): Profile is_instance with runtime_checkable vs has_attr
     # Note from: https://docs.python.org/3/library/typing.html#typing.runtime_checkable
     #
@@ -168,7 +190,7 @@ def log(
         entity_path=entity_path,
         components=components,
         num_instances=num_instances,
-        timeless=timeless,
+        static=static,
         recording=recording,
     )
 
@@ -180,6 +202,7 @@ def log_components(
     *,
     num_instances: int | None = None,
     timeless: bool = False,
+    static: bool = False,
     recording: RecordingStream | None = None,
     strict: bool | None = None,
 ) -> None:
@@ -203,21 +226,45 @@ def log_components(
 
     components:
         A collection of `ComponentBatchLike` objects that
+
     num_instances:
         Optional. The number of instances in each batch. If not provided, the max of all
         components will be used instead.
+
     timeless:
-        If true, the entity will be timeless (default: False).
+        Deprecated. Refer to `static` instead.
+
+    static:
+        If true, the components will be logged as static data.
+
+        Static data has no time associated with it, exists on all timelines, and unconditionally shadows
+        any temporal data of the same type.
+
+        Otherwise, the data will be timestamped automatically with `log_time` and `log_tick`.
+        Additional timelines set by [`rerun.set_time_sequence`][], [`rerun.set_time_seconds`][] or
+        [`rerun.set_time_nanos`][] will also be included.
+
     recording:
         Specifies the [`rerun.RecordingStream`][] to use. If left unspecified,
         defaults to the current active data recording, if there is one. See
         also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
+
     strict:
         If True, raise exceptions on non-loggable data.
         If False, warn on non-loggable data.
         if None, use the global default from `rerun.strict_mode()`
 
     """
+
+    if timeless is True:
+        import warnings
+
+        warnings.warn(
+            message=("`timeless` is deprecated as an argument to `log`; prefer `static` instead"),
+            category=DeprecationWarning,
+        )
+        static = True
+
     # Convert to a native recording
     recording = RecordingStream.to_native(recording)
 
@@ -269,7 +316,7 @@ def log_components(
         bindings.log_arrow_msg(  # pyright: ignore[reportGeneralTypeIssues]
             entity_path,
             components=splats,
-            timeless=timeless,
+            statically=static,
             recording=recording,
         )
 
@@ -277,7 +324,7 @@ def log_components(
     bindings.log_arrow_msg(  # pyright: ignore[reportGeneralTypeIssues]
         entity_path,
         components=instanced,
-        timeless=timeless,
+        statically=static,
         recording=recording,
     )
 
@@ -288,6 +335,7 @@ def log_file_from_path(
     file_path: str | Path,
     *,
     entity_path_prefix: str | None = None,
+    static: bool = False,
     timeless: bool = False,
     recording: RecordingStream | None = None,
 ) -> None:
@@ -310,7 +358,17 @@ def log_file_from_path(
         What should the logged entity paths be prefixed with?
 
     timeless:
-        Should the logged data be timeless? (default: False)
+        Deprecated. Refer to `static` instead.
+
+    static:
+        If true, the components will be logged as static data.
+
+        Static data has no time associated with it, exists on all timelines, and unconditionally shadows
+        any temporal data of the same type.
+
+        Otherwise, the data will be timestamped automatically with `log_time` and `log_tick`.
+        Additional timelines set by [`rerun.set_time_sequence`][], [`rerun.set_time_seconds`][] or
+        [`rerun.set_time_nanos`][] will also be included.
 
     recording:
         Specifies the [`rerun.RecordingStream`][] to use. If left unspecified,
@@ -318,11 +376,19 @@ def log_file_from_path(
         also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
 
     """
+    if timeless is True:
+        import warnings
+
+        warnings.warn(
+            message=("`timeless` is deprecated as an argument to `log`; prefer `static` instead"),
+            category=DeprecationWarning,
+        )
+        static = True
 
     bindings.log_file_from_path(
         Path(file_path),
         entity_path_prefix=entity_path_prefix,
-        timeless=timeless,
+        statically=static,
         recording=recording,
     )
 
@@ -334,6 +400,7 @@ def log_file_from_contents(
     file_contents: bytes,
     *,
     entity_path_prefix: str | None = None,
+    static: bool = False,
     timeless: bool | None = None,
     recording: RecordingStream | None = None,
 ) -> None:
@@ -359,7 +426,17 @@ def log_file_from_contents(
         What should the logged entity paths be prefixed with?
 
     timeless:
-        Should the logged data be timeless? (default: False)
+        Deprecated. Refer to `static` instead.
+
+    static:
+        If true, the components will be logged as static data.
+
+        Static data has no time associated with it, exists on all timelines, and unconditionally shadows
+        any temporal data of the same type.
+
+        Otherwise, the data will be timestamped automatically with `log_time` and `log_tick`.
+        Additional timelines set by [`rerun.set_time_sequence`][], [`rerun.set_time_seconds`][] or
+        [`rerun.set_time_nanos`][] will also be included.
 
     recording:
         Specifies the [`rerun.RecordingStream`][] to use. If left unspecified,
@@ -372,7 +449,7 @@ def log_file_from_contents(
         Path(file_path),
         file_contents,
         entity_path_prefix=entity_path_prefix,
-        timeless=timeless,
+        statically=static,
         recording=recording,
     )
 

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -316,7 +316,7 @@ def log_components(
         bindings.log_arrow_msg(  # pyright: ignore[reportGeneralTypeIssues]
             entity_path,
             components=splats,
-            statically=static,
+            static_=static,
             recording=recording,
         )
 
@@ -324,7 +324,7 @@ def log_components(
     bindings.log_arrow_msg(  # pyright: ignore[reportGeneralTypeIssues]
         entity_path,
         components=instanced,
-        statically=static,
+        static_=static,
         recording=recording,
     )
 
@@ -388,7 +388,7 @@ def log_file_from_path(
     bindings.log_file_from_path(
         Path(file_path),
         entity_path_prefix=entity_path_prefix,
-        statically=static,
+        static_=static,
         recording=recording,
     )
 
@@ -449,7 +449,7 @@ def log_file_from_contents(
         Path(file_path),
         file_contents,
         entity_path_prefix=entity_path_prefix,
-        statically=static,
+        static_=static,
         recording=recording,
     )
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -44,7 +44,7 @@ class AnnotationContext(Archetype):
     image[100:180, 130:280] = 2
 
     # Log an annotation context to assign a label and color to each class
-    rr.log("segmentation", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), timeless=True)
+    rr.log("segmentation", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), static=True)
 
     rr.log("segmentation/image", rr.SegmentationImage(image))
     ```

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -35,7 +35,7 @@ class Asset3D(Asset3DExt, Archetype):
 
     rr.init("rerun_example_asset3d", spawn=True)
 
-    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)  # Set an up-axis
+    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)  # Set an up-axis
     rr.log("world/asset", rr.Asset3D(path=sys.argv[1]))
     ```
     <center>

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -48,7 +48,7 @@ class SegmentationImage(SegmentationImageExt, Archetype):
     rr.init("rerun_example_segmentation_image", spawn=True)
 
     # Assign a label and color to each class
-    rr.log("/", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), timeless=True)
+    rr.log("/", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), static=True)
 
     rr.log("image", rr.SegmentationImage(image))
     ```

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
@@ -38,10 +38,10 @@ class SeriesLine(Archetype):
     rr.init("rerun_example_series_line_style", spawn=True)
 
     # Set up plot styling:
-    # They are logged timeless as they don't change over time and apply to all timelines.
+    # They are logged static as they don't change over time and apply to all timelines.
     # Log two lines series under a shared root so that they show in the same plot by default.
-    rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)", width=2), timeless=True)
-    rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)", width=4), timeless=True)
+    rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)", width=2), static=True)
+    rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)", width=4), static=True)
 
     # Log the data on a timeline called "step".
     for t in range(0, int(tau * 2 * 100.0)):

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
@@ -38,7 +38,7 @@ class SeriesLine(Archetype):
     rr.init("rerun_example_series_line_style", spawn=True)
 
     # Set up plot styling:
-    # They are logged timeless as they don't change over time and apply to all timelines.
+    # They are logged statically as they don't change over time and apply to all timelines.
     # Log two lines series under a shared root so that they show in the same plot by default.
     rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)", width=2), static=True)
     rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)", width=4), static=True)

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
@@ -38,7 +38,7 @@ class SeriesLine(Archetype):
     rr.init("rerun_example_series_line_style", spawn=True)
 
     # Set up plot styling:
-    # They are logged static as they don't change over time and apply to all timelines.
+    # They are logged timeless as they don't change over time and apply to all timelines.
     # Log two lines series under a shared root so that they show in the same plot by default.
     rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)", width=2), static=True)
     rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)", width=4), static=True)

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
@@ -38,7 +38,7 @@ class SeriesLine(Archetype):
     rr.init("rerun_example_series_line_style", spawn=True)
 
     # Set up plot styling:
-    # They are logged statically as they don't change over time and apply to all timelines.
+    # They are logged as static as they don't change over time and apply to all timelines.
     # Log two lines series under a shared root so that they show in the same plot by default.
     rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)", width=2), static=True)
     rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)", width=4), static=True)

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
@@ -38,7 +38,7 @@ class SeriesPoint(Archetype):
     rr.init("rerun_example_series_point_style", spawn=True)
 
     # Set up plot styling:
-    # They are logged static as they don't change over time and apply to all timelines.
+    # They are logged timeless as they don't change over time and apply to all timelines.
     # Log two point series under a shared root so that they show in the same plot by default.
     rr.log(
         "trig/sin",

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
@@ -38,7 +38,7 @@ class SeriesPoint(Archetype):
     rr.init("rerun_example_series_point_style", spawn=True)
 
     # Set up plot styling:
-    # They are logged timeless as they don't change over time and apply to all timelines.
+    # They are logged static as they don't change over time and apply to all timelines.
     # Log two point series under a shared root so that they show in the same plot by default.
     rr.log(
         "trig/sin",
@@ -48,7 +48,7 @@ class SeriesPoint(Archetype):
             marker="circle",
             marker_size=4,
         ),
-        timeless=True,
+        static=True,
     )
     rr.log(
         "trig/cos",
@@ -58,7 +58,7 @@ class SeriesPoint(Archetype):
             marker="cross",
             marker_size=2,
         ),
-        timeless=True,
+        static=True,
     )
 
     # Log the data on a timeline called "step".

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
@@ -38,7 +38,7 @@ class SeriesPoint(Archetype):
     rr.init("rerun_example_series_point_style", spawn=True)
 
     # Set up plot styling:
-    # They are logged timeless as they don't change over time and apply to all timelines.
+    # They are logged statically as they don't change over time and apply to all timelines.
     # Log two point series under a shared root so that they show in the same plot by default.
     rr.log(
         "trig/sin",

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
@@ -38,7 +38,7 @@ class SeriesPoint(Archetype):
     rr.init("rerun_example_series_point_style", spawn=True)
 
     # Set up plot styling:
-    # They are logged statically as they don't change over time and apply to all timelines.
+    # They are logged as static as they don't change over time and apply to all timelines.
     # Log two point series under a shared root so that they show in the same plot by default.
     rr.log(
         "trig/sin",

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -37,7 +37,7 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
 
     rr.init("rerun_example_view_coordinates", spawn=True)
 
-    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)  # Set an up-axis
+    rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)  # Set an up-axis
     rr.log(
         "world/xyz",
         rr.Arrows3D(

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -202,7 +202,7 @@ def serve(
     The WebSocket server will buffer all log data in memory so that late connecting viewers will get all the data.
     You can limit the amount of data buffered by the WebSocket server with the `server_memory_limit` argument.
     Once reached, the earliest logged data will be dropped.
-    Note that this means that timeless data may be dropped if logged early.
+    Note that this means that static data may be dropped if logged early (see https://github.com/rerun-io/rerun/issues/5531).
 
     This function returns immediately.
 
@@ -214,7 +214,7 @@ def serve(
         The port to serve the web viewer on (defaults to 9090).
     ws_port:
         The port to serve the WebSocket server on (defaults to 9877)
-    default_blueprint
+    default_blueprint:
         Optionally set a default blueprint to use for this application. If the application
         already has an active blueprint, the new blueprint won't become active until the user
         clicks the "reset blueprint" button. If you want to activate the new blueprint
@@ -247,6 +247,7 @@ def serve(
         ).storage
 
     recording = RecordingStream.to_native(recording)
+    # TODO(#5531): keep static data around.
     bindings.serve(
         open_browser,
         web_port,

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -914,14 +914,14 @@ fn reset_time(recording: Option<&PyRecordingStream>) {
 #[pyo3(signature = (
     entity_path,
     components,
-    timeless,
+    statically,
     recording=None,
 ))]
 fn log_arrow_msg(
     py: Python<'_>,
     entity_path: &str,
     components: &PyDict,
-    timeless: bool,
+    statically: bool,
     recording: Option<&PyRecordingStream>,
 ) -> PyResult<()> {
     let Some(recording) = get_data_recording(recording) else {
@@ -939,7 +939,7 @@ fn log_arrow_msg(
         &TimePoint::default(),
     )?;
 
-    recording.record_row(row, !timeless);
+    recording.record_row(row, !statically);
 
     py.allow_threads(flush_garbage_queue);
 
@@ -950,17 +950,24 @@ fn log_arrow_msg(
 #[pyo3(signature = (
     file_path,
     entity_path_prefix = None,
-    timeless = false,
+    statically = false,
     recording = None,
 ))]
 fn log_file_from_path(
     py: Python<'_>,
     file_path: std::path::PathBuf,
     entity_path_prefix: Option<String>,
-    timeless: bool,
+    statically: bool,
     recording: Option<&PyRecordingStream>,
 ) -> PyResult<()> {
-    log_file(py, file_path, None, entity_path_prefix, timeless, recording)
+    log_file(
+        py,
+        file_path,
+        None,
+        entity_path_prefix,
+        statically,
+        recording,
+    )
 }
 
 #[pyfunction]
@@ -968,7 +975,7 @@ fn log_file_from_path(
     file_path,
     file_contents,
     entity_path_prefix = None,
-    timeless = false,
+    statically = false,
     recording = None,
 ))]
 fn log_file_from_contents(
@@ -976,7 +983,7 @@ fn log_file_from_contents(
     file_path: std::path::PathBuf,
     file_contents: &[u8],
     entity_path_prefix: Option<String>,
-    timeless: bool,
+    statically: bool,
     recording: Option<&PyRecordingStream>,
 ) -> PyResult<()> {
     log_file(
@@ -984,7 +991,7 @@ fn log_file_from_contents(
         file_path,
         Some(file_contents),
         entity_path_prefix,
-        timeless,
+        statically,
         recording,
     )
 }
@@ -994,7 +1001,7 @@ fn log_file(
     file_path: std::path::PathBuf,
     file_contents: Option<&[u8]>,
     entity_path_prefix: Option<String>,
-    timeless: bool,
+    statically: bool,
     recording: Option<&PyRecordingStream>,
 ) -> PyResult<()> {
     let Some(recording) = get_data_recording(recording) else {
@@ -1007,12 +1014,12 @@ fn log_file(
                 file_path,
                 std::borrow::Cow::Borrowed(contents),
                 entity_path_prefix.map(Into::into),
-                timeless,
+                statically,
             )
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
     } else {
         recording
-            .log_file_from_path(file_path, entity_path_prefix.map(Into::into), timeless)
+            .log_file_from_path(file_path, entity_path_prefix.map(Into::into), statically)
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
     }
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -914,14 +914,14 @@ fn reset_time(recording: Option<&PyRecordingStream>) {
 #[pyo3(signature = (
     entity_path,
     components,
-    statically,
+    static_,
     recording=None,
 ))]
 fn log_arrow_msg(
     py: Python<'_>,
     entity_path: &str,
     components: &PyDict,
-    statically: bool,
+    static_: bool,
     recording: Option<&PyRecordingStream>,
 ) -> PyResult<()> {
     let Some(recording) = get_data_recording(recording) else {
@@ -939,7 +939,7 @@ fn log_arrow_msg(
         &TimePoint::default(),
     )?;
 
-    recording.record_row(row, !statically);
+    recording.record_row(row, !static_);
 
     py.allow_threads(flush_garbage_queue);
 
@@ -950,24 +950,17 @@ fn log_arrow_msg(
 #[pyo3(signature = (
     file_path,
     entity_path_prefix = None,
-    statically = false,
+    static_ = false,
     recording = None,
 ))]
 fn log_file_from_path(
     py: Python<'_>,
     file_path: std::path::PathBuf,
     entity_path_prefix: Option<String>,
-    statically: bool,
+    static_: bool,
     recording: Option<&PyRecordingStream>,
 ) -> PyResult<()> {
-    log_file(
-        py,
-        file_path,
-        None,
-        entity_path_prefix,
-        statically,
-        recording,
-    )
+    log_file(py, file_path, None, entity_path_prefix, static_, recording)
 }
 
 #[pyfunction]
@@ -975,7 +968,7 @@ fn log_file_from_path(
     file_path,
     file_contents,
     entity_path_prefix = None,
-    statically = false,
+    static_ = false,
     recording = None,
 ))]
 fn log_file_from_contents(
@@ -983,7 +976,7 @@ fn log_file_from_contents(
     file_path: std::path::PathBuf,
     file_contents: &[u8],
     entity_path_prefix: Option<String>,
-    statically: bool,
+    static_: bool,
     recording: Option<&PyRecordingStream>,
 ) -> PyResult<()> {
     log_file(
@@ -991,7 +984,7 @@ fn log_file_from_contents(
         file_path,
         Some(file_contents),
         entity_path_prefix,
-        statically,
+        static_,
         recording,
     )
 }
@@ -1001,7 +994,7 @@ fn log_file(
     file_path: std::path::PathBuf,
     file_contents: Option<&[u8]>,
     entity_path_prefix: Option<String>,
-    statically: bool,
+    static_: bool,
     recording: Option<&PyRecordingStream>,
 ) -> PyResult<()> {
     let Some(recording) = get_data_recording(recording) else {
@@ -1014,12 +1007,12 @@ fn log_file(
                 file_path,
                 std::borrow::Cow::Borrowed(contents),
                 entity_path_prefix.map(Into::into),
-                statically,
+                static_,
             )
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
     } else {
         recording
-            .log_file_from_path(file_path, entity_path_prefix.map(Into::into), statically)
+            .log_file_from_path(file_path, entity_path_prefix.map(Into::into), static_)
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
     }
 

--- a/tests/python/release_checklist/check_annotations.py
+++ b/tests/python/release_checklist/check_annotations.py
@@ -24,12 +24,12 @@ Hover over each of the elements and confirm it shows the label as "red" or "gree
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def log_annotations() -> None:
     # Log an annotation context to assign a label and color to each class
-    rr.log("/", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), timeless=True)
+    rr.log("/", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), static=True)
 
     # Log a batch of 2 rectangles with different `class_ids`
     rr.log("detections", rr.Boxes2D(mins=[[200, 50], [75, 150]], sizes=[[30, 30], [20, 20]], class_ids=[1, 2]))

--- a/tests/python/release_checklist/check_container_hierarchy.py
+++ b/tests/python/release_checklist/check_container_hierarchy.py
@@ -58,7 +58,7 @@ TODO(ab): be _way_ more specific exact actions and expected outcomes when drag-a
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def log_some_space_views() -> None:

--- a/tests/python/release_checklist/check_context_menu_add_entity_to_new_space_view.py
+++ b/tests/python/release_checklist/check_context_menu_add_entity_to_new_space_view.py
@@ -26,7 +26,7 @@ README = """
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def blueprint() -> rrb.BlueprintLike:

--- a/tests/python/release_checklist/check_context_menu_collapse_expand_all.py
+++ b/tests/python/release_checklist/check_context_menu_collapse_expand_all.py
@@ -27,7 +27,7 @@ README = """
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def blueprint() -> rrb.BlueprintLike:

--- a/tests/python/release_checklist/check_context_menu_invalid_sub_container.py
+++ b/tests/python/release_checklist/check_context_menu_invalid_sub_container.py
@@ -19,7 +19,7 @@ README = """
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def blueprint() -> rrb.BlueprintLike:

--- a/tests/python/release_checklist/check_context_menu_multi_selection.py
+++ b/tests/python/release_checklist/check_context_menu_multi_selection.py
@@ -61,7 +61,7 @@ Space view + 'box2d' data result    Hide all
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def blueprint() -> rrb.BlueprintLike:

--- a/tests/python/release_checklist/check_context_menu_single_selection.py
+++ b/tests/python/release_checklist/check_context_menu_single_selection.py
@@ -82,7 +82,7 @@ space view (child list)   Hide
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def blueprint() -> rrb.BlueprintLike:

--- a/tests/python/release_checklist/check_context_menu_single_selection_blueprint_tree.py
+++ b/tests/python/release_checklist/check_context_menu_single_selection_blueprint_tree.py
@@ -65,7 +65,7 @@ Space View                 Hide (or Show, depending on visibility)
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def blueprint() -> rrb.BlueprintLike:

--- a/tests/python/release_checklist/check_context_menu_suggested_origin.py
+++ b/tests/python/release_checklist/check_context_menu_suggested_origin.py
@@ -41,7 +41,7 @@ ENTITY                      CLASS       EXPECTED ORIGIN
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def blueprint() -> rrb.BlueprintLike:
@@ -55,7 +55,7 @@ def blueprint() -> rrb.BlueprintLike:
 def log_some_space_views() -> None:
     rr.set_time_sequence("frame_nr", 0)
     rr.log("/", rr.Boxes3D(centers=[0, 0, 0], half_sizes=[1, 1, 1]))
-    rr.log("/world", rr.ViewCoordinates.RIGHT_HAND_Y_DOWN, timeless=True)
+    rr.log("/world", rr.ViewCoordinates.RIGHT_HAND_Y_DOWN, static=True)
     rr.log(
         "/world/camera/image",
         rr.Pinhole(

--- a/tests/python/release_checklist/check_focus.py
+++ b/tests/python/release_checklist/check_focus.py
@@ -18,7 +18,7 @@ README = """
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def blueprint() -> rrb.BlueprintLike:

--- a/tests/python/release_checklist/check_heuristics_2d.py
+++ b/tests/python/release_checklist/check_heuristics_2d.py
@@ -39,7 +39,7 @@ def log_image_nested(path: str, height: int, width: int, color: tuple[int, int, 
 
 
 def log_annotation_context() -> None:
-    rr.log("/", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), timeless=True)
+    rr.log("/", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), static=True)
 
 
 def log_segmentation(path: str, height: int, width: int, class_id: int) -> None:
@@ -49,7 +49,7 @@ def log_segmentation(path: str, height: int, width: int, class_id: int) -> None:
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def log_images() -> None:

--- a/tests/python/release_checklist/check_heuristics_mixed_2d_and_3d.py
+++ b/tests/python/release_checklist/check_heuristics_mixed_2d_and_3d.py
@@ -34,7 +34,7 @@ def log_image(path: str, height: int, width: int, color: tuple[int, int, int]) -
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def log_images() -> None:

--- a/tests/python/release_checklist/check_hover_select_reset.py
+++ b/tests/python/release_checklist/check_hover_select_reset.py
@@ -37,7 +37,7 @@ Finally, try hitting escape and check whether that deselects whatever was curren
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def log_plots() -> None:

--- a/tests/python/release_checklist/check_parallelism_caching_reentrancy.py
+++ b/tests/python/release_checklist/check_parallelism_caching_reentrancy.py
@@ -35,7 +35,7 @@ If nothing weird happens, you can close this recording.
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def log_text_logs() -> None:

--- a/tests/python/release_checklist/check_plot_overrides.py
+++ b/tests/python/release_checklist/check_plot_overrides.py
@@ -37,7 +37,7 @@ If nothing weird happens, you can close this recording.
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def log_plots() -> None:

--- a/tests/python/release_checklist/check_scalar_clears.py
+++ b/tests/python/release_checklist/check_scalar_clears.py
@@ -19,14 +19,14 @@ If so, you can close this recording.
 
 
 def log_readme() -> None:
-    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def log_plots() -> None:
     from math import sin, tau
 
-    rr.log("plots/line", rr.SeriesLine(), timeless=True)
-    rr.log("plots/point", rr.SeriesPoint(), timeless=True)
+    rr.log("plots/line", rr.SeriesLine(), static=True)
+    rr.log("plots/point", rr.SeriesPoint(), static=True)
 
     for t in range(0, int(tau * 2 * 10.0)):
         rr.set_time_sequence("frame_nr", t)

--- a/tests/python/release_checklist/main.py
+++ b/tests/python/release_checklist/main.py
@@ -20,7 +20,7 @@ def log_checks(args: argparse.Namespace) -> None:
 
 def log_readme() -> None:
     with open(join(dirname(__file__), "README.md")) as f:
-        rr.log("readme", rr.TextDocument(f.read(), media_type=rr.MediaType.MARKDOWN), timeless=True)
+        rr.log("readme", rr.TextDocument(f.read(), media_type=rr.MediaType.MARKDOWN), static=True)
 
 
 def main() -> None:

--- a/tests/python/roundtrips/view_coordinates/main.py
+++ b/tests/python/roundtrips/view_coordinates/main.py
@@ -16,7 +16,7 @@ def main() -> None:
 
     rr.script_setup(args, "rerun_example_roundtrip_view_coordinates")
 
-    rr.log("/", rr.ViewCoordinates.RDF, timeless=True)
+    rr.log("/", rr.ViewCoordinates.RDF, static=True)
 
     rr.script_teardown(args)
 

--- a/tests/python/test_api/main.py
+++ b/tests/python/test_api/main.py
@@ -54,7 +54,7 @@ def run_segmentation() -> None:
     # Log an initial segmentation map with arbitrary colors
     rr.set_time_seconds("sim_time", 2)
 
-    rr.log("seg_test", rr.AnnotationContext([(13, "label1"), (42, "label2"), (99, "label3")]), timeless=False)
+    rr.log("seg_test", rr.AnnotationContext([(13, "label1"), (42, "label2"), (99, "label3")]), static=False)
 
     rr.log(
         "logs/seg_test_log",
@@ -68,7 +68,7 @@ def run_segmentation() -> None:
     rr.log(
         "seg_test",
         rr.AnnotationContext([(13, "label1", (255, 0, 0)), (42, "label2", (0, 255, 0)), (99, "label3", (0, 0, 255))]),
-        timeless=False,
+        static=False,
     )
     rr.log("logs/seg_test_log", rr.TextLog("points/rects with user specified colors"))
 
@@ -84,7 +84,7 @@ def run_segmentation() -> None:
                 rr.AnnotationInfo(99, label="label3"),
             ]
         ),
-        timeless=False,
+        static=False,
     )
     rr.log("logs/seg_test_log", rr.TextLog("label1 disappears and everything with label3 is now default colored again"))
 

--- a/tests/python/test_api/main.py
+++ b/tests/python/test_api/main.py
@@ -98,7 +98,7 @@ def small_image() -> None:
 
 
 def transforms() -> None:
-    rr.log("transforms", rr.ViewCoordinates.RIGHT_HAND_Y_UP, timeless=True)
+    rr.log("transforms", rr.ViewCoordinates.RIGHT_HAND_Y_UP, static=True)
 
     # Log a disconnected space (this doesn't do anything here, but can be used to force a new space)
     rr.log("transforms/disconnected", rr.DisconnectedSpace())
@@ -218,7 +218,7 @@ def run_rects() -> None:
 
 
 def run_text_logs() -> None:
-    rr.log("logs", rr.TextLog("Text with explicitly set color", color=[255, 215, 0]), timeless=True)
+    rr.log("logs", rr.TextLog("Text with explicitly set color", color=[255, 215, 0]), static=True)
     rr.log("logs", rr.TextLog("this entry has loglevel TRACE", level="TRACE"))
 
     logging.getLogger().addHandler(rr.LoggingHandler("logs/handler"))
@@ -255,10 +255,10 @@ def transforms_rigid_3d() -> None:
     rotation_speed_moon = 5.0
 
     # Planetary motion is typically in the XY plane.
-    rr.log("transforms3d", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)
-    rr.log("transforms3d/sun", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)
-    rr.log("transforms3d/sun/planet", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)
-    rr.log("transforms3d/sun/planet/moon", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)
+    rr.log("transforms3d", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
+    rr.log("transforms3d/sun", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
+    rr.log("transforms3d/sun/planet", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
+    rr.log("transforms3d/sun/planet/moon", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
 
     # All are in the center of their own space:
     rr.log("transforms3d/sun", rr.Points3D([0.0, 0.0, 0.0], radii=1.0, colors=[255, 200, 10]))

--- a/tests/python/visible_history_playground/main.py
+++ b/tests/python/visible_history_playground/main.py
@@ -13,13 +13,13 @@ rr.script_add_args(parser)
 args = parser.parse_args()
 rr.script_setup(args, "rerun_example_visible_history_playground")
 
-rr.log("bbox", rr.Boxes2D(centers=[50, 3.5], half_sizes=[50, 4.5], colors=[255, 0, 0]), timeless=True)
+rr.log("bbox", rr.Boxes2D(centers=[50, 3.5], half_sizes=[50, 4.5], colors=[255, 0, 0]), static=True)
 rr.log("transform", rr.Transform3D(translation=[0, 0, 0]))
-rr.log("some/nested/pinhole", rr.Pinhole(focal_length=3, width=3, height=3), timeless=True)
+rr.log("some/nested/pinhole", rr.Pinhole(focal_length=3, width=3, height=3), static=True)
 
-rr.log("3dworld/depthimage/pinhole", rr.Pinhole(focal_length=20, width=100, height=10), timeless=True)
-rr.log("3dworld/image", rr.Transform3D(translation=[0, 1, 0]), timeless=True)
-rr.log("3dworld/image/pinhole", rr.Pinhole(focal_length=20, width=100, height=10), timeless=True)
+rr.log("3dworld/depthimage/pinhole", rr.Pinhole(focal_length=20, width=100, height=10), static=True)
+rr.log("3dworld/image", rr.Transform3D(translation=[0, 1, 0]), static=True)
+rr.log("3dworld/image/pinhole", rr.Pinhole(focal_length=20, width=100, height=10), static=True)
 
 date_offset = int(datetime.datetime(year=2023, month=1, day=1).timestamp())
 


### PR DESCRIPTION
Just exposing all the new static stuff to the Python SDK, and trying to kill the "timeless" terminology in the process.

---

Part of a PR series that removes the concept of timeless data in favor of the much simpler concept of static data:
- #5534
- #5535
- #5536
- #5537
- #5540

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5534/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5534/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5534/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5534)
- [Docs preview](https://rerun.io/preview/24f325db942c73a3f243649f14e4b0d6454967d6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/24f325db942c73a3f243649f14e4b0d6454967d6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)