### PR TITLE
Update example thumbnails

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -228,6 +228,7 @@
     "Nichol",
     "Nikhila",
     "nohash",
+    "NOLINT",
     "noqa",
     "numpages",
     "numpy",

--- a/examples/cpp/clock/README.md
+++ b/examples/cpp/clock/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "Clock"
 thumbnail = "https://static.rerun.io/clock/8c49e25f5cac4d6a1d7d0490b14cf6881bdb707b/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/cpp/clock/README.md
+++ b/examples/cpp/clock/README.md
@@ -1,6 +1,6 @@
 <!--[metadata]
 title = "Clock"
-thumbnail = "https://static.rerun.io/clock/ae4b8970edba8480431cb71e57b8cddd9e1769c7/480w.png"
+thumbnail = "https://static.rerun.io/clock/8c49e25f5cac4d6a1d7d0490b14cf6881bdb707b/480w.png"
 -->
 
 

--- a/examples/cpp/eigen_opencv/README.md
+++ b/examples/cpp/eigen_opencv/README.md
@@ -2,8 +2,8 @@
 title = "Eigen and OpenCV C++ Integration"
 source = "https://github.com/rerun-io/cpp-example-opencv-eigen"
 tags = ["2D", "3D", "C++", "Eigen", "OpenCV"]
-thumbnail = "https://static.rerun.io/cpp-example-opencv-eigen/2fc6355fd87fbb4d07cda384ee8805edb68b5e01/480w.png"
-thumbnail_dimensions = [480, 267]
+thumbnail = "https://static.rerun.io/eigen-and-opencv-c-integration/5d271725bb9215b55f53767c9dc0db980c73dade/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 This is a minimal CMake project that shows how to use Rerun in your code in conjunction with [Eigen](https://eigen.tuxfamily.org/) and [OpenCV](https://opencv.org/).

--- a/examples/cpp/incremental_logging/README.md
+++ b/examples/cpp/incremental_logging/README.md
@@ -3,7 +3,7 @@ title = "Incremental Logging"
 tags = ["3D", "api-example"]
 description = "Showcases how to incrementally log data belonging to the same archetype."
 thumbnail = "https://static.rerun.io/incremental_logging/b7a2bd889b09c3840f56dc31bd6d677934ab3126/480w.png"
-thumbnail_dimensions = [480, 285]
+thumbnail_dimensions = [480, 301]
 -->
 
 

--- a/examples/cpp/minimal/README.md
+++ b/examples/cpp/minimal/README.md
@@ -1,6 +1,6 @@
 <!--[metadata]
 title = "Minimal example"
-thumbnail = "https://static.rerun.io/minimal/0e47ac513ab25d56cf2b493128097d499a07e5e8/480w.png"
+thumbnail = "https://static.rerun.io/minimal-example/9e694c0689f20323ed0053506a7a099f7391afca/480w.png"
 -->
 
 

--- a/examples/cpp/minimal/README.md
+++ b/examples/cpp/minimal/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "Minimal example"
 thumbnail = "https://static.rerun.io/minimal-example/9e694c0689f20323ed0053506a7a099f7391afca/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/cpp/stdio/README.md
+++ b/examples/cpp/stdio/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "Standard Input/Output example"
 thumbnail = "https://static.rerun.io/stdio/25c5aba992d4c8b3861386d8d9539a4823dca117/480w.png"
+thumbnail_dimensions = [480, 298]
 -->
 
 

--- a/examples/cpp/vrs/README.md
+++ b/examples/cpp/vrs/README.md
@@ -2,8 +2,8 @@
 title = "VRS Viewer"
 source = "https://github.com/rerun-io/cpp-example-vrs"
 tags = ["2D", "3D", "vrs", "viewer", "C++"]
-thumbnail = "https://static.rerun.io/cpp-example-vrs/c765460d4448da27bb9ee2a2a15f092f82a402d2/480w.png"
-thumbnail_dimensions = [480, 286]
+thumbnail = "https://static.rerun.io/vrs-viewer/28da92ebc2f0bccd5cf904314d2f8b0b0c45c879/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/arflow/README.md
+++ b/examples/python/arflow/README.md
@@ -2,8 +2,8 @@
 title = "ARFlow: A Framework for Simplifying AR Experimentation Workflow"
 source = "https://github.com/cake-lab/ARFlow"
 tags = ["3D", "Augmented Reality", "Spatial Computing"]
-thumbnail = "https://static.rerun.io/arflow/cc3b0c748e8fc49a78b33631a7005ede3fce44be/480w.png"
-thumbnail_dimensions = [480, 261]
+thumbnail = "https://static.rerun.io/arflow/a6b509af10a42b3c7ad3909d44e972a3cb1a9c41/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/arkit_scenes/README.md
+++ b/examples/python/arkit_scenes/README.md
@@ -2,8 +2,8 @@
 title = "ARKit Scenes"
 tags = ["2D", "3D", "depth", "mesh", "object-detection", "pinhole-camera"]
 description = "Visualize the ARKitScenes dataset, which contains color+depth images, the reconstructed mesh and labeled bounding boxes."
-thumbnail = "https://static.rerun.io/arkit_scenes/fb9ec9e8d965369d39d51b17fc7fc5bae6be10cc/480w.png"
-thumbnail_dimensions = [480, 243]
+thumbnail = "https://static.rerun.io/arkit-scenes/6d920eaa42fb86cfd264d47180ecbecbb6dd3e09/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "main"
 -->
 

--- a/examples/python/clock/README.md
+++ b/examples/python/clock/README.md
@@ -1,7 +1,7 @@
 <!--[metadata]
 title = "Clock"
-thumbnail = "https://static.rerun.io/clock/ae4b8970edba8480431cb71e57b8cddd9e1769c7/480w.png"
-thumbnail_dimensions = [480, 341]
+thumbnail = "https://static.rerun.io/clock/8c49e25f5cac4d6a1d7d0490b14cf6881bdb707b/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/controlnet/README.md
+++ b/examples/python/controlnet/README.md
@@ -2,8 +2,8 @@
 title = "ControlNet"
 tags = ["controlnet", "canny", "huggingface", "stable-diffusion", "tensor", "text"]
 description = "Use Hugging Face's ControlNet to generate an image from text, conditioned on detected edges from another image."
-thumbnail = "https://static.rerun.io/controlnet/8aace9c59a423c2eeabe4b7f9abb5187559c52e8/480w.png"
-thumbnail_dimensions = [480, 303]
+thumbnail = "https://static.rerun.io/controlnet/2e984b27dd8120fb89d4e805df9da506ea6d9138/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 <picture>

--- a/examples/python/depth_guided_stable_diffusion/README.md
+++ b/examples/python/depth_guided_stable_diffusion/README.md
@@ -1,8 +1,8 @@
 <!--[metadata]
 title = "Depth Guided Stable Diffusion"
 tags = ["2D", "depth", "huggingface", "stable-diffusion", "tensor", "text"]
-thumbnail = "https://static.rerun.io/depth_guided_stable_diffusion/a85516aba09f72649517891d767e15383ce7f4ea/480w.png"
-thumbnail_dimensions = [480, 253]
+thumbnail = "https://static.rerun.io/stable-diffusiuon/55fd41b25d4f7c55e7493640905a21e41021969f/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "nightly"
 -->
 

--- a/examples/python/detect_and_track_objects/README.md
+++ b/examples/python/detect_and_track_objects/README.md
@@ -2,8 +2,8 @@
 title = "Detect and Track Objects"
 tags = ["2D", "huggingface", "object-detection", "object-tracking", "opencv"]
 description = "Visualize object detection and segmentation using the Huggingface `transformers` library."
-thumbnail = "https://static.rerun.io/detect_and_track_objects/59f5b97a8724f9037353409ab3d0b7cb47d1544b/480w.png"
-thumbnail_dimensions = [480, 279]
+thumbnail = "https://static.rerun.io/detect-and-track-objects/63d7684ab1504c86a5375cb5db0fc515af433e08/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "release"
 -->
 

--- a/examples/python/dicom_mri/README.md
+++ b/examples/python/dicom_mri/README.md
@@ -2,8 +2,8 @@
 title = "Dicom MRI"
 tags = ["tensor", "mri", "dicom"]
 description = "Example using a DICOM MRI scan. This demonstrates the flexible tensor slicing capabilities of the Rerun viewer."
-thumbnail = "https://static.rerun.io/dicom_mri/e39f34a1b1ddd101545007f43a61783e1d2e5f8e/480w.png"
-thumbnail_dimensions = [480, 285]
+thumbnail = "https://static.rerun.io/dicom-mri/d5a434f92504e8dda8af6c7f4eded2a9d662c991/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "main"
 -->
 

--- a/examples/python/differentiable_blocks_world/README.md
+++ b/examples/python/differentiable_blocks_world/README.md
@@ -2,8 +2,8 @@
 title = "Differentiable Blocks World: Qualitative 3D Decomposition by Rendering Primitives"
 source = "https://github.com/rerun-io/differentiable-blocksworld"
 tags = ["3D", "mesh", "pinhole-camera"]
-thumbnail = "https://static.rerun.io/dbw/1da9e778d5fc9875a28a1fd74b61654c287e950d/480w.png"
-thumbnail_dimensions = [480, 311]
+thumbnail = "https://static.rerun.io/differentiable-blocks/42f3a5481162a0e75f1c52ef1a12d4fedb35389e/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/face_tracking/README.md
+++ b/examples/python/face_tracking/README.md
@@ -1,8 +1,8 @@
 <!--[metadata]
 title = "Face Tracking"
 tags = ["2D", "3D", "camera", "face-tracking", "live", "mediapipe", "time-series"]
-thumbnail = "https://static.rerun.io/mp_face/f5ee03278408bf8277789b637857d5a4fda7eba3/480w.png"
-thumbnail_dimensions = [480, 335]
+thumbnail = "https://static.rerun.io/face-tracking/f798733b72c703ee82cc946df39f32fa1145c23b/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/gesture_detection/README.md
+++ b/examples/python/gesture_detection/README.md
@@ -2,8 +2,8 @@
 title = "Hand Tracking and Gesture Recognition"
 tags = ["mediapipe", "keypoint-detection", "2D", "3D"]
 description = "Use the MediaPipe Gesture Detection solution to track hand and recognize gestures in image/video."
-thumbnail = "https://static.rerun.io/gesture_detection/2a5a3ec83962623063297fd95de57062372d5db0/480w.png"
-thumbnail_dimensions = [480, 259]
+thumbnail = "https://static.rerun.io/hand-tracking-and-gesture-recognition/56d097e347af2a4b7c4649c7d994cc038c02c2f4/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/human_pose_tracking/README.md
+++ b/examples/python/human_pose_tracking/README.md
@@ -2,8 +2,8 @@
 title = "Human Pose Tracking"
 tags = ["mediapipe", "keypoint-detection", "2D", "3D"]
 description = "Use the MediaPipe Pose solution to detect and track a human pose in video."
-thumbnail = "https://static.rerun.io/human_pose_tracking/37d47fe7e3476513f9f58c38da515e2cd4a093f9/480w.png"
-thumbnail_dimensions = [480, 272]
+thumbnail = "https://static.rerun.io/human-pose-tracking/5d62a38b48bed1467698d4dc95c1f9fba786d254/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "main"
 -->
 

--- a/examples/python/lidar/README.md
+++ b/examples/python/lidar/README.md
@@ -2,8 +2,8 @@
 title = "Lidar"
 tags = ["lidar", "3D"]
 description = "Visualize the lidar data from the nuScenes dataset."
-thumbnail = "https://static.rerun.io/lidar/bcea9337044919c1524429bd26bc51a3c4db8ccb/480w.png"
-thumbnail_dimensions = [480, 286]
+thumbnail = "https://static.rerun.io/lidar/caaf3b9531e50285442d17f0bc925eb7c8e12246/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/limap/README.md
+++ b/examples/python/limap/README.md
@@ -2,7 +2,7 @@
 title = "3D Line Mapping Revisited"
 source = "https://github.com/rerun-io/limap"
 tags = ["2D", "3D", "structure-from-motion", "time-series", "line-detection", "pinhole-camera"]
-thumbnail = "https://static.rerun.io/3d-line-mapping-revisited/be0a3b8ac0836036862d773b4276ea9d7ffb27b8/480w.png"
+thumbnail = "https://static.rerun.io/3d-line-mapping-revisited/be0a3b8ac0836036862d773b4276ea9d7ffb27b8/480w.png" # NOLINT
 thumbnail_dimensions = [480, 480]
 -->
 

--- a/examples/python/limap/README.md
+++ b/examples/python/limap/README.md
@@ -2,8 +2,8 @@
 title = "3D Line Mapping Revisited"
 source = "https://github.com/rerun-io/limap"
 tags = ["2D", "3D", "structure-from-motion", "time-series", "line-detection", "pinhole-camera"]
-thumbnail = "https://static.rerun.io/limap/30b9ad1ae36df7dc809edfd40c11620292bc7294/480w.png"
-thumbnail_dimensions = [480, 277]
+thumbnail = "https://static.rerun.io/3d-line-mapping-revisited/be0a3b8ac0836036862d773b4276ea9d7ffb27b8/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/live_camera_edge_detection/README.md
+++ b/examples/python/live_camera_edge_detection/README.md
@@ -1,8 +1,8 @@
 <!--[metadata]
 title = "Live Camera Edge Detection"
 tags = ["2D", "canny", "live", "opencv"]
-thumbnail = "https://static.rerun.io/live_camera_edge_detection/bf877bffd225f6c62cae3b87eecbc8e247abb202/480w.png"
-thumbnail_dimensions = [480, 364]
+thumbnail = "https://static.rerun.io/live-camera-edge-detection/f747bcf9ff3039c895f0bf0290e2dea0a72631ea/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/llm_embedding_ner/README.md
+++ b/examples/python/llm_embedding_ner/README.md
@@ -1,8 +1,8 @@
 <!--[metadata]
 title = "LLM Embedding-Based Named Entity Recognition"
 tags = ["LLM", "embeddings", "classification", "huggingface", "text"]
-thumbnail = "https://static.rerun.io/llm_embedding_ner/d98c09dd6bfa20ceea3e431c37dc295a4009fa1b/480w.png"
-thumbnail_dimensions = [480, 279]
+thumbnail = "https://static.rerun.io/llm-embedding/999737b3b78d762e70116bc23929ebfde78e18c6/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 <picture>

--- a/examples/python/mcc/README.md
+++ b/examples/python/mcc/README.md
@@ -2,8 +2,8 @@
 title = "Single Image 3D Reconstruction using MCC, SAM, and ZoeDepth"
 source = "https://github.com/rerun-io/MCC"
 tags = ["2D", "3D", "segmentation", "point-cloud", "sam"]
-thumbnail = "https://static.rerun.io/mcc/d244be2806b5abcc0e905a2c262b491b73914658/480w.png"
-thumbnail_dimensions = [480, 274]
+thumbnail = "https://static.rerun.io/single-image-3D-reconstruction/c54498053d53148cfa43901f39a084c549df2b72/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/minimal/README.md
+++ b/examples/python/minimal/README.md
@@ -1,7 +1,7 @@
 <!--[metadata]
 title = "Minimal example"
-thumbnail = "https://static.rerun.io/minimal/0e47ac513ab25d56cf2b493128097d499a07e5e8/480w.png"
-thumbnail_dimensions = [480, 322]
+thumbnail = "https://static.rerun.io/minimal-example/9e694c0689f20323ed0053506a7a099f7391afca/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/multiprocessing/README.md
+++ b/examples/python/multiprocessing/README.md
@@ -1,7 +1,7 @@
 <!--[metadata]
 title = "Multiprocessing"
-thumbnail = "https://static.rerun.io/multiprocessing/72bcb7550d84f8e5ed5a39221093239e655f06de/480w.png"
-thumbnail_dimensions = [480, 308]
+thumbnail = "https://static.rerun.io/multiprocessing/959e2c675f52a7ca83e11e5170903e8f0f53f5ed/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/multithreading/README.md
+++ b/examples/python/multithreading/README.md
@@ -1,7 +1,7 @@
 <!--[metadata]
 title = "Multithreading"
-thumbnail = "https://static.rerun.io/multithreading/8521bf95a7ff6004c932e8fb72429683928fbab4/480w.png"
-thumbnail_dimensions = [480, 312]
+thumbnail = "https://static.rerun.io/multithreading/80a3e566d6d9f8f17b04c839cd0ae2380c2baf02/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/objectron/README.md
+++ b/examples/python/objectron/README.md
@@ -2,8 +2,8 @@
 title = "Objectron"
 tags = ["2D", "3D", "object-detection", "pinhole-camera"]
 description = "Example of using the Rerun SDK to log the Google Research Objectron dataset."
-thumbnail = "https://static.rerun.io/objectron/8ea3a37e6b4af2e06f8e2ea5e70c1951af67fea8/480w.png"
-thumbnail_dimensions = [480, 268]
+thumbnail = "https://static.rerun.io/objectron/b645ef3c8eff33fbeaefa6d37e0f9711be15b202/480w.png"
+thumbnail_dimensions = [480, 480]
 # channel = "release"  - Disabled because it sometimes have bad first-frame heuristics
 build_args = ["--frames=150"]
 -->

--- a/examples/python/plots/README.md
+++ b/examples/python/plots/README.md
@@ -2,8 +2,8 @@
 title = "Plots"
 tags = ["2D", "plots", "api-example"]
 description = "Demonstration of various plots and charts supported by Rerun."
-thumbnail = "https://static.rerun.io/plots/c5b91cf0bf2eaf91c71d6cdcd4fe312d4aeac572/480w.png"
-thumbnail_dimensions = [480, 271]
+thumbnail = "https://static.rerun.io/plots/e8e51071f6409f61dc04a655d6b9e1caf8179226/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "main"
 -->
 

--- a/examples/python/raw_mesh/README.md
+++ b/examples/python/raw_mesh/README.md
@@ -2,8 +2,8 @@
 title = "Raw Mesh"
 tags = ["mesh"]
 description = "Demonstrates logging of raw 3D mesh data with simple material properties."
-thumbnail = "https://static.rerun.io/raw_mesh/d5d008b9f1b53753a86efe2580443a9265070b77/480w.png"
-thumbnail_dimensions = [480, 296]
+thumbnail = "https://static.rerun.io/raw-mesh/7731418dda47e15dbfc0f9a2c32673909071cb40/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "release"
 -->
 

--- a/examples/python/rgbd/README.md
+++ b/examples/python/rgbd/README.md
@@ -2,8 +2,8 @@
 title = "RGBD"
 tags = ["2D", "3D", "depth", "nyud", "pinhole-camera"]
 description = "Visualizes an example recording from the NYUD dataset with RGB and Depth channels."
-thumbnail = "https://static.rerun.io/rgbd/4109d29ed52fa0a8f980fcdd0e9673360c76879f/480w.png"
-thumbnail_dimensions = [480, 254]
+thumbnail = "https://static.rerun.io/rgbd/2fde3a620adc8bd9a5680260f0792d16ac5498bd/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "release"
 build_args = ["--frames=300"]
 -->

--- a/examples/python/ros_node/README.md
+++ b/examples/python/ros_node/README.md
@@ -1,8 +1,8 @@
 <!--[metadata]
 title = "ROS Node"
 tags = ["2D", "3D", "mesh", "pinhole-camera", "ros", "time-series"]
-thumbnail = "https://static.rerun.io/ros_node/de224f02697d8fa26a387e497ef5823a68122356/480w.png"
-thumbnail_dimensions = [480, 266]
+thumbnail = "https://static.rerun.io/ros-node/93169b35c17f5ec02d94150efb74c7ba06372842/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/segment_anything_model/README.md
+++ b/examples/python/segment_anything_model/README.md
@@ -2,8 +2,8 @@
 title = "Segment Anything Model"
 tags = ["2D", "sam", "segmentation"]
 description = "Example of using Rerun to log and visualize the output of Meta AI's Segment Anything model."
-thumbnail = "https://static.rerun.io/segment_anything_model/6aa2651907efbcf81be55b343caa76b9de5f2138/480w.png"
-thumbnail_dimensions = [480, 283]
+thumbnail = "https://static.rerun.io/segment-anything-model/36438df27a287e5eff3a673e2464af071e665fdf/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "release"
 -->
 

--- a/examples/python/shape_pointe/README.md
+++ b/examples/python/shape_pointe/README.md
@@ -2,8 +2,8 @@
 title = "Point-E and Shap-E"
 source = "https://github.com/rerun-io/point-shap-e"
 tags = ["3D", "diffusion", "point", "mesh"]
-thumbnail = "https://static.rerun.io/overview/6516611ebcf25c4b946e3d99c21c6930d4c9f0bd/480w.png"
-thumbnail_dimensions = [480, 293]
+thumbnail = "https://static.rerun.io/point-e/5b5beb36dce77d2dac7123b197b825421afcaec0/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/signed_distance_fields/README.md
+++ b/examples/python/signed_distance_fields/README.md
@@ -1,8 +1,8 @@
 <!--[metadata]
 title = "Signed Distance Fields"
 tags = ["3D", "mesh", "tensor"]
-thumbnail = "https://static.rerun.io/signed_distance_fields/99f6a886ed6f41b6a8e9023ba917a98668eaee70/480w.png"
-thumbnail_dimensions = [480, 294]
+thumbnail = "https://static.rerun.io/signed-distance-fields/0b0a200e0a5ec2b16e5f7d2da09b3ec6af3bac2d/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/simplerecon/README.md
+++ b/examples/python/simplerecon/README.md
@@ -2,8 +2,8 @@
 title = "SimpleRecon: 3D Reconstruction Without 3D Convolutions"
 source = "https://github.com/rerun-io/simplerecon"
 tags = ["3D", "depth", "time-series", "pinhole-camera", "mesh"]
-thumbnail = "https://static.rerun.io/simplerecon/e309760134e44ba5ca1a547cb310d47a19257e5b/480w.png"
-thumbnail_dimensions = [480, 271]
+thumbnail = "https://static.rerun.io/simplecon/e0f234159cc0f934e6d4a26886b751579f5191f0/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/slahmr/README.md
+++ b/examples/python/slahmr/README.md
@@ -2,8 +2,8 @@
 title = "Decoupling Human and Camera Motion from Videos in the Wild"
 source = "https://github.com/rerun-io/slahmr"
 tags = ["3D", "SLAM", "keypoint-detection", "mesh", "time-series"]
-thumbnail = "https://static.rerun.io/slahmr/3fad4f6b2c1a807fb92e8d33a2f90f7391c290a2/480w.png"
-thumbnail_dimensions = [480, 293]
+thumbnail = "https://static.rerun.io/decoupling-human/2f1c7f027668a6fb15865c51197d2ea98b5725a6/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/structure_from_motion/README.md
+++ b/examples/python/structure_from_motion/README.md
@@ -2,8 +2,8 @@
 title = "Structure from Motion"
 tags = ["2D", "3D", "colmap", "pinhole-camera", "time-series"]
 description = "Visualize a sparse reconstruction by COLMAP, a general-purpose Structure-from-Motion and Multi-View Stereo pipeline."
-thumbnail = "https://static.rerun.io/structure_from_motion/b17f8824291fa1102a4dc2184d13c91f92d2279c/480w.png"
-thumbnail_dimensions = [480, 275]
+thumbnail = "https://static.rerun.io/structure-from-motion/af24e5e8961f46a9c10399dbc31b6611eea563b4/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "main"
 build_args = ["--dataset=colmap_fiat", "--resize=800x600"]
 -->

--- a/examples/python/tapir/README.md
+++ b/examples/python/tapir/README.md
@@ -2,8 +2,8 @@
 title = "TAPIR: Tracking Any Point with per-frame Initialization and temporal Refinement"
 source = "https://github.com/rerun-io/tapnet"
 tags = ["2D", "point-tracking", "time-series", "tensor", "jax"]
-thumbnail = "https://static.rerun.io/tapir/f6a7697848c2ac1e7f0b8db5964f39133c520896/480w.png"
-thumbnail_dimensions = [480, 288]
+thumbnail = "https://static.rerun.io/tapir/35e5cdca6938d6d26a901f9345b1c331ea8ca96c/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/python/widebaseline/README.md
+++ b/examples/python/widebaseline/README.md
@@ -2,8 +2,8 @@
 title = "Learning to Render Novel Views from Wide-Baseline Stereo Pairs"
 source = "https://github.com/rerun-io/cross_attention_renderer/"
 tags = ["2D", "3D", "view-synthesis", "time-series", "pinhole-camera"]
-thumbnail = "https://static.rerun.io/widebaseline/7bee6a2a13ede34f06a962019080d0dc102707b5/480w.png"
-thumbnail_dimensions = [480, 316]
+thumbnail = "https://static.rerun.io/learning-to-render/75c96220e356938037dce35fcb5349f5f8064d8f/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/rust/clock/README.md
+++ b/examples/rust/clock/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "Clock"
 thumbnail = "https://static.rerun.io/clock/8c49e25f5cac4d6a1d7d0490b14cf6881bdb707b/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/rust/clock/README.md
+++ b/examples/rust/clock/README.md
@@ -1,6 +1,6 @@
 <!--[metadata]
 title = "Clock"
-thumbnail = "https://static.rerun.io/clock/ae4b8970edba8480431cb71e57b8cddd9e1769c7/480w.png"
+thumbnail = "https://static.rerun.io/clock/8c49e25f5cac4d6a1d7d0490b14cf6881bdb707b/480w.png"
 -->
 
 

--- a/examples/rust/custom_space_view/README.md
+++ b/examples/rust/custom_space_view/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "Custom Space View UI"
 thumbnail = "https://static.rerun.io/custom_space_view/e05a073d64003645b6af6de91b068c2f646c1b8a/480w.jpeg"
+thumbnail_dimensions = [480, 343]
 -->
 
 

--- a/examples/rust/extend_viewer_ui/README.md
+++ b/examples/rust/extend_viewer_ui/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "Extend Viewer UI"
 thumbnail = "https://static.rerun.io/extend_viewer_ui/6ccfbe3718a50e659c484d31033db0bd9d40c262/480w.png"
+thumbnail_dimensions = [480, 290]
 -->
 
 

--- a/examples/rust/incremental_logging/README.md
+++ b/examples/rust/incremental_logging/README.md
@@ -3,7 +3,7 @@ title = "Incremental Logging"
 tags = ["3D", "api-example"]
 description = "Showcases how to incrementally log data belonging to the same archetype."
 thumbnail = "https://static.rerun.io/incremental_logging/b7a2bd889b09c3840f56dc31bd6d677934ab3126/480w.png"
-thumbnail_dimensions = [480, 285]
+thumbnail_dimensions = [480, 301]
 -->
 
 

--- a/examples/rust/minimal/README.md
+++ b/examples/rust/minimal/README.md
@@ -1,6 +1,6 @@
 <!--[metadata]
 title = "Minimal example"
-thumbnail = "https://static.rerun.io/minimal/0e47ac513ab25d56cf2b493128097d499a07e5e8/480w.png"
+thumbnail = "https://static.rerun.io/minimal-example/9e694c0689f20323ed0053506a7a099f7391afca/480w.png"
 -->
 
 

--- a/examples/rust/minimal/README.md
+++ b/examples/rust/minimal/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "Minimal example"
 thumbnail = "https://static.rerun.io/minimal-example/9e694c0689f20323ed0053506a7a099f7391afca/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/rust/minimal_serve/README.md
+++ b/examples/rust/minimal_serve/README.md
@@ -1,6 +1,6 @@
 <!--[metadata]
 title = "Minimal `serve` example"
-thumbnail = "https://static.rerun.io/minimal/0e47ac513ab25d56cf2b493128097d499a07e5e8/480w.png"
+thumbnail = "https://static.rerun.io/minimal-example/9e694c0689f20323ed0053506a7a099f7391afca/480w.png"
 -->
 
 

--- a/examples/rust/minimal_serve/README.md
+++ b/examples/rust/minimal_serve/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "Minimal `serve` example"
 thumbnail = "https://static.rerun.io/minimal-example/9e694c0689f20323ed0053506a7a099f7391afca/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 

--- a/examples/rust/objectron/README.md
+++ b/examples/rust/objectron/README.md
@@ -3,6 +3,7 @@ title = "Objectron"
 tags = ["2D", "3D", "object-detection", "pinhole-camera"]
 description = "Example of using the Rerun SDK to log the Google Research Objectron dataset."
 thumbnail = "https://static.rerun.io/objectron/b645ef3c8eff33fbeaefa6d37e0f9711be15b202/480w.png"
+thumbnail_dimensions = [480, 480]
 build_args = ["--frames=100"]
 -->
 

--- a/examples/rust/objectron/README.md
+++ b/examples/rust/objectron/README.md
@@ -2,7 +2,7 @@
 title = "Objectron"
 tags = ["2D", "3D", "object-detection", "pinhole-camera"]
 description = "Example of using the Rerun SDK to log the Google Research Objectron dataset."
-thumbnail = "https://static.rerun.io/objectron/8ea3a37e6b4af2e06f8e2ea5e70c1951af67fea8/480w.png"
+thumbnail = "https://static.rerun.io/objectron/b645ef3c8eff33fbeaefa6d37e0f9711be15b202/480w.png"
 build_args = ["--frames=100"]
 -->
 

--- a/examples/rust/raw_mesh/README.md
+++ b/examples/rust/raw_mesh/README.md
@@ -1,7 +1,7 @@
 <!--[metadata]
 title = "Raw Mesh"
 description = "Demonstrates logging of raw 3D mesh data with simple material properties."
-thumbnail = "https://static.rerun.io/raw_mesh/d5d008b9f1b53753a86efe2580443a9265070b77/480w.png"
+thumbnail = "https://static.rerun.io/raw-mesh/7731418dda47e15dbfc0f9a2c32673909071cb40/480w.png"
 -->
 
 <picture>

--- a/examples/rust/raw_mesh/README.md
+++ b/examples/rust/raw_mesh/README.md
@@ -2,6 +2,7 @@
 title = "Raw Mesh"
 description = "Demonstrates logging of raw 3D mesh data with simple material properties."
 thumbnail = "https://static.rerun.io/raw-mesh/7731418dda47e15dbfc0f9a2c32673909071cb40/480w.png"
+thumbnail_dimensions = [480, 480]
 -->
 
 <picture>

--- a/examples/rust/stdio/README.md
+++ b/examples/rust/stdio/README.md
@@ -1,6 +1,7 @@
 <!--[metadata]
 title = "Standard Input/Output example"
 thumbnail = "https://static.rerun.io/stdio/25c5aba992d4c8b3861386d8d9539a4823dca117/480w.png"
+thumbnail_dimensions = [480, 298]
 -->
 
 

--- a/scripts/ci/thumbnails.py
+++ b/scripts/ci/thumbnails.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import argparse
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, Generator

--- a/scripts/ci/thumbnails.py
+++ b/scripts/ci/thumbnails.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, Generator
@@ -30,52 +31,67 @@ def get_thumbnail_dimensions(thumbnail: str) -> tuple[int, int]:
 
 
 def examples_with_thumbnails() -> Generator[Example, None, None]:
-    for path in Path("examples/python").iterdir():
-        if (path / "README.md").exists():
-            readme = (path / "README.md").read_text()
-            fm = load_frontmatter(readme)
-            if fm is not None and fm.get("thumbnail"):
-                yield Example(path, readme, fm)
+    def single_language(lang: str) -> Generator[Example, None, None]:
+        for path in Path(f"examples/{lang}").iterdir():
+            if (path / "README.md").exists():
+                readme = (path / "README.md").read_text()
+                fm = load_frontmatter(readme)
+                if fm is not None and fm.get("thumbnail"):
+                    yield Example(path, readme, fm)
+
+    yield from single_language("c")
+    yield from single_language("cpp")
+    yield from single_language("rust")
+    yield from single_language("python")
 
 
 def update() -> None:
-    for example in examples_with_thumbnails():
-        width, height = get_thumbnail_dimensions(example.fm["thumbnail"])
+    with ThreadPoolExecutor() as ex:
 
-        if "thumbnail_dimensions" not in example.fm:
-            start = example.readme.find("thumbnail: ")
-            assert start != -1
-            end = example.readme.find("\n", start)
-            assert end != -1
-            start = end + 1
-        else:
-            start = example.readme.find("thumbnail_dimensions = ")
-            assert start != -1
-            end = example.readme.find("\n", start)
-            assert end != -1
+        def work(example: Example):
+            width, height = get_thumbnail_dimensions(example.fm["thumbnail"])
 
-        (example.path / "README.md").write_text(
-            example.readme[:start] + f"thumbnail_dimensions = [{width}, {height}]" + example.readme[end:]
-        )
+            if "thumbnail_dimensions" not in example.fm:
+                start = example.readme.find("thumbnail: ")
+                assert start != -1
+                end = example.readme.find("\n", start)
+                assert end != -1
+                start = end + 1
+            else:
+                start = example.readme.find("thumbnail_dimensions = ")
+                assert start != -1
+                end = example.readme.find("\n", start)
+                assert end != -1
 
-        print(f"✔ {example.path}")
+            (example.path / "README.md").write_text(
+                example.readme[:start] + f"thumbnail_dimensions = [{width}, {height}]" + example.readme[end:]
+            )
+
+            print(f"✔ {example.path}")
+
+        ex.map(work, examples_with_thumbnails())
 
 
 def check() -> None:
     bad = False
-    for example in examples_with_thumbnails():
-        if not example.fm.get("thumbnail_dimensions"):
-            print(f"{example.path} has no `thumbnail_dimensions`")
-            bad = True
-            continue
+    with ThreadPoolExecutor() as ex:
 
-        current = tuple(example.fm["thumbnail_dimensions"])
-        actual = get_thumbnail_dimensions(example.fm["thumbnail"])
-        if current != actual:
-            print(f"{example.path} `thumbnail_dimensions` are incorrect (current: {current}, actual: {actual})")
-            bad = True
+        def work(example: Example):
+            nonlocal bad
+            if not example.fm.get("thumbnail_dimensions"):
+                print(f"{example.path} has no `thumbnail_dimensions`")
+                bad = True
+                return
 
-        print(f"✔ {example.path}")
+            current = tuple(example.fm["thumbnail_dimensions"])
+            actual = get_thumbnail_dimensions(example.fm["thumbnail"])
+            if current != actual:
+                print(f"{example.path} `thumbnail_dimensions` are incorrect (current: {current}, actual: {actual})")
+                bad = True
+            else:
+                print(f"✔ {example.path}")
+
+        ex.map(work, examples_with_thumbnails())
 
     if bad:
         print("Please run `scripts/ci/thumbnails.py update`.")


### PR DESCRIPTION
### What
- Closes https://github.com/rerun-io/rerun/issues/5453


Some changes to the `scripts/ci/thumbnails.py` script:
- Parallelized because it took quite a while to run, and was embarrassingly parallel
- Improved the output of `check` to not print a checkmark if the thumbnail dimensions were incorrect
- Made both `check` and `update` also look through readmes of other examples

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5615/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5615/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5615/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5615)
- [Docs preview](https://rerun.io/preview/18e9c7fea1befe50a6ad871a4a8b696bbbddd78f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/18e9c7fea1befe50a6ad871a4a8b696bbbddd78f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)