### PR TITLE
Document `data-inline-viewer`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,3 +55,24 @@ Once the snippet is in `snippet/all`, it may be referenced in a documentation Ma
 ```
 snippet: my-example
 ```
+
+### Screenshot links
+
+If a screenshot shows an example or snippet which is runnable and built on CI, then you can turn the screenshot
+to a link to `app.rerun.io` pointing at the example using the `data-inline-viewer` attribute.
+
+Add the attribute to any `<picture>` element like so:
+
+```html
+<picture data-inline-viewer="snippets/segmentation_image_simple">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/segmentation_image_simple/eb49e0b8cb870c75a69e2a47a2d202e5353115f6/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/segmentation_image_simple/eb49e0b8cb870c75a69e2a47a2d202e5353115f6/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/segmentation_image_simple/eb49e0b8cb870c75a69e2a47a2d202e5353115f6/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/segmentation_image_simple/eb49e0b8cb870c75a69e2a47a2d202e5353115f6/1200w.png">
+  <img src="https://static.rerun.io/segmentation_image_simple/eb49e0b8cb870c75a69e2a47a2d202e5353115f6/full.png">
+</picture>
+```
+
+The value should be:
+- `examples/{NAME}` for examples
+- `snippets/{NAME}` for snippets

--- a/examples/python/arkit_scenes/README.md
+++ b/examples/python/arkit_scenes/README.md
@@ -8,7 +8,7 @@ channel = "main"
 -->
 
 
-<picture data-inline-viewer="arkit_scenes">
+<picture data-inline-viewer="examples/arkit_scenes">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/arkit_scenes/fb9ec9e8d965369d39d51b17fc7fc5bae6be10cc/480w.png">
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/arkit_scenes/fb9ec9e8d965369d39d51b17fc7fc5bae6be10cc/768w.png">
   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/arkit_scenes/fb9ec9e8d965369d39d51b17fc7fc5bae6be10cc/1024w.png">

--- a/examples/python/detect_and_track_objects/README.md
+++ b/examples/python/detect_and_track_objects/README.md
@@ -8,7 +8,7 @@ channel = "release"
 -->
 
 
-<picture data-inline-viewer="detect_and_track_objects">
+<picture data-inline-viewer="examples/detect_and_track_objects">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/detect_and_track_objects/59f5b97a8724f9037353409ab3d0b7cb47d1544b/480w.png">
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/detect_and_track_objects/59f5b97a8724f9037353409ab3d0b7cb47d1544b/768w.png">
   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/detect_and_track_objects/59f5b97a8724f9037353409ab3d0b7cb47d1544b/1024w.png">

--- a/examples/python/dicom_mri/README.md
+++ b/examples/python/dicom_mri/README.md
@@ -8,7 +8,7 @@ channel = "main"
 -->
 
 
-<picture data-inline-viewer="dicom_mri">
+<picture data-inline-viewer="examples/dicom_mri">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/dicom_mri/e39f34a1b1ddd101545007f43a61783e1d2e5f8e/480w.png">
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/dicom_mri/e39f34a1b1ddd101545007f43a61783e1d2e5f8e/768w.png">
   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/dicom_mri/e39f34a1b1ddd101545007f43a61783e1d2e5f8e/1024w.png">

--- a/examples/python/dna/README.md
+++ b/examples/python/dna/README.md
@@ -7,7 +7,7 @@ thumbnail_dimensions = [480, 285]
 channel = "main"
 -->
 
-<picture data-inline-viewer="dna">
+<picture data-inline-viewer="examples/dna">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/helix/f4c375546fa9d24f7cd3a1a715ebf75b2978817a/480w.png">
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/helix/f4c375546fa9d24f7cd3a1a715ebf75b2978817a/768w.png">
   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/helix/f4c375546fa9d24f7cd3a1a715ebf75b2978817a/1024w.png">

--- a/examples/python/human_pose_tracking/README.md
+++ b/examples/python/human_pose_tracking/README.md
@@ -7,7 +7,7 @@ thumbnail_dimensions = [480, 272]
 channel = "main"
 -->
 
-<picture data-inline-viewer="human_pose_tracking">
+<picture data-inline-viewer="examples/human_pose_tracking">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/human_pose_tracking/37d47fe7e3476513f9f58c38da515e2cd4a093f9/480w.png">
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/human_pose_tracking/37d47fe7e3476513f9f58c38da515e2cd4a093f9/768w.png">
   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/human_pose_tracking/37d47fe7e3476513f9f58c38da515e2cd4a093f9/1024w.png">

--- a/examples/python/incremental_logging/README.md
+++ b/examples/python/incremental_logging/README.md
@@ -7,7 +7,7 @@ thumbnail_dimensions = [480, 301]
 -->
 
 
-<picture data-inline-viewer="incremental_logging">
+<picture data-inline-viewer="examples/incremental_logging">
   <img src="https://static.rerun.io/incremental_logging/b7a2bd889b09c3840f56dc31bd6d677934ab3126/full.png" alt="">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/incremental_logging/b7a2bd889b09c3840f56dc31bd6d677934ab3126/480w.png">
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/incremental_logging/b7a2bd889b09c3840f56dc31bd6d677934ab3126/768w.png">

--- a/examples/python/nuscenes/README.md
+++ b/examples/python/nuscenes/README.md
@@ -8,7 +8,7 @@ channel = "release"
 build_args = ["--seconds=5"]
 -->
 
-<picture data-inline-viewer="nuscenes">
+<picture data-inline-viewer="examples/nuscenes">
   <img src="https://static.rerun.io/nuscenes/64a50a9d67cbb69ae872551989ee807b195f6b5d/full.png" alt="">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/nuscenes/64a50a9d67cbb69ae872551989ee807b195f6b5d/480w.png">
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/nuscenes/64a50a9d67cbb69ae872551989ee807b195f6b5d/768w.png">

--- a/examples/python/open_photogrammetry_format/README.md
+++ b/examples/python/open_photogrammetry_format/README.md
@@ -8,7 +8,7 @@ channel = "release"
 build_args = ["--jpeg-quality=50"]
 -->
 
-<picture data-inline-viewer="open_photogrammetry_format">
+<picture data-inline-viewer="examples/open_photogrammetry_format">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/open_photogrammetry_format/603d5605f9670889bc8bce3365f16b831fce1eb1/480w.png">
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/open_photogrammetry_format/603d5605f9670889bc8bce3365f16b831fce1eb1/768w.png">
   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/open_photogrammetry_format/603d5605f9670889bc8bce3365f16b831fce1eb1/1024w.png">

--- a/examples/python/plots/README.md
+++ b/examples/python/plots/README.md
@@ -8,7 +8,7 @@ channel = "main"
 -->
 
 
-<picture data-inline-viewer="plots">
+<picture data-inline-viewer="examples/plots">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/plots/c5b91cf0bf2eaf91c71d6cdcd4fe312d4aeac572/480w.png">
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/plots/c5b91cf0bf2eaf91c71d6cdcd4fe312d4aeac572/768w.png">
   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/plots/c5b91cf0bf2eaf91c71d6cdcd4fe312d4aeac572/1024w.png">

--- a/examples/python/raw_mesh/README.md
+++ b/examples/python/raw_mesh/README.md
@@ -7,7 +7,7 @@ thumbnail_dimensions = [480, 296]
 channel = "release"
 -->
 
-<picture data-inline-viewer="raw_mesh">
+<picture data-inline-viewer="examples/raw_mesh">
   <img src="https://static.rerun.io/raw_mesh/d5d008b9f1b53753a86efe2580443a9265070b77/full.png" alt="">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/raw_mesh/d5d008b9f1b53753a86efe2580443a9265070b77/480w.png">
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/raw_mesh/d5d008b9f1b53753a86efe2580443a9265070b77/768w.png">

--- a/examples/python/rgbd/README.md
+++ b/examples/python/rgbd/README.md
@@ -8,7 +8,7 @@ channel = "release"
 build_args = ["--frames=300"]
 -->
 
-<picture data-inline-viewer="rgbd">
+<picture data-inline-viewer="examples/rgbd">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/rgbd/4109d29ed52fa0a8f980fcdd0e9673360c76879f/480w.png">
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/rgbd/4109d29ed52fa0a8f980fcdd0e9673360c76879f/768w.png">
   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/rgbd/4109d29ed52fa0a8f980fcdd0e9673360c76879f/1024w.png">

--- a/examples/python/segment_anything_model/README.md
+++ b/examples/python/segment_anything_model/README.md
@@ -8,7 +8,7 @@ channel = "release"
 -->
 
 
-<picture data-inline-viewer="segment_anything_model">
+<picture data-inline-viewer="examples/segment_anything_model">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/segment_anything_model/6aa2651907efbcf81be55b343caa76b9de5f2138/480w.png">
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/segment_anything_model/6aa2651907efbcf81be55b343caa76b9de5f2138/768w.png">
   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/segment_anything_model/6aa2651907efbcf81be55b343caa76b9de5f2138/1024w.png">

--- a/examples/python/structure_from_motion/README.md
+++ b/examples/python/structure_from_motion/README.md
@@ -9,7 +9,7 @@ build_args = ["--dataset=colmap_fiat", "--resize=800x600"]
 -->
 
 
-<picture data-inline-viewer="structure_from_motion">
+<picture data-inline-viewer="examples/structure_from_motion">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/structure_from_motion/b17f8824291fa1102a4dc2184d13c91f92d2279c/480w.png">
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/structure_from_motion/b17f8824291fa1102a4dc2184d13c91f92d2279c/768w.png">
   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/structure_from_motion/b17f8824291fa1102a4dc2184d13c91f92d2279c/1024w.png">


### PR DESCRIPTION
### What

- Closes https://github.com/rerun-io/rerun/issues/5316

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5618/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5618/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5618/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5618)
- [Docs preview](https://rerun.io/preview/5d11587b3ddcf4f179ed9c79515aa57e383ebd96/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5d11587b3ddcf4f179ed9c79515aa57e383ebd96/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)