### PR TITLE
Don't merge recording and blueprint in --test-receive

### DIFF
--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -793,7 +793,8 @@ fn assert_receive_into_entity_db(
 ) -> anyhow::Result<re_entity_db::EntityDb> {
     re_log::info!("Receiving messages into a EntityDb…");
 
-    let mut db: Option<re_entity_db::EntityDb> = None;
+    let mut rec: Option<re_entity_db::EntityDb> = None;
+    let mut bp: Option<re_entity_db::EntityDb> = None;
 
     let mut num_messages = 0;
 
@@ -810,9 +811,14 @@ fn assert_receive_into_entity_db(
 
                 match msg.payload {
                     SmartMessagePayload::Msg(msg) => {
-                        let mut_db = db.get_or_insert_with(|| {
-                            re_entity_db::EntityDb::new(msg.store_id().clone())
-                        });
+                        let mut_db = match msg.store_id().kind {
+                            re_log_types::StoreKind::Recording => rec.get_or_insert_with(|| {
+                                re_entity_db::EntityDb::new(msg.store_id().clone())
+                            }),
+                            re_log_types::StoreKind::Blueprint => bp.get_or_insert_with(|| {
+                                re_entity_db::EntityDb::new(msg.store_id().clone())
+                            }),
+                        };
 
                         mut_db.add(&msg)?;
                         num_messages += 1;
@@ -820,7 +826,7 @@ fn assert_receive_into_entity_db(
                     SmartMessagePayload::Quit(err) => {
                         if let Some(err) = err {
                             anyhow::bail!("data source has disconnected unexpectedly: {err}")
-                        } else if let Some(db) = db {
+                        } else if let Some(db) = rec {
                             db.store().sanity_check()?;
                             anyhow::ensure!(0 < num_messages, "No messages received");
                             re_log::info!("Successfully ingested {num_messages} messages.");


### PR DESCRIPTION
### What
This was causing CI failures.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5560/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5560/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5560/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5560)
- [Docs preview](https://rerun.io/preview/3747cde334e6ed28de85c5d41353423813d5d706/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3747cde334e6ed28de85c5d41353423813d5d706/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)