### PR TITLE
Improve logging around blueprint saving during shutdown

### DIFF
--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -974,8 +974,10 @@ impl App {
                             store_hub.set_active_recording_id(store_id.clone());
                         }
                         StoreKind::Blueprint => {
-                            re_log::debug!("Activating newly loaded blueprint");
                             if let Some(info) = entity_db.store_info() {
+                                re_log::debug!(
+                                    "Activating blueprint that was loaded from {channel_source}"
+                                );
                                 let app_id = info.application_id.clone();
                                 store_hub.set_blueprint_for_app_id(store_id.clone(), app_id);
                             } else {

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1179,20 +1179,26 @@ impl eframe::App for App {
     }
 
     fn save(&mut self, storage: &mut dyn eframe::Storage) {
-        if self.startup_options.persist_state {
-            // Save the app state
-            eframe::set_value(storage, eframe::APP_KEY, &self.state);
+        if !self.startup_options.persist_state {
+            return;
+        }
 
-            // Save the blueprints
-            // TODO(#2579): implement web-storage for blueprints as well
-            if let Some(hub) = &mut self.store_hub {
-                match hub.gc_and_persist_app_blueprints(&self.state.app_options) {
-                    Ok(f) => f,
-                    Err(err) => {
-                        re_log::error!("Saving blueprints failed: {err}");
-                    }
-                };
-            }
+        re_tracing::profile_function!();
+
+        // Save the app state
+        eframe::set_value(storage, eframe::APP_KEY, &self.state);
+
+        // Save the blueprints
+        // TODO(#2579): implement web-storage for blueprints as well
+        if let Some(hub) = &mut self.store_hub {
+            match hub.gc_and_persist_app_blueprints(&self.state.app_options) {
+                Ok(f) => f,
+                Err(err) => {
+                    re_log::error!("Saving blueprints failed: {err}");
+                }
+            };
+        } else {
+            re_log::error!("Could not save blueprints: the store hub is not available");
         }
     }
 


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/5629

Ignore whitespace when reading the diff

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5664/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5664/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5664/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5664)
- [Docs preview](https://rerun.io/preview/3661ee3766211d083f381da0ad1d912c1382d5ef/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/3661ee3766211d083f381da0ad1d912c1382d5ef/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)