### PR TITLE
Support toggling item visibility on touch screens

### DIFF
--- a/crates/re_ui/examples/re_ui_example.rs
+++ b/crates/re_ui/examples/re_ui_example.rs
@@ -382,7 +382,7 @@ impl eframe::App for ExampleApp {
                                     let mut item = re_ui
                                         .list_item(label)
                                         .selected(Some(i) == self.selected_list_item)
-                                        .active(i != 3)
+                                        .interactive(i != 3)
                                         .with_buttons(|re_ui, ui| {
                                             re_ui.small_icon_button(ui, &re_ui::icons::ADD)
                                                 | re_ui.small_icon_button(ui, &re_ui::icons::REMOVE)

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -441,12 +441,9 @@ impl<'a> ListItem<'a> {
         let mut collapse_response = None;
 
         if ui.is_rect_visible(bg_rect) {
-            let mut visuals = if self.interactive {
-                ui.style()
-                    .interact_selectable(&style_response, self.selected)
-            } else {
-                ui.visuals().widgets.inactive
-            };
+            let mut visuals = ui
+                .style()
+                .interact_selectable(&style_response, self.selected);
 
             // TODO(ab): use design tokens instead
             if self.weak {

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -272,6 +272,8 @@ impl<'a> ListItem<'a> {
 
     /// Provide a closure to display on-hover buttons on the right of the item.
     ///
+    /// Buttons also show when the item is selected, in order to support clicking them on touch screens.
+    ///
     /// Notes:
     /// - If buttons are used, the item will allocate the full available width of the parent. If the
     ///   enclosing UI adapts to the childrens width, it will unnecessarily grow. If buttons aren't
@@ -484,7 +486,8 @@ impl<'a> ListItem<'a> {
             // that we aren't dragging anything.
             let should_show_buttons = self.active
                 && full_span_response.contains_pointer()
-                && !egui::DragAndDrop::has_any_payload(ui.ctx());
+                && !egui::DragAndDrop::has_any_payload(ui.ctx())
+                || self.selected; // by showing the buttons when selected, we allow users to find them on touch screens
             let button_response = if should_show_buttons {
                 if let Some(buttons) = self.buttons_fn {
                     let mut ui =

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -496,7 +496,7 @@ impl<'a> ListItem<'a> {
                 icon_fn(re_ui, ui, icon_rect, visuals);
             }
 
-            // We can't use `.hovered()` or the buttons dissappear just as the user clicks,
+            // We can't use `.hovered()` or the buttons disappear just as the user clicks,
             // so we use `contains_pointer` instead. That also means we need to check
             // that we aren't dragging anything.
             let should_show_buttons = interactive

--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -479,13 +479,11 @@ impl<'a> ListItem<'a> {
                 icon_fn(self.re_ui, ui, icon_rect, visuals);
             }
 
-            // Handle buttons
-            // Note: We should be able to just use `response.hovered()` here, which only returns `true` if no drag is in
-            // progress. Due to the response merging we do above, this breaks though. This is why we do an explicit
-            // rectangle and drag payload check.
-            //TODO(ab): refactor responses to address that.
+            // We can't use `.hovered()` or the buttons dissappear just as the user clicks,
+            // so we use `contains_pointer` instead. That also means we need to check
+            // that we aren't dragging anything.
             let should_show_buttons = self.active
-                && ui.rect_contains_pointer(rect)
+                && full_span_response.contains_pointer()
                 && !egui::DragAndDrop::has_any_payload(ui.ctx());
             let button_response = if should_show_buttons {
                 if let Some(buttons) = self.buttons_fn {

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -131,7 +131,7 @@ fn recording_list_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) -> bool {
         } else {
             ctx.re_ui
                 .list_item(app_id)
-                .active(false)
+                .interactive(false)
                 .show_hierarchical_with_content(
                     ui,
                     ui.make_persistent_id(app_id),

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -226,7 +226,7 @@ fn container_children(
             ListItem::new(ctx.re_ui, "empty — use the + button to add content")
                 .weak(true)
                 .italics(true)
-                .active(false)
+                .interactive(false)
                 .show_flat(ui);
         }
     };

--- a/crates/re_viewer/src/ui/space_view_space_origin_ui.rs
+++ b/crates/re_viewer/src/ui/space_view_space_origin_ui.rs
@@ -212,7 +212,7 @@ fn space_view_space_origin_widget_editing_ui(
             )
             .weak(true)
             .italics(true)
-            .active(false)
+            .interactive(false)
             .show_flat(ui);
         }
     };


### PR DESCRIPTION
### What
You can now click the "hover" buttons on list items on touch screens, by first selecting the item, which will now make the buttons appear.

I also did a few other improvements.

**Best reviewed commit by commit**

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5624/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5624/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5624/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5624)
- [Docs preview](https://rerun.io/preview/0e0bee82f711f38ac23dcae16ffed87bf9cf96b0/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0e0bee82f711f38ac23dcae16ffed87bf9cf96b0/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)