### PR TITLE
Fix layouting issue on welcome screen for narrow window, triggering debug assertion

### DIFF
--- a/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
@@ -192,6 +192,7 @@ fn onboarding_content_ui(ui: &mut Ui, command_sender: &CommandSender, accepts_co
     let column_width = ((ui.available_width() + grid_spacing.x) / column_count as f32
         - grid_spacing.x)
         .floor()
+        .at_least(MIN_COLUMN_WIDTH)
         .at_most(MAX_COLUMN_WIDTH);
 
     ui.horizontal(|ui| {


### PR DESCRIPTION
### What

* Fixes #5649

~This is a speculative fix, didn't have a repro.~ From the callstack we know that a certain `ui.set_max_width(column_width - 8.0);` might have gotten a too small width. Looking at how `column_width` is produced this may very well happen if for some reason there's very little `available_width`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5650/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5650/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5650/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5650)
- [Docs preview](https://rerun.io/preview/4207de64817bf7002b8ff271b8a875ab63f62b23/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4207de64817bf7002b8ff271b8a875ab63f62b23/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)