### PR TITLE
Allow setting custom names to container

### DIFF
--- a/crates/re_space_view/src/lib.rs
+++ b/crates/re_space_view/src/lib.rs
@@ -15,7 +15,7 @@ mod visualizable;
 pub use data_query::{DataQuery, EntityOverrideContext, PropertyResolver};
 pub use heuristics::suggest_space_view_for_each_entity;
 pub use screenshot::ScreenshotMode;
-pub use space_view::{SpaceViewBlueprint, SpaceViewName};
+pub use space_view::SpaceViewBlueprint;
 pub use space_view_contents::SpaceViewContents;
 pub use sub_archetypes::{
     entity_path_for_space_view_sub_archetype, query_space_view_sub_archetype,

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -14,35 +14,11 @@ use re_types::{
 use re_types_core::archetypes::Clear;
 use re_types_core::Archetype as _;
 use re_viewer_context::{
-    DataResult, OverridePath, PerSystemEntities, PropertyOverrides, RecommendedSpaceView,
-    SpaceViewClass, SpaceViewClassIdentifier, SpaceViewId, SpaceViewState, StoreContext,
-    SystemCommand, SystemCommandSender as _, SystemExecutionOutput, ViewQuery, ViewerContext,
+    ContentsName, DataResult, OverridePath, PerSystemEntities, PropertyOverrides,
+    RecommendedSpaceView, SpaceViewClass, SpaceViewClassIdentifier, SpaceViewId, SpaceViewState,
+    StoreContext, SystemCommand, SystemCommandSender as _, SystemExecutionOutput, ViewQuery,
+    ViewerContext,
 };
-
-// ----------------------------------------------------------------------------
-
-/// The name of a space view.
-///
-/// Space views are unnamed by default, but have a placeholder name to be used in the UI.
-#[derive(Clone, Debug)]
-pub enum SpaceViewName {
-    /// This space view has been given a name by the user.
-    Named(String),
-
-    /// This space view is unnamed and should be displayed with this placeholder name.
-    Placeholder(String),
-}
-
-impl AsRef<str> for SpaceViewName {
-    #[inline]
-    fn as_ref(&self) -> &str {
-        match self {
-            SpaceViewName::Named(name) | SpaceViewName::Placeholder(name) => name,
-        }
-    }
-}
-
-// ----------------------------------------------------------------------------
 
 /// A view of a space.
 ///
@@ -96,7 +72,6 @@ impl SpaceViewBlueprint {
     }
 
     /// Placeholder name displayed in the UI if the user hasn't explicitly named the space view.
-    #[allow(clippy::unused_self)]
     pub fn missing_name_placeholder(&self) -> String {
         let entity_path = self
             .space_origin
@@ -125,12 +100,12 @@ impl SpaceViewBlueprint {
 
     /// Returns this space view's display name
     ///
-    /// When returning [`SpaceViewName::Placeholder`], the UI should display the resulting name using
+    /// When returning [`ContentsName::Placeholder`], the UI should display the resulting name using
     /// `re_ui::LabelStyle::Unnamed`.
-    pub fn display_name_or_default(&self) -> SpaceViewName {
+    pub fn display_name_or_default(&self) -> ContentsName {
         self.display_name.clone().map_or_else(
-            || SpaceViewName::Placeholder(self.missing_name_placeholder()),
-            SpaceViewName::Named,
+            || ContentsName::Placeholder(self.missing_name_placeholder()),
+            ContentsName::Named,
         )
     }
 

--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -206,8 +206,9 @@ fn item_to_string(blueprint: &ViewportBlueprint, item: &Item) -> String {
             format!("{}:{}", path.entity_path, path.component_name.short_name(),)
         }
         Item::Container(container_id) => {
+            // TODO(#4678): unnamed container should have their label formatted accordingly (subdued)
             if let Some(container) = blueprint.container(container_id) {
-                format!("{:?}", container.container_kind)
+                container.display_name_or_default().as_ref().to_owned()
             } else {
                 "<removed Container>".to_owned()
             }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -17,11 +17,12 @@ use re_types::{
 use re_ui::list_item::ListItem;
 use re_ui::{ReUi, SyntaxHighlighting as _};
 use re_viewer_context::{
-    gpu_bridge::colormap_dropdown_button_ui, ContainerId, DataQueryResult, HoverHighlight, Item,
-    SpaceViewClass, SpaceViewClassIdentifier, SpaceViewId, UiVerbosity, ViewerContext,
+    gpu_bridge::colormap_dropdown_button_ui, ContainerId, Contents, DataQueryResult,
+    HoverHighlight, Item, SpaceViewClass, SpaceViewClassIdentifier, SpaceViewId, UiVerbosity,
+    ViewerContext,
 };
 use re_viewport::{
-    context_menu_ui_for_item, icon_for_container_kind, space_view_name_style, Contents,
+    context_menu_ui_for_item, icon_for_container_kind, space_view_name_style,
     SelectionUpdateBehavior, Viewport, ViewportBlueprint,
 };
 

--- a/crates/re_viewer_context/src/contents.rs
+++ b/crates/re_viewer_context/src/contents.rs
@@ -1,0 +1,124 @@
+use std::convert::{TryFrom, TryInto};
+
+use egui_tiles::TileId;
+
+use re_log_types::EntityPath;
+
+use crate::item::Item;
+use crate::{BlueprintId, BlueprintIdRegistry, ContainerId, SpaceViewId};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Contents {
+    Container(ContainerId),
+    SpaceView(SpaceViewId),
+}
+
+impl Contents {
+    pub fn try_from(path: &EntityPath) -> Option<Self> {
+        if path.starts_with(SpaceViewId::registry()) {
+            Some(Self::SpaceView(SpaceViewId::from_entity_path(path)))
+        } else if path.starts_with(ContainerId::registry()) {
+            Some(Self::Container(ContainerId::from_entity_path(path)))
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_entity_path(&self) -> EntityPath {
+        match self {
+            Self::Container(id) => id.as_entity_path(),
+            Self::SpaceView(id) => id.as_entity_path(),
+        }
+    }
+
+    #[inline]
+    pub fn as_tile_id(&self) -> TileId {
+        match self {
+            Self::Container(id) => blueprint_id_to_tile_id(id),
+            Self::SpaceView(id) => blueprint_id_to_tile_id(id),
+        }
+    }
+
+    #[inline]
+    pub fn as_item(&self) -> Item {
+        match self {
+            Contents::Container(container_id) => Item::Container(*container_id),
+            Contents::SpaceView(space_view_id) => Item::SpaceView(*space_view_id),
+        }
+    }
+
+    #[inline]
+    pub fn as_container_id(&self) -> Option<ContainerId> {
+        match self {
+            Self::Container(id) => Some(*id),
+            Self::SpaceView(_) => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_space_view_id(&self) -> Option<SpaceViewId> {
+        match self {
+            Self::SpaceView(id) => Some(*id),
+            Self::Container(_) => None,
+        }
+    }
+}
+
+impl TryFrom<Item> for Contents {
+    type Error = ();
+
+    fn try_from(item: Item) -> Result<Self, Self::Error> {
+        (&item).try_into()
+    }
+}
+
+impl TryFrom<&Item> for Contents {
+    type Error = ();
+
+    fn try_from(item: &Item) -> Result<Self, Self::Error> {
+        match item {
+            Item::Container(id) => Ok(Self::Container(*id)),
+            Item::SpaceView(id) => Ok(Self::SpaceView(*id)),
+            _ => Err(()),
+        }
+    }
+}
+
+impl From<SpaceViewId> for Contents {
+    #[inline]
+    fn from(id: SpaceViewId) -> Self {
+        Self::SpaceView(id)
+    }
+}
+
+impl From<ContainerId> for Contents {
+    #[inline]
+    fn from(id: ContainerId) -> Self {
+        Self::Container(id)
+    }
+}
+
+/// The name of a [`Contents`].
+#[derive(Clone, Debug)]
+pub enum ContentsName {
+    /// This [`Contents`] has been given a name by the user.
+    Named(String),
+
+    /// This [`Contents`] is unnamed and should be displayed with this placeholder name.
+    Placeholder(String),
+}
+
+impl AsRef<str> for ContentsName {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        match self {
+            ContentsName::Named(name) | ContentsName::Placeholder(name) => name,
+        }
+    }
+}
+
+#[inline]
+pub fn blueprint_id_to_tile_id<T: BlueprintIdRegistry>(id: &BlueprintId<T>) -> TileId {
+    TileId::from_u64(id.hash())
+}

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -10,6 +10,7 @@ mod caches;
 mod collapsed_id;
 mod command_sender;
 mod component_ui_registry;
+mod contents;
 mod item;
 mod query_context;
 mod selection_history;
@@ -37,6 +38,7 @@ pub use command_sender::{
     command_channel, CommandReceiver, CommandSender, SystemCommand, SystemCommandSender,
 };
 pub use component_ui_registry::{ComponentUiRegistry, UiVerbosity};
+pub use contents::{blueprint_id_to_tile_id, Contents, ContentsName};
 pub use item::Item;
 pub use query_context::{DataQueryResult, DataResultHandle, DataResultNode, DataResultTree};
 pub use selection_history::SelectionHistory;
@@ -66,6 +68,7 @@ pub use viewer_context::{RecordingConfig, ViewerContext};
 
 #[cfg(not(target_arch = "wasm32"))]
 mod clipboard;
+
 #[cfg(not(target_arch = "wasm32"))]
 pub use clipboard::Clipboard;
 

--- a/crates/re_viewport/src/add_space_view_or_container_modal.rs
+++ b/crates/re_viewport/src/add_space_view_or_container_modal.rs
@@ -2,11 +2,12 @@
 
 use itertools::Itertools;
 
-use crate::container::blueprint_id_to_tile_id;
 use crate::{icon_for_container_kind, ViewportBlueprint};
 use re_space_view::SpaceViewBlueprint;
 use re_ui::ReUi;
-use re_viewer_context::{ContainerId, RecommendedSpaceView, ViewerContext};
+use re_viewer_context::{
+    blueprint_id_to_tile_id, ContainerId, RecommendedSpaceView, ViewerContext,
+};
 
 #[derive(Default)]
 pub struct AddSpaceViewOrContainerModal {

--- a/crates/re_viewport/src/container.rs
+++ b/crates/re_viewport/src/container.rs
@@ -9,108 +9,10 @@ use re_query::query_archetype;
 use re_types::blueprint::components::Visible;
 use re_types_core::archetypes::Clear;
 use re_viewer_context::{
-    BlueprintId, BlueprintIdRegistry, ContainerId, Item, SpaceViewId, SystemCommand,
-    SystemCommandSender as _, ViewerContext,
+    ContainerId, Contents, SpaceViewId, SystemCommand, SystemCommandSender as _, ViewerContext,
 };
 
 use crate::blueprint::components::GridColumns;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Contents {
-    Container(ContainerId),
-    SpaceView(SpaceViewId),
-}
-
-impl Contents {
-    fn try_from(path: &EntityPath) -> Option<Self> {
-        if path.starts_with(SpaceViewId::registry()) {
-            Some(Self::SpaceView(SpaceViewId::from_entity_path(path)))
-        } else if path.starts_with(ContainerId::registry()) {
-            Some(Self::Container(ContainerId::from_entity_path(path)))
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    fn as_entity_path(&self) -> EntityPath {
-        match self {
-            Self::Container(id) => id.as_entity_path(),
-            Self::SpaceView(id) => id.as_entity_path(),
-        }
-    }
-
-    #[inline]
-    pub fn as_tile_id(&self) -> TileId {
-        match self {
-            Self::Container(id) => blueprint_id_to_tile_id(id),
-            Self::SpaceView(id) => blueprint_id_to_tile_id(id),
-        }
-    }
-
-    #[inline]
-    pub fn as_item(&self) -> Item {
-        match self {
-            Contents::Container(container_id) => Item::Container(*container_id),
-            Contents::SpaceView(space_view_id) => Item::SpaceView(*space_view_id),
-        }
-    }
-
-    #[inline]
-    pub fn as_container_id(&self) -> Option<ContainerId> {
-        match self {
-            Self::Container(id) => Some(*id),
-            Self::SpaceView(_) => None,
-        }
-    }
-
-    #[inline]
-    pub fn as_space_view_id(&self) -> Option<SpaceViewId> {
-        match self {
-            Self::SpaceView(id) => Some(*id),
-            Self::Container(_) => None,
-        }
-    }
-}
-
-impl TryFrom<Item> for Contents {
-    type Error = ();
-
-    fn try_from(item: Item) -> Result<Self, Self::Error> {
-        (&item).try_into()
-    }
-}
-
-impl TryFrom<&Item> for Contents {
-    type Error = ();
-
-    fn try_from(item: &Item) -> Result<Self, Self::Error> {
-        match item {
-            Item::Container(id) => Ok(Self::Container(*id)),
-            Item::SpaceView(id) => Ok(Self::SpaceView(*id)),
-            _ => Err(()),
-        }
-    }
-}
-
-#[inline]
-pub fn blueprint_id_to_tile_id<T: BlueprintIdRegistry>(id: &BlueprintId<T>) -> TileId {
-    TileId::from_u64(id.hash())
-}
-
-impl From<SpaceViewId> for Contents {
-    #[inline]
-    fn from(id: SpaceViewId) -> Self {
-        Self::SpaceView(id)
-    }
-}
-
-impl From<ContainerId> for Contents {
-    #[inline]
-    fn from(id: ContainerId) -> Self {
-        Self::Container(id)
-    }
-}
 
 /// The native version of a [`crate::blueprint::archetypes::ContainerBlueprint`].
 ///

--- a/crates/re_viewport/src/context_menu/actions/collapse_expand_all.rs
+++ b/crates/re_viewport/src/context_menu/actions/collapse_expand_all.rs
@@ -1,8 +1,7 @@
 use re_entity_db::InstancePath;
-use re_viewer_context::{CollapseScope, ContainerId, Item, SpaceViewId};
+use re_viewer_context::{CollapseScope, ContainerId, Contents, Item, SpaceViewId};
 
 use crate::context_menu::{ContextMenuAction, ContextMenuContext};
-use crate::Contents;
 
 /// Collapse or expand all items in the selection.
 // TODO(ab): the current implementation makes strong assumptions of which CollapseScope to use based

--- a/crates/re_viewport/src/context_menu/actions/remove.rs
+++ b/crates/re_viewport/src/context_menu/actions/remove.rs
@@ -1,9 +1,8 @@
 use re_entity_db::InstancePath;
 use re_log_types::EntityPathRule;
-use re_viewer_context::{ContainerId, Item, SpaceViewId};
+use re_viewer_context::{ContainerId, Contents, Item, SpaceViewId};
 
 use crate::context_menu::{ContextMenuAction, ContextMenuContext};
-use crate::Contents;
 
 /// Remove a container, space view, or data result.
 pub(crate) struct RemoveAction;

--- a/crates/re_viewport/src/context_menu/actions/show_hide.rs
+++ b/crates/re_viewport/src/context_menu/actions/show_hide.rs
@@ -1,8 +1,7 @@
 use re_entity_db::InstancePath;
-use re_viewer_context::{ContainerId, Item, SpaceViewId};
+use re_viewer_context::{ContainerId, Contents, Item, SpaceViewId};
 
 use crate::context_menu::{ContextMenuAction, ContextMenuContext};
-use crate::Contents;
 
 pub(crate) struct ShowAction;
 

--- a/crates/re_viewport/src/context_menu/mod.rs
+++ b/crates/re_viewport/src/context_menu/mod.rs
@@ -2,9 +2,9 @@ use itertools::Itertools;
 use once_cell::sync::OnceCell;
 
 use re_entity_db::InstancePath;
-use re_viewer_context::{ContainerId, Item, ItemCollection, SpaceViewId, ViewerContext};
+use re_viewer_context::{ContainerId, Contents, Item, ItemCollection, SpaceViewId, ViewerContext};
 
-use crate::{ContainerBlueprint, Contents, ViewportBlueprint};
+use crate::{ContainerBlueprint, ViewportBlueprint};
 
 mod actions;
 mod sub_menu;

--- a/crates/re_viewport/src/lib.rs
+++ b/crates/re_viewport/src/lib.rs
@@ -24,7 +24,7 @@ mod viewport_blueprint_ui;
 /// Unstable. Used for the ongoing blueprint experimentation.
 pub mod blueprint;
 
-pub use container::{ContainerBlueprint, Contents};
+pub use container::ContainerBlueprint;
 pub use context_menu::{context_menu_ui_for_item, SelectionUpdateBehavior};
 pub use viewport::{Viewport, ViewportState};
 pub use viewport_blueprint::ViewportBlueprint;

--- a/crates/re_viewport/src/lib.rs
+++ b/crates/re_viewport/src/lib.rs
@@ -28,7 +28,7 @@ pub use container::ContainerBlueprint;
 pub use context_menu::{context_menu_ui_for_item, SelectionUpdateBehavior};
 pub use viewport::{Viewport, ViewportState};
 pub use viewport_blueprint::ViewportBlueprint;
-pub use viewport_blueprint_ui::space_view_name_style;
+pub use viewport_blueprint_ui::contents_name_style;
 
 pub mod external {
     pub use re_space_view;

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -10,16 +10,15 @@ use re_entity_db::EntityPropertyMap;
 use re_renderer::ScreenshotProcessor;
 use re_ui::{Icon, ReUi};
 use re_viewer_context::{
-    ContainerId, Item, SpaceViewClassIdentifier, SpaceViewClassRegistry, SpaceViewId,
-    SpaceViewState, SystemExecutionOutput, ViewQuery, ViewerContext,
+    blueprint_id_to_tile_id, ContainerId, Contents, Item, SpaceViewClassIdentifier,
+    SpaceViewClassRegistry, SpaceViewId, SpaceViewState, SystemExecutionOutput, ViewQuery,
+    ViewerContext,
 };
 
-use crate::container::blueprint_id_to_tile_id;
 use crate::screenshot::handle_pending_space_view_screenshots;
 use crate::{
-    add_space_view_or_container_modal::AddSpaceViewOrContainerModal, container::Contents,
-    context_menu_ui_for_item, icon_for_container_kind,
-    space_view_entity_picker::SpaceViewEntityPicker,
+    add_space_view_or_container_modal::AddSpaceViewOrContainerModal, context_menu_ui_for_item,
+    icon_for_container_kind, space_view_entity_picker::SpaceViewEntityPicker,
     system_execution::execute_systems_for_all_space_views, SelectionUpdateBehavior,
     ViewportBlueprint,
 };

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -923,9 +923,27 @@ impl TabWidget {
                 if let Some(Contents::Container(container_id)) =
                     tab_viewer.contents_per_tile_id.get(&tile_id)
                 {
+                    let (label, user_named) = if let Some(container_blueprint) =
+                        tab_viewer.viewport_blueprint.container(container_id)
+                    {
+                        (
+                            container_blueprint
+                                .display_name_or_default()
+                                .as_ref()
+                                .into(),
+                            container_blueprint.display_name.is_some(),
+                        )
+                    } else {
+                        re_log::warn_once!("Container {container_id} missing during egui_tiles");
+                        (
+                            tab_viewer.ctx.re_ui.error_text("Internal error").into(),
+                            false,
+                        )
+                    };
+
                     TabDesc {
-                        label: format!("{:?}", container.kind()).into(),
-                        user_named: false,
+                        label,
+                        user_named,
                         icon: icon_for_container_kind(&container.kind()),
                         item: Some(Item::Container(*container_id)),
                     }

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -12,15 +12,15 @@ use re_query::query_archetype;
 use re_space_view::SpaceViewBlueprint;
 use re_types::blueprint::components::ViewerRecommendationHash;
 use re_viewer_context::{
-    ContainerId, Item, SpaceViewClassIdentifier, SpaceViewId, SpaceViewSpawnHeuristics,
-    ViewerContext,
+    blueprint_id_to_tile_id, ContainerId, Contents, Item, SpaceViewClassIdentifier, SpaceViewId,
+    SpaceViewSpawnHeuristics, ViewerContext,
 };
 
 use crate::{
     blueprint::components::{
         AutoLayout, AutoSpaceViews, IncludedSpaceView, RootContainer, SpaceViewMaximized,
     },
-    container::{blueprint_id_to_tile_id, ContainerBlueprint, Contents},
+    container::ContainerBlueprint,
     viewport::TreeAction,
     VIEWPORT_PATH,
 };

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -6,22 +6,22 @@ use smallvec::SmallVec;
 use re_entity_db::InstancePath;
 use re_log_types::EntityPath;
 use re_log_types::EntityPathRule;
-use re_space_view::{SpaceViewBlueprint, SpaceViewName};
+use re_space_view::SpaceViewBlueprint;
 use re_types::blueprint::components::Visible;
 use re_ui::{drag_and_drop::DropTarget, list_item::ListItem, ReUi};
-use re_viewer_context::{CollapseScope, DataResultTree};
+use re_viewer_context::{CollapseScope, Contents, ContentsName, DataResultTree};
 use re_viewer_context::{
     ContainerId, DataQueryResult, DataResultNode, HoverHighlight, Item, SpaceViewId, ViewerContext,
 };
 
 use crate::context_menu::context_menu_ui_for_item;
-use crate::{container::Contents, SelectionUpdateBehavior, Viewport};
+use crate::{SelectionUpdateBehavior, Viewport};
 
 /// The style to use for displaying this space view name in the UI.
-pub fn space_view_name_style(name: &SpaceViewName) -> re_ui::LabelStyle {
+pub fn space_view_name_style(name: &ContentsName) -> re_ui::LabelStyle {
     match name {
-        SpaceViewName::Named(_) => re_ui::LabelStyle::Normal,
-        SpaceViewName::Placeholder(_) => re_ui::LabelStyle::Unnamed,
+        ContentsName::Named(_) => re_ui::LabelStyle::Normal,
+        ContentsName::Placeholder(_) => re_ui::LabelStyle::Unnamed,
     }
 }
 

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -18,7 +18,7 @@ use crate::context_menu::context_menu_ui_for_item;
 use crate::{SelectionUpdateBehavior, Viewport};
 
 /// The style to use for displaying this space view name in the UI.
-pub fn space_view_name_style(name: &ContentsName) -> re_ui::LabelStyle {
+pub fn contents_name_style(name: &ContentsName) -> re_ui::LabelStyle {
     match name {
         ContentsName::Named(_) => re_ui::LabelStyle::Normal,
         ContentsName::Placeholder(_) => re_ui::LabelStyle::Unnamed,
@@ -263,19 +263,18 @@ impl Viewport<'_, '_> {
         };
 
         let item = Item::Container(container_id);
+        let container_name = container_blueprint.display_name_or_default();
 
-        let item_response = ListItem::new(
-            ctx.re_ui,
-            format!("Viewport ({:?})", container_blueprint.container_kind),
-        )
-        .selected(ctx.selection().contains_item(&item))
-        .draggable(false)
-        .drop_target_style(self.state.is_candidate_drop_parent_container(&container_id))
-        .label_style(re_ui::LabelStyle::Unnamed)
-        .with_icon(crate::icon_for_container_kind(
-            &container_blueprint.container_kind,
-        ))
-        .show_flat(ui);
+        let item_response =
+            ListItem::new(ctx.re_ui, format!("Viewport ({})", container_name.as_ref()))
+                .selected(ctx.selection().contains_item(&item))
+                .draggable(false)
+                .drop_target_style(self.state.is_candidate_drop_parent_container(&container_id))
+                .label_style(contents_name_style(&container_name))
+                .with_icon(crate::icon_for_container_kind(
+                    &container_blueprint.container_kind,
+                ))
+                .show_flat(ui);
 
         for child in &container_blueprint.contents {
             self.contents_ui(ctx, ui, child, true);
@@ -318,42 +317,41 @@ impl Viewport<'_, '_> {
 
         let default_open = true;
 
+        let container_name = container_blueprint.display_name_or_default();
+
         let re_ui::list_item::ShowCollapsingResponse {
             item_response: response,
             body_response,
-        } = ListItem::new(
-            ctx.re_ui,
-            format!("{:?}", container_blueprint.container_kind),
-        )
-        .subdued(!container_visible)
-        .selected(ctx.selection().contains_item(&item))
-        .draggable(true)
-        .drop_target_style(self.state.is_candidate_drop_parent_container(container_id))
-        .label_style(re_ui::LabelStyle::Unnamed)
-        .with_icon(crate::icon_for_container_kind(
-            &container_blueprint.container_kind,
-        ))
-        .with_buttons(|re_ui, ui| {
-            let vis_response = visibility_button_ui(re_ui, ui, parent_visible, &mut visible);
+        } = ListItem::new(ctx.re_ui, container_name.as_ref())
+            .subdued(!container_visible)
+            .selected(ctx.selection().contains_item(&item))
+            .draggable(true)
+            .drop_target_style(self.state.is_candidate_drop_parent_container(container_id))
+            .label_style(contents_name_style(&container_name))
+            .with_icon(crate::icon_for_container_kind(
+                &container_blueprint.container_kind,
+            ))
+            .with_buttons(|re_ui, ui| {
+                let vis_response = visibility_button_ui(re_ui, ui, parent_visible, &mut visible);
 
-            let remove_response = remove_button_ui(re_ui, ui, "Remove container");
-            if remove_response.clicked() {
-                self.blueprint.mark_user_interaction(ctx);
-                self.blueprint.remove_contents(content);
-            }
-
-            remove_response | vis_response
-        })
-        .show_hierarchical_with_content(
-            ui,
-            CollapseScope::BlueprintTree.container(*container_id),
-            default_open,
-            |_, ui| {
-                for child in &container_blueprint.contents {
-                    self.contents_ui(ctx, ui, child, container_visible);
+                let remove_response = remove_button_ui(re_ui, ui, "Remove container");
+                if remove_response.clicked() {
+                    self.blueprint.mark_user_interaction(ctx);
+                    self.blueprint.remove_contents(content);
                 }
-            },
-        );
+
+                remove_response | vis_response
+            })
+            .show_hierarchical_with_content(
+                ui,
+                CollapseScope::BlueprintTree.container(*container_id),
+                default_open,
+                |_, ui| {
+                    for child in &container_blueprint.contents {
+                        self.contents_ui(ctx, ui, child, container_visible);
+                    }
+                },
+            );
 
         context_menu_ui_for_item(
             ctx,
@@ -411,7 +409,7 @@ impl Viewport<'_, '_> {
             item_response: mut response,
             body_response,
         } = ListItem::new(ctx.re_ui, space_view_name.as_ref())
-            .label_style(space_view_name_style(&space_view_name))
+            .label_style(contents_name_style(&space_view_name))
             .with_icon(space_view.class(ctx.space_view_class_registry).icon())
             .selected(ctx.selection().contains_item(&item))
             .draggable(true)

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -125,6 +125,7 @@ class Container:
         row_shares: Optional[RowShareArrayLike] = None,
         grid_columns: Optional[int] = None,
         active_tab: Optional[int | str] = None,
+        name: Utf8Like | None,
     ):
         """
         Construct a new container.
@@ -148,6 +149,8 @@ class Container:
             The number of columns in the grid. This is only applicable to `Grid` containers.
         active_tab
             The active tab in the container. This is only applicable to `Tabs` containers.
+        name
+            The name of the container
 
         """
         self.id = uuid.uuid4()
@@ -157,6 +160,7 @@ class Container:
         self.row_shares = row_shares
         self.grid_columns = grid_columns
         self.active_tab = active_tab
+        self.name = name
 
     def blueprint_path(self) -> str:
         """
@@ -195,6 +199,7 @@ class Container:
             visible=True,
             grid_columns=self.grid_columns,
             active_tab=active_tab_path,
+            display_name=self.name,
         )
 
         stream.log(self.blueprint_path(), arch)  # type: ignore[attr-defined]

--- a/rerun_py/rerun_sdk/rerun/blueprint/containers.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/containers.py
@@ -35,7 +35,9 @@ class Horizontal(Container):
             The name of the container
 
         """
-        super().__init__(*args, contents=contents, kind=ContainerKind.Horizontal, column_shares=column_shares, name=name)
+        super().__init__(
+            *args, contents=contents, kind=ContainerKind.Horizontal, column_shares=column_shares, name=name
+        )
 
 
 class Vertical(Container):

--- a/rerun_py/rerun_sdk/rerun/blueprint/containers.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/containers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from ..datatypes import Utf8Like
 from .api import Container, SpaceView
 from .components import ColumnShareArrayLike, RowShareArrayLike
 from .components.container_kind import ContainerKind
@@ -10,7 +11,12 @@ from .components.container_kind import ContainerKind
 class Horizontal(Container):
     """A horizontal container."""
 
-    def __init__(self, *contents: Container | SpaceView, column_shares: Optional[ColumnShareArrayLike] = None):
+    def __init__(
+        self,
+        *contents: Container | SpaceView,
+        column_shares: Optional[ColumnShareArrayLike] = None,
+        name: Utf8Like | None = None,
+    ):
         """
         Construct a new horizontal container.
 
@@ -21,15 +27,22 @@ class Horizontal(Container):
         column_shares
             The layout shares of the columns in the container. The share is used to determine what fraction of the total width each
             column should take up. The column with index `i` will take up the fraction `shares[i] / total_shares`.
+        name
+            The name of the container
 
         """
-        super().__init__(*contents, kind=ContainerKind.Horizontal, column_shares=column_shares)
+        super().__init__(*contents, kind=ContainerKind.Horizontal, column_shares=column_shares, name=name)
 
 
 class Vertical(Container):
     """A vertical container."""
 
-    def __init__(self, *contents: Container | SpaceView, row_shares: Optional[RowShareArrayLike] = None):
+    def __init__(
+        self,
+        *contents: Container | SpaceView,
+        row_shares: Optional[RowShareArrayLike] = None,
+        name: Utf8Like | None = None,
+    ):
         """
         Construct a new vertical container.
 
@@ -40,9 +53,11 @@ class Vertical(Container):
         row_shares
             The layout shares of the rows in the container. The share is used to determine what fraction of the total height each
             row should take up. The row with index `i` will take up the fraction `shares[i] / total_shares`.
+        name
+            The name of the container
 
         """
-        super().__init__(*contents, kind=ContainerKind.Vertical, row_shares=row_shares)
+        super().__init__(*contents, kind=ContainerKind.Vertical, row_shares=row_shares, name=name)
 
 
 class Grid(Container):
@@ -54,6 +69,7 @@ class Grid(Container):
         column_shares: Optional[ColumnShareArrayLike] = None,
         row_shares: Optional[RowShareArrayLike] = None,
         grid_columns: Optional[int] = None,
+        name: Utf8Like | None = None,
     ):
         """
         Construct a new grid container.
@@ -70,6 +86,8 @@ class Grid(Container):
             row should take up. The row with index `i` will take up the fraction `shares[i] / total_shares`.
         grid_columns
             The number of columns in the grid.
+        name
+            The name of the container
 
         """
         super().__init__(
@@ -78,13 +96,19 @@ class Grid(Container):
             column_shares=column_shares,
             row_shares=row_shares,
             grid_columns=grid_columns,
+            name=name,
         )
 
 
 class Tabs(Container):
     """A tab container."""
 
-    def __init__(self, *contents: Container | SpaceView, active_tab: Optional[int | str] = None):
+    def __init__(
+        self,
+        *contents: Container | SpaceView,
+        active_tab: Optional[int | str] = None,
+        name: Utf8Like | None = None,
+    ):
         """
         Construct a new tab container.
 
@@ -94,6 +118,8 @@ class Tabs(Container):
             All positional arguments are the contents of the container, which may be either other containers or space views.
         active_tab:
             The index or name of the active tab.
+        name
+            The name of the container
 
         """
-        super().__init__(*contents, kind=ContainerKind.Tabs, active_tab=active_tab)
+        super().__init__(*contents, kind=ContainerKind.Tabs, active_tab=active_tab, name=name)


### PR DESCRIPTION
### What

As the title say ☝🏻 

Decisions:
- Keep "Viewport" in the name of the root container (see screenshot below).
- Refactor some stuff:
  - moved `Contents` to re_viewer_contex (I actually been meaning to do that for a while but can't remember why now)
  - moved/renamed `SpaceViewName` to `ContentsName` in re_viewer_context

⚠️  review commit by commit


https://github.com/rerun-io/rerun/assets/49431240/cac22100-c0fb-4ff8-9fe0-195607c222a4



```python
import rerun as rr
import rerun.blueprint as rrb

rr.init(
    "rerun_example_demo",
    blueprint=rrb.Horizontal(
        rrb.Vertical(
            rrb.Spatial3DView(origin="/point3d"),
            rrb.Spatial3DView(origin="/point3d"),
            name="First Vertical",
        ),
        rrb.Vertical(
            rrb.Spatial3DView(origin="/point3d"),
            rrb.Spatial3DView(origin="/point3d"),
            name="Second Vertical",
        ),
        name="Top-Level",
    ),
)
rr.connect()

rr.log("point3d", rr.Points3D([0, 1, 2]))
```

<img width="263" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/7ca42f6c-209e-4fec-b5df-1a2ab2558e48">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5626/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5626/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5626/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5626)
- [Docs preview](https://rerun.io/preview/df3fd74ffb59adfb22bfa15b1b28fea2e916d2b5/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/df3fd74ffb59adfb22bfa15b1b28fea2e916d2b5/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)