### PR TITLE
Docs: improve discoverability of image compression

### DIFF
--- a/crates/re_types/definitions/rerun/archetypes/image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/image.fbs
@@ -16,10 +16,16 @@ namespace rerun.archetypes;
 /// Leading and trailing unit-dimensions are ignored, so that
 /// `1x640x480x3x1` is treated as a `640x480x3` RGB image.
 ///
+/// Rerun also supports compressed image encoded as JPEG, N12, and YUY2.
+/// Using these formats can save a lot of bandwidth and memory.
+/// \python To compress an image, use [`rerun.Image.compress`][].
+/// \python To pass in an already encoded image, use  [`rerun.ImageEncoded`][].
+/// \rust See [`crate::components::TensorData`] for more.
+/// \cpp See [`rerun::datatypes::TensorBuffer`] for more.
+///
 /// \cpp Since the underlying `rerun::datatypes::TensorData` uses `rerun::Collection` internally,
 /// \cpp data can be passed in without a copy from raw pointers or by reference from `std::vector`/`std::array`/c-arrays.
 /// \cpp If needed, this "borrow-behavior" can be extended by defining your own `rerun::CollectionAdapter`.
-/// \python For an easy way to pass in image formats or encoded images, see [`rerun.ImageEncoded`][].
 ///
 /// \example image_simple image="https://static.rerun.io/image_simple/06ba7f8582acc1ffb42a7fd0006fad7816f3e4e4/1200w.png"
 table Image (

--- a/crates/re_types/definitions/rerun/archetypes/image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/image.fbs
@@ -18,9 +18,9 @@ namespace rerun.archetypes;
 ///
 /// Rerun also supports compressed image encoded as JPEG, N12, and YUY2.
 /// Using these formats can save a lot of bandwidth and memory.
-/// \python To compress an image, use [`rerun.Image.compress`][].
-/// \python To pass in an already encoded image, use  [`rerun.ImageEncoded`][].
-/// \rust See [`crate::components::TensorData`] for more.
+/// \py To compress an image, use [`rerun.Image.compress`][].
+/// \py To pass in an already encoded image, use  [`rerun.ImageEncoded`][].
+/// \rs See [`crate::components::TensorData`] for more.
 /// \cpp See [`rerun::datatypes::TensorBuffer`] for more.
 ///
 /// \cpp Since the underlying `rerun::datatypes::TensorData` uses `rerun::Collection` internally,

--- a/crates/re_types/definitions/rerun/archetypes/points2d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/points2d.fbs
@@ -28,8 +28,8 @@ table Points2D (
 
   /// Optional colors for the points.
   ///
-  /// \python The colors are interpreted as RGB or RGBA in sRGB gamma-space,
-  /// \python As either 0-1 floats or 0-255 integers, with separate alpha.
+  /// \py The colors are interpreted as RGB or RGBA in sRGB gamma-space,
+  /// \py As either 0-1 floats or 0-255 integers, with separate alpha.
   colors: [rerun.components.Color] ("attr.rerun.component_recommended", nullable, order: 2100);
 
   // --- Optional ---

--- a/crates/re_types/definitions/rerun/archetypes/points3d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/points3d.fbs
@@ -26,8 +26,8 @@ table Points3D (
 
   /// Optional colors for the points.
   ///
-  /// \python The colors are interpreted as RGB or RGBA in sRGB gamma-space,
-  /// \python As either 0-1 floats or 0-255 integers, with separate alpha.
+  /// \py The colors are interpreted as RGB or RGBA in sRGB gamma-space,
+  /// \py As either 0-1 floats or 0-255 integers, with separate alpha.
   colors: [rerun.components.Color] ("attr.rerun.component_recommended", nullable, order: 2100);
 
   // --- Optional ---

--- a/crates/re_types/definitions/rerun/datatypes/tensor_buffer.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/tensor_buffer.fbs
@@ -110,7 +110,7 @@ union TensorBuffer (
   /// First comes entire image in Y, followed by interleaved lines ordered as U0, V0, U1, V1, etc.
   NV12: NV12Buffer (transparent),
 
-  /// YUY2, also known as YUYV is a YUV 4:2:2 chrome downsampled format with 8 bits per channel.
+  /// YUY2, also known as YUYV is a YUV 4:2:2 chroma downsampled format with 8 bits per channel.
   ///
   /// The order of the channels is Y0, U0, Y1, V0.
   YUY2: YUY2Buffer (transparent),

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -33,7 +33,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// Rerun also supports compressed image encoded as JPEG, N12, and YUY2.
 /// Using these formats can save a lot of bandwidth and memory.
-///
 /// See [`crate::components::TensorData`] for more.
 ///
 /// ## Example

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -31,6 +31,11 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// Leading and trailing unit-dimensions are ignored, so that
 /// `1x640x480x3x1` is treated as a `640x480x3` RGB image.
 ///
+/// Rerun also supports compressed image encoded as JPEG, N12, and YUY2.
+/// Using these formats can save a lot of bandwidth and memory.
+///
+/// See [`crate::components::TensorData`] for more.
+///
 /// ## Example
 ///
 /// ### `image_simple`:

--- a/crates/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/re_types/src/datatypes/tensor_buffer.rs
@@ -67,7 +67,7 @@ pub enum TensorBuffer {
     /// First comes entire image in Y, followed by interleaved lines ordered as U0, V0, U1, V1, etc.
     Nv12(::re_types_core::ArrowBuffer<u8>),
 
-    /// YUY2, also known as YUYV is a YUV 4:2:2 chrome downsampled format with 8 bits per channel.
+    /// YUY2, also known as YUYV is a YUV 4:2:2 chroma downsampled format with 8 bits per channel.
     ///
     /// The order of the channels is Y0, U0, Y1, V0.
     Yuy2(::re_types_core::ArrowBuffer<u8>),

--- a/crates/re_types_builder/src/codegen/common.rs
+++ b/crates/re_types_builder/src/codegen/common.rs
@@ -12,35 +12,6 @@ fn is_blank<T: AsRef<str>>(line: T) -> bool {
     line.as_ref().chars().all(char::is_whitespace)
 }
 
-/// Retrieves the global and tagged documentation from a [`Docs`] object.
-pub fn get_documentation(docs: &Docs, tags: &[&str]) -> Vec<String> {
-    let mut lines = docs.doc.clone();
-
-    for tag in tags {
-        lines.extend(
-            docs.tagged_docs
-                .get(*tag)
-                .unwrap_or(&Vec::new())
-                .iter()
-                .cloned(),
-        );
-    }
-
-    // NOTE: remove duplicated blank lines.
-    lines.dedup();
-
-    // NOTE: remove trailing blank lines.
-    while let Some(line) = lines.last() {
-        if line.is_empty() {
-            lines.pop();
-        } else {
-            break;
-        }
-    }
-
-    lines
-}
-
 #[derive(Clone)]
 pub struct ExampleInfo<'a> {
     /// The snake_case name of the example.

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -2265,7 +2265,7 @@ fn quote_field_docs(field: &ObjectField) -> TokenStream {
 }
 
 fn lines_from_docs(docs: &Docs) -> Vec<String> {
-    let mut lines = docs.doc_lines_for_untagged_and(&["cpp", "c++"]);
+    let mut lines = docs.doc_lines_for_untagged_and("cpp");
 
     let required = true;
     let examples = collect_snippets_for_api_docs(docs, "cpp", required).unwrap_or_default();

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -2265,7 +2265,7 @@ fn quote_field_docs(field: &ObjectField) -> TokenStream {
 }
 
 fn lines_from_docs(docs: &Docs) -> Vec<String> {
-    let mut lines = docs.doc_lines_for(&["cpp", "c++"]);
+    let mut lines = docs.doc_lines_for_untagged_and(&["cpp", "c++"]);
 
     let required = true;
     let examples = collect_snippets_for_api_docs(docs, "cpp", required).unwrap_or_default();

--- a/crates/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/re_types_builder/src/codegen/cpp/mod.rs
@@ -2265,7 +2265,7 @@ fn quote_field_docs(field: &ObjectField) -> TokenStream {
 }
 
 fn lines_from_docs(docs: &Docs) -> Vec<String> {
-    let mut lines = crate::codegen::get_documentation(docs, &["cpp", "c++"]);
+    let mut lines = docs.doc_lines_for(&["cpp", "c++"]);
 
     let required = true;
     let examples = collect_snippets_for_api_docs(docs, "cpp", required).unwrap_or_default();

--- a/crates/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/re_types_builder/src/codegen/docs/mod.rs
@@ -141,7 +141,7 @@ fn index_page(kind: ObjectKind, order: u64, prelude: &str, objects: &[&Object]) 
 fn object_page(reporter: &Reporter, object: &Object, object_map: &ObjectMap) -> String {
     let is_unreleased = object.is_attr_set(crate::ATTR_DOCS_UNRELEASED);
 
-    let top_level_docs = object.docs.doc_lines_for_untagged_and(&[]);
+    let top_level_docs = object.docs.untagged();
 
     if top_level_docs.is_empty() {
         reporter.error(&object.virtpath, &object.fqname, "Undocumented object");

--- a/crates/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/re_types_builder/src/codegen/docs/mod.rs
@@ -9,8 +9,6 @@ use crate::{
 
 type ObjectMap = std::collections::BTreeMap<String, Object>;
 
-use super::common::get_documentation;
-
 macro_rules! putln {
     ($o:ident) => ( writeln!($o).ok() );
     ($o:ident, $($tt:tt)*) => ( writeln!($o, $($tt)*).ok() );
@@ -143,7 +141,7 @@ fn index_page(kind: ObjectKind, order: u64, prelude: &str, objects: &[&Object]) 
 fn object_page(reporter: &Reporter, object: &Object, object_map: &ObjectMap) -> String {
     let is_unreleased = object.is_attr_set(crate::ATTR_DOCS_UNRELEASED);
 
-    let top_level_docs = get_documentation(&object.docs, &[]);
+    let top_level_docs = object.docs.doc_lines_for(&[]);
 
     if top_level_docs.is_empty() {
         reporter.error(&object.virtpath, &object.fqname, "Undocumented object");

--- a/crates/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/re_types_builder/src/codegen/docs/mod.rs
@@ -141,19 +141,16 @@ fn index_page(kind: ObjectKind, order: u64, prelude: &str, objects: &[&Object]) 
 fn object_page(reporter: &Reporter, object: &Object, object_map: &ObjectMap) -> String {
     let is_unreleased = object.is_attr_set(crate::ATTR_DOCS_UNRELEASED);
 
-    let top_level_docs = object.docs.doc_lines_for(&[]);
+    let top_level_docs = object.docs.doc_lines_for_untagged_and(&[]);
 
     if top_level_docs.is_empty() {
         reporter.error(&object.virtpath, &object.fqname, "Undocumented object");
     }
 
-    let examples = object
-        .docs
-        .tagged_docs
-        .get("example")
+    let examples = &object.docs.doc_lines_tagged("example");
+    let examples = examples
         .iter()
-        .flat_map(|v| v.iter())
-        .map(ExampleInfo::parse)
+        .map(|line| ExampleInfo::parse(line))
         .collect::<Vec<_>>();
 
     let mut page = String::new();

--- a/crates/re_types_builder/src/codegen/mod.rs
+++ b/crates/re_types_builder/src/codegen/mod.rs
@@ -32,7 +32,7 @@ pub(crate) use macros::autogen_warning; // Hack for declaring macros as `pub(cra
 // ---
 
 pub(crate) mod common;
-use self::common::{get_documentation, StringExt};
+use self::common::StringExt;
 
 mod cpp;
 mod docs;

--- a/crates/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/re_types_builder/src/codegen/python/mod.rs
@@ -1950,7 +1950,8 @@ fn quote_init_method(
         obj.fields
             .iter()
             .filter_map(|field| {
-                if field.docs.doc.is_empty() {
+                let doc_content = crate::codegen::get_documentation(&field.docs, &["py", "python"]);
+                if doc_content.is_empty() {
                     if !field.is_testing() && obj.fields.len() > 1 {
                         reporter.error(
                             &field.virtpath,
@@ -1960,8 +1961,6 @@ fn quote_init_method(
                     }
                     None
                 } else {
-                    let doc_content =
-                        crate::codegen::get_documentation(&field.docs, &["py", "python"]);
                     Some(format!(
                         "{}:\n    {}",
                         field.name,

--- a/crates/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/re_types_builder/src/codegen/python/mod.rs
@@ -1157,7 +1157,7 @@ fn quote_obj_docs(obj: &Object) -> String {
 }
 
 fn lines_from_docs(docs: &Docs) -> Vec<String> {
-    let mut lines = crate::codegen::get_documentation(docs, &["py", "python"]);
+    let mut lines = docs.doc_lines_for(&["py", "python"]);
 
     let examples = collect_snippets_for_api_docs(docs, "py", true).unwrap();
     if !examples.is_empty() {
@@ -1208,7 +1208,7 @@ fn quote_doc_from_fields(objects: &Objects, fields: &Vec<ObjectField>) -> String
     let mut lines = vec!["Must be one of:".to_owned(), String::new()];
 
     for field in fields {
-        let mut content = crate::codegen::get_documentation(&field.docs, &["py", "python"]);
+        let mut content = field.docs.doc_lines_for(&["py", "python"]);
         for line in &mut content {
             if line.starts_with(char::is_whitespace) {
                 line.remove(0);
@@ -1250,7 +1250,7 @@ fn quote_union_kind_from_fields(fields: &Vec<ObjectField>) -> String {
     let mut lines = vec!["Possible values:".to_owned(), String::new()];
 
     for field in fields {
-        let mut content = crate::codegen::get_documentation(&field.docs, &["py", "python"]);
+        let mut content = field.docs.doc_lines_for(&["py", "python"]);
         for line in &mut content {
             if line.starts_with(char::is_whitespace) {
                 line.remove(0);
@@ -1950,7 +1950,7 @@ fn quote_init_method(
         obj.fields
             .iter()
             .filter_map(|field| {
-                let doc_content = crate::codegen::get_documentation(&field.docs, &["py", "python"]);
+                let doc_content = field.docs.doc_lines_for(&["py", "python"]);
                 if doc_content.is_empty() {
                     if !field.is_testing() && obj.fields.len() > 1 {
                         reporter.error(

--- a/crates/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/re_types_builder/src/codegen/python/mod.rs
@@ -1157,7 +1157,7 @@ fn quote_obj_docs(obj: &Object) -> String {
 }
 
 fn lines_from_docs(docs: &Docs) -> Vec<String> {
-    let mut lines = docs.doc_lines_for(&["py", "python"]);
+    let mut lines = docs.doc_lines_for_untagged_and(&["py", "python"]);
 
     let examples = collect_snippets_for_api_docs(docs, "py", true).unwrap();
     if !examples.is_empty() {
@@ -1208,7 +1208,7 @@ fn quote_doc_from_fields(objects: &Objects, fields: &Vec<ObjectField>) -> String
     let mut lines = vec!["Must be one of:".to_owned(), String::new()];
 
     for field in fields {
-        let mut content = field.docs.doc_lines_for(&["py", "python"]);
+        let mut content = field.docs.doc_lines_for_untagged_and(&["py", "python"]);
         for line in &mut content {
             if line.starts_with(char::is_whitespace) {
                 line.remove(0);
@@ -1250,7 +1250,7 @@ fn quote_union_kind_from_fields(fields: &Vec<ObjectField>) -> String {
     let mut lines = vec!["Possible values:".to_owned(), String::new()];
 
     for field in fields {
-        let mut content = field.docs.doc_lines_for(&["py", "python"]);
+        let mut content = field.docs.doc_lines_for_untagged_and(&["py", "python"]);
         for line in &mut content {
             if line.starts_with(char::is_whitespace) {
                 line.remove(0);
@@ -1950,7 +1950,7 @@ fn quote_init_method(
         obj.fields
             .iter()
             .filter_map(|field| {
-                let doc_content = field.docs.doc_lines_for(&["py", "python"]);
+                let doc_content = field.docs.doc_lines_for_untagged_and(&["py", "python"]);
                 if doc_content.is_empty() {
                     if !field.is_testing() && obj.fields.len() > 1 {
                         reporter.error(

--- a/crates/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/re_types_builder/src/codegen/python/mod.rs
@@ -1157,7 +1157,7 @@ fn quote_obj_docs(obj: &Object) -> String {
 }
 
 fn lines_from_docs(docs: &Docs) -> Vec<String> {
-    let mut lines = docs.doc_lines_for_untagged_and(&["py", "python"]);
+    let mut lines = docs.doc_lines_for_untagged_and("py");
 
     let examples = collect_snippets_for_api_docs(docs, "py", true).unwrap();
     if !examples.is_empty() {
@@ -1208,7 +1208,7 @@ fn quote_doc_from_fields(objects: &Objects, fields: &Vec<ObjectField>) -> String
     let mut lines = vec!["Must be one of:".to_owned(), String::new()];
 
     for field in fields {
-        let mut content = field.docs.doc_lines_for_untagged_and(&["py", "python"]);
+        let mut content = field.docs.doc_lines_for_untagged_and("py");
         for line in &mut content {
             if line.starts_with(char::is_whitespace) {
                 line.remove(0);
@@ -1250,7 +1250,7 @@ fn quote_union_kind_from_fields(fields: &Vec<ObjectField>) -> String {
     let mut lines = vec!["Possible values:".to_owned(), String::new()];
 
     for field in fields {
-        let mut content = field.docs.doc_lines_for_untagged_and(&["py", "python"]);
+        let mut content = field.docs.doc_lines_for_untagged_and("py");
         for line in &mut content {
             if line.starts_with(char::is_whitespace) {
                 line.remove(0);
@@ -1950,7 +1950,7 @@ fn quote_init_method(
         obj.fields
             .iter()
             .filter_map(|field| {
-                let doc_content = field.docs.doc_lines_for_untagged_and(&["py", "python"]);
+                let doc_content = field.docs.doc_lines_for_untagged_and("py");
                 if doc_content.is_empty() {
                     if !field.is_testing() && obj.fields.len() > 1 {
                         reporter.error(

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -714,7 +714,7 @@ fn quote_obj_docs(reporter: &Reporter, obj: &Object) -> TokenStream {
 }
 
 fn doc_as_lines(reporter: &Reporter, virtpath: &str, fqname: &str, docs: &Docs) -> Vec<String> {
-    let mut lines = docs.doc_lines_for_untagged_and(&["rs", "rust"]);
+    let mut lines = docs.doc_lines_for_untagged_and("rs");
 
     let examples = collect_snippets_for_api_docs(docs, "rs", true)
         .map_err(|err| reporter.error(virtpath, fqname, err))

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -714,7 +714,7 @@ fn quote_obj_docs(reporter: &Reporter, obj: &Object) -> TokenStream {
 }
 
 fn doc_as_lines(reporter: &Reporter, virtpath: &str, fqname: &str, docs: &Docs) -> Vec<String> {
-    let mut lines = docs.doc_lines_for(&["rs", "rust"]);
+    let mut lines = docs.doc_lines_for_untagged_and(&["rs", "rust"]);
 
     let examples = collect_snippets_for_api_docs(docs, "rs", true)
         .map_err(|err| reporter.error(virtpath, fqname, err))

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -714,7 +714,7 @@ fn quote_obj_docs(reporter: &Reporter, obj: &Object) -> TokenStream {
 }
 
 fn doc_as_lines(reporter: &Reporter, virtpath: &str, fqname: &str, docs: &Docs) -> Vec<String> {
-    let mut lines = crate::codegen::get_documentation(docs, &["rs", "rust"]);
+    let mut lines = docs.doc_lines_for(&["rs", "rust"]);
 
     let examples = collect_snippets_for_api_docs(docs, "rs", true)
         .map_err(|err| reporter.error(virtpath, fqname, err))

--- a/crates/re_types_builder/src/docs.rs
+++ b/crates/re_types_builder/src/docs.rs
@@ -1,180 +1,97 @@
-use std::collections::{BTreeMap, HashSet};
-
-use anyhow::Context as _;
-use camino::{Utf8Path, Utf8PathBuf};
-use itertools::Itertools as _;
-
 /// A high-level representation of a flatbuffers object's documentation.
 #[derive(Debug, Clone)]
 pub struct Docs {
-    /// General documentation for the object.
+    /// All docmentation lines, including the leading tag, if any.
     ///
-    /// Each entry in the vector is a line of comment,
-    /// excluding the leading space end trailing newline,
-    /// i.e. the `COMMENT` from `/// COMMENT\n`
+    /// If the tag is the empty string, it means the line is untagged.
     ///
-    /// See also [`Docs::tagged_docs`].
-    doc: Vec<String>,
-
-    /// Tagged documentation for the object.
-    ///
-    /// Each entry in the vector is a line of comment,
-    /// excluding the leading space end trailing newline,
-    /// i.e. the `COMMENT` from `/// \py COMMENT\n`
-    ///
-    /// E.g. the following will be associated with the `py` tag:
-    /// ```flatbuffers
-    /// /// \py Something something about how this fields behave in python.
-    /// my_field: uint32,
-    /// ```
-    ///
-    /// See also [`Docs::doc`].
-    tagged_docs: BTreeMap<String, Vec<String>>,
+    /// Each line excludes the leading space and trailing newline.
+    /// * `/// COMMENT\n`      =>  `("", "COMMENT")`
+    /// * `/// \py COMMENT\n`  =>  `("py", "COMMENT")`.
+    lines: Vec<(String, String)>,
 }
 
 impl Docs {
     pub fn from_raw_docs(
-        filepath: &Utf8Path,
         docs: Option<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<&'_ str>>>,
     ) -> Self {
-        // Contents of all the files included using `\include:<path>`.
-        let mut included_files = BTreeMap::default();
-
-        let include_file = |included_files: &mut BTreeMap<_, _>, raw_path: &str| {
-            let path: Utf8PathBuf = raw_path
-                .parse()
-                .with_context(|| format!("couldn't parse included path: {raw_path:?}"))
-                .unwrap();
-
-            let path = filepath.parent().unwrap().join(path);
-
-            included_files
-                .entry(path.clone())
-                .or_insert_with(|| {
-                    std::fs::read_to_string(&path)
-                        .with_context(|| {
-                            format!("couldn't parse read file at included path: {path:?}")
-                        })
-                        .unwrap()
-                })
-                .clone()
+        let parse_line = |line: &str| {
+            if let Some(line) = line.strip_prefix(" \\") {
+                // \tagged comment
+                let tag = line.split_whitespace().next().unwrap().to_owned();
+                let line = &line[tag.len()..];
+                if let Some(line) = line.strip_prefix(' ') {
+                    // Removed space between tag and comment.
+                    (tag, line.to_owned())
+                } else {
+                    assert!(line.is_empty());
+                    (tag, String::new())
+                }
+            } else if let Some(line) = line.strip_prefix(' ') {
+                // Removed space between `///` and comment.
+                (String::new(), line.to_owned())
+            } else {
+                assert!(
+                    line.is_empty(),
+                    "Comments should start with a single space; found {line:?}"
+                );
+                (String::new(), String::new())
+            }
         };
 
-        // language-agnostic docs
-        let doc = docs
+        let lines: Vec<(String, String)> = docs
             .into_iter()
             .flat_map(|doc| doc.into_iter())
-            // NOTE: discard tagged lines!
-            .filter(|line| !line.trim().starts_with('\\'))
-            .flat_map(|line| {
-                assert!(!line.ends_with('\n'));
-                assert!(!line.ends_with('\r'));
+            .map(parse_line)
+            .collect();
 
-                if let Some((_, path)) = line.split_once("\\include:") {
-                    include_file(&mut included_files, path)
-                        .lines()
-                        .map(|line| line.to_owned())
-                        .collect_vec()
-                } else if let Some(line) = line.strip_prefix(' ') {
-                    // Removed space between `///` and comment.
-                    vec![line.to_owned()]
-                } else {
-                    assert!(
-                        line.is_empty(),
-                        "{filepath}: Comments should start with a single space; found {line:?}"
-                    );
-                    vec![line.to_owned()]
-                }
-            })
-            .collect::<Vec<_>>();
+        for (tag, comment) in &lines {
+            assert!(
+                matches!(tag.as_str(), "" | "example" | "cpp" | "py" | "rs"),
+                "Unsupported tag: '\\{tag} {comment}'"
+            );
+        }
 
-        // tagged docs, e.g. `\py this only applies to python!`
-        let tagged_docs = {
-            let tagged_lines = docs
-                .into_iter()
-                .flat_map(|doc| doc.into_iter())
-                // NOTE: discard _un_tagged lines!
-                .filter_map(|line| {
-                    let trimmed = line.trim();
-                    trimmed.starts_with('\\').then(|| {
-                        let tag = trimmed.split_whitespace().next().unwrap();
-                        let line = &trimmed[tag.len()..];
-                        let tag = tag[1..].to_owned();
-                        if let Some(line) = line.strip_prefix(' ') {
-                            // Removed space between tag and comment.
-                            (tag, line.to_owned())
-                        } else {
-                            assert!(line.is_empty());
-                            (tag, String::default())
-                        }
-                    })
-                })
-                .flat_map(|(tag, line)| {
-                    if let Some((_, path)) = line.split_once("\\include:") {
-                        include_file(&mut included_files, path)
-                            .lines()
-                            .map(|line| (tag.clone(), line.to_owned()))
-                            .collect_vec()
-                    } else {
-                        vec![(tag, line)]
-                    }
-                })
-                .collect::<Vec<_>>();
-
-            let all_tags: HashSet<_> = tagged_lines.iter().map(|(tag, _)| tag).collect();
-            let mut tagged_docs = BTreeMap::new();
-
-            for cur_tag in all_tags {
-                assert!(
-                    matches!(cur_tag.as_str(), "example" | "py" | "rs" | "cpp"),
-                    "Unsupported tag: \\{cur_tag}"
-                );
-
-                tagged_docs.insert(
-                    cur_tag.clone(),
-                    tagged_lines
-                        .iter()
-                        .filter(|(tag, _)| cur_tag == tag)
-                        .map(|(_, line)| line.clone())
-                        .collect(),
-                );
-            }
-
-            tagged_docs
-        };
-
-        Self { doc, tagged_docs }
+        Self { lines }
     }
 
     /// Get all doc lines that start with the given tag.
     ///
     /// For instance, pass `"example"` to get all lines that start with `"\example"`.
     pub fn doc_lines_tagged(&self, tag: &str) -> Vec<&str> {
-        if let Some(lines) = self.tagged_docs.get(tag) {
-            lines.iter().map(|s| s.as_str()).collect()
-        } else {
-            Vec::new()
-        }
+        self.lines_with_tag_matching(|t| t == tag)
     }
 
     /// Get all doc lines that are untagged.
     pub fn untagged(&self) -> Vec<String> {
-        self.doc_lines_for_untagged_and("")
+        self.lines_with_tag_matching(|t| t.is_empty())
+            .iter()
+            .map(|&s| s.to_owned())
+            .collect()
     }
 
     /// Get all doc lines that are untagged, or match the given tag.
     ///
     /// For instance, pass `"py"` to get all lines that are untagged or starta with `"\py"`.
     pub fn doc_lines_for_untagged_and(&self, tag: &str) -> Vec<String> {
-        let mut lines = self.doc.clone();
+        self.lines_with_tag_matching(|t| t.is_empty() || t == tag)
+            .iter()
+            .map(|&s| s.to_owned())
+            .collect()
+    }
 
-        lines.extend(
-            self.tagged_docs
-                .get(tag)
-                .unwrap_or(&Vec::new())
-                .iter()
-                .cloned(),
-        );
+    pub fn lines_with_tag_matching(&self, include_tag: impl Fn(&str) -> bool) -> Vec<&str> {
+        let mut lines: Vec<&str> = self
+            .lines
+            .iter()
+            .filter_map(|(tag, line)| {
+                if include_tag(tag) {
+                    Some(line.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
 
         // NOTE: remove duplicated blank lines.
         lines.dedup();

--- a/crates/re_types_builder/src/docs.rs
+++ b/crates/re_types_builder/src/docs.rs
@@ -125,6 +125,11 @@ impl Docs {
             let mut tagged_docs = BTreeMap::new();
 
             for cur_tag in all_tags {
+                assert!(
+                    matches!(cur_tag.as_str(), "example" | "py" | "rs" | "cpp"),
+                    "Unsupported tag: \\{cur_tag}"
+                );
+
                 tagged_docs.insert(
                     cur_tag.clone(),
                     tagged_lines
@@ -152,21 +157,24 @@ impl Docs {
         }
     }
 
-    /// Get all doc lines that are untagged, or match any of the given tags.
+    /// Get all doc lines that are untagged.
+    pub fn untagged(&self) -> Vec<String> {
+        self.doc_lines_for_untagged_and("")
+    }
+
+    /// Get all doc lines that are untagged, or match the given tag.
     ///
-    /// For instance, pass `["py"]` to get all lines that are untagged or starta with `"\python"`.
-    pub fn doc_lines_for_untagged_and(&self, tags: &[&str]) -> Vec<String> {
+    /// For instance, pass `"py"` to get all lines that are untagged or starta with `"\py"`.
+    pub fn doc_lines_for_untagged_and(&self, tag: &str) -> Vec<String> {
         let mut lines = self.doc.clone();
 
-        for tag in tags {
-            lines.extend(
-                self.tagged_docs
-                    .get(*tag)
-                    .unwrap_or(&Vec::new())
-                    .iter()
-                    .cloned(),
-            );
-        }
+        lines.extend(
+            self.tagged_docs
+                .get(tag)
+                .unwrap_or(&Vec::new())
+                .iter()
+                .cloned(),
+        );
 
         // NOTE: remove duplicated blank lines.
         lines.dedup();

--- a/crates/re_types_builder/src/docs.rs
+++ b/crates/re_types_builder/src/docs.rs
@@ -1,0 +1,180 @@
+use std::collections::{BTreeMap, HashSet};
+
+use anyhow::Context as _;
+use camino::{Utf8Path, Utf8PathBuf};
+use itertools::Itertools as _;
+
+/// A high-level representation of a flatbuffers object's documentation.
+#[derive(Debug, Clone)]
+pub struct Docs {
+    /// General documentation for the object.
+    ///
+    /// Each entry in the vector is a line of comment,
+    /// excluding the leading space end trailing newline,
+    /// i.e. the `COMMENT` from `/// COMMENT\n`
+    ///
+    /// See also [`Docs::tagged_docs`].
+    pub doc: Vec<String>,
+
+    /// Tagged documentation for the object.
+    ///
+    /// Each entry in the vector is a line of comment,
+    /// excluding the leading space end trailing newline,
+    /// i.e. the `COMMENT` from `/// \py COMMENT\n`
+    ///
+    /// E.g. the following will be associated with the `py` tag:
+    /// ```flatbuffers
+    /// /// \py Something something about how this fields behave in python.
+    /// my_field: uint32,
+    /// ```
+    ///
+    /// See also [`Docs::doc`].
+    pub tagged_docs: BTreeMap<String, Vec<String>>,
+
+    /// Contents of all the files included using `\include:<path>`.
+    pub included_files: BTreeMap<Utf8PathBuf, String>,
+}
+
+impl Docs {
+    pub fn from_raw_docs(
+        filepath: &Utf8Path,
+        docs: Option<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<&'_ str>>>,
+    ) -> Self {
+        let mut included_files = BTreeMap::default();
+
+        let include_file = |included_files: &mut BTreeMap<_, _>, raw_path: &str| {
+            let path: Utf8PathBuf = raw_path
+                .parse()
+                .with_context(|| format!("couldn't parse included path: {raw_path:?}"))
+                .unwrap();
+
+            let path = filepath.parent().unwrap().join(path);
+
+            included_files
+                .entry(path.clone())
+                .or_insert_with(|| {
+                    std::fs::read_to_string(&path)
+                        .with_context(|| {
+                            format!("couldn't parse read file at included path: {path:?}")
+                        })
+                        .unwrap()
+                })
+                .clone()
+        };
+
+        // language-agnostic docs
+        let doc = docs
+            .into_iter()
+            .flat_map(|doc| doc.into_iter())
+            // NOTE: discard tagged lines!
+            .filter(|line| !line.trim().starts_with('\\'))
+            .flat_map(|line| {
+                assert!(!line.ends_with('\n'));
+                assert!(!line.ends_with('\r'));
+
+                if let Some((_, path)) = line.split_once("\\include:") {
+                    include_file(&mut included_files, path)
+                        .lines()
+                        .map(|line| line.to_owned())
+                        .collect_vec()
+                } else if let Some(line) = line.strip_prefix(' ') {
+                    // Removed space between `///` and comment.
+                    vec![line.to_owned()]
+                } else {
+                    assert!(
+                        line.is_empty(),
+                        "{filepath}: Comments should start with a single space; found {line:?}"
+                    );
+                    vec![line.to_owned()]
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // tagged docs, e.g. `\py this only applies to python!`
+        let tagged_docs = {
+            let tagged_lines = docs
+                .into_iter()
+                .flat_map(|doc| doc.into_iter())
+                // NOTE: discard _un_tagged lines!
+                .filter_map(|line| {
+                    let trimmed = line.trim();
+                    trimmed.starts_with('\\').then(|| {
+                        let tag = trimmed.split_whitespace().next().unwrap();
+                        let line = &trimmed[tag.len()..];
+                        let tag = tag[1..].to_owned();
+                        if let Some(line) = line.strip_prefix(' ') {
+                            // Removed space between tag and comment.
+                            (tag, line.to_owned())
+                        } else {
+                            assert!(line.is_empty());
+                            (tag, String::default())
+                        }
+                    })
+                })
+                .flat_map(|(tag, line)| {
+                    if let Some((_, path)) = line.split_once("\\include:") {
+                        include_file(&mut included_files, path)
+                            .lines()
+                            .map(|line| (tag.clone(), line.to_owned()))
+                            .collect_vec()
+                    } else {
+                        vec![(tag, line)]
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            let all_tags: HashSet<_> = tagged_lines.iter().map(|(tag, _)| tag).collect();
+            let mut tagged_docs = BTreeMap::new();
+
+            for cur_tag in all_tags {
+                tagged_docs.insert(
+                    cur_tag.clone(),
+                    tagged_lines
+                        .iter()
+                        .filter(|(tag, _)| cur_tag == tag)
+                        .map(|(_, line)| line.clone())
+                        .collect(),
+                );
+            }
+
+            tagged_docs
+        };
+
+        Self {
+            doc,
+            tagged_docs,
+            included_files,
+        }
+    }
+
+    /// Get all doc lines that are untagged, or match any of the given tags.
+    ///
+    /// For instance, pass `["py"]` to get all lines that are untagged or starta with `"\python"`.
+    pub fn doc_lines_for(&self, tags: &[&str]) -> Vec<String> {
+        let mut lines = self.doc.clone();
+
+        for tag in tags {
+            lines.extend(
+                self.tagged_docs
+                    .get(*tag)
+                    .unwrap_or(&Vec::new())
+                    .iter()
+                    .cloned(),
+            );
+        }
+
+        // NOTE: remove duplicated blank lines.
+        lines.dedup();
+
+        // NOTE: remove trailing blank lines.
+        while let Some(line) = lines.last() {
+            if line.is_empty() {
+                lines.pop();
+            } else {
+                break;
+            }
+        }
+
+        lines
+    }
+}

--- a/crates/re_types_builder/src/docs.rs
+++ b/crates/re_types_builder/src/docs.rs
@@ -30,9 +30,6 @@ pub struct Docs {
     ///
     /// See also [`Docs::doc`].
     tagged_docs: BTreeMap<String, Vec<String>>,
-
-    /// Contents of all the files included using `\include:<path>`.
-    included_files: BTreeMap<Utf8PathBuf, String>,
 }
 
 impl Docs {
@@ -40,6 +37,7 @@ impl Docs {
         filepath: &Utf8Path,
         docs: Option<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<&'_ str>>>,
     ) -> Self {
+        // Contents of all the files included using `\include:<path>`.
         let mut included_files = BTreeMap::default();
 
         let include_file = |included_files: &mut BTreeMap<_, _>, raw_path: &str| {
@@ -140,11 +138,7 @@ impl Docs {
             tagged_docs
         };
 
-        Self {
-            doc,
-            tagged_docs,
-            included_files,
-        }
+        Self { doc, tagged_docs }
     }
 
     /// Get all doc lines that start with the given tag.

--- a/crates/re_types_builder/src/docs.rs
+++ b/crates/re_types_builder/src/docs.rs
@@ -14,7 +14,7 @@ pub struct Docs {
     /// i.e. the `COMMENT` from `/// COMMENT\n`
     ///
     /// See also [`Docs::tagged_docs`].
-    pub doc: Vec<String>,
+    doc: Vec<String>,
 
     /// Tagged documentation for the object.
     ///
@@ -29,10 +29,10 @@ pub struct Docs {
     /// ```
     ///
     /// See also [`Docs::doc`].
-    pub tagged_docs: BTreeMap<String, Vec<String>>,
+    tagged_docs: BTreeMap<String, Vec<String>>,
 
     /// Contents of all the files included using `\include:<path>`.
-    pub included_files: BTreeMap<Utf8PathBuf, String>,
+    included_files: BTreeMap<Utf8PathBuf, String>,
 }
 
 impl Docs {
@@ -147,10 +147,21 @@ impl Docs {
         }
     }
 
+    /// Get all doc lines that start with the given tag.
+    ///
+    /// For instance, pass `"example"` to get all lines that start with `"\example"`.
+    pub fn doc_lines_tagged(&self, tag: &str) -> Vec<&str> {
+        if let Some(lines) = self.tagged_docs.get(tag) {
+            lines.iter().map(|s| s.as_str()).collect()
+        } else {
+            Vec::new()
+        }
+    }
+
     /// Get all doc lines that are untagged, or match any of the given tags.
     ///
     /// For instance, pass `["py"]` to get all lines that are untagged or starta with `"\python"`.
-    pub fn doc_lines_for(&self, tags: &[&str]) -> Vec<String> {
+    pub fn doc_lines_for_untagged_and(&self, tags: &[&str]) -> Vec<String> {
         let mut lines = self.doc.clone();
 
         for tag in tags {

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -139,6 +139,8 @@ mod format;
 #[allow(clippy::unimplemented)]
 mod objects;
 
+mod docs;
+
 pub mod report;
 
 /// In-memory generated files.
@@ -147,15 +149,18 @@ pub mod report;
 /// etc), and finally written to disk by the I/O pass.
 pub type GeneratedFiles = std::collections::BTreeMap<camino::Utf8PathBuf, String>;
 
-pub use self::arrow_registry::{ArrowRegistry, LazyDatatype, LazyField};
-pub use self::codegen::{
-    CodeGenerator, CppCodeGenerator, DocsCodeGenerator, PythonCodeGenerator, RustCodeGenerator,
+pub use self::{
+    arrow_registry::{ArrowRegistry, LazyDatatype, LazyField},
+    codegen::{
+        CodeGenerator, CppCodeGenerator, DocsCodeGenerator, PythonCodeGenerator, RustCodeGenerator,
+    },
+    docs::Docs,
+    format::{CodeFormatter, CppCodeFormatter, PythonCodeFormatter, RustCodeFormatter},
+    objects::{
+        Attributes, ElementType, Object, ObjectClass, ObjectField, ObjectKind, Objects, Type,
+    },
+    report::{Report, Reporter},
 };
-pub use self::format::{CodeFormatter, CppCodeFormatter, PythonCodeFormatter, RustCodeFormatter};
-pub use self::objects::{
-    Attributes, Docs, ElementType, Object, ObjectClass, ObjectField, ObjectKind, Objects, Type,
-};
-pub use self::report::{Report, Reporter};
 
 // --- Attributes ---
 

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -395,6 +395,37 @@ impl Docs {
             included_files,
         }
     }
+
+    /// Get all doc lines that are untagged, or match any of the given tags.
+    ///
+    /// For instance, pass `["py"]` to get all lines that are untagged or starta with `"\python"`.
+    pub fn doc_lines_for(&self, tags: &[&str]) -> Vec<String> {
+        let mut lines = self.doc.clone();
+
+        for tag in tags {
+            lines.extend(
+                self.tagged_docs
+                    .get(*tag)
+                    .unwrap_or(&Vec::new())
+                    .iter()
+                    .cloned(),
+            );
+        }
+
+        // NOTE: remove duplicated blank lines.
+        lines.dedup();
+
+        // NOTE: remove trailing blank lines.
+        while let Some(line) = lines.last() {
+            if line.is_empty() {
+                lines.pop();
+            } else {
+                break;
+            }
+        }
+
+        lines
+    }
 }
 
 /// A high-level representation of a flatbuffers object, which can be either a struct, a union or

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -327,7 +327,7 @@ impl Object {
             "Bad filepath: {filepath:?}"
         );
 
-        let docs = Docs::from_raw_docs(&filepath, obj.documentation());
+        let docs = Docs::from_raw_docs(obj.documentation());
         let attrs = Attributes::from_raw_attrs(obj.attributes());
         let kind = ObjectKind::from_pkg_name(&pkg_name, &attrs);
 
@@ -407,7 +407,7 @@ impl Object {
             .unwrap();
         let filepath = filepath_from_declaration_file(include_dir_path, &virtpath);
 
-        let docs = Docs::from_raw_docs(&filepath, enm.documentation());
+        let docs = Docs::from_raw_docs(enm.documentation());
         let attrs = Attributes::from_raw_attrs(enm.attributes());
         let kind = ObjectKind::from_pkg_name(&pkg_name, &attrs);
 
@@ -647,7 +647,7 @@ impl ObjectField {
             .unwrap();
         let filepath = filepath_from_declaration_file(include_dir_path, &virtpath);
 
-        let docs = Docs::from_raw_docs(&filepath, field.documentation());
+        let docs = Docs::from_raw_docs(field.documentation());
 
         let attrs = Attributes::from_raw_attrs(field.attributes());
 
@@ -695,7 +695,7 @@ impl ObjectField {
             .unwrap();
         let filepath = filepath_from_declaration_file(include_dir_path, &virtpath);
 
-        let docs = Docs::from_raw_docs(&filepath, val.documentation());
+        let docs = Docs::from_raw_docs(val.documentation());
 
         let attrs = Attributes::from_raw_attrs(val.attributes());
 

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -3,15 +3,15 @@
 //! The semantic pass transforms the low-level raw reflection data into higher level types that
 //! are much easier to inspect and manipulate / friendler to work with.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 use anyhow::Context as _;
 use camino::{Utf8Path, Utf8PathBuf};
 use itertools::Itertools;
 
 use crate::{
-    root_as_schema, FbsBaseType, FbsEnum, FbsEnumVal, FbsField, FbsKeyValue, FbsObject, FbsSchema,
-    FbsType, Reporter, ATTR_RERUN_OVERRIDE_TYPE,
+    root_as_schema, Docs, FbsBaseType, FbsEnum, FbsEnumVal, FbsField, FbsKeyValue, FbsObject,
+    FbsSchema, FbsType, Reporter, ATTR_RERUN_OVERRIDE_TYPE,
 };
 
 // ---
@@ -250,181 +250,6 @@ impl ObjectKind {
             ObjectKind::Component => "Components",
             ObjectKind::Archetype => "Archetypes",
         }
-    }
-}
-
-/// A high-level representation of a flatbuffers object's documentation.
-#[derive(Debug, Clone)]
-pub struct Docs {
-    /// General documentation for the object.
-    ///
-    /// Each entry in the vector is a line of comment,
-    /// excluding the leading space end trailing newline,
-    /// i.e. the `COMMENT` from `/// COMMENT\n`
-    ///
-    /// See also [`Docs::tagged_docs`].
-    pub doc: Vec<String>,
-
-    /// Tagged documentation for the object.
-    ///
-    /// Each entry in the vector is a line of comment,
-    /// excluding the leading space end trailing newline,
-    /// i.e. the `COMMENT` from `/// \py COMMENT\n`
-    ///
-    /// E.g. the following will be associated with the `py` tag:
-    /// ```flatbuffers
-    /// /// \py Something something about how this fields behave in python.
-    /// my_field: uint32,
-    /// ```
-    ///
-    /// See also [`Docs::doc`].
-    pub tagged_docs: BTreeMap<String, Vec<String>>,
-
-    /// Contents of all the files included using `\include:<path>`.
-    pub included_files: BTreeMap<Utf8PathBuf, String>,
-}
-
-impl Docs {
-    fn from_raw_docs(
-        filepath: &Utf8Path,
-        docs: Option<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<&'_ str>>>,
-    ) -> Self {
-        let mut included_files = BTreeMap::default();
-
-        let include_file = |included_files: &mut BTreeMap<_, _>, raw_path: &str| {
-            let path: Utf8PathBuf = raw_path
-                .parse()
-                .with_context(|| format!("couldn't parse included path: {raw_path:?}"))
-                .unwrap();
-
-            let path = filepath.parent().unwrap().join(path);
-
-            included_files
-                .entry(path.clone())
-                .or_insert_with(|| {
-                    std::fs::read_to_string(&path)
-                        .with_context(|| {
-                            format!("couldn't parse read file at included path: {path:?}")
-                        })
-                        .unwrap()
-                })
-                .clone()
-        };
-
-        // language-agnostic docs
-        let doc = docs
-            .into_iter()
-            .flat_map(|doc| doc.into_iter())
-            // NOTE: discard tagged lines!
-            .filter(|line| !line.trim().starts_with('\\'))
-            .flat_map(|line| {
-                assert!(!line.ends_with('\n'));
-                assert!(!line.ends_with('\r'));
-
-                if let Some((_, path)) = line.split_once("\\include:") {
-                    include_file(&mut included_files, path)
-                        .lines()
-                        .map(|line| line.to_owned())
-                        .collect_vec()
-                } else if let Some(line) = line.strip_prefix(' ') {
-                    // Removed space between `///` and comment.
-                    vec![line.to_owned()]
-                } else {
-                    assert!(
-                        line.is_empty(),
-                        "{filepath}: Comments should start with a single space; found {line:?}"
-                    );
-                    vec![line.to_owned()]
-                }
-            })
-            .collect::<Vec<_>>();
-
-        // tagged docs, e.g. `\py this only applies to python!`
-        let tagged_docs = {
-            let tagged_lines = docs
-                .into_iter()
-                .flat_map(|doc| doc.into_iter())
-                // NOTE: discard _un_tagged lines!
-                .filter_map(|line| {
-                    let trimmed = line.trim();
-                    trimmed.starts_with('\\').then(|| {
-                        let tag = trimmed.split_whitespace().next().unwrap();
-                        let line = &trimmed[tag.len()..];
-                        let tag = tag[1..].to_owned();
-                        if let Some(line) = line.strip_prefix(' ') {
-                            // Removed space between tag and comment.
-                            (tag, line.to_owned())
-                        } else {
-                            assert!(line.is_empty());
-                            (tag, String::default())
-                        }
-                    })
-                })
-                .flat_map(|(tag, line)| {
-                    if let Some((_, path)) = line.split_once("\\include:") {
-                        include_file(&mut included_files, path)
-                            .lines()
-                            .map(|line| (tag.clone(), line.to_owned()))
-                            .collect_vec()
-                    } else {
-                        vec![(tag, line)]
-                    }
-                })
-                .collect::<Vec<_>>();
-
-            let all_tags: HashSet<_> = tagged_lines.iter().map(|(tag, _)| tag).collect();
-            let mut tagged_docs = BTreeMap::new();
-
-            for cur_tag in all_tags {
-                tagged_docs.insert(
-                    cur_tag.clone(),
-                    tagged_lines
-                        .iter()
-                        .filter(|(tag, _)| cur_tag == tag)
-                        .map(|(_, line)| line.clone())
-                        .collect(),
-                );
-            }
-
-            tagged_docs
-        };
-
-        Self {
-            doc,
-            tagged_docs,
-            included_files,
-        }
-    }
-
-    /// Get all doc lines that are untagged, or match any of the given tags.
-    ///
-    /// For instance, pass `["py"]` to get all lines that are untagged or starta with `"\python"`.
-    pub fn doc_lines_for(&self, tags: &[&str]) -> Vec<String> {
-        let mut lines = self.doc.clone();
-
-        for tag in tags {
-            lines.extend(
-                self.tagged_docs
-                    .get(*tag)
-                    .unwrap_or(&Vec::new())
-                    .iter()
-                    .cloned(),
-            );
-        }
-
-        // NOTE: remove duplicated blank lines.
-        lines.dedup();
-
-        // NOTE: remove trailing blank lines.
-        while let Some(line) = lines.last() {
-            if line.is_empty() {
-                lines.pop();
-            } else {
-                break;
-            }
-        }
-
-        lines
     }
 }
 

--- a/docs/content/reference/types/archetypes/image.md
+++ b/docs/content/reference/types/archetypes/image.md
@@ -12,6 +12,9 @@ The shape of the `TensorData` must be mappable to:
 Leading and trailing unit-dimensions are ignored, so that
 `1x640x480x3x1` is treated as a `640x480x3` RGB image.
 
+Rerun also supports compressed image encoded as JPEG, N12, and YUY2.
+Using these formats can save a lot of bandwidth and memory.
+
 ## Components
 
 **Required**: [`TensorData`](../components/tensor_data.md)

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -29,8 +29,8 @@ namespace rerun::archetypes {
     ///
     /// Rerun also supports compressed image encoded as JPEG, N12, and YUY2.
     /// Using these formats can save a lot of bandwidth and memory.
-    ///
     /// See [`rerun::datatypes::TensorBuffer`] for more.
+    ///
     /// Since the underlying `rerun::datatypes::TensorData` uses `rerun::Collection` internally,
     /// data can be passed in without a copy from raw pointers or by reference from `std::vector`/`std::array`/c-arrays.
     /// If needed, this "borrow-behavior" can be extended by defining your own `rerun::CollectionAdapter`.

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -27,6 +27,10 @@ namespace rerun::archetypes {
     /// Leading and trailing unit-dimensions are ignored, so that
     /// `1x640x480x3x1` is treated as a `640x480x3` RGB image.
     ///
+    /// Rerun also supports compressed image encoded as JPEG, N12, and YUY2.
+    /// Using these formats can save a lot of bandwidth and memory.
+    ///
+    /// See [`rerun::datatypes::TensorBuffer`] for more.
     /// Since the underlying `rerun::datatypes::TensorData` uses `rerun::Collection` internally,
     /// data can be passed in without a copy from raw pointers or by reference from `std::vector`/`std::array`/c-arrays.
     /// If needed, this "borrow-behavior" can be extended by defining your own `rerun::CollectionAdapter`.

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
@@ -85,7 +85,7 @@ namespace rerun::datatypes {
             /// First comes entire image in Y, followed by interleaved lines ordered as U0, V0, U1, V1, etc.
             rerun::Collection<uint8_t> nv12;
 
-            /// YUY2, also known as YUYV is a YUV 4:2:2 chrome downsampled format with 8 bits per channel.
+            /// YUY2, also known as YUYV is a YUV 4:2:2 chroma downsampled format with 8 bits per channel.
             ///
             /// The order of the channels is Y0, U0, Y1, V0.
             rerun::Collection<uint8_t> yuy2;
@@ -420,7 +420,7 @@ namespace rerun::datatypes {
             return self;
         }
 
-        /// YUY2, also known as YUYV is a YUV 4:2:2 chrome downsampled format with 8 bits per channel.
+        /// YUY2, also known as YUYV is a YUV 4:2:2 chroma downsampled format with 8 bits per channel.
         ///
         /// The order of the channels is Y0, U0, Y1, V0.
         static TensorBuffer yuy2(rerun::Collection<uint8_t> yuy2) {

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -30,7 +30,11 @@ class Image(ImageExt, Archetype):
     Leading and trailing unit-dimensions are ignored, so that
     `1x640x480x3x1` is treated as a `640x480x3` RGB image.
 
-    For an easy way to pass in image formats or encoded images, see [`rerun.ImageEncoded`][].
+    Rerun also supports compressed image encoded as JPEG, N12, and YUY2.
+    Using these formats can save a lot of bandwidth and memory.
+
+    To compress an image, use [`rerun.Image.compress`][].
+    To pass in an already encoded image, use  [`rerun.ImageEncoded`][].
 
     Example
     -------

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -32,7 +32,6 @@ class Image(ImageExt, Archetype):
 
     Rerun also supports compressed image encoded as JPEG, N12, and YUY2.
     Using these formats can save a lot of bandwidth and memory.
-
     To compress an image, use [`rerun.Image.compress`][].
     To pass in an already encoded image, use  [`rerun.ImageEncoded`][].
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
@@ -88,7 +88,7 @@ class TensorBuffer(TensorBufferExt):
         First comes entire image in Y, followed by interleaved lines ordered as U0, V0, U1, V1, etc.
 
     * YUY2 (npt.NDArray[np.uint8]):
-        YUY2, also known as YUYV is a YUV 4:2:2 chrome downsampled format with 8 bits per channel.
+        YUY2, also known as YUYV is a YUV 4:2:2 chroma downsampled format with 8 bits per channel.
 
         The order of the channels is Y0, U0, Y1, V0.
     """
@@ -141,7 +141,7 @@ class TensorBuffer(TensorBufferExt):
         First comes entire image in Y, followed by interleaved lines ordered as U0, V0, U1, V1, etc.
 
     * "YUY2":
-        YUY2, also known as YUYV is a YUV 4:2:2 chrome downsampled format with 8 bits per channel.
+        YUY2, also known as YUYV is a YUV 4:2:2 chroma downsampled format with 8 bits per channel.
 
         The order of the channels is Y0, U0, Y1, V0.
     """


### PR DESCRIPTION
### What
We often talk to customers that are unaware that we support logging encoded/compressed images.
So I added some docs for this (in 3096c17).

This became a 🐰🕳️ because the doc tags (`\py` etc) didn't work as expected: they would put all language-specific stuff _at the end_, but in this case I wanted it interleaved into the rest of the docs. So I fixed that, with a lot of effort.
Now `\cpp`, `\py`, `\rs` acts like a simple per-line filter.

In the meantime I removed some unused code, making everything shorter in the process.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5675/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5675/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5675/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5675)
- [Docs preview](https://rerun.io/preview/5e9c4730e352b2fa9ed32406937e317552387660/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5e9c4730e352b2fa9ed32406937e317552387660/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)