### PR TITLE
Refactor `Selection` use a `BTreeMap` and make it more encapsulated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,6 +2640,7 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
+ "serde",
 ]
 
 [[package]]
@@ -5088,6 +5089,7 @@ dependencies = [
  "egui_tiles",
  "glam",
  "half 2.3.1",
+ "indexmap 2.1.0",
  "itertools 0.12.0",
  "macaw",
  "ndarray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ half = "2.3.1"
 hyper = "0.14"
 image = { version = "0.24", default-features = false }
 indent = "0.1"
+indexmap = "2.1"                                                   # Version chosen to align with other dependencies
 indicatif = "0.17.7"                                               # Progress bar
 infer = "0.15"                                                     # infer MIME type by checking the magic number signaturefer MIME type by checking the magic number signature
 insta = "1.23"

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -641,7 +641,7 @@ pub fn picking(
         });
     };
 
-    ctx.select_hovered_on_click(&response, re_viewer_context::Selection(hovered_items));
+    ctx.select_hovered_on_click(&response, hovered_items.into_iter());
 
     Ok(response)
 }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -758,7 +758,7 @@ fn show_list_item_for_container_child(
         &response,
         SelectionUpdateBehavior::Ignore,
     );
-    ctx.select_hovered_on_click(&response, std::iter::once(item));
+    ctx.select_hovered_on_click(&response, item);
 
     if remove_contents {
         viewport.blueprint.mark_user_interaction(ctx);

--- a/crates/re_viewer_context/Cargo.toml
+++ b/crates/re_viewer_context/Cargo.toml
@@ -37,6 +37,7 @@ egui.workspace = true
 egui_tiles.workspace = true
 glam = { workspace = true, features = ["serde"] }
 half.workspace = true
+indexmap = { workspace = true, features = ["std", "serde"] }
 itertools.workspace = true
 macaw.workspace = true
 ndarray.workspace = true

--- a/crates/re_viewer_context/src/item.rs
+++ b/crates/re_viewer_context/src/item.rs
@@ -6,7 +6,7 @@ use crate::{ContainerId, SpaceViewId};
 /// One "thing" in the UI.
 ///
 /// This is the granularity of what is selectable and hoverable.
-#[derive(Clone, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Deserialize, serde::Serialize)]
 pub enum Item {
     /// A recording (or blueprint)
     StoreId(re_log_types::StoreId),

--- a/crates/re_viewer_context/src/selection_history.rs
+++ b/crates/re_viewer_context/src/selection_history.rs
@@ -36,7 +36,7 @@ impl SelectionHistory {
 
         let mut i = 0;
         self.stack.retain_mut(|selection| {
-            selection.retain(f);
+            selection.retain(|item, _| f(item));
             let retain = !selection.is_empty();
             if !retain && i <= self.current {
                 self.current = self.current.saturating_sub(1);

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -145,7 +145,7 @@ impl Selection {
     }
 
     pub fn iter_items(&self) -> impl Iterator<Item = &Item> {
-        self.0.iter().map(|(item, _)| item)
+        self.0.keys()
     }
 
     pub fn iter_space_context(&self) -> impl Iterator<Item = &SelectedSpaceContext> {

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -103,13 +103,6 @@ where
 }
 
 impl Selection {
-    // pub fn resolve_mono_instance_path_items(&mut self, ctx: &ViewerContext<'_>) {
-    //     for (item, _) in self.iter_mut() {
-    //         *item =
-    //             resolve_mono_instance_path_item(&ctx.current_query(), ctx.entity_db.store(), item);
-    //     }
-    // }
-
     /// For each item in this selection, if it refers to the first element of an instance with a
     /// single element, resolve it to a splatted entity path.
     pub fn into_mono_instance_path_items(self, ctx: &ViewerContext<'_>) -> Self {

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -1,6 +1,6 @@
 use ahash::HashMap;
+use indexmap::IndexMap;
 use parking_lot::Mutex;
-use std::collections::BTreeMap;
 
 use re_entity_db::EntityPath;
 
@@ -83,7 +83,7 @@ impl InteractionHighlight {
 ///
 /// Used to store what is currently selected and/or hovered.
 #[derive(Debug, Default, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Selection(BTreeMap<Item, Option<SelectedSpaceContext>>);
+pub struct Selection(IndexMap<Item, Option<SelectedSpaceContext>>);
 
 impl From<Item> for Selection {
     #[inline]
@@ -125,7 +125,7 @@ impl Selection {
 
     /// The first selected object if any.
     pub fn first_item(&self) -> Option<&Item> {
-        self.0.first_key_value().map(|(item, _)| item)
+        self.0.keys().next()
     }
 
     /// Check if the selection contains a single item and returns it if so.

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -82,7 +82,7 @@ impl InteractionHighlight {
 ///
 /// Used to store what is currently selected and/or hovered.
 #[derive(Debug, Default, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Selection(pub Vec<(Item, Option<SelectedSpaceContext>)>);
+pub struct Selection(Vec<(Item, Option<SelectedSpaceContext>)>);
 
 impl From<Item> for Selection {
     #[inline]
@@ -93,27 +93,11 @@ impl From<Item> for Selection {
 
 impl<T> From<T> for Selection
 where
-    T: Iterator<Item = Item>,
+    T: Iterator<Item = (Item, Option<SelectedSpaceContext>)>,
 {
     #[inline]
     fn from(value: T) -> Self {
-        Selection(value.map(|item| (item, None)).collect())
-    }
-}
-
-impl std::ops::Deref for Selection {
-    type Target = Vec<(Item, Option<SelectedSpaceContext>)>;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Selection {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        Selection(value.collect())
     }
 }
 
@@ -171,6 +155,34 @@ impl Selection {
     /// Retains elements that fulfill a certain condition.
     pub fn retain(&mut self, f: impl Fn(&Item) -> bool) {
         self.0.retain(|(item, _)| f(item));
+    }
+
+    /// Returns the number of items in the selection.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Check if the selection is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns an iterator over the items and their selected space context.
+    pub fn iter(&self) -> impl Iterator<Item = &(Item, Option<SelectedSpaceContext>)> {
+        self.0.iter()
+    }
+
+    /// Returns a mutable iterator over the items and their selected space context.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut (Item, Option<SelectedSpaceContext>)> {
+        self.0.iter_mut()
+    }
+
+    /// Extend the selection with more items.
+    pub fn extend(
+        &mut self,
+        other: impl IntoIterator<Item = (Item, Option<SelectedSpaceContext>)>,
+    ) {
+        self.0.extend(other);
     }
 }
 

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -109,7 +109,7 @@ impl<'a> ViewerContext<'a> {
         }
 
         if response.double_clicked() {
-            if let Some((item, _)) = selection.first() {
+            if let Some(item) = selection.first_item() {
                 self.command_sender
                     .send_system(crate::SystemCommand::SetFocus(item.clone()));
             }

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -100,8 +100,7 @@ impl<'a> ViewerContext<'a> {
     ) {
         re_tracing::profile_function!();
 
-        let mut selection = selection.into();
-        selection.resolve_mono_instance_path_items(self);
+        let selection = selection.into().into_mono_instance_path_items(self);
         let selection_state = self.selection_state();
 
         if response.hovered() {

--- a/crates/re_viewport/src/context_menu/mod.rs
+++ b/crates/re_viewport/src/context_menu/mod.rs
@@ -66,8 +66,7 @@ pub fn context_menu_ui_for_item(
                     // When the context menu is triggered open, we check if we're part of the selection,
                     // and, if not, we update the selection to include only the item that was clicked.
                     if item_response.hovered() && item_response.secondary_clicked() {
-                        ctx.selection_state()
-                            .set_selection(std::iter::once(item.clone()));
+                        ctx.selection_state().set_selection(item.clone());
 
                         show_context_menu(&Selection::from(item.clone()));
                     } else {
@@ -80,8 +79,7 @@ pub fn context_menu_ui_for_item(
 
             SelectionUpdateBehavior::OverrideSelection => {
                 if item_response.secondary_clicked() {
-                    ctx.selection_state()
-                        .set_selection(std::iter::once(item.clone()));
+                    ctx.selection_state().set_selection(item.clone());
                 }
 
                 show_context_menu(&Selection::from(item.clone()));


### PR DESCRIPTION
### What

This PR change `Selection` to use a `BTreeMap<Item, Option<SelectedSpaceContext>>` instead of a `Vec<(Item, Option<SelectedSpaceContext>)`. This is a much better model for the selection that we currently have (`Item` may not be duplicated, even with different space context) and paves the way for a clean "remove" API (needed by #5465).

**NOTE**: with this approach we loose ordering by "cmd-click". 
Advantage:
- in some case its better (e.g when selecting multiple instances of the same entity, now they are sorted by instance key)
- the selection panel is sorted by "category" of item
Disadvantage:
- well, not the order of clicks, so Selection Panel ordering be slightly surprising in some cases

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5569/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5569/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5569/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5569)
- [Docs preview](https://rerun.io/preview/fe5c33da7ac42466e55073e658fd9a1edef5fd9e/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/fe5c33da7ac42466e55073e658fd9a1edef5fd9e/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)