### PR TITLE
Add blueprint to LLM Embedding Ner example

### DIFF
--- a/examples/python/llm_embedding_ner/main.py
+++ b/examples/python/llm_embedding_ner/main.py
@@ -14,6 +14,7 @@ from collections import defaultdict
 from typing import Any
 
 import rerun as rr
+import rerun.blueprint as rrb
 import torch
 import umap
 from transformers import AutoModelForTokenClassification, AutoTokenizer, pipeline
@@ -165,7 +166,19 @@ def main() -> None:
     rr.script_add_args(parser)
     args = parser.parse_args()
 
-    rr.script_setup(args, "rerun_example_llm_embedding_ner")
+    rr.script_setup(
+        args,
+        "rerun_example_llm_embedding_ner",
+        blueprint=rrb.Horizontal(
+            rrb.Vertical(
+                rrb.TextDocumentView(origin="/text", name="Original Text"),
+                rrb.TextDocumentView(origin="/tokenized_text", name="Tokenized Text"),
+                rrb.TextDocumentView(origin="/named_entities", name="Named Entities"),
+                row_shares=[3, 2, 2],
+            ),
+            rrb.Spatial3DView(origin="/umap_embeddings", name="UMAP Embeddings"),
+        ),
+    )
     run_llm_ner(args.text)
     rr.script_teardown(args)
 


### PR DESCRIPTION
### What

Add blueprint to LLM Embedding Ner example

<img width="1982" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/2eabe5a7-d7a5-4998-a2a4-159ccf3b320d">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5614/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5614/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5614/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5614)
- [Docs preview](https://rerun.io/preview/66e788d6aa6f9966f54a7e8ad0b888da91e93220/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/66e788d6aa6f9966f54a7e8ad0b888da91e93220/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)