### PR TITLE
Make arrow null fields nullable in C++

### DIFF
--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -2345,7 +2345,7 @@ fn quote_arrow_field_type(
 ) -> TokenStream {
     let name = &field.name;
     let datatype = quote_arrow_data_type(&field.typ, objects, includes, false);
-    let is_nullable = field.is_nullable;
+    let is_nullable = field.is_nullable || field.typ == Type::Unit; // null type is always nullable
 
     quote! {
         arrow::field(#name, #datatype, #is_nullable)
@@ -2359,9 +2359,9 @@ fn quote_arrow_elem_type(
 ) -> TokenStream {
     let typ: Type = elem_type.clone().into();
     let datatype = quote_arrow_data_type(&typ, objects, includes, false);
-
+    let is_nullable = typ == Type::Unit; // null type must be nullable
     quote! {
-        arrow::field("item", #datatype, false)
+        arrow::field("item", #datatype, #is_nullable)
     }
 }
 

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -798,7 +798,7 @@ impl ObjectField {
         let typ = Type::from_raw_type(&virtpath, enums, objs, field.type_(), &attrs);
         let order = attrs.get::<u32>(&fqname, crate::ATTR_ORDER);
 
-        let is_nullable = attrs.has(crate::ATTR_NULLABLE);
+        let is_nullable = attrs.has(crate::ATTR_NULLABLE) || typ == Type::Unit; // null type is always nullable
         let is_deprecated = field.deprecated();
 
         Self {
@@ -852,7 +852,8 @@ impl ObjectField {
             &attrs,
         );
 
-        let is_nullable = attrs.has(crate::ATTR_NULLABLE);
+        let is_nullable = attrs.has(crate::ATTR_NULLABLE) || typ == Type::Unit; // null type is always nullable
+
         // TODO(cmc): not sure about this, but fbs unions are a bit weird that way
         let is_deprecated = false;
 

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -854,7 +854,6 @@ impl ObjectField {
 
         let is_nullable = attrs.has(crate::ATTR_NULLABLE) || typ == Type::Unit; // null type is always nullable
 
-        // TODO(cmc): not sure about this, but fbs unions are a bit weird that way
         let is_deprecated = false;
 
         if attrs.has(crate::ATTR_ORDER) {

--- a/rerun_cpp/src/rerun/blueprint/components/background3d_kind.cpp
+++ b/rerun_cpp/src/rerun/blueprint/components/background3d_kind.cpp
@@ -11,9 +11,9 @@ namespace rerun {
         Loggable<blueprint::components::Background3DKind>::arrow_datatype() {
         static const auto datatype = arrow::sparse_union({
             arrow::field("_null_markers", arrow::null(), true, nullptr),
-            arrow::field("GradientDark", arrow::null(), false),
-            arrow::field("GradientBright", arrow::null(), false),
-            arrow::field("SolidColor", arrow::null(), false),
+            arrow::field("GradientDark", arrow::null(), true),
+            arrow::field("GradientBright", arrow::null(), true),
+            arrow::field("SolidColor", arrow::null(), true),
         });
         return datatype;
     }

--- a/rerun_cpp/src/rerun/blueprint/components/container_kind.cpp
+++ b/rerun_cpp/src/rerun/blueprint/components/container_kind.cpp
@@ -11,10 +11,10 @@ namespace rerun {
         Loggable<blueprint::components::ContainerKind>::arrow_datatype() {
         static const auto datatype = arrow::sparse_union({
             arrow::field("_null_markers", arrow::null(), true, nullptr),
-            arrow::field("Tabs", arrow::null(), false),
-            arrow::field("Horizontal", arrow::null(), false),
-            arrow::field("Vertical", arrow::null(), false),
-            arrow::field("Grid", arrow::null(), false),
+            arrow::field("Tabs", arrow::null(), true),
+            arrow::field("Horizontal", arrow::null(), true),
+            arrow::field("Vertical", arrow::null(), true),
+            arrow::field("Grid", arrow::null(), true),
         });
         return datatype;
     }

--- a/rerun_cpp/src/rerun/blueprint/components/corner2d.cpp
+++ b/rerun_cpp/src/rerun/blueprint/components/corner2d.cpp
@@ -11,10 +11,10 @@ namespace rerun {
         Loggable<blueprint::components::Corner2D>::arrow_datatype() {
         static const auto datatype = arrow::sparse_union({
             arrow::field("_null_markers", arrow::null(), true, nullptr),
-            arrow::field("LeftTop", arrow::null(), false),
-            arrow::field("RightTop", arrow::null(), false),
-            arrow::field("LeftBottom", arrow::null(), false),
-            arrow::field("RightBottom", arrow::null(), false),
+            arrow::field("LeftTop", arrow::null(), true),
+            arrow::field("RightTop", arrow::null(), true),
+            arrow::field("LeftBottom", arrow::null(), true),
+            arrow::field("RightBottom", arrow::null(), true),
         });
         return datatype;
     }

--- a/rerun_cpp/src/rerun/components/marker_shape.cpp
+++ b/rerun_cpp/src/rerun/components/marker_shape.cpp
@@ -10,16 +10,16 @@ namespace rerun {
     const std::shared_ptr<arrow::DataType>& Loggable<components::MarkerShape>::arrow_datatype() {
         static const auto datatype = arrow::sparse_union({
             arrow::field("_null_markers", arrow::null(), true, nullptr),
-            arrow::field("Circle", arrow::null(), false),
-            arrow::field("Diamond", arrow::null(), false),
-            arrow::field("Square", arrow::null(), false),
-            arrow::field("Cross", arrow::null(), false),
-            arrow::field("Plus", arrow::null(), false),
-            arrow::field("Up", arrow::null(), false),
-            arrow::field("Down", arrow::null(), false),
-            arrow::field("Left", arrow::null(), false),
-            arrow::field("Right", arrow::null(), false),
-            arrow::field("Asterisk", arrow::null(), false),
+            arrow::field("Circle", arrow::null(), true),
+            arrow::field("Diamond", arrow::null(), true),
+            arrow::field("Square", arrow::null(), true),
+            arrow::field("Cross", arrow::null(), true),
+            arrow::field("Plus", arrow::null(), true),
+            arrow::field("Up", arrow::null(), true),
+            arrow::field("Down", arrow::null(), true),
+            arrow::field("Left", arrow::null(), true),
+            arrow::field("Right", arrow::null(), true),
+            arrow::field("Asterisk", arrow::null(), true),
         });
         return datatype;
     }

--- a/rerun_cpp/tests/generated/components/enum_test.cpp
+++ b/rerun_cpp/tests/generated/components/enum_test.cpp
@@ -10,12 +10,12 @@ namespace rerun {
     const std::shared_ptr<arrow::DataType>& Loggable<components::EnumTest>::arrow_datatype() {
         static const auto datatype = arrow::sparse_union({
             arrow::field("_null_markers", arrow::null(), true, nullptr),
-            arrow::field("Up", arrow::null(), false),
-            arrow::field("Down", arrow::null(), false),
-            arrow::field("Right", arrow::null(), false),
-            arrow::field("Left", arrow::null(), false),
-            arrow::field("Forward", arrow::null(), false),
-            arrow::field("Back", arrow::null(), false),
+            arrow::field("Up", arrow::null(), true),
+            arrow::field("Down", arrow::null(), true),
+            arrow::field("Right", arrow::null(), true),
+            arrow::field("Left", arrow::null(), true),
+            arrow::field("Forward", arrow::null(), true),
+            arrow::field("Back", arrow::null(), true),
         });
         return datatype;
     }


### PR DESCRIPTION
* Closes #5459

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5551/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5551/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5551/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5551)
- [Docs preview](https://rerun.io/preview/4fdba96c770a32dad1a69dbbfad20c5b0a73abf8/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4fdba96c770a32dad1a69dbbfad20c5b0a73abf8/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)