### PR TITLE
Add blueprint to Human Pose Tracking example

### DIFF
--- a/examples/python/human_pose_tracking/main.py
+++ b/examples/python/human_pose_tracking/main.py
@@ -190,23 +190,6 @@ def get_downloaded_path(dataset_dir: Path, video_name: str) -> str:
     return str(destination_path)
 
 
-def get_blueprint() -> rrb.BlueprintLike:
-    return rrb.Viewport(
-        rrb.Horizontal(
-            rrb.Vertical(
-                rrb.Spatial2DView(origin="video", name="Segmentation/reprojection"),
-                rrb.Spatial3DView(origin="person", name="3D pose"),
-            ),
-            rrb.Vertical(
-                rrb.Spatial2DView(origin="video/rgb", name="Raw video"),
-                rrb.TextDocumentView(origin="description", name="Description"),
-                row_shares=[1, 3],
-            ),
-            column_shares=[2, 1],
-        )
-    )
-
-
 def main() -> None:
     # Ensure the logging gets written to stderr:
     logging.getLogger().addHandler(logging.StreamHandler())
@@ -231,7 +214,22 @@ def main() -> None:
     rr.script_add_args(parser)
 
     args = parser.parse_args()
-    rr.script_setup(args, "rerun_example_human_pose_tracking", blueprint=get_blueprint())
+    rr.script_setup(
+        args,
+        "rerun_example_human_pose_tracking",
+        blueprint=rrb.Horizontal(
+            rrb.Vertical(
+                rrb.Spatial2DView(origin="video", name="Result"),
+                rrb.Spatial3DView(origin="person", name="3D pose"),
+            ),
+            rrb.Vertical(
+                rrb.Spatial2DView(origin="video/rgb", name="Raw video"),
+                rrb.TextDocumentView(origin="description", name="Description"),
+                row_shares=[2, 3],
+            ),
+            column_shares=[3, 2],
+        ),
+    )
 
     video_path = args.video_path  # type: str
     if not video_path:

--- a/examples/python/human_pose_tracking/main.py
+++ b/examples/python/human_pose_tracking/main.py
@@ -16,11 +16,11 @@ import numpy as np
 import numpy.typing as npt
 import requests
 import rerun as rr  # pip install rerun-sdk
+import rerun.blueprint as rrb
 
 EXAMPLE_DIR: Final = Path(os.path.dirname(__file__))
 DATASET_DIR: Final = EXAMPLE_DIR / "dataset" / "pose_movement"
 DATASET_URL_BASE: Final = "https://storage.googleapis.com/rerun-example-datasets/pose_movement"
-
 
 DESCRIPTION = """
 # Human Pose Tracking
@@ -190,6 +190,23 @@ def get_downloaded_path(dataset_dir: Path, video_name: str) -> str:
     return str(destination_path)
 
 
+def get_blueprint() -> rrb.BlueprintLike:
+    return rrb.Viewport(
+        rrb.Horizontal(
+            rrb.Vertical(
+                rrb.Spatial2DView(origin="video", name="Segmentation/reprojection"),
+                rrb.Spatial3DView(origin="person", name="3D pose"),
+            ),
+            rrb.Vertical(
+                rrb.Spatial2DView(origin="video/rgb", name="Raw video"),
+                rrb.TextDocumentView(origin="description", name="Description"),
+                row_shares=[1, 3],
+            ),
+            column_shares=[2, 1],
+        )
+    )
+
+
 def main() -> None:
     # Ensure the logging gets written to stderr:
     logging.getLogger().addHandler(logging.StreamHandler())
@@ -214,7 +231,7 @@ def main() -> None:
     rr.script_add_args(parser)
 
     args = parser.parse_args()
-    rr.script_setup(args, "rerun_example_human_pose_tracking")
+    rr.script_setup(args, "rerun_example_human_pose_tracking", blueprint=get_blueprint())
 
     video_path = args.video_path  # type: str
     if not video_path:


### PR DESCRIPTION
### What

Add blueprint to Human Pose Tracking. That example was pretty good already, but still a nice touch.

<img width="1665" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/49bc0d54-f47e-4460-aab8-f6734e8a78d8">



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5612/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5612/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5612/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5612)
- [Docs preview](https://rerun.io/preview/2a0e41c68fa57f01eeccf451bcba4dfe0de2fa7d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2a0e41c68fa57f01eeccf451bcba4dfe0de2fa7d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)