### PR TITLE
Add blueprint to Signed Distance Fields example

### DIFF
--- a/examples/python/signed_distance_fields/README.md
+++ b/examples/python/signed_distance_fields/README.md
@@ -5,13 +5,12 @@ thumbnail = "https://static.rerun.io/signed-distance-fields/0b0a200e0a5ec2b16e5f
 thumbnail_dimensions = [480, 480]
 -->
 
-
 <picture>
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/signed_distance_fields/99f6a886ed6f41b6a8e9023ba917a98668eaee70/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/signed_distance_fields/99f6a886ed6f41b6a8e9023ba917a98668eaee70/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/signed_distance_fields/99f6a886ed6f41b6a8e9023ba917a98668eaee70/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/signed_distance_fields/99f6a886ed6f41b6a8e9023ba917a98668eaee70/1200w.png">
-  <img src="https://static.rerun.io/signed_distance_fields/99f6a886ed6f41b6a8e9023ba917a98668eaee70/full.png" alt="Signed Distance Fields example screenshot">
+  <img src="https://static.rerun.io/signed_distance_fields/1380524f963af0cbd615989a6e382ca86148f6da/full.png" alt="Signed Distance Fields example screenshot">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/signed_distance_fields/1380524f963af0cbd615989a6e382ca86148f6da/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/signed_distance_fields/1380524f963af0cbd615989a6e382ca86148f6da/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/signed_distance_fields/1380524f963af0cbd615989a6e382ca86148f6da/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/signed_distance_fields/1380524f963af0cbd615989a6e382ca86148f6da/1200w.png">
 </picture>
 
 Generate Signed Distance Fields for arbitrary meshes using both traditional methods and the one described in the [DeepSDF paper](https://arxiv.org/abs/1901.05103), and visualize the results using the Rerun SDK.

--- a/examples/python/signed_distance_fields/main.py
+++ b/examples/python/signed_distance_fields/main.py
@@ -37,6 +37,7 @@ import mesh_to_sdf
 import numpy as np
 import numpy.typing as npt
 import rerun as rr  # pip install rerun-sdk
+import rerun.blueprint as rrb
 import trimesh
 from download_dataset import AVAILABLE_MESHES, ensure_mesh_downloaded
 from trimesh import Trimesh
@@ -194,7 +195,20 @@ def main() -> None:
     rr.script_add_args(parser)
     args = parser.parse_args()
 
-    rr.script_setup(args, "rerun_example_signed_distance_fields")
+    rr.script_setup(
+        args,
+        "rerun_example_signed_distance_fields",
+        blueprint=rrb.Horizontal(
+            rrb.Vertical(
+                rrb.Horizontal(
+                    rrb.Spatial3DView(name="Input Mesh", origin="/world/mesh"),
+                    rrb.TensorView(name="SDF", origin="/tensor"),
+                ),
+                rrb.TextLogView(name="Execution Log"),
+            ),
+            rrb.Spatial3DView(name="Distance Field Samples", origin="/world/sdf"),
+        ),
+    )
 
     mesh_path = args.mesh_path
     if mesh_path is None:

--- a/scripts/ci/thumbnails.py
+++ b/scripts/ci/thumbnails.py
@@ -34,7 +34,7 @@ def examples_with_thumbnails() -> Generator[Example, None, None]:
     def single_language(lang: str) -> Generator[Example, None, None]:
         for path in Path(f"examples/{lang}").iterdir():
             if (path / "README.md").exists():
-                readme = (path / "README.md").read_text()
+                readme = (path / "README.md").read_text(encoding="utf-8")
                 fm = load_frontmatter(readme)
                 if fm is not None and fm.get("thumbnail"):
                     yield Example(path, readme, fm)
@@ -64,7 +64,9 @@ def update() -> None:
                 assert end != -1
 
             (example.path / "README.md").write_text(
-                example.readme[:start] + f"thumbnail_dimensions = [{width}, {height}]" + example.readme[end:]
+                example.readme[:start] + f"thumbnail_dimensions = [{width}, {height}]" + example.readme[end:],
+                encoding="utf-8",
+                newline='\n',
             )
 
             print(f"✔ {example.path}")

--- a/scripts/ci/thumbnails.py
+++ b/scripts/ci/thumbnails.py
@@ -66,7 +66,7 @@ def update() -> None:
             (example.path / "README.md").write_text(
                 example.readme[:start] + f"thumbnail_dimensions = [{width}, {height}]" + example.readme[end:],
                 encoding="utf-8",
-                newline='\n',
+                newline="\n",
             )
 
             print(f"✔ {example.path}")


### PR DESCRIPTION
### What

Also replace the somewhat broken screenshot it had (thumbnail was alright)

![image](https://github.com/rerun-io/rerun/assets/1220815/1496c03b-a4d8-4e38-8e9d-075e0da9fc75)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5635/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5635/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5635/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5635)
- [Docs preview](https://rerun.io/preview/8bd47c05b89f3eefd1fda0e4a9564799b8c5a76d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/8bd47c05b89f3eefd1fda0e4a9564799b8c5a76d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)