### PR TITLE
Fix crashing when querying app url from python without webviewer & build info

### DIFF
--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -930,7 +930,7 @@ fn version() -> String {
 /// Get a url to an instance of the web-viewer
 ///
 /// This may point to app.rerun.io or localhost depending on
-/// whether `start_web_viewer_server` was called.
+/// whether [`start_web_viewer_server`] was called.
 #[pyfunction]
 fn get_app_url() -> String {
     #[cfg(feature = "web_viewer")]

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -930,7 +930,7 @@ fn version() -> String {
 /// Get a url to an instance of the web-viewer
 ///
 /// This may point to app.rerun.io or localhost depending on
-/// whether `host_assets` was called.
+/// whether `start_web_viewer_server` was called.
 #[pyfunction]
 fn get_app_url() -> String {
     #[cfg(feature = "web_viewer")]
@@ -939,8 +939,14 @@ fn get_app_url() -> String {
     }
 
     let build_info = re_build_info::build_info!();
-    let short_git_hash = &build_info.git_hash[..7];
-    format!("https://app.rerun.io/commit/{short_git_hash}")
+    if let Some(short_git_hash) = build_info.git_hash.get(..7) {
+        format!("https://app.rerun.io/commit/{short_git_hash}")
+    } else {
+        re_log::warn_once!(
+            "No valid git hash found in build info. Defaulting to app.rerun.io for app url."
+        );
+        "https://app.rerun.io".to_owned()
+    }
 }
 
 // TODO(jleibs) expose this as a python type

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -930,7 +930,7 @@ fn version() -> String {
 /// Get a url to an instance of the web-viewer
 ///
 /// This may point to app.rerun.io or localhost depending on
-/// whether [`start_web_viewer_server`] was called.
+/// whether [`start_web_viewer_server()`] was called.
 #[pyfunction]
 fn get_app_url() -> String {
     #[cfg(feature = "web_viewer")]


### PR DESCRIPTION
### What

Excluded from changelog since this can't happen in the releases we ship. Bit of a nieche case you'll hit when running a python notebook with a local rerun build that is lacking the webviewer.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5667/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5667/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5667/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5667)
- [Docs preview](https://rerun.io/preview/f5e2106e27d5c62d59c5cba403cd16743b02f20b/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f5e2106e27d5c62d59c5cba403cd16743b02f20b/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)