### PR TITLE
Add blueprint to the RGBD example

### DIFF
--- a/examples/python/rgbd/main.py
+++ b/examples/python/rgbd/main.py
@@ -19,6 +19,7 @@ import numpy as np
 import numpy.typing as npt
 import requests
 import rerun as rr  # pip install rerun-sdk
+import rerun.blueprint as rrb
 from tqdm import tqdm
 
 DEPTH_IMAGE_SCALING: Final = 1e4
@@ -160,7 +161,20 @@ def main() -> None:
     rr.script_add_args(parser)
     args = parser.parse_args()
 
-    rr.script_setup(args, "rerun_example_rgbd")
+    rr.script_setup(
+        args,
+        "rerun_example_rgbd",
+        blueprint=rrb.Horizontal(
+            rrb.Spatial3DView(name="3D", origin="world"),
+            rrb.Vertical(
+                # Put the origin for both 2D spaces where the pinhole is logged. Doing so allows them to understand how they're connected to the 3D space.
+                # This enables interactions like clicking on a point in the 3D space to show the corresponding point in the 2D spaces and vice versa.
+                rrb.Spatial2DView(name="Depth & RGB", origin="world/camera/image"),
+                rrb.Spatial2DView(name="RGB", origin="world/camera/image", contents="world/camera/image/rgb"),
+            ),
+            column_shares=[2, 1],
+        ),
+    )
     recording_path = ensure_recording_downloaded(args.recording)
 
     log_nyud_data(


### PR DESCRIPTION
### What

straight forward one, still better with blueprint that without

![image](https://github.com/rerun-io/rerun/assets/1220815/a5dfd820-ef7b-49c8-9f83-4d0c6ceb507c)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5623/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5623/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5623/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5623)
- [Docs preview](https://rerun.io/preview/5ab75e993add7467596178e7d71bc9feef0b6984/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5ab75e993add7467596178e7d71bc9feef0b6984/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)