### PR TITLE
Use container names in some blueprints

### DIFF
--- a/examples/python/arkit_scenes/main.py
+++ b/examples/python/arkit_scenes/main.py
@@ -347,6 +347,7 @@ def main() -> None:
                     origin=primary_camera_entity,
                     contents=["$origin/depth", "/world/annotations/**"],
                 ),
+                name="2D",
             ),
             rrb.TextDocumentView(name="Readme"),
         ),

--- a/examples/python/blueprint_stocks/main.py
+++ b/examples/python/blueprint_stocks/main.py
@@ -74,6 +74,7 @@ def stock_grid(symbols: list[str], dates: list[Any]) -> rrb.ViewportLike:
             rrb.Horizontal(
                 contents=[rrb.TextDocumentView(name=f"{symbol}", origin=f"/stocks/{symbol}/info")]
                 + [rrb.TimeSeriesView(name=f"{day}", origin=f"/stocks/{symbol}/{day}") for day in dates],
+                name=symbol,
             )
             for symbol in symbols
         ]

--- a/examples/python/depth_guided_stable_diffusion/main.py
+++ b/examples/python/depth_guided_stable_diffusion/main.py
@@ -128,6 +128,7 @@ expense of slower inference. This parameter will be modulated by `strength`.
                     rrb.Tabs(
                         rrb.Spatial2DView(name="Image original", origin="image/original"),
                         rrb.TensorView(name="Image preprocessed", origin="input_image/preprocessed"),
+                        name="Image Inputs",
                     ),
                     rrb.Vertical(
                         rrb.TextLogView(name="Prompt", contents=["prompt/text", "prompt/text_negative"]),
@@ -136,7 +137,9 @@ expense of slower inference. This parameter will be modulated by `strength`.
                             rrb.TensorView(name="Unconditional embeddings", origin="prompt/uncond_embeddings"),
                         ),
                         rrb.BarChartView(name="Prompt ids", origin="prompt/text_input"),
+                        name="Prompt Inputs",
                     ),
+                    name="Inputs",
                 ),
                 rrb.Vertical(
                     rrb.Tabs(
@@ -145,11 +148,14 @@ expense of slower inference. This parameter will be modulated by `strength`.
                         rrb.Spatial2DView(name="Depth normalized", origin="depth/normalized"),
                         rrb.TensorView(name="Depth input pre-processed", origin="depth/input_preprocessed"),
                         active_tab="Depth interpolated",
+                        name="Depth",
                     ),
                     rrb.Tabs(
                         rrb.TensorView(name="Encoded input", origin="encoded_input_image"),
                         rrb.TensorView(name="Decoded init latents", origin="decoded_init_latents"),
+                        name="Initialization",
                     ),
+                    name="Depth & Initialization",
                 ),
                 rrb.Vertical(
                     rrb.Spatial2DView(name="Image diffused", origin="image/diffused"),
@@ -158,6 +164,7 @@ expense of slower inference. This parameter will be modulated by `strength`.
                         rrb.TensorView(name="Diffusion latents", origin="diffusion/latents"),
                         # rrb.TensorView(name="Noise Prediction", origin="diffusion/noise_pred"),
                     ),
+                    name="Output & Iteration",
                 ),
             ),
             rrb.SelectionPanel(expanded=False),

--- a/examples/python/depth_guided_stable_diffusion/main.py
+++ b/examples/python/depth_guided_stable_diffusion/main.py
@@ -103,7 +103,7 @@ usually at the expense of lower image quality.
     parser.add_argument(
         "--num-inference-steps",
         type=int,
-        default=10,
+        default=20,
         help="""
 The number of denoising steps. More denoising steps usually lead to a higher quality image at the
 expense of slower inference. This parameter will be modulated by `strength`.

--- a/examples/python/rgbd/main.py
+++ b/examples/python/rgbd/main.py
@@ -171,6 +171,7 @@ def main() -> None:
                 # This enables interactions like clicking on a point in the 3D space to show the corresponding point in the 2D spaces and vice versa.
                 rrb.Spatial2DView(name="Depth & RGB", origin="world/camera/image"),
                 rrb.Spatial2DView(name="RGB", origin="world/camera/image", contents="world/camera/image/rgb"),
+                name="2D",
             ),
             column_shares=[2, 1],
         ),


### PR DESCRIPTION
### What

Wherever it makes sense.
Also (unrelated) bump the number of iterations on depth guided stable diffusion to make the result look better by default. This example runs only on nightly, so it's not affecting PR & main build performance.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5652/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5652/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5652/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5652)
- [Docs preview](https://rerun.io/preview/4fa66859734f386ef617f89c0e800e3dc547a345/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4fa66859734f386ef617f89c0e800e3dc547a345/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)