### PR TITLE
Use script_setup in blueprint_stocks example

### DIFF
--- a/examples/python/blueprint_stocks/main.py
+++ b/examples/python/blueprint_stocks/main.py
@@ -166,7 +166,7 @@ def main() -> None:
         else:
             blueprint = viewport
 
-    rr.init("rerun_example_blueprint_stocks", spawn=True, blueprint=blueprint)
+    rr.script_setup(args, "rerun_example_blueprint_stocks", blueprint=blueprint)
 
     # In a future blueprint release, this can move into the blueprint as well
     for symbol in symbols:


### PR DESCRIPTION
### What
Script flags weren't working as expected.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5677/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5677/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5677/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5677)
- [Docs preview](https://rerun.io/preview/39b2ddeadbb4b16e5438a2bbe10aec0058b3d9d6/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/39b2ddeadbb4b16e5438a2bbe10aec0058b3d9d6/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)