### PR TITLE
Add option to include blueprint in an `.rrd` when calling `.save(…)`

### DIFF
--- a/crates/re_build_examples/src/example.rs
+++ b/crates/re_build_examples/src/example.rs
@@ -160,10 +160,15 @@ pub struct ExampleCategory {
 #[derive(Default, Clone, Copy, serde::Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Channel {
+    /// Our main examples, built on each PR
     #[default]
     Main,
-    Nightly,
+
+    /// Examples built for each release, plus all `Main` examples.
     Release,
+
+    /// Examples built nightly, plus all `Main` and `Nightly`.
+    Nightly,
 }
 
 impl Channel {

--- a/crates/re_build_info/src/build_info.rs
+++ b/crates/re_build_info/src/build_info.rs
@@ -113,6 +113,10 @@ impl std::fmt::Display for BuildInfo {
             write!(f, ", built {datetime}")?;
         }
 
+        if cfg!(debug_assertions) {
+            write!(f, " (debug)")?;
+        }
+
         Ok(())
     }
 }

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1554,7 +1554,7 @@ impl RecordingStream {
 
         // If a blueprint was provided, send it first.
         if let Some(blueprint) = blueprint {
-            send_blueprint(blueprint, &sink);
+            Self::send_blueprint(blueprint, &sink);
         }
 
         self.set_sink(Box::new(sink));
@@ -1669,7 +1669,7 @@ impl RecordingStream {
 
         // If a blueprint was provided, store it first.
         if let Some(blueprint) = blueprint {
-            send_blueprint(blueprint, &sink);
+            Self::send_blueprint(blueprint, &sink);
         }
 
         self.set_sink(Box::new(sink));
@@ -1720,22 +1720,23 @@ impl RecordingStream {
             re_log::warn_once!("Recording disabled - call to disconnect() ignored");
         }
     }
-}
 
-fn send_blueprint(blueprint: Vec<LogMsg>, sink: &dyn crate::sink::LogSink) {
-    let mut store_id = None;
-    for msg in blueprint {
-        if store_id.is_none() {
-            store_id = Some(msg.store_id().clone());
+    /// Send the blueprint to the sink, and then activate it.
+    pub fn send_blueprint(blueprint: Vec<LogMsg>, sink: &dyn crate::sink::LogSink) {
+        let mut store_id = None;
+        for msg in blueprint {
+            if store_id.is_none() {
+                store_id = Some(msg.store_id().clone());
+            }
+            sink.send(msg);
         }
-        sink.send(msg);
-    }
-    if let Some(store_id) = store_id {
-        // Let the viewer know that the blueprint has been fully received,
-        // and that it can now be activated.
-        // We don't want to activate half-loaded blueprints, because that can be confusing,
-        // and can also lead to problems with space-view heuristics.
-        sink.send(LogMsg::ActivateStore(store_id));
+        if let Some(store_id) = store_id {
+            // Let the viewer know that the blueprint has been fully received,
+            // and that it can now be activated.
+            // We don't want to activate half-loaded blueprints, because that can be confusing,
+            // and can also lead to problems with space-view heuristics.
+            sink.send(LogMsg::ActivateStore(store_id));
+        }
     }
 }
 

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1654,6 +1654,7 @@ impl RecordingStream {
     /// See [`Self::set_sink`] for more information.
     ///
     /// If a blueprint was provided, it will be stored first in the file.
+    /// Blueprints are currently an experimental part of the Rust SDK.
     pub fn save_opts(
         &self,
         path: impl Into<std::path::PathBuf>,

--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -15,6 +15,7 @@ import numpy as np
 import numpy.typing as npt
 import requests
 import rerun as rr  # pip install rerun-sdk
+import rerun.blueprint as rbl
 from read_write_model import Camera, read_model
 from tqdm import tqdm
 
@@ -221,7 +222,17 @@ def main() -> None:
     if args.resize:
         args.resize = tuple(int(x) for x in args.resize.split("x"))
 
-    rr.script_setup(args, "rerun_example_structure_from_motion")
+    blueprint = rbl.Vertical(
+        rbl.Spatial3DView(name="3D", origin="/"),
+        rbl.Horizontal(
+            rbl.TextDocumentView(name="README", origin="/description"),
+            rbl.Spatial2DView(name="Camera", origin="/camera/image"),
+            rbl.TimeSeriesView(origin="/plot"),
+        ),
+        row_shares=[3, 2],
+    )
+
+    rr.script_setup(args, "rerun_example_structure_from_motion", blueprint=blueprint)
     dataset_path = get_downloaded_dataset_path(args.dataset)
     read_and_log_sparse_reconstruction(dataset_path, filter_output=not args.unfiltered, resize=args.resize)
     rr.script_teardown(args)

--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -15,7 +15,7 @@ import numpy as np
 import numpy.typing as npt
 import requests
 import rerun as rr  # pip install rerun-sdk
-import rerun.blueprint as rbl
+import rerun.blueprint as rrb
 from read_write_model import Camera, read_model
 from tqdm import tqdm
 
@@ -222,12 +222,12 @@ def main() -> None:
     if args.resize:
         args.resize = tuple(int(x) for x in args.resize.split("x"))
 
-    blueprint = rbl.Vertical(
-        rbl.Spatial3DView(name="3D", origin="/"),
-        rbl.Horizontal(
-            rbl.TextDocumentView(name="README", origin="/description"),
-            rbl.Spatial2DView(name="Camera", origin="/camera/image"),
-            rbl.TimeSeriesView(origin="/plot"),
+    blueprint = rrb.Vertical(
+        rrb.Spatial3DView(name="3D", origin="/"),
+        rrb.Horizontal(
+            rrb.TextDocumentView(name="README", origin="/description"),
+            rrb.Spatial2DView(name="Camera", origin="/camera/image"),
+            rrb.TimeSeriesView(origin="/plot"),
         ),
         row_shares=[3, 2],
     )

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -102,7 +102,7 @@ def script_setup(
 
     # NOTE: mypy thinks these methods don't exist because they're monkey-patched.
     if args.stdout:
-        rec.stdout()  # type: ignore[attr-defined]
+        rec.stdout(blueprint=blueprint)  # type: ignore[attr-defined]
     elif args.serve:
         rec.serve(blueprint=blueprint)  # type: ignore[attr-defined]
     elif args.connect:

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -104,7 +104,7 @@ def script_setup(
     if args.stdout:
         rec.stdout()  # type: ignore[attr-defined]
     elif args.serve:
-        rec.serve()  # type: ignore[attr-defined]
+        rec.serve(blueprint=blueprint)  # type: ignore[attr-defined]
     elif args.connect:
         # Send logging data to separate `rerun` process.
         # You can omit the argument to connect to the default address,

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -111,7 +111,7 @@ def script_setup(
         # which is `127.0.0.1:9876`.
         rec.connect(args.addr, blueprint=blueprint)  # type: ignore[attr-defined]
     elif args.save is not None:
-        rec.save(args.save)  # type: ignore[attr-defined]
+        rec.save(args.save, blueprint=blueprint)  # type: ignore[attr-defined]
     elif not args.headless:
         rec.spawn(blueprint=blueprint)  # type: ignore[attr-defined]
 

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -44,6 +44,10 @@ def connect(
 
     """
 
+    if not bindings.is_enabled():
+        logging.warning("Rerun is disabled - connect() call ignored")
+        return
+
     application_id = get_application_id(recording=recording)
     if application_id is None:
         raise ValueError(

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -109,7 +109,7 @@ def save(
     bindings.save(path=str(path), blueprint=blueprint_storage, recording=recording)
 
 
-def stdout(recording: RecordingStream | None = None) -> None:
+def stdout(blueprint: BlueprintLike | None = None, recording: RecordingStream | None = None) -> None:
     """
     Stream all log-data to stdout.
 
@@ -122,6 +122,8 @@ def stdout(recording: RecordingStream | None = None) -> None:
 
     Parameters
     ----------
+    blueprint: Optional[BlueprintLike]
+        An optional blueprint to configure the UI.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
         If left unspecified, defaults to the current active data recording, if there is one.
@@ -133,8 +135,19 @@ def stdout(recording: RecordingStream | None = None) -> None:
         logging.warning("Rerun is disabled - save() call ignored. You must call rerun.init before saving a recording.")
         return
 
+    application_id = get_application_id(recording=recording)
+    if application_id is None:
+        raise ValueError(
+            "No application id found. You must call rerun.init before connecting to a viewer, or provide a recording."
+        )
+
+    # If a blueprint is provided, we need to create a blueprint storage object
+    blueprint_storage = None
+    if blueprint is not None:
+        blueprint_storage = create_in_memory_blueprint(application_id=application_id, blueprint=blueprint).storage
+
     recording = RecordingStream.to_native(recording)
-    bindings.stdout(recording=recording)
+    bindings.stdout(blueprint=blueprint_storage, recording=recording)
 
 
 def disconnect(recording: RecordingStream | None = None) -> None:

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -43,9 +43,8 @@ def connect(
         See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
 
     """
-    application_id = get_application_id(recording=recording)
-    recording = RecordingStream.to_native(recording)
 
+    application_id = get_application_id(recording=recording)
     if application_id is None:
         raise ValueError(
             "No application id found. You must call rerun.init before connecting to a viewer, or provide a recording."
@@ -55,6 +54,8 @@ def connect(
     blueprint_storage = None
     if blueprint is not None:
         blueprint_storage = create_in_memory_blueprint(application_id=application_id, blueprint=blueprint).storage
+
+    recording = RecordingStream.to_native(recording)
 
     bindings.connect(addr=addr, flush_timeout_sec=flush_timeout_sec, blueprint=blueprint_storage, recording=recording)
 

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -29,13 +29,13 @@ def connect(
 
     Parameters
     ----------
-    addr
+    addr:
         The ip:port to connect to
-    flush_timeout_sec: float
+    flush_timeout_sec:
         The minimum time the SDK will wait during a flush before potentially
         dropping data if progress is not being made. Passing `None` indicates no timeout,
         and can cause a call to `flush` to block indefinitely.
-    blueprint: Optional[BlueprintLike]
+    blueprint:
         An optional blueprint to configure the UI.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
@@ -77,9 +77,9 @@ def save(
 
     Parameters
     ----------
-    path : str
+    path:
         The path to save the data to.
-    blueprint: Optional[BlueprintLike]
+    blueprint:
         An optional blueprint to configure the UI.
         This will be written first to the .rrd file, before appending the recording data.
     recording:
@@ -122,7 +122,7 @@ def stdout(blueprint: BlueprintLike | None = None, recording: RecordingStream | 
 
     Parameters
     ----------
-    blueprint: Optional[BlueprintLike]
+    blueprint:
         An optional blueprint to configure the UI.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
@@ -218,13 +218,13 @@ def serve(
 
     Parameters
     ----------
-    open_browser
+    open_browser:
         Open the default browser to the viewer.
     web_port:
         The port to serve the web viewer on (defaults to 9090).
     ws_port:
         The port to serve the WebSocket server on (defaults to 9877)
-    blueprint: Optional[BlueprintLike]
+    blueprint:
         An optional blueprint to configure the UI.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
@@ -296,19 +296,19 @@ def spawn(
 
     Parameters
     ----------
-    port : int
+    port:
         The port to listen on.
-    connect
+    connect:
         also connect to the viewer and stream logging data to it.
-    memory_limit
+    memory_limit:
         An upper limit on how much memory the Rerun Viewer should use.
         When this limit is reached, Rerun will drop the oldest data.
         Example: `16GB` or `50%` (of system total).
-    recording
+    recording:
         Specifies the [`rerun.RecordingStream`][] to use if `connect = True`.
         If left unspecified, defaults to the current active data recording, if there is one.
         See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
-    blueprint: Optional[BlueprintLike]
+    blueprint:
         An optional blueprint to configure the UI.
 
     """

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -580,8 +580,12 @@ fn save(
 }
 
 #[pyfunction]
-#[pyo3(signature = (recording = None))]
-fn stdout(recording: Option<&PyRecordingStream>, py: Python<'_>) -> PyResult<()> {
+#[pyo3(signature = (blueprint = None, recording = None))]
+fn stdout(
+    blueprint: Option<&PyMemorySinkStorage>,
+    recording: Option<&PyRecordingStream>,
+    py: Python<'_>,
+) -> PyResult<()> {
     let Some(recording) = get_data_recording(recording) else {
         return Ok(());
     };
@@ -590,7 +594,7 @@ fn stdout(recording: Option<&PyRecordingStream>, py: Python<'_>) -> PyResult<()>
     // Release the GIL in case any flushing behavior needs to cleanup a python object.
     py.allow_threads(|| {
         let res = recording
-            .stdout()
+            .stdout_opts(blueprint.map(|b| b.inner.take()))
             .map_err(|err| PyRuntimeError::new_err(err.to_string()));
         flush_garbage_queue();
         res


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5558

This adds an optional `blueprint` argument to `rr.save` which if provided, will end up first in the written .rrd file.

When using `rr.script_setup` (like all our examples do) with a `blueprint`, `--save` will put that blueprint in the .rrd file.

This should mean that the examples build by CI will include blueprints.

**BONUS**: this also adds the blueprint to `rr.serve` and `rr.stdout` (and `--serve/--stdout` in our examples).

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5572/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5572/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5572/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5572)
- [Docs preview](https://rerun.io/preview/3ec8fddde8caa12a00097353c257fdd60be9a48f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3ec8fddde8caa12a00097353c257fdd60be9a48f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)