### PR TITLE
Fix C++ and Python data loader examples to use nanoseconds instead of seconds

### DIFF
--- a/examples/cpp/external_data_loader/main.cpp
+++ b/examples/cpp/external_data_loader/main.cpp
@@ -17,7 +17,7 @@ void set_time_from_args(const rerun::RecordingStream& rec, cxxopts::ParseResult&
             if (pos != std::string::npos) {
                 auto timeline_name = time_str.substr(0, pos);
                 int64_t time = std::stol(time_str.substr(pos + 1));
-                rec.set_time_seconds(timeline_name, static_cast<double>(time));
+                rec.set_time_nanos(timeline_name, time);
             }
         }
     }

--- a/examples/python/external_data_loader/main.py
+++ b/examples/python/external_data_loader/main.py
@@ -87,7 +87,7 @@ def set_time_from_args() -> None:
             if len(parts) != 2:
                 continue
             timeline_name, time = parts
-            rr.set_time_seconds(timeline_name, float(time))
+            rr.set_time_nanos(timeline_name, int(time))
 
         for time_str in args.sequence:
             parts = time_str.split("=")


### PR DESCRIPTION
### What
See title. The Rust example seems to be correct already.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
