### PR TITLE
Fix controlnet example for current `controlnet` package version and add blueprint

### DIFF
--- a/examples/python/controlnet/main.py
+++ b/examples/python/controlnet/main.py
@@ -29,12 +29,10 @@ from diffusers import (
 
 RERUN_LOGO_URL = "https://storage.googleapis.com/rerun-example-datasets/controlnet/rerun-icon-1000.png"
 
-# (pipe, step_index, timestep, callback_kwargs):
-
 
 def controlnet_callback(
     pipe: StableDiffusionXLControlNetPipeline, step_index: int, timestep: float, callback_kwargs: dict
-) -> None:
+) -> dict:
     rr.set_time_sequence("iteration", step_index)
     rr.set_time_seconds("timestep", timestep)
     latents = callback_kwargs["latents"]

--- a/examples/python/controlnet/main.py
+++ b/examples/python/controlnet/main.py
@@ -31,7 +31,10 @@ RERUN_LOGO_URL = "https://storage.googleapis.com/rerun-example-datasets/controln
 
 # (pipe, step_index, timestep, callback_kwargs):
 
-def controlnet_callback(pipe: StableDiffusionXLControlNetPipeline, step_index: int, timestep: float, callback_kwargs: dict) -> None:
+
+def controlnet_callback(
+    pipe: StableDiffusionXLControlNetPipeline, step_index: int, timestep: float, callback_kwargs: dict
+) -> None:
     rr.set_time_sequence("iteration", step_index)
     rr.set_time_seconds("timestep", timestep)
     latents = callback_kwargs["latents"]
@@ -130,7 +133,22 @@ def main() -> None:
     rr.script_add_args(parser)
     args = parser.parse_args()
 
-    rr.script_setup(args, "rerun_example_controlnet")
+    rr.script_setup(
+        args,
+        "rerun_example_controlnet",
+        blueprint=rrb.Horizontal(
+            rrb.Grid(
+                rrb.Spatial2DView(origin="input/raw"),
+                rrb.Spatial2DView(origin="input/canny"),
+                rrb.Vertical(
+                    rrb.TextDocumentView(origin="positive_prompt"),
+                    rrb.TextDocumentView(origin="negative_prompt"),
+                ),
+                rrb.TensorView(origin="latent"),
+            ),
+            rrb.Spatial2DView(origin="output"),
+        ),
+    )
     run_canny_controlnet(args.img_path, args.prompt, args.negative_prompt)
     rr.script_teardown(args)
 

--- a/examples/python/controlnet/main.py
+++ b/examples/python/controlnet/main.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import os
+from typing import Any
 
 import cv2
 import numpy as np
@@ -31,8 +32,8 @@ RERUN_LOGO_URL = "https://storage.googleapis.com/rerun-example-datasets/controln
 
 
 def controlnet_callback(
-    pipe: StableDiffusionXLControlNetPipeline, step_index: int, timestep: float, callback_kwargs: dict
-) -> dict:
+    pipe: StableDiffusionXLControlNetPipeline, step_index: int, timestep: float, callback_kwargs: dict[str, Any]
+) -> dict[str, Any]:
     rr.set_time_sequence("iteration", step_index)
     rr.set_time_seconds("timestep", timestep)
     latents = callback_kwargs["latents"]


### PR DESCRIPTION
### What

Again, this time the default view names were good enough, so didn't specify them.
Example looks now like in the marketing material out of the box ✨

![image](https://github.com/rerun-io/rerun/assets/1220815/2ac9a735-b9d8-4db7-b134-ca93f2247999)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5634/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5634/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5634/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5634)
- [Docs preview](https://rerun.io/preview/03c6a4905631d445446c9041e1e72f44949d3d42/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/03c6a4905631d445446c9041e1e72f44949d3d42/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)