### PR TITLE
Switch the blueprint timeline from seconds to sequence

### DIFF
--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -14,10 +14,9 @@ use re_types::{
 use re_types_core::archetypes::Clear;
 use re_types_core::Archetype as _;
 use re_viewer_context::{
-    blueprint_timepoint_for_writes, DataResult, PerSystemEntities, PropertyOverrides,
-    RecommendedSpaceView, SpaceViewClass, SpaceViewClassIdentifier, SpaceViewId, SpaceViewState,
-    StoreContext, SystemCommand, SystemCommandSender as _, SystemExecutionOutput, ViewQuery,
-    ViewerContext,
+    DataResult, PerSystemEntities, PropertyOverrides, RecommendedSpaceView, SpaceViewClass,
+    SpaceViewClassIdentifier, SpaceViewId, SpaceViewState, StoreContext, SystemCommand,
+    SystemCommandSender as _, SystemExecutionOutput, ViewQuery, ViewerContext,
 };
 
 // ----------------------------------------------------------------------------
@@ -194,7 +193,7 @@ impl SpaceViewBlueprint {
     /// Otherwise, incremental calls to `set_` functions will write just the necessary component
     /// update directly to the store.
     pub fn save_to_blueprint_store(&self, ctx: &ViewerContext<'_>) {
-        let timepoint = blueprint_timepoint_for_writes();
+        let timepoint = ctx.store_context.blueprint_timepoint_for_writes();
 
         let Self {
             id,
@@ -237,8 +236,9 @@ impl SpaceViewBlueprint {
     /// Creates a new [`SpaceViewBlueprint`] with the same contents, but a different [`SpaceViewId`]
     ///
     /// Also duplicates all the queries in the space view.
-    pub fn duplicate(&self, blueprint: &EntityDb, query: &LatestAtQuery) -> Self {
+    pub fn duplicate(&self, store_context: &StoreContext<'_>, query: &LatestAtQuery) -> Self {
         let mut pending_writes = Vec::new();
+        let blueprint = store_context.blueprint;
 
         let current_path = self.entity_path();
         let new_id = SpaceViewId::random();
@@ -256,7 +256,7 @@ impl SpaceViewBlueprint {
 
                 if let Ok(row) = DataRow::from_cells(
                     RowId::new(),
-                    blueprint_timepoint_for_writes(),
+                    store_context.blueprint_timepoint_for_writes(),
                     sub_path,
                     1,
                     info.components

--- a/crates/re_viewer/src/ui/override_ui.rs
+++ b/crates/re_viewer/src/ui/override_ui.rs
@@ -13,8 +13,8 @@ use re_types_core::{
     ComponentName,
 };
 use re_viewer_context::{
-    blueprint_timepoint_for_writes, DataResult, OverridePath, SystemCommand,
-    SystemCommandSender as _, UiVerbosity, ViewSystemIdentifier, ViewerContext,
+    DataResult, OverridePath, SystemCommand, SystemCommandSender as _, UiVerbosity,
+    ViewSystemIdentifier, ViewerContext,
 };
 
 pub fn override_ui(
@@ -267,7 +267,7 @@ pub fn add_new_override(
 
                         match DataRow::from_cells(
                             RowId::new(),
-                            blueprint_timepoint_for_writes(),
+                            ctx.store_context.blueprint_timepoint_for_writes(),
                             override_path.clone(),
                             1,
                             [splat_cell, initial_data],

--- a/crates/re_viewer_context/src/blueprint_helpers.rs
+++ b/crates/re_viewer_context/src/blueprint_helpers.rs
@@ -1,18 +1,29 @@
-use re_log_types::{DataCell, DataRow, EntityPath, RowId, Time, TimePoint, Timeline};
+use re_log_types::{DataCell, DataRow, EntityPath, RowId, TimePoint, Timeline};
 use re_types::{components::InstanceKey, AsComponents, ComponentBatch, ComponentName};
 
 use crate::{StoreContext, SystemCommand, SystemCommandSender as _, ViewerContext};
 
 #[inline]
 pub fn blueprint_timeline() -> Timeline {
-    Timeline::new_temporal("blueprint")
+    Timeline::new_sequence("blueprint")
 }
 
 impl StoreContext<'_> {
     /// The timepoint to use when writing an update to the blueprint.
     #[inline]
     pub fn blueprint_timepoint_for_writes(&self) -> TimePoint {
-        TimePoint::from([(blueprint_timeline(), Time::now().into())])
+        let timeline = blueprint_timeline();
+
+        let mut max_time = self
+            .blueprint
+            .times_per_timeline()
+            .get(&timeline)
+            .and_then(|times| times.last_key_value())
+            .map_or(0.into(), |(time, _)| *time);
+
+        max_time += 1.into();
+
+        TimePoint::from([(timeline, max_time)])
     }
 }
 

--- a/crates/re_viewer_context/src/blueprint_helpers.rs
+++ b/crates/re_viewer_context/src/blueprint_helpers.rs
@@ -1,22 +1,24 @@
 use re_log_types::{DataCell, DataRow, EntityPath, RowId, Time, TimePoint, Timeline};
 use re_types::{components::InstanceKey, AsComponents, ComponentBatch, ComponentName};
 
-use crate::{SystemCommand, SystemCommandSender as _, ViewerContext};
+use crate::{StoreContext, SystemCommand, SystemCommandSender as _, ViewerContext};
 
 #[inline]
 pub fn blueprint_timeline() -> Timeline {
     Timeline::new_temporal("blueprint")
 }
 
-/// The timepoint to use when writing an update to the blueprint.
-#[inline]
-pub fn blueprint_timepoint_for_writes() -> TimePoint {
-    TimePoint::from([(blueprint_timeline(), Time::now().into())])
+impl StoreContext<'_> {
+    /// The timepoint to use when writing an update to the blueprint.
+    #[inline]
+    pub fn blueprint_timepoint_for_writes(&self) -> TimePoint {
+        TimePoint::from([(blueprint_timeline(), Time::now().into())])
+    }
 }
 
 impl ViewerContext<'_> {
     pub fn save_blueprint_archetype(&self, entity_path: EntityPath, components: &dyn AsComponents) {
-        let timepoint = blueprint_timepoint_for_writes();
+        let timepoint = self.store_context.blueprint_timepoint_for_writes();
 
         let data_row =
             match DataRow::from_archetype(RowId::new(), timepoint.clone(), entity_path, components)
@@ -57,7 +59,7 @@ impl ViewerContext<'_> {
         data_cell.compute_size_bytes();
 
         let num_instances = components.num_instances() as u32;
-        let timepoint = blueprint_timepoint_for_writes();
+        let timepoint = self.store_context.blueprint_timepoint_for_writes();
 
         re_log::trace!(
             "Writing {} components of type {:?} to {:?}",
@@ -124,7 +126,7 @@ impl ViewerContext<'_> {
             return;
         };
 
-        let timepoint = blueprint_timepoint_for_writes();
+        let timepoint = self.store_context.blueprint_timepoint_for_writes();
         let cell = DataCell::from_arrow_empty(component_name, datatype.clone());
 
         match DataRow::from_cells1(

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -29,7 +29,7 @@ pub use annotations::{
     AnnotationMap, Annotations, ResolvedAnnotationInfo, ResolvedAnnotationInfos,
 };
 pub use app_options::AppOptions;
-pub use blueprint_helpers::{blueprint_timeline, blueprint_timepoint_for_writes};
+pub use blueprint_helpers::blueprint_timeline;
 pub use blueprint_id::{BlueprintId, BlueprintIdRegistry, ContainerId, SpaceViewId};
 pub use caches::{Cache, Caches};
 pub use collapsed_id::{CollapseItem, CollapseScope, CollapsedId};

--- a/crates/re_viewport/src/container.rs
+++ b/crates/re_viewport/src/container.rs
@@ -9,8 +9,8 @@ use re_query::query_archetype;
 use re_types::blueprint::components::Visible;
 use re_types_core::archetypes::Clear;
 use re_viewer_context::{
-    blueprint_timepoint_for_writes, BlueprintId, BlueprintIdRegistry, ContainerId, Item,
-    SpaceViewId, SystemCommand, SystemCommandSender as _, ViewerContext,
+    BlueprintId, BlueprintIdRegistry, ContainerId, Item, SpaceViewId, SystemCommand,
+    SystemCommandSender as _, ViewerContext,
 };
 
 use crate::blueprint::components::GridColumns;
@@ -218,7 +218,7 @@ impl ContainerBlueprint {
     /// Otherwise, incremental calls to `set_` functions will write just the necessary component
     /// update directly to the store.
     pub fn save_to_blueprint_store(&self, ctx: &ViewerContext<'_>) {
-        let timepoint = blueprint_timepoint_for_writes();
+        let timepoint = ctx.store_context.blueprint_timepoint_for_writes();
 
         let Self {
             id,

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -237,7 +237,7 @@ impl ViewportBlueprint {
     ) -> Option<SpaceViewId> {
         let space_view = self.space_view(space_view_id)?;
 
-        let new_space_view = space_view.duplicate(ctx.store_context.blueprint, ctx.blueprint_query);
+        let new_space_view = space_view.duplicate(ctx.store_context, ctx.blueprint_query);
         let new_space_view_id = new_space_view.id;
 
         let parent_and_pos =

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -456,8 +456,7 @@ def create_in_memory_blueprint(*, application_id: str, blueprint: BlueprintLike)
         )
     )
 
-    # TODO(jleibs): This should use a monotonic seq
-    blueprint_stream.set_time_seconds("blueprint", 1)  # type: ignore[attr-defined]
+    blueprint_stream.set_time_sequence("blueprint", 0)  # type: ignore[attr-defined]
 
     blueprint._log_to_stream(blueprint_stream)
 


### PR DESCRIPTION
### What
 - Resolves: https://github.com/rerun-io/rerun/issues/5222

Confirmed working in blueprint inspector:
![image](https://github.com/rerun-io/rerun/assets/3312232/0f0a1a73-5f89-4f3d-859a-4263ba7f3ed8)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5539/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5539/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5539/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5539)
- [Docs preview](https://rerun.io/preview/53c919201d689b77aac31aa8a226f0422262ea66/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/53c919201d689b77aac31aa8a226f0422262ea66/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)