### PR TITLE
Fix depth cloud bounding boxes for depth cloud visualizations with transforms

### DIFF
--- a/crates/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/re_renderer/src/renderer/depth_cloud.rs
@@ -168,7 +168,7 @@ pub struct DepthCloud {
 
 impl DepthCloud {
     /// World-space bounding-box.
-    pub fn bbox(&self) -> macaw::BoundingBox {
+    pub fn world_space_bbox(&self) -> macaw::BoundingBox {
         let max_depth = self.max_depth_in_world;
         let w = self.depth_dimensions.x as f32;
         let h = self.depth_dimensions.y as f32;

--- a/crates/re_space_view_spatial/src/visualizers/images.rs
+++ b/crates/re_space_view_spatial/src/visualizers/images.rs
@@ -384,8 +384,8 @@ impl ImageVisualizer {
                         Ok(cloud) => {
                             self.data.add_bounding_box(
                                 ent_path.hash(),
-                                cloud.bbox(),
-                                cloud.world_from_rdf,
+                                cloud.world_space_bbox(),
+                                glam::Affine3A::IDENTITY,
                             );
                             self.depth_cloud_entities.insert(ent_path.hash());
                             depth_clouds.push(cloud);


### PR DESCRIPTION
### What

Bounding box was accidentally transformed twice!
Noticed by @roym899  - bounding boxes for depth clouds are still not perfect since they take the bounding box of the full theoretical frustum and not the points displayed, but it's a lot better

Before:
<img width="967" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/cb2af9e4-a35b-48b3-b76c-793932717690">

After:
<img width="975" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/468711fa-fff8-4bb8-b401-9ea54dbfedd8">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5578/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5578/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5578/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5578)
- [Docs preview](https://rerun.io/preview/ef53c8daf8f6a2b26616e8e4a5efaf35aeccc9ba/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ef53c8daf8f6a2b26616e8e4a5efaf35aeccc9ba/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)