### PR TITLE
Static data 4: static-aware Rust SDK

### DIFF
--- a/crates/re_data_source/src/data_loader/mod.rs
+++ b/crates/re_data_source/src/data_loader/mod.rs
@@ -102,6 +102,7 @@ impl DataLoaderSettings {
         if let Some(timepoint) = timepoint {
             if timepoint.is_static() {
                 args.push("--timeless".to_owned());
+                args.push("--static".to_owned());
             }
 
             for (timeline, time) in timepoint.iter() {

--- a/crates/re_data_source/src/data_loader/mod.rs
+++ b/crates/re_data_source/src/data_loader/mod.rs
@@ -101,7 +101,7 @@ impl DataLoaderSettings {
 
         if let Some(timepoint) = timepoint {
             if timepoint.is_static() {
-                args.push("--timeless".to_owned());
+                args.push("--timeless".to_owned()); // for backwards compatibility
                 args.push("--static".to_owned());
             }
 

--- a/crates/re_query_cache/tests/latest_at.rs
+++ b/crates/re_query_cache/tests/latest_at.rs
@@ -68,7 +68,7 @@ fn static_query() {
         DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 2, positions).unwrap();
     insert_and_react(&mut store, &mut caches, &row);
 
-    // Assign one of them a color with an explicit instance.. statically!
+    // Assign one of them a color with an explicit instance.. static_!
     let color_instances = vec![InstanceKey(1)];
     let colors = vec![MyColor::from_rgb(255, 0, 0)];
     let row = DataRow::from_cells2_sized(

--- a/crates/re_query_cache/tests/range.rs
+++ b/crates/re_query_cache/tests/range.rs
@@ -158,7 +158,7 @@ fn static_range() {
         .unwrap();
         insert_and_react(&mut store, &mut caches, &row);
 
-        // Insert statically too!
+        // Insert static_ too!
         let row = DataRow::from_cells2_sized(
             RowId::new(),
             entity_path.clone(),

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -476,7 +476,7 @@ impl RecordingStreamBuilder {
     /// The WebSocket server will buffer all log data in memory so that late connecting viewers will get all the data.
     /// You can limit the amount of data buffered by the WebSocket server with the `server_memory_limit` argument.
     /// Once reached, the earliest logged data will be dropped.
-    /// Note that this means that timeless data may be dropped if logged early.
+    /// Note that this means that static data may be dropped if logged early (see <https://github.com/rerun-io/rerun/issues/5531>).
     ///
     /// ## Example
     ///
@@ -499,6 +499,8 @@ impl RecordingStreamBuilder {
     ///            true)?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    //
+    // # TODO(#5531): keep static data around.
     #[cfg(feature = "web_viewer")]
     pub fn serve(
         self,
@@ -860,7 +862,7 @@ impl RecordingStream {
     /// or an [`EntityPath`] constructed with [`crate::entity_path`].
     /// See <https://www.rerun.io/docs/concepts/entity-path> for more on entity paths.
     ///
-    /// See also: [`Self::log_timeless`] for logging timeless data.
+    /// See also: [`Self::log_static`] for logging static data.
     ///
     /// Internally, the stream will automatically micro-batch multiple log calls to optimize
     /// transport.
@@ -885,7 +887,18 @@ impl RecordingStream {
         ent_path: impl Into<EntityPath>,
         arch: &impl AsComponents,
     ) -> RecordingStreamResult<()> {
-        self.log_with_timeless(ent_path, false, arch)
+        self.log_with_static(ent_path, false, arch)
+    }
+
+    #[deprecated(since = "0.16.0", note = "use `log_static` instead")]
+    #[doc(hidden)]
+    #[inline]
+    pub fn log_timeless(
+        &self,
+        ent_path: impl Into<EntityPath>,
+        arch: &impl AsComponents,
+    ) -> RecordingStreamResult<()> {
+        self.log_static(ent_path, arch)
     }
 
     /// Log data to Rerun.
@@ -893,8 +906,8 @@ impl RecordingStream {
     /// It can be used to log anything
     /// that implements the [`AsComponents`], such as any [archetype](https://docs.rs/rerun/latest/rerun/archetypes/index.html).
     ///
-    /// Timeless data is present on all timelines and behaves as if it was recorded infinitely far
-    /// into the past.
+    /// Static data has no time associated with it, exists on all timelines, and unconditionally shadows
+    /// any temporal data of the same type.
     /// All timestamp data associated with this message will be dropped right before sending it to Rerun.
     ///
     /// This is most often used for [`rerun::ViewCoordinates`](https://docs.rs/rerun/latest/rerun/archetypes/struct.ViewCoordinates.html) and
@@ -909,20 +922,32 @@ impl RecordingStream {
     /// [SDK Micro Batching]: https://www.rerun.io/docs/reference/sdk-micro-batching
     /// [component bundle]: [`AsComponents`]
     #[inline]
-    pub fn log_timeless(
+    pub fn log_static(
         &self,
         ent_path: impl Into<EntityPath>,
         arch: &impl AsComponents,
     ) -> RecordingStreamResult<()> {
-        self.log_with_timeless(ent_path, true, arch)
+        self.log_with_static(ent_path, true, arch)
+    }
+
+    #[deprecated(since = "0.16.0", note = "use `log_static` instead")]
+    #[doc(hidden)]
+    #[inline]
+    pub fn log_with_timeless(
+        &self,
+        ent_path: impl Into<EntityPath>,
+        statically: bool,
+        arch: &impl AsComponents,
+    ) -> RecordingStreamResult<()> {
+        self.log_with_static(ent_path, statically, arch)
     }
 
     /// Logs the contents of a [component bundle] into Rerun.
     ///
-    /// If `timeless` is set to `true`, all timestamp data associated with this message will be
+    /// If `statically` is set to `true`, all timestamp data associated with this message will be
     /// dropped right before sending it to Rerun.
-    /// Timeless data is present on all timelines and behaves as if it was recorded infinitely far
-    /// into the past.
+    /// Static data has no time associated with it, exists on all timelines, and unconditionally shadows
+    /// any temporal data of the same type.
     ///
     /// Otherwise, the data will be timestamped automatically based on the [`RecordingStream`]'s
     /// internal clock.
@@ -940,17 +965,17 @@ impl RecordingStream {
     /// [SDK Micro Batching]: https://www.rerun.io/docs/reference/sdk-micro-batching
     /// [component bundle]: [`AsComponents`]
     #[inline]
-    pub fn log_with_timeless(
+    pub fn log_with_static(
         &self,
         ent_path: impl Into<EntityPath>,
-        timeless: bool,
+        statically: bool,
         arch: &impl AsComponents,
     ) -> RecordingStreamResult<()> {
         let row_id = RowId::new(); // Create row-id as early as possible. It has a timestamp and is used to estimate e2e latency.
         self.log_component_batches_impl(
             row_id,
             ent_path,
-            timeless,
+            statically,
             arch.as_component_batches()
                 .iter()
                 .map(|any_comp_batch| any_comp_batch.as_ref()),
@@ -959,10 +984,10 @@ impl RecordingStream {
 
     /// Logs a set of [`ComponentBatch`]es into Rerun.
     ///
-    /// If `timeless` is set to `false`, all timestamp data associated with this message will be
+    /// If `statically` is set to `true`, all timestamp data associated with this message will be
     /// dropped right before sending it to Rerun.
-    /// Timeless data is present on all timelines and behaves as if it was recorded infinitely far
-    /// into the past.
+    /// Static data has no time associated with it, exists on all timelines, and unconditionally shadows
+    /// any temporal data of the same type.
     ///
     /// Otherwise, the data will be timestamped automatically based on the [`RecordingStream`]'s
     /// internal clock.
@@ -983,18 +1008,18 @@ impl RecordingStream {
     pub fn log_component_batches<'a>(
         &self,
         ent_path: impl Into<EntityPath>,
-        timeless: bool,
+        statically: bool,
         comp_batches: impl IntoIterator<Item = &'a dyn ComponentBatch>,
     ) -> RecordingStreamResult<()> {
         let row_id = RowId::new(); // Create row-id as early as possible. It has a timestamp and is used to estimate e2e latency.
-        self.log_component_batches_impl(row_id, ent_path, timeless, comp_batches)
+        self.log_component_batches_impl(row_id, ent_path, statically, comp_batches)
     }
 
     fn log_component_batches_impl<'a>(
         &self,
         row_id: RowId,
         ent_path: impl Into<EntityPath>,
-        timeless: bool,
+        statically: bool,
         comp_batches: impl IntoIterator<Item = &'a dyn ComponentBatch>,
     ) -> RecordingStreamResult<()> {
         if !self.is_enabled() {
@@ -1071,13 +1096,13 @@ impl RecordingStream {
         };
 
         if let Some(splatted) = splatted {
-            self.record_row(splatted, !timeless);
+            self.record_row(splatted, !statically);
         }
 
         // Always the primary component last so range-based queries will include the other data.
         // Since the primary component can't be splatted it must be in here, see(#1215).
         if let Some(instanced) = instanced {
-            self.record_row(instanced, !timeless);
+            self.record_row(instanced, !statically);
         }
 
         Ok(())
@@ -1096,9 +1121,9 @@ impl RecordingStream {
         &self,
         filepath: impl AsRef<std::path::Path>,
         entity_path_prefix: Option<EntityPath>,
-        timeless: bool,
+        statically: bool,
     ) -> RecordingStreamResult<()> {
-        self.log_file(filepath, None, entity_path_prefix, timeless)
+        self.log_file(filepath, None, entity_path_prefix, statically)
     }
 
     /// Logs the given `contents` using all [`re_data_source::DataLoader`]s available.
@@ -1115,9 +1140,9 @@ impl RecordingStream {
         filepath: impl AsRef<std::path::Path>,
         contents: std::borrow::Cow<'_, [u8]>,
         entity_path_prefix: Option<EntityPath>,
-        timeless: bool,
+        statically: bool,
     ) -> RecordingStreamResult<()> {
-        self.log_file(filepath, Some(contents), entity_path_prefix, timeless)
+        self.log_file(filepath, Some(contents), entity_path_prefix, statically)
     }
 
     #[cfg(feature = "data_loaders")]
@@ -1126,7 +1151,7 @@ impl RecordingStream {
         filepath: impl AsRef<std::path::Path>,
         contents: Option<std::borrow::Cow<'_, [u8]>>,
         entity_path_prefix: Option<EntityPath>,
-        timeless: bool,
+        statically: bool,
     ) -> RecordingStreamResult<()> {
         let Some(store_info) = self.store_info().clone() else {
             re_log::warn!("Ignored call to log_file() because RecordingStream has not been properly initialized");
@@ -1147,7 +1172,7 @@ impl RecordingStream {
             store_id: store_info.store_id,
             opened_store_id: None,
             entity_path_prefix,
-            timepoint: (!timeless).then(|| {
+            timepoint: (!statically).then(|| {
                 self.with(|inner| {
                     // Get the current time on all timelines, for the current recording, on the current
                     // thread…
@@ -1383,9 +1408,6 @@ impl RecordingStream {
     #[inline]
     pub fn record_row(&self, mut row: DataRow, inject_time: bool) {
         let f = move |inner: &RecordingStreamInner| {
-            // TODO(#2074): Adding a timeline to something timeless would suddenly make it not
-            // timeless… so for now it cannot even have a tick :/
-            //
             // NOTE: We're incrementing the current tick still.
             let tick = inner
                 .tick

--- a/crates/re_types/src/archetypes/annotation_context.rs
+++ b/crates/re_types/src/archetypes/annotation_context.rs
@@ -42,7 +42,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         .spawn()?;
 ///
 ///     // create an annotation context to describe the classes
-///     rec.log_timeless(
+///     rec.log_static(
 ///         "segmentation",
 ///         &rerun::AnnotationContext::new([
 ///             (1, "red", rerun::Rgba32::from_rgb(255, 0, 0)),

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -39,7 +39,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d").spawn()?;
 ///
-///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+///     rec.log_static("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;
 ///
 ///     Ok(())

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -55,7 +55,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///     ]);
 ///
 ///     // log the annotation and the image
-///     rec.log_timeless("/", &annotation)?;
+///     rec.log_static("/", &annotation)?;
 ///
 ///     rec.log("image", &rerun::SegmentationImage::try_from(image)?)?;
 ///

--- a/crates/re_types/src/archetypes/series_line.rs
+++ b/crates/re_types/src/archetypes/series_line.rs
@@ -37,16 +37,16 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_series_line_style").spawn()?;
 ///
 ///     // Set up plot styling:
-///     // They are logged timeless as they don't change over time and apply to all timelines.
+///     // They are logged static as they don't change over time and apply to all timelines.
 ///     // Log two lines series under a shared root so that they show in the same plot by default.
-///     rec.log_timeless(
+///     rec.log_static(
 ///         "trig/sin",
 ///         &rerun::SeriesLine::new()
 ///             .with_color([255, 0, 0])
 ///             .with_name("sin(0.01t)")
 ///             .with_width(2.0),
 ///     )?;
-///     rec.log_timeless(
+///     rec.log_static(
 ///         "trig/cos",
 ///         &rerun::SeriesLine::new()
 ///             .with_color([0, 255, 0])

--- a/crates/re_types/src/archetypes/series_point.rs
+++ b/crates/re_types/src/archetypes/series_point.rs
@@ -37,9 +37,9 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_series_point_style").spawn()?;
 ///
 ///     // Set up plot styling:
-///     // They are logged timeless as they don't change over time and apply to all timelines.
+///     // They are logged static as they don't change over time and apply to all timelines.
 ///     // Log two point series under a shared root so that they show in the same plot by default.
-///     rec.log_timeless(
+///     rec.log_static(
 ///         "trig/sin",
 ///         &rerun::SeriesPoint::new()
 ///             .with_color([255, 0, 0])
@@ -47,7 +47,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///             .with_marker(rerun::components::MarkerShape::Circle)
 ///             .with_marker_size(4.0),
 ///     )?;
-///     rec.log_timeless(
+///     rec.log_static(
 ///         "trig/cos",
 ///         &rerun::SeriesPoint::new()
 ///             .with_color([0, 255, 0])

--- a/crates/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/re_types/src/archetypes/view_coordinates.rs
@@ -37,7 +37,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").spawn()?;
 ///
-///     rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+///     rec.log_static("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 ///     rec.log(
 ///         "world/xyz",
 ///         &rerun::Arrows3D::from_vectors(

--- a/docs/snippets/all/annotation-context/example.rs
+++ b/docs/snippets/all/annotation-context/example.rs
@@ -1,6 +1,6 @@
 // Annotation context with two classes, using two labeled classes, of which ones defines a color.
 MsgSender::new("masks") // Applies to all entities below "masks".
-    .with_timeless(true)
+    .with_static(true)
     .with_component(&[AnnotationContext {
         class_map: [
             ClassDescription {
@@ -28,7 +28,7 @@ MsgSender::new("masks") // Applies to all entities below "masks".
 
 // Annotation context with simple keypoints & keypoint connections.
 MsgSender::new("detections") // Applies to all entities below "detections".
-    .with_timeless(true)
+    .with_static(true)
     .with_component(&[AnnotationContext {
         class_map: std::iter::once((
             ClassId(0),

--- a/docs/snippets/all/annotation_context_connections.rs
+++ b/docs/snippets/all/annotation_context_connections.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log an annotation context to assign a label and color to each class
     // Create a class description with labels and color for each keypoint ID as well as some
     // connections between keypoints.
-    rec.log_timeless(
+    rec.log_static(
         "/",
         &rerun::AnnotationContext::new([rerun::ClassDescription {
             info: 0.into(),

--- a/docs/snippets/all/annotation_context_rects.rs
+++ b/docs/snippets/all/annotation_context_rects.rs
@@ -5,7 +5,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rerun::RecordingStreamBuilder::new("rerun_example_annotation_context_rects").spawn()?;
 
     // Log an annotation context to assign a label and color to each class
-    rec.log_timeless(
+    rec.log_static(
         "/",
         &rerun::AnnotationContext::new([
             (1, "red", rerun::Rgba32::from_rgb(255, 0, 0)),

--- a/docs/snippets/all/annotation_context_segmentation.rs
+++ b/docs/snippets/all/annotation_context_segmentation.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .spawn()?;
 
     // create an annotation context to describe the classes
-    rec.log_timeless(
+    rec.log_static(
         "segmentation",
         &rerun::AnnotationContext::new([
             (1, "red", rerun::Rgba32::from_rgb(255, 0, 0)),

--- a/docs/snippets/all/asset3d_out_of_tree.rs
+++ b/docs/snippets/all/asset3d_out_of_tree.rs
@@ -13,7 +13,7 @@ fn main() -> anyhow::Result<()> {
 
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d_out_of_tree").spawn()?;
 
-    rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+    rec.log_static("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
 
     rec.set_time_sequence("frame", 0);
     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;

--- a/docs/snippets/all/asset3d_simple.rs
+++ b/docs/snippets/all/asset3d_simple.rs
@@ -10,7 +10,7 @@ fn main() -> anyhow::Result<()> {
 
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_asset3d").spawn()?;
 
-    rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+    rec.log_static("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log("world/asset", &rerun::Asset3D::from_file(path)?)?;
 
     Ok(())

--- a/docs/snippets/all/log-file/example.rs
+++ b/docs/snippets/all/log-file/example.rs
@@ -2,4 +2,4 @@
 
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_log_file").spawn()?;
 
-    rec.log_file_from_path(&args[1], None /* prefix */, true /* timeless */)?;
+    rec.log_file_from_path(&args[1], None /* prefix */, true /* static */)?;

--- a/docs/snippets/all/scalar_multiple_plots.rs
+++ b/docs/snippets/all/scalar_multiple_plots.rs
@@ -5,22 +5,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut lcg_state = 0_i64;
 
     // Set up plot styling:
-    // They are logged timeless as they don't change over time and apply to all timelines.
+    // They are logged static as they don't change over time and apply to all timelines.
     // Log two lines series under a shared root so that they show in the same plot by default.
-    rec.log_timeless(
+    rec.log_static(
         "trig/sin",
         &rerun::SeriesLine::new()
             .with_color([255, 0, 0])
             .with_name("sin(0.01t)"),
     )?;
-    rec.log_timeless(
+    rec.log_static(
         "trig/cos",
         &rerun::SeriesLine::new()
             .with_color([0, 255, 0])
             .with_name("cos(0.01t)"),
     )?;
     // Log scattered points under a different root so that they show in a different plot by default.
-    rec.log_timeless("scatter/lcg", &rerun::SeriesPoint::new())?;
+    rec.log_static("scatter/lcg", &rerun::SeriesPoint::new())?;
 
     for t in 0..((std::f32::consts::TAU * 2.0 * 100.0) as i64) {
         rec.set_time_sequence("step", t);

--- a/docs/snippets/all/segmentation_image_simple.rs
+++ b/docs/snippets/all/segmentation_image_simple.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ]);
 
     // log the annotation and the image
-    rec.log_timeless("/", &annotation)?;
+    rec.log_static("/", &annotation)?;
 
     rec.log("image", &rerun::SegmentationImage::try_from(image)?)?;
 

--- a/docs/snippets/all/series_line_style.rs
+++ b/docs/snippets/all/series_line_style.rs
@@ -4,16 +4,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_series_line_style").spawn()?;
 
     // Set up plot styling:
-    // They are logged timeless as they don't change over time and apply to all timelines.
+    // They are logged static as they don't change over time and apply to all timelines.
     // Log two lines series under a shared root so that they show in the same plot by default.
-    rec.log_timeless(
+    rec.log_static(
         "trig/sin",
         &rerun::SeriesLine::new()
             .with_color([255, 0, 0])
             .with_name("sin(0.01t)")
             .with_width(2.0),
     )?;
-    rec.log_timeless(
+    rec.log_static(
         "trig/cos",
         &rerun::SeriesLine::new()
             .with_color([0, 255, 0])

--- a/docs/snippets/all/series_point_style.rs
+++ b/docs/snippets/all/series_point_style.rs
@@ -4,9 +4,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_series_point_style").spawn()?;
 
     // Set up plot styling:
-    // They are logged timeless as they don't change over time and apply to all timelines.
+    // They are logged static as they don't change over time and apply to all timelines.
     // Log two point series under a shared root so that they show in the same plot by default.
-    rec.log_timeless(
+    rec.log_static(
         "trig/sin",
         &rerun::SeriesPoint::new()
             .with_color([255, 0, 0])
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_marker(rerun::components::MarkerShape::Circle)
             .with_marker_size(4.0),
     )?;
-    rec.log_timeless(
+    rec.log_static(
         "trig/cos",
         &rerun::SeriesPoint::new()
             .with_color([0, 255, 0])

--- a/docs/snippets/all/view_coordinates_simple.rs
+++ b/docs/snippets/all/view_coordinates_simple.rs
@@ -3,7 +3,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_view_coordinates").spawn()?;
 
-    rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
+    rec.log_static("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?; // Set an up-axis
     rec.log(
         "world/xyz",
         &rerun::Arrows3D::from_vectors(

--- a/examples/rust/clock/src/main.rs
+++ b/examples/rust/clock/src/main.rs
@@ -39,9 +39,9 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
     const WIDTH_M: f32 = 0.4;
     const WIDTH_H: f32 = 0.6;
 
-    rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Y_UP)?;
+    rec.log_static("world", &rerun::ViewCoordinates::RIGHT_HAND_Y_UP)?;
 
-    rec.log_timeless(
+    rec.log_static(
         "world/frame",
         &rerun::Boxes3D::from_half_sizes([(LENGTH_S, LENGTH_S, 1.0)]),
     )?;

--- a/examples/rust/external_data_loader/src/main.rs
+++ b/examples/rust/external_data_loader/src/main.rs
@@ -41,9 +41,13 @@ struct Args {
     #[argh(option)]
     entity_path_prefix: Option<String>,
 
-    /// optionally mark data to be logged as timeless
+    /// deprecated: alias for `--static`
     #[argh(switch)]
     timeless: bool,
+
+    /// optionally mark data to be logged statically
+    #[argh(arg_name = "static", switch)]
+    statically: bool,
 
     /// optional timestamps to log at (e.g. `--time sim_time=1709203426`) (repeatable)
     #[argh(option)]
@@ -99,9 +103,9 @@ fn main() -> anyhow::Result<()> {
         .entity_path_prefix
         .map_or_else(|| rerun::EntityPath::new(vec![]), rerun::EntityPath::from);
 
-    rec.log_with_timeless(
+    rec.log_with_static(
         entity_path_prefix.join(&rerun::EntityPath::from_file_path(&args.filepath)),
-        args.timeless,
+        args.statically || args.timeless,
         &rerun::TextDocument::new(text).with_media_type(MediaType::MARKDOWN),
     )?;
 

--- a/examples/rust/incremental_logging/src/main.rs
+++ b/examples/rust/incremental_logging/src/main.rs
@@ -38,7 +38,7 @@ let radii = [rerun::Radius(0.1); 10];
 
 // Only log colors and radii once.
 rec.set_time_sequence("frame_nr", 0);
-rec.log_component_batches("points", false, /* timeless */ [&colors as &dyn rerun::ComponentBatch, &radii])?;
+rec.log_component_batches("points", false /* static */, [&colors as &dyn rerun::ComponentBatch, &radii])?;
 
 let mut rng = rand::thread_rng();
 let dist = Uniform::new(-5., 5.);
@@ -56,7 +56,7 @@ Move the time cursor around, and notice how the colors and radii from frame 0 ar
 "#;
 
 fn run(rec: &rerun::RecordingStream) -> anyhow::Result<()> {
-    rec.log_timeless(
+    rec.log_static(
         "readme",
         &rerun::TextDocument::new(README).with_media_type(rerun::MediaType::MARKDOWN),
     )?;
@@ -69,13 +69,13 @@ fn run(rec: &rerun::RecordingStream) -> anyhow::Result<()> {
     rec.set_time_sequence("frame_nr", 0);
     rec.log_component_batches(
         "points",
-        false, /* timeless */
+        false, /* static */
         [&colors as &dyn rerun::ComponentBatch, &radii],
     )?;
-    // Logging timelessly would also work.
+    // Logging statically would also work.
     // rec.log_component_batches(
     //     "points",
-    //     true, /* timeless */
+    //     true, /* static */
     //     [&colors as &dyn rerun::ComponentBatch, &radii],
     // )?;
 

--- a/examples/rust/log_file/src/main.rs
+++ b/examples/rust/log_file/src/main.rs
@@ -43,7 +43,7 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
 
         if !args.from_contents {
             // Either log the file using its path…
-            rec.log_file_from_path(filepath, prefix.clone(), true /* timeless */)?;
+            rec.log_file_from_path(filepath, prefix.clone(), true /* static */)?;
         } else {
             // …or using its contents if you already have them loaded for some reason.
             if filepath.is_file() {
@@ -52,7 +52,7 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
                     filepath,
                     std::borrow::Cow::Borrowed(&contents),
                     prefix.clone(),
-                    true, /* timeless */
+                    true, /* static */
                 )?;
             }
         }

--- a/examples/rust/objectron/src/main.rs
+++ b/examples/rust/objectron/src/main.rs
@@ -115,13 +115,13 @@ fn log_baseline_objects(
 
     for (id, bbox_half_size, transform, label) in boxes {
         let path = format!("world/annotations/box-{id}");
-        rec.log_timeless(
+        rec.log_static(
             path.clone(),
             &rerun::Boxes3D::from_half_sizes([bbox_half_size])
                 .with_labels([label])
                 .with_colors([rerun::Color::from_rgb(160, 230, 130)]),
         )?;
-        rec.log_timeless(path, &rerun::Transform3D::new(transform))?;
+        rec.log_static(path, &rerun::Transform3D::new(transform))?;
     }
 
     Ok(())
@@ -331,7 +331,7 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
     let annotations = read_annotations(&store_info.path_annotations)?;
 
     // See https://github.com/google-research-datasets/Objectron/issues/39 for coordinate systems
-    rec.log_timeless("world", &rerun::ViewCoordinates::RUB)?;
+    rec.log_static("world", &rerun::ViewCoordinates::RUB)?;
 
     log_baseline_objects(rec, &annotations.objects)?;
 

--- a/examples/rust/raw_mesh/src/main.rs
+++ b/examples/rust/raw_mesh/src/main.rs
@@ -164,7 +164,7 @@ fn run(rec: &RecordingStream, args: &Args) -> anyhow::Result<()> {
     // Log raw glTF nodes and their transforms with Rerun
     for root in nodes {
         re_log::info!(scene = root.name, "logging glTF scene");
-        rec.log_timeless(root.name.as_str(), &rerun::ViewCoordinates::RIGHT_HAND_Y_UP)?;
+        rec.log_static(root.name.as_str(), &rerun::ViewCoordinates::RIGHT_HAND_Y_UP)?;
         log_node(rec, root)?;
     }
 

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -505,11 +505,7 @@ namespace rerun {
             );
             RR_RETURN_NOT_OK(err);
 
-            return try_log_serialized_batches(
-                entity_path,
-                static_,
-                std::move(serialized_batches)
-            );
+            return try_log_serialized_batches(entity_path, static_, std::move(serialized_batches));
         }
 
         /// Logs several serialized batches batches, returning an error on failure.

--- a/tests/rust/roundtrips/view_coordinates/src/main.rs
+++ b/tests/rust/roundtrips/view_coordinates/src/main.rs
@@ -10,7 +10,7 @@ struct Args {
 }
 
 fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
-    rec.log_timeless("/", &ViewCoordinates::RDF)?;
+    rec.log_static("/", &ViewCoordinates::RDF)?;
     Ok(())
 }
 

--- a/tests/rust/test_api/src/main.rs
+++ b/tests/rust/test_api/src/main.rs
@@ -348,7 +348,7 @@ fn test_transforms_3d(rec: &RecordingStream) -> anyhow::Result<()> {
         rec: &RecordingStream,
         ent_path: impl Into<EntityPath>,
     ) -> anyhow::Result<()> {
-        rec.log_timeless(ent_path, &ViewCoordinates::RIGHT_HAND_Z_UP)
+        rec.log_static(ent_path, &ViewCoordinates::RIGHT_HAND_Z_UP)
             .map_err(Into::into)
     }
     log_coordinate_space(rec, "transforms3d")?;


### PR DESCRIPTION
Just exposing all the new static stuff to the Rust SDK, and trying to kill the "timeless" terminology in the process.

---

Part of a PR series that removes the concept of timeless data in favor of the much simpler concept of static data:
- #5534
- #5535
- #5536
- #5537
- #5540

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5534/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5534/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5534/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5534)
- [Docs preview](https://rerun.io/preview/7300851b52da5876fad4d2503da1eb660b92580b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7300851b52da5876fad4d2503da1eb660b92580b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)