### PR TITLE
Fix recommendation from one Space View class affecting recommendation from another

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4923,6 +4923,7 @@ dependencies = [
  "mime_guess2",
  "mint",
  "ndarray",
+ "nohash-hasher",
  "once_cell",
  "ply-rs",
  "rand",

--- a/crates/re_types/Cargo.toml
+++ b/crates/re_types/Cargo.toml
@@ -71,6 +71,7 @@ itertools.workspace = true
 linked-hash-map.workspace = true
 mime_guess2.workspace = true
 ndarray.workspace = true
+nohash-hasher.workspace = true
 once_cell.workspace = true
 ply-rs.workspace = true
 smallvec.workspace = true

--- a/crates/re_types/src/blueprint/components/mod.rs
+++ b/crates/re_types/src/blueprint/components/mod.rs
@@ -13,6 +13,7 @@ mod row_share;
 mod space_view_class;
 mod space_view_origin;
 mod viewer_recommendation_hash;
+mod viewer_recommendation_hash_ext;
 mod visible;
 mod visible_ext;
 

--- a/crates/re_types/src/blueprint/components/viewer_recommendation_hash_ext.rs
+++ b/crates/re_types/src/blueprint/components/viewer_recommendation_hash_ext.rs
@@ -1,0 +1,10 @@
+use super::ViewerRecommendationHash;
+
+impl std::hash::Hash for ViewerRecommendationHash {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write_u64(self.0 .0);
+    }
+}
+
+impl nohash_hasher::IsEnabled for ViewerRecommendationHash {}

--- a/crates/re_viewer_context/src/space_view/spawn_heuristics.rs
+++ b/crates/re_viewer_context/src/space_view/spawn_heuristics.rs
@@ -1,7 +1,9 @@
-use re_log_types::{EntityPath, EntityPathFilter, EntityPathSubs};
+use re_log_types::{hash::Hash64, EntityPath, EntityPathFilter, EntityPathSubs};
+
+use crate::SpaceViewClassIdentifier;
 
 /// Properties of a space view that as recommended to be spawned by default via space view spawn heuristics.
-#[derive(Hash, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct RecommendedSpaceView {
     pub origin: EntityPath,
     pub query_filter: EntityPathFilter,
@@ -41,5 +43,23 @@ impl RecommendedSpaceView {
     #[inline]
     pub fn root() -> Self {
         Self::new_subtree(EntityPath::root())
+    }
+
+    /// Hash together with the Space View class id to the `ViewerRecommendationHash` component.
+    ///
+    /// Recommendations are usually tied to a specific Space View class.
+    /// Therefore, to identify a recommendation for identification purposes, the class id should be included in the hash.
+    pub fn recommendation_hash(
+        &self,
+        class_id: SpaceViewClassIdentifier,
+    ) -> re_types::blueprint::components::ViewerRecommendationHash {
+        let Self {
+            origin,
+            query_filter,
+        } = self;
+
+        Hash64::hash((origin, query_filter, class_id))
+            .hash64()
+            .into()
     }
 }


### PR DESCRIPTION
### What

This broke recently due to the tracking of space view recommendation hashes _without_ taking into account their class.
Cleaned up the whole thing a little bit in the progress.

* Fixes #5455
    * Also mentioned on this ticket is this issue but it turned out to be unrelated (thus now a separate ticket) #5553
    * 5455 is new to 0.15alpha, but 5553 happens on 0.14!

---

For this script:
```py
import rerun as rr

rr.init("rerun_example_bug")
rr.connect()
rr.set_time_sequence("frame_nr", 0)

rr.log("boxes3d", rr.Boxes3D(centers=[[0, 0, 0], [1, 1.5, 1.15], [3, 2, 1]], half_sizes=[0.5, 1, 0.5] * 3))
rr.log("boxes2d", rr.Boxes2D(centers=[[0, 0], [1.3, 0.5], [3, 2]], half_sizes=[0.5, 1] * 3))
rr.log("text_logs", rr.TextLog("Hello, world!", level=rr.TextLogLevel.INFO))
rr.log("points2d", rr.Points2D([[0, 0], [1, 1], [3, 2]], labels=["a", "b", "c"]))
```

Before: Only text view visible.

After:
<img width="1425" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/b6491052-9ae1-4199-a515-1f457515a7ec">



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
