### PR TITLE
New data APIs 2: cached latest-at queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4599,6 +4599,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "re_query_cache2"
+version = "0.15.0-alpha.5"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "backtrace",
+ "criterion",
+ "indent",
+ "itertools 0.12.0",
+ "mimalloc",
+ "nohash-hasher",
+ "parking_lot",
+ "paste",
+ "rand",
+ "re_data_store",
+ "re_format",
+ "re_log",
+ "re_log_types",
+ "re_query2",
+ "re_tracing",
+ "re_types",
+ "re_types_core",
+ "seq-macro",
+ "similar-asserts",
+ "web-time",
+]
+
+[[package]]
 name = "re_renderer"
 version = "0.15.0-alpha.5"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ re_memory = { path = "crates/re_memory", version = "=0.15.0-alpha.5", default-fe
 re_query = { path = "crates/re_query", version = "=0.15.0-alpha.5", default-features = false }
 re_query2 = { path = "crates/re_query2", version = "=0.15.0-alpha.5", default-features = false }
 re_query_cache = { path = "crates/re_query_cache", version = "=0.15.0-alpha.5", default-features = false }
+re_query_cache2 = { path = "crates/re_query_cache2", version = "=0.15.0-alpha.5", default-features = false }
 re_renderer = { path = "crates/re_renderer", version = "=0.15.0-alpha.5", default-features = false }
 re_sdk = { path = "crates/re_sdk", version = "=0.15.0-alpha.5", default-features = false }
 re_sdk_comms = { path = "crates/re_sdk_comms", version = "=0.15.0-alpha.5", default-features = false }

--- a/crates/re_query_cache2/Cargo.toml
+++ b/crates/re_query_cache2/Cargo.toml
@@ -1,0 +1,65 @@
+[package]
+name = "re_query_cache2"
+authors.workspace = true
+description = "Temporary crate meant to replace re_query_cache"
+edition.workspace = true
+homepage.workspace = true
+include.workspace = true
+license.workspace = true
+# TODO(cmc): Replace re_query with this crate. Never publish this one.
+publish = false
+readme = "README.md"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+
+[features]
+default = []
+
+[dependencies]
+# Rerun dependencies:
+re_data_store.workspace = true
+re_format.workspace = true
+re_log.workspace = true
+re_log_types.workspace = true
+re_query2.workspace = true
+re_tracing.workspace = true
+re_types_core.workspace = true
+
+# External dependencies:
+ahash.workspace = true
+anyhow.workspace = true
+backtrace.workspace = true
+indent.workspace = true
+itertools.workspace = true
+nohash-hasher.workspace = true
+parking_lot.workspace = true
+paste.workspace = true
+seq-macro.workspace = true
+web-time.workspace = true
+
+
+[dev-dependencies]
+re_types = { workspace = true, features = ["datagen"] }
+
+criterion.workspace = true
+mimalloc.workspace = true
+rand = { workspace = true, features = ["std", "std_rng"] }
+similar-asserts.workspace = true
+
+
+[lib]
+bench = false
+
+
+[[bench]]
+name = "flat_vec_deque"
+harness = false
+
+[[bench]]
+name = "latest_at"
+harness = false

--- a/crates/re_query_cache2/README.md
+++ b/crates/re_query_cache2/README.md
@@ -1,0 +1,5 @@
+# re_query_cache2
+
+Temporary crate for implementing the new cached data APIs. Not published.
+
+Will replace `re_query_cache2` when ready.

--- a/crates/re_query_cache2/benches/flat_vec_deque.rs
+++ b/crates/re_query_cache2/benches/flat_vec_deque.rs
@@ -1,0 +1,333 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use itertools::Itertools as _;
+
+use re_query_cache2::FlatVecDeque;
+
+// ---
+
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+criterion_group!(
+    benches,
+    range,
+    insert,
+    insert_many,
+    insert_deque,
+    remove,
+    remove_range
+);
+criterion_main!(benches);
+
+// ---
+
+// `cargo test` also runs the benchmark setup code, so make sure they run quickly:
+#[cfg(debug_assertions)]
+mod constants {
+    pub const INITIAL_VALUES_PER_ENTRY: usize = 1;
+    pub const INITIAL_NUM_ENTRIES: usize = 1;
+    pub const ADDED_VALUES_PER_ENTRY: usize = 1;
+    pub const ADDED_NUM_ENTRIES: usize = 1;
+}
+
+#[cfg(not(debug_assertions))]
+mod constants {
+    pub const INITIAL_VALUES_PER_ENTRY: usize = 1000;
+    pub const INITIAL_NUM_ENTRIES: usize = 100;
+    pub const ADDED_VALUES_PER_ENTRY: usize = 1000;
+    pub const ADDED_NUM_ENTRIES: usize = 5;
+}
+
+#[allow(clippy::wildcard_imports)]
+use self::constants::*;
+
+// ---
+
+fn range(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
+    }
+
+    let mut group = c.benchmark_group("flat_vec_deque");
+    group.throughput(criterion::Throughput::Elements(
+        (ADDED_NUM_ENTRIES * ADDED_VALUES_PER_ENTRY) as _,
+    ));
+
+    {
+        group.bench_function("range/prefilled/front", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let v: FlatVecDeque<i64> = base.clone();
+                v.range(0..ADDED_NUM_ENTRIES)
+                    .map(ToOwned::to_owned)
+                    .collect_vec()
+            });
+        });
+        group.bench_function("range/prefilled/middle", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let v: FlatVecDeque<i64> = base.clone();
+                v.range(
+                    INITIAL_NUM_ENTRIES / 2 - ADDED_NUM_ENTRIES / 2
+                        ..INITIAL_NUM_ENTRIES / 2 + ADDED_NUM_ENTRIES / 2,
+                )
+                .map(ToOwned::to_owned)
+                .collect_vec()
+            });
+        });
+        group.bench_function("range/prefilled/back", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let v: FlatVecDeque<i64> = base.clone();
+                v.range(INITIAL_NUM_ENTRIES - ADDED_NUM_ENTRIES..INITIAL_NUM_ENTRIES)
+                    .map(ToOwned::to_owned)
+                    .collect_vec()
+            });
+        });
+    }
+}
+
+fn insert(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
+    }
+
+    let added = (0..ADDED_VALUES_PER_ENTRY as i64).collect_vec();
+
+    let mut group = c.benchmark_group("flat_vec_deque");
+    group.throughput(criterion::Throughput::Elements(added.len() as _));
+
+    {
+        group.bench_function("insert/empty", |b| {
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+                v.insert(0, added.clone());
+                v
+            });
+        });
+    }
+
+    {
+        group.bench_function("insert/prefilled/front", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.insert(0, added.clone());
+                v
+            });
+        });
+        group.bench_function("insert/prefilled/middle", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.insert(INITIAL_NUM_ENTRIES / 2, added.clone());
+                v
+            });
+        });
+        group.bench_function("insert/prefilled/back", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.insert(INITIAL_NUM_ENTRIES, added.clone());
+                v
+            });
+        });
+    }
+}
+
+fn insert_many(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
+    }
+
+    let added = (0..ADDED_NUM_ENTRIES as i64)
+        .map(|_| (0..ADDED_VALUES_PER_ENTRY as i64).collect_vec())
+        .collect_vec();
+
+    let mut group = c.benchmark_group("flat_vec_deque");
+    group.throughput(criterion::Throughput::Elements(
+        (ADDED_NUM_ENTRIES * ADDED_VALUES_PER_ENTRY) as _,
+    ));
+
+    {
+        group.bench_function("insert_many/empty", |b| {
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+                v.insert_many(0, added.clone());
+                v
+            });
+        });
+    }
+
+    {
+        group.bench_function("insert_many/prefilled/front", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.insert_many(0, added.clone());
+                v
+            });
+        });
+        group.bench_function("insert_many/prefilled/middle", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.insert_many(INITIAL_NUM_ENTRIES / 2, added.clone());
+                v
+            });
+        });
+        group.bench_function("insert_many/prefilled/back", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.insert_many(INITIAL_NUM_ENTRIES, added.clone());
+                v
+            });
+        });
+    }
+}
+
+fn insert_deque(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
+    }
+
+    let mut added: FlatVecDeque<i64> = FlatVecDeque::new();
+    for i in 0..ADDED_NUM_ENTRIES {
+        added.insert(i, (0..ADDED_VALUES_PER_ENTRY as i64).collect_vec());
+    }
+
+    let added = FlatVecDeque::from_vecs(
+        std::iter::repeat_with(|| (0..ADDED_VALUES_PER_ENTRY as i64).collect_vec())
+            .take(ADDED_NUM_ENTRIES),
+    );
+
+    let mut group = c.benchmark_group("flat_vec_deque");
+    group.throughput(criterion::Throughput::Elements(
+        (ADDED_NUM_ENTRIES * ADDED_VALUES_PER_ENTRY) as _,
+    ));
+
+    {
+        group.bench_function("insert_deque/empty", |b| {
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+                v.insert_deque(0, added.clone());
+                v
+            });
+        });
+    }
+
+    {
+        group.bench_function("insert_deque/prefilled/front", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.insert_deque(0, added.clone());
+                v
+            });
+        });
+        group.bench_function("insert_deque/prefilled/middle", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.insert_deque(INITIAL_NUM_ENTRIES / 2, added.clone());
+                v
+            });
+        });
+        group.bench_function("insert_deque/prefilled/back", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.insert_deque(INITIAL_NUM_ENTRIES, added.clone());
+                v
+            });
+        });
+    }
+}
+
+fn remove(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
+    }
+
+    let mut group = c.benchmark_group("flat_vec_deque");
+    group.throughput(criterion::Throughput::Elements(1));
+
+    {
+        group.bench_function("remove/prefilled/front", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.remove(0);
+                v
+            });
+        });
+        group.bench_function("remove/prefilled/middle", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.remove(INITIAL_NUM_ENTRIES / 2);
+                v
+            });
+        });
+        group.bench_function("remove/prefilled/back", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.remove(INITIAL_NUM_ENTRIES - 1);
+                v
+            });
+        });
+    }
+}
+
+fn remove_range(c: &mut Criterion) {
+    if std::env::var("CI").is_ok() {
+        return;
+    }
+
+    let mut group = c.benchmark_group("flat_vec_deque");
+    group.throughput(criterion::Throughput::Elements(
+        (ADDED_NUM_ENTRIES * ADDED_VALUES_PER_ENTRY) as _,
+    ));
+
+    {
+        group.bench_function("remove_range/prefilled/front", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.remove_range(0..ADDED_NUM_ENTRIES);
+                v
+            });
+        });
+        group.bench_function("remove_range/prefilled/middle", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.remove_range(
+                    INITIAL_NUM_ENTRIES / 2 - ADDED_NUM_ENTRIES / 2
+                        ..INITIAL_NUM_ENTRIES / 2 + ADDED_NUM_ENTRIES / 2,
+                );
+                v
+            });
+        });
+        group.bench_function("remove_range/prefilled/back", |b| {
+            let base = create_prefilled();
+            b.iter(|| {
+                let mut v: FlatVecDeque<i64> = base.clone();
+                v.remove_range(INITIAL_NUM_ENTRIES - ADDED_NUM_ENTRIES..INITIAL_NUM_ENTRIES);
+                v
+            });
+        });
+    }
+}
+
+// ---
+
+fn create_prefilled() -> FlatVecDeque<i64> {
+    FlatVecDeque::from_vecs(
+        std::iter::repeat_with(|| (0..INITIAL_VALUES_PER_ENTRY as i64).collect_vec())
+            .take(INITIAL_NUM_ENTRIES),
+    )
+}

--- a/crates/re_query_cache2/benches/latest_at.rs
+++ b/crates/re_query_cache2/benches/latest_at.rs
@@ -1,0 +1,374 @@
+//! Contains:
+//! - A 1:1 port of the benchmarks in `crates/re_query/benches/query_benchmarks.rs`, with caching enabled.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use itertools::Itertools;
+use re_data_store::{DataStore, LatestAtQuery, StoreSubscriber};
+use re_log_types::{entity_path, DataRow, EntityPath, RowId, TimeInt, TimeType, Timeline};
+use re_query2::{clamped_zip_1x1, PromiseResolver};
+use re_query_cache2::{CachedLatestAtResults, Caches};
+use re_types::{
+    archetypes::Points2D,
+    components::{Color, InstanceKey, Position2D, Text},
+    Archetype as _,
+};
+use re_types_core::Loggable as _;
+
+// ---
+
+// `cargo test` also runs the benchmark setup code, so make sure they run quickly:
+#[cfg(debug_assertions)]
+mod constants {
+    pub const NUM_FRAMES_POINTS: u32 = 1;
+    pub const NUM_POINTS: u32 = 1;
+    pub const NUM_FRAMES_STRINGS: u32 = 1;
+    pub const NUM_STRINGS: u32 = 1;
+}
+
+#[cfg(not(debug_assertions))]
+mod constants {
+    pub const NUM_FRAMES_POINTS: u32 = 1_000;
+    pub const NUM_POINTS: u32 = 1_000;
+    pub const NUM_FRAMES_STRINGS: u32 = 1_000;
+    pub const NUM_STRINGS: u32 = 1_000;
+}
+
+#[allow(clippy::wildcard_imports)]
+use self::constants::*;
+
+// ---
+
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+criterion_group!(
+    benches,
+    mono_points,
+    mono_strings,
+    batch_points,
+    batch_strings
+);
+criterion_main!(benches);
+
+// ---
+
+fn mono_points(c: &mut Criterion) {
+    // Each mono point gets logged at a different path
+    let paths = (0..NUM_POINTS)
+        .map(move |point_idx| entity_path!("points", point_idx))
+        .collect_vec();
+    let msgs = build_points_rows(&paths, 1);
+
+    {
+        let mut group = c.benchmark_group("arrow_mono_points2");
+        // Mono-insert is slow -- decrease the sample size
+        group.sample_size(10);
+        group.throughput(criterion::Throughput::Elements(
+            (NUM_POINTS * NUM_FRAMES_POINTS) as _,
+        ));
+        group.bench_function("insert", |b| {
+            b.iter(|| insert_rows(msgs.iter()));
+        });
+    }
+
+    {
+        let mut group = c.benchmark_group("arrow_mono_points2");
+        group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
+        let (caches, store) = insert_rows(msgs.iter());
+        group.bench_function("query", |b| {
+            b.iter(|| query_and_visit_points(&caches, &store, &paths));
+        });
+    }
+}
+
+fn mono_strings(c: &mut Criterion) {
+    // Each mono string gets logged at a different path
+    let paths = (0..NUM_STRINGS)
+        .map(move |string_idx| entity_path!("strings", string_idx))
+        .collect_vec();
+    let msgs = build_strings_rows(&paths, 1);
+
+    {
+        let mut group = c.benchmark_group("arrow_mono_strings2");
+        group.sample_size(10);
+        group.throughput(criterion::Throughput::Elements(
+            (NUM_STRINGS * NUM_FRAMES_STRINGS) as _,
+        ));
+        group.bench_function("insert", |b| {
+            b.iter(|| insert_rows(msgs.iter()));
+        });
+    }
+
+    {
+        let mut group = c.benchmark_group("arrow_mono_strings2");
+        group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
+        let (caches, store) = insert_rows(msgs.iter());
+        group.bench_function("query", |b| {
+            b.iter(|| query_and_visit_strings(&caches, &store, &paths));
+        });
+    }
+}
+
+fn batch_points(c: &mut Criterion) {
+    // Batch points are logged together at a single path
+    let paths = [EntityPath::from("points")];
+    let msgs = build_points_rows(&paths, NUM_POINTS as _);
+
+    {
+        let mut group = c.benchmark_group("arrow_batch_points2");
+        group.throughput(criterion::Throughput::Elements(
+            (NUM_POINTS * NUM_FRAMES_POINTS) as _,
+        ));
+        group.bench_function("insert", |b| {
+            b.iter(|| insert_rows(msgs.iter()));
+        });
+    }
+
+    {
+        let mut group = c.benchmark_group("arrow_batch_points2");
+        group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
+        let (caches, store) = insert_rows(msgs.iter());
+        group.bench_function("query", |b| {
+            b.iter(|| query_and_visit_points(&caches, &store, &paths));
+        });
+    }
+}
+
+fn batch_strings(c: &mut Criterion) {
+    // Batch strings are logged together at a single path
+    let paths = [EntityPath::from("points")];
+    let msgs = build_strings_rows(&paths, NUM_STRINGS as _);
+
+    {
+        let mut group = c.benchmark_group("arrow_batch_strings2");
+        group.throughput(criterion::Throughput::Elements(
+            (NUM_STRINGS * NUM_FRAMES_STRINGS) as _,
+        ));
+        group.bench_function("insert", |b| {
+            b.iter(|| insert_rows(msgs.iter()));
+        });
+    }
+
+    {
+        let mut group = c.benchmark_group("arrow_batch_strings2");
+        group.throughput(criterion::Throughput::Elements(NUM_POINTS as _));
+        let (caches, store) = insert_rows(msgs.iter());
+        group.bench_function("query", |b| {
+            b.iter(|| query_and_visit_strings(&caches, &store, &paths));
+        });
+    }
+}
+
+// --- Helpers ---
+
+pub fn build_some_point2d(len: usize) -> Vec<Position2D> {
+    use rand::Rng as _;
+    let mut rng = rand::thread_rng();
+
+    (0..len)
+        .map(|_| Position2D::new(rng.gen_range(0.0..10.0), rng.gen_range(0.0..10.0)))
+        .collect()
+}
+
+/// Create `len` dummy colors
+pub fn build_some_colors(len: usize) -> Vec<Color> {
+    (0..len).map(|i| Color::from(i as u32)).collect()
+}
+
+/// Build a ([`Timeline`], [`TimeInt`]) tuple from `frame_nr` suitable for inserting in a [`re_log_types::TimePoint`].
+pub fn build_frame_nr(frame_nr: TimeInt) -> (Timeline, TimeInt) {
+    (Timeline::new("frame_nr", TimeType::Sequence), frame_nr)
+}
+
+pub fn build_some_strings(len: usize) -> Vec<Text> {
+    use rand::Rng as _;
+    let mut rng = rand::thread_rng();
+
+    (0..len)
+        .map(|_| {
+            let ilen: usize = rng.gen_range(0..10000);
+            let s: String = rand::thread_rng()
+                .sample_iter(&rand::distributions::Alphanumeric)
+                .take(ilen)
+                .map(char::from)
+                .collect();
+            Text::from(s)
+        })
+        .collect()
+}
+
+fn build_points_rows(paths: &[EntityPath], num_points: usize) -> Vec<DataRow> {
+    (0..NUM_FRAMES_POINTS)
+        .flat_map(move |frame_idx| {
+            paths.iter().map(move |path| {
+                let mut row = DataRow::from_cells2(
+                    RowId::new(),
+                    path.clone(),
+                    [build_frame_nr((frame_idx as i64).try_into().unwrap())],
+                    num_points as _,
+                    (
+                        build_some_point2d(num_points),
+                        build_some_colors(num_points),
+                    ),
+                )
+                .unwrap();
+                // NOTE: Using unsized cells will crash in debug mode, and benchmarks are run for 1 iteration,
+                // in debug mode, by the standard test harness.
+                if cfg!(debug_assertions) {
+                    row.compute_all_size_bytes();
+                }
+                row
+            })
+        })
+        .collect()
+}
+
+fn build_strings_rows(paths: &[EntityPath], num_strings: usize) -> Vec<DataRow> {
+    (0..NUM_FRAMES_STRINGS)
+        .flat_map(move |frame_idx| {
+            paths.iter().map(move |path| {
+                let mut row = DataRow::from_cells2(
+                    RowId::new(),
+                    path.clone(),
+                    [build_frame_nr((frame_idx as i64).try_into().unwrap())],
+                    num_strings as _,
+                    // We still need to create points because they are the primary for the
+                    // archetype query we want to do. We won't actually deserialize the points
+                    // during the query -- we just need it for the primary keys.
+                    // TODO(jleibs): switch this to use `TextEntry` once the new type has
+                    // landed.
+                    (
+                        build_some_point2d(num_strings),
+                        build_some_strings(num_strings),
+                    ),
+                )
+                .unwrap();
+                // NOTE: Using unsized cells will crash in debug mode, and benchmarks are run for 1 iteration,
+                // in debug mode, by the standard test harness.
+                if cfg!(debug_assertions) {
+                    row.compute_all_size_bytes();
+                }
+                row
+            })
+        })
+        .collect()
+}
+
+fn insert_rows<'a>(msgs: impl Iterator<Item = &'a DataRow>) -> (Caches, DataStore) {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+    let mut caches = Caches::new(&store);
+
+    msgs.for_each(|row| {
+        caches.on_events(&[store.insert_row(row).unwrap()]);
+    });
+
+    (caches, store)
+}
+
+struct SavePoint {
+    _pos: Position2D,
+    _color: Option<Color>,
+}
+
+fn query_and_visit_points(
+    caches: &Caches,
+    store: &DataStore,
+    paths: &[EntityPath],
+) -> Vec<SavePoint> {
+    let mut resolver = PromiseResolver::default();
+
+    let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
+    let query = LatestAtQuery::new(timeline_frame_nr, NUM_FRAMES_POINTS as i64 / 2);
+
+    let mut ret = Vec::with_capacity(NUM_POINTS as _);
+
+    // TODO(jleibs): Add Radius once we have support for it in field_types
+    for entity_path in paths {
+        let results: CachedLatestAtResults = caches.latest_at(
+            store,
+            &query,
+            entity_path,
+            Points2D::all_components().iter().cloned(), // no generics!
+        );
+
+        let points = results.get_required::<Position2D>().unwrap();
+        let colors = results.get_optional::<Color>();
+
+        let points = points
+            .iter_dense::<Position2D>(&mut resolver)
+            .flatten()
+            .unwrap()
+            .copied();
+
+        let colors = colors
+            .iter_dense::<Color>(&mut resolver)
+            .flatten()
+            .unwrap()
+            .copied();
+        let color_default_fn = || Color::from(0xFF00FFFF);
+
+        for (point, color) in clamped_zip_1x1(points, colors, color_default_fn) {
+            ret.push(SavePoint {
+                _pos: point,
+                _color: Some(color),
+            });
+        }
+    }
+    assert_eq!(NUM_POINTS as usize, ret.len());
+    ret
+}
+
+struct SaveString {
+    _label: Option<Text>,
+}
+
+fn query_and_visit_strings(
+    caches: &Caches,
+    store: &DataStore,
+    paths: &[EntityPath],
+) -> Vec<SaveString> {
+    let mut resolver = PromiseResolver::default();
+
+    let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
+    let query = LatestAtQuery::new(timeline_frame_nr, NUM_FRAMES_STRINGS as i64 / 2);
+
+    let mut strings = Vec::with_capacity(NUM_STRINGS as _);
+
+    for entity_path in paths {
+        let results: CachedLatestAtResults = caches.latest_at(
+            store,
+            &query,
+            entity_path,
+            Points2D::all_components().iter().cloned(), // no generics!
+        );
+
+        let points = results.get_required::<Position2D>().unwrap();
+        let colors = results.get_optional::<Text>();
+
+        let points = points
+            .iter_dense::<Position2D>(&mut resolver)
+            .flatten()
+            .unwrap()
+            .copied();
+
+        let labels = colors
+            .iter_dense::<Text>(&mut resolver)
+            .flatten()
+            .unwrap()
+            .cloned();
+        let label_default_fn = || Text(String::new().into());
+
+        for (_point, label) in clamped_zip_1x1(points, labels, label_default_fn) {
+            strings.push(SaveString {
+                _label: Some(label),
+            });
+        }
+    }
+    assert_eq!(NUM_STRINGS as usize, strings.len());
+    criterion::black_box(strings)
+}

--- a/crates/re_query_cache2/benches/latest_at.rs
+++ b/crates/re_query_cache2/benches/latest_at.rs
@@ -280,7 +280,7 @@ fn query_and_visit_points(
     store: &DataStore,
     paths: &[EntityPath],
 ) -> Vec<SavePoint> {
-    let mut resolver = PromiseResolver::default();
+    let resolver = PromiseResolver::default();
 
     let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
     let query = LatestAtQuery::new(timeline_frame_nr, NUM_FRAMES_POINTS as i64 / 2);
@@ -300,13 +300,13 @@ fn query_and_visit_points(
         let colors = results.get_optional::<Color>();
 
         let points = points
-            .iter_dense::<Position2D>(&mut resolver)
+            .iter_dense::<Position2D>(&resolver)
             .flatten()
             .unwrap()
             .copied();
 
         let colors = colors
-            .iter_dense::<Color>(&mut resolver)
+            .iter_dense::<Color>(&resolver)
             .flatten()
             .unwrap()
             .copied();
@@ -332,7 +332,7 @@ fn query_and_visit_strings(
     store: &DataStore,
     paths: &[EntityPath],
 ) -> Vec<SaveString> {
-    let mut resolver = PromiseResolver::default();
+    let resolver = PromiseResolver::default();
 
     let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
     let query = LatestAtQuery::new(timeline_frame_nr, NUM_FRAMES_STRINGS as i64 / 2);
@@ -351,13 +351,13 @@ fn query_and_visit_strings(
         let colors = results.get_optional::<Text>();
 
         let points = points
-            .iter_dense::<Position2D>(&mut resolver)
+            .iter_dense::<Position2D>(&resolver)
             .flatten()
             .unwrap()
             .copied();
 
         let labels = colors
-            .iter_dense::<Text>(&mut resolver)
+            .iter_dense::<Text>(&resolver)
             .flatten()
             .unwrap()
             .cloned();

--- a/crates/re_query_cache2/benches/latest_at.rs
+++ b/crates/re_query_cache2/benches/latest_at.rs
@@ -297,7 +297,7 @@ fn query_and_visit_points(
         );
 
         let points = results.get_required::<Position2D>().unwrap();
-        let colors = results.get_optional::<Color>();
+        let colors = results.get_or_empty::<Color>();
 
         let points = points
             .iter_dense::<Position2D>(&resolver)
@@ -348,7 +348,7 @@ fn query_and_visit_strings(
         );
 
         let points = results.get_required::<Position2D>().unwrap();
-        let colors = results.get_optional::<Text>();
+        let colors = results.get_or_empty::<Text>();
 
         let points = points
             .iter_dense::<Position2D>(&resolver)

--- a/crates/re_query_cache2/examples/latest_at.rs
+++ b/crates/re_query_cache2/examples/latest_at.rs
@@ -15,7 +15,7 @@ fn main() -> anyhow::Result<()> {
     let store = store()?;
     eprintln!("store:\n{}", store.to_data_table()?);
 
-    let mut resolver = PromiseResolver::default();
+    let resolver = PromiseResolver::default();
 
     let entity_path = "points";
     let timeline = Timeline::new("frame_nr", TimeType::Sequence);
@@ -63,7 +63,7 @@ fn main() -> anyhow::Result<()> {
     //
     // Otherwise, this will trigger a deserialization and cache the result for next time.
 
-    let points = match points.iter_dense::<MyPoint>(&mut resolver).flatten() {
+    let points = match points.iter_dense::<MyPoint>(&resolver).flatten() {
         PromiseResult::Pending => {
             // Handle the fact that the data isn't ready appropriately.
             return Ok(());
@@ -72,7 +72,7 @@ fn main() -> anyhow::Result<()> {
         PromiseResult::Error(err) => return Err(err.into()),
     };
 
-    let colors = match colors.iter_dense::<MyColor>(&mut resolver).flatten() {
+    let colors = match colors.iter_dense::<MyColor>(&resolver).flatten() {
         PromiseResult::Pending => {
             // Handle the fact that the data isn't ready appropriately.
             return Ok(());
@@ -81,7 +81,7 @@ fn main() -> anyhow::Result<()> {
         PromiseResult::Error(err) => return Err(err.into()),
     };
 
-    let labels = match labels.iter_sparse::<MyLabel>(&mut resolver).flatten() {
+    let labels = match labels.iter_sparse::<MyLabel>(&resolver).flatten() {
         PromiseResult::Pending => {
             // Handle the fact that the data isn't ready appropriately.
             return Ok(());

--- a/crates/re_query_cache2/examples/latest_at.rs
+++ b/crates/re_query_cache2/examples/latest_at.rs
@@ -1,0 +1,140 @@
+use itertools::Itertools;
+use re_data_store::{DataStore, LatestAtQuery};
+use re_log_types::example_components::{MyColor, MyLabel, MyPoint, MyPoints};
+use re_log_types::{build_frame_nr, DataRow, RowId, TimeType, Timeline};
+use re_types_core::{Archetype as _, Loggable as _};
+
+use re_query_cache2::{
+    clamped_zip_1x2, CachedLatestAtComponentResults, CachedLatestAtResults, PromiseResolver,
+    PromiseResult,
+};
+
+// ---
+
+fn main() -> anyhow::Result<()> {
+    let store = store()?;
+    eprintln!("store:\n{}", store.to_data_table()?);
+
+    let mut resolver = PromiseResolver::default();
+
+    let entity_path = "points";
+    let timeline = Timeline::new("frame_nr", TimeType::Sequence);
+    let query = LatestAtQuery::latest(timeline);
+    eprintln!("query:{query:?}");
+
+    let caches = re_query_cache2::Caches::new(&store);
+
+    // First, get the results for this query.
+    //
+    // They might or might not already be cached. We won't know for sure until we try to access
+    // each individual component's data below.
+    let results: CachedLatestAtResults = caches.latest_at(
+        &store,
+        &query,
+        &entity_path.into(),
+        MyPoints::all_components().iter().cloned(), // no generics!
+    );
+
+    // Then, grab the results for each individual components.
+    // * `get_required` returns an error if the component batch is missing
+    // * `get_optional` returns an empty set of results if the component if missing
+    // * `get` returns an option
+    //
+    // At this point we still don't know whether they are cached or not. That's the next step.
+    let points: &CachedLatestAtComponentResults = results.get_required::<MyPoint>()?;
+    let colors: &CachedLatestAtComponentResults = results.get_optional::<MyColor>();
+    let labels: &CachedLatestAtComponentResults = results.get_optional::<MyLabel>();
+
+    // Then comes the time to resolve/convert and deserialize the data.
+    // These steps have to be done together for efficiency reasons.
+    //
+    // Both the resolution and deserialization steps might fail, which is why this returns a `Result<Result<T>>`.
+    // Use `PromiseResult::flatten` to simplify it down to a single result.
+    //
+    // A choice now has to be made regarding the nullability of the _component batch's instances_.
+    // Our IDL doesn't support nullable instances at the moment -- so for the foreseeable future you probably
+    // shouldn't be using anything but `iter_dense`.
+    //
+    // This is the step at which caching comes into play.
+    //
+    // If the data has already been accessed with the same nullability characteristics in the
+    // past, then this will just grab the pre-deserialized, pre-resolved/pre-converted result from
+    // the cache.
+    //
+    // Otherwise, this will trigger a deserialization and cache the result for next time.
+
+    let points = match points.iter_dense::<MyPoint>(&mut resolver).flatten() {
+        PromiseResult::Pending => {
+            // Handle the fact that the data isn't ready appropriately.
+            return Ok(());
+        }
+        PromiseResult::Ready(data) => data,
+        PromiseResult::Error(err) => return Err(err.into()),
+    };
+
+    let colors = match colors.iter_dense::<MyColor>(&mut resolver).flatten() {
+        PromiseResult::Pending => {
+            // Handle the fact that the data isn't ready appropriately.
+            return Ok(());
+        }
+        PromiseResult::Ready(data) => data,
+        PromiseResult::Error(err) => return Err(err.into()),
+    };
+
+    let labels = match labels.iter_sparse::<MyLabel>(&mut resolver).flatten() {
+        PromiseResult::Pending => {
+            // Handle the fact that the data isn't ready appropriately.
+            return Ok(());
+        }
+        PromiseResult::Ready(data) => data,
+        PromiseResult::Error(err) => return Err(err.into()),
+    };
+
+    // With the data now fully resolved/converted and deserialized, the joining logic can be
+    // applied.
+    //
+    // In most cases this will be either a clamped zip, or no joining at all.
+
+    let color_default_fn = || {
+        static DEFAULT: MyColor = MyColor(0xFF00FFFF);
+        &DEFAULT
+    };
+    let label_default_fn = || None;
+
+    let results =
+        clamped_zip_1x2(points, colors, color_default_fn, labels, label_default_fn).collect_vec();
+
+    eprintln!("results:\n{results:#?}");
+
+    Ok(())
+}
+
+// ---
+
+fn store() -> anyhow::Result<DataStore> {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        re_types::components::InstanceKey::name(),
+        Default::default(),
+    );
+
+    let entity_path = "points";
+
+    {
+        let timepoint = [build_frame_nr(123)];
+
+        let points = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+        let row = DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 2, points)?;
+        store.insert_row(&row)?;
+
+        let colors = vec![MyColor::from_rgb(255, 0, 0)];
+        let row = DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 1, colors)?;
+        store.insert_row(&row)?;
+
+        let labels = vec![MyLabel("a".into()), MyLabel("b".into())];
+        let row = DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 2, labels)?;
+        store.insert_row(&row)?;
+    }
+
+    Ok(store)
+}

--- a/crates/re_query_cache2/examples/latest_at.rs
+++ b/crates/re_query_cache2/examples/latest_at.rs
@@ -37,13 +37,13 @@ fn main() -> anyhow::Result<()> {
 
     // Then, grab the results for each individual components.
     // * `get_required` returns an error if the component batch is missing
-    // * `get_optional` returns an empty set of results if the component if missing
+    // * `get_or_empty` returns an empty set of results if the component if missing
     // * `get` returns an option
     //
     // At this point we still don't know whether they are cached or not. That's the next step.
     let points: &CachedLatestAtComponentResults = results.get_required::<MyPoint>()?;
-    let colors: &CachedLatestAtComponentResults = results.get_optional::<MyColor>();
-    let labels: &CachedLatestAtComponentResults = results.get_optional::<MyLabel>();
+    let colors: &CachedLatestAtComponentResults = results.get_or_empty::<MyColor>();
+    let labels: &CachedLatestAtComponentResults = results.get_or_empty::<MyLabel>();
 
     // Then comes the time to resolve/convert and deserialize the data.
     // These steps have to be done together for efficiency reasons.

--- a/crates/re_query_cache2/src/cache.rs
+++ b/crates/re_query_cache2/src/cache.rs
@@ -1,0 +1,176 @@
+use std::{collections::BTreeSet, sync::Arc};
+
+use ahash::{HashMap, HashSet};
+use parking_lot::RwLock;
+
+use re_data_store::{DataStore, StoreDiff, StoreEvent, StoreSubscriber, TimeInt};
+use re_log_types::{EntityPath, StoreId, Timeline};
+use re_types_core::ComponentName;
+
+use crate::LatestAtCache;
+
+// ---
+
+/// Uniquely identifies cached query results in the [`Caches`].
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CacheKey {
+    pub entity_path: EntityPath,
+    pub timeline: Timeline,
+    pub component_name: ComponentName,
+}
+
+impl std::fmt::Debug for CacheKey {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            entity_path,
+            timeline,
+            component_name,
+        } = self;
+        f.write_fmt(format_args!(
+            "{entity_path}:{component_name} on {}",
+            timeline.name()
+        ))
+    }
+}
+
+impl CacheKey {
+    #[inline]
+    pub fn new(
+        entity_path: impl Into<EntityPath>,
+        timeline: impl Into<Timeline>,
+        component_name: impl Into<ComponentName>,
+    ) -> Self {
+        Self {
+            entity_path: entity_path.into(),
+            timeline: timeline.into(),
+            component_name: component_name.into(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Caches {
+    /// The [`StoreId`] of the associated [`DataStore`].
+    pub(crate) store_id: StoreId,
+
+    // NOTE: `Arc` so we can cheaply free the top-level lock early when needed.
+    pub(crate) per_cache_key: RwLock<HashMap<CacheKey, Arc<RwLock<LatestAtCache>>>>,
+}
+
+impl Caches {
+    #[inline]
+    pub fn new(store: &DataStore) -> Self {
+        Self {
+            store_id: store.id().clone(),
+            per_cache_key: Default::default(),
+        }
+    }
+}
+
+impl StoreSubscriber for Caches {
+    #[inline]
+    fn name(&self) -> String {
+        "rerun.store_subscribers.QueryCache".into()
+    }
+
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn on_events(&mut self, events: &[StoreEvent]) {
+        re_tracing::profile_function!(format!("num_events={}", events.len()));
+
+        #[derive(Default, Debug)]
+        struct CompactedEvents {
+            timeless: HashSet<(EntityPath, ComponentName)>,
+            temporal: HashMap<CacheKey, BTreeSet<TimeInt>>,
+        }
+
+        let mut compacted = CompactedEvents::default();
+
+        for event in events {
+            let StoreEvent {
+                store_id,
+                store_generation: _,
+                event_id: _,
+                diff,
+            } = event;
+
+            assert!(
+                self.store_id == *store_id,
+                "attempted to use a query cache {} with the wrong datastore ({})",
+                self.store_id,
+                store_id,
+            );
+
+            let StoreDiff {
+                kind: _, // Don't care: both additions and deletions invalidate query results.
+                row_id: _,
+                times,
+                entity_path,
+                cells,
+            } = diff;
+
+            {
+                re_tracing::profile_scope!("compact events");
+
+                if times.is_empty() {
+                    for component_name in cells.keys() {
+                        compacted
+                            .timeless
+                            .insert((entity_path.clone(), *component_name));
+                    }
+                }
+
+                for &(timeline, data_time) in times {
+                    for component_name in cells.keys() {
+                        let key = CacheKey::new(entity_path.clone(), timeline, *component_name);
+                        let data_times = compacted.temporal.entry(key).or_default();
+                        data_times.insert(data_time);
+                    }
+                }
+            }
+        }
+
+        let caches = self.per_cache_key.write();
+        // NOTE: Don't release the top-level lock -- even though this cannot happen yet with
+        // our current macro-architecture, we want to prevent queries from concurrently
+        // running while we're updating the invalidation flags.
+
+        {
+            re_tracing::profile_scope!("timeless");
+
+            // TODO(cmc): This is horribly stupid and slow and can easily be made faster by adding
+            // yet another layer of caching indirection.
+            // But since this pretty much never happens in practice, let's not go there until we
+            // have metrics showing that show we need to.
+            for (entity_path, component_name) in compacted.timeless {
+                for (key, cache) in caches.iter() {
+                    if key.entity_path == entity_path && key.component_name == component_name {
+                        cache.write().pending_invalidations.insert(TimeInt::STATIC);
+                    }
+                }
+            }
+        }
+
+        {
+            re_tracing::profile_scope!("temporal");
+
+            for (key, times) in compacted.temporal {
+                if let Some(cache) = caches.get(&key) {
+                    cache
+                        .write()
+                        .pending_invalidations
+                        .extend(times.iter().copied());
+                }
+            }
+        }
+    }
+}

--- a/crates/re_query_cache2/src/cache.rs
+++ b/crates/re_query_cache2/src/cache.rs
@@ -89,7 +89,7 @@ impl StoreSubscriber for Caches {
 
         #[derive(Default, Debug)]
         struct CompactedEvents {
-            timeless: HashSet<(EntityPath, ComponentName)>,
+            static_: HashSet<(EntityPath, ComponentName)>,
             temporal: HashMap<CacheKey, BTreeSet<TimeInt>>,
         }
 
@@ -124,7 +124,7 @@ impl StoreSubscriber for Caches {
                 if times.is_empty() {
                     for component_name in cells.keys() {
                         compacted
-                            .timeless
+                            .static_
                             .insert((entity_path.clone(), *component_name));
                     }
                 }
@@ -151,7 +151,7 @@ impl StoreSubscriber for Caches {
             // yet another layer of caching indirection.
             // But since this pretty much never happens in practice, let's not go there until we
             // have metrics showing that show we need to.
-            for (entity_path, component_name) in compacted.timeless {
+            for (entity_path, component_name) in compacted.static_ {
                 for (key, cache) in caches.iter() {
                     if key.entity_path == entity_path && key.component_name == component_name {
                         cache.write().pending_invalidations.insert(TimeInt::STATIC);

--- a/crates/re_query_cache2/src/flat_vec_deque.rs
+++ b/crates/re_query_cache2/src/flat_vec_deque.rs
@@ -1,0 +1,945 @@
+use std::{collections::VecDeque, ops::Range};
+
+use itertools::Itertools as _;
+
+use re_types_core::SizeBytes;
+
+// ---
+
+/// A [`FlatVecDeque`] that can be erased into a trait object.
+///
+/// Methods that don't require monomorphization over `T` are made dynamically dispatchable.
+pub trait ErasedFlatVecDeque: std::any::Any {
+    fn as_any(&self) -> &dyn std::any::Any;
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
+
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any>;
+
+    /// Dynamically dispatches to [`FlatVecDeque::num_entries`].
+    ///
+    /// This is prefixed with `dyn_` to avoid method dispatch ambiguities that are very hard to
+    /// avoid even with explicit syntax and that silently lead to infinite recursions.
+    fn dyn_num_entries(&self) -> usize;
+
+    /// Dynamically dispatches to [`FlatVecDeque::num_values`].
+    ///
+    /// This is prefixed with `dyn_` to avoid method dispatch ambiguities that are very hard to
+    /// avoid even with explicit syntax and that silently lead to infinite recursions.
+    fn dyn_num_values(&self) -> usize;
+
+    /// Dynamically dispatches to [`FlatVecDeque::remove`].
+    ///
+    /// This is prefixed with `dyn_` to avoid method dispatch ambiguities that are very hard to
+    /// avoid even with explicit syntax and that silently lead to infinite recursions.
+    fn dyn_remove(&mut self, at: usize);
+
+    /// Dynamically dispatches to [`FlatVecDeque::remove`].
+    ///
+    /// This is prefixed with `dyn_` to avoid method dispatch ambiguities that are very hard to
+    /// avoid even with explicit syntax and that silently lead to infinite recursions.
+    fn dyn_remove_range(&mut self, range: Range<usize>);
+
+    /// Dynamically dispatches to [`FlatVecDeque::truncate`].
+    ///
+    /// This is prefixed with `dyn_` to avoid method dispatch ambiguities that are very hard to
+    /// avoid even with explicit syntax and that silently lead to infinite recursions.
+    fn dyn_truncate(&mut self, at: usize);
+
+    /// Dynamically dispatches to [`<FlatVecDeque<T> as SizeBytes>::total_size_bytes(self)`].
+    ///
+    /// This is prefixed with `dyn_` to avoid method dispatch ambiguities that are very hard to
+    /// avoid even with explicit syntax and that silently lead to infinite recursions.
+    fn dyn_total_size_bytes(&self) -> u64;
+}
+
+impl<T: SizeBytes + 'static> ErasedFlatVecDeque for FlatVecDeque<T> {
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
+    }
+
+    #[inline]
+    fn dyn_num_entries(&self) -> usize {
+        self.num_entries()
+    }
+
+    #[inline]
+    fn dyn_num_values(&self) -> usize {
+        self.num_values()
+    }
+
+    #[inline]
+    fn dyn_remove(&mut self, at: usize) {
+        FlatVecDeque::<T>::remove(self, at);
+    }
+
+    #[inline]
+    fn dyn_remove_range(&mut self, range: Range<usize>) {
+        FlatVecDeque::<T>::remove_range(self, range);
+    }
+
+    #[inline]
+    fn dyn_truncate(&mut self, at: usize) {
+        FlatVecDeque::<T>::truncate(self, at);
+    }
+
+    #[inline]
+    fn dyn_total_size_bytes(&self) -> u64 {
+        <FlatVecDeque<T> as SizeBytes>::total_size_bytes(self)
+    }
+}
+
+// ---
+
+/// A double-ended queue implemented with a pair of growable ring buffers, where every single
+/// entry is a flattened array of values.
+///
+/// Logically like a `VecDeque<Box<[T]>>`, but with a less fragmented memory layout (each `Box<[T]>`
+/// gets copied/inlined into the `FlatVecDeque`).
+/// `FlatVecDeque` therefore optimizes for reads (cache locality, specifically) while `VecDeque<Box<[T]>>`
+/// optimizes for writes.
+///
+/// You can think of this as the native/deserialized version of an Arrow `ListArray`.
+/// This is particularly useful when working with many small arrays of data (e.g. Rerun's
+/// `TimeSeriesScalar`s).
+//
+// TODO(cmc): We could even use a bitmap for T=Option<Something>, which would bring this that much
+// closer to a deserialized version of an Arrow array.
+#[derive(Debug, Clone)]
+pub struct FlatVecDeque<T> {
+    /// Stores every value in the `FlatVecDeque` in a flattened `VecDeque`.
+    ///
+    /// E.g.:
+    /// - `FlatVecDeque[]` -> values=`[]`.
+    /// - `FlatVecDeque[[], [], []]` -> values=`[]`.
+    /// - `FlatVecDeque[[], [0], [1, 2, 3], [4, 5]]` -> values=`[0, 1, 2, 3, 4, 5]`.
+    values: VecDeque<T>,
+
+    /// Keeps track of each entry, i.e. logical slices of data.
+    ///
+    /// E.g.:
+    /// - `FlatVecDeque[]` -> offsets=`[]`.
+    /// - `FlatVecDeque[[], [], []]` -> offsets=`[0, 0, 0]`.
+    /// - `FlatVecDeque[[], [0], [1, 2, 3], [4, 5]]` -> offsets=`[0, 1, 4, 6]`.
+    offsets: VecDeque<usize>,
+}
+
+impl<T: SizeBytes> SizeBytes for FlatVecDeque<T> {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        // NOTE: It's all on the heap at this point.
+
+        let values_size_bytes = if T::is_pod() {
+            (self.num_values() * std::mem::size_of::<T>()) as _
+        } else {
+            self.values
+                .iter()
+                .map(SizeBytes::total_size_bytes)
+                .sum::<u64>()
+        };
+
+        let offsets_size_bytes = self.num_entries() * std::mem::size_of::<usize>();
+
+        values_size_bytes + offsets_size_bytes as u64
+    }
+}
+
+impl<T> From<VecDeque<T>> for FlatVecDeque<T> {
+    #[inline]
+    fn from(values: VecDeque<T>) -> Self {
+        let num_values = values.len();
+        Self {
+            values,
+            offsets: std::iter::once(num_values).collect(),
+        }
+    }
+}
+
+impl<T> From<Vec<T>> for FlatVecDeque<T> {
+    #[inline]
+    fn from(values: Vec<T>) -> Self {
+        let num_values = values.len();
+        Self {
+            values: values.into(),
+            offsets: std::iter::once(num_values).collect(),
+        }
+    }
+}
+
+impl<T> Default for FlatVecDeque<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> FlatVecDeque<T> {
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            values: VecDeque::new(),
+            offsets: VecDeque::new(),
+        }
+    }
+
+    #[inline]
+    pub fn from_vecs(entries: impl IntoIterator<Item = Vec<T>>) -> Self {
+        let mut this = Self::new();
+
+        // NOTE: Do not use any of the insertion methods, they rely on `from_vecs` in the first
+        // place!
+        let mut value_offset = 0;
+        for entry in entries {
+            value_offset += entry.len(); // increment first!
+            this.offsets.push_back(value_offset);
+            this.values.extend(entry);
+        }
+
+        this
+    }
+
+    /// How many entries are there in the deque?
+    ///
+    /// Keep in mind: each entry is itself an array of values.
+    /// Use [`Self::num_values`] to get the total number of values across all entries.
+    #[inline]
+    pub fn num_entries(&self) -> usize {
+        self.offsets.len()
+    }
+
+    /// How many values are there in the deque?
+    ///
+    /// Keep in mind: each entry in the deque holds an array of values.
+    /// Use [`Self::num_entries`] to get the total number of entries, irrelevant of how many
+    /// values each entry holds.
+    #[inline]
+    pub fn num_values(&self) -> usize {
+        self.values.len()
+    }
+
+    #[inline]
+    fn value_offset(&self, entry_index: usize) -> usize {
+        if entry_index == 0 {
+            0
+        } else {
+            self.offsets[entry_index - 1]
+        }
+    }
+
+    #[inline]
+    fn iter_offset_ranges(&self) -> impl Iterator<Item = Range<usize>> + '_ {
+        std::iter::once(0)
+            .chain(self.offsets.iter().copied())
+            .tuple_windows::<(_, _)>()
+            .map(|(start, end)| (start..end))
+    }
+}
+
+// ---
+
+impl<T> FlatVecDeque<T> {
+    /// Iterates over all the entries in the deque.
+    ///
+    /// This is the same as `self.range(0..self.num_entries())`.
+    ///
+    /// Keep in mind that each entry is an array of values!
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = &[T]> {
+        self.range(0..self.num_entries())
+    }
+
+    /// Iterates over all the entries in the deque in the given `entry_range`.
+    ///
+    /// Keep in mind that each entry is an array of values!
+    #[inline]
+    pub fn range(&self, entry_range: Range<usize>) -> impl Iterator<Item = &[T]> {
+        let (values_left, values_right) = self.values.as_slices();
+        // NOTE: We can't slice into our offsets, we don't even know if they're contiguous in
+        // memory at this point -> skip() and take().
+        self.iter_offset_ranges()
+            .skip(entry_range.start)
+            .take(entry_range.len())
+            .map(|offsets| {
+                if offsets.is_empty() {
+                    return &[] as &'_ [T];
+                }
+
+                // NOTE: We do not need `make_contiguous` here because we always guarantee
+                // that a single entry's worth of values is fully contained in either the left or
+                // right buffer, but never straddling across both.
+                if offsets.start < values_left.len() {
+                    &values_left[offsets]
+                } else {
+                    &values_right[offsets]
+                }
+            })
+    }
+}
+
+#[test]
+fn range() {
+    let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+
+    assert_eq!(0, v.num_entries());
+    assert_eq!(0, v.num_values());
+
+    v.insert_many(0, [vec![1, 2, 3], vec![4, 5, 6, 7], vec![8, 9, 10]]);
+    assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7], &[8, 9, 10]], &v);
+
+    assert_iter_eq(&[&[1, 2, 3]], v.range(0..1));
+    assert_iter_eq(&[&[4, 5, 6, 7]], v.range(1..2));
+    assert_iter_eq(&[&[8, 9, 10]], v.range(2..3));
+
+    assert_iter_eq(
+        &[&[1, 2, 3], &[4, 5, 6, 7], &[8, 9, 10]],
+        v.range(0..v.num_entries()),
+    );
+
+    assert_iter_eq(&[&[1, 2, 3], &[4, 5, 6, 7], &[8, 9, 10]], v.iter());
+}
+
+// ---
+
+impl<T> FlatVecDeque<T> {
+    /// Prepends an entry comprised of `values` to the deque.
+    ///
+    /// This is the same as `self.insert(0, values)`.
+    ///
+    /// See [`Self::insert`] for more information.
+    #[inline]
+    pub fn push_front(&mut self, values: impl IntoIterator<Item = T>) {
+        self.insert(0, values);
+    }
+
+    /// Appends an entry comprised of `values` to the deque.
+    ///
+    /// This is the same as `self.insert(self.num_entries(), values)`.
+    ///
+    /// See [`Self::insert`] for more information.
+    #[inline]
+    pub fn push_back(&mut self, values: impl IntoIterator<Item = T>) {
+        self.insert(self.num_entries(), values);
+    }
+
+    /// Inserts a single entry at `entry_index`, comprised of the multiple elements given as `values`.
+    ///
+    /// This is O(1) if `entry_index` corresponds to either the start or the end of the deque.
+    /// Otherwise, this requires splitting the deque into two pieces then stitching them back together
+    /// at both ends of the added data.
+    ///
+    /// Panics if `entry_index` is out of bounds.
+    /// Panics if `values` is empty.
+    #[inline]
+    pub fn insert(&mut self, entry_index: usize, values: impl IntoIterator<Item = T>) {
+        let values: VecDeque<T> = values.into_iter().collect();
+        let deque = values.into();
+        self.insert_deque(entry_index, deque);
+    }
+
+    /// Prepends multiple entries, each comprised of the multiple elements given in `entries`,
+    /// to the deque.
+    ///
+    /// This is the same as `self.insert_many(0, entries)`.
+    ///
+    /// See [`Self::insert_many`] for more information.
+    #[inline]
+    pub fn push_many_front(&mut self, entries: impl IntoIterator<Item = Vec<T>>) {
+        self.insert_many(0, entries);
+    }
+
+    /// Appends multiple entries, each comprised of the multiple elements given in `entries`,
+    /// to the deque.
+    ///
+    /// This is the same as `self.insert_many(self.num_entries(), entries)`.
+    ///
+    /// See [`Self::insert_many`] for more information.
+    #[inline]
+    pub fn push_many_back(&mut self, entries: impl IntoIterator<Item = Vec<T>>) {
+        self.insert_many(self.num_entries(), entries);
+    }
+
+    /// Inserts multiple entries, starting at `entry_index` onwards, each comprised of the multiple elements
+    /// given in `entries`.
+    ///
+    /// This is O(1) if `entry_index` corresponds to either the start or the end of the deque.
+    /// Otherwise, this requires splitting the deque into two pieces then stitching them back together
+    /// at both ends of the added data.
+    ///
+    /// Panics if `entry_index` is out of bounds.
+    /// Panics if any of the value arrays in `entries` is empty.
+    #[inline]
+    pub fn insert_many(&mut self, entry_index: usize, entries: impl IntoIterator<Item = Vec<T>>) {
+        let deque = Self::from_vecs(entries);
+        self.insert_deque(entry_index, deque);
+    }
+
+    /// Prepends another full deque to the deque.
+    ///
+    /// This is the same as `self.insert_deque(0, rhs)`.
+    ///
+    /// See [`Self::insert_deque`] for more information.
+    #[inline]
+    pub fn push_front_deque(&mut self, rhs: FlatVecDeque<T>) {
+        self.insert_deque(0, rhs);
+    }
+
+    /// Appends another full deque to the deque.
+    ///
+    /// This is the same as `self.insert_deque(0, rhs)`.
+    ///
+    /// See [`Self::insert_deque`] for more information.
+    #[inline]
+    pub fn push_back_deque(&mut self, rhs: FlatVecDeque<T>) {
+        self.insert_deque(self.num_entries(), rhs);
+    }
+
+    /// Inserts another full deque, starting at `entry_index` and onwards.
+    ///
+    /// This is O(1) if `entry_index` corresponds to either the start or the end of the deque.
+    /// Otherwise, this requires splitting the deque into two pieces then stitching them back together
+    /// at both ends of the added data.
+    ///
+    /// Panics if `entry_index` is out of bounds.
+    /// Panics if any of the value arrays in `entries` is empty.
+    pub fn insert_deque(&mut self, entry_index: usize, mut rhs: FlatVecDeque<T>) {
+        // NOTE: We're inserting _beyond_ the last element.
+        if entry_index == self.num_entries() {
+            let max_value_offset = self.offsets.back().copied().unwrap_or_default();
+            self.offsets
+                .extend(rhs.offsets.into_iter().map(|o| o + max_value_offset));
+            self.values.extend(rhs.values);
+            return;
+        } else if entry_index == 0 {
+            rhs.push_back_deque(std::mem::take(self));
+            *self = rhs;
+            return;
+        }
+
+        let right = self.split_off(entry_index);
+        self.push_back_deque(rhs);
+        self.push_back_deque(right);
+
+        debug_assert!(self.iter_offset_ranges().all(|r| r.start <= r.end));
+    }
+}
+
+#[test]
+fn insert() {
+    let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+
+    assert_eq!(0, v.num_entries());
+    assert_eq!(0, v.num_values());
+
+    v.insert(0, [1, 2, 3]);
+    assert_deque_eq(&[&[1, 2, 3]], &v);
+
+    v.insert(0, [4, 5, 6, 7]);
+    assert_deque_eq(&[&[4, 5, 6, 7], &[1, 2, 3]], &v);
+
+    v.insert(0, [8, 9]);
+    assert_deque_eq(&[&[8, 9], &[4, 5, 6, 7], &[1, 2, 3]], &v);
+
+    v.insert(2, [10, 11, 12, 13]);
+    assert_deque_eq(&[&[8, 9], &[4, 5, 6, 7], &[10, 11, 12, 13], &[1, 2, 3]], &v);
+
+    v.insert(v.num_entries(), [14, 15]);
+    assert_deque_eq(
+        &[
+            &[8, 9],
+            &[4, 5, 6, 7],
+            &[10, 11, 12, 13],
+            &[1, 2, 3],
+            &[14, 15],
+        ],
+        &v,
+    );
+
+    v.insert(v.num_entries() - 1, [42]);
+    assert_deque_eq(
+        &[
+            &[8, 9],
+            &[4, 5, 6, 7],
+            &[10, 11, 12, 13],
+            &[1, 2, 3],
+            &[42],
+            &[14, 15],
+        ],
+        &v,
+    );
+}
+
+#[test]
+fn insert_empty() {
+    let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+
+    assert_eq!(0, v.num_entries());
+    assert_eq!(0, v.num_values());
+
+    v.push_back([]);
+    v.push_back([]);
+    v.push_back([]);
+
+    assert_deque_eq(&[&[], &[], &[]], &v);
+}
+
+// Simulate the bug that was making everything crash on the face tracking example (ultimately
+// caused by recursive clears).
+#[test]
+fn insert_some_and_empty() {
+    let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+
+    assert_eq!(0, v.num_entries());
+    assert_eq!(0, v.num_values());
+
+    v.push_back([0]);
+    v.push_back([]);
+
+    v.push_back([1]);
+    v.push_back([]);
+
+    v.push_back([2]);
+    v.push_back([]);
+
+    // That used to crash.
+    assert_deque_eq(&[&[0], &[], &[1], &[], &[2], &[]], &v);
+}
+
+#[test]
+fn insert_many() {
+    let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+
+    assert_eq!(0, v.num_entries());
+    assert_eq!(0, v.num_values());
+
+    v.insert_many(0, [vec![1, 2, 3], vec![4, 5, 6, 7], vec![8, 9, 10]]);
+    assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7], &[8, 9, 10]], &v);
+
+    v.insert_many(0, [vec![20], vec![21], vec![22]]);
+    assert_deque_eq(
+        &[&[20], &[21], &[22], &[1, 2, 3], &[4, 5, 6, 7], &[8, 9, 10]],
+        &v,
+    );
+
+    v.insert_many(4, [vec![41, 42], vec![43]]);
+    assert_deque_eq(
+        &[
+            &[20],
+            &[21],
+            &[22],
+            &[1, 2, 3],
+            &[41, 42],
+            &[43],
+            &[4, 5, 6, 7],
+            &[8, 9, 10],
+        ],
+        &v,
+    );
+
+    v.insert_many(v.num_entries(), [vec![100], vec![200, 300, 400]]);
+    assert_deque_eq(
+        &[
+            &[20],
+            &[21],
+            &[22],
+            &[1, 2, 3],
+            &[41, 42],
+            &[43],
+            &[4, 5, 6, 7],
+            &[8, 9, 10],
+            &[100],
+            &[200, 300, 400],
+        ],
+        &v,
+    );
+}
+
+#[test]
+fn insert_deque() {
+    let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+
+    assert_eq!(0, v.num_entries());
+    assert_eq!(0, v.num_values());
+
+    v.insert_deque(
+        0,
+        FlatVecDeque::from_vecs([vec![1, 2, 3], vec![4, 5, 6, 7], vec![8, 9, 10]]),
+    );
+    assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7], &[8, 9, 10]], &v);
+
+    v.insert_deque(0, FlatVecDeque::from_vecs([vec![20], vec![21], vec![22]]));
+    assert_deque_eq(
+        &[&[20], &[21], &[22], &[1, 2, 3], &[4, 5, 6, 7], &[8, 9, 10]],
+        &v,
+    );
+
+    v.insert_deque(4, FlatVecDeque::from_vecs([vec![41, 42], vec![43]]));
+    assert_deque_eq(
+        &[
+            &[20],
+            &[21],
+            &[22],
+            &[1, 2, 3],
+            &[41, 42],
+            &[43],
+            &[4, 5, 6, 7],
+            &[8, 9, 10],
+        ],
+        &v,
+    );
+
+    v.insert_deque(
+        v.num_entries(),
+        FlatVecDeque::from_vecs([vec![100], vec![200, 300, 400]]),
+    );
+    assert_deque_eq(
+        &[
+            &[20],
+            &[21],
+            &[22],
+            &[1, 2, 3],
+            &[41, 42],
+            &[43],
+            &[4, 5, 6, 7],
+            &[8, 9, 10],
+            &[100],
+            &[200, 300, 400],
+        ],
+        &v,
+    );
+}
+
+// ---
+
+impl<T> FlatVecDeque<T> {
+    /// Splits the deque into two at the given index.
+    ///
+    /// Returns a newly allocated `FlatVecDeque`. `self` contains entries `[0, entry_index)`,
+    /// and the returned deque contains entries `[entry_index, num_entries)`.
+    ///
+    /// Note that the capacity of `self` does not change.
+    ///
+    /// Panics if `entry_index` is out of bounds.
+    #[inline]
+    #[must_use = "use `.truncate()` if you don't need the other half"]
+    pub fn split_off(&mut self, entry_index: usize) -> Self {
+        let value_offset = self.value_offset(entry_index);
+
+        let mut offsets = self.offsets.split_off(entry_index);
+        for offset in &mut offsets {
+            *offset -= value_offset;
+        }
+
+        Self {
+            values: self.values.split_off(value_offset),
+            offsets,
+        }
+    }
+
+    /// Shortens the deque, keeping all entries up to `entry_index` (excluded), and
+    /// dropping the rest.
+    ///
+    /// If `entry_index` is greater or equal to [`Self::num_entries`], this has no effect.
+    #[inline]
+    pub fn truncate(&mut self, entry_index: usize) {
+        if entry_index < self.num_entries() {
+            self.values.truncate(self.value_offset(entry_index));
+            self.offsets.truncate(entry_index);
+        }
+    }
+
+    /// Removes the entry at `entry_index` from the deque.
+    ///
+    /// This is O(1) if `entry_index` corresponds to either the start or the end of the deque.
+    /// Otherwise, this requires splitting the deque into three pieces, dropping the superfluous
+    /// one, then stitching the two remaining pices back together.
+    ///
+    /// Panics if `entry_index` is out of bounds.
+    pub fn remove(&mut self, entry_index: usize) {
+        let (start_offset, end_offset) = (
+            self.value_offset(entry_index),
+            self.value_offset(entry_index + 1),
+        );
+        let offset_count = end_offset - start_offset;
+
+        if entry_index + 1 == self.num_entries() {
+            self.offsets.truncate(self.num_entries() - 1);
+            self.values.truncate(self.values.len() - offset_count);
+            return;
+        } else if entry_index == 0 {
+            *self = self.split_off(entry_index + 1);
+            return;
+        }
+
+        // NOTE: elegant, but way too slow :)
+        // let right = self.split_off(entry_index + 1);
+        // _ = self.split_off(self.num_entries() - 1);
+        // self.push_back_deque(right);
+
+        _ = self.offsets.remove(entry_index);
+        for offset in self.offsets.range_mut(entry_index..) {
+            *offset -= offset_count;
+        }
+
+        let right = self.values.split_off(end_offset);
+        self.values.truncate(self.values.len() - offset_count);
+        self.values.extend(right);
+    }
+
+    /// Removes all entries within the given `entry_range` from the deque.
+    ///
+    /// This is O(1) if `entry_range` either starts at the beginning of the deque, or ends at
+    /// the end of the deque, or both.
+    /// Otherwise, this requires splitting the deque into three pieces, dropping the superfluous
+    /// one, then stitching the two remaining pieces back together.
+    ///
+    /// Panics if `entry_range` is either out of bounds or isn't monotonically increasing.
+    #[inline]
+    pub fn remove_range(&mut self, entry_range: Range<usize>) {
+        assert!(entry_range.start <= entry_range.end);
+
+        if entry_range.start == entry_range.end {
+            return;
+        }
+
+        let (start_offset, end_offset) = (
+            self.value_offset(entry_range.start),
+            self.value_offset(entry_range.end),
+        );
+        let offset_count = end_offset - start_offset;
+
+        // Reminder: `entry_range.end` is exclusive.
+        if entry_range.end == self.num_entries() {
+            self.offsets
+                .truncate(self.num_entries() - entry_range.len());
+            self.values.truncate(self.values.len() - offset_count);
+            return;
+        } else if entry_range.start == 0 {
+            *self = self.split_off(entry_range.end);
+            return;
+        }
+
+        let right = self.split_off(entry_range.end);
+        _ = self.split_off(self.num_entries() - entry_range.len());
+        self.push_back_deque(right);
+    }
+}
+
+#[test]
+fn truncate() {
+    let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+
+    assert_eq!(0, v.num_entries());
+    assert_eq!(0, v.num_values());
+
+    v.insert_many(0, [vec![1, 2, 3], vec![4, 5, 6, 7], vec![8, 9, 10]]);
+    assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7], &[8, 9, 10]], &v);
+
+    {
+        let mut v = v.clone();
+        v.truncate(0);
+        assert_deque_eq(&[], &v);
+    }
+
+    {
+        let mut v = v.clone();
+        v.truncate(1);
+        assert_deque_eq(&[&[1, 2, 3]], &v);
+    }
+
+    {
+        let mut v = v.clone();
+        v.truncate(2);
+        assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7]], &v);
+    }
+
+    {
+        let mut v = v.clone();
+        v.truncate(3);
+        assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7], &[8, 9, 10]], &v);
+    }
+}
+
+#[test]
+fn split_off() {
+    let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+
+    assert_eq!(0, v.num_entries());
+    assert_eq!(0, v.num_values());
+
+    v.insert_many(0, [vec![1, 2, 3], vec![4, 5, 6, 7], vec![8, 9, 10]]);
+    assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7], &[8, 9, 10]], &v);
+
+    {
+        let mut left = v.clone();
+        let right = left.split_off(0);
+
+        assert_deque_eq(&[], &left);
+        assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7], &[8, 9, 10]], &right);
+    }
+
+    {
+        let mut left = v.clone();
+        let right = left.split_off(1);
+
+        assert_deque_eq(&[&[1, 2, 3]], &left);
+        assert_deque_eq(&[&[4, 5, 6, 7], &[8, 9, 10]], &right);
+    }
+
+    {
+        let mut left = v.clone();
+        let right = left.split_off(2);
+
+        assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7]], &left);
+        assert_deque_eq(&[&[8, 9, 10]], &right);
+    }
+
+    {
+        let mut left = v.clone();
+        let right = left.split_off(3);
+
+        assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7], &[8, 9, 10]], &left);
+        assert_deque_eq(&[], &right);
+    }
+}
+
+#[test]
+fn remove() {
+    let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+
+    assert_eq!(0, v.num_entries());
+    assert_eq!(0, v.num_values());
+
+    v.insert(0, [1, 2, 3]);
+    assert_deque_eq(&[&[1, 2, 3]], &v);
+
+    v.remove(0);
+    assert_deque_eq(&[], &v);
+
+    v.insert(0, [1, 2, 3]);
+    assert_deque_eq(&[&[1, 2, 3]], &v);
+
+    v.insert(1, [4, 5, 6, 7]);
+    assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7]], &v);
+
+    v.insert(2, [8, 9]);
+    assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7], &[8, 9]], &v);
+
+    v.remove(0);
+    assert_deque_eq(&[&[4, 5, 6, 7], &[8, 9]], &v);
+
+    v.insert(0, [1, 2, 3]);
+    assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7], &[8, 9]], &v);
+
+    v.remove(1);
+    assert_deque_eq(&[&[1, 2, 3], &[8, 9]], &v);
+
+    v.insert(1, [4, 5, 6, 7]);
+    assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7], &[8, 9]], &v);
+
+    v.remove(2);
+    assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7]], &v);
+
+    v.remove(0);
+    assert_deque_eq(&[&[4, 5, 6, 7]], &v);
+
+    v.remove(0);
+    assert_deque_eq(&[], &v);
+}
+
+#[test]
+#[should_panic(expected = "Out of bounds access")]
+fn remove_empty() {
+    let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+
+    assert_eq!(0, v.num_entries());
+    assert_eq!(0, v.num_values());
+
+    v.remove(0);
+}
+
+#[test]
+#[should_panic(expected = "Out of bounds access")]
+fn remove_oob() {
+    let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+
+    assert_eq!(0, v.num_entries());
+    assert_eq!(0, v.num_values());
+
+    v.insert(0, [1, 2, 3]);
+    assert_deque_eq(&[&[1, 2, 3]], &v);
+
+    assert_eq!(1, v.num_entries());
+    assert_eq!(3, v.num_values());
+
+    v.remove(1);
+}
+
+#[test]
+fn remove_range() {
+    let mut v: FlatVecDeque<i64> = FlatVecDeque::new();
+
+    assert_eq!(0, v.num_entries());
+    assert_eq!(0, v.num_values());
+
+    v.insert_many(0, [vec![1, 2, 3], vec![4, 5, 6, 7], vec![8, 9, 10]]);
+    assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7], &[8, 9, 10]], &v);
+
+    {
+        let mut v = v.clone();
+        v.remove_range(0..1);
+        assert_deque_eq(&[&[4, 5, 6, 7], &[8, 9, 10]], &v);
+    }
+
+    {
+        let mut v = v.clone();
+        v.remove_range(1..2);
+        assert_deque_eq(&[&[1, 2, 3], &[8, 9, 10]], &v);
+    }
+
+    {
+        let mut v = v.clone();
+        v.remove_range(2..3);
+        assert_deque_eq(&[&[1, 2, 3], &[4, 5, 6, 7]], &v);
+    }
+
+    {
+        let mut v = v.clone();
+        v.remove_range(0..2);
+        assert_deque_eq(&[&[8, 9, 10]], &v);
+    }
+
+    {
+        let mut v = v.clone();
+        v.remove_range(1..3);
+        assert_deque_eq(&[&[1, 2, 3]], &v);
+    }
+
+    {
+        let mut v = v.clone();
+        v.remove_range(0..3);
+        assert_deque_eq(&[], &v);
+    }
+}
+
+// ---
+
+#[cfg(test)]
+fn assert_deque_eq(expected: &[&'_ [i64]], got: &FlatVecDeque<i64>) {
+    similar_asserts::assert_eq!(expected, got.iter().collect_vec());
+}
+
+#[cfg(test)]
+fn assert_iter_eq<'a>(expected: &[&'_ [i64]], got: impl Iterator<Item = &'a [i64]>) {
+    similar_asserts::assert_eq!(expected, got.collect_vec());
+}

--- a/crates/re_query_cache2/src/latest_at/mod.rs
+++ b/crates/re_query_cache2/src/latest_at/mod.rs
@@ -1,0 +1,5 @@
+mod query;
+mod results;
+
+pub use self::query::LatestAtCache;
+pub use self::results::{CachedLatestAtComponentResults, CachedLatestAtResults};

--- a/crates/re_query_cache2/src/latest_at/query.rs
+++ b/crates/re_query_cache2/src/latest_at/query.rs
@@ -1,0 +1,265 @@
+use std::collections::BTreeSet;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering::Relaxed;
+use std::{collections::BTreeMap, sync::Arc};
+
+use ahash::HashMap;
+
+use parking_lot::RwLock;
+use re_data_store::{DataStore, LatestAtQuery, TimeInt};
+use re_log_types::EntityPath;
+use re_query2::Promise;
+use re_types_core::ComponentName;
+use re_types_core::SizeBytes;
+
+use crate::{CacheKey, CachedLatestAtComponentResults, CachedLatestAtResults, Caches};
+
+// ---
+
+impl Caches {
+    /// Queries for the given `component_names` using latest-at semantics.
+    ///
+    /// See [`CachedLatestAtResults`] for more information about how to handle the results.
+    ///
+    /// This is a cached API -- data will be lazily cached upon access.
+    pub fn latest_at(
+        &self,
+        store: &DataStore,
+        query: &LatestAtQuery,
+        entity_path: &EntityPath,
+        component_names: impl IntoIterator<Item = ComponentName>,
+    ) -> CachedLatestAtResults {
+        re_tracing::profile_function!(entity_path.to_string());
+
+        let mut results = CachedLatestAtResults::default();
+
+        for component_name in component_names {
+            let key = CacheKey::new(entity_path.clone(), query.timeline(), component_name);
+            let cache = Arc::clone(
+                self.per_cache_key
+                    .write()
+                    .entry(key.clone())
+                    .or_insert_with(|| Arc::new(RwLock::new(LatestAtCache::new(key.clone())))),
+            );
+
+            let mut cache = cache.write();
+            cache.handle_pending_invalidation();
+            if let Some(cached) = cache.latest_at(store, query, entity_path, component_name) {
+                results.add(component_name, cached);
+            }
+        }
+
+        results
+    }
+}
+
+// ---
+
+/// Caches the results of `LatestAt` queries for a given [`CacheKey`].
+pub struct LatestAtCache {
+    /// For debugging purposes.
+    pub cache_key: CacheKey,
+
+    /// Organized by _query_ time.
+    ///
+    /// If the data you're looking for isn't in here, try partially running the query and check
+    /// if there is any data available for the resulting _data_ time in [`Self::per_data_time`].
+    //
+    // NOTE: `Arc` so we can share buckets across query time & data time.
+    pub per_query_time: BTreeMap<TimeInt, Arc<CachedLatestAtComponentResults>>,
+
+    /// Organized by _data_ time.
+    ///
+    /// Due to how our latest-at semantics work, any number of queries at time `T+n` where `n >= 0`
+    /// can result in a data time of `T`.
+    //
+    // NOTE: `Arc` so we can share buckets across query time & data time.
+    pub per_data_time: BTreeMap<TimeInt, Arc<CachedLatestAtComponentResults>>,
+
+    /// These timestamps have been invalidated asynchronously.
+    ///
+    /// The next time this cache gets queried, it must remove any invalidated entries accordingly.
+    ///
+    /// Invalidation is deferred to query time because it is far more efficient that way: the frame
+    /// time effectively behaves as a natural micro-batching mechanism.
+    pub pending_invalidations: BTreeSet<TimeInt>,
+}
+
+impl LatestAtCache {
+    #[inline]
+    pub fn new(cache_key: CacheKey) -> Self {
+        Self {
+            cache_key,
+            per_query_time: Default::default(),
+            per_data_time: Default::default(),
+            pending_invalidations: Default::default(),
+        }
+    }
+}
+
+impl std::fmt::Debug for LatestAtCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            cache_key,
+            per_query_time,
+            per_data_time,
+            pending_invalidations: _,
+        } = self;
+
+        let mut strings = Vec::new();
+
+        let data_times_per_bucket: HashMap<_, _> = per_data_time
+            .iter()
+            .map(|(time, bucket)| (Arc::as_ptr(bucket), *time))
+            .collect();
+
+        for (query_time, bucket) in per_query_time {
+            let query_time = cache_key.timeline.typ().format_utc(*query_time);
+            let data_time = data_times_per_bucket.get(&Arc::as_ptr(bucket)).map_or_else(
+                || "MISSING?!".to_owned(),
+                |t| cache_key.timeline.typ().format_utc(*t),
+            );
+            strings.push(format!(
+                "query_time={query_time} -> data_time={data_time} ({})",
+                re_format::format_bytes(bucket.cached_heap_size_bytes.load(Relaxed) as _),
+            ));
+            strings.push(indent::indent_all_by(2, format!("{bucket:?}")));
+        }
+
+        if strings.is_empty() {
+            return f.write_str("<empty>");
+        }
+
+        f.write_str(&strings.join("\n").replace("\n\n", "\n"))
+    }
+}
+
+impl SizeBytes for LatestAtCache {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        let Self {
+            cache_key: _,
+            per_query_time,
+            per_data_time,
+            pending_invalidations,
+        } = self;
+
+        let per_query_time = per_query_time
+            .keys()
+            .map(|k| k.total_size_bytes())
+            .sum::<u64>();
+        let per_data_time = per_data_time.total_size_bytes();
+        let pending_invalidations = pending_invalidations.total_size_bytes();
+
+        per_query_time + per_data_time + pending_invalidations
+    }
+}
+
+impl LatestAtCache {
+    /// Queries cached latest-at data for a single component.
+    pub fn latest_at(
+        &mut self,
+        store: &DataStore,
+        query: &LatestAtQuery,
+        entity_path: &EntityPath,
+        component_name: ComponentName,
+    ) -> Option<Arc<CachedLatestAtComponentResults>> {
+        re_tracing::profile_scope!("latest_at", format!("{query:?}"));
+
+        let LatestAtCache {
+            cache_key: _,
+            per_query_time,
+            per_data_time,
+            pending_invalidations: _,
+        } = self;
+
+        let query_time_bucket_at_query_time = match per_query_time.entry(query.at()) {
+            std::collections::btree_map::Entry::Occupied(entry) => {
+                // Fastest path: we have an entry for this exact query time, no need to look any
+                // further.
+                re_log::trace!(query_time=?query.at(), "cache hit (query time)");
+                return Some(Arc::clone(entry.get()));
+            }
+            std::collections::btree_map::Entry::Vacant(entry) => entry,
+        };
+
+        let result = store.latest_at(query, entity_path, component_name, &[component_name]);
+
+        // NOTE: cannot `result.and_then(...)` or borrowck gets lost.
+        if let Some((data_time, row_id, mut cells)) = result {
+            // Fast path: we've run the query and realized that we already have the data for the resulting
+            // _data_ time, so let's use that to avoid join & deserialization costs.
+            if let Some(data_time_bucket_at_data_time) = per_data_time.get(&data_time) {
+                re_log::trace!(query_time=?query.at(), ?data_time, "cache hit (data time)");
+
+                query_time_bucket_at_query_time.insert(Arc::clone(data_time_bucket_at_data_time));
+
+                // We now know for a fact that a query at that data time would yield the same
+                // results: copy the bucket accordingly so that the next cache hit for that query
+                // time ends up taking the fastest path.
+                let query_time_bucket_at_data_time = per_query_time.entry(data_time);
+                query_time_bucket_at_data_time
+                    .and_modify(|v| *v = Arc::clone(data_time_bucket_at_data_time))
+                    .or_insert(Arc::clone(data_time_bucket_at_data_time));
+
+                return Some(Arc::clone(data_time_bucket_at_data_time));
+            }
+
+            // Soundness:
+            // * `cells[0]` is guaranteed to exist since we passed in `&[component_name]`
+            // * `cells[0]` is guaranteed to be non-null, otherwise this whole result would be null
+            let Some(cell) = cells[0].take() else {
+                debug_assert!(cells[0].is_some(), "unreachable: `cells[0]` is missing");
+                return None;
+            };
+
+            let bucket = Arc::new(CachedLatestAtComponentResults {
+                index: (data_time, row_id),
+                promise: Some(Promise::new(cell)),
+                cached_dense: Default::default(),
+                cached_sparse: Default::default(),
+                cached_heap_size_bytes: AtomicU64::new(0),
+            });
+
+            // Slowest path: this is a complete cache miss.
+            {
+                re_log::trace!(query_time=?query.at(), ?data_time, "cache miss");
+
+                let query_time_bucket_at_query_time =
+                    query_time_bucket_at_query_time.insert(Arc::clone(&bucket));
+
+                let data_time_bucket_at_data_time = per_data_time.entry(data_time);
+                data_time_bucket_at_data_time
+                    .and_modify(|v| *v = Arc::clone(query_time_bucket_at_query_time))
+                    .or_insert(Arc::clone(query_time_bucket_at_query_time));
+            }
+
+            Some(bucket)
+        } else {
+            None
+        }
+    }
+
+    pub fn handle_pending_invalidation(&mut self) {
+        let Self {
+            cache_key: _,
+            per_query_time,
+            per_data_time,
+            pending_invalidations,
+        } = self;
+
+        let pending_invalidations = std::mem::take(pending_invalidations);
+
+        // First, remove any data indexed by a _query time_ that's more recent than the oldest
+        // _data time_ that's been invalidated.
+        //
+        // Note that this data time might very well be `TimeInt::STATIC`, in which case the entire
+        // query-time-based index will be dropped.
+        if let Some(&oldest_data_time) = pending_invalidations.first() {
+            per_query_time.retain(|&query_time, _| query_time < oldest_data_time);
+        }
+
+        // Second, remove any data indexed by _data time_, if it's been invalidated.
+        per_data_time.retain(|data_time, _| !pending_invalidations.contains(data_time));
+    }
+}

--- a/crates/re_query_cache2/src/latest_at/results.rs
+++ b/crates/re_query_cache2/src/latest_at/results.rs
@@ -19,7 +19,7 @@ use crate::{
 /// The data is both deserialized and resolved/converted.
 ///
 /// Use [`CachedLatestAtResults::get`], [`CachedLatestAtResults::get_required`] and
-/// [`CachedLatestAtResults::get_optional`] in order to access the results for each individual component.
+/// [`CachedLatestAtResults::get_or_empty`] in order to access the results for each individual component.
 #[derive(Debug)]
 pub struct CachedLatestAtResults {
     /// The compound index of this query result.
@@ -75,7 +75,7 @@ impl CachedLatestAtResults {
     ///
     /// Returns empty results if the component is not present.
     #[inline]
-    pub fn get_optional<C: Component>(&self) -> &CachedLatestAtComponentResults {
+    pub fn get_or_empty<C: Component>(&self) -> &CachedLatestAtComponentResults {
         if let Some(component) = self.components.get(&C::name()) {
             component
         } else {

--- a/crates/re_query_cache2/src/latest_at/results.rs
+++ b/crates/re_query_cache2/src/latest_at/results.rs
@@ -1,0 +1,343 @@
+use std::sync::{
+    atomic::{AtomicU64, Ordering::Relaxed},
+    Arc, OnceLock,
+};
+
+use nohash_hasher::IntMap;
+
+use re_log_types::{DataCell, RowId, TimeInt};
+use re_types_core::{Component, ComponentName, DeserializationError, SizeBytes};
+
+use crate::{
+    ErasedFlatVecDeque, FlatVecDeque, Promise, PromiseResolver, PromiseResult, QueryError,
+};
+
+// ---
+
+/// Cached results for a latest-at query.
+///
+/// The data is both deserialized and resolved/converted.
+///
+/// Use [`CachedLatestAtResults::get`], [`CachedLatestAtResults::get_required`] and
+/// [`CachedLatestAtResults::get_optional`] in order to access the results for each individual component.
+#[derive(Debug)]
+pub struct CachedLatestAtResults {
+    /// The compound index of this query result.
+    ///
+    /// A latest-at query is a compound operation that gathers data from many different rows.
+    /// The index of that compound result corresponds to the index of most the recent row in all the
+    /// sub-results, as defined by time and row-id order.
+    pub compound_index: (TimeInt, RowId),
+
+    /// Results for each individual component.
+    pub components: IntMap<ComponentName, Arc<CachedLatestAtComponentResults>>,
+}
+
+impl Default for CachedLatestAtResults {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            compound_index: (TimeInt::STATIC, RowId::ZERO),
+            components: Default::default(),
+        }
+    }
+}
+
+impl CachedLatestAtResults {
+    #[inline]
+    pub fn contains(&self, component_name: impl Into<ComponentName>) -> bool {
+        self.components.contains_key(&component_name.into())
+    }
+
+    /// Returns the [`CachedLatestAtComponentResults`] for the specified [`Component`].
+    #[inline]
+    pub fn get<C: Component>(&self) -> Option<&CachedLatestAtComponentResults> {
+        self.components.get(&C::name()).map(|arc| &**arc)
+    }
+
+    /// Returns the [`CachedLatestAtComponentResults`] for the specified [`Component`].
+    ///
+    /// Returns an error if the component is not present.
+    #[inline]
+    pub fn get_required<C: Component>(&self) -> crate::Result<&CachedLatestAtComponentResults> {
+        if let Some(component) = self.components.get(&C::name()) {
+            Ok(component)
+        } else {
+            Err(DeserializationError::MissingComponent {
+                component: C::name(),
+                backtrace: ::backtrace::Backtrace::new_unresolved(),
+            }
+            .into())
+        }
+    }
+
+    /// Returns the [`CachedLatestAtComponentResults`] for the specified [`Component`].
+    ///
+    /// Returns empty results if the component is not present.
+    #[inline]
+    pub fn get_optional<C: Component>(&self) -> &CachedLatestAtComponentResults {
+        if let Some(component) = self.components.get(&C::name()) {
+            component
+        } else {
+            static EMPTY: CachedLatestAtComponentResults = CachedLatestAtComponentResults::empty();
+            &EMPTY
+        }
+    }
+}
+
+impl CachedLatestAtResults {
+    #[doc(hidden)]
+    #[inline]
+    pub fn add(
+        &mut self,
+        component_name: ComponentName,
+        cached: Arc<CachedLatestAtComponentResults>,
+    ) {
+        // NOTE: Since this is a compound API that actually emits multiple queries, the index of the
+        // final result is the most recent index among all of its components, as defined by time
+        // and row-id order.
+        //
+        // TODO(#5303): We have to ignore the cluster key in this piece of logic for backwards compatibility
+        // reasons with the legacy instance-key model. This will go away next.
+        use re_types_core::Loggable as _;
+        if component_name != re_types_core::components::InstanceKey::name()
+            && cached.index > self.compound_index
+        {
+            self.compound_index = cached.index;
+        }
+
+        self.components.insert(component_name, cached);
+    }
+}
+
+// ---
+
+/// Lazily cached results for a particular component when using a cached latest-at query.
+pub struct CachedLatestAtComponentResults {
+    pub(crate) index: (TimeInt, RowId),
+
+    // Option so we can have a constant default value for `Self`.
+    pub(crate) promise: Option<Promise>,
+
+    /// The resolved, converted, deserialized dense data.
+    pub(crate) cached_dense: OnceLock<Box<dyn ErasedFlatVecDeque + Send + Sync>>,
+
+    /// The resolved, converted, deserialized sparse data.
+    pub(crate) cached_sparse: OnceLock<Box<dyn ErasedFlatVecDeque + Send + Sync>>,
+
+    pub(crate) cached_heap_size_bytes: AtomicU64,
+}
+
+impl CachedLatestAtComponentResults {
+    #[inline]
+    pub const fn empty() -> Self {
+        Self {
+            index: (TimeInt::STATIC, RowId::ZERO),
+            promise: None,
+            cached_dense: OnceLock::new(),
+            cached_sparse: OnceLock::new(),
+            cached_heap_size_bytes: AtomicU64::new(0),
+        }
+    }
+}
+
+impl SizeBytes for CachedLatestAtComponentResults {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.cached_heap_size_bytes.load(Relaxed)
+    }
+}
+
+impl std::fmt::Debug for CachedLatestAtComponentResults {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            index,
+            promise: _,
+            cached_dense: _,  // we can't, we don't know the type
+            cached_sparse: _, // we can't, we don't know the type
+            cached_heap_size_bytes,
+        } = self;
+
+        f.write_fmt(format_args!(
+            "[{:?}#{}] {}",
+            index.0,
+            index.1,
+            re_format::format_bytes(cached_heap_size_bytes.load(Relaxed) as _)
+        ))
+    }
+}
+
+impl CachedLatestAtComponentResults {
+    #[inline]
+    pub fn index(&self) -> &(TimeInt, RowId) {
+        &self.index
+    }
+
+    /// Returns the component data as a dense vector.
+    ///
+    /// Returns an error if the component is missing or cannot be deserialized.
+    ///
+    /// Use [`PromiseResult::flatten`] to merge the results of resolving the promise and of
+    /// deserializing the data into a single one, if you don't need the extra flexibility.
+    #[inline]
+    pub fn to_dense<C: 'static + Component + Send + Sync>(
+        &self,
+        resolver: &mut PromiseResolver,
+    ) -> PromiseResult<crate::Result<&[C]>> {
+        if let Some(cell) = self.promise.as_ref() {
+            resolver
+                .resolve(cell)
+                .map(|cell| self.downcast_dense::<C>(&cell))
+        } else {
+            // Manufactured empty result.
+            PromiseResult::Ready(Ok(&[]))
+        }
+    }
+
+    /// Iterates over the component data, assuming it is dense.
+    ///
+    /// Returns an error if the component is missing or cannot be deserialized.
+    ///
+    /// Use [`PromiseResult::flatten`] to merge the results of resolving the promise and of
+    /// deserializing the data into a single one, if you don't need the extra flexibility.
+    #[inline]
+    pub fn iter_dense<C: 'static + Component + Send + Sync>(
+        &self,
+        resolver: &mut PromiseResolver,
+    ) -> PromiseResult<crate::Result<impl ExactSizeIterator<Item = &C>>> {
+        self.to_dense(resolver)
+            .map(|data| data.map(|data| data.iter()))
+    }
+
+    /// Returns the component data as a sparse vector.
+    ///
+    /// Returns an error if the component is missing or cannot be deserialized.
+    ///
+    /// Use [`PromiseResult::flatten`] to merge the results of resolving the promise and of
+    /// deserializing the data into a single one, if you don't need the extra flexibility.
+    #[inline]
+    pub fn to_sparse<C: 'static + Component + Send + Sync>(
+        &self,
+        resolver: &mut PromiseResolver,
+    ) -> PromiseResult<crate::Result<&[Option<C>]>> {
+        if let Some(cell) = self.promise.as_ref() {
+            resolver
+                .resolve(cell)
+                .map(|cell| self.downcast_sparse::<C>(&cell))
+        } else {
+            // Manufactured empty result.
+            PromiseResult::Ready(Ok(&[]))
+        }
+    }
+
+    /// Iterates over the component data, assuming it is sparse.
+    ///
+    /// Returns an error if the component is missing or cannot be deserialized.
+    ///
+    /// Use [`PromiseResult::flatten`] to merge the results of resolving the promise and of
+    /// deserializing the data into a single one, if you don't need the extra flexibility.
+    #[inline]
+    pub fn iter_sparse<C: 'static + Component + Send + Sync>(
+        &self,
+        resolver: &mut PromiseResolver,
+    ) -> PromiseResult<crate::Result<impl ExactSizeIterator<Item = Option<&C>>>> {
+        self.to_sparse(resolver)
+            .map(|data| data.map(|data| data.iter().map(Option::as_ref)))
+    }
+}
+
+impl CachedLatestAtComponentResults {
+    fn downcast_dense<C: 'static + Component + Send + Sync>(
+        &self,
+        cell: &DataCell,
+    ) -> crate::Result<&[C]> {
+        // `OnceLock::get` is non-blocking -- this is a best-effort fast path in case the
+        // data has already been computed.
+        //
+        // See next comment as to why we need this.
+        if let Some(cached) = self.cached_dense.get() {
+            return downcast(&**cached);
+        }
+
+        // We have to do this outside of the callback in order to propagate errors.
+        // Hence the early exit check above.
+        let data = cell
+            .try_to_native::<C>()
+            .map_err(|err| DeserializationError::DataCellError(err.to_string()))?;
+
+        #[allow(clippy::borrowed_box)]
+        let cached: &Box<dyn ErasedFlatVecDeque + Send + Sync> =
+            self.cached_dense.get_or_init(move || {
+                self.cached_heap_size_bytes
+                    .fetch_add(data.total_size_bytes(), Relaxed);
+                Box::new(FlatVecDeque::from(data))
+            });
+
+        downcast(&**cached)
+    }
+
+    fn downcast_sparse<C: 'static + Component + Send + Sync>(
+        &self,
+        cell: &DataCell,
+    ) -> crate::Result<&[Option<C>]> {
+        // `OnceLock::get` is non-blocking -- this is a best-effort fast path in case the
+        // data has already been computed.
+        //
+        // See next comment as to why we need this.
+        if let Some(cached) = self.cached_sparse.get() {
+            return downcast_opt(&**cached);
+        }
+
+        // We have to do this outside of the callback in order to propagate errors.
+        // Hence the early exit check above.
+        let data = cell
+            .try_to_native_opt::<C>()
+            .map_err(|err| DeserializationError::DataCellError(err.to_string()))?;
+
+        #[allow(clippy::borrowed_box)]
+        let cached: &Box<dyn ErasedFlatVecDeque + Send + Sync> =
+            self.cached_sparse.get_or_init(move || {
+                self.cached_heap_size_bytes
+                    .fetch_add(data.total_size_bytes(), Relaxed);
+                Box::new(FlatVecDeque::from(data))
+            });
+
+        downcast_opt(&**cached)
+    }
+}
+
+fn downcast<C: 'static + Component + Send + Sync>(
+    cached: &(dyn ErasedFlatVecDeque + Send + Sync),
+) -> crate::Result<&[C]> {
+    let cached = cached
+        .as_any()
+        .downcast_ref::<FlatVecDeque<C>>()
+        .ok_or_else(|| QueryError::TypeMismatch {
+            actual: "<unknown>".into(),
+            requested: C::name(),
+        })?;
+
+    if cached.num_entries() != 1 {
+        return Err(anyhow::anyhow!("latest_at deque must be single entry").into());
+    }
+    // unwrap checked just above ^^^
+    Ok(cached.iter().next().unwrap())
+}
+
+fn downcast_opt<C: 'static + Component + Send + Sync>(
+    cached: &(dyn ErasedFlatVecDeque + Send + Sync),
+) -> crate::Result<&[Option<C>]> {
+    let cached = cached
+        .as_any()
+        .downcast_ref::<FlatVecDeque<Option<C>>>()
+        .ok_or_else(|| QueryError::TypeMismatch {
+            actual: "<unknown>".into(),
+            requested: C::name(),
+        })?;
+
+    if cached.num_entries() != 1 {
+        return Err(anyhow::anyhow!("latest_at deque must be single entry").into());
+    }
+    // unwrap checked just above ^^^
+    Ok(cached.iter().next().unwrap())
+}

--- a/crates/re_query_cache2/src/latest_at/results.rs
+++ b/crates/re_query_cache2/src/latest_at/results.rs
@@ -182,7 +182,7 @@ impl CachedLatestAtComponentResults {
     #[inline]
     pub fn to_dense<C: 'static + Component + Send + Sync>(
         &self,
-        resolver: &mut PromiseResolver,
+        resolver: &PromiseResolver,
     ) -> PromiseResult<crate::Result<&[C]>> {
         if let Some(cell) = self.promise.as_ref() {
             resolver
@@ -203,7 +203,7 @@ impl CachedLatestAtComponentResults {
     #[inline]
     pub fn iter_dense<C: 'static + Component + Send + Sync>(
         &self,
-        resolver: &mut PromiseResolver,
+        resolver: &PromiseResolver,
     ) -> PromiseResult<crate::Result<impl ExactSizeIterator<Item = &C>>> {
         self.to_dense(resolver)
             .map(|data| data.map(|data| data.iter()))
@@ -218,7 +218,7 @@ impl CachedLatestAtComponentResults {
     #[inline]
     pub fn to_sparse<C: 'static + Component + Send + Sync>(
         &self,
-        resolver: &mut PromiseResolver,
+        resolver: &PromiseResolver,
     ) -> PromiseResult<crate::Result<&[Option<C>]>> {
         if let Some(cell) = self.promise.as_ref() {
             resolver
@@ -239,7 +239,7 @@ impl CachedLatestAtComponentResults {
     #[inline]
     pub fn iter_sparse<C: 'static + Component + Send + Sync>(
         &self,
-        resolver: &mut PromiseResolver,
+        resolver: &PromiseResolver,
     ) -> PromiseResult<crate::Result<impl ExactSizeIterator<Item = Option<&C>>>> {
         self.to_sparse(resolver)
             .map(|data| data.map(|data| data.iter().map(Option::as_ref)))

--- a/crates/re_query_cache2/src/lib.rs
+++ b/crates/re_query_cache2/src/lib.rs
@@ -1,0 +1,22 @@
+//! Caching datastructures for `re_query`.
+
+mod cache;
+mod flat_vec_deque;
+mod latest_at;
+
+pub use self::cache::{CacheKey, Caches};
+pub use self::flat_vec_deque::{ErasedFlatVecDeque, FlatVecDeque};
+pub use self::latest_at::{CachedLatestAtComponentResults, CachedLatestAtResults};
+
+pub(crate) use self::latest_at::LatestAtCache;
+
+pub use re_query2::{
+    clamped_zip::*, Promise, PromiseId, PromiseResolver, PromiseResult, QueryError, Result,
+};
+
+pub mod external {
+    pub use re_query2;
+
+    pub use paste;
+    pub use seq_macro;
+}

--- a/crates/re_query_cache2/tests/latest_at.rs
+++ b/crates/re_query_cache2/tests/latest_at.rs
@@ -1,0 +1,526 @@
+//! Contains:
+//! - A 1:1 port of the tests in `crates/re_query/tests/archetype_query_tests.rs`, with caching enabled.
+//! - Invalidation tests.
+
+use re_data_store::{DataStore, LatestAtQuery, StoreSubscriber};
+use re_log_types::{
+    build_frame_nr,
+    example_components::{MyColor, MyPoint, MyPoints},
+    DataRow, EntityPath, RowId, TimePoint,
+};
+use re_query2::PromiseResolver;
+use re_query_cache2::Caches;
+use re_types::Archetype as _;
+use re_types_core::{components::InstanceKey, Loggable as _};
+
+// ---
+
+#[test]
+fn simple_query() {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+    let mut caches = Caches::new(&store);
+
+    let entity_path = "point";
+    let timepoint = [build_frame_nr(123)];
+
+    // Create some positions with implicit instances
+    let positions = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+    let row =
+        DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 2, positions).unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    // Assign one of them a color with an explicit instance
+    let color_instances = vec![InstanceKey(1)];
+    let colors = vec![MyColor::from_rgb(255, 0, 0)];
+    let row = DataRow::from_cells2_sized(
+        RowId::new(),
+        entity_path,
+        timepoint,
+        1,
+        (color_instances, colors),
+    )
+    .unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    query_and_compare(&caches, &store, &query, &entity_path.into());
+}
+
+#[test]
+fn static_query() {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+    let mut caches = Caches::new(&store);
+
+    let entity_path = "point";
+    let timepoint = [build_frame_nr(123)];
+
+    // Create some positions with implicit instances
+    let positions = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+    let row =
+        DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 2, positions).unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    // Assign one of them a color with an explicit instance.. statically!
+    let color_instances = vec![InstanceKey(1)];
+    let colors = vec![MyColor::from_rgb(255, 0, 0)];
+    let row = DataRow::from_cells2_sized(
+        RowId::new(),
+        entity_path,
+        TimePoint::default(),
+        1,
+        (color_instances, colors),
+    )
+    .unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    query_and_compare(&caches, &store, &query, &entity_path.into());
+}
+
+#[test]
+fn no_instance_join_query() {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+    let mut caches = Caches::new(&store);
+
+    let entity_path = "point";
+    let timepoint = [build_frame_nr(123)];
+
+    // Create some positions with an implicit instance
+    let positions = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+    let row =
+        DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 2, positions).unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    // Assign them colors with explicit instances
+    let colors = vec![MyColor::from_rgb(255, 0, 0), MyColor::from_rgb(0, 255, 0)];
+    let row = DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 2, colors).unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    query_and_compare(&caches, &store, &query, &entity_path.into());
+}
+
+#[test]
+fn missing_column_join_query() {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+    let mut caches = Caches::new(&store);
+
+    let entity_path = "point";
+    let timepoint = [build_frame_nr(123)];
+
+    // Create some positions with an implicit instance
+    let positions = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+    let row =
+        DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 2, positions).unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    query_and_compare(&caches, &store, &query, &entity_path.into());
+}
+
+#[test]
+fn splatted_query() {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+    let mut caches = Caches::new(&store);
+
+    let entity_path = "point";
+    let timepoint = [build_frame_nr(123)];
+
+    // Create some positions with implicit instances
+    let positions = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+    let row =
+        DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 2, positions).unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    // Assign all of them a color via splat
+    let color_instances = vec![InstanceKey::SPLAT];
+    let colors = vec![MyColor::from_rgb(255, 0, 0)];
+    let row = DataRow::from_cells2_sized(
+        RowId::new(),
+        entity_path,
+        timepoint,
+        1,
+        (color_instances, colors),
+    )
+    .unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    let query = re_data_store::LatestAtQuery::new(timepoint[0].0, timepoint[0].1);
+    query_and_compare(&caches, &store, &query, &entity_path.into());
+}
+
+#[test]
+fn invalidation_xxx() {
+    let entity_path = "point";
+
+    let test_invalidation = |query: LatestAtQuery,
+                             present_data_timepoint: TimePoint,
+                             past_data_timepoint: TimePoint,
+                             future_data_timepoint: TimePoint| {
+        let mut store = DataStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            InstanceKey::name(),
+            Default::default(),
+        );
+        let mut caches = Caches::new(&store);
+
+        // Create some positions with implicit instances
+        let positions = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+        let row = DataRow::from_cells1_sized(
+            RowId::new(),
+            entity_path,
+            present_data_timepoint.clone(),
+            2,
+            positions,
+        )
+        .unwrap();
+        insert_and_react(&mut store, &mut caches, &row);
+
+        // Assign one of them a color with an explicit instance
+        let color_instances = vec![InstanceKey(1)];
+        let colors = vec![MyColor::from_rgb(1, 2, 3)];
+        let row = DataRow::from_cells2_sized(
+            RowId::new(),
+            entity_path,
+            present_data_timepoint.clone(),
+            1,
+            (color_instances, colors),
+        )
+        .unwrap();
+        insert_and_react(&mut store, &mut caches, &row);
+
+        query_and_compare(&caches, &store, &query, &entity_path.into());
+
+        // --- Modify present ---
+
+        // Modify the PoV component
+        let positions = vec![MyPoint::new(10.0, 20.0), MyPoint::new(30.0, 40.0)];
+        let row = DataRow::from_cells1_sized(
+            RowId::new(),
+            entity_path,
+            present_data_timepoint.clone(),
+            2,
+            positions,
+        )
+        .unwrap();
+        insert_and_react(&mut store, &mut caches, &row);
+
+        query_and_compare(&caches, &store, &query, &entity_path.into());
+
+        // Modify the optional component
+        let colors = vec![MyColor::from_rgb(4, 5, 6), MyColor::from_rgb(7, 8, 9)];
+        let row = DataRow::from_cells1_sized(
+            RowId::new(),
+            entity_path,
+            present_data_timepoint,
+            2,
+            colors,
+        )
+        .unwrap();
+        insert_and_react(&mut store, &mut caches, &row);
+
+        query_and_compare(&caches, &store, &query, &entity_path.into());
+
+        // --- Modify past ---
+
+        // Modify the PoV component
+        let positions = vec![MyPoint::new(100.0, 200.0), MyPoint::new(300.0, 400.0)];
+        let row = DataRow::from_cells1_sized(
+            RowId::new(),
+            entity_path,
+            past_data_timepoint.clone(),
+            2,
+            positions,
+        )
+        .unwrap();
+        insert_and_react(&mut store, &mut caches, &row);
+
+        query_and_compare(&caches, &store, &query, &entity_path.into());
+
+        // Modify the optional component
+        let colors = vec![MyColor::from_rgb(10, 11, 12), MyColor::from_rgb(13, 14, 15)];
+        let row =
+            DataRow::from_cells1_sized(RowId::new(), entity_path, past_data_timepoint, 2, colors)
+                .unwrap();
+        insert_and_react(&mut store, &mut caches, &row);
+
+        query_and_compare(&caches, &store, &query, &entity_path.into());
+
+        // --- Modify future ---
+
+        // Modify the PoV component
+        let positions = vec![MyPoint::new(1000.0, 2000.0), MyPoint::new(3000.0, 4000.0)];
+        let row = DataRow::from_cells1_sized(
+            RowId::new(),
+            entity_path,
+            future_data_timepoint.clone(),
+            2,
+            positions,
+        )
+        .unwrap();
+        insert_and_react(&mut store, &mut caches, &row);
+
+        query_and_compare(&caches, &store, &query, &entity_path.into());
+
+        // Modify the optional component
+        let colors = vec![MyColor::from_rgb(16, 17, 18)];
+        let row =
+            DataRow::from_cells1_sized(RowId::new(), entity_path, future_data_timepoint, 1, colors)
+                .unwrap();
+        insert_and_react(&mut store, &mut caches, &row);
+
+        query_and_compare(&caches, &store, &query, &entity_path.into());
+    };
+
+    let timeless = TimePoint::default();
+    let frame_122 = build_frame_nr(122);
+    let frame_123 = build_frame_nr(123);
+    let frame_124 = build_frame_nr(124);
+
+    test_invalidation(
+        LatestAtQuery::new(frame_123.0, frame_123.1),
+        [frame_123].into(),
+        [frame_122].into(),
+        [frame_124].into(),
+    );
+
+    test_invalidation(
+        LatestAtQuery::new(frame_123.0, frame_123.1),
+        [frame_123].into(),
+        timeless,
+        [frame_124].into(),
+    );
+}
+
+// Test the following scenario:
+// ```py
+// rr.log("points", rr.Points3D([1, 2, 3]), static=True)
+//
+// # Do first query here: LatestAt(+inf)
+// # Expected: points=[[1,2,3]] colors=[]
+//
+// rr.set_time(2)
+// rr.log_components("points", rr.components.MyColor(0xFF0000))
+//
+// # Do second query here: LatestAt(+inf)
+// # Expected: points=[[1,2,3]] colors=[0xFF0000]
+//
+// rr.set_time(3)
+// rr.log_components("points", rr.components.MyColor(0x0000FF))
+//
+// # Do third query here: LatestAt(+inf)
+// # Expected: points=[[1,2,3]] colors=[0x0000FF]
+//
+// rr.set_time(3)
+// rr.log_components("points", rr.components.MyColor(0x00FF00))
+//
+// # Do fourth query here: LatestAt(+inf)
+// # Expected: points=[[1,2,3]] colors=[0x00FF00]
+// ```
+#[test]
+fn invalidation_of_future_optionals() {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+    let mut caches = Caches::new(&store);
+
+    let entity_path = "points";
+
+    let timeless = TimePoint::default();
+    let frame2 = [build_frame_nr(2)];
+    let frame3 = [build_frame_nr(3)];
+
+    let query_time = [build_frame_nr(9999)];
+
+    let positions = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+    let row =
+        DataRow::from_cells1_sized(RowId::new(), entity_path, timeless, 2, positions).unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    let query = re_data_store::LatestAtQuery::new(query_time[0].0, query_time[0].1);
+    query_and_compare(&caches, &store, &query, &entity_path.into());
+
+    let color_instances = vec![InstanceKey::SPLAT];
+    let colors = vec![MyColor::from_rgb(255, 0, 0)];
+    let row = DataRow::from_cells2_sized(
+        RowId::new(),
+        entity_path,
+        frame2,
+        1,
+        (color_instances, colors),
+    )
+    .unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    let query = re_data_store::LatestAtQuery::new(query_time[0].0, query_time[0].1);
+    query_and_compare(&caches, &store, &query, &entity_path.into());
+
+    let color_instances = vec![InstanceKey::SPLAT];
+    let colors = vec![MyColor::from_rgb(0, 0, 255)];
+    let row = DataRow::from_cells2_sized(
+        RowId::new(),
+        entity_path,
+        frame3,
+        1,
+        (color_instances, colors),
+    )
+    .unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    let query = re_data_store::LatestAtQuery::new(query_time[0].0, query_time[0].1);
+    query_and_compare(&caches, &store, &query, &entity_path.into());
+
+    let color_instances = vec![InstanceKey::SPLAT];
+    let colors = vec![MyColor::from_rgb(0, 255, 0)];
+    let row = DataRow::from_cells2_sized(
+        RowId::new(),
+        entity_path,
+        frame3,
+        1,
+        (color_instances, colors),
+    )
+    .unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    let query = re_data_store::LatestAtQuery::new(query_time[0].0, query_time[0].1);
+    query_and_compare(&caches, &store, &query, &entity_path.into());
+}
+
+#[test]
+fn static_invalidation() {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+    let mut caches = Caches::new(&store);
+
+    let entity_path = "points";
+
+    let timeless = TimePoint::default();
+
+    let query_time = [build_frame_nr(9999)];
+
+    let positions = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+    let row = DataRow::from_cells1_sized(RowId::new(), entity_path, timeless.clone(), 2, positions)
+        .unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    let query = re_data_store::LatestAtQuery::new(query_time[0].0, query_time[0].1);
+    query_and_compare(&caches, &store, &query, &entity_path.into());
+
+    let color_instances = vec![InstanceKey::SPLAT];
+    let colors = vec![MyColor::from_rgb(255, 0, 0)];
+    let row = DataRow::from_cells2_sized(
+        RowId::new(),
+        entity_path,
+        timeless.clone(),
+        1,
+        (color_instances, colors),
+    )
+    .unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    let query = re_data_store::LatestAtQuery::new(query_time[0].0, query_time[0].1);
+    query_and_compare(&caches, &store, &query, &entity_path.into());
+
+    let color_instances = vec![InstanceKey::SPLAT];
+    let colors = vec![MyColor::from_rgb(0, 0, 255)];
+    let row = DataRow::from_cells2_sized(
+        RowId::new(),
+        entity_path,
+        timeless,
+        1,
+        (color_instances, colors),
+    )
+    .unwrap();
+    insert_and_react(&mut store, &mut caches, &row);
+
+    let query = re_data_store::LatestAtQuery::new(query_time[0].0, query_time[0].1);
+    query_and_compare(&caches, &store, &query, &entity_path.into());
+}
+
+// ---
+
+fn insert_and_react(store: &mut DataStore, caches: &mut Caches, row: &DataRow) {
+    caches.on_events(&[store.insert_row(row).unwrap()]);
+}
+
+fn query_and_compare(
+    caches: &Caches,
+    store: &DataStore,
+    query: &LatestAtQuery,
+    entity_path: &EntityPath,
+) {
+    re_log::setup_logging();
+
+    let mut resolver = PromiseResolver::default();
+
+    for _ in 0..3 {
+        let cached = caches.latest_at(
+            store,
+            query,
+            entity_path,
+            MyPoints::all_components().iter().copied(),
+        );
+
+        let cached_points = cached.get_required::<MyPoint>().unwrap();
+        let cached_point_data = cached_points
+            .to_dense::<MyPoint>(&mut resolver)
+            .flatten()
+            .unwrap();
+
+        let cached_colors = cached.get_optional::<MyColor>();
+        let cached_color_data = cached_colors
+            .to_sparse::<MyColor>(&mut resolver)
+            .flatten()
+            .unwrap();
+
+        let expected = re_query2::latest_at(
+            store,
+            query,
+            entity_path,
+            MyPoints::all_components().iter().copied(),
+        );
+
+        let expected_points = expected.get_required::<MyPoint>().unwrap();
+        let expected_point_data = expected_points
+            .to_dense::<MyPoint>(&mut resolver)
+            .flatten()
+            .unwrap();
+
+        let expected_colors = expected.get_optional::<MyColor>();
+        let expected_color_data = expected_colors
+            .to_sparse::<MyColor>(&mut resolver)
+            .flatten()
+            .unwrap();
+
+        // eprintln!("{}", store.to_data_table().unwrap());
+
+        similar_asserts::assert_eq!(expected.compound_index, cached.compound_index);
+        similar_asserts::assert_eq!(expected_point_data, cached_point_data);
+        similar_asserts::assert_eq!(expected_color_data, cached_color_data);
+    }
+}

--- a/crates/re_query_cache2/tests/latest_at.rs
+++ b/crates/re_query_cache2/tests/latest_at.rs
@@ -492,7 +492,7 @@ fn query_and_compare(
             .flatten()
             .unwrap();
 
-        let cached_colors = cached.get_optional::<MyColor>();
+        let cached_colors = cached.get_or_empty::<MyColor>();
         let cached_color_data = cached_colors
             .to_sparse::<MyColor>(&resolver)
             .flatten()
@@ -511,7 +511,7 @@ fn query_and_compare(
             .flatten()
             .unwrap();
 
-        let expected_colors = expected.get_optional::<MyColor>();
+        let expected_colors = expected.get_or_empty::<MyColor>();
         let expected_color_data = expected_colors
             .to_sparse::<MyColor>(&resolver)
             .flatten()

--- a/crates/re_query_cache2/tests/latest_at.rs
+++ b/crates/re_query_cache2/tests/latest_at.rs
@@ -476,7 +476,7 @@ fn query_and_compare(
 ) {
     re_log::setup_logging();
 
-    let mut resolver = PromiseResolver::default();
+    let resolver = PromiseResolver::default();
 
     for _ in 0..3 {
         let cached = caches.latest_at(
@@ -488,13 +488,13 @@ fn query_and_compare(
 
         let cached_points = cached.get_required::<MyPoint>().unwrap();
         let cached_point_data = cached_points
-            .to_dense::<MyPoint>(&mut resolver)
+            .to_dense::<MyPoint>(&resolver)
             .flatten()
             .unwrap();
 
         let cached_colors = cached.get_optional::<MyColor>();
         let cached_color_data = cached_colors
-            .to_sparse::<MyColor>(&mut resolver)
+            .to_sparse::<MyColor>(&resolver)
             .flatten()
             .unwrap();
 
@@ -507,13 +507,13 @@ fn query_and_compare(
 
         let expected_points = expected.get_required::<MyPoint>().unwrap();
         let expected_point_data = expected_points
-            .to_dense::<MyPoint>(&mut resolver)
+            .to_dense::<MyPoint>(&resolver)
             .flatten()
             .unwrap();
 
         let expected_colors = expected.get_optional::<MyColor>();
         let expected_color_data = expected_colors
-            .to_sparse::<MyColor>(&mut resolver)
+            .to_sparse::<MyColor>(&resolver)
             .flatten()
             .unwrap();
 

--- a/crates/re_types_core/src/size_bytes.rs
+++ b/crates/re_types_core/src/size_bytes.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::sync::Arc;
 
 use arrow2::datatypes::{DataType, Field};
@@ -67,6 +67,19 @@ impl<K: SizeBytes, V: SizeBytes> SizeBytes for BTreeMap<K, V> {
         };
 
         keys_size_bytes + values_size_bytes
+    }
+}
+
+impl<K: SizeBytes> SizeBytes for BTreeSet<K> {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        // NOTE: It's all on the heap at this point.
+
+        if K::is_pod() {
+            (self.len() * std::mem::size_of::<K>()) as _
+        } else {
+            self.iter().map(SizeBytes::total_size_bytes).sum::<u64>()
+        }
     }
 }
 


### PR DESCRIPTION
Static-aware, key-less, component-based, cached latest-at APIs.

The overall structure of this new cache is very similar to what we had before. Effectively it is just an extremely simplified version of `re_query_cache`.

This introduces a new temporary `re_query_cache2` crate, which won't ever be published.
It will replace the existing `re_query_cache` crate once all the necessary features have been backported.

- Fixes #3232
- Fixes #4733
- Fixes #4734
- Part of #3379
- Part of #1893  

Example:
```rust
let caches = re_query_cache2::Caches::new(&store);

// First, get the results for this query.
//
// They might or might not already be cached. We won't know for sure until we try to access
// each individual component's data below.
let results: CachedLatestAtResults = caches.latest_at(
    &store,
    &query,
    &entity_path.into(),
    MyPoints::all_components().iter().cloned(), // no generics!
);

// Then, grab the results for each individual components.
// * `get_required` returns an error if the component batch is missing
// * `get_optional` returns an empty set of results if the component if missing
// * `get` returns an option
//
// At this point we still don't know whether they are cached or not. That's the next step.
let points: &CachedLatestAtComponentResults = results.get_required::<MyPoint>()?;
let colors: &CachedLatestAtComponentResults = results.get_optional::<MyColor>();
let labels: &CachedLatestAtComponentResults = results.get_optional::<MyLabel>();

// Then comes the time to resolve/convert and deserialize the data.
// These steps have to be done together for efficiency reasons.
//
// Both the resolution and deserialization steps might fail, which is why this returns a `Result<Result<T>>`.
// Use `PromiseResult::flatten` to simplify it down to a single result.
//
// A choice now has to be made regarding the nullability of the _component batch's instances_.
// Our IDL doesn't support nullable instances at the moment -- so for the foreseeable future you probably
// shouldn't be using anything but `iter_dense`.
//
// This is the step at which caching comes into play.
//
// If the data has already been accessed with the same nullability characteristics in the
// past, then this will just grab the pre-deserialized, pre-resolved/pre-converted result from
// the cache.
//
// Otherwise, this will trigger a deserialization and cache the result for next time.

let points = match points.iter_dense::<MyPoint>(&mut resolver).flatten() {
    PromiseResult::Pending => {
        // Handle the fact that the data isn't ready appropriately.
        return Ok(());
    }
    PromiseResult::Ready(data) => data,
    PromiseResult::Error(err) => return Err(err.into()),
};

let colors = match colors.iter_dense::<MyColor>(&mut resolver).flatten() {
    PromiseResult::Pending => {
        // Handle the fact that the data isn't ready appropriately.
        return Ok(());
    }
    PromiseResult::Ready(data) => data,
    PromiseResult::Error(err) => return Err(err.into()),
};

let labels = match labels.iter_sparse::<MyLabel>(&mut resolver).flatten() {
    PromiseResult::Pending => {
        // Handle the fact that the data isn't ready appropriately.
        return Ok(());
    }
    PromiseResult::Ready(data) => data,
    PromiseResult::Error(err) => return Err(err.into()),
};

// With the data now fully resolved/converted and deserialized, the joining logic can be
// applied.
//
// In most cases this will be either a clamped zip, or no joining at all.

let color_default_fn = || {
    static DEFAULT: MyColor = MyColor(0xFF00FFFF);
    &DEFAULT
};
let label_default_fn = || None;

let results =
    clamped_zip_1x2(points, colors, color_default_fn, labels, label_default_fn).collect_vec();
```


---

Part of a PR series to completely revamp the data APIs in preparation for the removal of instance keys and the introduction of promises:
- #5573
- #5574
- #5581
- #5605
- #5606
- #5633
- #5673
- #5679
- #5687
- #5755
- TODO
- TODO

Builds on top of the static data PR series:
- #5534

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5573/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5573/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5573/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5573)
- [Docs preview](https://rerun.io/preview/ee4ede4da39b143658ded57a2f23898db5473668/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ee4ede4da39b143658ded57a2f23898db5473668/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)