### PR TITLE
Simplify blueprint API by removing Viewport concept

### DIFF
--- a/examples/python/blueprint/main.py
+++ b/examples/python/blueprint/main.py
@@ -6,7 +6,7 @@ import argparse
 
 import numpy as np
 import rerun as rr  # pip install rerun-sdk
-from rerun.blueprint import Blueprint, BlueprintPanel, Grid, SelectionPanel, Spatial2DView, TimePanel, Viewport
+from rerun.blueprint import Blueprint, BlueprintPanel, Grid, SelectionPanel, Spatial2DView, TimePanel
 
 
 def main() -> None:
@@ -26,16 +26,14 @@ def main() -> None:
         # If auto_space_views is True, the blueprint will automatically add one of the heuristic
         # space views, which will include the image and both rectangles.
         blueprint = Blueprint(
-            Viewport(
-                Grid(
-                    Spatial2DView(name="Rect 0", origin="/", contents=["image", "rect/0"]),
-                    Spatial2DView(name="Rect 1", origin="/", contents=["image", "rect/1"]),
-                ),
-                auto_space_views=args.auto_space_views,
+            Grid(
+                Spatial2DView(name="Rect 0", origin="/", contents=["image", "rect/0"]),
+                Spatial2DView(name="Rect 1", origin="/", contents=["image", "rect/1"]),
             ),
             BlueprintPanel(expanded=False),
             SelectionPanel(expanded=False),
             TimePanel(expanded=False),
+            auto_space_views=args.auto_space_views,
         )
 
     rr.init("rerun_example_blueprint", spawn=True, blueprint=blueprint)

--- a/examples/python/blueprint_stocks/main.py
+++ b/examples/python/blueprint_stocks/main.py
@@ -21,17 +21,17 @@ import yfinance as yf
 ################################################################################
 
 
-def auto_blueprint() -> rrb.ViewportLike:
+def auto_blueprint() -> rrb.BlueprintLike:
     """A blueprint enabling auto space views, which matches the application default."""
-    return rrb.Viewport(auto_space_views=True, auto_layout=True)
+    return rrb.Blueprint(auto_space_views=True, auto_layout=True)
 
 
-def one_stock(symbol: str) -> rrb.ViewportLike:
+def one_stock(symbol: str) -> rrb.ContainerLike:
     """Create a blueprint showing a single stock."""
     return rrb.TimeSeriesView(name=f"{symbol}", origin=f"/stocks/{symbol}")
 
 
-def one_stock_with_info(symbol: str) -> rrb.ViewportLike:
+def one_stock_with_info(symbol: str) -> rrb.ContainerLike:
     """Create a blueprint showing a single stock with its info arranged vertically."""
     return rrb.Vertical(
         rrb.TextDocumentView(name=f"{symbol}", origin=f"/stocks/{symbol}/info"),
@@ -40,7 +40,7 @@ def one_stock_with_info(symbol: str) -> rrb.ViewportLike:
     )
 
 
-def compare_two(symbol1: str, symbol2: str, day: Any) -> rrb.ViewportLike:
+def compare_two(symbol1: str, symbol2: str, day: Any) -> rrb.ContainerLike:
     """Create a blueprint comparing 2 stocks for a single day."""
     return rrb.TimeSeriesView(
         name=f"{symbol1} vs {symbol2} ({day})",
@@ -51,7 +51,7 @@ def compare_two(symbol1: str, symbol2: str, day: Any) -> rrb.ViewportLike:
     )
 
 
-def one_stock_no_peaks(symbol: str) -> rrb.ViewportLike:
+def one_stock_no_peaks(symbol: str) -> rrb.ContainerLike:
     """
     Create a blueprint showing a single stock without annotated peaks.
 
@@ -67,7 +67,7 @@ def one_stock_no_peaks(symbol: str) -> rrb.ViewportLike:
     )
 
 
-def stock_grid(symbols: list[str], dates: list[Any]) -> rrb.ViewportLike:
+def stock_grid(symbols: list[str], dates: list[Any]) -> rrb.ContainerLike:
     """Create a grid of stocks and their time series over all days."""
     return rrb.Vertical(
         contents=[
@@ -81,7 +81,7 @@ def stock_grid(symbols: list[str], dates: list[Any]) -> rrb.ViewportLike:
     )
 
 
-def hide_panels(viewport: rrb.ViewportLike) -> rrb.BlueprintLike:
+def hide_panels(viewport: rrb.ContainerLike) -> rrb.BlueprintLike:
     """Wrap a viewport in a blueprint that hides the time and selection panels."""
     return rrb.Blueprint(
         viewport,
@@ -145,25 +145,26 @@ def main() -> None:
     symbols = ["AAPL", "AMZN", "GOOGL", "META", "MSFT"]
     dates = list(filter(lambda x: x.weekday() < 5, [current_date - dt.timedelta(days=i) for i in range(7, 0, -1)]))
 
-    blueprint: rrb.BlueprintLike
-
     if args.blueprint == "auto":
         blueprint = auto_blueprint()
-    elif args.blueprint == "one-stock":
-        blueprint = one_stock("AAPL")
-    elif args.blueprint == "one-stock-with-info":
-        blueprint = one_stock_with_info("AMZN")
-    elif args.blueprint == "one-stock-no-peaks":
-        blueprint = one_stock_no_peaks("GOOGL")
-    elif args.blueprint == "compare-two":
-        blueprint = compare_two("META", "MSFT", dates[-1])
-    elif args.blueprint == "grid":
-        blueprint = stock_grid(symbols, dates)
     else:
-        raise ValueError(f"Unknown blueprint: {args.blueprint}")
+        if args.blueprint == "one-stock":
+            viewport = one_stock("AAPL")
+        elif args.blueprint == "one-stock-with-info":
+            viewport = one_stock_with_info("AMZN")
+        elif args.blueprint == "one-stock-no-peaks":
+            viewport = one_stock_no_peaks("GOOGL")
+        elif args.blueprint == "compare-two":
+            viewport = compare_two("META", "MSFT", dates[-1])
+        elif args.blueprint == "grid":
+            viewport = stock_grid(symbols, dates)
+        else:
+            raise ValueError(f"Unknown blueprint: {args.blueprint}")
 
-    if not args.show_panels:
-        blueprint = hide_panels(blueprint)
+        if not args.show_panels:
+            blueprint = hide_panels(viewport)
+        else:
+            blueprint = viewport
 
     rr.init("rerun_example_blueprint_stocks", spawn=True, blueprint=blueprint)
 

--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -241,6 +241,7 @@ SECTION_TABLE: Final[list[Section]] = [
             "Blueprint",
             "BlueprintPart",
             "Container",
+            "ContainerLike",
             "Horizontal",
             "Vertical",
             "Grid",

--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -256,7 +256,6 @@ SECTION_TABLE: Final[list[Section]] = [
             "BlueprintPanel",
             "SelectionPanel",
             "TimePanel",
-            "Viewport",
         ],
     ),
     Section(

--- a/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 __all__ = [
-    "archetypes",
     "BarChartView",
     "Blueprint",
     "BlueprintLike",
     "BlueprintPanel",
     "BlueprintPart",
-    "components",
-    "datatypes",
+    "Container",
+    "ContainerLike",
     "Grid",
     "Horizontal",
     "SelectionPanel",
+    "SpaceView",
     "Spatial2DView",
     "Spatial3DView",
     "Tabs",
@@ -21,10 +21,9 @@ __all__ = [
     "TimePanel",
     "TimeSeriesView",
     "Vertical",
-    "Viewport",
-    "ViewportLike",
-    "SpaceView",
-    "Container",
+    "archetypes",
+    "components",
+    "datatypes",
 ]
 
 from . import archetypes, components, datatypes
@@ -34,11 +33,10 @@ from .api import (
     BlueprintPanel,
     BlueprintPart,
     Container,
+    ContainerLike,
     SelectionPanel,
     SpaceView,
     TimePanel,
-    Viewport,
-    ViewportLike,
 )
 from .containers import Grid, Horizontal, Tabs, Vertical
 from .space_views import (

--- a/tests/python/blueprint/main.py
+++ b/tests/python/blueprint/main.py
@@ -11,31 +11,28 @@ from rerun.blueprint import (
     Tabs,
     TimePanel,
     Vertical,
-    Viewport,
 )
 
 if __name__ == "__main__":
     blueprint = Blueprint(
-        Viewport(
-            Vertical(
-                Spatial3DView(origin="/test1"),
-                Horizontal(
-                    Tabs(
-                        Spatial3DView(origin="/test1"),
-                        Spatial2DView(origin="/test2"),
-                    ),
-                    Grid(
-                        Spatial3DView(origin="/test1"),
-                        Spatial2DView(origin="/test2"),
-                        Spatial3DView(origin="/test1"),
-                        Spatial2DView(origin="/test2"),
-                        grid_columns=3,
-                        column_shares=[1, 1, 1],
-                    ),
-                    column_shares=[1, 2],
+        Vertical(
+            Spatial3DView(origin="/test1"),
+            Horizontal(
+                Tabs(
+                    Spatial3DView(origin="/test1"),
+                    Spatial2DView(origin="/test2"),
                 ),
-                row_shares=[2, 1],
-            )
+                Grid(
+                    Spatial3DView(origin="/test1"),
+                    Spatial2DView(origin="/test2"),
+                    Spatial3DView(origin="/test1"),
+                    Spatial2DView(origin="/test2"),
+                    grid_columns=3,
+                    column_shares=[1, 1, 1],
+                ),
+                column_shares=[1, 2],
+            ),
+            row_shares=[2, 1],
         ),
         TimePanel(expanded=False),
     )

--- a/tests/python/release_checklist/check_context_menu_add_entity_to_new_space_view.py
+++ b/tests/python/release_checklist/check_context_menu_add_entity_to_new_space_view.py
@@ -30,18 +30,16 @@ def log_readme() -> None:
 
 
 def blueprint() -> rrb.BlueprintLike:
-    return rrb.Viewport(
-        rrb.Horizontal(
-            rrb.TextDocumentView(origin="readme"),
-            rrb.Vertical(
-                rrb.Spatial3DView(origin="/boxes3d"),
-                rrb.Spatial2DView(origin="/boxes2d"),
-                rrb.TextLogView(origin="/text_logs"),
-                rrb.BarChartView(origin="/bars"),
-                rrb.TensorView(origin="/tensor"),
-            ),
-            column_shares=[2, 1],
-        )
+    return rrb.Horizontal(
+        rrb.TextDocumentView(origin="readme"),
+        rrb.Vertical(
+            rrb.Spatial3DView(origin="/boxes3d"),
+            rrb.Spatial2DView(origin="/boxes2d"),
+            rrb.TextLogView(origin="/text_logs"),
+            rrb.BarChartView(origin="/bars"),
+            rrb.TensorView(origin="/tensor"),
+        ),
+        column_shares=[2, 1],
     )
 
 

--- a/tests/python/release_checklist/check_context_menu_collapse_expand_all.py
+++ b/tests/python/release_checklist/check_context_menu_collapse_expand_all.py
@@ -31,18 +31,16 @@ def log_readme() -> None:
 
 
 def blueprint() -> rrb.BlueprintLike:
-    return rrb.Viewport(
-        rrb.Horizontal(
-            rrb.TextDocumentView(origin="readme"),
-            rrb.Vertical(
-                rrb.Horizontal(
-                    rrb.Vertical(
-                        rrb.Spatial3DView(origin="/"),
-                    )
+    return rrb.Horizontal(
+        rrb.TextDocumentView(origin="readme"),
+        rrb.Vertical(
+            rrb.Horizontal(
+                rrb.Vertical(
+                    rrb.Spatial3DView(origin="/"),
                 )
-            ),
-            column_shares=[2, 1],
-        )
+            )
+        ),
+        column_shares=[2, 1],
     )
 
 

--- a/tests/python/release_checklist/check_context_menu_invalid_sub_container.py
+++ b/tests/python/release_checklist/check_context_menu_invalid_sub_container.py
@@ -23,20 +23,18 @@ def log_readme() -> None:
 
 
 def blueprint() -> rrb.BlueprintLike:
-    return rrb.Viewport(
-        rrb.Horizontal(
-            rrb.TextDocumentView(origin="readme"),
-            rrb.Grid(
-                rrb.Vertical(
-                    rrb.Spatial3DView(origin="/"),
-                ),
-                rrb.Horizontal(
-                    rrb.Spatial2DView(origin="/"),
-                ),
-                grid_columns=1,
+    return rrb.Horizontal(
+        rrb.TextDocumentView(origin="readme"),
+        rrb.Grid(
+            rrb.Vertical(
+                rrb.Spatial3DView(origin="/"),
             ),
-            column_shares=[2, 1],
-        )
+            rrb.Horizontal(
+                rrb.Spatial2DView(origin="/"),
+            ),
+            grid_columns=1,
+        ),
+        column_shares=[2, 1],
     )
 
 

--- a/tests/python/release_checklist/check_context_menu_multi_selection.py
+++ b/tests/python/release_checklist/check_context_menu_multi_selection.py
@@ -65,15 +65,13 @@ def log_readme() -> None:
 
 
 def blueprint() -> rrb.BlueprintLike:
-    return rrb.Viewport(
-        rrb.Horizontal(
-            rrb.TextDocumentView(origin="readme"),
-            rrb.Vertical(
-                rrb.Spatial3DView(origin="/"),
-                rrb.Spatial2DView(origin="/"),
-            ),
-            column_shares=[2, 1],
-        )
+    return rrb.Horizontal(
+        rrb.TextDocumentView(origin="readme"),
+        rrb.Vertical(
+            rrb.Spatial3DView(origin="/"),
+            rrb.Spatial2DView(origin="/"),
+        ),
+        column_shares=[2, 1],
     )
 
 

--- a/tests/python/release_checklist/check_context_menu_single_selection.py
+++ b/tests/python/release_checklist/check_context_menu_single_selection.py
@@ -86,15 +86,13 @@ def log_readme() -> None:
 
 
 def blueprint() -> rrb.BlueprintLike:
-    return rrb.Viewport(
-        rrb.Horizontal(
-            rrb.TextDocumentView(origin="readme"),
-            rrb.Vertical(
-                rrb.Spatial3DView(origin="/"),
-                rrb.Spatial2DView(origin="/"),
-            ),
-            column_shares=[2, 1],
-        )
+    return rrb.Horizontal(
+        rrb.TextDocumentView(origin="readme"),
+        rrb.Vertical(
+            rrb.Spatial3DView(origin="/"),
+            rrb.Spatial2DView(origin="/"),
+        ),
+        column_shares=[2, 1],
     )
 
 

--- a/tests/python/release_checklist/check_context_menu_single_selection_blueprint_tree.py
+++ b/tests/python/release_checklist/check_context_menu_single_selection_blueprint_tree.py
@@ -69,11 +69,9 @@ def log_readme() -> None:
 
 
 def blueprint() -> rrb.BlueprintLike:
-    return rrb.Viewport(
-        rrb.Horizontal(
-            rrb.TextDocumentView(origin="readme"),
-            rrb.Vertical(rrb.Spatial3DView(origin="/")),
-        )
+    return rrb.Horizontal(
+        rrb.TextDocumentView(origin="readme"),
+        rrb.Vertical(rrb.Spatial3DView(origin="/")),
     )
 
 

--- a/tests/python/release_checklist/check_context_menu_suggested_origin.py
+++ b/tests/python/release_checklist/check_context_menu_suggested_origin.py
@@ -45,12 +45,10 @@ def log_readme() -> None:
 
 
 def blueprint() -> rrb.BlueprintLike:
-    return rrb.Viewport(
-        rrb.Horizontal(
-            rrb.TextDocumentView(origin="readme"),
-            rrb.Spatial3DView(origin="/", contents="", name="root entity"),
-            column_shares=[2, 1],
-        )
+    return rrb.Horizontal(
+        rrb.TextDocumentView(origin="readme"),
+        rrb.Spatial3DView(origin="/", contents="", name="root entity"),
+        column_shares=[2, 1],
     )
 
 

--- a/tests/python/release_checklist/check_focus.py
+++ b/tests/python/release_checklist/check_focus.py
@@ -22,12 +22,10 @@ def log_readme() -> None:
 
 
 def blueprint() -> rrb.BlueprintLike:
-    return rrb.Viewport(
-        rrb.Horizontal(
-            rrb.Tabs(*[rrb.TextDocumentView(origin="readme") for _ in range(100)]),
-            rrb.Vertical(rrb.Spatial3DView(origin="/", name="SV1"), rrb.Spatial3DView(origin="/", name="SV2")),
-            column_shares=[1, 2],
-        )
+    return rrb.Horizontal(
+        rrb.Tabs(*[rrb.TextDocumentView(origin="readme") for _ in range(100)]),
+        rrb.Vertical(rrb.Spatial3DView(origin="/", name="SV1"), rrb.Spatial3DView(origin="/", name="SV2")),
+        column_shares=[1, 2],
     )
 
 


### PR DESCRIPTION
### What
In writing the documentation I realized the distinction between the `rrb.Blueprint` object and the `rrb.Viewport` object was not meaningful enough to warrant its own concept for the user.

Practically, the only time a user would ever use `rrb.Viewport` was to set `auto_layout`, `auto_space_views`, (and maybe maximized if we expose an API for that). Most of the other time they use a `ContainerLike` anyways. This makes introducing the extra `Viewport` indirection just feel like cognitive overhead.

This moves the viewport properties to `rrb.Blueprint` object directly, and makes the viewport just be a single optional `ContainerLike` on the blueprint.

Before:
```
ContainerLike: Container | SpaceView

Viewport:
  root_container: ContainerLike
  auto_layout: bool
  auto_space_views: bool

ViewportLike: Viewport | ContainerLIke


Blueprint:
  viewport: ViewportLike
  blueprint_panel: BlueprintPanel
  selection_panel: SelectionPanel
  time_panel: TimePanel
```

After
```
ContainerLike: Container | SpaceView

Blueprint:
  viewport: ContainerLike
  blueprint_panel: BlueprintPanel
  selection_panel: SelectionPanel
  time_panel: TimePanel
  auto_layout: bool
  auto_space_views: bool
```

Note: this does not change the archetype or viewer side of the code -- only the exposed APIs.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5656/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5656/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5656/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5656)
- [Docs preview](https://rerun.io/preview/711bafa6af2902189d2458127e25468b1d8a03eb/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/711bafa6af2902189d2458127e25468b1d8a03eb/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)