### PR TITLE
Select active recording if nothing else is selected

### DIFF
--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -305,12 +305,22 @@ impl AppState {
             ui,
             app_blueprint.time_panel_expanded,
         );
-        selection_panel.show_panel(
-            &ctx,
-            ui,
-            &mut viewport,
-            app_blueprint.selection_panel_expanded,
-        );
+
+        {
+            if ctx.selection().is_empty() {
+                // Make sure something is selected before showing the selection panel.
+                ctx.selection_state()
+                    .set_selection(re_viewer_context::Item::StoreId(
+                        ctx.entity_db.store_id().clone(),
+                    ));
+            }
+            selection_panel.show_panel(
+                &ctx,
+                ui,
+                &mut viewport,
+                app_blueprint.selection_panel_expanded,
+            );
+        }
 
         let central_panel_frame = egui::Frame {
             fill: ui.style().visuals.panel_fill,

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -110,9 +110,7 @@ impl SelectionPanel {
         re_tracing::profile_function!();
 
         if ctx.selection().is_empty() {
-            // If nothing is selected, we fall back to selecting the current recording.
-            ctx.selection_state()
-                .set_selection(Item::StoreId(ctx.entity_db.store_id().clone()));
+            return;
         }
 
         // no gap before the first item title

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -110,7 +110,9 @@ impl SelectionPanel {
         re_tracing::profile_function!();
 
         if ctx.selection().is_empty() {
-            return;
+            // If nothing is selected, we fall back to selecting the current recording.
+            ctx.selection_state()
+                .set_selection(Item::StoreId(ctx.entity_db.store_id().clone()));
         }
 
         // no gap before the first item title


### PR DESCRIPTION
### What
If nothing is selected (or user presses escape), the active recording gets selected.

In a future PR I will improve the contents of the selection panel when a recording is selected, e.g. show the blueprints in the recording etc, but for that I need to do some refactors first.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5627/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5627/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5627/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5627)
- [Docs preview](https://rerun.io/preview/88a9b028b16bf7c2750b808ba4b10b49393e81a1/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/88a9b028b16bf7c2750b808ba4b10b49393e81a1/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)