### PR TITLE
Fix broken 2D Space View heuristics in Python Notebooks

### DIFF
--- a/crates/re_space_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/re_space_view_spatial/src/max_image_dimension_subscriber.rs
@@ -32,7 +32,7 @@ impl MaxImageDimensions {
 }
 
 #[derive(Default)]
-struct MaxImageDimensionSubscriber {
+pub struct MaxImageDimensionSubscriber {
     max_dimensions: HashMap<StoreId, MaxImageDimensions>,
 }
 

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -63,8 +63,9 @@ impl SpaceViewClass for SpatialSpaceView2D {
         &self,
         system_registry: &mut re_viewer_context::SpaceViewSystemRegistrator<'_>,
     ) -> Result<(), SpaceViewClassRegistryError> {
-        // Ensure spatial topology is registered.
+        // Ensure spatial topology & max image dimension is registered.
         crate::spatial_topology::SpatialTopologyStoreSubscriber::subscription_handle();
+        crate::max_image_dimension_subscriber::MaxImageDimensionSubscriber::subscription_handle();
 
         register_spatial_contexts(system_registry)?;
         register_2d_spatial_visualizers(system_registry)?;
@@ -410,7 +411,7 @@ fn recommended_space_views_with_image_splits(
             }
         }
     } else {
-        // Otherwise we can use the space as it is
+        // Otherwise use
         recommended.push(RecommendedSpaceView::new_subtree(recommended_root.clone()));
     }
 }

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -411,7 +411,7 @@ fn recommended_space_views_with_image_splits(
             }
         }
     } else {
-        // Otherwise use
+        // Otherwise we can use the space as it is.
         recommended.push(RecommendedSpaceView::new_subtree(recommended_root.clone()));
     }
 }

--- a/crates/re_space_view_spatial/src/spatial_topology.rs
+++ b/crates/re_space_view_spatial/src/spatial_topology.rs
@@ -44,6 +44,7 @@ bitflags::bitflags! {
 /// Within the tree of all subspaces, every entity is contained in exactly one subspace.
 /// The subtree at (and including) the `origin` minus the
 /// subtrees of all child spaces are considered to be contained in a subspace.
+#[derive(Debug)]
 pub struct SubSpace {
     /// The transform root of this subspace.
     ///
@@ -166,7 +167,7 @@ impl StoreSubscriber for SpatialTopologyStoreSubscriber {
     }
 }
 
-/// Spatial toopological information about a store.
+/// Spatial topological information about a store.
 ///
 /// Describes how 2D & 3D spaces are connected/disconnected.
 ///

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -954,7 +954,7 @@ impl App {
                             store_hub.set_active_recording_id(store_id.clone());
                         }
                         StoreKind::Blueprint => {
-                            // We wait with activaing blueprints until they are fully loaded,
+                            // We wait with activating blueprints until they are fully loaded,
                             // so that we don't run heuristics on half-loaded blueprints.
                             // TODO(#5297): heed special "end-of-blueprint" message to activate blueprint.
                             // Otherwise on a mixed connection (SDK sending both blueprint and recording)

--- a/pixi.toml
+++ b/pixi.toml
@@ -46,11 +46,15 @@ rerun-release = "cargo run --package rerun-cli --no-default-features --features 
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-web = """
-     rustup target add wasm32-unknown-unknown
-  && cargo run -p re_build_web_viewer -- --debug
-  && cargo run --package rerun-cli --no-default-features --features web_viewer -- --web-viewer
-"""
+rerun-web = { cmd = "cargo run --package rerun-cli --no-default-features --features web_viewer -- --web-viewer", depends_on = [
+  "rerun-build-web",
+] }
+
+# Compile the web-viewer wasm, does not include the cli.
+#
+# This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
+# (this looks heavy but takes typically below 0.1s!)
+rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run -p re_build_web_viewer -- --debug"
 
 # Compile and run the web-viewer in release mode via rerun-cli.
 #
@@ -58,11 +62,16 @@ rerun-web = """
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-release-web = """
-     rustup target add wasm32-unknown-unknown
-  && cargo run -p re_build_web_viewer -- --release
-  && cargo run --package rerun-cli --no-default-features --features web_viewer --release -- --web-viewer
-"""
+rerun-web-release = { cmd = "cargo run --package rerun-cli --no-default-features --features web_viewer --release -- --web-viewer", depends_on = [
+  "rerun-build-web-release",
+] }
+
+# Compile the web-viewer wasm in release mode, doe not include the cli.
+#
+# This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
+# (this looks heavy but takes typically below 0.1s!)
+rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run -p re_build_web_viewer -- --release"
+
 
 build-examples = "cargo run -q --locked -p re_build_examples --"
 


### PR DESCRIPTION
### What

* Fixes #5654

could in theory affect also non-notebooks, but practically in only manifested there.
Fixes a few typos I encountered on the way and added a new pixi command for building the rerun webviewer wasm.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5674/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5674/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5674/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5674)
- [Docs preview](https://rerun.io/preview/618e0091e723020b96d06445d36c51c14a9067e3/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/618e0091e723020b96d06445d36c51c14a9067e3/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)