### PR TITLE
Removing items with the context menu now also removes them from the selection

### DIFF
--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -286,7 +286,10 @@ impl ApplicationSelectionState {
         *self.hovered_this_frame.lock() = hovered.into();
     }
 
-    /// Remove items from the selection, ignoring whether they are actually selected.
+    /// Remove given items from the selection.
+    ///
+    /// Has no effect on items that were not selected in the first place.
+    /// Ignores `ItemSpaceContext`s in the passed collection if any.
     pub fn remove_from_selection(&self, items: impl Into<ItemCollection>) {
         let removed_items = items.into();
         self.selection_this_frame

--- a/crates/re_viewer_context/src/selection_state.rs
+++ b/crates/re_viewer_context/src/selection_state.rs
@@ -286,6 +286,14 @@ impl ApplicationSelectionState {
         *self.hovered_this_frame.lock() = hovered.into();
     }
 
+    /// Remove items from the selection, ignoring whether they are actually selected.
+    pub fn remove_from_selection(&self, items: impl Into<ItemCollection>) {
+        let removed_items = items.into();
+        self.selection_this_frame
+            .lock()
+            .retain(|item, _| !removed_items.contains_item(item));
+    }
+
     /// Select passed objects unless already selected in which case they get unselected.
     /// If however an object is already selected but now gets passed a *different* selected space context, it stays selected after all
     /// but with an updated selected space context!

--- a/crates/re_viewport/src/context_menu/actions/remove.rs
+++ b/crates/re_viewport/src/context_menu/actions/remove.rs
@@ -33,6 +33,9 @@ impl ContextMenuAction for RemoveAction {
             .mark_user_interaction(ctx.viewer_context);
         ctx.viewport_blueprint
             .remove_contents(Contents::Container(*container_id));
+        ctx.viewer_context
+            .selection_state()
+            .remove_from_selection(Item::Container(*container_id));
     }
 
     fn process_space_view(&self, ctx: &ContextMenuContext<'_>, space_view_id: &SpaceViewId) {
@@ -40,6 +43,9 @@ impl ContextMenuAction for RemoveAction {
             .mark_user_interaction(ctx.viewer_context);
         ctx.viewport_blueprint
             .remove_contents(Contents::SpaceView(*space_view_id));
+        ctx.viewer_context
+            .selection_state()
+            .remove_from_selection(Item::SpaceView(*space_view_id));
     }
 
     fn process_data_result(
@@ -53,6 +59,10 @@ impl ContextMenuAction for RemoveAction {
                 ctx.viewer_context,
                 EntityPathRule::including_subtree(instance_path.entity_path.clone()),
             );
+
+            ctx.viewer_context
+                .selection_state()
+                .remove_from_selection(Item::DataResult(*space_view_id, instance_path.clone()));
         }
     }
 }


### PR DESCRIPTION
### What

What the title says.
- Fixes #5465 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5598/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5598/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5598/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5598)
- [Docs preview](https://rerun.io/preview/85e8eb0e47d2602ced27f2a7439304caff963482/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/85e8eb0e47d2602ced27f2a7439304caff963482/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)