### PR TITLE
Avoid warning on win/mac by not making the blueprint stream thread-local

### DIFF
--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -473,9 +473,15 @@ def create_in_memory_blueprint(*, application_id: str, blueprint: BlueprintLike)
     # Convert the BlueprintLike to a full blueprint
     blueprint = blueprint.to_blueprint()
 
+    # We only use this stream object directly, so don't need to make it
+    # default or thread default. Making it the thread-default will also
+    # lead to an unnecessary warning on mac/win.
     blueprint_stream = RecordingStream(
         bindings.new_blueprint(
             application_id=application_id,
+            make_default=False,
+            make_thread_default=False,
+            default_enabled=True,
         )
     )
 


### PR DESCRIPTION
### What
Enabling thread_local for the blueprint was causing a warning on windows/mac, that in turn would cause
our e2e tests to fail.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5638/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5638/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5638/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5638)
- [Docs preview](https://rerun.io/preview/5806a292e7bea8543d44cb161edeea9a72c48b9a/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5806a292e7bea8543d44cb161edeea9a72c48b9a/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)