### PR TITLE
Fix missing application id in RRT* example

### DIFF
--- a/examples/python/rrt-star/main.py
+++ b/examples/python/rrt-star/main.py
@@ -259,7 +259,7 @@ def main() -> None:
     parser.add_argument("--max-step-size", type=float, default=0.1)
     parser.add_argument("--iterations", type=int, help="How many iterations it should do")
     args = parser.parse_args()
-    rr.script_setup(args, "")
+    rr.script_setup(args, "rerun_example_rrt_star")
 
     max_step_size = args.max_step_size
     neighborhood_size = max_step_size * 1.5

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -156,10 +156,10 @@ def lint_line(
 
     if not is_in_docstring:
         if m := re.search(
-            r'(RecordingStreamBuilder::new|\.init|RecordingStream)\("(\w+)',
+            r'(RecordingStreamBuilder::new|\.init|RecordingStream)\("(\w*)',
             line,
         ) or re.search(
-            r'(rr.script_setup)\(args, "(\w+)',
+            r'(rr.script_setup)\(args, "(\w*)',
             line,
         ):
             app_id = m.group(2)
@@ -229,6 +229,7 @@ def test_lint_line() -> None:
         "template <typename... Args>",
         'protoc_prebuilt::init("22.0")',
         'rr.init("rerun_example_app")',
+        'rr.script_setup(args, "rerun_example_app")',
         """
         #[inline]
         fn foo(mut self) -> Self {
@@ -310,6 +311,7 @@ def test_lint_line() -> None:
         'RecordingStream("missing_prefix")',
         'rr.init("missing_prefix")',
         'rr.script_setup(args, "missing_prefix")',
+        'rr.script_setup(args, "")',
         "I accidentally wrote the same same word twice",
         "fn foo(mut self) -> Self {",
         "fn deref(&self) -> Self::Target {",


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5668

(we seed the RNG for examples that start with "rerun_example_")

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5676/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5676/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5676/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5676)
- [Docs preview](https://rerun.io/preview/59dd55d0123687ba0d419e658e6a89c3592ab9e9/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/59dd55d0123687ba0d419e658e6a89c3592ab9e9/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)