### PR TITLE
Fix not creating 3D space views for pinhole-only 3D scenes

### DIFF
--- a/crates/re_space_view_spatial/src/space_view_3d.rs
+++ b/crates/re_space_view_spatial/src/space_view_3d.rs
@@ -212,36 +212,58 @@ impl SpaceViewClass for SpatialSpaceView3D {
             recommended_space_views: topo
                 .iter_subspaces()
                 .filter_map(|subspace| {
-                    if !subspace.supports_3d_content() || subspace.entities.is_empty() {
-                        None
-                    } else {
-                        // Creates space views at each view coordinates if there's any.
-                        // (yes, we do so even if they're empty at the moment!)
-                        //
-                        // An exception to this rule is not to create a view there if this is already _also_ a subspace root.
-                        // (e.g. this also has a camera or a `disconnect` logged there)
-                        let mut origins = subspace
-                            .heuristic_hints
-                            .iter()
-                            .filter(|(path, hint)| {
-                                hint.contains(HeuristicHints::ViewCoordinates3d)
-                                    && !subspace.child_spaces.contains(path)
-                            })
-                            .map(|(path, _)| path.clone())
-                            .collect::<Vec<_>>();
-
-                        // If there's no view coordinates or there are still some entities not covered,
-                        // create a view at the subspace origin.
-                        if !origins.iter().contains(&subspace.origin)
-                            && indicated_entities
-                                .intersection(&subspace.entities)
-                                .any(|e| origins.iter().all(|origin| !e.starts_with(origin)))
-                        {
-                            origins.push(subspace.origin.clone());
-                        }
-
-                        Some(origins.into_iter().map(RecommendedSpaceView::new_subtree))
+                    if !subspace.supports_3d_content() {
+                        return None;
                     }
+
+                    let mut pinhole_child_spaces = subspace
+                        .child_spaces
+                        .iter()
+                        .filter(|child| {
+                            topo.subspace_for_subspace_origin(child.hash()).map_or(
+                                false,
+                                |child_space| {
+                                    child_space.connection_to_parent.is_connected_pinhole()
+                                },
+                            )
+                        })
+                        .peekable(); // Don't collect the iterator, we're only interested in 'any'-style operations.
+
+                    // Empty space views are still of interest if any of the child spaces is connected via a pinhole.
+                    if subspace.entities.is_empty() && pinhole_child_spaces.peek().is_none() {
+                        return None;
+                    }
+
+                    // Creates space views at each view coordinates if there's any.
+                    // (yes, we do so even if they're empty at the moment!)
+                    //
+                    // An exception to this rule is not to create a view there if this is already _also_ a subspace root.
+                    // (e.g. this also has a camera or a `disconnect` logged there)
+                    let mut origins = subspace
+                        .heuristic_hints
+                        .iter()
+                        .filter(|(path, hint)| {
+                            hint.contains(HeuristicHints::ViewCoordinates3d)
+                                && !subspace.child_spaces.contains(path)
+                        })
+                        .map(|(path, _)| path.clone())
+                        .collect::<Vec<_>>();
+
+                    let path_not_covered_yet =
+                        |e: &EntityPath| origins.iter().all(|origin| !e.starts_with(origin));
+
+                    // If there's no view coordinates or there are still some entities not covered,
+                    // create a view at the subspace origin.
+                    if !origins.iter().contains(&subspace.origin)
+                        && (indicated_entities
+                            .intersection(&subspace.entities)
+                            .any(path_not_covered_yet)
+                            || pinhole_child_spaces.any(path_not_covered_yet))
+                    {
+                        origins.push(subspace.origin.clone());
+                    }
+
+                    Some(origins.into_iter().map(RecommendedSpaceView::new_subtree))
                 })
                 .flatten()
                 .collect(),


### PR DESCRIPTION
### What

* Fixes #5553

`python /Users/andreas/dev/rerun-io/rerun/docs/snippets/all/pinhole_simple.py`



Before (0.14):
![image](https://github.com/rerun-io/rerun/assets/1220815/1b447151-86a1-4873-9283-905e0276a9b0)


After:
![image](https://github.com/rerun-io/rerun/assets/1220815/f7f0d75b-0866-4f3b-9322-570b1f60deb2)



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
