### PR TITLE
[TBD] Selection panel auto-collapses when selection is empty

### DIFF
--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -45,7 +45,7 @@ impl SelectionPanel {
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         viewport: &mut Viewport<'_, '_>,
-        expanded: bool,
+        mut expanded: bool,
     ) {
         let screen_width = ui.ctx().screen_rect().width();
 
@@ -61,6 +61,8 @@ impl SelectionPanel {
 
         // Always reset the VH highlight, and let the UI re-set it if needed.
         ctx.rec_cfg.time_ctrl.write().highlighted_range = None;
+
+        expanded &= !ctx.selection().is_empty();
 
         panel.show_animated_inside(ui, expanded, |ui: &mut egui::Ui| {
             // Set the clip rectangle to the panel for the benefit of nested, "full span" widgets


### PR DESCRIPTION
### What

The selection panel now auto-collapses when the selection is empty.

https://github.com/rerun-io/rerun/assets/49431240/914c8ee2-23bd-41bb-b524-f9e34d393e28


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5608/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5608/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5608/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5608)
- [Docs preview](https://rerun.io/preview/a3351b07fe10841cbd00a9be776883454e0a6d20/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a3351b07fe10841cbd00a9be776883454e0a6d20/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)