### PR TITLE
Add blueprint to Live Camera Edge Detection example

### DIFF
--- a/examples/python/live_camera_edge_detection/main.py
+++ b/examples/python/live_camera_edge_detection/main.py
@@ -10,6 +10,7 @@ import argparse
 
 import cv2
 import rerun as rr  # pip install rerun-sdk
+import rerun.blueprint as rrb
 
 
 def run_canny(num_frames: int | None) -> None:
@@ -62,7 +63,18 @@ def main() -> None:
     rr.script_add_args(parser)
     args = parser.parse_args()
 
-    rr.script_setup(args, "rerun_example_live_camera_edge_detection")
+    rr.script_setup(
+        args,
+        "rerun_example_live_camera_edge_detection",
+        blueprint=rrb.Vertical(
+            rrb.Horizontal(
+                rrb.Spatial2DView(origin="/image/rgb", name="Video"),
+                rrb.Spatial2DView(origin="/image/gray", name="Video (Grayscale)"),
+            ),
+            rrb.Spatial2DView(origin="/image/canny", name="Canny Edge Detector"),
+            row_shares=[1, 2],
+        ),
+    )
 
     run_canny(args.num_frames)
 


### PR DESCRIPTION
### What

Add blueprint to Live Camera Edge Detection example:

<img width="1121" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/82507b98-485f-499e-a35f-eabba8c53f3c">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5613/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5613/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5613/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5613)
- [Docs preview](https://rerun.io/preview/ebd7e2fa11ced1becfd06d333933741e7fe288f1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ebd7e2fa11ced1becfd06d333933741e7fe288f1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)