### PR TITLE
Rename some structures and APIs around selection

### DIFF
--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -9,7 +9,7 @@ use re_space_view::ScreenshotMode;
 use re_types::components::{DepthMeter, InstanceKey, TensorData, ViewCoordinates};
 use re_types::tensor_data::TensorDataMeaning;
 use re_viewer_context::{
-    HoverHighlight, Item, SelectedSpaceContext, SelectionHighlight, SpaceViewHighlights,
+    HoverHighlight, Item, ItemSpaceContext, SelectionHighlight, SpaceViewHighlights,
     SpaceViewState, SpaceViewSystemExecutionError, TensorDecodeCache, TensorStatsCache,
     UiVerbosity, ViewContextCollection, ViewQuery, ViewerContext, VisualizerCollection,
 };
@@ -613,7 +613,7 @@ pub fn picking(
 
     if let Some((_, context)) = hovered_items.first_mut() {
         *context = Some(match spatial_kind {
-            SpatialSpaceViewKind::TwoD => SelectedSpaceContext::TwoD {
+            SpatialSpaceViewKind::TwoD => ItemSpaceContext::TwoD {
                 space_2d: query.space_origin.clone(),
                 pos: picking_context
                     .pointer_in_space2d
@@ -621,7 +621,7 @@ pub fn picking(
             },
             SpatialSpaceViewKind::ThreeD => {
                 let hovered_point = picking_result.space_position();
-                SelectedSpaceContext::ThreeD {
+                ItemSpaceContext::ThreeD {
                     space_3d: query.space_origin.clone(),
                     pos: hovered_point,
                     tracked_entity: state.state_3d.tracked_entity.clone(),

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -9,8 +9,8 @@ use re_renderer::view_builder::{TargetConfiguration, ViewBuilder};
 use re_space_view::controls::{DRAG_PAN2D_BUTTON, RESET_VIEW_BUTTON_TEXT, ZOOM_SCROLL_MODIFIER};
 use re_types::{archetypes::Pinhole, components::ViewCoordinates};
 use re_viewer_context::{
-    gpu_bridge, SelectedSpaceContext, SpaceViewSystemExecutionError, SystemExecutionOutput,
-    ViewQuery, ViewerContext,
+    gpu_bridge, ItemSpaceContext, SpaceViewSystemExecutionError, SystemExecutionOutput, ViewQuery,
+    ViewerContext,
 };
 
 use super::{
@@ -364,7 +364,7 @@ pub fn view_2d(
         ));
 
         // Make sure to _first_ draw the selected, and *then* the hovered context on top!
-        for selected_context in ctx.selection_state().selected_space_context() {
+        for selected_context in ctx.selection_state().item_space_contexts() {
             painter.extend(show_projections_from_3d_space(
                 ui,
                 query.space_origin,
@@ -507,11 +507,11 @@ fn show_projections_from_3d_space(
     ui: &egui::Ui,
     space: &EntityPath,
     ui_from_canvas: &RectTransform,
-    space_context: &SelectedSpaceContext,
+    space_context: &ItemSpaceContext,
     color: egui::Color32,
 ) -> Vec<Shape> {
     let mut shapes = Vec::new();
-    if let SelectedSpaceContext::ThreeD {
+    if let ItemSpaceContext::ThreeD {
         point_in_space_cameras: target_spaces,
         ..
     } = space_context

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -364,7 +364,7 @@ pub fn view_2d(
         ));
 
         // Make sure to _first_ draw the selected, and *then* the hovered context on top!
-        for selected_context in ctx.selection_state().item_space_contexts() {
+        for selected_context in ctx.selection_state().selection_space_contexts() {
             painter.extend(show_projections_from_3d_space(
                 ui,
                 query.space_origin,

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -17,7 +17,7 @@ use re_space_view::{
 };
 use re_types::{components::ViewCoordinates, view_coordinates::SignedAxis3};
 use re_viewer_context::{
-    gpu_bridge, Item, SelectedSpaceContext, SpaceViewSystemExecutionError, SystemExecutionOutput,
+    gpu_bridge, Item, ItemSpaceContext, SpaceViewSystemExecutionError, SystemExecutionOutput,
     ViewQuery, ViewerContext,
 };
 
@@ -615,7 +615,7 @@ pub fn view_3d(
             .ok();
     }
 
-    for selected_context in ctx.selection_state().selected_space_context() {
+    for selected_context in ctx.selection_state().item_space_contexts() {
         show_projections_from_2d_space(
             &mut line_builder,
             space_cameras,
@@ -839,11 +839,11 @@ fn show_projections_from_2d_space(
     line_builder: &mut re_renderer::LineDrawableBuilder<'_>,
     space_cameras: &[SpaceCamera3D],
     state: &SpatialSpaceViewState,
-    space_context: &SelectedSpaceContext,
+    space_context: &ItemSpaceContext,
     color: egui::Color32,
 ) {
     match space_context {
-        SelectedSpaceContext::TwoD { space_2d, pos } => {
+        ItemSpaceContext::TwoD { space_2d, pos } => {
             if let Some(cam) = space_cameras.iter().find(|cam| &cam.ent_path == space_2d) {
                 if let Some(pinhole) = cam.pinhole.as_ref() {
                     // Render a thick line to the actual z value if any and a weaker one as an extension
@@ -879,7 +879,7 @@ fn show_projections_from_2d_space(
                 }
             }
         }
-        SelectedSpaceContext::ThreeD {
+        ItemSpaceContext::ThreeD {
             pos: Some(pos),
             tracked_entity: Some(tracked_entity),
             ..
@@ -906,7 +906,7 @@ fn show_projections_from_2d_space(
                 }
             }
         }
-        SelectedSpaceContext::ThreeD { .. } => {}
+        ItemSpaceContext::ThreeD { .. } => {}
     }
 }
 

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -615,7 +615,7 @@ pub fn view_3d(
             .ok();
     }
 
-    for selected_context in ctx.selection_state().item_space_contexts() {
+    for selected_context in ctx.selection_state().selection_space_contexts() {
         show_projections_from_2d_space(
             &mut line_builder,
             space_cameras,

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -174,7 +174,7 @@ impl AppState {
             recording_config_entry(recording_configs, entity_db.store_id().clone(), entity_db);
 
         if ui.input(|i| i.key_pressed(egui::Key::Escape)) {
-            rec_cfg.selection_state.clear_current();
+            rec_cfg.selection_state.clear_selection();
         }
 
         let applicable_entities_per_visualizer = space_view_class_registry

--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -1,6 +1,6 @@
 use egui::RichText;
 use re_ui::UICommand;
-use re_viewer_context::{Item, Selection, SelectionHistory};
+use re_viewer_context::{Item, ItemCollection, SelectionHistory};
 use re_viewport::ViewportBlueprint;
 
 // ---
@@ -16,7 +16,7 @@ impl SelectionHistoryUi {
         ui: &mut egui::Ui,
         blueprint: &ViewportBlueprint,
         history: &mut SelectionHistory,
-    ) -> Option<Selection> {
+    ) -> Option<ItemCollection> {
         let next = self.next_button_ui(re_ui, ui, blueprint, history);
         let prev = self.prev_button_ui(re_ui, ui, blueprint, history);
         prev.or(next)
@@ -28,7 +28,7 @@ impl SelectionHistoryUi {
         ui: &mut egui::Ui,
         blueprint: &ViewportBlueprint,
         history: &mut SelectionHistory,
-    ) -> Option<Selection> {
+    ) -> Option<ItemCollection> {
         // undo selection
         if let Some(previous) = history.previous() {
             let response = re_ui
@@ -78,7 +78,7 @@ impl SelectionHistoryUi {
         ui: &mut egui::Ui,
         blueprint: &ViewportBlueprint,
         history: &mut SelectionHistory,
-    ) -> Option<Selection> {
+    ) -> Option<ItemCollection> {
         // redo selection
         if let Some(next) = history.next() {
             let response = re_ui
@@ -156,7 +156,7 @@ fn item_kind_ui(ui: &mut egui::Ui, sel: &Item) {
     ui.weak(RichText::new(format!("({})", sel.kind())));
 }
 
-fn selection_to_string(blueprint: &ViewportBlueprint, selection: &Selection) -> String {
+fn selection_to_string(blueprint: &ViewportBlueprint, selection: &ItemCollection) -> String {
     debug_assert!(
         !selection.is_empty(),
         "History should never contain empty selections."

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -41,8 +41,8 @@ pub use item::Item;
 pub use query_context::{DataQueryResult, DataResultHandle, DataResultNode, DataResultTree};
 pub use selection_history::SelectionHistory;
 pub use selection_state::{
-    ApplicationSelectionState, HoverHighlight, InteractionHighlight, SelectedSpaceContext,
-    Selection, SelectionHighlight,
+    ApplicationSelectionState, HoverHighlight, InteractionHighlight, ItemCollection,
+    ItemSpaceContext, SelectionHighlight,
 };
 pub use space_view::{
     DataResult, IdentifiedViewSystem, OverridePath, PerSystemDataResults, PerSystemEntities,

--- a/crates/re_viewer_context/src/selection_history.rs
+++ b/crates/re_viewer_context/src/selection_history.rs
@@ -1,4 +1,4 @@
-use crate::selection_state::Selection;
+use crate::selection_state::ItemCollection;
 
 use super::Item;
 
@@ -6,11 +6,11 @@ use super::Item;
 #[derive(Debug, Clone)]
 pub struct HistoricalSelection {
     pub index: usize,
-    pub selection: Selection,
+    pub selection: ItemCollection,
 }
 
-impl From<(usize, Selection)> for HistoricalSelection {
-    fn from((index, selection): (usize, Selection)) -> Self {
+impl From<(usize, ItemCollection)> for HistoricalSelection {
+    fn from((index, selection): (usize, ItemCollection)) -> Self {
         Self { index, selection }
     }
 }
@@ -26,7 +26,7 @@ pub struct SelectionHistory {
     pub current: usize,
 
     /// Oldest first.
-    pub stack: Vec<Selection>,
+    pub stack: Vec<ItemCollection>,
 }
 
 impl SelectionHistory {
@@ -69,7 +69,7 @@ impl SelectionHistory {
     }
 
     #[must_use]
-    pub fn select_previous(&mut self) -> Option<Selection> {
+    pub fn select_previous(&mut self) -> Option<ItemCollection> {
         if let Some(previous) = self.previous() {
             if previous.index != self.current {
                 self.current = previous.index;
@@ -80,7 +80,7 @@ impl SelectionHistory {
     }
 
     #[must_use]
-    pub fn select_next(&mut self) -> Option<Selection> {
+    pub fn select_next(&mut self) -> Option<ItemCollection> {
         if let Some(next) = self.next() {
             if next.index != self.current {
                 self.current = next.index;
@@ -90,7 +90,7 @@ impl SelectionHistory {
         None
     }
 
-    pub fn update_selection(&mut self, selection: &Selection) {
+    pub fn update_selection(&mut self, selection: &ItemCollection) {
         // Selecting nothing is irrelevant from a history standpoint.
         if selection.is_empty() {
             return;

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -8,8 +8,10 @@ use crate::{item::resolve_mono_instance_path_item, ViewerContext};
 
 use super::{Item, SelectionHistory};
 
+/// Context information that a space view might attach to an item from [`ItemCollection`] and useful
+/// for how a selection might be displayed and interacted with.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub enum SelectedSpaceContext {
+pub enum ItemSpaceContext {
     /// Hovering/Selecting in a 2D space.
     TwoD {
         space_2d: EntityPath,
@@ -79,34 +81,34 @@ impl InteractionHighlight {
     }
 }
 
-/// An ordered collection of [`Item`] and optional associated selected space context objects.
+/// An ordered collection of [`Item`] and optional associated space context objects.
 ///
 /// Used to store what is currently selected and/or hovered.
 #[derive(Debug, Default, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Selection(IndexMap<Item, Option<SelectedSpaceContext>>);
+pub struct ItemCollection(IndexMap<Item, Option<ItemSpaceContext>>);
 
-impl From<Item> for Selection {
+impl From<Item> for ItemCollection {
     #[inline]
     fn from(val: Item) -> Self {
-        Selection([(val, None)].into())
+        ItemCollection([(val, None)].into())
     }
 }
 
-impl<T> From<T> for Selection
+impl<T> From<T> for ItemCollection
 where
-    T: Iterator<Item = (Item, Option<SelectedSpaceContext>)>,
+    T: Iterator<Item = (Item, Option<ItemSpaceContext>)>,
 {
     #[inline]
     fn from(value: T) -> Self {
-        Selection(value.collect())
+        ItemCollection(value.collect())
     }
 }
 
-impl Selection {
+impl ItemCollection {
     /// For each item in this selection, if it refers to the first element of an instance with a
     /// single element, resolve it to a splatted entity path.
     pub fn into_mono_instance_path_items(self, ctx: &ViewerContext<'_>) -> Self {
-        Selection(
+        ItemCollection(
             self.0
                 .into_iter()
                 .map(|(item, space_ctx)| {
@@ -141,7 +143,7 @@ impl Selection {
         self.0.keys()
     }
 
-    pub fn iter_space_context(&self) -> impl Iterator<Item = &SelectedSpaceContext> {
+    pub fn iter_space_context(&self) -> impl Iterator<Item = &ItemSpaceContext> {
         self.0
             .iter()
             .filter_map(|(_, space_context)| space_context.as_ref())
@@ -166,7 +168,7 @@ impl Selection {
     }
 
     /// Retains elements that fulfill a certain condition.
-    pub fn retain(&mut self, f: impl FnMut(&Item, &mut Option<SelectedSpaceContext>) -> bool) {
+    pub fn retain(&mut self, f: impl FnMut(&Item, &mut Option<ItemSpaceContext>) -> bool) {
         self.0.retain(f);
     }
 
@@ -181,20 +183,17 @@ impl Selection {
     }
 
     /// Returns an iterator over the items and their selected space context.
-    pub fn iter(&self) -> impl Iterator<Item = (&Item, &Option<SelectedSpaceContext>)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&Item, &Option<ItemSpaceContext>)> {
         self.0.iter()
     }
 
     /// Returns a mutable iterator over the items and their selected space context.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&Item, &mut Option<SelectedSpaceContext>)> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&Item, &mut Option<ItemSpaceContext>)> {
         self.0.iter_mut()
     }
 
     /// Extend the selection with more items.
-    pub fn extend(
-        &mut self,
-        other: impl IntoIterator<Item = (Item, Option<SelectedSpaceContext>)>,
-    ) {
+    pub fn extend(&mut self, other: impl IntoIterator<Item = (Item, Option<ItemSpaceContext>)>) {
         self.0.extend(other);
     }
 }
@@ -211,19 +210,19 @@ pub struct ApplicationSelectionState {
     pub history: Mutex<SelectionHistory>,
 
     /// Selection of the previous frame. Read from this.
-    selection_previous_frame: Selection,
+    selection_previous_frame: ItemCollection,
 
     /// Selection of the current frame. Write to this.
     #[serde(skip)]
-    selection_this_frame: Mutex<Selection>,
+    selection_this_frame: Mutex<ItemCollection>,
 
     /// What objects are hovered? Read from this.
     #[serde(skip)]
-    hovered_previous_frame: Selection,
+    hovered_previous_frame: ItemCollection,
 
     /// What objects are hovered? Write to this.
     #[serde(skip)]
-    hovered_this_frame: Mutex<Selection>,
+    hovered_this_frame: Mutex<ItemCollection>,
 }
 
 impl ApplicationSelectionState {
@@ -261,39 +260,39 @@ impl ApplicationSelectionState {
     }
 
     /// Clears the current selection out.
-    pub fn clear_current(&self) {
-        self.set_selection(Selection::default());
+    pub fn clear_selection(&self) {
+        self.set_selection(ItemCollection::default());
     }
 
     /// Sets several objects to be selected, updating history as needed.
     ///
     /// Clears the selected space context if none was specified.
-    pub fn set_selection(&self, items: impl Into<Selection>) {
+    pub fn set_selection(&self, items: impl Into<ItemCollection>) {
         *self.selection_this_frame.lock() = items.into();
     }
 
     /// Returns the current selection.
-    pub fn current(&self) -> &Selection {
+    pub fn selected_items(&self) -> &ItemCollection {
         &self.selection_previous_frame
     }
 
     /// Returns the currently hovered objects.
-    pub fn hovered(&self) -> &Selection {
+    pub fn hovered_items(&self) -> &ItemCollection {
         &self.hovered_previous_frame
     }
 
-    /// Set the hovered objects. Will be in [`Self::hovered`] on the next frame.
-    pub fn set_hovered(&self, hovered: impl Into<Selection>) {
+    /// Set the hovered objects. Will be in [`Self::hovered_items`] on the next frame.
+    pub fn set_hovered(&self, hovered: impl Into<ItemCollection>) {
         *self.hovered_this_frame.lock() = hovered.into();
     }
 
     /// Select passed objects unless already selected in which case they get unselected.
     /// If however an object is already selected but now gets passed a *different* selected space context, it stays selected after all
     /// but with an updated selected space context!
-    pub fn toggle_selection(&self, toggle_items: Selection) {
+    pub fn toggle_selection(&self, toggle_items: ItemCollection) {
         re_tracing::profile_function!();
 
-        let mut toggle_items_set: HashMap<Item, Option<SelectedSpaceContext>> = toggle_items
+        let mut toggle_items_set: HashMap<Item, Option<ItemSpaceContext>> = toggle_items
             .iter()
             .map(|(item, ctx)| (item.clone(), ctx.clone()))
             .collect();
@@ -335,11 +334,11 @@ impl ApplicationSelectionState {
         *self.selection_this_frame.lock() = new_selection;
     }
 
-    pub fn selected_space_context(&self) -> impl Iterator<Item = &SelectedSpaceContext> {
+    pub fn item_space_contexts(&self) -> impl Iterator<Item = &ItemSpaceContext> {
         self.selection_previous_frame.iter_space_context()
     }
 
-    pub fn hovered_space_context(&self) -> Option<&SelectedSpaceContext> {
+    pub fn hovered_space_context(&self) -> Option<&ItemSpaceContext> {
         self.hovered_previous_frame.iter_space_context().next()
     }
 

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -334,7 +334,7 @@ impl ApplicationSelectionState {
         *self.selection_this_frame.lock() = new_selection;
     }
 
-    pub fn item_space_contexts(&self) -> impl Iterator<Item = &ItemSpaceContext> {
+    pub fn selection_space_contexts(&self) -> impl Iterator<Item = &ItemSpaceContext> {
         self.selection_previous_frame.iter_space_context()
     }
 

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -6,7 +6,7 @@ use re_entity_db::entity_db::EntityDb;
 
 use crate::{
     query_context::DataQueryResult, AppOptions, ApplicableEntities, ApplicationSelectionState,
-    Caches, CommandSender, ComponentUiRegistry, IndicatedEntities, PerVisualizer, Selection,
+    Caches, CommandSender, ComponentUiRegistry, IndicatedEntities, ItemCollection, PerVisualizer,
     SpaceViewClassRegistry, SpaceViewId, StoreContext, SystemCommandSender as _, TimeControl,
 };
 
@@ -74,13 +74,13 @@ pub struct ViewerContext<'a> {
 
 impl<'a> ViewerContext<'a> {
     /// Returns the current selection.
-    pub fn selection(&self) -> &Selection {
-        self.rec_cfg.selection_state.current()
+    pub fn selection(&self) -> &ItemCollection {
+        self.rec_cfg.selection_state.selected_items()
     }
 
     /// Returns the currently hovered objects.
-    pub fn hovered(&self) -> &Selection {
-        self.rec_cfg.selection_state.hovered()
+    pub fn hovered(&self) -> &ItemCollection {
+        self.rec_cfg.selection_state.hovered_items()
     }
 
     pub fn selection_state(&self) -> &ApplicationSelectionState {
@@ -96,7 +96,7 @@ impl<'a> ViewerContext<'a> {
     pub fn select_hovered_on_click(
         &self,
         response: &egui::Response,
-        selection: impl Into<Selection>,
+        selection: impl Into<ItemCollection>,
     ) {
         re_tracing::profile_function!();
 

--- a/crates/re_viewport/src/space_view_highlights.rs
+++ b/crates/re_viewport/src/space_view_highlights.rs
@@ -42,7 +42,7 @@ pub fn highlights_for_space_view(
                 .add(&instance, next_selection_mask());
         };
 
-    for current_selection in ctx.selection_state().current().iter_items() {
+    for current_selection in ctx.selection_state().selected_items().iter_items() {
         match current_selection {
             Item::StoreId(_) | Item::SpaceView(_) | Item::Container(_) => {}
 
@@ -78,7 +78,7 @@ pub fn highlights_for_space_view(
         OutlineMaskPreference::some(hover_mask_index, 0)
     };
 
-    for current_hover in ctx.selection_state().hovered().iter_items() {
+    for current_hover in ctx.selection_state().hovered_items().iter_items() {
         match current_hover {
             Item::StoreId(_) | Item::SpaceView(_) | Item::Container(_) => {}
 

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -76,7 +76,7 @@ impl Viewport<'_, '_> {
 
                     // clear selection upon clicking on empty space
                     if empty_space_response.clicked() {
-                        ctx.selection_state().clear_current();
+                        ctx.selection_state().clear_selection();
                     }
 
                     // handle drag and drop interaction on empty space


### PR DESCRIPTION
### What

This PR is pure renames, to address some seriously bad names and bring some consistency.

- `Selection` -> `ItemCollection`
- `SelectedSpaceContext` -> `ItemSpaceContext`
- in `ApplicationSelectionState` (which contains both the selection and hovered states:
  - `clear_current` -> `clear_selection`
  - `current` -> `selected_items`
  - `hovered` -> `hovered_items`
  - `selected_space_context` -> `selection_space_contexts`

**Reviewer**: check `selection_state.rs`. Everything else is just Rust analyser's work.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5597/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5597/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5597/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5597)
- [Docs preview](https://rerun.io/preview/79db70275f6c80dcef78b2452e3fc5515891321c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/79db70275f6c80dcef78b2452e3fc5515891321c/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)