### PR TITLE
New data APIs 3: Send/Sync/'static `Component`, once and for all

### DIFF
--- a/crates/re_query_cache/src/cache.rs
+++ b/crates/re_query_cache/src/cache.rs
@@ -734,9 +734,7 @@ impl CacheBucket {
 
     /// Iterate over the batches of the specified non-optional component.
     #[inline]
-    pub fn iter_component<C: Component + Send + Sync + 'static>(
-        &self,
-    ) -> Option<impl Iterator<Item = &[C]>> {
+    pub fn iter_component<C: Component>(&self) -> Option<impl Iterator<Item = &[C]>> {
         let data = self
             .components
             .get(&C::name())
@@ -746,9 +744,7 @@ impl CacheBucket {
 
     /// Iterate over the batches of the specified optional component.
     #[inline]
-    pub fn iter_component_opt<C: Component + Send + Sync + 'static>(
-        &self,
-    ) -> Option<impl Iterator<Item = &[Option<C>]>> {
+    pub fn iter_component_opt<C: Component>(&self) -> Option<impl Iterator<Item = &[Option<C>]>> {
         let data = self
             .components
             .get(&C::name())
@@ -823,7 +819,7 @@ impl CacheBucket {
 
     /// Get the raw batches for the specified non-optional component.
     #[inline]
-    pub fn component<C: Component + Send + Sync + 'static>(&self) -> Option<&FlatVecDeque<C>> {
+    pub fn component<C: Component>(&self) -> Option<&FlatVecDeque<C>> {
         self.components
             .get(&C::name())
             .and_then(|data| data.as_any().downcast_ref::<FlatVecDeque<C>>())
@@ -831,7 +827,7 @@ impl CacheBucket {
 
     /// Range over the batches of the specified non-optional component.
     #[inline]
-    pub fn range_component<C: Component + Send + Sync + 'static>(
+    pub fn range_component<C: Component>(
         &self,
         entry_range: Range<usize>,
     ) -> Option<impl Iterator<Item = &[C]>> {
@@ -844,9 +840,7 @@ impl CacheBucket {
 
     /// Get the raw batches for the specified optional component.
     #[inline]
-    pub fn component_opt<C: Component + Send + Sync + 'static>(
-        &self,
-    ) -> Option<&FlatVecDeque<Option<C>>> {
+    pub fn component_opt<C: Component>(&self) -> Option<&FlatVecDeque<Option<C>>> {
         self.components
             .get(&C::name())
             .and_then(|data| data.as_any().downcast_ref::<FlatVecDeque<Option<C>>>())
@@ -854,7 +848,7 @@ impl CacheBucket {
 
     /// Range over the batches of the specified optional component.
     #[inline]
-    pub fn range_component_opt<C: Component + Send + Sync + 'static>(
+    pub fn range_component_opt<C: Component>(
         &self,
         entry_range: Range<usize>,
     ) -> Option<impl Iterator<Item = &[Option<C>]>> {
@@ -934,8 +928,8 @@ macro_rules! impl_insert {
         ) -> ::re_query::Result<u64>
         where
             A: Archetype,
-            $($pov: Component + Send + Sync + 'static,)+
-            $($comp: Component + Send + Sync + 'static,)*
+            $($pov: Component,)+
+            $($comp: Component,)*
         {
             // NOTE: not `profile_function!` because we want them merged together.
             re_tracing::profile_scope!("CacheBucket::insert", format!("arch={} pov={} comp={}", A::name(), $N, $M));
@@ -992,7 +986,7 @@ impl CacheBucket {
     ) -> ::re_query::Result<u64>
     where
         A: Archetype,
-        R1: Component + Send + Sync + 'static,
+        R1: Component,
     {
         self.insert_pov1_comp0::<A, R1>(query_time, arch_view)
     }
@@ -1002,7 +996,7 @@ impl CacheBucket {
     });
 
     #[inline]
-    fn insert_component<A: Archetype, C: Component + Send + Sync + 'static>(
+    fn insert_component<A: Archetype, C: Component>(
         &mut self,
         at: usize,
         arch_view: &ArchetypeView<A>,
@@ -1041,7 +1035,7 @@ impl CacheBucket {
 
     /// This will insert an empty slice for a missing component (instead of N `None` values).
     #[inline]
-    fn insert_component_opt<A: Archetype, C: Component + Send + Sync + 'static>(
+    fn insert_component_opt<A: Archetype, C: Component>(
         &mut self,
         at: usize,
         arch_view: &ArchetypeView<A>,

--- a/crates/re_query_cache/src/latest_at.rs
+++ b/crates/re_query_cache/src/latest_at.rs
@@ -145,8 +145,8 @@ macro_rules! impl_query_archetype_latest_at {
         ) -> ::re_query::Result<()>
         where
             A: Archetype + 'a,
-            $($pov: Component + Send + Sync + 'static,)+
-            $($comp: Component + Send + Sync + 'static,)*
+            $($pov: Component,)+
+            $($comp: Component,)*
             F: FnMut(
                 (
                     (TimeInt, RowId),

--- a/crates/re_query_cache/src/query.rs
+++ b/crates/re_query_cache/src/query.rs
@@ -39,7 +39,7 @@ impl Caches {
     ) -> ::re_query::Result<()>
     where
         A: Archetype + 'a,
-        R1: Component + Send + Sync + 'static,
+        R1: Component,
         F: FnMut(((TimeInt, RowId), &[InstanceKey], &[R1])),
     {
         self.query_archetype_pov1_comp0::<A, R1, F>(store, query, entity_path, f)
@@ -60,8 +60,8 @@ macro_rules! impl_query_archetype {
         ) -> ::re_query::Result<()>
         where
             A: Archetype + 'a,
-            $($pov: Component + Send + Sync + 'static,)+
-            $($comp: Component + Send + Sync + 'static,)*
+            $($pov: Component,)+
+            $($comp: Component,)*
             F: FnMut(
                 (
                     (TimeInt, RowId),
@@ -159,7 +159,7 @@ impl Caches {
     ) -> ::re_query::Result<()>
     where
         A: Archetype + 'a,
-        R1: Component + Send + Sync + 'static,
+        R1: Component,
         F: FnMut(((TimeInt, RowId), &[InstanceKey], &[R1])),
     {
         self.query_archetype_with_history_pov1_comp0::<A, R1, F>(
@@ -186,8 +186,8 @@ macro_rules! impl_query_archetype_with_history {
         ) -> ::re_query::Result<()>
         where
             A: Archetype + 'a,
-            $($pov: Component + Send + Sync + 'static,)+
-            $($comp: Component + Send + Sync + 'static,)*
+            $($pov: Component,)+
+            $($comp: Component,)*
             F: FnMut(
                 (
                     (TimeInt, RowId),

--- a/crates/re_query_cache/src/range.rs
+++ b/crates/re_query_cache/src/range.rs
@@ -165,8 +165,8 @@ macro_rules! impl_query_archetype_range {
         ) -> ::re_query::Result<()>
         where
             A: Archetype + 'a,
-            $($pov: Component + Send + Sync + 'static,)+
-            $($comp: Component + Send + Sync + 'static,)*
+            $($pov: Component,)+
+            $($comp: Component,)*
             F: FnMut(
                 std::ops::Range<usize>,
                 (
@@ -218,8 +218,8 @@ macro_rules! impl_query_archetype_range {
             ) -> crate::Result<u64>
             where
                 A: Archetype + 'a,
-                $($pov: Component + Send + Sync + 'static,)+
-                $($comp: Component + Send + Sync + 'static,)*
+                $($pov: Component,)+
+                $($comp: Component,)*
             {
                 re_tracing::profile_scope!("fill");
 

--- a/crates/re_query_cache2/src/latest_at/results.rs
+++ b/crates/re_query_cache2/src/latest_at/results.rs
@@ -180,7 +180,7 @@ impl CachedLatestAtComponentResults {
     /// Use [`PromiseResult::flatten`] to merge the results of resolving the promise and of
     /// deserializing the data into a single one, if you don't need the extra flexibility.
     #[inline]
-    pub fn to_dense<C: 'static + Component + Send + Sync>(
+    pub fn to_dense<C: Component>(
         &self,
         resolver: &PromiseResolver,
     ) -> PromiseResult<crate::Result<&[C]>> {
@@ -201,7 +201,7 @@ impl CachedLatestAtComponentResults {
     /// Use [`PromiseResult::flatten`] to merge the results of resolving the promise and of
     /// deserializing the data into a single one, if you don't need the extra flexibility.
     #[inline]
-    pub fn iter_dense<C: 'static + Component + Send + Sync>(
+    pub fn iter_dense<C: Component>(
         &self,
         resolver: &PromiseResolver,
     ) -> PromiseResult<crate::Result<impl ExactSizeIterator<Item = &C>>> {
@@ -216,7 +216,7 @@ impl CachedLatestAtComponentResults {
     /// Use [`PromiseResult::flatten`] to merge the results of resolving the promise and of
     /// deserializing the data into a single one, if you don't need the extra flexibility.
     #[inline]
-    pub fn to_sparse<C: 'static + Component + Send + Sync>(
+    pub fn to_sparse<C: Component>(
         &self,
         resolver: &PromiseResolver,
     ) -> PromiseResult<crate::Result<&[Option<C>]>> {
@@ -237,7 +237,7 @@ impl CachedLatestAtComponentResults {
     /// Use [`PromiseResult::flatten`] to merge the results of resolving the promise and of
     /// deserializing the data into a single one, if you don't need the extra flexibility.
     #[inline]
-    pub fn iter_sparse<C: 'static + Component + Send + Sync>(
+    pub fn iter_sparse<C: Component>(
         &self,
         resolver: &PromiseResolver,
     ) -> PromiseResult<crate::Result<impl ExactSizeIterator<Item = Option<&C>>>> {
@@ -247,10 +247,7 @@ impl CachedLatestAtComponentResults {
 }
 
 impl CachedLatestAtComponentResults {
-    fn downcast_dense<C: 'static + Component + Send + Sync>(
-        &self,
-        cell: &DataCell,
-    ) -> crate::Result<&[C]> {
+    fn downcast_dense<C: Component>(&self, cell: &DataCell) -> crate::Result<&[C]> {
         // `OnceLock::get` is non-blocking -- this is a best-effort fast path in case the
         // data has already been computed.
         //
@@ -276,10 +273,7 @@ impl CachedLatestAtComponentResults {
         downcast(&**cached)
     }
 
-    fn downcast_sparse<C: 'static + Component + Send + Sync>(
-        &self,
-        cell: &DataCell,
-    ) -> crate::Result<&[Option<C>]> {
+    fn downcast_sparse<C: Component>(&self, cell: &DataCell) -> crate::Result<&[Option<C>]> {
         // `OnceLock::get` is non-blocking -- this is a best-effort fast path in case the
         // data has already been computed.
         //
@@ -306,9 +300,7 @@ impl CachedLatestAtComponentResults {
     }
 }
 
-fn downcast<C: 'static + Component + Send + Sync>(
-    cached: &(dyn ErasedFlatVecDeque + Send + Sync),
-) -> crate::Result<&[C]> {
+fn downcast<C: Component>(cached: &(dyn ErasedFlatVecDeque + Send + Sync)) -> crate::Result<&[C]> {
     let cached = cached
         .as_any()
         .downcast_ref::<FlatVecDeque<C>>()
@@ -324,7 +316,7 @@ fn downcast<C: 'static + Component + Send + Sync>(
     Ok(cached.iter().next().unwrap())
 }
 
-fn downcast_opt<C: 'static + Component + Send + Sync>(
+fn downcast_opt<C: Component>(
     cached: &(dyn ErasedFlatVecDeque + Send + Sync),
 ) -> crate::Result<&[Option<C>]> {
     let cached = cached

--- a/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
@@ -130,8 +130,8 @@ macro_rules! impl_process_archetype {
         where
             S: IdentifiedViewSystem,
             A: Archetype + 'a,
-            $($pov: Component + Send + Sync + 'static,)+
-            $($comp: Component + Send + Sync + 'static,)*
+            $($pov: Component,)+
+            $($comp: Component,)*
             F: FnMut(
                 &ViewerContext<'_>,
                 &EntityPath,

--- a/crates/re_types_core/src/loggable.rs
+++ b/crates/re_types_core/src/loggable.rs
@@ -21,7 +21,7 @@ use crate::{Archetype, ComponentBatch, DatatypeBatch, LoggableBatch};
 /// automatically derives the [`LoggableBatch`] implementation (and by extension
 /// [`DatatypeBatch`]/[`ComponentBatch`]), which makes it possible to work with lists' worth of data
 /// in a generic fashion.
-pub trait Loggable: Clone + Sized + SizeBytes {
+pub trait Loggable: 'static + Send + Sync + Clone + Sized + SizeBytes {
     type Name: std::fmt::Display;
 
     /// The fully-qualified name of this loggable, e.g. `rerun.datatypes.Vec2D`.


### PR DESCRIPTION
A trivial PR that essentially just does this:
```diff
- pub trait Loggable: Clone + Sized + SizeBytes {
+ pub trait Loggable: 'static + Send + Sync + Clone + Sized + SizeBytes {
```

because im very tired of carrying these clauses around manually everywhere.

---

Part of a PR series to completely revamp the data APIs in preparation for the removal of instance keys and the introduction of promises:
- #5573
- #5574
- #5581
- #5605
- #5606
- #5633
- #5673
- #5679
- #5687
- #5755
- TODO
- TODO

Builds on top of the static data PR series:
- #5534

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5573/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5573/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5573/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5573)
- [Docs preview](https://rerun.io/preview/0008cc68d3963f8b054af3aa82753b8c535e511b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0008cc68d3963f8b054af3aa82753b8c535e511b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)