### PR TITLE
Do not display non-visualizable items as hidden in the blueprint tree

### DIFF
--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -570,9 +570,7 @@ impl Viewport<'_, '_> {
             ctx.re_ui.warning_text(item_label)
         };
 
-        let subdued = !space_view_visible
-            || !visible
-            || data_result_node.map_or(true, |n| n.data_result.visualizers.is_empty());
+        let subdued = !space_view_visible || !visible;
 
         let list_item = ListItem::new(ctx.re_ui, item_label)
             .selected(is_selected)


### PR DESCRIPTION
### What

I posit that displaying visibility is more important than visualizability in the blueprint tree. This PR stops confounding both aspects in the styling.

- Fixes #5469

Before/after:

<img width="188" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/1772f396-225f-4a4d-a25f-4f66e0ab7b4c">
<img width="247" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/3e485645-ff07-4f89-b70a-6c1e99bc9b3c">

<br/><br/>

It would still be interesting to somehow display visualizability there. We need a design for that.

- Relates to #5410


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5600/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5600/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5600/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5600)
- [Docs preview](https://rerun.io/preview/b2e30f22c442163dfed3b12dbb7df4585e1fba8c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b2e30f22c442163dfed3b12dbb7df4585e1fba8c/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)