### PR TITLE
Remove unstable notes from blueprint type docs, some minor cleanup

### DIFF
--- a/crates/re_entity_db/src/blueprint/components/entity_properties_component.rs
+++ b/crates/re_entity_db/src/blueprint/components/entity_properties_component.rs
@@ -22,8 +22,6 @@ use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The configurable set of overridable properties.
-///
-/// Unstable. Used for the ongoing blueprint experimentations.
 #[derive(Clone)]
 pub struct EntityPropertiesComponent(pub crate::EntityProperties);
 

--- a/crates/re_types/definitions/rerun/blueprint/archetypes/space_view_contents.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/archetypes/space_view_contents.fbs
@@ -21,6 +21,13 @@ namespace rerun.blueprint.archetypes;
 /// If there are multiple rules of the same specificity, the last one wins.
 /// If no rules match, the path is excluded.
 ///
+/// Specifying a path without a `+` or `-` prefix is equivalent to `+`:
+/// ```diff
+/// /world/**           # add everything…
+/// - /world/roads/**   # …but remove all roads…
+/// /world/roads/main   # …but show main road
+/// ```
+///
 /// The `/**` suffix matches the whole subtree, i.e. self and any child, recursively
 /// (`/world/**` matches both `/world` and `/world/car/driver`).
 /// Other uses of `*` are not (yet) supported.
@@ -38,8 +45,6 @@ namespace rerun.blueprint.archetypes;
 /// The last rule matching `/world/car/hood` is `- /world/car/**`, so it is excluded.
 /// The last rule matching `/world` is `- /world`, so it is excluded.
 /// The last rule matching `/world/house` is `+ /world/**`, so it is included.
-///
-/// Unstable. Used for the ongoing blueprint experimentations.
 table SpaceViewContents (
     "attr.rerun.scope": "blueprint",
     "attr.rust.derive": "Default"

--- a/crates/re_types/definitions/rerun/blueprint/archetypes/viewport_blueprint.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/archetypes/viewport_blueprint.fbs
@@ -25,7 +25,7 @@ table ViewportBlueprint (
     /// Show one tab as maximized?
     maximized: rerun.blueprint.components.SpaceViewMaximized ("attr.rerun.component_optional", nullable, order: 3000);
 
-    // TODO(andreas): This is to be removed in the future, all new Space Views without an explicit container
+    // TODO(andreas): This is to be removed in the future, all new space views without an explicit container
     // should always insert themselves using a heuristic.
     /// Whether the viewport layout is determined automatically.
     ///
@@ -33,19 +33,19 @@ table ViewportBlueprint (
     /// This defaults to `false` and is automatically set to `false` when there is user determined layout.
     auto_layout: rerun.blueprint.components.AutoLayout ("attr.rerun.component_optional", nullable, order: 4000);
 
-    // TODO(jleibs): This should come with an optional container id that specifies where to insert new Space Views.
-    /// Whether or not Space Views should be created automatically.
+    // TODO(jleibs): This should come with an optional container id that specifies where to insert new space views.
+    /// Whether or not space views should be created automatically.
     ///
-    /// If `true`, the viewer will only add Space Views that it hasn't considered previously (as identified by `past_viewer_recommendations`)
-    /// and which aren't deemed redundant to existing Space Views.
-    /// This defaults to `false` and is automatically set to `false` when the user adds Space Views manually in the viewer.
+    /// If `true`, the viewer will only add space views that it hasn't considered previously (as identified by `past_viewer_recommendations`)
+    /// and which aren't deemed redundant to existing space views.
+    /// This defaults to `false` and is automatically set to `false` when the user adds space views manually in the viewer.
     auto_space_views: rerun.blueprint.components.AutoSpaceViews ("attr.rerun.component_optional", nullable, order: 5000);
 
-    /// Hashes of all recommended Space Views the viewer has already added and that should not be added again.
+    /// Hashes of all recommended space views the viewer has already added and that should not be added again.
     ///
     /// This is an internal field and should not be set usually.
-    /// If you want the viewer from stopping to add Space Views, you should set `auto_space_views` to `false`.
+    /// If you want the viewer from stopping to add space views, you should set `auto_space_views` to `false`.
     ///
-    /// The viewer uses this to determine whether it should keep adding Space Views.
+    /// The viewer uses this to determine whether it should keep adding space views.
     past_viewer_recommendations: [rerun.blueprint.components.ViewerRecommendationHash] ("attr.rerun.component_optional", nullable, order: 6000);
 }

--- a/crates/re_types/definitions/rerun/blueprint/components/auto_layout.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/auto_layout.fbs
@@ -10,8 +10,6 @@ namespace rerun.blueprint.components;
 // ---
 
 /// Whether the viewport layout is determined automatically.
-///
-/// Unstable. Used for the ongoing blueprint experimentations.
 struct AutoLayout (
   "attr.arrow.transparent",
   "attr.rerun.scope": "blueprint",

--- a/crates/re_types/definitions/rerun/blueprint/components/auto_space_views.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/auto_space_views.fbs
@@ -9,9 +9,7 @@ namespace rerun.blueprint.components;
 
 // ---
 
-/// Whether or not space views should be created automatically.
-///
-/// Unstable. Used for the ongoing blueprint experimentations.
+/// Whether or not Space Views should be created automatically.
 struct AutoSpaceViews (
   "attr.arrow.transparent",
   "attr.rerun.scope": "blueprint",

--- a/crates/re_types/definitions/rerun/blueprint/components/auto_space_views.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/auto_space_views.fbs
@@ -9,7 +9,7 @@ namespace rerun.blueprint.components;
 
 // ---
 
-/// Whether or not Space Views should be created automatically.
+/// Whether or not space views should be created automatically.
 struct AutoSpaceViews (
   "attr.arrow.transparent",
   "attr.rerun.scope": "blueprint",

--- a/crates/re_types/definitions/rerun/blueprint/components/background_3d_kind.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/background_3d_kind.fbs
@@ -8,7 +8,7 @@ include "rerun/attributes.fbs";
 namespace rerun.blueprint.components;
 
 
-/// The type of the background in 3D Space Views.
+/// The type of the background in 3D space views.
 enum Background3DKind: byte (
     "attr.rerun.scope": "blueprint",
     "attr.docs.unreleased"

--- a/crates/re_types/definitions/rerun/blueprint/components/entity_properties_component.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/entity_properties_component.fbs
@@ -10,8 +10,6 @@ namespace rerun.blueprint.components;
 // ---
 
 /// The configurable set of overridable properties.
-///
-/// Unstable. Used for the ongoing blueprint experimentations.
 table EntityPropertiesComponent (
   "attr.rerun.scope": "blueprint",
   "attr.rust.derive_only": "Clone",

--- a/crates/re_types/definitions/rerun/blueprint/components/included_space_view.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/included_space_view.fbs
@@ -10,9 +10,7 @@ namespace rerun.blueprint.components;
 // ---
 
 
-/// The id of a `SpaceView`.
-///
-/// Unstable. Used for the ongoing blueprint experimentations.
+/// The unique id of a Space View, used to refer to views in containers.
 table IncludedSpaceView (
   "attr.rerun.scope": "blueprint",
   "attr.python.aliases": "npt.NDArray[np.uint8], npt.ArrayLike, Sequence[int], bytes",

--- a/crates/re_types/definitions/rerun/blueprint/components/included_space_view.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/included_space_view.fbs
@@ -10,7 +10,7 @@ namespace rerun.blueprint.components;
 // ---
 
 
-/// The unique id of a Space View, used to refer to views in containers.
+/// The unique id of a space view, used to refer to views in containers.
 table IncludedSpaceView (
   "attr.rerun.scope": "blueprint",
   "attr.python.aliases": "npt.NDArray[np.uint8], npt.ArrayLike, Sequence[int], bytes",

--- a/crates/re_types/definitions/rerun/blueprint/components/query_expression.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/query_expression.fbs
@@ -18,8 +18,6 @@ namespace rerun.blueprint.components;
 /// The `/**` suffix matches the whole subtree, i.e. self and any child, recursively
 /// (`/world/**` matches both `/world` and `/world/car/driver`).
 /// Other uses of `*` are not (yet) supported.
-///
-/// Unstable. Used for the ongoing blueprint experimentations.
 table QueryExpression (
   "attr.rerun.scope": "blueprint",
   "attr.arrow.transparent",

--- a/crates/re_types/definitions/rerun/blueprint/components/space_view_maximized.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/space_view_maximized.fbs
@@ -9,7 +9,7 @@ namespace rerun.blueprint.components;
 
 // ---
 
-/// Whether a Space View is maximized.
+/// Whether a space view is maximized.
 table SpaceViewMaximized (
   "attr.rerun.scope": "blueprint",
   "attr.python.aliases": "npt.NDArray[np.uint8], npt.ArrayLike, Sequence[int], bytes",

--- a/crates/re_types/definitions/rerun/blueprint/components/space_view_maximized.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/space_view_maximized.fbs
@@ -9,9 +9,7 @@ namespace rerun.blueprint.components;
 
 // ---
 
-/// Whether a space view is maximized.
-///
-/// Unstable. Used for the ongoing blueprint experimentations.
+/// Whether a Space View is maximized.
 table SpaceViewMaximized (
   "attr.rerun.scope": "blueprint",
   "attr.python.aliases": "npt.NDArray[np.uint8], npt.ArrayLike, Sequence[int], bytes",

--- a/crates/re_types/definitions/rerun/blueprint/components/visible_time_range.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/visible_time_range.fbs
@@ -9,7 +9,7 @@ namespace rerun.blueprint.components;
 
 // ---
 
-/// The range of values that will be included in a Space View query.
+/// The range of values that will be included in a space view query.
 table VisibleTimeRange (
   "attr.arrow.transparent",
   "attr.rerun.scope": "blueprint",

--- a/crates/re_types/src/blueprint/archetypes/space_view_contents.rs
+++ b/crates/re_types/src/blueprint/archetypes/space_view_contents.rs
@@ -35,6 +35,13 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// If there are multiple rules of the same specificity, the last one wins.
 /// If no rules match, the path is excluded.
 ///
+/// Specifying a path without a `+` or `-` prefix is equivalent to `+`:
+/// ```diff
+/// /world/**           # add everything…
+/// - /world/roads/**   # …but remove all roads…
+/// /world/roads/main   # …but show main road
+/// ```
+///
 /// The `/**` suffix matches the whole subtree, i.e. self and any child, recursively
 /// (`/world/**` matches both `/world` and `/world/car/driver`).
 /// Other uses of `*` are not (yet) supported.
@@ -52,8 +59,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// The last rule matching `/world/car/hood` is `- /world/car/**`, so it is excluded.
 /// The last rule matching `/world` is `- /world`, so it is excluded.
 /// The last rule matching `/world/house` is `+ /world/**`, so it is included.
-///
-/// Unstable. Used for the ongoing blueprint experimentations.
 #[derive(Clone, Debug, Default)]
 pub struct SpaceViewContents {
     /// The `QueryExpression` that populates the contents for the `SpaceView`.

--- a/crates/re_types/src/blueprint/components/background3d_kind.rs
+++ b/crates/re_types/src/blueprint/components/background3d_kind.rs
@@ -21,7 +21,7 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Component**: The type of the background in 3D Space Views.
+/// **Component**: The type of the background in 3D space views.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum Background3DKind {
     /// Gradient depending on the direction of the view, dark theme.

--- a/crates/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/re_types/src/blueprint/components/query_expression.rs
@@ -31,8 +31,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// The `/**` suffix matches the whole subtree, i.e. self and any child, recursively
 /// (`/world/**` matches both `/world` and `/world/car/driver`).
 /// Other uses of `*` are not (yet) supported.
-///
-/// Unstable. Used for the ongoing blueprint experimentations.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct QueryExpression(pub crate::datatypes::Utf8);

--- a/crates/re_types/src/blueprint/components/visible_time_range.rs
+++ b/crates/re_types/src/blueprint/components/visible_time_range.rs
@@ -21,7 +21,7 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Component**: The range of values that will be included in a Space View query.
+/// **Component**: The range of values that will be included in a space view query.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct VisibleTimeRange(pub crate::blueprint::datatypes::VisibleTimeRange);

--- a/crates/re_viewport/src/blueprint/archetypes/viewport_blueprint.rs
+++ b/crates/re_viewport/src/blueprint/archetypes/viewport_blueprint.rs
@@ -39,19 +39,19 @@ pub struct ViewportBlueprint {
     /// This defaults to `false` and is automatically set to `false` when there is user determined layout.
     pub auto_layout: Option<crate::blueprint::components::AutoLayout>,
 
-    /// Whether or not Space Views should be created automatically.
+    /// Whether or not space views should be created automatically.
     ///
-    /// If `true`, the viewer will only add Space Views that it hasn't considered previously (as identified by `past_viewer_recommendations`)
-    /// and which aren't deemed redundant to existing Space Views.
-    /// This defaults to `false` and is automatically set to `false` when the user adds Space Views manually in the viewer.
+    /// If `true`, the viewer will only add space views that it hasn't considered previously (as identified by `past_viewer_recommendations`)
+    /// and which aren't deemed redundant to existing space views.
+    /// This defaults to `false` and is automatically set to `false` when the user adds space views manually in the viewer.
     pub auto_space_views: Option<crate::blueprint::components::AutoSpaceViews>,
 
-    /// Hashes of all recommended Space Views the viewer has already added and that should not be added again.
+    /// Hashes of all recommended space views the viewer has already added and that should not be added again.
     ///
     /// This is an internal field and should not be set usually.
-    /// If you want the viewer from stopping to add Space Views, you should set `auto_space_views` to `false`.
+    /// If you want the viewer from stopping to add space views, you should set `auto_space_views` to `false`.
     ///
-    /// The viewer uses this to determine whether it should keep adding Space Views.
+    /// The viewer uses this to determine whether it should keep adding space views.
     pub past_viewer_recommendations:
         Option<Vec<crate::blueprint::components::ViewerRecommendationHash>>,
 }

--- a/crates/re_viewport/src/blueprint/components/auto_layout.rs
+++ b/crates/re_viewport/src/blueprint/components/auto_layout.rs
@@ -22,8 +22,6 @@ use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Whether the viewport layout is determined automatically.
-///
-/// Unstable. Used for the ongoing blueprint experimentations.
 #[derive(Clone, Debug, Copy)]
 #[repr(transparent)]
 pub struct AutoLayout(pub bool);

--- a/crates/re_viewport/src/blueprint/components/auto_space_views.rs
+++ b/crates/re_viewport/src/blueprint/components/auto_space_views.rs
@@ -21,9 +21,7 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Component**: Whether or not space views should be created automatically.
-///
-/// Unstable. Used for the ongoing blueprint experimentations.
+/// **Component**: Whether or not Space Views should be created automatically.
 #[derive(Clone, Debug, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct AutoSpaceViews(pub bool);

--- a/crates/re_viewport/src/blueprint/components/auto_space_views.rs
+++ b/crates/re_viewport/src/blueprint/components/auto_space_views.rs
@@ -21,7 +21,7 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Component**: Whether or not Space Views should be created automatically.
+/// **Component**: Whether or not space views should be created automatically.
 #[derive(Clone, Debug, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct AutoSpaceViews(pub bool);

--- a/crates/re_viewport/src/blueprint/components/included_space_view.rs
+++ b/crates/re_viewport/src/blueprint/components/included_space_view.rs
@@ -21,9 +21,7 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Component**: The id of a `SpaceView`.
-///
-/// Unstable. Used for the ongoing blueprint experimentations.
+/// **Component**: The unique id of a Space View, used to refer to views in containers.
 #[derive(Clone, Debug, Default)]
 #[repr(transparent)]
 pub struct IncludedSpaceView(pub crate::datatypes::Uuid);

--- a/crates/re_viewport/src/blueprint/components/included_space_view.rs
+++ b/crates/re_viewport/src/blueprint/components/included_space_view.rs
@@ -21,7 +21,7 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Component**: The unique id of a Space View, used to refer to views in containers.
+/// **Component**: The unique id of a space view, used to refer to views in containers.
 #[derive(Clone, Debug, Default)]
 #[repr(transparent)]
 pub struct IncludedSpaceView(pub crate::datatypes::Uuid);

--- a/crates/re_viewport/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_viewport/src/blueprint/components/space_view_maximized.rs
@@ -21,7 +21,7 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Component**: Whether a Space View is maximized.
+/// **Component**: Whether a space view is maximized.
 #[derive(Clone, Debug, Default)]
 #[repr(transparent)]
 pub struct SpaceViewMaximized(pub crate::datatypes::Uuid);

--- a/crates/re_viewport/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_viewport/src/blueprint/components/space_view_maximized.rs
@@ -21,9 +21,7 @@ use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
-/// **Component**: Whether a space view is maximized.
-///
-/// Unstable. Used for the ongoing blueprint experimentations.
+/// **Component**: Whether a Space View is maximized.
 #[derive(Clone, Debug, Default)]
 #[repr(transparent)]
 pub struct SpaceViewMaximized(pub crate::datatypes::Uuid);

--- a/rerun_cpp/src/rerun/blueprint/archetypes/space_view_contents.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/space_view_contents.hpp
@@ -28,6 +28,13 @@ namespace rerun::blueprint::archetypes {
     /// If there are multiple rules of the same specificity, the last one wins.
     /// If no rules match, the path is excluded.
     ///
+    /// Specifying a path without a `+` or `-` prefix is equivalent to `+`:
+    /// ```diff
+    /// /world/**           # add everything…
+    /// - /world/roads/**   # …but remove all roads…
+    /// /world/roads/main   # …but show main road
+    /// ```
+    ///
     /// The `/**` suffix matches the whole subtree, i.e. self and any child, recursively
     /// (`/world/**` matches both `/world` and `/world/car/driver`).
     /// Other uses of `*` are not (yet) supported.
@@ -45,8 +52,6 @@ namespace rerun::blueprint::archetypes {
     /// The last rule matching `/world/car/hood` is `- /world/car/**`, so it is excluded.
     /// The last rule matching `/world` is `- /world`, so it is excluded.
     /// The last rule matching `/world/house` is `+ /world/**`, so it is included.
-    ///
-    /// Unstable. Used for the ongoing blueprint experimentations.
     struct SpaceViewContents {
         /// The `QueryExpression` that populates the contents for the `SpaceView`.
         ///

--- a/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.hpp
@@ -38,19 +38,19 @@ namespace rerun::blueprint::archetypes {
         /// This defaults to `false` and is automatically set to `false` when there is user determined layout.
         std::optional<rerun::blueprint::components::AutoLayout> auto_layout;
 
-        /// Whether or not Space Views should be created automatically.
+        /// Whether or not space views should be created automatically.
         ///
-        /// If `true`, the viewer will only add Space Views that it hasn't considered previously (as identified by `past_viewer_recommendations`)
-        /// and which aren't deemed redundant to existing Space Views.
-        /// This defaults to `false` and is automatically set to `false` when the user adds Space Views manually in the viewer.
+        /// If `true`, the viewer will only add space views that it hasn't considered previously (as identified by `past_viewer_recommendations`)
+        /// and which aren't deemed redundant to existing space views.
+        /// This defaults to `false` and is automatically set to `false` when the user adds space views manually in the viewer.
         std::optional<rerun::blueprint::components::AutoSpaceViews> auto_space_views;
 
-        /// Hashes of all recommended Space Views the viewer has already added and that should not be added again.
+        /// Hashes of all recommended space views the viewer has already added and that should not be added again.
         ///
         /// This is an internal field and should not be set usually.
-        /// If you want the viewer from stopping to add Space Views, you should set `auto_space_views` to `false`.
+        /// If you want the viewer from stopping to add space views, you should set `auto_space_views` to `false`.
         ///
-        /// The viewer uses this to determine whether it should keep adding Space Views.
+        /// The viewer uses this to determine whether it should keep adding space views.
         std::optional<Collection<rerun::blueprint::components::ViewerRecommendationHash>>
             past_viewer_recommendations;
 
@@ -102,11 +102,11 @@ namespace rerun::blueprint::archetypes {
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        /// Whether or not Space Views should be created automatically.
+        /// Whether or not space views should be created automatically.
         ///
-        /// If `true`, the viewer will only add Space Views that it hasn't considered previously (as identified by `past_viewer_recommendations`)
-        /// and which aren't deemed redundant to existing Space Views.
-        /// This defaults to `false` and is automatically set to `false` when the user adds Space Views manually in the viewer.
+        /// If `true`, the viewer will only add space views that it hasn't considered previously (as identified by `past_viewer_recommendations`)
+        /// and which aren't deemed redundant to existing space views.
+        /// This defaults to `false` and is automatically set to `false` when the user adds space views manually in the viewer.
         ViewportBlueprint with_auto_space_views(
             rerun::blueprint::components::AutoSpaceViews _auto_space_views
         ) && {
@@ -115,12 +115,12 @@ namespace rerun::blueprint::archetypes {
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        /// Hashes of all recommended Space Views the viewer has already added and that should not be added again.
+        /// Hashes of all recommended space views the viewer has already added and that should not be added again.
         ///
         /// This is an internal field and should not be set usually.
-        /// If you want the viewer from stopping to add Space Views, you should set `auto_space_views` to `false`.
+        /// If you want the viewer from stopping to add space views, you should set `auto_space_views` to `false`.
         ///
-        /// The viewer uses this to determine whether it should keep adding Space Views.
+        /// The viewer uses this to determine whether it should keep adding space views.
         ViewportBlueprint with_past_viewer_recommendations(
             Collection<rerun::blueprint::components::ViewerRecommendationHash>
                 _past_viewer_recommendations

--- a/rerun_cpp/src/rerun/blueprint/components/auto_layout.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/auto_layout.hpp
@@ -16,8 +16,6 @@ namespace arrow {
 
 namespace rerun::blueprint::components {
     /// **Component**: Whether the viewport layout is determined automatically.
-    ///
-    /// Unstable. Used for the ongoing blueprint experimentations.
     struct AutoLayout {
         bool auto_layout;
 

--- a/rerun_cpp/src/rerun/blueprint/components/auto_space_views.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/auto_space_views.hpp
@@ -15,7 +15,7 @@ namespace arrow {
 } // namespace arrow
 
 namespace rerun::blueprint::components {
-    /// **Component**: Whether or not Space Views should be created automatically.
+    /// **Component**: Whether or not space views should be created automatically.
     struct AutoSpaceViews {
         bool auto_space_views;
 

--- a/rerun_cpp/src/rerun/blueprint/components/auto_space_views.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/auto_space_views.hpp
@@ -15,9 +15,7 @@ namespace arrow {
 } // namespace arrow
 
 namespace rerun::blueprint::components {
-    /// **Component**: Whether or not space views should be created automatically.
-    ///
-    /// Unstable. Used for the ongoing blueprint experimentations.
+    /// **Component**: Whether or not Space Views should be created automatically.
     struct AutoSpaceViews {
         bool auto_space_views;
 

--- a/rerun_cpp/src/rerun/blueprint/components/background3d_kind.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/background3d_kind.hpp
@@ -15,7 +15,7 @@ namespace arrow {
 } // namespace arrow
 
 namespace rerun::blueprint::components {
-    /// **Component**: The type of the background in 3D Space Views.
+    /// **Component**: The type of the background in 3D space views.
     enum class Background3DKind : uint8_t {
 
         /// Gradient depending on the direction of the view, dark theme.

--- a/rerun_cpp/src/rerun/blueprint/components/entity_properties_component.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/entity_properties_component.hpp
@@ -18,8 +18,6 @@ namespace arrow {
 
 namespace rerun::blueprint::components {
     /// **Component**: The configurable set of overridable properties.
-    ///
-    /// Unstable. Used for the ongoing blueprint experimentations.
     struct EntityPropertiesComponent {
         rerun::Collection<uint8_t> props;
 

--- a/rerun_cpp/src/rerun/blueprint/components/included_space_view.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/included_space_view.hpp
@@ -11,9 +11,7 @@
 #include <memory>
 
 namespace rerun::blueprint::components {
-    /// **Component**: The id of a `SpaceView`.
-    ///
-    /// Unstable. Used for the ongoing blueprint experimentations.
+    /// **Component**: The unique id of a Space View, used to refer to views in containers.
     struct IncludedSpaceView {
         rerun::datatypes::Uuid space_view_id;
 

--- a/rerun_cpp/src/rerun/blueprint/components/included_space_view.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/included_space_view.hpp
@@ -11,7 +11,7 @@
 #include <memory>
 
 namespace rerun::blueprint::components {
-    /// **Component**: The unique id of a Space View, used to refer to views in containers.
+    /// **Component**: The unique id of a space view, used to refer to views in containers.
     struct IncludedSpaceView {
         rerun::datatypes::Uuid space_view_id;
 

--- a/rerun_cpp/src/rerun/blueprint/components/query_expression.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/query_expression.hpp
@@ -22,8 +22,6 @@ namespace rerun::blueprint::components {
     /// The `/**` suffix matches the whole subtree, i.e. self and any child, recursively
     /// (`/world/**` matches both `/world` and `/world/car/driver`).
     /// Other uses of `*` are not (yet) supported.
-    ///
-    /// Unstable. Used for the ongoing blueprint experimentations.
     struct QueryExpression {
         rerun::datatypes::Utf8 filter;
 

--- a/rerun_cpp/src/rerun/blueprint/components/space_view_maximized.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/space_view_maximized.hpp
@@ -11,7 +11,7 @@
 #include <memory>
 
 namespace rerun::blueprint::components {
-    /// **Component**: Whether a Space View is maximized.
+    /// **Component**: Whether a space view is maximized.
     struct SpaceViewMaximized {
         rerun::datatypes::Uuid space_view_id;
 

--- a/rerun_cpp/src/rerun/blueprint/components/space_view_maximized.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/space_view_maximized.hpp
@@ -11,9 +11,7 @@
 #include <memory>
 
 namespace rerun::blueprint::components {
-    /// **Component**: Whether a space view is maximized.
-    ///
-    /// Unstable. Used for the ongoing blueprint experimentations.
+    /// **Component**: Whether a Space View is maximized.
     struct SpaceViewMaximized {
         rerun::datatypes::Uuid space_view_id;
 

--- a/rerun_cpp/src/rerun/blueprint/components/visible_time_range.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/visible_time_range.hpp
@@ -10,7 +10,7 @@
 #include <memory>
 
 namespace rerun::blueprint::components {
-    /// **Component**: The range of values that will be included in a Space View query.
+    /// **Component**: The range of values that will be included in a space view query.
     struct VisibleTimeRange {
         rerun::blueprint::datatypes::VisibleTimeRange value;
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_contents.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_contents.py
@@ -34,6 +34,13 @@ class SpaceViewContents(Archetype):
     If there are multiple rules of the same specificity, the last one wins.
     If no rules match, the path is excluded.
 
+    Specifying a path without a `+` or `-` prefix is equivalent to `+`:
+    ```diff
+    /world/**           # add everything…
+    - /world/roads/**   # …but remove all roads…
+    /world/roads/main   # …but show main road
+    ```
+
     The `/**` suffix matches the whole subtree, i.e. self and any child, recursively
     (`/world/**` matches both `/world` and `/world/car/driver`).
     Other uses of `*` are not (yet) supported.
@@ -51,8 +58,6 @@ class SpaceViewContents(Archetype):
     The last rule matching `/world/car/hood` is `- /world/car/**`, so it is excluded.
     The last rule matching `/world` is `- /world`, so it is excluded.
     The last rule matching `/world/house` is `+ /world/**`, so it is included.
-
-    Unstable. Used for the ongoing blueprint experimentations.
     """
 
     def __init__(self: Any, query: datatypes.Utf8ArrayLike):

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/viewport_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/viewport_blueprint.py
@@ -48,18 +48,18 @@ class ViewportBlueprint(Archetype):
             If `true`, the container layout will be reset whenever a new space view is added or removed.
             This defaults to `false` and is automatically set to `false` when there is user determined layout.
         auto_space_views:
-            Whether or not Space Views should be created automatically.
+            Whether or not space views should be created automatically.
 
-            If `true`, the viewer will only add Space Views that it hasn't considered previously (as identified by `past_viewer_recommendations`)
-            and which aren't deemed redundant to existing Space Views.
-            This defaults to `false` and is automatically set to `false` when the user adds Space Views manually in the viewer.
+            If `true`, the viewer will only add space views that it hasn't considered previously (as identified by `past_viewer_recommendations`)
+            and which aren't deemed redundant to existing space views.
+            This defaults to `false` and is automatically set to `false` when the user adds space views manually in the viewer.
         past_viewer_recommendations:
-            Hashes of all recommended Space Views the viewer has already added and that should not be added again.
+            Hashes of all recommended space views the viewer has already added and that should not be added again.
 
             This is an internal field and should not be set usually.
-            If you want the viewer from stopping to add Space Views, you should set `auto_space_views` to `false`.
+            If you want the viewer from stopping to add space views, you should set `auto_space_views` to `false`.
 
-            The viewer uses this to determine whether it should keep adding Space Views.
+            The viewer uses this to determine whether it should keep adding space views.
 
         """
 
@@ -138,11 +138,11 @@ class ViewportBlueprint(Archetype):
         default=None,
         converter=blueprint_components.AutoSpaceViewsBatch._optional,  # type: ignore[misc]
     )
-    # Whether or not Space Views should be created automatically.
+    # Whether or not space views should be created automatically.
     #
-    # If `true`, the viewer will only add Space Views that it hasn't considered previously (as identified by `past_viewer_recommendations`)
-    # and which aren't deemed redundant to existing Space Views.
-    # This defaults to `false` and is automatically set to `false` when the user adds Space Views manually in the viewer.
+    # If `true`, the viewer will only add space views that it hasn't considered previously (as identified by `past_viewer_recommendations`)
+    # and which aren't deemed redundant to existing space views.
+    # This defaults to `false` and is automatically set to `false` when the user adds space views manually in the viewer.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
@@ -151,12 +151,12 @@ class ViewportBlueprint(Archetype):
         default=None,
         converter=blueprint_components.ViewerRecommendationHashBatch._optional,  # type: ignore[misc]
     )
-    # Hashes of all recommended Space Views the viewer has already added and that should not be added again.
+    # Hashes of all recommended space views the viewer has already added and that should not be added again.
     #
     # This is an internal field and should not be set usually.
-    # If you want the viewer from stopping to add Space Views, you should set `auto_space_views` to `false`.
+    # If you want the viewer from stopping to add space views, you should set `auto_space_views` to `false`.
     #
-    # The viewer uses this to determine whether it should keep adding Space Views.
+    # The viewer uses this to determine whether it should keep adding space views.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/auto_layout.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/auto_layout.py
@@ -18,11 +18,7 @@ __all__ = ["AutoLayout", "AutoLayoutArrayLike", "AutoLayoutBatch", "AutoLayoutLi
 
 @define(init=False)
 class AutoLayout(AutoLayoutExt):
-    """
-    **Component**: Whether the viewport layout is determined automatically.
-
-    Unstable. Used for the ongoing blueprint experimentations.
-    """
+    """**Component**: Whether the viewport layout is determined automatically."""
 
     def __init__(self: Any, auto_layout: AutoLayoutLike):
         """Create a new instance of the AutoLayout component."""

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/auto_space_views.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/auto_space_views.py
@@ -24,7 +24,7 @@ __all__ = [
 
 @define(init=False)
 class AutoSpaceViews(AutoSpaceViewsExt):
-    """**Component**: Whether or not Space Views should be created automatically."""
+    """**Component**: Whether or not space views should be created automatically."""
 
     def __init__(self: Any, auto_space_views: AutoSpaceViewsLike):
         """Create a new instance of the AutoSpaceViews component."""

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/auto_space_views.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/auto_space_views.py
@@ -24,11 +24,7 @@ __all__ = [
 
 @define(init=False)
 class AutoSpaceViews(AutoSpaceViewsExt):
-    """
-    **Component**: Whether or not space views should be created automatically.
-
-    Unstable. Used for the ongoing blueprint experimentations.
-    """
+    """**Component**: Whether or not Space Views should be created automatically."""
 
     def __init__(self: Any, auto_space_views: AutoSpaceViewsLike):
         """Create a new instance of the AutoSpaceViews component."""

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/background3d_kind.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/background3d_kind.py
@@ -24,7 +24,7 @@ from enum import Enum
 
 
 class Background3DKind(Enum):
-    """**Component**: The type of the background in 3D Space Views."""
+    """**Component**: The type of the background in 3D space views."""
 
     GradientDark = 1
     """Gradient depending on the direction of the view, dark theme."""

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/entity_properties_component.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/entity_properties_component.py
@@ -28,11 +28,7 @@ __all__ = [
 
 @define(init=False)
 class EntityPropertiesComponent:
-    """
-    **Component**: The configurable set of overridable properties.
-
-    Unstable. Used for the ongoing blueprint experimentations.
-    """
+    """**Component**: The configurable set of overridable properties."""
 
     def __init__(self: Any, props: EntityPropertiesComponentLike):
         """Create a new instance of the EntityPropertiesComponent component."""

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/included_space_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/included_space_view.py
@@ -12,7 +12,7 @@ __all__ = ["IncludedSpaceView", "IncludedSpaceViewBatch", "IncludedSpaceViewType
 
 
 class IncludedSpaceView(datatypes.Uuid):
-    """**Component**: The unique id of a Space View, used to refer to views in containers."""
+    """**Component**: The unique id of a space view, used to refer to views in containers."""
 
     # You can define your own __init__ function as a member of IncludedSpaceViewExt in included_space_view_ext.py
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/included_space_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/included_space_view.py
@@ -12,11 +12,7 @@ __all__ = ["IncludedSpaceView", "IncludedSpaceViewBatch", "IncludedSpaceViewType
 
 
 class IncludedSpaceView(datatypes.Uuid):
-    """
-    **Component**: The id of a `SpaceView`.
-
-    Unstable. Used for the ongoing blueprint experimentations.
-    """
+    """**Component**: The unique id of a Space View, used to refer to views in containers."""
 
     # You can define your own __init__ function as a member of IncludedSpaceViewExt in included_space_view_ext.py
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/query_expression.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/query_expression.py
@@ -23,8 +23,6 @@ class QueryExpression(datatypes.Utf8):
     The `/**` suffix matches the whole subtree, i.e. self and any child, recursively
     (`/world/**` matches both `/world` and `/world/car/driver`).
     Other uses of `*` are not (yet) supported.
-
-    Unstable. Used for the ongoing blueprint experimentations.
     """
 
     # You can define your own __init__ function as a member of QueryExpressionExt in query_expression_ext.py

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_maximized.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_maximized.py
@@ -12,11 +12,7 @@ __all__ = ["SpaceViewMaximized", "SpaceViewMaximizedBatch", "SpaceViewMaximizedT
 
 
 class SpaceViewMaximized(datatypes.Uuid):
-    """
-    **Component**: Whether a space view is maximized.
-
-    Unstable. Used for the ongoing blueprint experimentations.
-    """
+    """**Component**: Whether a Space View is maximized."""
 
     # You can define your own __init__ function as a member of SpaceViewMaximizedExt in space_view_maximized_ext.py
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_maximized.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_maximized.py
@@ -12,7 +12,7 @@ __all__ = ["SpaceViewMaximized", "SpaceViewMaximizedBatch", "SpaceViewMaximizedT
 
 
 class SpaceViewMaximized(datatypes.Uuid):
-    """**Component**: Whether a Space View is maximized."""
+    """**Component**: Whether a space view is maximized."""
 
     # You can define your own __init__ function as a member of SpaceViewMaximizedExt in space_view_maximized_ext.py
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visible_time_range.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visible_time_range.py
@@ -12,7 +12,7 @@ __all__ = ["VisibleTimeRange", "VisibleTimeRangeBatch", "VisibleTimeRangeType"]
 
 
 class VisibleTimeRange(blueprint_datatypes.VisibleTimeRange):
-    """**Component**: The range of values that will be included in a Space View query."""
+    """**Component**: The range of values that will be included in a space view query."""
 
     # You can define your own __init__ function as a member of VisibleTimeRangeExt in visible_time_range_ext.py
 


### PR DESCRIPTION
### What

* Fixes #5527

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5625/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5625/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5625/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5625)
- [Docs preview](https://rerun.io/preview/861e0663ce88cdf222b06931252274ed71a54d48/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/861e0663ce88cdf222b06931252274ed71a54d48/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)