### PR TITLE
Fix RERUN_C_BUILD_ARTIFACT path value if CARGO_BUILD_TARGET env variable is set

### DIFF
--- a/crates/rerun_c/CMakeLists.txt
+++ b/crates/rerun_c/CMakeLists.txt
@@ -2,11 +2,11 @@
 
 # Determine Rust's librerun path.
 if(APPLE)
-    set(RERUN_C_BUILD_ARTIFACT ${CMAKE_CURRENT_SOURCE_DIR}/../../target/release/librerun_c.a)
+    set(RERUN_C_BUILD_ARTIFACT ${CMAKE_CURRENT_SOURCE_DIR}/../../target/$ENV{CARGO_BUILD_TARGET}/release/librerun_c.a)
 elseif(UNIX) # if(LINUX) # CMake 3.25
-    set(RERUN_C_BUILD_ARTIFACT ${CMAKE_CURRENT_SOURCE_DIR}/../../target/release/librerun_c.a)
+    set(RERUN_C_BUILD_ARTIFACT ${CMAKE_CURRENT_SOURCE_DIR}/../../target/$ENV{CARGO_BUILD_TARGET}/release/librerun_c.a)
 elseif(WIN32)
-    set(RERUN_C_BUILD_ARTIFACT ${CMAKE_CURRENT_SOURCE_DIR}/../../target/release/rerun_c.lib)
+    set(RERUN_C_BUILD_ARTIFACT ${CMAKE_CURRENT_SOURCE_DIR}/../../target/$ENV{CARGO_BUILD_TARGET}/release/rerun_c.lib)
 else()
     message(FATAL_ERROR "Unsupported platform.")
 endif()


### PR DESCRIPTION
### What

When building the conda-forge package for the C++ bindings for rerun-sdk, I encountered a failure of the following type (see https://github.com/conda-forge/staged-recipes/pull/25648#issuecomment-2000481352):
~~~
[307/532] Linking CXX shared library rerun_cpp/librerun_sdk.so
FAILED: rerun_cpp/librerun_sdk.so 
: && $BUILD_PREFIX/bin/x86_64-conda-linux-gnu-c++ -fPIC -fvisibility-inlines-hidden -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local/src/conda/librerun-sdk-0.14.1 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix -O3 -DNDEBUG  -Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -Wl,--allow-shlib-undefined -Wl,-rpath,$PREFIX/lib -Wl,-rpath-link,$PREFIX/lib -L$PREFIX/lib -shared -Wl,-soname,librerun_sdk.so -o rerun_cpp/librerun_sdk.so rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/annotation_context.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/arrows2d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/arrows2d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/arrows3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/arrows3d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/asset3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/asset3d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/bar_chart.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/bar_chart_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/boxes2d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/boxes2d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/boxes3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/boxes3d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/clear.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/clear_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/depth_image.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/depth_image_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/disconnected_space.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/image.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/image_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/line_strips2d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/line_strips3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/mesh3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/pinhole.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/pinhole_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/points2d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/points3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/scalar.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/segmentation_image.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/segmentation_image_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/series_line.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/series_point.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/tensor.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/tensor_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/text_document.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/text_log.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/time_series_scalar.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/transform3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/transform3d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/view_coordinates.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/view_coordinates_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/container_blueprint.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/plot_legend.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/scalar_axis.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/space_view_blueprint.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/viewport_blueprint.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/active_tab.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/auto_layout.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/auto_space_views.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/column_shares.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/container_kind.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/corner2d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/entities_determined_by_user.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/entity_properties_component.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/grid_columns.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/included_contents.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/included_queries.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/included_space_views.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/lock_range_during_zoom.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/panel_view.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/query_expressions.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/root_container.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/row_shares.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/space_view_class.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/space_view_maximized.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/space_view_origin.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/viewport_layout.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/visible.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/datatypes/legend.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/component_type.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/annotation_context.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/annotation_context_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/blob.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/class_id.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/clear_is_recursive.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/color.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/color_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/depth_meter.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/disconnected_space.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/draw_order.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/half_sizes2d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/half_sizes2d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/half_sizes3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/half_sizes3d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/instance_key.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/keypoint_id.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/line_strip2d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/line_strip3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/marker_shape.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/marker_shape_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/marker_size.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/material.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/material_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/media_type.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/media_type_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/mesh_properties.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/mesh_properties_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/name.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/name_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/out_of_tree_transform3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/pinhole_projection.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/pinhole_projection_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/position2d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/position2d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/position3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/position3d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/radius.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/range1d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/resolution.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/resolution_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/rotation3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/rotation3d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/scalar.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/scalar_scattering.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/stroke_width.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/tensor_data.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/tensor_data_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/texcoord2d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/texcoord2d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/text.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/text_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/text_log_level.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/text_log_level_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/transform3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/vector2d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/vector2d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/vector3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/vector3d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/view_coordinates.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/view_coordinates_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/components/visualizer_overrides.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/config.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/data_cell.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/angle.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/annotation_info.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/annotation_info_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/class_description.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/class_description_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/class_description_map_elem.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/class_description_map_elem_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/class_id.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/entity_path.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/float32.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/keypoint_id.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/keypoint_pair.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/keypoint_pair_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/mat3x3.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/mat3x3_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/mat4x4.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/mat4x4_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/material.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/mesh_properties.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/quaternion.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/quaternion_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/rgba32.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/rgba32_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/rotation3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/rotation3d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/rotation_axis_angle.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/rotation_axis_angle_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/scale3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/tensor_buffer.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/tensor_buffer_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/tensor_data.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/tensor_data_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/tensor_dimension.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/tensor_dimension_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/transform3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/translation_and_mat3x3.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/translation_and_mat3x3_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/translation_rotation_scale3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/translation_rotation_scale3d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/uint32.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/utf8.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/utf8_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/uuid.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/uvec2d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/uvec3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/uvec4d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/vec2d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/vec2d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/vec3d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/vec3d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/vec4d.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/vec4d_ext.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/demo_utils.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/entity_path.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/error.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/indicator_component.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/recording_stream.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/sdk_info.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/spawn.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/spawn_options.cpp.o rerun_cpp/CMakeFiles/rerun_sdk.dir/src/rerun/string_utils.cpp.o  $SRC_DIR/crates/rerun_c/../../target/release/librerun_c.a  $PREFIX/lib/libarrow.so.1200.1.0  -lm -ldl -pthread && :
$BUILD_PREFIX/bin/../lib/gcc/x86_64-conda-linux-gnu/12.3.0/../../../../x86_64-conda-linux-gnu/bin/ld: cannot find $SRC_DIR/crates/rerun_c/../../target/release/librerun_c.a: No such file or directory
collect2: error: ld returned 1 exit status
~~~

It turned out that this was due to some rust activation script in conda-forge, that defined the `CARGO_BUILD_TARGET` env variable, and that apparently changed the location of the `librerun_c.a` library generated by cargo. To handle this, I modified the CMake code as reported in this PR. If the `CARGO_BUILD_TARGET` env variable is not defined, `$ENV{CARGO_BUILD_TARGET}` evalutes to an empty string, and the behaviour is exactly the same that you have before this PR. 

I am not sure if it make sense to have this patch upstream, but I guess even to just ask that it was more efficient to open a PR rather than to open an issue to ask if it could make sense to open a PR. If you think it is better no to have this change upstream, feel free to close the PR, we can just keep the patch locally in https://github.com/conda-forge/librerun-sdk-feedstock/blob/main/recipe/fixrerun_c_location.patch .


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5547/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5547/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5547/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5547)
- [Docs preview](https://rerun.io/preview/3af4793c662b313c1cc14062566eca05e4e34dda/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3af4793c662b313c1cc14062566eca05e4e34dda/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)