### PR TITLE
Moved taplo back to the default feature in `pixi.toml`

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -156,6 +156,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.9.1-h1ff36dd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
@@ -304,6 +305,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.1.10-he8610fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/taplo-0.9.1-hb8f9562_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
@@ -460,6 +462,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.9.1-h236d3af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
@@ -615,6 +618,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.9.1-h16c8c8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
@@ -743,6 +747,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/taplo-0.9.1-h7f3b576_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.11.0-h91493d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
@@ -902,6 +907,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.9.1-h1ff36dd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
@@ -1051,6 +1057,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.1.10-he8610fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/taplo-0.9.1-hb8f9562_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
@@ -1188,6 +1195,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.9.1-h236d3af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
@@ -1325,6 +1333,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.9.1-h16c8c8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
@@ -1454,6 +1463,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/taplo-0.9.1-h7f3b576_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
@@ -1466,571 +1476,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
-      - pypi: https://files.pythonhosted.org/packages/88/8c/61021c45428ad2ef6131c6068d14f7f0968767e972e427cd87bd25c9ea7b/argcomplete-3.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f3/18/3e867ab37a24fdf073c1617b9c7830e06ec270b1ea4694a624038fc40a03/colorlog-6.8.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8e/41/9307e4f5f9976bc8b7fea0b66367734e8faf3ec84bc0d412d8cfabbb66cd/distlib-0.3.8-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/81/54/84d42a0bee35edba99dee7b59a8d4970eccdd44b99fe728ed912106fc781/filelock-3.13.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c2/55/c0d4ca1e6f68da8a1c7055ad80d4bf1fef651af08a68b52323cee97880c9/nox-2024.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/16/65/0d0bdfdac31e2db8c6d6c18fe1e00236f0dea279f9846f94a9aafa49cfc9/virtualenv-20.25.1-py3-none-any.whl
-  taplo:
-    channels:
-    - url: https://conda.anaconda.org/conda-forge/
-    packages:
-      linux-64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.16-haed3651_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.10-ha9bf9b1_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.14-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-h4466546_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-he635cd5_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.1-hbfc29b2_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.6-h9e7f0e3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.3-hffff1cc_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.5.2-h4893938_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.15-h4466546_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-h4466546_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.3-h137ae52_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.267-he0cb598_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binaryen-117-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/black-24.2.0-py311h38be061_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.27.0-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-16-16.0.6-default_h127d8a8_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-16.0.6-default_h127d8a8_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-tools-16.0.6-default_h127d8a8_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.27.6-hcfe8598_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/doxygen-1.9.7-h661eb56_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-24.3.7-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.42-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.0-hed5481d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.2-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/just-1.24.0-he8a937b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.1-cxx17_h59595ed_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.2-h6bfc85a_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.2-h59595ed_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.2-h59595ed_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.2-hc6145d9_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.2-h757c851_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.2-hb016d2e_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.2-h757c851_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-21_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-21_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp16-16.0.6-default_h127d8a8_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-18.1.1-default_h5d6823c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.5.0-hca28451_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.22.0-h9be4e54_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.22.0-hc7a4891_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.1-h15f2491_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-21_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hb3ce162_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm16-16.0.6-hb3ce162_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm18-18.1.1-h2448989_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.9.0-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.26-pthreads_h413a1c8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.2-h352af49_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h5a48ba9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.46.0-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.5-h232c23b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.4.0-py311h63ff55d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/meilisearch-1.5.1-he8a937b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.8.0-py311h459d7ec_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.1-h924138e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-18.19.0-hb753e55_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.0-h1e5e2c1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/prettier-2.8.8-h75cfd52_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.8-py311h459d7ec_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.2-py311h39c9aba_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.8-hab00c5b_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-50.0-hd3aeb46_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.09.01-h7f4b329_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.4-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.2.2-py311h7145743_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.6-h06160fa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.8.1-he8a937b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.10.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/typos-1.19.0-he8a937b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-h11edf95_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
-      - pypi: https://files.pythonhosted.org/packages/88/8c/61021c45428ad2ef6131c6068d14f7f0968767e972e427cd87bd25c9ea7b/argcomplete-3.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f3/18/3e867ab37a24fdf073c1617b9c7830e06ec270b1ea4694a624038fc40a03/colorlog-6.8.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8e/41/9307e4f5f9976bc8b7fea0b66367734e8faf3ec84bc0d412d8cfabbb66cd/distlib-0.3.8-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/81/54/84d42a0bee35edba99dee7b59a8d4970eccdd44b99fe728ed912106fc781/filelock-3.13.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c2/55/c0d4ca1e6f68da8a1c7055ad80d4bf1fef651af08a68b52323cee97880c9/nox-2024.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/16/65/0d0bdfdac31e2db8c6d6c18fe1e00236f0dea279f9846f94a9aafa49cfc9/virtualenv-20.25.1-py3-none-any.whl
-      osx-64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.16-h9d28af5_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.10-hf9de6f9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.14-h10d778d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-h905ab21_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h30f2259_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.1-hce3b3da_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.6-hf76ed93_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.3-ha335edc_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.5.2-h6f42f56_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.15-h905ab21_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-h905ab21_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.3-hf5b2fc6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.267-h232afc9_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/binaryen-117-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/black-24.2.0-py311h6eed73b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.27.0-h10d778d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-format-16-16.0.6-default_h7151d67_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-format-16.0.6-default_h7151d67_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-tools-16.0.6-default_h7151d67_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.27.6-hf40c264_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/doxygen-1.9.7-hd7636e7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-24.3.7-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.42-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.0-h31b1b29_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.2-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/just-1.24.0-h11a7dfb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.1-cxx17_hc1bcbd7_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.2-he79e29d_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.2-h000cb23_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.2-h000cb23_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.2-h2382776_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.2-h7e3fe20_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.2-ha5acb15_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.2-h7e3fe20_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-21_osx64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-21_osx64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp16-16.0.6-default_h7151d67_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang13-18.1.1-default_h0edc4dd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.5.0-h726d00d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.22.0-h651e89d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.22.0-ha67e85c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.62.1-h384b2fc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-21_osx64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-hbedff68_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm16-16.0.6-hbedff68_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm18-18.1.1-hbcf5fad_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.26-openmp_hfef2a42_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.2-h381d950_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.3-h4e4d658_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.09.01-h81f5012_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.2-h92b6c6a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.47.0-h67532ce_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.5-hc0ae0f7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.6-hb6ac08f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.4.0-py311h24bb903_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.8.0-py311he705e18_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-h93d8f39_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.1-hb8565cd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/nodejs-18.19.0-h119ffd7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.0-h6c6cd50_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/prettier-2.8.8-h3db311d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.8-py311he705e18_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.2-py311h54e7ce8_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.8-h9f0c242_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.09.01-hb168e87_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.4-h0dc2134_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.2.2-py311hfff7943_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.8.1-h7205ca4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.10.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/typos-1.19.0-h11a7dfb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
-      - pypi: https://files.pythonhosted.org/packages/88/8c/61021c45428ad2ef6131c6068d14f7f0968767e972e427cd87bd25c9ea7b/argcomplete-3.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f3/18/3e867ab37a24fdf073c1617b9c7830e06ec270b1ea4694a624038fc40a03/colorlog-6.8.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8e/41/9307e4f5f9976bc8b7fea0b66367734e8faf3ec84bc0d412d8cfabbb66cd/distlib-0.3.8-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/81/54/84d42a0bee35edba99dee7b59a8d4970eccdd44b99fe728ed912106fc781/filelock-3.13.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c2/55/c0d4ca1e6f68da8a1c7055ad80d4bf1fef651af08a68b52323cee97880c9/nox-2024.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/16/65/0d0bdfdac31e2db8c6d6c18fe1e00236f0dea279f9846f94a9aafa49cfc9/virtualenv-20.25.1-py3-none-any.whl
-      osx-arm64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.16-h0d2f7a6_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.10-h677d54c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.14-h93a5062_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.18-h677d54c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.2-h59ac3ca_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.1-hfe5d766_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.6-h9ac2cdb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.3-hb8a1441_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.5.2-h4398043_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.15-h677d54c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.18-h677d54c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.26.3-h0de420c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.267-h2fb64bc_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/binaryen-117-hebf3989_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/black-24.2.0-py311h267d04e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.27.0-h93a5062_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-16-16.0.6-default_he012953_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-16.0.6-default_he012953_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-tools-16.0.6-default_he012953_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.27.6-h1c59155_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/doxygen-1.9.7-h0e2417a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-24.3.7-hebf3989_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.42-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.0-hc6770e3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.2-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/just-1.24.0-h5ef7bb8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240116.1-cxx17_hebf3989_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.2-h5233fb5_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.2-h13dd4ca_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.2-h13dd4ca_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.2-h95ca633_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.2-hdc5392b_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.2-hfef958d_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.2-hef52601_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-21_osxarm64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-21_osxarm64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp16-16.0.6-default_he012953_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-18.1.1-default_h83d0a53_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.5.0-h2d989ff_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.22.0-hbebe991_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.22.0-h8a76758_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.62.1-h9c18a4f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-21_osxarm64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h2621b3d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm16-16.0.6-haab561b_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm18-18.1.1-h30cc82d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.26-openmp_h6c19121_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.2-hf6ce1d5_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.3-hbfab5d5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.09.01-h7b2c953_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.2-h091b4b1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.19.0-h026a170_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.47.0-h93a5062_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.5-h0d0cfa8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.6-hcd81f8e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.4.0-py311h71175c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.8.0-py311h05b510d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.1-hffc8910_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-18.19.0-h5f47a4d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py311h7125741_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.0-h3d3088e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-2.8.8-ha12bae2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.8-py311h05b510d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.2-py311hd7bc329_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.8-hdf0ec26_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.09.01-h4cba328_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.4-hb547adb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.2.2-py311h8c97afb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.8.1-h69fbcac_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.10.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.19.0-h5ef7bb8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
-      - pypi: https://files.pythonhosted.org/packages/88/8c/61021c45428ad2ef6131c6068d14f7f0968767e972e427cd87bd25c9ea7b/argcomplete-3.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f3/18/3e867ab37a24fdf073c1617b9c7830e06ec270b1ea4694a624038fc40a03/colorlog-6.8.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8e/41/9307e4f5f9976bc8b7fea0b66367734e8faf3ec84bc0d412d8cfabbb66cd/distlib-0.3.8-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/81/54/84d42a0bee35edba99dee7b59a8d4970eccdd44b99fe728ed912106fc781/filelock-3.13.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c2/55/c0d4ca1e6f68da8a1c7055ad80d4bf1fef651af08a68b52323cee97880c9/nox-2024.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/16/65/0d0bdfdac31e2db8c6d6c18fe1e00236f0dea279f9846f94a9aafa49cfc9/virtualenv-20.25.1-py3-none-any.whl
-      win-64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.16-h7613915_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.10-hf6fcf4e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.14-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-hf6fcf4e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-h3df98b0_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.1-h4e3df0f_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.6-hf0b8b6f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.3-h96fac68_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.5.2-h08df315_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.15-hf6fcf4e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-hf6fcf4e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.26.3-h6047f0a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.267-h558341a_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/binaryen-117-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/black-24.2.0-py311h1ea47a8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.27.0-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/clang-format-16.0.6-default_h3a3e6c3_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/clang-tools-16.0.6-default_h3a3e6c3_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-3.27.6-hf0feee3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/doxygen-1.9.7-h849606c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-24.3.7-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.42-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.2-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.0.0-h57928b3_49841.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/just-1.24.0-h7f3b576_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.1-cxx17_h63175ca_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-14.0.2-h2a83f13_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-14.0.2-h63175ca_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-14.0.2-h63175ca_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-14.0.2-h02312f3_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-14.0.2-h55b4db4_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-14.0.2-hcb01e45_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-14.0.2-h89268de_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-21_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-21_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-18.1.1-default_hf64faad_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.5.0-hd5e4a3a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.22.0-h9cad5c0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.22.0-hb581fae_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.62.1-h5273850_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-21_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-14.0.2-h7ec3a38_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.3-h503648d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.09.01-hf8d8778_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.2-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.48.0-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.5-hc3477c8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/maturin-1.4.0-py311h9a9e57f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.0.0-h66d3029_49657.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.8.0-py311ha68e1ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ninja-1.11.1-h91493d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/nodejs-18.19.0-h57928b3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py311h0b4df5a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.0-heb0c069_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/prettier-2.8.8-hd2f1330_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.8-py311ha68e1ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-14.0.2-py311h6a6099b_13_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.8-h2628c8c_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2023.09.01-hd3b24a8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.2.2-py311hc14472d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/taplo-0.8.1-h7f3b576_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.11.0-h91493d7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.10.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/typos-1.19.0-h7f3b576_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hcf57466_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.38.33130-h82b7239_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.38.33130-hcb4865c_18.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
@@ -2204,25 +1649,6 @@ packages:
 - kind: conda
   name: aws-c-auth
   version: 0.7.16
-  build: h0d2f7a6_8
-  build_number: 8
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.16-h0d2f7a6_8.conda
-  sha256: 82006dd3067f4d09fd8cee0ea9c4836b6ac0c02db68acd001ff5c7b8669522b5
-  md5: a37cb159ebfb3d3adc1a351c98c1027f
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-c-sdkutils >=0.1.15,<0.1.16.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 89205
-  timestamp: 1710282202281
-- kind: conda
-  name: aws-c-auth
-  version: 0.7.16
   build: h51b92d1_6
   build_number: 6
   subdir: osx-arm64
@@ -2239,28 +1665,6 @@ packages:
   license_family: Apache
   size: 89495
   timestamp: 1708633374785
-- kind: conda
-  name: aws-c-auth
-  version: 0.7.16
-  build: h7613915_8
-  build_number: 8
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.16-h7613915_8.conda
-  sha256: 9ac4ebfc14faa7377a0df29ebf562d55e04a99d6d72f8ce8bb6a661e4753cde3
-  md5: 61c802b7e9c8d6215116c01ce7d582d9
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-c-sdkutils >=0.1.15,<0.1.16.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 99468
-  timestamp: 1710282357839
 - kind: conda
   name: aws-c-auth
   version: 0.7.16
@@ -2300,45 +1704,6 @@ packages:
   license_family: Apache
   size: 90856
   timestamp: 1708633418805
-- kind: conda
-  name: aws-c-auth
-  version: 0.7.16
-  build: h9d28af5_8
-  build_number: 8
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.16-h9d28af5_8.conda
-  sha256: f75a39577b61fc649e3a8c926b91218ebad6ea78beb2f2b16f90d3ae9493c1c4
-  md5: 0b451cddce1ea8f9247b386ba3285edc
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-c-sdkutils >=0.1.15,<0.1.16.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 90270
-  timestamp: 1710282294532
-- kind: conda
-  name: aws-c-auth
-  version: 0.7.16
-  build: haed3651_8
-  build_number: 8
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.16-haed3651_8.conda
-  sha256: 75a540b313e5dc212fc0a6057f8a5bee2dda443f17a5a076bd3ea4d7195d483e
-  md5: ce96c083829ab2727c942243ac93ffe0
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-c-sdkutils >=0.1.15,<0.1.16.0a0
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  size: 103298
-  timestamp: 1710281865011
 - kind: conda
   name: aws-c-auth
   version: 0.7.16
@@ -2437,21 +1802,6 @@ packages:
 - kind: conda
   name: aws-c-cal
   version: 0.6.10
-  build: h677d54c_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.10-h677d54c_2.conda
-  sha256: d4f0fa97a3f6f5a090b0c9ed078fedf6b50f19a406d272f8e4b2b214f074323e
-  md5: a501703d122cdf7cf38c1bbc8c16f981
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 38986
-  timestamp: 1709815581194
-- kind: conda
-  name: aws-c-cal
-  version: 0.6.10
   build: h7beb4c2_1
   build_number: 1
   subdir: osx-64
@@ -2481,23 +1831,6 @@ packages:
   license_family: Apache
   size: 48505
   timestamp: 1708003694470
-- kind: conda
-  name: aws-c-cal
-  version: 0.6.10
-  build: ha9bf9b1_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.10-ha9bf9b1_2.conda
-  sha256: e45d9f1eb862f566bdea3d3229dfc74f31e647a72198fe04aab58ccc03a30a37
-  md5: ce2471034f5459a39636aacc292c96b6
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - libgcc-ng >=12
-  - openssl >=3.2.1,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 55421
-  timestamp: 1709815095625
 - kind: conda
   name: aws-c-cal
   version: 0.6.10
@@ -2536,24 +1869,6 @@ packages:
 - kind: conda
   name: aws-c-cal
   version: 0.6.10
-  build: hf6fcf4e_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.10-hf6fcf4e_2.conda
-  sha256: 800b25ee5590f3ddd9186e225c756b9e5d00d3ecce8c2de5d9343af85213d883
-  md5: 7490ede93a75acc3589a2e43f77c79e9
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 55818
-  timestamp: 1709815582485
-- kind: conda
-  name: aws-c-cal
-  version: 0.6.10
   build: hf888d4c_1
   build_number: 1
   subdir: osx-arm64
@@ -2566,21 +1881,6 @@ packages:
   license_family: Apache
   size: 39206
   timestamp: 1708003965707
-- kind: conda
-  name: aws-c-cal
-  version: 0.6.10
-  build: hf9de6f9_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.10-hf9de6f9_2.conda
-  sha256: cb9b20aeec4cd037117fd0bfe2ae5a0a5f6a08a71f941be0f163bb27c87b98ea
-  md5: 393dbe9973160cb09cb3594c9246e260
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 45249
-  timestamp: 1709815427644
 - kind: conda
   name: aws-c-common
   version: 0.9.10
@@ -2694,60 +1994,6 @@ packages:
   size: 225560
   timestamp: 1707964559211
 - kind: conda
-  name: aws-c-common
-  version: 0.9.14
-  build: h10d778d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.14-h10d778d_0.conda
-  sha256: 1d207a8aee42700763e6a7801c69721ccc06ce75e62e0e5d8fc6df0197c0a88b
-  md5: c620ac518f3086eaf4f105f64908a57c
-  license: Apache-2.0
-  license_family: Apache
-  size: 208228
-  timestamp: 1709669491258
-- kind: conda
-  name: aws-c-common
-  version: 0.9.14
-  build: h93a5062_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.14-h93a5062_0.conda
-  sha256: c58aea968814459ef485c1f1aeb889423b0fa808b7c1216d96d5282ff2e796ab
-  md5: 028bc18a1ef8bb1a4e4d6ec94e9b50da
-  license: Apache-2.0
-  license_family: Apache
-  size: 203827
-  timestamp: 1709669473014
-- kind: conda
-  name: aws-c-common
-  version: 0.9.14
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.14-hcfcfb64_0.conda
-  sha256: 46f4dced6c9d553d65e6f721d51ef43e6a343487a3073299c03a073161d7637f
-  md5: 169998d49ac3c4800187bfc546e1d165
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 222375
-  timestamp: 1709669884758
-- kind: conda
-  name: aws-c-common
-  version: 0.9.14
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.14-hd590300_0.conda
-  sha256: c71dd835b1d8c7097c8d152a65680f119a203b73a6a62c5aac414bafe5e997ad
-  md5: d44fe0d9a6971a4fb245be0055775d9d
-  depends:
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  size: 225655
-  timestamp: 1709669368566
-- kind: conda
   name: aws-c-compression
   version: 0.2.17
   build: h7f92143_7
@@ -2818,52 +2064,6 @@ packages:
 - kind: conda
   name: aws-c-compression
   version: 0.2.18
-  build: h4466546_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-h4466546_2.conda
-  sha256: 7fcc6a924691f9de65c82fd559cb1cb2ebd121c42da544a9a43623d69a284e23
-  md5: b0d9153fc7cfa8dc36b8703e1a59f5f3
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  size: 19072
-  timestamp: 1709815144275
-- kind: conda
-  name: aws-c-compression
-  version: 0.2.18
-  build: h677d54c_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.18-h677d54c_2.conda
-  sha256: bbc73d8ec3d760d528f15edad66835d1fe63a035f254e760235e745cf360de20
-  md5: 71e953c1c0fac25dd5d65d63d47389d8
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 17911
-  timestamp: 1709815495665
-- kind: conda
-  name: aws-c-compression
-  version: 0.2.18
-  build: h905ab21_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-h905ab21_2.conda
-  sha256: 021cee135f0d9b58fbc8d212618cd9bd6bd0012da41a6469edf010b2853dd3ef
-  md5: ffd7cfb55b1aa4e3eef477583b1ad87d
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 17930
-  timestamp: 1709815482244
-- kind: conda
-  name: aws-c-compression
-  version: 0.2.18
   build: hd481e46_1
   build_number: 1
   subdir: win-64
@@ -2910,24 +2110,6 @@ packages:
   license_family: Apache
   size: 18067
   timestamp: 1708003629797
-- kind: conda
-  name: aws-c-compression
-  version: 0.2.18
-  build: hf6fcf4e_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-hf6fcf4e_2.conda
-  sha256: ecb5ab2353c4499311fe17c82210955a498526c9563861777b3b0cd6dcc5cfea
-  md5: 6efdf7af73d7043a00394a2f1b039650
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 22366
-  timestamp: 1709815905155
 - kind: conda
   name: aws-c-compression
   version: 0.2.18
@@ -3061,62 +2243,6 @@ packages:
 - kind: conda
   name: aws-c-event-stream
   version: 0.4.2
-  build: h30f2259_6
-  build_number: 6
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h30f2259_6.conda
-  sha256: 65ea5552f7a87783b75a3ecf6e4acd2aee5357c4275a9932d732ee516acab0a9
-  md5: 0923a8e81839b0b2d9787d85d635b196
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - libcxx >=16
-  license: Apache-2.0
-  license_family: Apache
-  size: 46261
-  timestamp: 1710264045535
-- kind: conda
-  name: aws-c-event-stream
-  version: 0.4.2
-  build: h3df98b0_6
-  build_number: 6
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-h3df98b0_6.conda
-  sha256: 823a4665b3d38a4078b34b6f891bd388400942a3bcbad55b4c6223c559b15de6
-  md5: 80ca7e9993f6b0141ae5425a69771a9a
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 54211
-  timestamp: 1710264185867
-- kind: conda
-  name: aws-c-event-stream
-  version: 0.4.2
-  build: h59ac3ca_6
-  build_number: 6
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.2-h59ac3ca_6.conda
-  sha256: 86db342fd921f17a50cf7648b45566b2449ac1408a94c2e6cae132b876f1c17c
-  md5: 7278d0ef10644f95a2dd619b9917e8a2
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - libcxx >=16
-  license: Apache-2.0
-  license_family: Apache
-  size: 47119
-  timestamp: 1710264020154
-- kind: conda
-  name: aws-c-event-stream
-  version: 0.4.2
   build: hb970d5a_4
   build_number: 4
   subdir: osx-64
@@ -3132,25 +2258,6 @@ packages:
   license_family: Apache
   size: 46676
   timestamp: 1708602620909
-- kind: conda
-  name: aws-c-event-stream
-  version: 0.4.2
-  build: he635cd5_6
-  build_number: 6
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-he635cd5_6.conda
-  sha256: 38a30beabafc1dd86c0264b6746315a1010e541a1b3ed7f97e1702873e5eaa51
-  md5: 58fc78e523e35a08423c913751a51fde
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  size: 53665
-  timestamp: 1710263650074
 - kind: conda
   name: aws-c-event-stream
   version: 0.4.2
@@ -3249,27 +2356,6 @@ packages:
 - kind: conda
   name: aws-c-http
   version: 0.8.1
-  build: h4e3df0f_7
-  build_number: 7
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.1-h4e3df0f_7.conda
-  sha256: 651bdcbe53630bf9665b76c18a6cb21a7b53fe347b03d88c1cb99ed0281c267e
-  md5: 08ba30d73686a5129f4209c25b31252a
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-compression >=0.2.18,<0.2.19.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 180557
-  timestamp: 1710264351681
-- kind: conda
-  name: aws-c-http
-  version: 0.8.1
   build: h5d7533a_5
   build_number: 5
   subdir: linux-64
@@ -3286,43 +2372,6 @@ packages:
   license_family: Apache
   size: 195024
   timestamp: 1708602547845
-- kind: conda
-  name: aws-c-http
-  version: 0.8.1
-  build: hbfc29b2_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.1-hbfc29b2_7.conda
-  sha256: 0dc5b73aa31cef3faeeb902a11f12e1244ac241f995d73e4f4e3e0c01622f7a1
-  md5: 8476ec099649e9a6de52f7f4d916cd2a
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-compression >=0.2.18,<0.2.19.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  size: 194307
-  timestamp: 1710263686092
-- kind: conda
-  name: aws-c-http
-  version: 0.8.1
-  build: hce3b3da_7
-  build_number: 7
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.1-hce3b3da_7.conda
-  sha256: a3e6bfd71bbc4119da1e79f2bce6094f045112c230b3fd5cc9e6ccd36aba3156
-  md5: d287122dfb77c5fa0147fdf368c86d54
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-compression >=0.2.18,<0.2.19.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 162710
-  timestamp: 1710263951106
 - kind: conda
   name: aws-c-http
   version: 0.8.1
@@ -3381,24 +2430,6 @@ packages:
   license_family: Apache
   size: 151481
   timestamp: 1708602772972
-- kind: conda
-  name: aws-c-http
-  version: 0.8.1
-  build: hfe5d766_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.1-hfe5d766_7.conda
-  sha256: 0a454c1280e87b4bfd3ab1d70498c5f60c62139ddcd06d1a68c39dcd81e05e75
-  md5: 4096407e9d908ef9a292980f93034fcd
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-compression >=0.2.18,<0.2.19.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 151329
-  timestamp: 1710264327114
 - kind: conda
   name: aws-c-io
   version: 0.13.36
@@ -3542,70 +2573,6 @@ packages:
   license_family: Apache
   size: 136989
   timestamp: 1708687976415
-- kind: conda
-  name: aws-c-io
-  version: 0.14.6
-  build: h9ac2cdb_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.6-h9ac2cdb_0.conda
-  sha256: 1dcae62df79786292e841275994c9ded564eb49d7200284c09f7d61326a06c1b
-  md5: b0c80a8220ddc90196e3b76d856dc6b0
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 136547
-  timestamp: 1710222457819
-- kind: conda
-  name: aws-c-io
-  version: 0.14.6
-  build: h9e7f0e3_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.6-h9e7f0e3_0.conda
-  sha256: bb9e7bee234532f7905faf4abc15e3a1be1d8f683b8a0d5863761daad18a7cac
-  md5: 3fef14ef6e79ea0da149cebb1d0635bf
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - s2n >=1.4.6,<1.4.7.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 157726
-  timestamp: 1710222250665
-- kind: conda
-  name: aws-c-io
-  version: 0.14.6
-  build: hf0b8b6f_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.6-hf0b8b6f_0.conda
-  sha256: ab046e34dcaa533d75f8f4892c63ec503812a69fa6e8d23bfbdb0d74926cdc40
-  md5: aee3f042f60da448ab622b0a149d6ec2
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 160412
-  timestamp: 1710222753707
-- kind: conda
-  name: aws-c-io
-  version: 0.14.6
-  build: hf76ed93_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.6-hf76ed93_0.conda
-  sha256: 824eb1fcf69f67c4fee4e05fd401dba6d5c55f9e37e3cb9904b8b81909e3c3be
-  md5: 586e11f2969f1f2a61104c5cec8a7957
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 137968
-  timestamp: 1710222523409
 - kind: conda
   name: aws-c-mqtt
   version: 0.10.0
@@ -3755,78 +2722,6 @@ packages:
   size: 157819
   timestamp: 1708621381498
 - kind: conda
-  name: aws-c-mqtt
-  version: 0.10.3
-  build: h96fac68_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.3-h96fac68_2.conda
-  sha256: 70b62dcf6314a9e1f514fe6f838eb02dfc4a28f4d17723768211a60c28c3429b
-  md5: 463c0be9e1fb416192174156f58bb2af
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 157436
-  timestamp: 1710283031953
-- kind: conda
-  name: aws-c-mqtt
-  version: 0.10.3
-  build: ha335edc_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.3-ha335edc_2.conda
-  sha256: 99304e5095193b937745d0ce6812d0333186a31c41a51b1e4297ddcd962824eb
-  md5: c8bacb9a988fd8fb6b560a966c4979a8
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 139008
-  timestamp: 1710282888188
-- kind: conda
-  name: aws-c-mqtt
-  version: 0.10.3
-  build: hb8a1441_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.3-hb8a1441_2.conda
-  sha256: 344ba23eb2cd45105a09d775dd7449e17304b3930d5ff08fbc1426f0f8030b08
-  md5: 26421a2d8a329048bb1a5673ce620de5
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 117955
-  timestamp: 1710282576148
-- kind: conda
-  name: aws-c-mqtt
-  version: 0.10.3
-  build: hffff1cc_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.3-hffff1cc_2.conda
-  sha256: 6b2de4a0e6e907310127b1025a0030d023e1051da48ea5821dcc6db094d69ab7
-  md5: 14ad8defb307e1edb293c3fc9da8648f
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  size: 163172
-  timestamp: 1710282530222
-- kind: conda
   name: aws-c-s3
   version: 0.4.7
   build: h0d871e0_2
@@ -3897,29 +2792,6 @@ packages:
 - kind: conda
   name: aws-c-s3
   version: 0.5.2
-  build: h08df315_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.5.2-h08df315_2.conda
-  sha256: 2f7af939a87176de471bac1a1c6cc7336c714a64c495f1a5d967e0cfa7bb0e07
-  md5: 0a7a232878640624469d3ca4923d146b
-  depends:
-  - aws-c-auth >=0.7.16,<0.7.17.0a0
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 101487
-  timestamp: 1710296653111
-- kind: conda
-  name: aws-c-s3
-  version: 0.5.2
   build: h09f5dbc_0
   subdir: osx-arm64
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.5.2-h09f5dbc_0.conda
@@ -3957,48 +2829,6 @@ packages:
   license_family: Apache
   size: 109725
   timestamp: 1709172552237
-- kind: conda
-  name: aws-c-s3
-  version: 0.5.2
-  build: h4398043_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.5.2-h4398043_2.conda
-  sha256: 27e90ada0ae6895159a49bc4ed7172b2757cd8fc63e0189dd8cce5d057c6ee06
-  md5: 5ddebd5447f4baba6215b1bafcf605dc
-  depends:
-  - aws-c-auth >=0.7.16,<0.7.17.0a0
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 90478
-  timestamp: 1710296516337
-- kind: conda
-  name: aws-c-s3
-  version: 0.5.2
-  build: h4893938_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.5.2-h4893938_2.conda
-  sha256: 312d67b236c9c6003f92f682c55ff344721f79d50d9a4bcdea44f2144f637642
-  md5: 7e24759a8b8ead67ce687f3c31ffd12f
-  depends:
-  - aws-c-auth >=0.7.16,<0.7.17.0a0
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - libgcc-ng >=12
-  - openssl >=3.2.1,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 105455
-  timestamp: 1710296220268
 - kind: conda
   name: aws-c-s3
   version: 0.5.2
@@ -4042,26 +2872,6 @@ packages:
   license_family: Apache
   size: 101468
   timestamp: 1709173131467
-- kind: conda
-  name: aws-c-s3
-  version: 0.5.2
-  build: h6f42f56_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.5.2-h6f42f56_2.conda
-  sha256: 950a37ab27ec0145a4c92a3524b8862a4f5affec08049dda7b9ab83403969fd6
-  md5: 9f5dc9ef044d3c13b0959d04a2005753
-  depends:
-  - aws-c-auth >=0.7.16,<0.7.17.0a0
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 91371
-  timestamp: 1710296654896
 - kind: conda
   name: aws-c-s3
   version: 0.5.2
@@ -4149,52 +2959,6 @@ packages:
 - kind: conda
   name: aws-c-sdkutils
   version: 0.1.15
-  build: h4466546_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.15-h4466546_2.conda
-  sha256: 349a05cf5fbcb3f6f358fc05098b210aa7da4ec3ab6d4719c79bb93b50a629f8
-  md5: 258194cedccd33fd8a7b95a8aa105015
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  size: 55383
-  timestamp: 1709830510021
-- kind: conda
-  name: aws-c-sdkutils
-  version: 0.1.15
-  build: h677d54c_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.15-h677d54c_2.conda
-  sha256: 02649707625df0c8908fd807f5d599b5f60b90d7b4e0e71953ff10b9aa0f010c
-  md5: a68e269534f50d5a94107b9b9b6be747
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 48880
-  timestamp: 1709830883787
-- kind: conda
-  name: aws-c-sdkutils
-  version: 0.1.15
-  build: h905ab21_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.15-h905ab21_2.conda
-  sha256: 77f58ac3aec0cd987f80e202a8197e123beb13b9b25b0137dd921c7a6ddc86ac
-  md5: bb1523b7de7ac6f112b1992cfcfb250b
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 50028
-  timestamp: 1709830709542
-- kind: conda
-  name: aws-c-sdkutils
-  version: 0.1.15
   build: hd481e46_1
   build_number: 1
   subdir: win-64
@@ -4241,24 +3005,6 @@ packages:
   license_family: Apache
   size: 50255
   timestamp: 1708014587926
-- kind: conda
-  name: aws-c-sdkutils
-  version: 0.1.15
-  build: hf6fcf4e_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.15-hf6fcf4e_2.conda
-  sha256: 03f361182431688732e7173f0d71e5778e0616e68d9ebf994d3ecb70483468a0
-  md5: 87fb9f67d4c936a704d6a23a748fad77
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 54282
-  timestamp: 1709830762581
 - kind: conda
   name: aws-c-sdkutils
   version: 0.1.15
@@ -4345,52 +3091,6 @@ packages:
 - kind: conda
   name: aws-checksums
   version: 0.1.18
-  build: h4466546_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-h4466546_2.conda
-  sha256: 9080f064f572ac1747d32b4dff30452ff44ef2df399e6ec7bf9730da1eb99bba
-  md5: 8a04fc5a5ecaba31f66904b47dcc7797
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  size: 49940
-  timestamp: 1709826415680
-- kind: conda
-  name: aws-checksums
-  version: 0.1.18
-  build: h677d54c_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.18-h677d54c_2.conda
-  sha256: 3a7cc8824a23a39478e479865df20d88c12a954895fb9c8a91152cc76976183a
-  md5: 21b73ab89b82b17ae50d635ce675fea6
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 48836
-  timestamp: 1709826804838
-- kind: conda
-  name: aws-checksums
-  version: 0.1.18
-  build: h905ab21_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-h905ab21_2.conda
-  sha256: 5760728e7320a01519bcbbae8dcd31b86e819f66c58f641b86b27ce592e5fff3
-  md5: f17e778398011e88d45edf58f24c18ae
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 48733
-  timestamp: 1709826868797
-- kind: conda
-  name: aws-checksums
-  version: 0.1.18
   build: hd481e46_1
   build_number: 1
   subdir: win-64
@@ -4437,24 +3137,6 @@ packages:
   license_family: Apache
   size: 48808
   timestamp: 1708017957232
-- kind: conda
-  name: aws-checksums
-  version: 0.1.18
-  build: hf6fcf4e_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-hf6fcf4e_2.conda
-  sha256: 1a67c0ee80cb2d18bd7cfc9ec1aae2ad78d51adc7ac9442ec70e370bbcef24de
-  md5: ffa6601a628ccc6ec5eddb0def2db1d2
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 52016
-  timestamp: 1709827173669
 - kind: conda
   name: aws-checksums
   version: 0.1.18
@@ -4674,105 +3356,6 @@ packages:
   size: 242812
   timestamp: 1709208518468
 - kind: conda
-  name: aws-crt-cpp
-  version: 0.26.3
-  build: h0de420c_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.26.3-h0de420c_2.conda
-  sha256: 578ffab0c981ea227d5a9d70b32af5bcba58c632d0f8b38d4eb1ed88cc05eaaa
-  md5: e6d964373064af06199c6e4dff9f174e
-  depends:
-  - aws-c-auth >=0.7.16,<0.7.17.0a0
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-c-mqtt >=0.10.3,<0.10.4.0a0
-  - aws-c-s3 >=0.5.2,<0.5.3.0a0
-  - aws-c-sdkutils >=0.1.15,<0.1.16.0a0
-  - libcxx >=16
-  license: Apache-2.0
-  license_family: Apache
-  size: 218109
-  timestamp: 1710309757551
-- kind: conda
-  name: aws-crt-cpp
-  version: 0.26.3
-  build: h137ae52_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.3-h137ae52_2.conda
-  sha256: 596b6d63352b7ae189842dc86510d53438f88d1e2c1d56779eeebc130beef2b6
-  md5: 21c8acfdfa31ab5582897dda7c9c8a75
-  depends:
-  - aws-c-auth >=0.7.16,<0.7.17.0a0
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-c-mqtt >=0.10.3,<0.10.4.0a0
-  - aws-c-s3 >=0.5.2,<0.5.3.0a0
-  - aws-c-sdkutils >=0.1.15,<0.1.16.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  size: 333634
-  timestamp: 1710309442818
-- kind: conda
-  name: aws-crt-cpp
-  version: 0.26.3
-  build: h6047f0a_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.26.3-h6047f0a_2.conda
-  sha256: 1cb3c3f8d0b19dad52eaa64758629f47aea88591cf3bc354fcb87c0923dc9e73
-  md5: 5c8a2ba1c7a6477b10d0bcd33ee1202f
-  depends:
-  - aws-c-auth >=0.7.16,<0.7.17.0a0
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-c-mqtt >=0.10.3,<0.10.4.0a0
-  - aws-c-s3 >=0.5.2,<0.5.3.0a0
-  - aws-c-sdkutils >=0.1.15,<0.1.16.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 242851
-  timestamp: 1710309795536
-- kind: conda
-  name: aws-crt-cpp
-  version: 0.26.3
-  build: hf5b2fc6_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.3-hf5b2fc6_2.conda
-  sha256: d4ec9488f2052276b4b119e62b2b08df52deec3e38dc7c57311f51413046de8b
-  md5: bcea6861674e784e2eb2f1de4f3bac35
-  depends:
-  - aws-c-auth >=0.7.16,<0.7.17.0a0
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-c-mqtt >=0.10.3,<0.10.4.0a0
-  - aws-c-s3 >=0.5.2,<0.5.3.0a0
-  - aws-c-sdkutils >=0.1.15,<0.1.16.0a0
-  - libcxx >=16
-  license: Apache-2.0
-  license_family: Apache
-  size: 280273
-  timestamp: 1710309758427
-- kind: conda
   name: aws-sdk-cpp
   version: 1.11.210
   build: ha042220_8
@@ -4848,50 +3431,6 @@ packages:
 - kind: conda
   name: aws-sdk-cpp
   version: 1.11.267
-  build: h232afc9_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.267-h232afc9_3.conda
-  sha256: d83b5e4728d61f996115251fbb1670b79c6b5c0a02f2f1f458b80a6b06b08eb1
-  md5: f707d57fee350a6b47726b2996f8e4e1
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - aws-crt-cpp >=0.26.3,<0.26.4.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 3367065
-  timestamp: 1710323636919
-- kind: conda
-  name: aws-sdk-cpp
-  version: 1.11.267
-  build: h2fb64bc_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.267-h2fb64bc_3.conda
-  sha256: 5ad2be70779844380b8b8567814ed3966ef2efd9c48cc258975cec7f072c9753
-  md5: e11e8d3c0ca63039e4b8101a5063fa30
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - aws-crt-cpp >=0.26.3,<0.26.4.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 3423557
-  timestamp: 1710323443841
-- kind: conda
-  name: aws-sdk-cpp
-  version: 1.11.267
   build: h4da54b2_1
   build_number: 1
   subdir: osx-64
@@ -4911,28 +3450,6 @@ packages:
   license_family: Apache
   size: 3375381
   timestamp: 1708527712169
-- kind: conda
-  name: aws-sdk-cpp
-  version: 1.11.267
-  build: h558341a_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.267-h558341a_3.conda
-  sha256: 886817ef6b059f715ab3d93025d5306c5046688fdbdade21f6fb3ce33e053561
-  md5: 42633be391d0a113f39356a37ce7ea40
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - aws-crt-cpp >=0.26.3,<0.26.4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 3409008
-  timestamp: 1710323920901
 - kind: conda
   name: aws-sdk-cpp
   version: 1.11.267
@@ -5000,29 +3517,6 @@ packages:
   license_family: Apache
   size: 3413748
   timestamp: 1708528552370
-- kind: conda
-  name: aws-sdk-cpp
-  version: 1.11.267
-  build: he0cb598_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.267-he0cb598_3.conda
-  sha256: 55bf5d47ba2591507abb9b2120905cdb0b1834b2867f03c6cff4bb88f7ec7c58
-  md5: ca4aebdc89bb9b08b3b6dd68ae09080d
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - aws-crt-cpp >=0.26.3,<0.26.4.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 3636564
-  timestamp: 1710322529863
 - kind: conda
   name: aws-sdk-cpp
   version: 1.11.267
@@ -5270,28 +3764,6 @@ packages:
   name: blackdoc
   version: 0.3.8
   build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
-  sha256: ec7b75c0f88db3e8c8b506ec48fa4fa210b0c1d09b0969df726a68b5563d151d
-  md5: c03749cb0d5874fd5b9c1620a3d230c4
-  depends:
-  - black
-  - importlib-metadata
-  - more-itertools
-  - python >=3.7
-  - rich
-  - tomli
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/blackdoc
-  size: 30092
-  timestamp: 1667565048643
-- kind: conda
-  name: blackdoc
-  version: 0.3.8
-  build: pyhd8ed1ab_0
   subdir: win-64
   noarch: python
   url: https://conda.anaconda.org/conda-forge/noarch/blackdoc-0.3.8-pyhd8ed1ab_0.tar.bz2
@@ -5535,18 +4007,6 @@ packages:
 - kind: conda
   name: c-ares
   version: 1.27.0
-  build: h10d778d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.27.0-h10d778d_0.conda
-  sha256: a53e14c071dcce756ce80673f2a90a1c6dff695a26bc9f5e54d56b55e76ee3dc
-  md5: 713dd57081dfe8535eb961b45ed26a0c
-  license: MIT
-  license_family: MIT
-  size: 148568
-  timestamp: 1708685147963
-- kind: conda
-  name: c-ares
-  version: 1.27.0
   build: h31becfc_0
   subdir: linux-aarch64
   url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.27.0-h31becfc_0.conda
@@ -5558,18 +4018,6 @@ packages:
   license_family: MIT
   size: 170421
   timestamp: 1708684764494
-- kind: conda
-  name: c-ares
-  version: 1.27.0
-  build: h93a5062_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.27.0-h93a5062_0.conda
-  sha256: a168e53ee462980cd78b324e055afdd00080ded378ca974969a0917eb4ae1ccb
-  md5: d3579ba506791b1f8f8a16cfc2885326
-  license: MIT
-  license_family: MIT
-  size: 145697
-  timestamp: 1708685057216
 - kind: conda
   name: c-ares
   version: 1.27.0
@@ -5586,20 +4034,6 @@ packages:
   license_family: MIT
   size: 153934
   timestamp: 1708685329364
-- kind: conda
-  name: c-ares
-  version: 1.27.0
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.27.0-hd590300_0.conda
-  sha256: 2a5866b19d28cb963fab291a62ff1c884291b9d6f59de14643e52f103e255749
-  md5: f6afff0e9ee08d2f1b897881a4f38cdb
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 163578
-  timestamp: 1708684786032
 - kind: conda
   name: c-compiler
   version: 1.6.0
@@ -5967,25 +4401,6 @@ packages:
 - kind: conda
   name: clang-format
   version: 16.0.6
-  build: default_h127d8a8_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/clang-format-16.0.6-default_h127d8a8_5.conda
-  sha256: 8ae23380654712d8e8440871419cd8409903c3e2fd7c051978f2923e662a9c92
-  md5: 1fe9ee2e961ecae22f5a0413b34f9f5d
-  depends:
-  - clang-format-16 16.0.6 default_h127d8a8_5
-  - libclang-cpp16 >=16.0.6,<16.1.0a0
-  - libgcc-ng >=12
-  - libllvm16 >=16.0.6,<16.1.0a0
-  - libstdcxx-ng >=12
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 21690
-  timestamp: 1709765119029
-- kind: conda
-  name: clang-format
-  version: 16.0.6
   build: default_h3a3e6c3_5
   build_number: 5
   subdir: win-64
@@ -6077,24 +4492,6 @@ packages:
 - kind: conda
   name: clang-format-16
   version: 16.0.6
-  build: default_h127d8a8_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/clang-format-16-16.0.6-default_h127d8a8_5.conda
-  sha256: 9843007a8ffd53008240aec77b74068733daf5a00c60480d0978d05146511522
-  md5: 72cd7fd253434f1c6c6ee0af962ee700
-  depends:
-  - libclang-cpp16 >=16.0.6,<16.1.0a0
-  - libgcc-ng >=12
-  - libllvm16 >=16.0.6,<16.1.0a0
-  - libstdcxx-ng >=12
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 61980
-  timestamp: 1709765062005
-- kind: conda
-  name: clang-format-16
-  version: 16.0.6
   build: default_h7151d67_5
   build_number: 5
   subdir: osx-64
@@ -6162,32 +4559,6 @@ packages:
   license_family: Apache
   size: 56848
   timestamp: 1706894594045
-- kind: conda
-  name: clang-tools
-  version: 16.0.6
-  build: default_h127d8a8_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/clang-tools-16.0.6-default_h127d8a8_5.conda
-  sha256: 4b1c26e1058995181efcbd31b9d952241f9c561aad79ca6b7261ec7dc4796bd7
-  md5: a85978ea2f9ea8b3a0c0b5ccea48a42e
-  depends:
-  - clang-format 16.0.6 default_h127d8a8_5
-  - libclang-cpp16 >=16.0.6,<16.1.0a0
-  - libclang13 >=16.0.6
-  - libgcc-ng >=12
-  - libllvm16 >=16.0.6,<16.1.0a0
-  - libstdcxx-ng >=12
-  constrains:
-  - clangdev 16.0.6
-  - clang 16.0.6.*
-  - llvm 16.0.6.*
-  - llvm-tools 16.0.6.*
-  - llvmdev 16.0.6.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 26812015
-  timestamp: 1709765163586
 - kind: conda
   name: clang-tools
   version: 16.0.6
@@ -6488,24 +4859,6 @@ packages:
   name: click
   version: 8.1.7
   build: unix_pyh707e725_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
-  sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
-  md5: f3ad426304898027fc619827ff428eca
-  depends:
-  - __unix
-  - python >=3.8
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/click
-  size: 84437
-  timestamp: 1692311973840
-- kind: conda
-  name: click
-  version: 8.1.7
-  build: unix_pyh707e725_0
   subdir: osx-arm64
   noarch: python
   url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
@@ -6522,25 +4875,6 @@ packages:
   - pkg:pypi/click
   size: 84437
   timestamp: 1692311973840
-- kind: conda
-  name: click
-  version: 8.1.7
-  build: win_pyh7428d3b_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
-  sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
-  md5: 3549ecbceb6cd77b91a105511b7d0786
-  depends:
-  - __win
-  - colorama
-  - python >=3.8
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/click
-  size: 85051
-  timestamp: 1692312207348
 - kind: conda
   name: click
   version: 8.1.7
@@ -6678,23 +5012,6 @@ packages:
   license_family: BSD
   size: 16525734
   timestamp: 1695270838345
-- kind: conda
-  name: colorama
-  version: 0.4.6
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-  md5: 3faab06a954c2a04039983f2c4a50d99
-  depends:
-  - python >=3.7
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/colorama
-  size: 25170
-  timestamp: 1666700778190
 - kind: conda
   name: colorama
   version: 0.4.6
@@ -7064,65 +5381,6 @@ packages:
   size: 1298784
   timestamp: 1710058440028
 - kind: conda
-  name: flatbuffers
-  version: 24.3.7
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-24.3.7-h59595ed_0.conda
-  sha256: 30b53ebe46e902ea80479406d8d849f6d552d1f3ea4ee0eef6048a7a2201d93e
-  md5: e72ffaf09c193f6bebbb0054079ab7d1
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1453620
-  timestamp: 1710058292298
-- kind: conda
-  name: flatbuffers
-  version: 24.3.7
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-24.3.7-h63175ca_0.conda
-  sha256: 40613c4386464f2a1fa8ccebf1a38fede56669b8cdb6e4b0307e427720805232
-  md5: 030adc8125b572439459ea9f063cf3de
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1727810
-  timestamp: 1710058620131
-- kind: conda
-  name: flatbuffers
-  version: 24.3.7
-  build: h73e2aa4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-24.3.7-h73e2aa4_0.conda
-  sha256: e4d0e09f5f27825fc8ccb42cc4ebb20951b364a303aa4e95fc996afbac78bf79
-  md5: 4bca4cc7c9864063a92b08fb6975b802
-  depends:
-  - libcxx >=16
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1336422
-  timestamp: 1710058653949
-- kind: conda
-  name: flatbuffers
-  version: 24.3.7
-  build: hebf3989_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-24.3.7-hebf3989_0.conda
-  sha256: accfeff694d2b95a4a0ec6cd2ae5206028ce63a72583523e74bbb9d8e5b9ab53
-  md5: 51f4a8e083d8caf54e945a9cf858a966
-  depends:
-  - libcxx >=16
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1278204
-  timestamp: 1710058972127
-- kind: conda
   name: gcc
   version: 12.3.0
   build: h8d2909c_2
@@ -7237,24 +5495,6 @@ packages:
   license_family: BSD
   size: 116549
   timestamp: 1594303828933
-- kind: conda
-  name: gitdb
-  version: 4.0.11
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
-  sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
-  md5: 623b19f616f2ca0c261441067e18ae40
-  depends:
-  - python >=3.7
-  - smmap >=3.0.1,<6
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/gitdb
-  size: 52872
-  timestamp: 1697791718749
 - kind: conda
   name: gitdb
   version: 4.0.11
@@ -7622,23 +5862,6 @@ packages:
   name: iniconfig
   version: 2.0.0
   build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-  sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  md5: f800d2da156d08e289b14e87e43c1ae5
-  depends:
-  - python >=3.7
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/iniconfig
-  size: 11101
-  timestamp: 1673103208955
-- kind: conda
-  name: iniconfig
-  version: 2.0.0
-  build: pyhd8ed1ab_0
   subdir: win-64
   noarch: python
   url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
@@ -7791,19 +6014,6 @@ packages:
 - kind: conda
   name: just
   version: 1.24.0
-  build: h11a7dfb_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/just-1.24.0-h11a7dfb_0.conda
-  sha256: 802572940bc1208d135637b9859517d4262d156d956a98c96ca5502240da7d7d
-  md5: 5ac25104279a5589381ade8bd8e56552
-  constrains:
-  - __osx >=10.12
-  license: CC0-1.0
-  size: 1113461
-  timestamp: 1708241218651
-- kind: conda
-  name: just
-  version: 1.24.0
   build: h1d8f897_0
   subdir: linux-aarch64
   url: https://conda.anaconda.org/conda-forge/linux-aarch64/just-1.24.0-h1d8f897_0.conda
@@ -7814,46 +6024,6 @@ packages:
   license: CC0-1.0
   size: 1104293
   timestamp: 1708246328468
-- kind: conda
-  name: just
-  version: 1.24.0
-  build: h5ef7bb8_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/just-1.24.0-h5ef7bb8_0.conda
-  sha256: 8a887ad3b46cb7df6e6f28301bf498a1d546a191b4e856f5ec68b51508534efd
-  md5: cd1e84db2e7aafc373279d6ac9746e20
-  constrains:
-  - __osx >=11.0
-  license: CC0-1.0
-  size: 1033268
-  timestamp: 1708241219422
-- kind: conda
-  name: just
-  version: 1.24.0
-  build: h7f3b576_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/just-1.24.0-h7f3b576_0.conda
-  sha256: 00ef2294055adaf43115f0929172e8cd6cecec3ec03fa73d0fd10d6c34ed4aa2
-  md5: 969f459714747b46af1159ee41dabd6d
-  depends:
-  - m2w64-gcc-libs
-  - m2w64-gcc-libs-core
-  license: CC0-1.0
-  size: 1166282
-  timestamp: 1708241728702
-- kind: conda
-  name: just
-  version: 1.24.0
-  build: he8a937b_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/just-1.24.0-he8a937b_0.conda
-  sha256: 6d230b47d7548158e92d54580abdb2c1c767c986dc3d72431db7025570bf82cd
-  md5: 1de85b6ac80b52ce66fab344945cf2c3
-  depends:
-  - libgcc-ng >=12
-  license: CC0-1.0
-  size: 1203601
-  timestamp: 1708240909235
 - kind: conda
   name: kernel-headers_linux-64
   version: 2.6.32
@@ -8323,47 +6493,6 @@ packages:
 - kind: conda
   name: libarrow
   version: 14.0.2
-  build: h2a83f13_13_cpu
-  build_number: 13
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-14.0.2-h2a83f13_13_cpu.conda
-  sha256: 1e20499fa3ec9e4abb03ec91fa5422019868b36dcf2ae3d123e1b5785a9c7424
-  md5: 3c1e5bd6b032045ee42bb09302f1c01f
-  depends:
-  - aws-crt-cpp >=0.26.3,<0.26.4.0a0
-  - aws-sdk-cpp >=1.11.267,<1.11.268.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libbrotlidec >=1.1.0,<1.2.0a0
-  - libbrotlienc >=1.1.0,<1.2.0a0
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libgoogle-cloud >=2.22.0,<2.23.0a0
-  - libgoogle-cloud-storage >=2.22.0,<2.23.0a0
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libutf8proc >=2.8.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - openssl >=3.2.1,<4.0a0
-  - orc >=2.0.0,<2.0.1.0a0
-  - re2
-  - snappy >=1.1.10,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
-  constrains:
-  - parquet-cpp <0.0a0
-  - arrow-cpp <0.0a0
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 4907643
-  timestamp: 1710345937957
-- kind: conda
-  name: libarrow
-  version: 14.0.2
   build: h4c2354f_10_cpu
   build_number: 10
   subdir: osx-arm64
@@ -8472,81 +6601,6 @@ packages:
   license_family: APACHE
   size: 8080771
   timestamp: 1708689749260
-- kind: conda
-  name: libarrow
-  version: 14.0.2
-  build: h5233fb5_13_cpu
-  build_number: 13
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.2-h5233fb5_13_cpu.conda
-  sha256: b2fdb38eac0220e2588548c13e1b599e567c147450e19011cb661786085c64f0
-  md5: 5964f068ac691eb417ecc6173e3ec288
-  depends:
-  - aws-crt-cpp >=0.26.3,<0.26.4.0a0
-  - aws-sdk-cpp >=1.11.267,<1.11.268.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - glog >=0.7.0,<0.8.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libbrotlidec >=1.1.0,<1.2.0a0
-  - libbrotlienc >=1.1.0,<1.2.0a0
-  - libcxx >=14
-  - libgoogle-cloud >=2.22.0,<2.23.0a0
-  - libgoogle-cloud-storage >=2.22.0,<2.23.0a0
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libutf8proc >=2.8.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - orc >=2.0.0,<2.0.1.0a0
-  - re2
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  constrains:
-  - parquet-cpp <0.0a0
-  - apache-arrow-proc =*=cpu
-  - arrow-cpp <0.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 5325718
-  timestamp: 1710345870461
-- kind: conda
-  name: libarrow
-  version: 14.0.2
-  build: h6bfc85a_13_cpu
-  build_number: 13
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.2-h6bfc85a_13_cpu.conda
-  sha256: f62f6a0a50b94f55c4ee90288b599c17980f1c0b7d18ae9533c42fc18437fc8f
-  md5: 0b97d14e02c9a6c3a259f9cd88335c9f
-  depends:
-  - aws-crt-cpp >=0.26.3,<0.26.4.0a0
-  - aws-sdk-cpp >=1.11.267,<1.11.268.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - glog >=0.7.0,<0.8.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libbrotlidec >=1.1.0,<1.2.0a0
-  - libbrotlienc >=1.1.0,<1.2.0a0
-  - libgcc-ng >=12
-  - libgoogle-cloud >=2.22.0,<2.23.0a0
-  - libgoogle-cloud-storage >=2.22.0,<2.23.0a0
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libstdcxx-ng >=12
-  - libutf8proc >=2.8.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - orc >=2.0.0,<2.0.1.0a0
-  - re2
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  constrains:
-  - apache-arrow-proc =*=cpu
-  - parquet-cpp <0.0a0
-  - arrow-cpp <0.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 8070162
-  timestamp: 1710345363045
 - kind: conda
   name: libarrow
   version: 14.0.2
@@ -8664,44 +6718,6 @@ packages:
   size: 5696868
   timestamp: 1708690271784
 - kind: conda
-  name: libarrow
-  version: 14.0.2
-  build: he79e29d_13_cpu
-  build_number: 13
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.2-he79e29d_13_cpu.conda
-  sha256: 613a144ad341462f08e7be43a028441501c810dc59023cbe12e3e56e27ad1c92
-  md5: 02fa4f5f3f8287b5914f8ee7cff7487b
-  depends:
-  - __osx >=10.13
-  - aws-crt-cpp >=0.26.3,<0.26.4.0a0
-  - aws-sdk-cpp >=1.11.267,<1.11.268.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - glog >=0.7.0,<0.8.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libbrotlidec >=1.1.0,<1.2.0a0
-  - libbrotlienc >=1.1.0,<1.2.0a0
-  - libcxx >=14
-  - libgoogle-cloud >=2.22.0,<2.23.0a0
-  - libgoogle-cloud-storage >=2.22.0,<2.23.0a0
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libutf8proc >=2.8.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - orc >=2.0.0,<2.0.1.0a0
-  - re2
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  constrains:
-  - arrow-cpp <0.0a0
-  - apache-arrow-proc =*=cpu
-  - parquet-cpp <0.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 5718166
-  timestamp: 1710346534084
-- kind: conda
   name: libarrow-acero
   version: 14.0.2
   build: h000cb23_10_cpu
@@ -8717,22 +6733,6 @@ packages:
   license_family: APACHE
   size: 512509
   timestamp: 1708690347206
-- kind: conda
-  name: libarrow-acero
-  version: 14.0.2
-  build: h000cb23_13_cpu
-  build_number: 13
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.2-h000cb23_13_cpu.conda
-  sha256: bd071a96a8b4da5cf7fe88d586c5ecc77cff17a80dc5bb46873c73d29c70f788
-  md5: f8a9bb4d1aef7853c734c829456efcff
-  depends:
-  - libarrow 14.0.2 he79e29d_13_cpu
-  - libcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  size: 512740
-  timestamp: 1710346674065
 - kind: conda
   name: libarrow-acero
   version: 14.0.2
@@ -8765,22 +6765,6 @@ packages:
   license_family: APACHE
   size: 494852
   timestamp: 1708691198827
-- kind: conda
-  name: libarrow-acero
-  version: 14.0.2
-  build: h13dd4ca_13_cpu
-  build_number: 13
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.2-h13dd4ca_13_cpu.conda
-  sha256: c43bf0f7c5fda78df3830656ad600b061fe3a3d1a2596f95e1d152fa9d36c936
-  md5: c9f53116aac6f41597e004e42f479591
-  depends:
-  - libarrow 14.0.2 h5233fb5_13_cpu
-  - libcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  size: 495434
-  timestamp: 1710345986422
 - kind: conda
   name: libarrow-acero
   version: 14.0.2
@@ -8834,23 +6818,6 @@ packages:
 - kind: conda
   name: libarrow-acero
   version: 14.0.2
-  build: h59595ed_13_cpu
-  build_number: 13
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.2-h59595ed_13_cpu.conda
-  sha256: 16cadd969ffd3d68a0821c7d9af4fb7772ad2f54187852b09026677a1c203410
-  md5: 28e25c6db46fc5542c858cf701909d84
-  depends:
-  - libarrow 14.0.2 h6bfc85a_13_cpu
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  size: 577795
-  timestamp: 1710345426232
-- kind: conda
-  name: libarrow-acero
-  version: 14.0.2
   build: h59595ed_3_cpu
   build_number: 3
   subdir: linux-64
@@ -8884,24 +6851,6 @@ packages:
   size: 430548
   timestamp: 1708690137226
 - kind: conda
-  name: libarrow-acero
-  version: 14.0.2
-  build: h63175ca_13_cpu
-  build_number: 13
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-14.0.2-h63175ca_13_cpu.conda
-  sha256: 8ee3b272ebdadbf4e41f4ea4d1b36db62555870378f8be941f83220bf3cd3b2e
-  md5: 389ccdec73910798474ab1517d5a5747
-  depends:
-  - libarrow 14.0.2 h2a83f13_13_cpu
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 431459
-  timestamp: 1710346036673
-- kind: conda
   name: libarrow-dataset
   version: 14.0.2
   build: h000cb23_10_cpu
@@ -8919,24 +6868,6 @@ packages:
   license_family: APACHE
   size: 511903
   timestamp: 1708690574393
-- kind: conda
-  name: libarrow-dataset
-  version: 14.0.2
-  build: h000cb23_13_cpu
-  build_number: 13
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.2-h000cb23_13_cpu.conda
-  sha256: 0f013a4a208723516f0049585994dc2363c120cf11c18849c4b3b01bc4986f40
-  md5: d6db4c70e3a1fc9ac0a48c9165e2e820
-  depends:
-  - libarrow 14.0.2 he79e29d_13_cpu
-  - libarrow-acero 14.0.2 h000cb23_13_cpu
-  - libcxx >=14
-  - libparquet 14.0.2 h381d950_13_cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 512999
-  timestamp: 1710347067673
 - kind: conda
   name: libarrow-dataset
   version: 14.0.2
@@ -8973,24 +6904,6 @@ packages:
   license_family: APACHE
   size: 526964
   timestamp: 1708691531170
-- kind: conda
-  name: libarrow-dataset
-  version: 14.0.2
-  build: h13dd4ca_13_cpu
-  build_number: 13
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.2-h13dd4ca_13_cpu.conda
-  sha256: a0833d1bc74cb554ab5da8b01f65c77525190b295da1d77071adc778ebfb1072
-  md5: 90c1416a2538df8b3343716cfec2c4f8
-  depends:
-  - libarrow 14.0.2 h5233fb5_13_cpu
-  - libarrow-acero 14.0.2 h13dd4ca_13_cpu
-  - libcxx >=14
-  - libparquet 14.0.2 hf6ce1d5_13_cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 527932
-  timestamp: 1710346391216
 - kind: conda
   name: libarrow-dataset
   version: 14.0.2
@@ -9050,25 +6963,6 @@ packages:
 - kind: conda
   name: libarrow-dataset
   version: 14.0.2
-  build: h59595ed_13_cpu
-  build_number: 13
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.2-h59595ed_13_cpu.conda
-  sha256: eae222df321ea3408a3b28ea85cb40504e86975cd6f258d37912f6ce6d0b9ad1
-  md5: 5266653f8b74e0ba57401be532055410
-  depends:
-  - libarrow 14.0.2 h6bfc85a_13_cpu
-  - libarrow-acero 14.0.2 h59595ed_13_cpu
-  - libgcc-ng >=12
-  - libparquet 14.0.2 h352af49_13_cpu
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  size: 581399
-  timestamp: 1710345583152
-- kind: conda
-  name: libarrow-dataset
-  version: 14.0.2
   build: h59595ed_3_cpu
   build_number: 3
   subdir: linux-64
@@ -9106,48 +7000,6 @@ packages:
   size: 429115
   timestamp: 1708690422907
 - kind: conda
-  name: libarrow-dataset
-  version: 14.0.2
-  build: h63175ca_13_cpu
-  build_number: 13
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-14.0.2-h63175ca_13_cpu.conda
-  sha256: 50ba7bff4899da18c8791071cbc733496eccc65d6948b2faac6a5f2e0a98e9b7
-  md5: daeb4b650d02b601783ea6799f9afd6c
-  depends:
-  - libarrow 14.0.2 h2a83f13_13_cpu
-  - libarrow-acero 14.0.2 h63175ca_13_cpu
-  - libparquet 14.0.2 h7ec3a38_13_cpu
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 429023
-  timestamp: 1710346405791
-- kind: conda
-  name: libarrow-flight
-  version: 14.0.2
-  build: h02312f3_13_cpu
-  build_number: 13
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-14.0.2-h02312f3_13_cpu.conda
-  sha256: 9a64a061f5d42e7c021f9e65066957cd1650f6a97cf3897363111b52f464021f
-  md5: f51f43c16adcee3ed9a1e151c1aeb92e
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 14.0.2 h2a83f13_13_cpu
-  - libgrpc >=1.62.1,<1.63.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 286961
-  timestamp: 1710346136713
-- kind: conda
   name: libarrow-flight
   version: 14.0.2
   build: h120cb0d_3_cpu
@@ -9169,27 +7021,6 @@ packages:
   license_family: APACHE
   size: 501085
   timestamp: 1706609649937
-- kind: conda
-  name: libarrow-flight
-  version: 14.0.2
-  build: h2382776_13_cpu
-  build_number: 13
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.2-h2382776_13_cpu.conda
-  sha256: bbd32e1906eb567d95d41b72d64f993d88761dc2b2760fe508854baab7802966
-  md5: 3bf6df6c793a2ea01f3e0612c741b372
-  depends:
-  - __osx >=10.13
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 14.0.2 he79e29d_13_cpu
-  - libcxx >=14
-  - libgrpc >=1.62.1,<1.63.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 322715
-  timestamp: 1710346774669
 - kind: conda
   name: libarrow-flight
   version: 14.0.2
@@ -9236,26 +7067,6 @@ packages:
 - kind: conda
   name: libarrow-flight
   version: 14.0.2
-  build: h95ca633_13_cpu
-  build_number: 13
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.2-h95ca633_13_cpu.conda
-  sha256: c44b819b5efb283c01aa43c805de17266cb407256c4e86427bb64b6cfd392e42
-  md5: 392cd88b061dbc1c4366871e65a68ed9
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 14.0.2 h5233fb5_13_cpu
-  - libcxx >=14
-  - libgrpc >=1.62.1,<1.63.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 333172
-  timestamp: 1710346111062
-- kind: conda
-  name: libarrow-flight
-  version: 14.0.2
   build: ha1803ca_3_cpu
   build_number: 3
   subdir: osx-64
@@ -9294,28 +7105,6 @@ packages:
   license_family: APACHE
   size: 332020
   timestamp: 1706610826254
-- kind: conda
-  name: libarrow-flight
-  version: 14.0.2
-  build: hc6145d9_13_cpu
-  build_number: 13
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.2-hc6145d9_13_cpu.conda
-  sha256: 5bb091f548f124d9aa0f1a2bb070be2f3713dabd7995e7b82c61427cf7b1f9a5
-  md5: be1e8c18e141e9fb3358f1225c583d0d
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 14.0.2 h6bfc85a_13_cpu
-  - libgcc-ng >=12
-  - libgrpc >=1.62.1,<1.63.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  - ucx >=1.15.0,<1.16.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 503693
-  timestamp: 1710345464269
 - kind: conda
   name: libarrow-flight
   version: 14.0.2
@@ -9459,26 +7248,6 @@ packages:
 - kind: conda
   name: libarrow-flight-sql
   version: 14.0.2
-  build: h55b4db4_13_cpu
-  build_number: 13
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-14.0.2-h55b4db4_13_cpu.conda
-  sha256: 4ba5130101c323580e9f8ae86ab9a7389aa1a27a62c1d793e89cc99d24ff84c2
-  md5: 8c27d39e7147c7ee420bcbdf12b83200
-  depends:
-  - libarrow 14.0.2 h2a83f13_13_cpu
-  - libarrow-flight 14.0.2 h02312f3_13_cpu
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 235314
-  timestamp: 1710346485995
-- kind: conda
-  name: libarrow-flight-sql
-  version: 14.0.2
   build: h5f273fa_10_cpu
   build_number: 10
   subdir: osx-arm64
@@ -9513,44 +7282,6 @@ packages:
   license_family: APACHE
   size: 195809
   timestamp: 1706609745191
-- kind: conda
-  name: libarrow-flight-sql
-  version: 14.0.2
-  build: h757c851_13_cpu
-  build_number: 13
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.2-h757c851_13_cpu.conda
-  sha256: 669a52f7240ab55fa51b89c805acb91c89975db6081347aff14ea8363c9f2b34
-  md5: 690b85e4586d37c997a090d42e20295a
-  depends:
-  - libarrow 14.0.2 h6bfc85a_13_cpu
-  - libarrow-flight 14.0.2 hc6145d9_13_cpu
-  - libgcc-ng >=12
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  size: 195497
-  timestamp: 1710345622444
-- kind: conda
-  name: libarrow-flight-sql
-  version: 14.0.2
-  build: h7e3fe20_13_cpu
-  build_number: 13
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.2-h7e3fe20_13_cpu.conda
-  sha256: 90bd62adf53cd99da17365ab73f53b90df0af79b6861a9e21051b1a0b811174e
-  md5: 4c5fea48489a40db78b2fcbfe262900f
-  depends:
-  - __osx >=10.13
-  - libarrow 14.0.2 he79e29d_13_cpu
-  - libarrow-flight 14.0.2 h2382776_13_cpu
-  - libcxx >=14
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 155420
-  timestamp: 1710347160360
 - kind: conda
   name: libarrow-flight-sql
   version: 14.0.2
@@ -9589,24 +7320,6 @@ packages:
   license_family: APACHE
   size: 182885
   timestamp: 1710293099163
-- kind: conda
-  name: libarrow-flight-sql
-  version: 14.0.2
-  build: hdc5392b_13_cpu
-  build_number: 13
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.2-hdc5392b_13_cpu.conda
-  sha256: a74ba3c1ed45cc6b89b66b5dd465d6a1210bc75481d79b80028034f404a7968a
-  md5: d98a1133d4bba9a05325954e662f5295
-  depends:
-  - libarrow 14.0.2 h5233fb5_13_cpu
-  - libarrow-flight 14.0.2 h95ca633_13_cpu
-  - libcxx >=14
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 163324
-  timestamp: 1710346482468
 - kind: conda
   name: libarrow-gandiva
   version: 14.0.2
@@ -9727,30 +7440,6 @@ packages:
 - kind: conda
   name: libarrow-gandiva
   version: 14.0.2
-  build: ha5acb15_13_cpu
-  build_number: 13
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.2-ha5acb15_13_cpu.conda
-  sha256: 6d06c71df682907daf6a37deac2fac394388b8e3947b5171ba6fa280e45b1ebc
-  md5: e864ce81130c6fbae77fd7ffb768b41d
-  depends:
-  - __osx >=10.13
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 14.0.2 he79e29d_13_cpu
-  - libcxx >=14
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libutf8proc >=2.8.0,<3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - re2
-  license: Apache-2.0
-  license_family: APACHE
-  size: 700321
-  timestamp: 1710346874742
-- kind: conda
-  name: libarrow-gandiva
-  version: 14.0.2
   build: hacb8726_3_cpu
   build_number: 3
   subdir: linux-64
@@ -9770,55 +7459,6 @@ packages:
   license_family: APACHE
   size: 895232
   timestamp: 1706609674431
-- kind: conda
-  name: libarrow-gandiva
-  version: 14.0.2
-  build: hb016d2e_13_cpu
-  build_number: 13
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.2-hb016d2e_13_cpu.conda
-  sha256: a82694957ba8209fa9eb7f5e26c4ad71a936fe3c963c133368c60da078267566
-  md5: 677a678f1794a6a6c4efff894a5a92cb
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 14.0.2 h6bfc85a_13_cpu
-  - libgcc-ng >=12
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libstdcxx-ng >=12
-  - libutf8proc >=2.8.0,<3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - re2
-  license: Apache-2.0
-  license_family: APACHE
-  size: 894432
-  timestamp: 1710345503892
-- kind: conda
-  name: libarrow-gandiva
-  version: 14.0.2
-  build: hcb01e45_13_cpu
-  build_number: 13
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-14.0.2-hcb01e45_13_cpu.conda
-  sha256: 0d5764893b016216fada279215d7ac77d7791f1e724cb3d977538720e1ab3158
-  md5: b01782c5a1e218bc257bb0a15fabd8b5
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 14.0.2 h2a83f13_13_cpu
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libutf8proc >=2.8.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - re2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 10177269
-  timestamp: 1710346223297
 - kind: conda
   name: libarrow-gandiva
   version: 14.0.2
@@ -9864,29 +7504,6 @@ packages:
   license_family: APACHE
   size: 688245
   timestamp: 1706610908126
-- kind: conda
-  name: libarrow-gandiva
-  version: 14.0.2
-  build: hfef958d_13_cpu
-  build_number: 13
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.2-hfef958d_13_cpu.conda
-  sha256: 692521ca74dc6ce6de168a5ae1d1c11136b0541af5e2aab388deeb3c35e61a59
-  md5: 28e850b27dd93367bb783d0d16d55afc
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 14.0.2 h5233fb5_13_cpu
-  - libcxx >=14
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libutf8proc >=2.8.0,<3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - re2
-  license: Apache-2.0
-  license_family: APACHE
-  size: 688483
-  timestamp: 1710346205367
 - kind: conda
   name: libarrow-substrait
   version: 14.0.2
@@ -9969,46 +7586,6 @@ packages:
 - kind: conda
   name: libarrow-substrait
   version: 14.0.2
-  build: h757c851_13_cpu
-  build_number: 13
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.2-h757c851_13_cpu.conda
-  sha256: e4e15042a93bc3a6e4e0717a2802c6859a5a9cafdcc8f49957f0948a249b2816
-  md5: 15c79e6f7b9686ebff4d687a33a52a76
-  depends:
-  - libarrow 14.0.2 h6bfc85a_13_cpu
-  - libarrow-acero 14.0.2 h59595ed_13_cpu
-  - libarrow-dataset 14.0.2 h59595ed_13_cpu
-  - libgcc-ng >=12
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  size: 518209
-  timestamp: 1710345660675
-- kind: conda
-  name: libarrow-substrait
-  version: 14.0.2
-  build: h7e3fe20_13_cpu
-  build_number: 13
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.2-h7e3fe20_13_cpu.conda
-  sha256: 4e27d6f673e8ef27d62d5c5a8bd00a8ae2b93d65c0b90373f2a5917479d6e68d
-  md5: c50111280b8d2f2c176d949e5c7ddfd1
-  depends:
-  - __osx >=10.13
-  - libarrow 14.0.2 he79e29d_13_cpu
-  - libarrow-acero 14.0.2 h000cb23_13_cpu
-  - libarrow-dataset 14.0.2 h000cb23_13_cpu
-  - libcxx >=14
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 454371
-  timestamp: 1710347255673
-- kind: conda
-  name: libarrow-substrait
-  version: 14.0.2
   build: h7fd9903_3_cpu
   build_number: 3
   subdir: osx-arm64
@@ -10025,29 +7602,6 @@ packages:
   license_family: APACHE
   size: 472877
   timestamp: 1706611234135
-- kind: conda
-  name: libarrow-substrait
-  version: 14.0.2
-  build: h89268de_13_cpu
-  build_number: 13
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-14.0.2-h89268de_13_cpu.conda
-  sha256: 816be5f4ac5ed5b35fcc3966b39314acbf9aef31e50162656b53d103560f002c
-  md5: c3599d0881c8f26df0900993f40f7c10
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 14.0.2 h2a83f13_13_cpu
-  - libarrow-acero 14.0.2 h63175ca_13_cpu
-  - libarrow-dataset 14.0.2 h63175ca_13_cpu
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 361120
-  timestamp: 1710346569221
 - kind: conda
   name: libarrow-substrait
   version: 14.0.2
@@ -10088,25 +7642,6 @@ packages:
   license_family: APACHE
   size: 503549
   timestamp: 1710293136119
-- kind: conda
-  name: libarrow-substrait
-  version: 14.0.2
-  build: hef52601_13_cpu
-  build_number: 13
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.2-hef52601_13_cpu.conda
-  sha256: 3a9302c70f68e7b1fd433b5b0176b8317fb85ea840155c520ae012c619c5785c
-  md5: d5ac1ee4616a6caa87ba3f84b47e3de1
-  depends:
-  - libarrow 14.0.2 h5233fb5_13_cpu
-  - libarrow-acero 14.0.2 h13dd4ca_13_cpu
-  - libarrow-dataset 14.0.2 h13dd4ca_13_cpu
-  - libcxx >=14
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 473073
-  timestamp: 1710346607250
 - kind: conda
   name: libarrow-substrait
   version: 14.0.2
@@ -10737,23 +8272,6 @@ packages:
 - kind: conda
   name: libclang-cpp16
   version: 16.0.6
-  build: default_h127d8a8_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp16-16.0.6-default_h127d8a8_5.conda
-  sha256: 8d034d92a7f7a9841796297bc18c2d8d8133583a6f3b661bfb1ca88ba01a076b
-  md5: 9fed40c47995a15eca939c4562d879bf
-  depends:
-  - libgcc-ng >=12
-  - libllvm16 >=16.0.6,<16.1.0a0
-  - libstdcxx-ng >=12
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 17942793
-  timestamp: 1709764754399
-- kind: conda
-  name: libclang-cpp16
-  version: 16.0.6
   build: default_h7151d67_5
   build_number: 5
   subdir: osx-64
@@ -10931,70 +8449,6 @@ packages:
   license_family: Apache
   size: 7164068
   timestamp: 1704280614681
-- kind: conda
-  name: libclang13
-  version: 18.1.1
-  build: default_h0edc4dd_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libclang13-18.1.1-default_h0edc4dd_0.conda
-  sha256: 6706f35efe4f45bd50c56854e93715eb59bb948feb098aabd23923d5bbd409a7
-  md5: badbda562ead0bcae661586067298002
-  depends:
-  - libcxx >=16.0.6
-  - libllvm18 >=18.1.1,<18.2.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 8055181
-  timestamp: 1710477023799
-- kind: conda
-  name: libclang13
-  version: 18.1.1
-  build: default_h5d6823c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-18.1.1-default_h5d6823c_0.conda
-  sha256: eab9467b8e7bef6152af4ac2a167abab76f5453396f62755605cfa53eadafea7
-  md5: 68ad4732fc951212bcc67e7d60de42e5
-  depends:
-  - libgcc-ng >=12
-  - libllvm18 >=18.1.1,<18.2.0a0
-  - libstdcxx-ng >=12
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 11069471
-  timestamp: 1710472508192
-- kind: conda
-  name: libclang13
-  version: 18.1.1
-  build: default_h83d0a53_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-18.1.1-default_h83d0a53_0.conda
-  sha256: a3e12d97d6f3a06b1375eca3057e12c262be568755236689efb076352eb84636
-  md5: 591cdf454c3db0328daf524a5b6b15d0
-  depends:
-  - libcxx >=16.0.6
-  - libllvm18 >=18.1.1,<18.2.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 7513624
-  timestamp: 1710475008752
-- kind: conda
-  name: libclang13
-  version: 18.1.1
-  build: default_hf64faad_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-18.1.1-default_hf64faad_0.conda
-  sha256: 36dbad4abb730d6ba9904d60cac670c2b9d19bd11a5664db67b9c17660cef43a
-  md5: 2a7bf5472a4decbe0f800c84c384fb08
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 25314400
-  timestamp: 1710479378028
 - kind: conda
   name: libclang13
   version: 18.1.1
@@ -11528,64 +8982,6 @@ packages:
   license_family: MIT
   size: 72544
   timestamp: 1710362309065
-- kind: conda
-  name: libexpat
-  version: 2.6.2
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
-  sha256: 331bb7c7c05025343ebd79f86ae612b9e1e74d2687b8f3179faec234f986ce19
-  md5: e7ba12deb7020dd080c6c70e7b6f6a3d
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - expat 2.6.2.*
-  license: MIT
-  license_family: MIT
-  size: 73730
-  timestamp: 1710362120304
-- kind: conda
-  name: libexpat
-  version: 2.6.2
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
-  sha256: 79f612f75108f3e16bbdc127d4885bb74729cf66a8702fca0373dad89d40c4b7
-  md5: bc592d03f62779511d392c175dcece64
-  constrains:
-  - expat 2.6.2.*
-  license: MIT
-  license_family: MIT
-  size: 139224
-  timestamp: 1710362609641
-- kind: conda
-  name: libexpat
-  version: 2.6.2
-  build: h73e2aa4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
-  sha256: a188a77b275d61159a32ab547f7d17892226e7dac4518d2c6ac3ac8fc8dfde92
-  md5: 3d1d51c8f716d97c864d12f7af329526
-  constrains:
-  - expat 2.6.2.*
-  license: MIT
-  license_family: MIT
-  size: 69246
-  timestamp: 1710362566073
-- kind: conda
-  name: libexpat
-  version: 2.6.2
-  build: hebf3989_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
-  sha256: ba7173ac30064ea901a4c9fb5a51846dcc25512ceb565759be7d18cbf3e5415e
-  md5: e3cde7cfa87f82f7cb13d482d5e0ad09
-  constrains:
-  - expat 2.6.2.*
-  license: MIT
-  license_family: MIT
-  size: 63655
-  timestamp: 1710362424980
 - kind: conda
   name: libffi
   version: 3.4.2
@@ -12189,102 +9585,6 @@ packages:
 - kind: conda
   name: libgoogle-cloud
   version: 2.22.0
-  build: h651e89d_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.22.0-h651e89d_1.conda
-  sha256: 39f2f50202e50e41ee8581c99a0b3023c2c21cab80ba597f8c5be7c8c8c6a059
-  md5: 3f2faf53ecb3b51b92b3eee155b50233
-  depends:
-  - __osx >=10.13
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libcxx >=16
-  - libgrpc >=1.62.0,<1.63.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - openssl >=3.2.1,<4.0a0
-  constrains:
-  - libgoogle-cloud 2.22.0 *_1
-  license: Apache-2.0
-  license_family: Apache
-  size: 849198
-  timestamp: 1709738549021
-- kind: conda
-  name: libgoogle-cloud
-  version: 2.22.0
-  build: h9be4e54_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.22.0-h9be4e54_1.conda
-  sha256: b9980209438b22113f4352df2b260bf43b2eb63a7b6325192ec5ae3a562872ed
-  md5: 4b4e36a91e7dabf7345b82d85767a7c3
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libgcc-ng >=12
-  - libgrpc >=1.62.0,<1.63.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  - openssl >=3.2.1,<4.0a0
-  constrains:
-  - libgoogle-cloud 2.22.0 *_1
-  license: Apache-2.0
-  license_family: Apache
-  size: 1209816
-  timestamp: 1709737846418
-- kind: conda
-  name: libgoogle-cloud
-  version: 2.22.0
-  build: h9cad5c0_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.22.0-h9cad5c0_1.conda
-  sha256: f76e892d13e1db405777c968787678d8ba912b7e4eef7f950fcdcca185e06e71
-  md5: 63cd44a71f00d4e72844bf0e8be56be4
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libgrpc >=1.62.0,<1.63.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - openssl >=3.2.1,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - libgoogle-cloud 2.22.0 *_1
-  license: Apache-2.0
-  license_family: Apache
-  size: 14420
-  timestamp: 1709737037941
-- kind: conda
-  name: libgoogle-cloud
-  version: 2.22.0
-  build: hbebe991_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.22.0-hbebe991_1.conda
-  sha256: a114b4d46eebede7e514abaf9203ea8c952a6382c5c57d1b989da062e3899bd7
-  md5: ec7ea95b08e8cbc39fa16b6eafee36e6
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libcxx >=16
-  - libgrpc >=1.62.0,<1.63.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - openssl >=3.2.1,<4.0a0
-  constrains:
-  - libgoogle-cloud 2.22.0 *_1
-  license: Apache-2.0
-  license_family: Apache
-  size: 836916
-  timestamp: 1709739767863
-- kind: conda
-  name: libgoogle-cloud
-  version: 2.22.0
   build: hd739bbb_1
   build_number: 1
   subdir: linux-aarch64
@@ -12393,93 +9693,6 @@ packages:
   license_family: Apache
   size: 749865
   timestamp: 1708638542903
-- kind: conda
-  name: libgoogle-cloud-storage
-  version: 2.22.0
-  build: h8a76758_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.22.0-h8a76758_1.conda
-  sha256: e23be5896fd78e0e8b1098aab8803192f0c4a328d3d30a57d20d80194045d793
-  md5: a89fb5b36b08efaae128d4933e593315
-  depends:
-  - libabseil
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl
-  - libcxx >=16
-  - libgoogle-cloud 2.22.0 hbebe991_1
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl
-  license: Apache-2.0
-  license_family: Apache
-  size: 507478
-  timestamp: 1709740510222
-- kind: conda
-  name: libgoogle-cloud-storage
-  version: 2.22.0
-  build: ha67e85c_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.22.0-ha67e85c_1.conda
-  sha256: e4f351e55fe7c0656cb608eba8690063e3b407d25a855c9d1fd832486d4a1244
-  md5: 0c25180c34b1a58d309b28386698fb6e
-  depends:
-  - libabseil
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl
-  - libcxx >=16
-  - libgoogle-cloud 2.22.0 h651e89d_1
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl
-  license: Apache-2.0
-  license_family: Apache
-  size: 523045
-  timestamp: 1709739227970
-- kind: conda
-  name: libgoogle-cloud-storage
-  version: 2.22.0
-  build: hb581fae_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.22.0-hb581fae_1.conda
-  sha256: 5ee34f168948211db14874f521e6edf9b4032d533c61fd429caaa282be1d0e7b
-  md5: f63348292dea55cf834e631cf26e2669
-  depends:
-  - libabseil
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl
-  - libgoogle-cloud 2.22.0 h9cad5c0_1
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 14330
-  timestamp: 1709737542249
-- kind: conda
-  name: libgoogle-cloud-storage
-  version: 2.22.0
-  build: hc7a4891_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.22.0-hc7a4891_1.conda
-  sha256: 0e00e1ca2a981db1c96071edf266bc29fd6f13ac484225de1736fc4dac5c64a8
-  md5: 7811f043944e010e54640918ea82cecd
-  depends:
-  - libabseil
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl
-  - libgcc-ng >=12
-  - libgoogle-cloud 2.22.0 h9be4e54_1
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl
-  license: Apache-2.0
-  license_family: Apache
-  size: 748818
-  timestamp: 1709738181078
 - kind: conda
   name: libgoogle-cloud-storage
   version: 2.22.0
@@ -12688,82 +9901,6 @@ packages:
 - kind: conda
   name: libgrpc
   version: 1.62.1
-  build: h15f2491_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.1-h15f2491_0.conda
-  sha256: 1d4ece94dfef73d904dcba0fd9d56098796f5fdc62ea5f9edff60c71be7a3d63
-  md5: 564517a8cbd095cff75eb996d33d2b7e
-  depends:
-  - c-ares >=1.27.0,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libgcc-ng >=12
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - re2
-  constrains:
-  - grpc-cpp =1.62.1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 7667664
-  timestamp: 1709938059287
-- kind: conda
-  name: libgrpc
-  version: 1.62.1
-  build: h384b2fc_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.62.1-h384b2fc_0.conda
-  sha256: 8c9898d259e2343df52259b599ec342c386679e1c420df603cba6f06078fcdd6
-  md5: 2ac05daca7276a4d6ca4465707670380
-  depends:
-  - __osx >=10.13
-  - c-ares >=1.27.0,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcxx >=16
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - re2
-  constrains:
-  - grpc-cpp =1.62.1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 4432823
-  timestamp: 1709938959215
-- kind: conda
-  name: libgrpc
-  version: 1.62.1
-  build: h5273850_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.62.1-h5273850_0.conda
-  sha256: 338cb58d1095ee651acd168af9636834b41908f7a94e613088e284dc53d2947c
-  md5: 99ac2f772591801641ec692fee843796
-  depends:
-  - c-ares >=1.27.0,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - re2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - grpc-cpp =1.62.1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 15963245
-  timestamp: 1709939262816
-- kind: conda
-  name: libgrpc
-  version: 1.62.1
   build: h98a9317_0
   subdir: linux-aarch64
   url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgrpc-1.62.1-h98a9317_0.conda
@@ -12786,30 +9923,6 @@ packages:
   license_family: APACHE
   size: 6820015
   timestamp: 1709938779780
-- kind: conda
-  name: libgrpc
-  version: 1.62.1
-  build: h9c18a4f_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.62.1-h9c18a4f_0.conda
-  sha256: b8c6b48430d0778e9452df88fa7c07fc7828aac87291372ac42dbe78be4078d5
-  md5: 24f15c1a9e111825d39bf77881430107
-  depends:
-  - c-ares >=1.27.0,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcxx >=16
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - re2
-  constrains:
-  - grpc-cpp =1.62.1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 4753906
-  timestamp: 1709939281511
 - kind: conda
   name: libhwloc
   version: 2.9.3
@@ -13504,58 +10617,6 @@ packages:
 - kind: conda
   name: libllvm18
   version: 18.1.1
-  build: h2448989_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm18-18.1.1-h2448989_0.conda
-  sha256: 4501e62ee42644f158b2273e6cef621c2bac148ebe729fb3ca10b337df83fa3a
-  md5: a77e3c2c568b3b5d8a79b158d0c5dd47
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxml2 >=2.12.5,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 38392079
-  timestamp: 1710432419352
-- kind: conda
-  name: libllvm18
-  version: 18.1.1
-  build: h30cc82d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm18-18.1.1-h30cc82d_0.conda
-  sha256: 35f2fbe7f87c9fda6f36c0ee8efc5b99c347a2f7a0d4bca3d0511b612773a30d
-  md5: a215b38429566e17aa4d9dba24680d0d
-  depends:
-  - libcxx >=16
-  - libxml2 >=2.12.5,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 25777635
-  timestamp: 1710434884978
-- kind: conda
-  name: libllvm18
-  version: 18.1.1
-  build: hbcf5fad_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm18-18.1.1-hbcf5fad_0.conda
-  sha256: d5f0042e48091740f7084d390a4948b2a739acbc4045f852f7561c0597e1a078
-  md5: 9cfc7fa4bdbf1f0558f053285b4b6afb
-  depends:
-  - libcxx >=16
-  - libxml2 >=2.12.5,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 27599082
-  timestamp: 1710435070093
-- kind: conda
-  name: libllvm18
-  version: 18.1.1
   build: hbfe100b_0
   subdir: linux-aarch64
   url: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm18-18.1.1-hbfe100b_0.conda
@@ -13879,25 +10940,6 @@ packages:
 - kind: conda
   name: libparquet
   version: 14.0.2
-  build: h352af49_13_cpu
-  build_number: 13
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.2-h352af49_13_cpu.conda
-  sha256: 3675da7fee45dfe0f053bbcb71b5dc32c58eba86eb04dd5e7dbd2e3f5b076edb
-  md5: 0c4ee07d6a56434b8e1abfdce42ffe9a
-  depends:
-  - libarrow 14.0.2 h6bfc85a_13_cpu
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.1,<4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1160002
-  timestamp: 1710345544372
-- kind: conda
-  name: libparquet
-  version: 14.0.2
   build: h352af49_3_cpu
   build_number: 3
   subdir: linux-64
@@ -13932,24 +10974,6 @@ packages:
   license_family: APACHE
   size: 925350
   timestamp: 1708690516278
-- kind: conda
-  name: libparquet
-  version: 14.0.2
-  build: h381d950_13_cpu
-  build_number: 13
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.2-h381d950_13_cpu.conda
-  sha256: e1227a121d942be15d02ec1fde3e43f2a17e5c5a37ed006e5382977d355a3294
-  md5: 273a1178373fffd8d76a8e813699297e
-  depends:
-  - libarrow 14.0.2 he79e29d_13_cpu
-  - libcxx >=14
-  - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.1,<4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 924906
-  timestamp: 1710346971895
 - kind: conda
   name: libparquet
   version: 14.0.2
@@ -13991,26 +11015,6 @@ packages:
 - kind: conda
   name: libparquet
   version: 14.0.2
-  build: h7ec3a38_13_cpu
-  build_number: 13
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-14.0.2-h7ec3a38_13_cpu.conda
-  sha256: d59b700882bbe39cb387151638bb0becbbb04c86a668426867fb32bad8a37d82
-  md5: babba3c50f817f425964de492844a521
-  depends:
-  - libarrow 14.0.2 h2a83f13_13_cpu
-  - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.1,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  size: 782893
-  timestamp: 1710346323580
-- kind: conda
-  name: libparquet
-  version: 14.0.2
   build: hb18b541_12_cpu
   build_number: 12
   subdir: linux-aarch64
@@ -14045,24 +11049,6 @@ packages:
   license_family: APACHE
   size: 910129
   timestamp: 1708691448291
-- kind: conda
-  name: libparquet
-  version: 14.0.2
-  build: hf6ce1d5_13_cpu
-  build_number: 13
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.2-hf6ce1d5_13_cpu.conda
-  sha256: f265cc71bb623ce3fef0a681a4744d35562e1ae9a8ed23707cf0d629dc2763ff
-  md5: 9451897b618c5007a9adc5d9b4ebb0e2
-  depends:
-  - libarrow 14.0.2 h5233fb5_13_cpu
-  - libcxx >=14
-  - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.1,<4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 909954
-  timestamp: 1710346299150
 - kind: conda
   name: libparquet
   version: 14.0.2
@@ -14221,61 +11207,6 @@ packages:
 - kind: conda
   name: libprotobuf
   version: 4.25.3
-  build: h08a7969_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
-  sha256: 70e0eef046033af2e8d21251a785563ad738ed5281c74e21c31c457780845dcd
-  md5: 6945825cebd2aeb16af4c69d97c32c13
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2811207
-  timestamp: 1709514552541
-- kind: conda
-  name: libprotobuf
-  version: 4.25.3
-  build: h4e4d658_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.3-h4e4d658_0.conda
-  sha256: 3f126769fb5820387d436370ad48600e05d038a28689fdf9988b64e1059947a8
-  md5: 57b7ee4f1fd8573781cfdabaec4a7782
-  depends:
-  - __osx >=10.13
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2216001
-  timestamp: 1709514908146
-- kind: conda
-  name: libprotobuf
-  version: 4.25.3
-  build: h503648d_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.3-h503648d_0.conda
-  sha256: 5d4c5592be3994657ebf47e52f26b734cc50b0ea9db007d920e2e31762aac216
-  md5: 4da7de0ba35777742edf67bf7a1075df
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5650604
-  timestamp: 1709514804631
-- kind: conda
-  name: libprotobuf
-  version: 4.25.3
   build: h648ac29_0
   subdir: linux-aarch64
   url: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-4.25.3-h648ac29_0.conda
@@ -14291,23 +11222,6 @@ packages:
   license_family: BSD
   size: 2576197
   timestamp: 1709513627963
-- kind: conda
-  name: libprotobuf
-  version: 4.25.3
-  build: hbfab5d5_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.3-hbfab5d5_0.conda
-  sha256: d754519abc3ddbdedab2a38d0639170f5347c1573eef80c707f3a8dc5dff706a
-  md5: 5f70b2b945a9741cba7e6dfe735a02a7
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2154402
-  timestamp: 1709514097574
 - kind: conda
   name: libre2-11
   version: 2023.06.02
@@ -14539,19 +11453,6 @@ packages:
 - kind: conda
   name: libsqlite
   version: 3.45.2
-  build: h091b4b1_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.2-h091b4b1_0.conda
-  sha256: 7c234320a1a2132b9cc972aaa06bb215bb220a5b1addb0bed7a5a321c805920e
-  md5: 9d07427ee5bd9afd1e11ce14368a48d6
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  license: Unlicense
-  size: 825300
-  timestamp: 1710255078823
-- kind: conda
-  name: libsqlite
-  version: 3.45.2
   build: h194ca79_0
   subdir: linux-aarch64
   url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.45.2-h194ca79_0.conda
@@ -14563,48 +11464,6 @@ packages:
   license: Unlicense
   size: 1038462
   timestamp: 1710253998432
-- kind: conda
-  name: libsqlite
-  version: 3.45.2
-  build: h2797004_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
-  sha256: 8cdbeb7902729e319510a82d7c642402981818702b58812af265ef55d1315473
-  md5: 866983a220e27a80cb75e85cb30466a1
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: Unlicense
-  size: 857489
-  timestamp: 1710254744982
-- kind: conda
-  name: libsqlite
-  version: 3.45.2
-  build: h92b6c6a_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.2-h92b6c6a_0.conda
-  sha256: 320ec73a4e3dd377757a2595770b8137ec4583df4d7782472d76377cdbdc4543
-  md5: 086f56e13a96a6cfb1bf640505ae6b70
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  license: Unlicense
-  size: 902355
-  timestamp: 1710254991672
-- kind: conda
-  name: libsqlite
-  version: 3.45.2
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.2-hcfcfb64_0.conda
-  sha256: 4bb24b986550275a6d02835150d943c4c675808d05c0efc5c2a22154d007a69f
-  md5: f95359f8dc5abf7da7776ece9ef10bc5
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Unlicense
-  size: 869606
-  timestamp: 1710255095740
 - kind: conda
   name: libssh2
   version: 1.11.0
@@ -14999,46 +11858,6 @@ packages:
   license_family: MIT
   size: 893348
   timestamp: 1693539405436
-- kind: conda
-  name: libuv
-  version: 1.47.0
-  build: h67532ce_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.47.0-h67532ce_0.conda
-  sha256: a452b8fbb906e72d6c633ed133413f6a604471597f4c80dc73b4e81d2ef56b32
-  md5: c2c8307836ecebc2799400a4eca27b37
-  license: MIT
-  license_family: MIT
-  size: 404907
-  timestamp: 1707450430194
-- kind: conda
-  name: libuv
-  version: 1.47.0
-  build: h93a5062_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.47.0-h93a5062_0.conda
-  sha256: 802da3ad57041480f15fe0581d6fcd421d9cdae17d796d2b126b0a12aa2d3d44
-  md5: b586a09ba87849e37634cbaf9ea0e60f
-  license: MIT
-  license_family: MIT
-  size: 404350
-  timestamp: 1707450365805
-- kind: conda
-  name: libuv
-  version: 1.48.0
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libuv-1.48.0-hcfcfb64_0.conda
-  sha256: 6151c51857c2407139ce22fdc956022353e675b2bc96991a9201d51cceaa90b4
-  md5: 485e49e1d500d996844df14cabf64d73
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  size: 289753
-  timestamp: 1709913743184
 - kind: conda
   name: libxcrypt
   version: 4.4.36
@@ -15560,24 +12379,6 @@ packages:
   name: markdown-it-py
   version: 3.0.0
   build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-  sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  md5: 93a8e71256479c62074356ef6ebf501b
-  depends:
-  - mdurl >=0.1,<1
-  - python >=3.8
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/markdown-it-py
-  size: 64356
-  timestamp: 1686175179621
-- kind: conda
-  name: markdown-it-py
-  version: 3.0.0
-  build: pyhd8ed1ab_0
   subdir: win-64
   noarch: python
   url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
@@ -15915,23 +12716,6 @@ packages:
   name: mypy_extensions
   version: 1.0.0
   build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-  sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-  md5: 4eccaeba205f0aed9ac3a9ea58568ca3
-  depends:
-  - python >=3.5
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/mypy-extensions
-  size: 10492
-  timestamp: 1675543414256
-- kind: conda
-  name: mypy_extensions
-  version: 1.0.0
-  build: pyha770c72_0
   subdir: win-64
   noarch: python
   url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
@@ -16197,79 +12981,6 @@ packages:
   license_family: MIT
   size: 15614862
   timestamp: 1700389549489
-- kind: conda
-  name: nodejs
-  version: 18.19.0
-  build: h119ffd7_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-18.19.0-h119ffd7_0.conda
-  sha256: 896ca8a8683f7d6c3402364f6d28bd00b9d3cb9acb88c85d2fc9ecefbbf4f7db
-  md5: 022ff05e89afedc3db2decb77a8af207
-  depends:
-  - icu >=73.2,<74.0a0
-  - libcxx >=14
-  - libuv >=1.47.0,<1.48.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - zlib
-  constrains:
-  - __osx >=10.15
-  license: MIT
-  license_family: MIT
-  size: 11439181
-  timestamp: 1707771884027
-- kind: conda
-  name: nodejs
-  version: 18.19.0
-  build: h57928b3_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/nodejs-18.19.0-h57928b3_0.conda
-  sha256: de01dd21f413e0e230b62082d5ee7f25b19b3c7296e1172c7cef94c9d36b8c38
-  md5: 41ce77dc534e5bc71b0fc1687a89dcfd
-  license: MIT
-  license_family: MIT
-  size: 22479049
-  timestamp: 1707403072267
-- kind: conda
-  name: nodejs
-  version: 18.19.0
-  build: h5f47a4d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-18.19.0-h5f47a4d_0.conda
-  sha256: 1263d3c8aa9adaf4e11616dc05fb28cfdb761d70f2298959728f847688073240
-  md5: 7798b881265f448c752fbae08e221b10
-  depends:
-  - icu >=73.2,<74.0a0
-  - libcxx >=14
-  - libuv >=1.47.0,<1.48.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - zlib
-  license: MIT
-  license_family: MIT
-  size: 10879191
-  timestamp: 1707778803050
-- kind: conda
-  name: nodejs
-  version: 18.19.0
-  build: hb753e55_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-18.19.0-hb753e55_0.conda
-  sha256: d233fe4da686125c2b89d588349eccc78cdcb5a75a2b5b5bc9dc4d0c8c23eda1
-  md5: 0b4a67051e3b3812818ccf2f4ee2fd4e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=73.2,<74.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libuv >=1.46.0,<1.47.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - zlib
-  license: MIT
-  license_family: MIT
-  size: 15917143
-  timestamp: 1707407233064
 - kind: conda
   name: nodejs
   version: 18.19.0
@@ -16666,63 +13377,6 @@ packages:
 - kind: conda
   name: orc
   version: 2.0.0
-  build: h1e5e2c1_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.0-h1e5e2c1_0.conda
-  sha256: ed8cfe1f35e8ef703e540e7731e77fade1410bba406e17727a10dee08c37d5b4
-  md5: 53e8f030579d34e1a36a735d527c021f
-  depends:
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 1028974
-  timestamp: 1710232781925
-- kind: conda
-  name: orc
-  version: 2.0.0
-  build: h3d3088e_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.0-h3d3088e_0.conda
-  sha256: 6a1f553e2ea3d2df3c465b02c7ece5c001cc2d3afb1fe7e2678a7ff7a5a14168
-  md5: a8e452c3f2b6fecfd86e8f2b72450a9b
-  depends:
-  - libcxx >=16
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 413922
-  timestamp: 1710233361620
-- kind: conda
-  name: orc
-  version: 2.0.0
-  build: h6c6cd50_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.0-h6c6cd50_0.conda
-  sha256: 0c198b6a8de238d53002e7c03e4b1e94e769cf388adac2717fdaadfee9381a14
-  md5: 5ce58b9a5679fe6640d6d68228099ce9
-  depends:
-  - __osx >=10.13
-  - libcxx >=16
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 433224
-  timestamp: 1710233383447
-- kind: conda
-  name: orc
-  version: 2.0.0
   build: h75d905f_0
   subdir: linux-aarch64
   url: https://conda.anaconda.org/conda-forge/linux-aarch64/orc-2.0.0-h75d905f_0.conda
@@ -16740,27 +13394,6 @@ packages:
   license_family: Apache
   size: 999580
   timestamp: 1710232876736
-- kind: conda
-  name: orc
-  version: 2.0.0
-  build: heb0c069_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.0-heb0c069_0.conda
-  sha256: 5a9c0904f38e5c2e1d1494bd192ff98fca13ca07ed1590497b16a801bef497a0
-  md5: 2733034196c084cdc07e0facfea995ea
-  depends:
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 953672
-  timestamp: 1710233287310
 - kind: conda
   name: packaging
   version: '23.2'
@@ -17205,35 +13838,6 @@ packages:
 - kind: conda
   name: pyarrow
   version: 14.0.2
-  build: py311h39c9aba_13_cpu
-  build_number: 13
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.2-py311h39c9aba_13_cpu.conda
-  sha256: 2eef5e752f71b9a2f74491e0f9d3c9e58761f179f8198cb8d710627ca3e9a13d
-  md5: e95c99f69395f1a43582de9b0d35a553
-  depends:
-  - libarrow 14.0.2 h6bfc85a_13_cpu
-  - libarrow-acero 14.0.2 h59595ed_13_cpu
-  - libarrow-dataset 14.0.2 h59595ed_13_cpu
-  - libarrow-flight 14.0.2 hc6145d9_13_cpu
-  - libarrow-flight-sql 14.0.2 h757c851_13_cpu
-  - libarrow-gandiva 14.0.2 hb016d2e_13_cpu
-  - libarrow-substrait 14.0.2 h757c851_13_cpu
-  - libgcc-ng >=12
-  - libparquet 14.0.2 h352af49_13_cpu
-  - libstdcxx-ng >=12
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 4543451
-  timestamp: 1710347598355
-- kind: conda
-  name: pyarrow
-  version: 14.0.2
   build: py311h39c9aba_3_cpu
   build_number: 3
   subdir: linux-64
@@ -17288,34 +13892,6 @@ packages:
   license_family: APACHE
   size: 4009410
   timestamp: 1708691836141
-- kind: conda
-  name: pyarrow
-  version: 14.0.2
-  build: py311h54e7ce8_13_cpu
-  build_number: 13
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.2-py311h54e7ce8_13_cpu.conda
-  sha256: 543f8b4e7cc6453b64b0dd20b43ac312cc61fe28e10869f04edf5ee29214ce13
-  md5: 9b4945755f71df2d66e2e9af881b4b0c
-  depends:
-  - libarrow 14.0.2 he79e29d_13_cpu
-  - libarrow-acero 14.0.2 h000cb23_13_cpu
-  - libarrow-dataset 14.0.2 h000cb23_13_cpu
-  - libarrow-flight 14.0.2 h2382776_13_cpu
-  - libarrow-flight-sql 14.0.2 h7e3fe20_13_cpu
-  - libarrow-gandiva 14.0.2 ha5acb15_13_cpu
-  - libarrow-substrait 14.0.2 h7e3fe20_13_cpu
-  - libcxx >=14
-  - libparquet 14.0.2 h381d950_13_cpu
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 4020354
-  timestamp: 1710348158705
 - kind: conda
   name: pyarrow
   version: 14.0.2
@@ -17377,36 +13953,6 @@ packages:
 - kind: conda
   name: pyarrow
   version: 14.0.2
-  build: py311h6a6099b_13_cpu
-  build_number: 13
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-14.0.2-py311h6a6099b_13_cpu.conda
-  sha256: 76d0f17e140cb3f22adefe568fa6fb5b0eaec250dc22306d4da21b8ce5869260
-  md5: b22193a1d8c2d28f6c3dbb94da33147d
-  depends:
-  - libarrow 14.0.2 h2a83f13_13_cpu
-  - libarrow-acero 14.0.2 h63175ca_13_cpu
-  - libarrow-dataset 14.0.2 h63175ca_13_cpu
-  - libarrow-flight 14.0.2 h02312f3_13_cpu
-  - libarrow-flight-sql 14.0.2 h55b4db4_13_cpu
-  - libarrow-gandiva 14.0.2 hcb01e45_13_cpu
-  - libarrow-substrait 14.0.2 h89268de_13_cpu
-  - libparquet 14.0.2 h7ec3a38_13_cpu
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3470330
-  timestamp: 1710349686722
-- kind: conda
-  name: pyarrow
-  version: 14.0.2
   build: py311hd7bc329_10_cpu
   build_number: 10
   subdir: osx-arm64
@@ -17433,35 +13979,6 @@ packages:
   license_family: APACHE
   size: 4094429
   timestamp: 1708693258443
-- kind: conda
-  name: pyarrow
-  version: 14.0.2
-  build: py311hd7bc329_13_cpu
-  build_number: 13
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.2-py311hd7bc329_13_cpu.conda
-  sha256: 077d688f4c748f99760d7b8555c6ecf0c071381d2978032316d0c50389a083a0
-  md5: fdd086b17f9ae33004bdd1991ccb1321
-  depends:
-  - libarrow 14.0.2 h5233fb5_13_cpu
-  - libarrow-acero 14.0.2 h13dd4ca_13_cpu
-  - libarrow-dataset 14.0.2 h13dd4ca_13_cpu
-  - libarrow-flight 14.0.2 h95ca633_13_cpu
-  - libarrow-flight-sql 14.0.2 hdc5392b_13_cpu
-  - libarrow-gandiva 14.0.2 hfef958d_13_cpu
-  - libarrow-substrait 14.0.2 hef52601_13_cpu
-  - libcxx >=14
-  - libparquet 14.0.2 hf6ce1d5_13_cpu
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 4084630
-  timestamp: 1710348774061
 - kind: conda
   name: pyarrow
   version: 14.0.2
@@ -17868,24 +14385,6 @@ packages:
   license_family: BSD
   size: 4724921
   timestamp: 1706524445013
-- kind: conda
-  name: rdma-core
-  version: '50.0'
-  build: hd3aeb46_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-50.0-hd3aeb46_1.conda
-  sha256: 85e38508eb4921e53cf1cb97435f9c9408ea2ddc582c6588ec50f3f3ec3abdc0
-  md5: f462219598fcf46c0cdfb985c3482b4f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libnl >=3.9.0,<4.0a0
-  - libstdcxx-ng >=12
-  license: Linux-OpenIB
-  license_family: BSD
-  size: 4713842
-  timestamp: 1710157799992
 - kind: conda
   name: re2
   version: 2023.06.02
@@ -18321,38 +14820,6 @@ packages:
   size: 333810
   timestamp: 1708664562153
 - kind: conda
-  name: s2n
-  version: 1.4.6
-  build: h06160fa_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.6-h06160fa_0.conda
-  sha256: 2d03e27d607e3b797ada1ab805deebdd321c3ec99c1581188ac22041c06fd7b6
-  md5: 88350a8ea5a9aa734b8b553bfd2ff78c
-  depends:
-  - libgcc-ng >=12
-  - openssl >=3.2.1,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 339401
-  timestamp: 1709937040957
-- kind: conda
-  name: semver
-  version: 2.13.0
-  build: pyh9f0ad1d_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
-  sha256: 673ef5ef04cef60c3584b1d9b81024646b9d9a4c50749356c7ba5cede755e61d
-  md5: 2cab9f3a9683cb40a2176ccaf76e66c6
-  depends:
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/semver
-  size: 15712
-  timestamp: 1603697876069
-- kind: conda
   name: semver
   version: 2.13.0
   build: pyh9f0ad1d_0
@@ -18452,23 +14919,6 @@ packages:
   license_family: MIT
   size: 213817
   timestamp: 1643442169866
-- kind: conda
-  name: smmap
-  version: 5.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-  sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  md5: 62f26a3d1387acee31322208f0cfa3e0
-  depends:
-  - python >=3.5
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/smmap
-  size: 22483
-  timestamp: 1634310465482
 - kind: conda
   name: smmap
   version: 5.0.0
@@ -18608,57 +15058,81 @@ packages:
   timestamp: 1602687595316
 - kind: conda
   name: taplo
-  version: 0.8.1
-  build: h69fbcac_0
+  version: 0.9.1
+  build: h16c8c8b_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.8.1-h69fbcac_0.conda
-  sha256: 5a46bbdac42c2aa1d59f3f7f61aa92eaed5f6936b01de4f3519f5ad40374973f
-  md5: 268425eeb6db286378bb05f69331feea
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.9.1-h16c8c8b_0.conda
+  sha256: 3a387ea7779d061d28af0426d1249fe81f798f35a2d0cb979a6ff84525187667
+  md5: 8171587b7a366dbbaab309ae1c45bd93
+  depends:
+  - openssl >=3.2.1,<4.0a0
+  constrains:
+  - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 3339855
-  timestamp: 1689048706766
+  size: 3560280
+  timestamp: 1710793219601
 - kind: conda
   name: taplo
-  version: 0.8.1
-  build: h7205ca4_0
+  version: 0.9.1
+  build: h1ff36dd_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.9.1-h1ff36dd_0.conda
+  sha256: 82b3528f63ae71e0158fdbf8b66e66f619cb70584c471f3d89a2ee6fd44ef20b
+  md5: 29207c9b716932300221e5acd0b310f7
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.2.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 3877123
+  timestamp: 1710792099600
+- kind: conda
+  name: taplo
+  version: 0.9.1
+  build: h236d3af_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.8.1-h7205ca4_0.conda
-  sha256: 493b5f8db450f37e8bb50fdfd02c06499c18391c806d2220e65ac801f6b7c2f0
-  md5: 8e99d4b2850401094fe7c83273d3c4e8
+  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.9.1-h236d3af_0.conda
+  sha256: 3e9032084b3f8d686b15f67500323ae2cae5637dc427b309b661a30026d8f00c
+  md5: 02c8d9c54b2887c5456fb7a0ecec62f3
+  depends:
+  - openssl >=3.2.1,<4.0a0
+  constrains:
+  - __osx >=10.12
   license: MIT
   license_family: MIT
-  size: 3446470
-  timestamp: 1689048461323
+  size: 3773670
+  timestamp: 1710793055293
 - kind: conda
   name: taplo
-  version: 0.8.1
+  version: 0.9.1
   build: h7f3b576_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/taplo-0.8.1-h7f3b576_0.conda
-  sha256: 4f0ddb3c2942ff9b2d627de9093075df30f28f64bf71520710c031cb7fff8d9d
-  md5: 2041cd474504dd82b83aa58ccec82a78
+  url: https://conda.anaconda.org/conda-forge/win-64/taplo-0.9.1-h7f3b576_0.conda
+  sha256: 7ef6b5f23fd749fde17628793e4e76e36395b9645a3d3b8b0fa5a4d9b2b9ccfb
+  md5: 0a798b7bf999885c00e40fcb0cfe7136
   depends:
   - m2w64-gcc-libs
   - m2w64-gcc-libs-core
   license: MIT
   license_family: MIT
-  size: 3652740
-  timestamp: 1689048946860
+  size: 3924159
+  timestamp: 1710794002174
 - kind: conda
   name: taplo
-  version: 0.8.1
-  build: he8a937b_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.8.1-he8a937b_0.conda
-  sha256: 901e0ba452bd249db45cbea25e7d865e43eb5322078e4724f43d83641b73335b
-  md5: 3d83fa9962fc353485bab815c9df9fe4
+  version: 0.9.1
+  build: hb8f9562_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/taplo-0.9.1-hb8f9562_0.conda
+  sha256: dbcd4fa63270cef1c777cdbba2b697845704470bb7f3011e2b1b318fb9eb59b7
+  md5: 0cf5ee26646e7780a0f89e0fbeac329e
   depends:
   - libgcc-ng >=12
+  - openssl >=3.2.1,<4.0a0
   license: MIT
   license_family: MIT
-  size: 3586993
-  timestamp: 1689047789269
+  size: 3717546
+  timestamp: 1710801928738
 - kind: conda
   name: tbb
   version: 2021.10.0
@@ -18846,23 +15320,6 @@ packages:
   name: tomli
   version: 2.0.1
   build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  md5: 5844808ffab9ebdb694585b50ba02a96
-  depends:
-  - python >=3.7
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/tomli
-  size: 15940
-  timestamp: 1644342331069
-- kind: conda
-  name: tomli
-  version: 2.0.1
-  build: pyhd8ed1ab_0
   subdir: win-64
   noarch: python
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
@@ -18878,23 +15335,6 @@ packages:
   - pkg:pypi/tomli
   size: 15940
   timestamp: 1644342331069
-- kind: conda
-  name: tomlkit
-  version: 0.12.3
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
-  sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
-  md5: 074d0ce7a6261ab8b497c3518796ef3e
-  depends:
-  - python >=3.7
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/tomlkit
-  size: 37132
-  timestamp: 1700046842169
 - kind: conda
   name: tomlkit
   version: 0.12.3
@@ -19105,20 +15545,6 @@ packages:
 - kind: conda
   name: typos
   version: 1.19.0
-  build: h11a7dfb_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/typos-1.19.0-h11a7dfb_0.conda
-  sha256: 79da26e5585382a4ec5dde9ba0d43435f0dd441e9f344ef99d12f2dab0117b74
-  md5: 97b99652ce2673198b2ab73b7cf85c31
-  constrains:
-  - __osx >=10.12
-  license: MIT
-  license_family: MIT
-  size: 3305763
-  timestamp: 1709332590675
-- kind: conda
-  name: typos
-  version: 1.19.0
   build: h1d8f897_0
   subdir: linux-aarch64
   url: https://conda.anaconda.org/conda-forge/linux-aarch64/typos-1.19.0-h1d8f897_0.conda
@@ -19130,49 +15556,6 @@ packages:
   license_family: MIT
   size: 3607084
   timestamp: 1709332306391
-- kind: conda
-  name: typos
-  version: 1.19.0
-  build: h5ef7bb8_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.19.0-h5ef7bb8_0.conda
-  sha256: d73ae2b63301e440049a9b0f78c9b6747d9ef1a6be360a5856ab77c6cefceca7
-  md5: 8516e396a23de65bad5066799fdbecf2
-  constrains:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 3307039
-  timestamp: 1709332619096
-- kind: conda
-  name: typos
-  version: 1.19.0
-  build: h7f3b576_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/typos-1.19.0-h7f3b576_0.conda
-  sha256: b9dc051dccb7cc9fb99d130f42703f0b14b711408d5b94d5864984b982981eb8
-  md5: 0066abed96ba51601722fda1eee87973
-  depends:
-  - m2w64-gcc-libs
-  - m2w64-gcc-libs-core
-  license: MIT
-  license_family: MIT
-  size: 2571575
-  timestamp: 1709333263031
-- kind: conda
-  name: typos
-  version: 1.19.0
-  build: he8a937b_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/typos-1.19.0-he8a937b_0.conda
-  sha256: ee886a360248e517b75980e7c7249fbba7bed97e5f67371257f8dc29b5c348df
-  md5: 97d8f139e4fb369369fb71f53e29be45
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 3616719
-  timestamp: 1709332292966
 - kind: conda
   name: tzdata
   version: 2024a
@@ -19199,25 +15582,6 @@ packages:
   license_family: PROPRIETARY
   size: 1283972
   timestamp: 1666630199266
-- kind: conda
-  name: ucx
-  version: 1.15.0
-  build: h11edf95_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-h11edf95_7.conda
-  sha256: 3e381ec5918045a43e0f349214a4d38e53990897ba07a6abf025f9e0156acaf2
-  md5: 20a94f617ad76922f8737ad1fe317f4d
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - rdma-core >=50.0
-  constrains:
-  - cuda-version >=11.2,<12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6847943
-  timestamp: 1710357262334
 - kind: conda
   name: ucx
   version: 1.15.0
@@ -19445,23 +15809,6 @@ packages:
   name: wheel
   version: 0.38.4
   build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
-  sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-  md5: c829cfb8cb826acb9de0ac1a2df0a940
-  depends:
-  - python >=3.7
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/wheel
-  size: 32521
-  timestamp: 1668051714265
-- kind: conda
-  name: wheel
-  version: 0.38.4
-  build: pyhd8ed1ab_0
   subdir: win-64
   noarch: python
   url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
@@ -19539,23 +15886,6 @@ packages:
   license: LGPL-2.1 and GPL-2.0
   size: 440555
   timestamp: 1660348056328
-- kind: conda
-  name: zipp
-  version: 3.17.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
-  md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-  depends:
-  - python >=3.8
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/zipp
-  size: 18954
-  timestamp: 1695255262261
 - kind: conda
   name: zipp
   version: 3.17.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,7 +23,6 @@ version = "0.1.0"                                                              #
 
 [environments]
 cpp = ["cpp"]
-taplo = ["taplo"]
 
 [tasks]
 # Note: extra CLI argument after `pixi run TASK` are passed to the task cmd.
@@ -79,12 +78,14 @@ lint-py-fmt-check = "ruff format --check --config rerun_py/pyproject.toml"
 lint-py-blackdoc = "blackdoc --check"
 lint-py-mypy = "mypy --install-types --non-interactive --no-warn-unused-ignore"
 lint-py-ruff = "ruff format --check --config rerun_py/pyproject.toml"
+lint-taplo = "taplo fmt --check --diff"
 lint-typos = "typos"
 
 misc-fmt = "prettier --write '**/*.{yml,yaml,js,css,html}'"
 misc-fmt-check = "prettier --check '**/*.{yml,yaml,js,css,html}'"
 ruff-fmt = "ruff format --config rerun_py/pyproject.toml ."
 ruff-fix = "ruff --fix --config rerun_py/pyproject.toml ."
+toml-fmt = "taplo fmt"
 
 py-build = "maturin develop --manifest-path rerun_py/Cargo.toml --extras=tests"
 
@@ -108,13 +109,6 @@ search-index = "cargo run -p re_build_search_index --release --"
 # Files are stored in the `meilisearch` directory, so you can fully wipe it via `rm -rf meilisearch`.
 meilisearch = "meilisearch --db-path=./meilisearch/data.ms --dump-dir=./meilisearch/dumps/ --snapshot-dir=./meilisearch/snapshots/ --env=development --no-analytics --experimental-reduce-indexing-memory-usage --master-key=test"
 
-# TODO(ab): move everything back to the main tasks/dependencies once taplo supports linux-aarch64.
-[feature.taplo]
-platforms = ["linux-64", "osx-arm64", "osx-64", "win-64"]
-
-[feature.taplo.tasks]
-lint-taplo = "taplo fmt --check --diff"
-toml-fmt = "taplo fmt"
 
 [feature.cpp.tasks]
 # All the cpp-* tasks can be configured with environment variables, e.g.: RERUN_WERROR=ON CXX=clang++
@@ -197,6 +191,7 @@ ninja = "1.11.1"
 doxygen = "1.9.7.*"
 binaryen = "117.*"   # for `wasm-opt`
 prettier = "2.8.8.*"
+taplo = "=0.9.1"
 tomlkit = "0.12.3.*"
 
 [pypi-dependencies]
@@ -205,9 +200,6 @@ nox = ">=2024.3.2" # the conda-forge package is (wrongly) tagged as platform-spe
 [target.linux-64.dependencies]
 patchelf = ">=0.17"
 meilisearch = "1.5.1.*" # not available for linux-aarch64
-
-[feature.taplo.dependencies]
-taplo = "=0.8.1" # not (yet?) available for linux-aarch64
 
 [feature.cpp.target.linux-64.dependencies]
 clang = "16.0.6"


### PR DESCRIPTION
### What

Taplo now supports linux-aarch64 so we no longer need to special-case it (https://github.com/conda-forge/taplo-feedstock/issues/3)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5587/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5587/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5587/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5587)
- [Docs preview](https://rerun.io/preview/40e7333ef4d9d008dc29a4983885987afbf65dad/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/40e7333ef4d9d008dc29a4983885987afbf65dad/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)