### PR TITLE
Fix indentation of leaf items in hierarchical lists

### DIFF
--- a/crates/re_data_ui/src/editors.rs
+++ b/crates/re_data_ui/src/editors.rs
@@ -260,6 +260,9 @@ fn edit_marker_shape_ui(
         .width(100.0)
         .height(320.0)
         .show_ui(ui, |ui| {
+            // no spacing between list items
+            ui.spacing_mut().item_spacing.y = 0.0;
+
             // Hack needed for ListItem to click its highlight bg rect correctly:
             ui.set_clip_rect(
                 ui.clip_rect()
@@ -272,7 +275,10 @@ fn edit_marker_shape_ui(
                         paint_marker(ui, marker.into(), rect, visuals.text_color());
                     })
                     .selected(edit_marker == marker);
-                if list_item.show(ui).clicked() {
+                if list_item
+                    .show(ui, re_ui::list_item::IndentMode::Flat)
+                    .clicked()
+                {
                     edit_marker = marker;
                 }
             }

--- a/crates/re_data_ui/src/editors.rs
+++ b/crates/re_data_ui/src/editors.rs
@@ -275,10 +275,7 @@ fn edit_marker_shape_ui(
                         paint_marker(ui, marker.into(), rect, visuals.text_color());
                     })
                     .selected(edit_marker == marker);
-                if list_item
-                    .show(ui, re_ui::list_item::IndentMode::Flat)
-                    .clicked()
-                {
+                if list_item.show_flat(ui).clicked() {
                     edit_marker = marker;
                 }
             }

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -756,7 +756,7 @@ impl TimePanel {
                             == HoverHighlight::Hovered,
                     )
                     .with_icon(&re_ui::icons::COMPONENT)
-                    .show(ui);
+                    .show(ui, re_ui::list_item::IndentMode::Hierarchical);
 
                 ui.set_clip_rect(clip_rect_save);
 

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -607,7 +607,7 @@ impl TimePanel {
             .width_allocation_mode(WidthAllocationMode::Compact)
             .selected(is_selected)
             .force_hovered(is_item_hovered)
-            .show_collapsing(
+            .show_hierarchical_with_content(
                 ui,
                 CollapseScope::StreamsTree.entity(tree.path.clone()),
                 default_open,
@@ -756,7 +756,7 @@ impl TimePanel {
                             == HoverHighlight::Hovered,
                     )
                     .with_icon(&re_ui::icons::COMPONENT)
-                    .show(ui, re_ui::list_item::IndentMode::Hierarchical);
+                    .show_hierarchical(ui);
 
                 ui.set_clip_rect(clip_rect_save);
 

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -1,4 +1,4 @@
-use re_ui::list_item::ListItem;
+use re_ui::list_item::{IndentMode, ListItem};
 use re_ui::{toasts, CommandPalette, ReUi, UICommand, UICommandSender};
 
 /// Sender that queues up the execution of a command.
@@ -260,7 +260,8 @@ impl eframe::App for ExampleApp {
                                 || re_ui::modal::Modal::new("Modal window").full_span_content(true),
                                 |_, ui, _| {
                                     for idx in 0..10 {
-                                        ListItem::new(&self.re_ui, format!("Item {idx}")).show(ui);
+                                        ListItem::new(&self.re_ui, format!("Item {idx}"))
+                                            .show(ui, IndentMode::Flat);
                                     }
                                 },
                             );
@@ -401,7 +402,7 @@ impl eframe::App for ExampleApp {
                                         item.with_icon(&re_ui::icons::SPACE_VIEW_TEXT)
                                     };
 
-                                    if item.show(ui).clicked() {
+                                    if item.show(ui, IndentMode::Flat).clicked() {
                                         self.selected_list_item = Some(i);
                                     }
                                 }
@@ -419,13 +420,26 @@ impl eframe::App for ExampleApp {
                             .list_item("Collapsing list item with icon")
                             .with_icon(&re_ui::icons::SPACE_VIEW_2D)
                             .show_collapsing(ui, "collapsing example", true, |_re_ui, ui| {
-                                self.re_ui.list_item("Sub-item").show(ui);
-                                self.re_ui.list_item("Sub-item").show(ui);
+                                self.re_ui
+                                    .list_item("Sub-item")
+                                    .show(ui, IndentMode::Hierarchical);
+                                self.re_ui
+                                    .list_item("Sub-item")
+                                    .show(ui, IndentMode::Hierarchical);
                                 self.re_ui
                                     .list_item("Sub-item with icon")
                                     .with_icon(&re_ui::icons::SPACE_VIEW_TEXT)
-                                    .show(ui);
-                                self.re_ui.list_item("Sub-item").show(ui);
+                                    .show(ui, IndentMode::Hierarchical);
+                                self.re_ui.list_item("Sub-item").show_collapsing(
+                                    ui,
+                                    "sub-collapsing",
+                                    true,
+                                    |_re_ui, ui| {
+                                        self.re_ui
+                                            .list_item("Sub-sub-item")
+                                            .show(ui, IndentMode::Hierarchical)
+                                    },
+                                );
                             });
                     });
                 });
@@ -643,6 +657,7 @@ impl egui_tiles::Behavior<Tab> for MyTileTreeBehavior {
 // DRAG AND DROP DEMO
 
 mod drag_and_drop {
+    use re_ui::list_item::IndentMode;
     use std::collections::HashSet;
 
     #[derive(Hash, Clone, Copy, PartialEq, Eq)]
@@ -678,7 +693,7 @@ mod drag_and_drop {
                     .list_item(label.as_str())
                     .selected(self.selected_items.contains(item_id))
                     .draggable(true)
-                    .show(ui);
+                    .show(ui, IndentMode::Flat);
 
                 //
                 // Handle item selection
@@ -769,6 +784,7 @@ mod hierarchical_drag_and_drop {
     use std::collections::{HashMap, HashSet};
 
     use egui::NumExt;
+    use re_ui::list_item::IndentMode;
 
     use re_ui::ReUi;
 
@@ -1087,7 +1103,7 @@ mod hierarchical_drag_and_drop {
                 .list_item(label)
                 .selected(self.selected(item_id))
                 .draggable(true)
-                .show(ui);
+                .show(ui, IndentMode::Hierarchical);
 
             self.handle_interaction(ui, item_id, false, &response, None);
         }

--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -1,4 +1,4 @@
-use re_ui::list_item::{IndentMode, ListItem};
+use re_ui::list_item::ListItem;
 use re_ui::{toasts, CommandPalette, ReUi, UICommand, UICommandSender};
 
 /// Sender that queues up the execution of a command.
@@ -261,7 +261,7 @@ impl eframe::App for ExampleApp {
                                 |_, ui, _| {
                                     for idx in 0..10 {
                                         ListItem::new(&self.re_ui, format!("Item {idx}"))
-                                            .show(ui, IndentMode::Flat);
+                                            .show_flat(ui);
                                     }
                                 },
                             );
@@ -402,7 +402,7 @@ impl eframe::App for ExampleApp {
                                         item.with_icon(&re_ui::icons::SPACE_VIEW_TEXT)
                                     };
 
-                                    if item.show(ui, IndentMode::Flat).clicked() {
+                                    if item.show_flat(ui).clicked() {
                                         self.selected_list_item = Some(i);
                                     }
                                 }
@@ -419,28 +419,31 @@ impl eframe::App for ExampleApp {
                         self.re_ui
                             .list_item("Collapsing list item with icon")
                             .with_icon(&re_ui::icons::SPACE_VIEW_2D)
-                            .show_collapsing(ui, "collapsing example", true, |_re_ui, ui| {
-                                self.re_ui
-                                    .list_item("Sub-item")
-                                    .show(ui, IndentMode::Hierarchical);
-                                self.re_ui
-                                    .list_item("Sub-item")
-                                    .show(ui, IndentMode::Hierarchical);
-                                self.re_ui
-                                    .list_item("Sub-item with icon")
-                                    .with_icon(&re_ui::icons::SPACE_VIEW_TEXT)
-                                    .show(ui, IndentMode::Hierarchical);
-                                self.re_ui.list_item("Sub-item").show_collapsing(
-                                    ui,
-                                    "sub-collapsing",
-                                    true,
-                                    |_re_ui, ui| {
-                                        self.re_ui
-                                            .list_item("Sub-sub-item")
-                                            .show(ui, IndentMode::Hierarchical)
-                                    },
-                                );
-                            });
+                            .show_hierarchical_with_content(
+                                ui,
+                                "collapsing example",
+                                true,
+                                |_re_ui, ui| {
+                                    self.re_ui.list_item("Sub-item").show_hierarchical(ui);
+                                    self.re_ui.list_item("Sub-item").show_hierarchical(ui);
+                                    self.re_ui
+                                        .list_item("Sub-item with icon")
+                                        .with_icon(&re_ui::icons::SPACE_VIEW_TEXT)
+                                        .show_hierarchical(ui);
+                                    self.re_ui
+                                        .list_item("Sub-item")
+                                        .show_hierarchical_with_content(
+                                            ui,
+                                            "sub-collapsing",
+                                            true,
+                                            |_re_ui, ui| {
+                                                self.re_ui
+                                                    .list_item("Sub-sub-item")
+                                                    .show_hierarchical(ui)
+                                            },
+                                        );
+                                },
+                            );
                     });
                 });
             });
@@ -657,7 +660,6 @@ impl egui_tiles::Behavior<Tab> for MyTileTreeBehavior {
 // DRAG AND DROP DEMO
 
 mod drag_and_drop {
-    use re_ui::list_item::IndentMode;
     use std::collections::HashSet;
 
     #[derive(Hash, Clone, Copy, PartialEq, Eq)]
@@ -693,7 +695,7 @@ mod drag_and_drop {
                     .list_item(label.as_str())
                     .selected(self.selected_items.contains(item_id))
                     .draggable(true)
-                    .show(ui, IndentMode::Flat);
+                    .show_flat(ui);
 
                 //
                 // Handle item selection
@@ -784,7 +786,6 @@ mod hierarchical_drag_and_drop {
     use std::collections::{HashMap, HashSet};
 
     use egui::NumExt;
-    use re_ui::list_item::IndentMode;
 
     use re_ui::ReUi;
 
@@ -1066,7 +1067,7 @@ mod hierarchical_drag_and_drop {
                 .selected(self.selected(item_id))
                 .draggable(true)
                 .drop_target_style(self.target_container == Some(item_id))
-                .show_collapsing(ui, item_id, true, |re_ui, ui| {
+                .show_hierarchical_with_content(ui, item_id, true, |re_ui, ui| {
                     self.container_children_ui(re_ui, ui, children);
                 });
 
@@ -1103,7 +1104,7 @@ mod hierarchical_drag_and_drop {
                 .list_item(label)
                 .selected(self.selected(item_id))
                 .draggable(true)
-                .show(ui, IndentMode::Hierarchical);
+                .show_hierarchical(ui);
 
             self.handle_interaction(ui, item_id, false, &response, None);
         }

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -226,8 +226,8 @@ impl<'a> ListItem<'a> {
     /// Override the hovered state even if the item is not actually hovered.
     ///
     /// Used to highlight items representing things that are hovered elsewhere in the UI. Note that
-    /// the [`egui::Response`] returned by [`Self::show`] and ]`Self::show_collapsing`] will still
-    /// reflect the actual hover state.
+    /// the [`egui::Response`] returned by [`Self::show_flat`], [`Self::show_hierarchical`], and
+    /// [`Self::show_hierarchical_with_content`] will still reflect the actual hover state.
     #[inline]
     pub fn force_hovered(mut self, force_hovered: bool) -> Self {
         self.force_hovered = force_hovered;
@@ -292,7 +292,7 @@ impl<'a> ListItem<'a> {
         ui.scope(|ui| self.ui(ui, None)).inner.response
     }
 
-    /// Draw the item as a leaf ndoe from a hierarchical list.
+    /// Draw the item as a leaf node from a hierarchical list.
     pub fn show_hierarchical(self, ui: &mut Ui) -> Response {
         // Note: the purpose of the scope is to minimise interferences on subsequent items' id
         ui.scope(|ui| {

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -92,7 +92,7 @@ fn loading_receivers_ui(
                     }
                     resp
                 })
-                .show(ui);
+                .show(ui, re_ui::list_item::IndentMode::Flat); // never more than one level deep
             if let SmartChannelSource::TcpServer { .. } = source.as_ref() {
                 response.on_hover_text("You can connect to this viewer from a Rerun SDK");
             }
@@ -203,15 +203,17 @@ fn recording_ui(
         list_item = list_item.force_hovered(true);
     }
 
-    let response = list_item.show(ui).on_hover_ui(|ui| {
-        entity_db.data_ui(
-            ctx,
-            ui,
-            re_viewer_context::UiVerbosity::Full,
-            &ctx.current_query(),
-            entity_db.store(),
-        );
-    });
+    let response = list_item
+        .show(ui, re_ui::list_item::IndentMode::Flat) // never more than one level deep
+        .on_hover_ui(|ui| {
+            entity_db.data_ui(
+                ctx,
+                ui,
+                re_viewer_context::UiVerbosity::Full,
+                &ctx.current_query(),
+                entity_db.store(),
+            );
+        });
 
     if response.hovered() {
         ctx.selection_state().set_hovered(item.clone());

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -92,7 +92,7 @@ fn loading_receivers_ui(
                     }
                     resp
                 })
-                .show(ui, re_ui::list_item::IndentMode::Flat); // never more than one level deep
+                .show_flat(ui); // never more than one level deep
             if let SmartChannelSource::TcpServer { .. } = source.as_ref() {
                 response.on_hover_text("You can connect to this viewer from a Rerun SDK");
             }
@@ -129,16 +129,19 @@ fn recording_list_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) -> bool {
             let entity_db = entity_dbs[0];
             recording_ui(ctx, ui, entity_db, Some(app_id), active_recording);
         } else {
-            ctx.re_ui.list_item(app_id).active(false).show_collapsing(
-                ui,
-                ui.make_persistent_id(app_id),
-                true,
-                |_, ui| {
-                    for entity_db in entity_dbs {
-                        recording_ui(ctx, ui, entity_db, None, active_recording);
-                    }
-                },
-            );
+            ctx.re_ui
+                .list_item(app_id)
+                .active(false)
+                .show_hierarchical_with_content(
+                    ui,
+                    ui.make_persistent_id(app_id),
+                    true,
+                    |_, ui| {
+                        for entity_db in entity_dbs {
+                            recording_ui(ctx, ui, entity_db, None, active_recording);
+                        }
+                    },
+                );
         }
     }
 
@@ -204,7 +207,7 @@ fn recording_ui(
     }
 
     let response = list_item
-        .show(ui, re_ui::list_item::IndentMode::Flat) // never more than one level deep
+        .show_flat(ui) // never more than one level deep
         .on_hover_ui(|ui| {
             entity_db.data_ui(
                 ctx,

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -227,7 +227,7 @@ fn container_children(
                 .weak(true)
                 .italics(true)
                 .active(false)
-                .show(ui);
+                .show(ui, re_ui::list_item::IndentMode::Flat);
         }
     };
 
@@ -380,7 +380,7 @@ fn what_is_selected_ui(
                     .with_icon(space_view.class(ctx.space_view_class_registry).icon())
                     .with_height(ReUi::title_bar_height())
                     .selected(true)
-                    .show(ui)
+                    .show(ui, re_ui::list_item::IndentMode::Flat)
                     .on_hover_text(hover_text);
             }
         }
@@ -485,7 +485,9 @@ fn item_title_ui(
         list_item = list_item.with_icon(icon);
     }
 
-    list_item.show(ui).on_hover_text(hover)
+    list_item
+        .show(ui, re_ui::list_item::IndentMode::Flat)
+        .on_hover_text(hover)
 }
 
 /// Display a list of all the space views an entity appears in.
@@ -749,7 +751,7 @@ fn show_list_item_for_container_child(
         list_item = list_item.force_hovered(true);
     }
 
-    let response = list_item.show(ui);
+    let response = list_item.show(ui, re_ui::list_item::IndentMode::Flat);
 
     context_menu_ui_for_item(
         ctx,

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -227,7 +227,7 @@ fn container_children(
                 .weak(true)
                 .italics(true)
                 .active(false)
-                .show(ui, re_ui::list_item::IndentMode::Flat);
+                .show_flat(ui);
         }
     };
 
@@ -380,7 +380,7 @@ fn what_is_selected_ui(
                     .with_icon(space_view.class(ctx.space_view_class_registry).icon())
                     .with_height(ReUi::title_bar_height())
                     .selected(true)
-                    .show(ui, re_ui::list_item::IndentMode::Flat)
+                    .show_flat(ui)
                     .on_hover_text(hover_text);
             }
         }
@@ -485,9 +485,7 @@ fn item_title_ui(
         list_item = list_item.with_icon(icon);
     }
 
-    list_item
-        .show(ui, re_ui::list_item::IndentMode::Flat)
-        .on_hover_text(hover)
+    list_item.show_flat(ui).on_hover_text(hover)
 }
 
 /// Display a list of all the space views an entity appears in.
@@ -751,7 +749,7 @@ fn show_list_item_for_container_child(
         list_item = list_item.force_hovered(true);
     }
 
-    let response = list_item.show(ui, re_ui::list_item::IndentMode::Flat);
+    let response = list_item.show_flat(ui);
 
     context_menu_ui_for_item(
         ctx,

--- a/crates/re_viewer/src/ui/space_view_space_origin_ui.rs
+++ b/crates/re_viewer/src/ui/space_view_space_origin_ui.rs
@@ -192,7 +192,7 @@ fn space_view_space_origin_widget_editing_ui(
                     .syntax_highlighted(ui.style()),
             )
             .force_hovered(*selected_suggestion == Some(idx))
-            .show(ui);
+            .show(ui, re_ui::list_item::IndentMode::Flat);
 
             if response.hovered() {
                 *selected_suggestion = None;
@@ -213,7 +213,7 @@ fn space_view_space_origin_widget_editing_ui(
             .weak(true)
             .italics(true)
             .active(false)
-            .show(ui);
+            .show(ui, re_ui::list_item::IndentMode::Flat);
         }
     };
 

--- a/crates/re_viewer/src/ui/space_view_space_origin_ui.rs
+++ b/crates/re_viewer/src/ui/space_view_space_origin_ui.rs
@@ -192,7 +192,7 @@ fn space_view_space_origin_widget_editing_ui(
                     .syntax_highlighted(ui.style()),
             )
             .force_hovered(*selected_suggestion == Some(idx))
-            .show(ui, re_ui::list_item::IndentMode::Flat);
+            .show_flat(ui);
 
             if response.hovered() {
                 *selected_suggestion = None;
@@ -213,7 +213,7 @@ fn space_view_space_origin_widget_editing_ui(
             .weak(true)
             .italics(true)
             .active(false)
-            .show(ui, re_ui::list_item::IndentMode::Flat);
+            .show_flat(ui);
         }
     };
 

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -275,7 +275,7 @@ impl Viewport<'_, '_> {
         .with_icon(crate::icon_for_container_kind(
             &container_blueprint.container_kind,
         ))
-        .show(ui);
+        .show(ui, re_ui::list_item::IndentMode::Flat);
 
         for child in &container_blueprint.contents {
             self.contents_ui(ctx, ui, child, true);
@@ -532,7 +532,7 @@ impl Viewport<'_, '_> {
                 .subdued(true)
                 .italics(true)
                 .with_icon(&re_ui::icons::LINK)
-                .show(ui)
+                .show(ui, re_ui::list_item::IndentMode::Hierarchical)
                 .on_hover_text(
                     "This subtree corresponds to the Space View's origin, and is displayed above \
                     the 'Projections' section. Click to select it.",
@@ -654,7 +654,7 @@ impl Viewport<'_, '_> {
                 )
                 .item_response
         } else {
-            list_item.show(ui)
+            list_item.show(ui, re_ui::list_item::IndentMode::Hierarchical)
         };
 
         let response = response.on_hover_ui(|ui| {

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -275,7 +275,7 @@ impl Viewport<'_, '_> {
         .with_icon(crate::icon_for_container_kind(
             &container_blueprint.container_kind,
         ))
-        .show(ui, re_ui::list_item::IndentMode::Flat);
+        .show_flat(ui);
 
         for child in &container_blueprint.contents {
             self.contents_ui(ctx, ui, child, true);
@@ -344,7 +344,7 @@ impl Viewport<'_, '_> {
 
             remove_response | vis_response
         })
-        .show_collapsing(
+        .show_hierarchical_with_content(
             ui,
             CollapseScope::BlueprintTree.container(*container_id),
             default_open,
@@ -429,7 +429,7 @@ impl Viewport<'_, '_> {
 
                 response | vis_response
             })
-            .show_collapsing(
+            .show_hierarchical_with_content(
                 ui,
                 CollapseScope::BlueprintTree.space_view(*space_view_id),
                 default_open,
@@ -532,7 +532,7 @@ impl Viewport<'_, '_> {
                 .subdued(true)
                 .italics(true)
                 .with_icon(&re_ui::icons::LINK)
-                .show(ui, re_ui::list_item::IndentMode::Hierarchical)
+                .show_hierarchical(ui)
                 .on_hover_text(
                     "This subtree corresponds to the Space View's origin, and is displayed above \
                     the 'Projections' section. Click to select it.",
@@ -621,7 +621,7 @@ impl Viewport<'_, '_> {
                 && Self::default_open_for_data_result(node);
 
             list_item
-                .show_collapsing(
+                .show_hierarchical_with_content(
                     ui,
                     CollapseScope::BlueprintTree.data_result(space_view.id, entity_path.clone()),
                     default_open,
@@ -654,7 +654,7 @@ impl Viewport<'_, '_> {
                 )
                 .item_response
         } else {
-            list_item.show(ui, re_ui::list_item::IndentMode::Hierarchical)
+            list_item.show_hierarchical(ui)
         };
 
         let response = response.on_hover_ui(|ui| {


### PR DESCRIPTION
### What

- Fixes #5457 (introduced in #5340)

Also sneaks a minor UI tweak in the plot marker selection list.

Before/after: 

<img width="161" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/02c82f20-5cfd-46d9-9493-f5ebaf4f13b0">
<img width="170" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/92a4f017-b15e-40ca-982f-8778f34ef382">

<br/>
<br/>

cc @martenbjork 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5590/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5590/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5590/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5590)
- [Docs preview](https://rerun.io/preview/380d08c73607cca35c2640ca2206e0d7c8676ed3/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/380d08c73607cca35c2640ca2206e0d7c8676ed3/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)