### PR TITLE
Include multi-platform dockerbuild with arm64 support

### DIFF
--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -86,7 +86,7 @@ jobs:
     name: Check if running codegen would produce any changes
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
     steps:
       # Note: We explicitly don't override `ref` here. We need to see if changes would be made
       # in a context where we have merged with main. Otherwise we might miss changes such as one
@@ -112,7 +112,7 @@ jobs:
     name: Rust lints (fmt, check, cranky, tests, doc)
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
     steps:
       - uses: actions/checkout@v4
 
@@ -183,7 +183,7 @@ jobs:
     name: Check Rust web build (wasm32 + wasm-bindgen)
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
     steps:
       - uses: actions/checkout@v4
 
@@ -268,7 +268,7 @@ jobs:
     name: Cargo Deny
     runs-on: ubuntu-latest
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
     steps:
       - uses: actions/checkout@v4
 
@@ -294,7 +294,7 @@ jobs:
     name: C++ tests
     runs-on: ubuntu-latest
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -36,7 +36,7 @@ jobs:
     name: Build Wheels
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
 
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -82,7 +82,7 @@ jobs:
             linux-x64)
               runner="ubuntu-latest-16-cores"
               target="x86_64-unknown-linux-gnu"
-              container="{'image': 'rerunio/ci_docker:0.11.0'}"
+              container="{'image': 'rerunio/ci_docker:0.12.0'}"
               lib_name="librerun_c.a"
               ;;
             windows-x64)

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -83,7 +83,7 @@ jobs:
             linux-x64)
               runner="ubuntu-latest-16-cores"
               target="x86_64-unknown-linux-gnu"
-              container="{'image': 'rerunio/ci_docker:0.11.0'}"
+              container="{'image': 'rerunio/ci_docker:0.12.0'}"
               bin_name="rerun"
               ;;
             windows-x64)

--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -101,8 +101,8 @@ jobs:
             linux-arm64)
                 runner="buildjet-8vcpu-ubuntu-2204-arm"
                 target="aarch64-unknown-linux-gnu"
-                container="null"
-                compat="manylinux_2_35" # TODO(#5512): bringing that down to manylinux_2_31 requires a custom container
+                container="{'image': 'rerunio/ci_docker:0.12.0'}"
+                compat="manylinux_2_31"
                 ;;
             linux-x64)
               runner="ubuntu-latest-16-cores"

--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -107,8 +107,8 @@ jobs:
             linux-x64)
               runner="ubuntu-latest-16-cores"
               target="x86_64-unknown-linux-gnu"
-              container="{'image': 'rerunio/ci_docker:0.11.0'}"
               compat="manylinux_2_31"
+              container="{'image': 'rerunio/ci_docker:0.12.0'}"
               ;;
             windows-x64)
               runner="windows-latest-8-cores"

--- a/.github/workflows/reusable_build_js.yml
+++ b/.github/workflows/reusable_build_js.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
 
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -63,7 +63,7 @@ jobs:
           if [ ${{ inputs.CHANNEL }} = "nightly" ]; then
             export DEFAULT_EXAMPLES_MANIFEST_URL="https://app.rerun.io/version/nightly/examples_manifest.json"
           fi
-          cargo run --locked -p re_build_web_viewer -- --release
+          pixi run cargo run --locked -p re_build_web_viewer -- --release
 
       # We build a single manifest pointing to the `commit`
       # All the `pr`, `main`, release tag, etc. variants will always just point to the resolved commit

--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
 
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable_bundle_and_upload_rerun_cpp.yml
+++ b/.github/workflows/reusable_bundle_and_upload_rerun_cpp.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     # Need container for arrow dependency.
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -102,7 +102,7 @@ jobs:
     name: Check if running codegen would produce any changes
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
     env:
       RUSTC_WRAPPER: "sccache"
     steps:

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -39,7 +39,7 @@ jobs:
     name: Rust lints (fmt, check, cranky, tests, doc)
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
     env:
       RUSTC_WRAPPER: "sccache"
     steps:
@@ -77,7 +77,7 @@ jobs:
     name: Check Rust web build (wasm32 + wasm-bindgen)
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
     env:
       RUSTC_WRAPPER: "sccache"
     steps:
@@ -135,7 +135,7 @@ jobs:
     name: Cargo Deny
     runs-on: ubuntu-latest
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -116,7 +116,7 @@ jobs:
     needs: [py-deploy-docs]
     runs-on: ubuntu-latest-16-cores
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
     steps:
       - name: Show context
         shell: bash

--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -1,4 +1,4 @@
-name: Reusable Buld and Upload Notebook
+name: Reusable Build and Upload Notebook
 
 on:
   workflow_call:
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: rerunio/ci_docker:0.11.0
+      image: rerunio/ci_docker:0.12.0
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -67,7 +67,7 @@ jobs:
             linux-x64)
               runner="ubuntu-latest-16-cores"
               target="x86_64-unknown-linux-gnu"
-              container="{'image': 'rerunio/ci_docker:0.11.0'}"
+              container="{'image': 'rerunio/ci_docker:0.12.0'}"
               ;;
             windows-x64)
               runner="windows-latest-8-cores"

--- a/ci_docker/Dockerfile
+++ b/ci_docker/Dockerfile
@@ -8,6 +8,8 @@ LABEL description="Docker image used for the CI of https://github.com/rerun-io/r
 # Install the ubuntu package dependencies
 # This mirrors scripts/setup.sh
 ENV DEBIAN_FRONTEND=noninteractive
+ARG TARGETARCH
+
 RUN set -eux; \
     apt-get update; \
     apt-get install -y ca-certificates lsb-release wget; \
@@ -58,8 +60,10 @@ RUN git clone --depth 1 --branch v23.5.9 https://github.com/google/flatbuffers.g
     make install && \
     cd .. && rm -rf flatbuffers
 
+
 # We need a more modern patchelf than ships on ubuntu-20.04
-RUN curl --fail -L https://github.com/NixOS/patchelf/releases/download/0.17.2/patchelf-0.17.2-x86_64.tar.gz | tar -xz ./bin/patchelf
+RUN arch=$(if [ "$TARGETARCH" = "arm64" ]; then echo "aarch64"; else echo "x86_64"; fi) && \
+    curl --fail -L https://github.com/NixOS/patchelf/releases/download/0.17.2/patchelf-0.17.2-${arch}.tar.gz | tar -xz ./bin/patchelf
 
 # TODO(andreas): Update cargo-deny below when updating rust version to 1.70.0 or above!
 ENV RUSTUP_HOME=/usr/local/rustup \
@@ -70,9 +74,10 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 
 # Install Rust
 # Borrowed from: https://github.com/rust-lang/docker-rust/blob/a8a2a9d/1.71.0/bookworm/Dockerfile
-RUN set -eux; \
-    rustArch='x86_64-unknown-linux-gnu'; \
-    rustupSha256='0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db'; \
+RUN arch=$(if [ "$TARGETARCH" = "arm64" ]; then echo "aarch64"; else echo "x86_64"; fi) && \
+    set -eux; \
+    rustArch="${arch}-unknown-linux-gnu"; \
+    rustupSha256=$(if [ "$TARGETARCH" = "arm64" ]; then echo "673e336c81c65e6b16dcdede33f4cc9ed0f08bde1dbe7a935f113605292dc800"; else echo "0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db"; fi); \
     url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustArch}/rustup-init"; \
     wget "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
@@ -104,7 +109,8 @@ ADD rerun_py/requirements-lint.txt requirements-lint.txt
 RUN pip install -r requirements-lint.txt
 
 # Note: We need a more modern binaryen than ships on ubuntu-20.4, so we pull it from github
-RUN curl --fail -L https://github.com/WebAssembly/binaryen/releases/download/version_112/binaryen-version_112-x86_64-linux.tar.gz | tar xzk --strip-components 1
+RUN arch=$(if [ "$TARGETARCH" = "arm64" ]; then echo "aarch64"; else echo "x86_64"; fi) && \
+    curl --fail -L https://github.com/WebAssembly/binaryen/releases/download/version_112/binaryen-version_112-${arch}-linux.tar.gz | tar xzk --strip-components 1
 
 # Increment this to invalidate cache
 ENV CACHE_KEY=rerun_docker_v0.10.0

--- a/ci_docker/Dockerfile
+++ b/ci_docker/Dockerfile
@@ -108,10 +108,6 @@ RUN pip install -r requirements-build.txt
 ADD rerun_py/requirements-lint.txt requirements-lint.txt
 RUN pip install -r requirements-lint.txt
 
-# Note: We need a more modern binaryen than ships on ubuntu-20.4, so we pull it from github
-RUN arch=$(if [ "$TARGETARCH" = "arm64" ]; then echo "aarch64"; else echo "x86_64"; fi) && \
-    curl --fail -L https://github.com/WebAssembly/binaryen/releases/download/version_112/binaryen-version_112-${arch}-linux.tar.gz | tar xzk --strip-components 1
-
 # Increment this to invalidate cache
 ENV CACHE_KEY=rerun_docker_v0.12.0
 

--- a/ci_docker/Dockerfile
+++ b/ci_docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 LABEL maintainer="opensource@rerun.io"
 # Remember to update the version in publish.sh
 # TODO(jleibs) use this version in the publish.sh script and below in the CACHE_KEY
-LABEL version="0.11.0"
+LABEL version="0.12.0"
 LABEL description="Docker image used for the CI of https://github.com/rerun-io/rerun"
 
 # Install the ubuntu package dependencies
@@ -113,7 +113,7 @@ RUN arch=$(if [ "$TARGETARCH" = "arm64" ]; then echo "aarch64"; else echo "x86_6
     curl --fail -L https://github.com/WebAssembly/binaryen/releases/download/version_112/binaryen-version_112-${arch}-linux.tar.gz | tar xzk --strip-components 1
 
 # Increment this to invalidate cache
-ENV CACHE_KEY=rerun_docker_v0.10.0
+ENV CACHE_KEY=rerun_docker_v0.12.0
 
 # See: https://github.com/actions/runner-images/issues/6775#issuecomment-1410270956
 RUN git config --system --add safe.directory '*'

--- a/ci_docker/publish.sh
+++ b/ci_docker/publish.sh
@@ -6,19 +6,6 @@ VERSION=0.11.0 # Bump on each new version. Remember to update the version in the
 # The build needs to run from top of repo to access the requirements.txt
 cd `git rev-parse --show-toplevel`
 
-# Pull :latest so we have the correct cache
-docker pull rerunio/ci_docker
-
 # Build the image
-docker build -t ci_docker -f ci_docker/Dockerfile .
-# This is necessary to build on mac, but is doing something weird with the Cache
-# TODO(jleibs): Make this all work portably with caching
-# docker buildx build --platform=linux/amd64 -t ci_docker -f ci_docker/Dockerfile .
-
-# Tag latest and version
-docker tag ci_docker rerunio/ci_docker
-docker tag ci_docker rerunio/ci_docker:$VERSION
-
-# Push the images back up
-docker push rerunio/ci_docker
-docker push rerunio/ci_docker:$VERSION
+# buildx wants to do all of this in one step
+docker buildx build --pull --platform linux/arm64,linux/amd64 -t rerunio/ci_docker -t rerunio/ci_docker:$VERSION --push -f ci_docker/Dockerfile .

--- a/ci_docker/publish.sh
+++ b/ci_docker/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-VERSION=0.11.0 # Bump on each new version. Remember to update the version in the Dockerfile too.
+VERSION=0.12.0 # Bump on each new version. Remember to update the version in the Dockerfile too.
 
 # The build needs to run from top of repo to access the requirements.txt
 cd `git rev-parse --show-toplevel`


### PR DESCRIPTION
### What
 - Switch to using docker buildx to create the docker environment
 - Update the platform-specific parts of the dockerfile to use the targetplatform
 - Bump the version to 0.12 just in case something goes wrong.
 - Start using the docker container on buildjet

```
$ docker buildx imagetools inspect  rerunio/ci_docker:0.12.0
Name:      docker.io/rerunio/ci_docker:0.12.0
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:9575a44a30152ef292c8f73e9546f1d431ea32246bc7a0043ba51f4df936c537
           
Manifests: 
  Name:        docker.io/rerunio/ci_docker:0.12.0@sha256:7e0e5a31234578d10c53733e9e703972d73ac7df992323d95feb60700cb94e4b
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/arm64
               
  Name:        docker.io/rerunio/ci_docker:0.12.0@sha256:e1861e823b15b3accf103c00910fa24a89aa274f02550b5458524322cc1f39ce
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/amd64
```

Successful buildjet run: https://github.com/rerun-io/rerun/actions/runs/8301499563/job/22721760001
![image](https://github.com/rerun-io/rerun/assets/3312232/8524e28e-8630-4c1e-a0e1-972e5a928487)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5543/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5543/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5543/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5543)
- [Docs preview](https://rerun.io/preview/3eb7524e2f955e97dcb423b6a16c10f7fdb75ba9/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3eb7524e2f955e97dcb423b6a16c10f7fdb75ba9/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)