### PR TITLE
Make space view use its own data-result when editing visible history

### DIFF
--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -391,8 +391,9 @@ impl SpaceViewBlueprint {
 
         let class = self.class(ctx.space_view_class_registry);
 
-        let root_data_result = self.root_data_result(ctx.store_context, ctx.blueprint_query);
-        let props = root_data_result
+        let space_view_data_result =
+            self.space_view_data_result(ctx.store_context, ctx.blueprint_query);
+        let props = space_view_data_result
             .individual_properties()
             .cloned()
             .unwrap_or_default();
@@ -415,7 +416,16 @@ impl SpaceViewBlueprint {
         self.id.as_entity_path()
     }
 
-    pub fn root_data_result(&self, ctx: &StoreContext<'_>, query: &LatestAtQuery) -> DataResult {
+    /// A special data result for the space view that sits "above" the [`SpaceViewContents`].
+    ///
+    /// This allows us to use interfaces that take a [`DataResult`] to modify things on the
+    /// space view that can then be inherited into the contents. For example, controlling
+    /// visible history.
+    pub fn space_view_data_result(
+        &self,
+        ctx: &StoreContext<'_>,
+        query: &LatestAtQuery,
+    ) -> DataResult {
         let base_override_root = self.entity_path();
         let individual_override_path =
             base_override_root.join(&DataResult::INDIVIDUAL_OVERRIDES_PREFIX.into());

--- a/crates/re_space_view/src/space_view_contents.rs
+++ b/crates/re_space_view/src/space_view_contents.rs
@@ -348,7 +348,7 @@ impl DataQueryPropertyResolver<'_> {
         // the space-view. This isn't totally generic once we add container overrides, but it's a start.
         let (mut root_entity_properties, root_component_overrides) = self
             .space_view
-            .root_data_result(ctx, query)
+            .space_view_data_result(ctx, query)
             .property_overrides
             .map(|p| (p.accumulated_properties, p.resolved_component_overrides))
             .unwrap_or_default();

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -847,7 +847,8 @@ fn blueprint_ui_for_space_view(
         );
 
         // Space View don't inherit properties.
-        let root_data_result = space_view.root_data_result(ctx.store_context, ctx.blueprint_query);
+        let root_data_result =
+            space_view.space_view_data_result(ctx.store_context, ctx.blueprint_query);
 
         let query_result = ctx.lookup_query_result(space_view.id);
         let Some(data_result) = query_result

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -847,29 +847,19 @@ fn blueprint_ui_for_space_view(
         );
 
         // Space View don't inherit properties.
-        let root_data_result =
+        let space_view_data_result =
             space_view.space_view_data_result(ctx.store_context, ctx.blueprint_query);
-
-        let query_result = ctx.lookup_query_result(space_view.id);
-        let Some(data_result) = query_result
-            .tree
-            .root_handle()
-            .and_then(|root| query_result.tree.lookup_result(root))
-        else {
-            re_log::error_once!("Could not find root data result for Space View {space_view_id:?}");
-            return;
-        };
 
         visual_time_range_ui(
             ctx,
             ui,
-            &query_result.tree,
-            data_result,
+            None, // There is no tree above the space view yet
+            &space_view_data_result,
             class_identifier,
             true,
         );
 
-        let mut props = root_data_result
+        let mut props = space_view_data_result
             .individual_properties()
             .cloned()
             .unwrap_or_default();
@@ -890,7 +880,7 @@ fn blueprint_ui_for_space_view(
             );
         }
 
-        root_data_result.save_individual_override_properties(ctx, Some(props));
+        space_view_data_result.save_individual_override_properties(ctx, Some(props));
     }
 }
 
@@ -1123,7 +1113,7 @@ fn entity_props_ui(
     visual_time_range_ui(
         ctx,
         ui,
-        &query_result.tree,
+        Some(&query_result.tree),
         data_result,
         *space_view_class,
         false,

--- a/crates/re_viewer/src/ui/visible_history.rs
+++ b/crates/re_viewer/src/ui/visible_history.rs
@@ -69,7 +69,7 @@ fn entity_with_visible_history(
 pub fn visual_time_range_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut Ui,
-    data_result_tree: &re_viewer_context::DataResultTree,
+    data_result_tree: Option<&re_viewer_context::DataResultTree>,
     data_result: &re_viewer_context::DataResult,
     space_view_class: SpaceViewClassIdentifier,
     is_space_view: bool,
@@ -92,10 +92,18 @@ pub fn visual_time_range_ui(
     let mut resolved_range = data_result
         .lookup_override::<VisibleTimeRange>(ctx)
         .unwrap_or(default_time_range(space_view_class));
-    let mut has_individual_range = data_result
-        .component_override_source(data_result_tree, &VisibleTimeRange::name())
-        .as_ref()
-        == Some(&data_result.entity_path);
+    let mut has_individual_range = if let Some(data_result_tree) = data_result_tree {
+        // If there is a data-tree, we know we have individual settings if we are our own source.
+        data_result
+            .component_override_source(data_result_tree, &VisibleTimeRange::name())
+            .as_ref()
+            == Some(&data_result.entity_path)
+    } else {
+        // Otherwise we can inspect directly.
+        data_result
+            .lookup_override::<VisibleTimeRange>(ctx)
+            .is_some()
+    };
 
     let collapsing_response = re_ui.collapsing_header(ui, "Visible time range", false, |ui| {
         let has_individual_range_before = has_individual_range;


### PR DESCRIPTION
### What
Also renamed the API because root_data_result is **very** overloaded.

* Fixes #5568

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5571/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5571/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5571/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5571)
- [Docs preview](https://rerun.io/preview/5f8ed4cf08e9cbc8b723284d2af622c664ede60c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5f8ed4cf08e9cbc8b723284d2af622c664ede60c/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)