### PR TITLE
Add blueprint APIs to common index for python docs

### DIFF
--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -65,6 +65,7 @@ def all_archetypes() -> list[str]:
 @dataclass
 class Section:
     title: str
+    sub_title: str | None = None
     func_list: list[str] | None = None
     class_list: list[str] | None = None
     gen_page: bool = True
@@ -106,33 +107,6 @@ SECTION_TABLE: Final[list[Section]] = [
             "set_time_nanos",
             "disable_timeline",
             "reset_time",
-        ],
-    ),
-    ################################################################################
-    # Blueprint APIs
-    Section(
-        title="Blueprint APIs",
-        mod_path="rerun.blueprint",
-        class_list=[
-            "Blueprint",
-            "BlueprintPart",
-            "Container",
-            "Horizontal",
-            "Vertical",
-            "Grid",
-            "Tabs",
-            "SpaceView",
-            "BarChartView",
-            "Spatial2DView",
-            "Spatial3DView",
-            "TensorView",
-            "TextDocumentView",
-            "TextLogView",
-            "TimeSeriesView",
-            "BlueprintPanel",
-            "SelectionPanel",
-            "TimePanel",
-            "Viewport",
         ],
     ),
     ################################################################################
@@ -240,7 +214,7 @@ SECTION_TABLE: Final[list[Section]] = [
         gen_page=False,
     ),
     ################################################################################
-    # Remaining sections of other referenced things
+    # Other referenced things
     Section(
         title="Enums",
         mod_path="rerun",
@@ -257,6 +231,54 @@ SECTION_TABLE: Final[list[Section]] = [
         class_list=["AsComponents", "ComponentBatchLike"],
         default_filters=False,
     ),
+    ################################################################################
+    # Blueprint APIs
+    Section(
+        title="Blueprint",
+        sub_title="APIs",
+        mod_path="rerun.blueprint",
+        class_list=[
+            "Blueprint",
+            "BlueprintPart",
+            "Container",
+            "Horizontal",
+            "Vertical",
+            "Grid",
+            "Tabs",
+            "SpaceView",
+            "BarChartView",
+            "Spatial2DView",
+            "Spatial3DView",
+            "TensorView",
+            "TextDocumentView",
+            "TextLogView",
+            "TimeSeriesView",
+            "BlueprintPanel",
+            "SelectionPanel",
+            "TimePanel",
+            "Viewport",
+        ],
+    ),
+    Section(
+        title="Blueprint",
+        sub_title="Archetypes",
+        mod_path="rerun.blueprint.archetypes",
+        show_tables=False,
+    ),
+    Section(
+        title="Blueprint",
+        sub_title="Components",
+        mod_path="rerun.blueprint.datatypes",
+        show_tables=False,
+    ),
+    Section(
+        title="Blueprint",
+        sub_title="Datatypes",
+        mod_path="rerun.blueprint.components",
+        show_tables=False,
+    ),
+    ################################################################################
+    # Remaining sections
     Section(
         title="Script Helpers",
         func_list=[
@@ -364,9 +386,14 @@ overview of what's possible and how.
     for section in SECTION_TABLE:
         if section.gen_page:
             # Turn the heading into a slug and add it to the nav
-            md_name = make_slug(section.title)
-            md_file = md_name + ".md"
-            nav[section.title] = md_file
+            if section.sub_title:
+                md_name = make_slug("_".join([section.title, section.sub_title]))
+                md_file = md_name + ".md"
+                nav[(section.title, section.sub_title)] = md_file
+            else:
+                md_name = make_slug(section.title)
+                md_file = md_name + ".md"
+                nav[section.title] = md_file
 
             # Write out the contents of this section
             write_path = common_dir.joinpath(md_file)

--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -109,6 +109,33 @@ SECTION_TABLE: Final[list[Section]] = [
         ],
     ),
     ################################################################################
+    # Blueprint APIs
+    Section(
+        title="Blueprint APIs",
+        mod_path="rerun.blueprint",
+        class_list=[
+            "Blueprint",
+            "BlueprintPart",
+            "Container",
+            "Horizontal",
+            "Vertical",
+            "Grid",
+            "Tabs",
+            "SpaceView",
+            "BarChartView",
+            "Spatial2DView",
+            "Spatial3DView",
+            "TensorView",
+            "TextDocumentView",
+            "TextLogView",
+            "TimeSeriesView",
+            "BlueprintPanel",
+            "SelectionPanel",
+            "TimePanel",
+            "Viewport",
+        ],
+    ),
+    ################################################################################
     # These sections don't have tables, but generate pages containing all the archetypes, components, datatypes
     Section(
         title="Archetypes",
@@ -375,6 +402,9 @@ overview of what's possible and how.
                 index_file.write("Class | Description\n")
                 index_file.write("-------- | -----------\n")
                 for class_name in section.class_list:
+                    if section.mod_path != "rerun":
+                        mod_tail = section.mod_path.split(".")[1:]
+                        class_name = ".".join(mod_tail + [class_name])
                     cls = rerun_pkg[class_name]
                     show_class = class_name
                     for maybe_strip in ["archetypes.", "components.", "datatypes."]:

--- a/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "Blueprint",
     "BlueprintLike",
     "BlueprintPanel",
+    "BlueprintPart",
     "components",
     "datatypes",
     "Grid",
@@ -22,6 +23,8 @@ __all__ = [
     "Vertical",
     "Viewport",
     "ViewportLike",
+    "SpaceView",
+    "Container",
 ]
 
 from . import archetypes, components, datatypes
@@ -29,7 +32,10 @@ from .api import (
     Blueprint,
     BlueprintLike,
     BlueprintPanel,
+    BlueprintPart,
+    Container,
     SelectionPanel,
+    SpaceView,
     TimePanel,
     Viewport,
     ViewportLike,

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -30,7 +30,7 @@ class SpaceView:
     - [rerun.blueprint.TextLogView][]
     - [rerun.blueprint.TimeSeriesView][]
 
-    This is an ergonomic helper on top of [rerun.blueprint.archetypes.SpaceViewBlueprint][].
+    These are ergonomic helpers on top of [rerun.blueprint.archetypes.SpaceViewBlueprint][].
     """
 
     def __init__(
@@ -121,7 +121,7 @@ class Container:
     - [rerun.blueprint.Grid][]
     - [rerun.blueprint.Tabs][]
 
-    This is an ergonomic helper on top of [rerun.blueprint.archetypes.ContainerBlueprint][].
+    These are ergonomic helpers on top of [rerun.blueprint.archetypes.ContainerBlueprint][].
     """
 
     def __init__(
@@ -312,7 +312,7 @@ class Panel:
     - [SelectionPanel][rerun.blueprint.SelectionPanel]
     - [TimePanel][rerun.blueprint.TimePanel]
 
-    This is an ergonomic helper on top of [rerun.blueprint.archetypes.PanelBlueprint][].
+    These are ergonomic helpers on top of [rerun.blueprint.archetypes.PanelBlueprint][].
     """
 
     def __init__(self, *, blueprint_path: str, expanded: bool | None = None):

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -21,10 +21,16 @@ class SpaceView:
     Base class for all space view types.
 
     Consider using one of the subclasses instead of this class directly:
-    - [Spatial3D][] for 3D space views
-    - [Spatial2D][] for 2D space views
 
-    This is an ergonomic helper on top of [rerun.blueprint.archetypes.SpaceViewBlueprint][].
+    - [rerun.blueprint.BarChartView][]
+    - [rerun.blueprint.Spatial2DView][]
+    - [rerun.blueprint.Spatial3DView][]
+    - [rerun.blueprint.TensorView][]
+    - [rerun.blueprint.TextDocumentView][]
+    - [rerun.blueprint.TextLogView][]
+    - [rerun.blueprint.TimeSeriesView][]
+
+    This is an ergonomic helper on top of `rerun.blueprint.archetypes.SpaceViewBlueprint`.
     """
 
     def __init__(
@@ -109,12 +115,13 @@ class Container:
     Base class for all container types.
 
     Consider using one of the subclasses instead of this class directly:
-    - [Horizontal][] for horizontal containers
-    - [Vertical][] for vertical containers
-    - [Grid][] for grid containers
-    - [Tabs][] for tab containers
 
-    This is an ergonomic helper on top of [rerun.blueprint.archetypes.ContainerBlueprint][].
+    - [rerun.blueprint.Horizontal][]
+    - [rerun.blueprint.Vertical][]
+    - [rerun.blueprint.Grid][]
+    - [rerun.blueprint.Tabs][]
+
+    This is an ergonomic helper on top of `rerun.blueprint.archetypes.ContainerBlueprint`.
     """
 
     def __init__(
@@ -227,7 +234,7 @@ class Viewport:
     """
     The top-level description of the Viewport.
 
-    This is an ergonomic helper on top of [rerun.blueprint.archetypes.ViewportBlueprint][].
+    This is an ergonomic helper on top of `rerun.blueprint.archetypes.ViewportBlueprint`.
     """
 
     def __init__(
@@ -300,11 +307,12 @@ class Panel:
     Base class for the panel types.
 
     Consider using one of the subclasses instead of this class directly:
-    - [BlueprintPanel][]
-    - [SelectionPanel][]
-    - [TimePanel][]
 
-    This is an ergonomic helper on top of [rerun.blueprint.archetypes.PanelBlueprint][].
+    - [BlueprintPanel][rerun.blueprint.BlueprintPanel]
+    - [SelectionPanel][rerun.blueprint.SelectionPanel]
+    - [TimePanel][rerun.blueprint.TimePanel]
+
+    This is an ergonomic helper on top of `rerun.blueprint.archetypes.PanelBlueprint`.
     """
 
     def __init__(self, *, blueprint_path: str, expanded: bool | None = None):
@@ -412,11 +420,12 @@ class Blueprint:
         """
         Construct a new blueprint from the given parts.
 
-        Each [BlueprintPart][] can be one of the following:
-        - [Viewport][]
-        - [BlueprintPanel][]
-        - [SelectionPanel][]
-        - [TimePanel][]
+        Each [BlueprintPart][rerun.blueprint.BlueprintPart] can be one of the following:
+
+        - [Viewport][rerun.blueprint.Viewport]
+        - [BlueprintPanel][rerun.blueprint.BlueprintPanel]
+        - [SelectionPanel][rerun.blueprint.SelectionPanel]
+        - [TimePanel][rerun.blueprint.TimePanel]
 
         It is an error to provide more than one of any type of part.
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import itertools
 import uuid
-from typing import Iterable, Optional, Union
+from typing import Iterable, Optional, Sequence, Union
 
 import rerun_bindings as bindings
 
@@ -30,7 +30,7 @@ class SpaceView:
     - [rerun.blueprint.TextLogView][]
     - [rerun.blueprint.TimeSeriesView][]
 
-    This is an ergonomic helper on top of `rerun.blueprint.archetypes.SpaceViewBlueprint`.
+    This is an ergonomic helper on top of [rerun.blueprint.archetypes.SpaceViewBlueprint][].
     """
 
     def __init__(
@@ -55,8 +55,8 @@ class SpaceView:
             The `EntityPath` to use as the origin of this space view. All other entities will be transformed
             to be displayed relative to this origin.
         contents
-            The contents of the space view. Most commonly specified as a query expression. The individual
-            sub-expressions must either be newline separate, or provided as a list of strings.
+            The contents of the space view specified as a query expression. This is either a single expression,
+            or a list of multiple expressions. See [rerun.blueprint.archetypes.SpaceViewContents][].
 
         """
         self.id = uuid.uuid4()
@@ -121,7 +121,7 @@ class Container:
     - [rerun.blueprint.Grid][]
     - [rerun.blueprint.Tabs][]
 
-    This is an ergonomic helper on top of `rerun.blueprint.archetypes.ContainerBlueprint`.
+    This is an ergonomic helper on top of [rerun.blueprint.archetypes.ContainerBlueprint][].
     """
 
     def __init__(
@@ -234,7 +234,7 @@ class Viewport:
     """
     The top-level description of the Viewport.
 
-    This is an ergonomic helper on top of `rerun.blueprint.archetypes.ViewportBlueprint`.
+    This is an ergonomic helper on top of [rerun.blueprint.archetypes.ViewportBlueprint][].
     """
 
     def __init__(
@@ -312,7 +312,7 @@ class Panel:
     - [SelectionPanel][rerun.blueprint.SelectionPanel]
     - [TimePanel][rerun.blueprint.TimePanel]
 
-    This is an ergonomic helper on top of `rerun.blueprint.archetypes.PanelBlueprint`.
+    This is an ergonomic helper on top of [rerun.blueprint.archetypes.PanelBlueprint][].
     """
 
     def __init__(self, *, blueprint_path: str, expanded: bool | None = None):

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import itertools
 import uuid
-from typing import Iterable, Optional, Sequence, Union
+from typing import Iterable, Optional, Union
 
 import rerun_bindings as bindings
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/space_views.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/space_views.py
@@ -23,9 +23,8 @@ class BarChartView(SpaceView):
             The `EntityPath` to use as the origin of this view. All other entities will be transformed
             to be displayed relative to this origin.
         contents
-            The contents of the view. Most commonly specified as a query expression. The individual
-            sub-expressions must either be newline separate, or provided as a list of strings.
-            See: [rerun.blueprint.components.QueryExpression][].
+            The contents of the space view specified as a query expression. This is either a single expression,
+            or a list of multiple expressions. See [rerun.blueprint.archetypes.SpaceViewContents][].
         name
             The name of the view.
 
@@ -52,9 +51,8 @@ class Spatial2DView(SpaceView):
             The `EntityPath` to use as the origin of this view. All other entities will be transformed
             to be displayed relative to this origin.
         contents
-            The contents of the view. Most commonly specified as a query expression. The individual
-            sub-expressions must either be newline separate, or provided as a list of strings.
-            See: [rerun.blueprint.components.QueryExpression][].
+            The contents of the space view specified as a query expression. This is either a single expression,
+            or a list of multiple expressions. See [rerun.blueprint.archetypes.SpaceViewContents][].
         name
             The name of the view.
 
@@ -81,9 +79,8 @@ class Spatial3DView(SpaceView):
             The `EntityPath` to use as the origin of this view. All other entities will be transformed
             to be displayed relative to this origin.
         contents
-            The contents of the view. Most commonly specified as a query expression. The individual
-            sub-expressions must either be newline separate, or provided as a list of strings.
-            See: [rerun.blueprint.components.QueryExpression][].
+            The contents of the space view specified as a query expression. This is either a single expression,
+            or a list of multiple expressions. See [rerun.blueprint.archetypes.SpaceViewContents][].
         name
             The name of the view.
 
@@ -110,9 +107,8 @@ class TensorView(SpaceView):
             The `EntityPath` to use as the origin of this view. All other entities will be transformed
             to be displayed relative to this origin.
         contents
-            The contents of the view. Most commonly specified as a query expression. The individual
-            sub-expressions must either be newline separate, or provided as a list of strings.
-            See: [rerun.blueprint.components.QueryExpression][].
+            The contents of the space view specified as a query expression. This is either a single expression,
+            or a list of multiple expressions. See [rerun.blueprint.archetypes.SpaceViewContents][].
         name
             The name of the view.
 
@@ -139,9 +135,8 @@ class TextDocumentView(SpaceView):
             The `EntityPath` to use as the origin of this view. All other entities will be transformed
             to be displayed relative to this origin.
         contents
-            The contents of the view. Most commonly specified as a query expression. The individual
-            sub-expressions must either be newline separate, or provided as a list of strings.
-            See: [rerun.blueprint.components.QueryExpression][].
+            The contents of the space view specified as a query expression. This is either a single expression,
+            or a list of multiple expressions. See [rerun.blueprint.archetypes.SpaceViewContents][].
         name
             The name of the view.
 
@@ -168,9 +163,8 @@ class TextLogView(SpaceView):
             The `EntityPath` to use as the origin of this view. All other entities will be transformed
             to be displayed relative to this origin.
         contents
-            The contents of the view. Most commonly specified as a query expression. The individual
-            sub-expressions must either be newline separate, or provided as a list of strings.
-            See: [rerun.blueprint.components.QueryExpression][].
+            The contents of the space view specified as a query expression. This is either a single expression,
+            or a list of multiple expressions. See [rerun.blueprint.archetypes.SpaceViewContents][].
         name
             The name of the view.
 
@@ -197,9 +191,8 @@ class TimeSeriesView(SpaceView):
             The `EntityPath` to use as the origin of this view. All other entities will be transformed
             to be displayed relative to this origin.
         contents
-            The contents of the view. Most commonly specified as a query expression. The individual
-            sub-expressions must either be newline separate, or provided as a list of strings.
-            See: [rerun.blueprint.components.QueryExpression][].
+            The contents of the space view specified as a query expression. This is either a single expression,
+            or a list of multiple expressions. See [rerun.blueprint.archetypes.SpaceViewContents][].
         name
             The name of the view.
 


### PR DESCRIPTION
### What
These docs could use their own inline examples, etc. but getting them into the python index is a good starting point.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5651/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5651/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5651/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5651)
- [Docs preview](https://rerun.io/preview/ff47637cd1cbb784f739b2d7c391e9840ca22bb7/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ff47637cd1cbb784f739b2d7c391e9840ca22bb7/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)