### PR TITLE
Fix log spam on invalid invalid query

### DIFF
--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -855,7 +855,7 @@ fn blueprint_ui_for_space_view(
             .root_handle()
             .and_then(|root| query_result.tree.lookup_result(root))
         else {
-            re_log::error!("Could not find root data result for Space View {space_view_id:?}");
+            // This can happen when the query was invalid for some reason.
             return;
         };
 


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/5568

Fixes recent regression of getting `Could not find root data result for Space View SpaceViewId(2e0664ef-251a-4813-9eae-f728818bf507)` spamed when editing the query expressions. E.g. this would trigger when changing a query from `+ $origin/**` to `+ $origin/*`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5566/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5566/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5566/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5566)
- [Docs preview](https://rerun.io/preview/ef13e85857d5947a9e60791547cc8f726ff8759f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ef13e85857d5947a9e60791547cc8f726ff8759f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)