### PR TITLE
Support loading multiple recordings and/or blueprints in web-viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,7 +1555,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.26.2"
-source = "git+https://github.com/emilk/egui.git?rev=bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb#bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb"
+source = "git+https://github.com/emilk/egui.git?rev=820fa3c43a2d20e140bc4525e0a1405e7420bb66#820fa3c43a2d20e140bc4525e0a1405e7420bb66"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1564,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.26.2"
-source = "git+https://github.com/emilk/egui.git?rev=bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb#bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb"
+source = "git+https://github.com/emilk/egui.git?rev=820fa3c43a2d20e140bc4525e0a1405e7420bb66#820fa3c43a2d20e140bc4525e0a1405e7420bb66"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1599,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.26.2"
-source = "git+https://github.com/emilk/egui.git?rev=bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb#bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb"
+source = "git+https://github.com/emilk/egui.git?rev=820fa3c43a2d20e140bc4525e0a1405e7420bb66#820fa3c43a2d20e140bc4525e0a1405e7420bb66"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1615,7 +1615,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.26.2"
-source = "git+https://github.com/emilk/egui.git?rev=bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb#bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb"
+source = "git+https://github.com/emilk/egui.git?rev=820fa3c43a2d20e140bc4525e0a1405e7420bb66#820fa3c43a2d20e140bc4525e0a1405e7420bb66"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1633,7 +1633,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.26.2"
-source = "git+https://github.com/emilk/egui.git?rev=bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb#bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb"
+source = "git+https://github.com/emilk/egui.git?rev=820fa3c43a2d20e140bc4525e0a1405e7420bb66#820fa3c43a2d20e140bc4525e0a1405e7420bb66"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1662,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.26.2"
-source = "git+https://github.com/emilk/egui.git?rev=bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb#bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb"
+source = "git+https://github.com/emilk/egui.git?rev=820fa3c43a2d20e140bc4525e0a1405e7420bb66#820fa3c43a2d20e140bc4525e0a1405e7420bb66"
 dependencies = [
  "egui",
  "ehttp",
@@ -1677,7 +1677,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.26.2"
-source = "git+https://github.com/emilk/egui.git?rev=bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb#bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb"
+source = "git+https://github.com/emilk/egui.git?rev=820fa3c43a2d20e140bc4525e0a1405e7420bb66#820fa3c43a2d20e140bc4525e0a1405e7420bb66"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.26.2"
-source = "git+https://github.com/emilk/egui.git?rev=bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb#bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb"
+source = "git+https://github.com/emilk/egui.git?rev=820fa3c43a2d20e140bc4525e0a1405e7420bb66#820fa3c43a2d20e140bc4525e0a1405e7420bb66"
 dependencies = [
  "egui",
 ]
@@ -1736,7 +1736,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.26.2"
-source = "git+https://github.com/emilk/egui.git?rev=bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb#bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb"
+source = "git+https://github.com/emilk/egui.git?rev=820fa3c43a2d20e140bc4525e0a1405e7420bb66#820fa3c43a2d20e140bc4525e0a1405e7420bb66"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.26.2"
-source = "git+https://github.com/emilk/egui.git?rev=bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb#bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb"
+source = "git+https://github.com/emilk/egui.git?rev=820fa3c43a2d20e140bc4525e0a1405e7420bb66#820fa3c43a2d20e140bc4525e0a1405e7420bb66"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -283,13 +283,13 @@ debug = true
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb" }      # egui master 2024-03-15
-eframe = { git = "https://github.com/emilk/egui.git", rev = "bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb" }      # egui master 2024-03-15
-egui = { git = "https://github.com/emilk/egui.git", rev = "bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb" }        # egui master 2024-03-15
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb" } # egui master 2024-03-15
-egui_plot = { git = "https://github.com/emilk/egui.git", rev = "bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb" }   # egui master 2024-03-15
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb" }   # egui master 2024-03-15
-emath = { git = "https://github.com/emilk/egui.git", rev = "bf7ffb982a6e8c0a40d0871c38bccacef9ee8efb" }       # egui master 2024-03-15
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "820fa3c43a2d20e140bc4525e0a1405e7420bb66" }      # egui master 2024-03-17
+eframe = { git = "https://github.com/emilk/egui.git", rev = "820fa3c43a2d20e140bc4525e0a1405e7420bb66" }      # egui master 2024-03-17
+egui = { git = "https://github.com/emilk/egui.git", rev = "820fa3c43a2d20e140bc4525e0a1405e7420bb66" }        # egui master 2024-03-17
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "820fa3c43a2d20e140bc4525e0a1405e7420bb66" } # egui master 2024-03-17
+egui_plot = { git = "https://github.com/emilk/egui.git", rev = "820fa3c43a2d20e140bc4525e0a1405e7420bb66" }   # egui master 2024-03-17
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "820fa3c43a2d20e140bc4525e0a1405e7420bb66" }   # egui master 2024-03-17
+emath = { git = "https://github.com/emilk/egui.git", rev = "820fa3c43a2d20e140bc4525e0a1405e7420bb66" }       # egui master 2024-03-17
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/crates/re_data_source/src/data_source.rs
+++ b/crates/re_data_source/src/data_source.rs
@@ -10,6 +10,8 @@ use anyhow::Context as _;
 #[derive(Debug, Clone)]
 pub enum DataSource {
     /// A remote RRD file, served over http.
+    ///
+    /// Could be either an `.rrd` recording or a `.rbl` blueprint.
     RrdHttpUrl(String),
 
     /// A path to a local file.
@@ -86,7 +88,7 @@ impl DataSource {
             DataSource::FilePath(file_source, path)
         } else if uri.starts_with("http://")
             || uri.starts_with("https://")
-            || (uri.starts_with("www.") && uri.ends_with(".rrd"))
+            || (uri.starts_with("www.") && (uri.ends_with(".rrd") || uri.ends_with(".rbl")))
         {
             DataSource::RrdHttpUrl(uri)
         } else if uri.starts_with("ws://") || uri.starts_with("wss://") {
@@ -95,7 +97,7 @@ impl DataSource {
         // Now we are into heuristics territory:
         } else if looks_like_a_file_path(&uri) {
             DataSource::FilePath(file_source, path)
-        } else if uri.ends_with(".rrd") {
+        } else if uri.ends_with(".rrd") || uri.ends_with(".rbl") {
             DataSource::RrdHttpUrl(uri)
         } else {
             // If this is sometyhing like `foo.com` we can't know what it is until we connect to it.
@@ -234,6 +236,7 @@ fn test_data_source_from_uri() {
         "https://foo.zip",
         "example.zip/foo.rrd",
         "www.foo.zip/foo.rrd",
+        "www.foo.zip/blueprint.rbl",
     ];
     let ws = ["ws://foo.zip", "wss://foo.zip", "127.0.0.1"];
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -263,6 +263,7 @@ impl App {
     }
 
     pub fn set_examples_manifest_url(&mut self, url: String) {
+        re_log::info!("Using manifest_url={url:?}");
         self.state
             .set_examples_manifest_url(&self.re_ui.egui_ctx, url);
     }

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -222,6 +222,8 @@ pub fn set_email(email: String) {
 
 enum EndpointCategory {
     /// Could be a local path (`/foo.rrd`) or a remote url (`http://foo.com/bar.rrd`).
+    ///
+    /// Could be a link to either an `.rrd` recording or a `.rbl` blueprint.
     HttpRrd(String),
 
     /// A remote Rerun server.
@@ -232,7 +234,7 @@ enum EndpointCategory {
 }
 
 fn categorize_uri(uri: &str) -> EndpointCategory {
-    if uri.starts_with("http") || uri.ends_with(".rrd") {
+    if uri.starts_with("http") || uri.ends_with(".rrd") || uri.ends_with(".rbl") {
         EndpointCategory::HttpRrd(uri.into())
     } else if uri.starts_with("ws:") || uri.starts_with("wss:") {
         EndpointCategory::WebSocket(uri.into())

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -133,22 +133,21 @@ fn create_app(
 
     let query_map = &cc.integration_info.web_info.location.query_map;
 
-    let manifest_url = match &manifest_url {
-        Some(url) => Some(url.as_str()),
-        None => query_map.get("manifest_url").map(String::as_str),
-    };
-    if let Some(url) = manifest_url {
-        app.set_examples_manifest_url(url.into());
-        re_log::info!("Using manifest_url={url:?}");
+    if let Some(manifest_url) = manifest_url {
+        app.set_examples_manifest_url(manifest_url.into());
+    } else {
+        for url in query_map.get("manifest_url").into_iter().flatten() {
+            app.set_examples_manifest_url(url.clone());
+        }
     }
 
-    let url = match &url {
-        Some(url) => Some(url.as_str()),
-        None => query_map.get("url").map(String::as_str),
-    };
     if let Some(url) = url {
-        let rx = url_to_receiver(url, egui_ctx.clone());
-        app.add_receiver(rx);
+        app.add_receiver(url_to_receiver(url, egui_ctx));
+    } else {
+        // NOTE: we support passing in multiple urls to multiple different recorording, blueprints, etc
+        for url in query_map.get("url").into_iter().flatten() {
+            app.add_receiver(url_to_receiver(url, egui_ctx.clone()));
+        }
     }
 
     app
@@ -261,21 +260,27 @@ fn get_persist_state(info: &eframe::IntegrationInfo) -> bool {
 
 fn get_query_bool(info: &eframe::IntegrationInfo, key: &str, default: bool) -> bool {
     let default_int = default as i32;
-    match info
-        .web_info
-        .location
-        .query_map
-        .get(key)
-        .map(String::as_str)
-    {
-        Some("0") => false,
-        Some("1") => true,
-        Some(other) => {
+
+    if let Some(values) = info.web_info.location.query_map.get(key) {
+        if values.len() == 1 {
+            match values[0].as_str() {
+                "0" => false,
+                "1" => true,
+                other => {
+                    re_log::warn!(
+                            "Unexpected value for '{key}' query: {other:?}. Expected either '0' or '1'. Defaulting to '{default_int}'."
+                        );
+                    default
+                }
+            }
+        } else {
             re_log::warn!(
-                "Unexpected value for '{key}' query: {other:?}. Expected either '0' or '1'. Defaulting to '{default_int}'."
+                "Found {} values for '{key}' query. Expected one or none. Defaulting to '{default_int}'.",
+                values.len()
             );
             default
         }
-        _ => default,
+    } else {
+        default
     }
 }


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5294

This adds support for passing multiple .rrd and/or .rbl files to the web-viewer by repeating the `url` query parameter.

### TODO
* [x] Test this

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5548/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5548/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5548/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5548)
- [Docs preview](https://rerun.io/preview/62af0e20b1216c2dfc66806d8470966259606981/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/62af0e20b1216c2dfc66806d8470966259606981/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)