### PR TITLE
`import rerun.blueprint as rbl` -> `import rerun.blueprint as rrb`

### DIFF
--- a/examples/python/arkit_scenes/main.py
+++ b/examples/python/arkit_scenes/main.py
@@ -10,7 +10,7 @@ from typing import Any, Tuple
 import cv2
 import numpy as np
 import rerun as rr  # pip install rerun-sdk
-import rerun.blueprint as rbl
+import rerun.blueprint as rrb
 import trimesh
 from download_dataset import AVAILABLE_RECORDINGS, ensure_recording_available
 from scipy.spatial.transform import Rotation as R
@@ -330,25 +330,25 @@ def main() -> None:
 
     primary_camera_entity = highres_entity_path if args.include_highres else lowres_posed_entity_path
 
-    blueprint = rbl.Horizontal(
-        rbl.Spatial3DView(name="3D"),
-        rbl.Vertical(
-            rbl.Tabs(
+    blueprint = rrb.Horizontal(
+        rrb.Spatial3DView(name="3D"),
+        rrb.Vertical(
+            rrb.Tabs(
                 # Note that we re-project the annotations into the 2D views:
                 # For this to work, the origin of the 2D views has to be a pinhole camera,
                 # this way the viewer knows how to project the 3D annotations into the 2D views.
-                rbl.Spatial2DView(
+                rrb.Spatial2DView(
                     name="RGB",
                     origin=primary_camera_entity,
                     contents=["$origin/rgb", "/world/annotations/**"],
                 ),
-                rbl.Spatial2DView(
+                rrb.Spatial2DView(
                     name="Depth",
                     origin=primary_camera_entity,
                     contents=["$origin/depth", "/world/annotations/**"],
                 ),
             ),
-            rbl.TextDocumentView(name="Readme"),
+            rrb.TextDocumentView(name="Readme"),
         ),
     )
 

--- a/examples/python/nuscenes/main.py
+++ b/examples/python/nuscenes/main.py
@@ -9,7 +9,7 @@ from typing import Any, Final
 import matplotlib
 import numpy as np
 import rerun as rr
-import rerun.blueprint as rbl
+import rerun.blueprint as rrb
 from download_dataset import MINISPLIT_SCENES, download_minisplit
 from nuscenes import nuscenes
 
@@ -257,15 +257,15 @@ def main() -> None:
 
     # Set up the Rerun Blueprint (how the visualization is organized):
     sensor_space_views = [
-        rbl.Spatial2DView(
+        rrb.Spatial2DView(
             name=sensor_name,
             origin=f"world/ego_vehicle/{sensor_name}",
         )
         for sensor_name in nuscene_sensor_names(nusc, args.scene_name)
     ]
-    blueprint = rbl.Vertical(
-        rbl.Spatial3DView(name="3D", origin="world"),
-        rbl.Grid(*sensor_space_views),
+    blueprint = rrb.Vertical(
+        rrb.Spatial3DView(name="3D", origin="world"),
+        rrb.Grid(*sensor_space_views),
         row_shares=[3, 2],
     )
 


### PR DESCRIPTION
That's what we settled on.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5592/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5592/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5592/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5592)
- [Docs preview](https://rerun.io/preview/0c10fe5f6058636e943b2c739244d90c294b2af1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0c10fe5f6058636e943b2c739244d90c294b2af1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)