### PR TITLE
Don't activate all blueprints in a data source when the end is reached

### DIFF
--- a/crates/re_entity_db/src/entity_db.rs
+++ b/crates/re_entity_db/src/entity_db.rs
@@ -525,7 +525,7 @@ impl EntityDb {
 
         let set_store_info_msg = self
             .store_info_msg()
-            .map(|msg| LogMsg::SetStoreInfo(msg.clone()));
+            .map(|msg| Ok(LogMsg::SetStoreInfo(msg.clone())));
 
         let time_filter = time_selection.map(|(timeline, range)| {
             (
@@ -540,10 +540,14 @@ impl EntityDb {
                 .map(|msg| LogMsg::ArrowMsg(self.store_id().clone(), msg))
         });
 
+        // Signal that the store is done loading.
+        // Important for blueprints.
+        let activate_store_msg = LogMsg::ActivateStore(self.store_id().clone());
+
         let messages: Result<Vec<_>, _> = set_store_info_msg
-            .map(re_log_types::DataTableResult::Ok)
             .into_iter()
             .chain(data_messages)
+            .chain(std::iter::once(Ok(activate_store_msg)))
             .collect();
 
         messages

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools as _;
-
 use re_data_source::{DataSource, FileContents};
 use re_entity_db::entity_db::EntityDb;
 use re_log_types::{FileSource, LogMsg, StoreKind};
@@ -917,39 +915,6 @@ impl App {
                         re_log::warn!("Data source {} has left unexpectedly: {err}", msg.source);
                     } else {
                         re_log::debug!("Data source {} has finished", msg.source);
-
-                        // This could be the signal that we finished loading a blueprint.
-                        // In that case, we want to make it the default.
-                        // We wait with activaing blueprints until they are fully loaded,
-                        // so that we don't run heuristics on half-loaded blueprints.
-                        // This is a fallback in case `LogMsg::ActivateStore` isn't sent (for whatever reason).
-
-                        let blueprints = store_hub
-                            .entity_dbs_from_channel_source(&channel_source)
-                            .filter_map(|entity_db| {
-                                if let Some(store_info) = entity_db.store_info() {
-                                    match store_info.store_id.kind {
-                                        StoreKind::Recording => {
-                                            // Recordings become active as soon as we start streaming them.
-                                        }
-                                        StoreKind::Blueprint => {
-                                            return Some(store_info.clone());
-                                        }
-                                    }
-                                }
-                                None
-                            })
-                            .collect_vec();
-
-                        for re_log_types::StoreInfo {
-                            store_id,
-                            application_id,
-                            ..
-                        } in blueprints
-                        {
-                            re_log::debug!("Activating newly loaded blueprint");
-                            store_hub.set_blueprint_for_app_id(store_id, application_id);
-                        }
                     }
                     continue;
                 }

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -291,15 +291,6 @@ impl StoreHub {
         self.store_bundle.contains(id)
     }
 
-    pub fn entity_dbs_from_channel_source<'a>(
-        &'a self,
-        source: &'a re_smart_channel::SmartChannelSource,
-    ) -> impl Iterator<Item = &EntityDb> + 'a {
-        self.store_bundle
-            .entity_dbs()
-            .filter(move |db| db.data_source.as_ref() == Some(source))
-    }
-
     /// Remove any recordings with a network source pointing at this `uri`.
     #[cfg(target_arch = "wasm32")]
     pub fn remove_recording_by_uri(&mut self, uri: &str) {


### PR DESCRIPTION
Instead rely on `LogMsg::ActivateStore`

* Closes https://github.com/rerun-io/rerun/issues/5584

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5648/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5648/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5648/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5648)
- [Docs preview](https://rerun.io/preview/0be33edf82f68ff9f6412da8d1d60233d80b8e57/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0be33edf82f68ff9f6412da8d1d60233d80b8e57/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)