### PR TITLE
Warn user when a software rasterizer is used

### DIFF
--- a/crates/re_renderer/src/context.rs
+++ b/crates/re_renderer/src/context.rs
@@ -543,7 +543,7 @@ fn log_adapter_info(info: &wgpu::AdapterInfo) {
 }
 
 /// A human-readable summary about an adapter
-fn adapter_info_summary(info: &wgpu::AdapterInfo) -> String {
+pub fn adapter_info_summary(info: &wgpu::AdapterInfo) -> String {
     let wgpu::AdapterInfo {
         name,
         vendor: _, // skip integer id

--- a/crates/re_renderer/src/context.rs
+++ b/crates/re_renderer/src/context.rs
@@ -532,7 +532,7 @@ fn log_adapter_info(info: &wgpu::AdapterInfo) {
     let human_readable_summary = adapter_info_summary(info);
 
     if is_software_rasterizer_with_known_crashes {
-        re_log::warn!("Software rasterizer detected - expect poor performance and crashes. See: https://www.rerun.io/docs/getting-started/troubleshooting#graphics-issues");
+        re_log::warn!("Bad software rasterizer detected - expect poor performance and crashes. See: https://www.rerun.io/docs/getting-started/troubleshooting#graphics-issues");
         re_log::info!("wgpu adapter {human_readable_summary}");
     } else if info.device_type == wgpu::DeviceType::Cpu {
         re_log::warn!("Software rasterizer detected - expect poor performance. See: https://www.rerun.io/docs/getting-started/troubleshooting#graphics-issues");

--- a/crates/re_renderer/src/lib.rs
+++ b/crates/re_renderer/src/lib.rs
@@ -51,7 +51,7 @@ pub use colormap::{
     colormap_inferno_srgb, colormap_magma_srgb, colormap_plasma_srgb, colormap_srgb,
     colormap_turbo_srgb, colormap_viridis_srgb, grayscale_srgb, Colormap,
 };
-pub use context::RenderContext;
+pub use context::{adapter_info_summary, RenderContext};
 pub use debug_label::DebugLabel;
 pub use depth_offset::DepthOffset;
 pub use line_drawable_builder::{LineDrawableBuilder, LineStripBuilder};

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -100,6 +100,28 @@ fn top_bar_ui(
             connection_status_ui(ui, app.msg_receive_set());
         }
 
+        if let Some(wgpu) = frame.wgpu_render_state() {
+            let info = wgpu.adapter.get_info();
+            if info.device_type == wgpu::DeviceType::Cpu {
+                // TODO(#4304): replace with a panel showing recent log messages
+                ui.hyperlink_to(
+                    egui::RichText::new("⚠ Software rasterizer ⚠")
+                        .small()
+                        .color(ui.visuals().warn_fg_color),
+                    "https://www.rerun.io/docs/getting-started/troubleshooting#graphics-issues",
+                )
+                .on_hover_ui(|ui| {
+                    ui.label("Software rasterizer detected - expect poor performance.");
+                    ui.label("Click for torubleshooting.");
+                    ui.add_space(8.0);
+                    ui.label(format!(
+                        "wgpu adapter {}",
+                        re_renderer::adapter_info_summary(&info)
+                    ));
+                });
+            }
+        }
+
         // Warn if in debug build
         if cfg!(debug_assertions) && !app.is_screenshotting() {
             ui.vertical_centered(|ui| {

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -113,7 +113,7 @@ fn top_bar_ui(
                 .on_hover_ui(|ui| {
                     ui.label("Software rasterizer detected - expect poor performance.");
                     ui.label(
-                        "Rerun requires hardware accelerated graphics (GPU) for good performance.",
+                        "Rerun requires hardware accelerated graphics (i.e. a GPU) for good performance.",
                     );
                     ui.label("Click for troubleshooting.");
                     ui.add_space(8.0);

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -112,6 +112,9 @@ fn top_bar_ui(
                 )
                 .on_hover_ui(|ui| {
                     ui.label("Software rasterizer detected - expect poor performance.");
+                    ui.label(
+                        "Rerun requires hardware accelerated graphics (GPU) for good performance.",
+                    );
                     ui.label("Click for troubleshooting.");
                     ui.add_space(8.0);
                     ui.label(format!(

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -112,7 +112,7 @@ fn top_bar_ui(
                 )
                 .on_hover_ui(|ui| {
                     ui.label("Software rasterizer detected - expect poor performance.");
-                    ui.label("Click for torubleshooting.");
+                    ui.label("Click for troubleshooting.");
                     ui.add_space(8.0);
                     ui.label(format!(
                         "wgpu adapter {}",


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5596
![software-rasterizer](https://github.com/rerun-io/rerun/assets/1148717/ccab5b1d-fb40-4c0d-9379-8bf00aa73725)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5655/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5655/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5655/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5655)
- [Docs preview](https://rerun.io/preview/4b8237229e8245e6b38dc915d52fc6d25fb34c95/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4b8237229e8245e6b38dc915d52fc6d25fb34c95/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)