### PR TITLE
Fix bad link from trouble shooting guide

### DIFF
--- a/docs/content/getting-started/troubleshooting.md
+++ b/docs/content/getting-started/troubleshooting.md
@@ -9,6 +9,7 @@ If you run into any issues don't hesitate to [open a ticket](https://github.com/
 or [join our Discord](https://discord.gg/Gcm8BbTaAj).
 
 ## Running on Linux
+
 Rerun should work out-of-the-box on Mac and Windows, but on Linux you need to first run:
 
 ```sh
@@ -54,6 +55,7 @@ sudo apt-get -y install \
 sometimes causes Rerun to crash. Try unsetting the wayland display (`unset WAYLAND_DISPLAY` or `WAYLAND_DISPLAY= `) as a workaround.
 
 ## Startup issues
+
 If Rerun is having trouble starting, you can try resetting its memory with:
 
 ```
@@ -61,20 +63,22 @@ rerun reset
 ```
 
 ## Graphics issues
+
 <!-- This section is linked to from `crates/re_viewer/src/native.rs` -->
 
 [Wgpu](https://github.com/gfx-rs/wgpu) (the graphics API we use) maintains a list of
 [known driver issues](https://github.com/gfx-rs/wgpu/wiki/Known-Driver-Issues) and workarounds for them.
 
 The configuration we use for wgpu can be influenced in the following ways:
-* pass `--renderer=<backend>` on startup: `<backend>` must be one of `vulkan`, `metal` or `gl` for native and
-  either `webgl` or `webgpu` for the web viewer (see also `--web-viewer` argument).
-  Naturally, support depends on your OS. The default backend is `vulkan` everywhere except on Mac where we use `metal`.
-  On the web we prefer WebGPU and fall back automatically to WebGL if no support for WebGPU was detected.
-    * For instance, you can try `rerun --renderer=gl` or for the web viewer respectively `rerun --web-viewer --renderer=webgl`.
-    * Alternatively, for the native viewer you can also use the `WGPU_BACKEND` environment variable with the above values.
-    * The web viewer is configured by the `renderer=<backend>` url argument, e.g. [https://app.rerun.io/?renderer=webgl]
-* `WGPU_POWER_PREF`: Overwrites the power setting used for choosing a graphics adapter, must be `high` or `low`. (Default is `high`)
+
+-   pass `--renderer=<backend>` on startup: `<backend>` must be one of `vulkan`, `metal` or `gl` for native and
+    either `webgl` or `webgpu` for the web viewer (see also `--web-viewer` argument).
+    Naturally, support depends on your OS. The default backend is `vulkan` everywhere except on Mac where we use `metal`.
+    On the web we prefer WebGPU and fall back automatically to WebGL if no support for WebGPU was detected.
+    -   For instance, you can try `rerun --renderer=gl` or for the web viewer respectively `rerun --web-viewer --renderer=webgl`.
+    -   Alternatively, for the native viewer you can also use the `WGPU_BACKEND` environment variable with the above values.
+    -   The web viewer is configured by the `renderer=<backend>` url argument, e.g. [https://app.rerun.io/?renderer=webgl]
+-   `WGPU_POWER_PREF`: Overwrites the power setting used for choosing a graphics adapter, must be `high` or `low`. (Default is `high`)
 
 We recommend setting these only if you're asked to try them or know what you're doing,
 since we don't support all of these settings equally well.
@@ -83,9 +87,10 @@ since we don't support all of these settings equally well.
 
 When using Wgpu's Vulkan backend (the default on Windows & Linux) on a computer that has both integrated and dedicated GPUs, a lot of issues can arise from Vulkan either picking the "wrong" GPU at runtime, or even simply from the fact that this choice conflicts with other driver picking technologies (e.g. NVIDIA Optimus).
 
-In both cases, forcing Vulkan to pick either the integrated or discrete GPU (try both!) using the [`VK_ICD_FILENAMES`](https://vulkan.lunarg.com/doc/view/1.3.204.1/mac/LoaderDriverInterface.html#user-content-driver-discovery) environment variable might help with crashes, artifacts and bad performance. E.g.:
-- Force the Intel integrated GPU:
-  - Linux: `export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/intel.json`.
-- Force the discrete Nvidia GPU:
-  - Linux: `export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia.json`.
-  - Windows: `set VK_ICD_FILENAMES=\windows\system32\nv-vk64.json`.
+In both cases, forcing Vulkan to pick either the integrated or discrete GPU (try both!) using the [`VK_ICD_FILENAMES`](https://vulkan.lunarg.com/doc/view/latest/mac/LoaderDriverInterface.html#user-content-driver-discovery) environment variable might help with crashes, artifacts and bad performance. E.g.:
+
+-   Force the Intel integrated GPU:
+    -   Linux: `export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/intel.json`.
+-   Force the discrete Nvidia GPU:
+    -   Linux: `export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia.json`.
+    -   Windows: `set VK_ICD_FILENAMES=\windows\system32\nv-vk64.json`.


### PR DESCRIPTION
### What
Looks like vulkan doesn't keep old docs up indefinitely. Switching link to latest instead.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5610/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5610/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5610/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5610)
- [Docs preview](https://rerun.io/preview/97dad63d96c63657e0b6020453285acf79755ffb/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/97dad63d96c63657e0b6020453285acf79755ffb/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)