### PR TITLE
Introduce the concepts of "default" and "active" blueprint. Make reset return to default.

### DIFF
--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -92,8 +92,9 @@ impl crate::DataUi for EntityDb {
 
         if ctx.store_context.is_default_blueprint(self.store_id()) {
             ui.add_space(8.0);
-            ui.label("This is the default blueprint");
-        }
+            ui.label("This is the default blueprint")
+               .on_hover_text("When you reset the blueprint for the app, this blueprint will be used as the template.");
+        };
 
         if verbosity == UiVerbosity::Full {
             sibling_stores_ui(ctx, ui, self);

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -90,6 +90,11 @@ impl crate::DataUi for EntityDb {
             }
         }
 
+        if ctx.store_context.is_default_blueprint(self.store_id()) {
+            ui.add_space(8.0);
+            ui.label("This is the default blueprint");
+        }
+
         if verbosity == UiVerbosity::Full {
             sibling_stores_ui(ctx, ui, self);
         }

--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -668,7 +668,13 @@ pub fn entity_db_button_ui(
     }
 
     if response.clicked() {
-        // Open the recording
+        // When we click on a recording, we directly activate it. This is safe to do because
+        // it's non-destructive and recordings are immutable. Switching back is easy.
+        // We don't do the same thing for blueprints as swapping them can be much more disruptive.
+        // It is much less obvious how to undo a blueprint switch and what happened to your original
+        // blueprint.
+        // TODO(jleibs): We should still have an `Activate this Blueprint` button in the selection panel
+        // for the blueprint.
         if store_id.kind == re_log_types::StoreKind::Recording {
             ctx.command_sender
                 .send_system(SystemCommand::ActivateRecording(store_id.clone()));

--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -668,9 +668,11 @@ pub fn entity_db_button_ui(
     }
 
     if response.clicked() {
-        // Open the recording / switch to this blueprint…
-        ctx.command_sender
-            .send_system(SystemCommand::ActivateStore(store_id.clone()));
+        // Open the recording
+        if store_id.kind == re_log_types::StoreKind::Recording {
+            ctx.command_sender
+                .send_system(SystemCommand::ActivateRecording(store_id.clone()));
+        }
 
         // …and select the store in the selection panel.
         // Note that we must do it in this order, since the selection state is stored in the recording.

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -16,8 +16,8 @@ impl DataUi for LogMsg {
         match self {
             LogMsg::SetStoreInfo(msg) => msg.data_ui(ctx, ui, verbosity, query, store),
             LogMsg::ArrowMsg(_, msg) => msg.data_ui(ctx, ui, verbosity, query, store),
-            LogMsg::ActivateStore(store_id) => {
-                ui.label(format!("ActivateStore({store_id})"));
+            LogMsg::BlueprintReady(store_id, ready_opts) => {
+                ui.label(format!("BlueprintReady({store_id}, {ready_opts})"));
             }
         }
     }

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -1,4 +1,6 @@
-use re_log_types::{ArrowMsg, DataTable, LogMsg, SetStoreInfo, StoreInfo};
+use re_log_types::{
+    ArrowMsg, BlueprintActivationCommand, DataTable, LogMsg, SetStoreInfo, StoreInfo,
+};
 use re_viewer_context::{UiVerbosity, ViewerContext};
 
 use super::DataUi;
@@ -16,8 +18,14 @@ impl DataUi for LogMsg {
         match self {
             LogMsg::SetStoreInfo(msg) => msg.data_ui(ctx, ui, verbosity, query, store),
             LogMsg::ArrowMsg(_, msg) => msg.data_ui(ctx, ui, verbosity, query, store),
-            LogMsg::BlueprintReady(store_id, ready_opts) => {
-                ui.label(format!("BlueprintReady({store_id}, {ready_opts})"));
+            LogMsg::BlueprintActivationCommand(BlueprintActivationCommand {
+                blueprint_id,
+                make_active,
+                make_default,
+            }) => {
+                ui.label(format!(
+                    "BlueprintActivationCommand({blueprint_id}, make_active: {make_active}, make_default: {make_default})"
+                ));
             }
         }
     }

--- a/crates/re_entity_db/src/entity_db.rs
+++ b/crates/re_entity_db/src/entity_db.rs
@@ -564,7 +564,7 @@ impl EntityDb {
         messages
     }
 
-    /// Make a clone of a [`StoreDb`] with a different [`StoreId`].
+    /// Make a clone of this [`EntityDb`] with a different [`StoreId`].
     pub fn clone_with_new_id(&self, new_id: StoreId) -> Result<EntityDb, Error> {
         self.store().sort_indices_if_needed();
 

--- a/crates/re_entity_db/src/entity_db.rs
+++ b/crates/re_entity_db/src/entity_db.rs
@@ -544,17 +544,13 @@ impl EntityDb {
         // We generally use `to_messages` to export a blueprint via "save". In that
         // case, we want to make the blueprint active and default when it's reloaded.
         // TODO(jleibs): Coupling this with the stored file instead of injecting seems
-        // architecturallyt weird. Would be great if we didn't need this in `.rbl` files
+        // architecturally weird. Would be great if we didn't need this in `.rbl` files
         // at all.
         let blueprint_ready = if self.store_kind() == StoreKind::Blueprint {
-            let activate_cmd = re_log_types::BlueprintActivationCommand {
-                blueprint_id: self.store_id().clone(),
-                make_active: true,
-                make_default: true,
-            }
-            .into();
+            let activate_cmd =
+                re_log_types::BlueprintActivationCommand::make_active(self.store_id().clone());
 
-            itertools::Either::Left(std::iter::once(Ok(activate_cmd)))
+            itertools::Either::Left(std::iter::once(Ok(activate_cmd.into())))
         } else {
             itertools::Either::Right(std::iter::empty())
         };

--- a/crates/re_entity_db/src/entity_db.rs
+++ b/crates/re_entity_db/src/entity_db.rs
@@ -540,12 +540,13 @@ impl EntityDb {
                 .map(|msg| LogMsg::ArrowMsg(self.store_id().clone(), msg))
         });
 
-        // Signal that the store is ready.
-        // Important for blueprints.
+        // If this is a blueprint, make sure to include the `BlueprintReady` message.
+        // We generally use `to_messages` to export a blueprint via "save". In that
+        // case, we want to make the blueprint active and default when it's reloaded.
+        // TODO(jleibs): Coupling this with the stored file instead of injecting seems
+        // architecturallyt weird. Would be great if we didn't need this in `.rbl` files
+        // at all.
         let blueprint_ready = if self.store_kind() == StoreKind::Blueprint {
-            // TODO(jleibs): Maybe make_active or make_default should be configurable.
-            // We generally use `to_messages` to export a blueprint via "save". In that
-            // case, we want to make the blueprint active and default when it's reloaded.
             let ready_msg = LogMsg::BlueprintReady(
                 self.store_id().clone(),
                 re_log_types::BlueprintReadyOpts {

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -205,6 +205,27 @@ impl std::fmt::Display for ApplicationId {
 
 // ----------------------------------------------------------------------------
 
+/// Options for configuring viewer behavior when a blueprint is ready.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)] // `PartialEq` used for tests in another crate
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct BlueprintReadyOpts {
+    /// Make this the active blueprint for the `app_id`.
+    pub make_active: bool,
+
+    /// Make this the default blueprint for the `app_id`.
+    pub make_default: bool,
+}
+
+impl std::fmt::Display for BlueprintReadyOpts {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "BlueprintReadyOpts {{ make_active: {}, make_default: {} }}",
+            self.make_active, self.make_default
+        )
+    }
+}
+
 /// The most general log message sent from the SDK to the server.
 #[must_use]
 #[derive(Clone, Debug, PartialEq)] // `PartialEq` used for tests in another crate
@@ -224,14 +245,14 @@ pub enum LogMsg {
     /// This is so that the viewer can wait with activating the blueprint until it is
     /// fully transmitted. Showing a half-transmitted blueprint can cause confusion,
     /// and also lead to problems with space-view heuristics.
-    ActivateStore(StoreId),
+    BlueprintReady(StoreId, BlueprintReadyOpts),
 }
 
 impl LogMsg {
     pub fn store_id(&self) -> &StoreId {
         match self {
             Self::SetStoreInfo(msg) => &msg.info.store_id,
-            Self::ArrowMsg(store_id, _) | Self::ActivateStore(store_id) => store_id,
+            Self::ArrowMsg(store_id, _) | Self::BlueprintReady(store_id, _) => store_id,
         }
     }
 
@@ -240,8 +261,8 @@ impl LogMsg {
             LogMsg::SetStoreInfo(store_info) => {
                 store_info.info.store_id = new_store_id;
             }
-            LogMsg::ArrowMsg(msg_store_id, _) | LogMsg::ActivateStore(msg_store_id) => {
-                *msg_store_id = new_store_id;
+            LogMsg::ArrowMsg(store_id, _) | LogMsg::BlueprintReady(store_id, _) => {
+                *store_id = new_store_id;
             }
         }
     }

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -26,7 +26,8 @@ mod spawn;
 pub use spawn::{spawn, SpawnError, SpawnOptions};
 
 pub use self::recording_stream::{
-    RecordingStream, RecordingStreamBuilder, RecordingStreamError, RecordingStreamResult,
+    forced_sink_path, RecordingStream, RecordingStreamBuilder, RecordingStreamError,
+    RecordingStreamResult,
 };
 
 pub use re_sdk_comms::{default_flush_timeout, default_server_addr};

--- a/crates/re_sdk/src/log_sink.rs
+++ b/crates/re_sdk/src/log_sink.rs
@@ -37,7 +37,7 @@ pub trait LogSink: Send + Sync + 'static {
 
     /// Send a blueprint directly to the log-sink.
     ///
-    /// This mirrors the behavior of [`RecordingStream::send_blueprint`].
+    /// This mirrors the behavior of [`crate::RecordingStream::send_blueprint`].
     fn send_blueprint(&self, blueprint: Vec<LogMsg>, activation_cmd: BlueprintActivationCommand) {
         let mut blueprint_id = None;
         for msg in blueprint {

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1554,7 +1554,7 @@ impl RecordingStream {
 
         // If a blueprint was provided, send it first.
         if let Some((blueprint, ready_opts)) = blueprint {
-            Self::send_blueprint(blueprint, ready_opts, &sink);
+            Self::send_blueprint_to_sink(blueprint, ready_opts, &sink);
         }
 
         self.set_sink(Box::new(sink));
@@ -1669,7 +1669,7 @@ impl RecordingStream {
 
         // If a blueprint was provided, store it first.
         if let Some((blueprint, ready_opts)) = blueprint {
-            Self::send_blueprint(blueprint, ready_opts, &sink);
+            Self::send_blueprint_to_sink(blueprint, ready_opts, &sink);
         }
 
         self.set_sink(Box::new(sink));
@@ -1719,7 +1719,7 @@ impl RecordingStream {
 
         // If a blueprint was provided, write it first.
         if let Some((blueprint, ready_opts)) = blueprint {
-            Self::send_blueprint(blueprint, ready_opts, &sink);
+            Self::send_blueprint_to_sink(blueprint, ready_opts, &sink);
         }
 
         self.set_sink(Box::new(sink));
@@ -1745,8 +1745,8 @@ impl RecordingStream {
         }
     }
 
-    /// Send the blueprint to the sink, and then activate it.
-    pub fn send_blueprint(
+    /// Send the blueprint directly to the sink associated with this stream, and then activate it.
+    pub fn send_blueprint_to_sink(
         blueprint: Vec<LogMsg>,
         ready_opts: BlueprintReadyOpts,
         sink: &dyn crate::sink::LogSink,
@@ -1764,6 +1764,24 @@ impl RecordingStream {
             // We don't want to activate half-loaded blueprints, because that can be confusing,
             // and can also lead to problems with space-view heuristics.
             sink.send(LogMsg::BlueprintReady(store_id, ready_opts));
+        }
+    }
+
+    /// Send a blueprint through this recording stream
+    pub fn send_blueprint(&self, blueprint: Vec<LogMsg>, ready_opts: BlueprintReadyOpts) {
+        let mut store_id = None;
+        for msg in blueprint {
+            if store_id.is_none() {
+                store_id = Some(msg.store_id().clone());
+            }
+            self.record_msg(msg);
+        }
+        if let Some(store_id) = store_id {
+            // Let the viewer know that the blueprint has been fully received,
+            // and that it can now be activated.
+            // We don't want to activate half-loaded blueprints, because that can be confusing,
+            // and can also lead to problems with space-view heuristics.
+            self.record_msg(LogMsg::BlueprintReady(store_id, ready_opts));
         }
     }
 }

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -37,7 +37,7 @@ const ENV_FORCE_SAVE: &str = "_RERUN_TEST_FORCE_SAVE";
 /// Furthermore, [`RecordingStream::set_sink`] calls after this should not swap out to a new sink but re-use the existing one.
 /// Note that creating a new [`crate::sink::FileSink`] to the same file path (even temporarily) can cause
 /// a race between file creation (and thus clearing) and pending file writes.
-fn forced_sink_path() -> Option<String> {
+pub fn forced_sink_path() -> Option<String> {
     std::env::var(ENV_FORCE_SAVE).ok()
 }
 

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -249,7 +249,7 @@ impl CongestionManager {
         #[allow(clippy::match_same_arms)]
         match msg {
             // we don't want to drop any of these
-            LogMsg::SetStoreInfo(_) | LogMsg::BlueprintReady { .. } => true,
+            LogMsg::SetStoreInfo(_) | LogMsg::BlueprintActivationCommand { .. } => true,
 
             LogMsg::ArrowMsg(_, arrow_msg) => self.should_send_time_point(&arrow_msg.timepoint_max),
         }

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -249,7 +249,7 @@ impl CongestionManager {
         #[allow(clippy::match_same_arms)]
         match msg {
             // we don't want to drop any of these
-            LogMsg::SetStoreInfo(_) | LogMsg::ActivateStore(_) => true,
+            LogMsg::SetStoreInfo(_) | LogMsg::BlueprintReady { .. } => true,
 
             LogMsg::ArrowMsg(_, arrow_msg) => self.should_send_time_point(&arrow_msg.timepoint_max),
         }

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -554,6 +554,7 @@ mod tests {
                 blueprint: &blueprint,
                 recording: &recording,
                 bundle: &Default::default(),
+                default_blueprint: None,
             };
 
             let mut query_result = contents.execute_query(&ctx, &visualizable_entities);
@@ -597,6 +598,7 @@ mod tests {
                 blueprint: &blueprint,
                 recording: &recording,
                 bundle: &Default::default(),
+                default_blueprint: None,
             };
 
             let mut query_result = contents.execute_query(&ctx, &visualizable_entities);
@@ -646,6 +648,7 @@ mod tests {
                 blueprint: &blueprint,
                 recording: &recording,
                 bundle: &Default::default(),
+                default_blueprint: None,
             };
 
             let mut query_result = contents.execute_query(&ctx, &visualizable_entities);
@@ -918,6 +921,7 @@ mod tests {
                 blueprint: &blueprint,
                 recording: &recording,
                 bundle: &Default::default(),
+                default_blueprint: None,
             };
             let mut query_result = space_view
                 .contents

--- a/crates/re_space_view/src/space_view_contents.rs
+++ b/crates/re_space_view/src/space_view_contents.rs
@@ -645,6 +645,7 @@ mod tests {
             blueprint: &blueprint,
             recording: &recording,
             bundle: &Default::default(),
+            default_blueprint: None,
         };
 
         struct Scenario {

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -25,6 +25,7 @@ pub enum UICommand {
     OpenRerunDiscord,
 
     ResetViewer,
+    ClearAndGenerateBlueprint,
 
     #[cfg(not(target_arch = "wasm32"))]
     OpenProfiler,
@@ -120,6 +121,12 @@ impl UICommand {
                 "Reset Viewer",
                 "Reset the Viewer to how it looked the first time you ran it, forgetting all stored blueprints and UI state",
             ),
+
+            Self::ClearAndGenerateBlueprint => (
+                "Clear and generate new blueprint",
+                "Clear the current blueprint and generate a new one based on heuristics."
+            ),
+
 
             #[cfg(not(target_arch = "wasm32"))]
             Self::OpenProfiler => (
@@ -262,6 +269,8 @@ impl UICommand {
             Self::Quit => Some(cmd(Key::Q)),
 
             Self::ResetViewer => Some(ctrl_shift(Key::R)),
+            Self::ClearAndGenerateBlueprint => None,
+
             #[cfg(not(target_arch = "wasm32"))]
             Self::OpenProfiler => Some(ctrl_shift(Key::P)),
             Self::ToggleMemoryPanel => Some(ctrl_shift(Key::M)),

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -978,9 +978,11 @@ impl App {
                     // Andled by EntityDb::add
                 }
 
-                LogMsg::BlueprintReady(store_id, ready_opts) => match store_id.kind {
+                LogMsg::BlueprintActivationCommand(cmd) => match store_id.kind {
                     StoreKind::Recording => {
-                        re_log::debug!("Unexpected `BlueprintReady` message for {store_id}");
+                        re_log::debug!(
+                            "Unexpected `BlueprintActivationCommand` message for {store_id}"
+                        );
                     }
                     StoreKind::Blueprint => {
                         if let Some(info) = entity_db.store_info() {
@@ -988,10 +990,10 @@ impl App {
                                 "Activating blueprint that was loaded from {channel_source}"
                             );
                             let app_id = info.application_id.clone();
-                            if ready_opts.make_default {
+                            if cmd.make_default {
                                 store_hub.set_default_blueprint_for_app_id(store_id, &app_id);
                             }
-                            if ready_opts.make_active {
+                            if cmd.make_active {
                                 store_hub
                                     .make_blueprint_active_for_app_id(store_id, &app_id)
                                     .unwrap_or_else(|err| {

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -372,10 +372,17 @@ impl App {
             }
 
             SystemCommand::ResetViewer => self.reset(store_hub, egui_ctx),
+            SystemCommand::ClearAndGenerateBlueprint => {
+                re_log::debug!("Clear and generate new blueprint");
+                // By clearing the default blueprint and the active blueprint
+                // it will be re-generated based on the default auto behavior.
+                store_hub.clear_default_blueprint();
+                store_hub.clear_active_blueprint();
+            }
             SystemCommand::ResetBlueprint => {
-                // By clearing the blueprint it will be re-populated with the defaults
+                // By clearing the blueprint the default blueprint will be restored
                 // at the beginning of the next frame.
-                re_log::debug!("Reset blueprint");
+                re_log::debug!("Reset blueprint to default");
                 store_hub.clear_active_blueprint();
                 egui_ctx.request_repaint(); // Many changes take a frame delay to show up.
             }
@@ -517,6 +524,10 @@ impl App {
             }
 
             UICommand::ResetViewer => self.command_sender.send_system(SystemCommand::ResetViewer),
+            UICommand::ClearAndGenerateBlueprint => {
+                self.command_sender
+                    .send_system(SystemCommand::ClearAndGenerateBlueprint);
+            }
 
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::OpenProfiler => {

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -967,25 +967,25 @@ impl App {
                     // Andled by EntityDb::add
                 }
 
-                LogMsg::ActivateStore(store_id) => {
-                    match store_id.kind {
-                        StoreKind::Recording => {
-                            re_log::debug!("Opening a new recording: {store_id}");
-                            store_hub.set_active_recording_id(store_id.clone());
-                        }
-                        StoreKind::Blueprint => {
-                            if let Some(info) = entity_db.store_info() {
-                                re_log::debug!(
-                                    "Activating blueprint that was loaded from {channel_source}"
-                                );
-                                let app_id = info.application_id.clone();
-                                store_hub.set_blueprint_for_app_id(store_id.clone(), app_id);
-                            } else {
-                                re_log::warn!("Got ActivateStore message without first receiving a SetStoreInfo");
-                            }
+                LogMsg::ActivateStore(store_id) => match store_id.kind {
+                    StoreKind::Recording => {
+                        re_log::debug!("Opening a new recording: {store_id}");
+                        store_hub.set_active_recording_id(store_id.clone());
+                    }
+                    StoreKind::Blueprint => {
+                        if let Some(info) = entity_db.store_info() {
+                            re_log::debug!(
+                                "Activating blueprint that was loaded from {channel_source}"
+                            );
+                            let app_id = info.application_id.clone();
+                            store_hub.set_default_blueprint_for_app_id(store_id, &app_id);
+                        } else {
+                            re_log::warn!(
+                                "Got ActivateStore message without first receiving a SetStoreInfo"
+                            );
                         }
                     }
-                }
+                },
             }
 
             // Do analytics after ingesting the new message,

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -336,8 +336,8 @@ impl App {
         egui_ctx: &egui::Context,
     ) {
         match cmd {
-            SystemCommand::ActivateStore(store_id) => {
-                store_hub.activate_store(store_id);
+            SystemCommand::ActivateRecording(store_id) => {
+                store_hub.activate_recording(store_id);
             }
             SystemCommand::CloseStore(store_id) => {
                 store_hub.remove(&store_id);

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -967,10 +967,9 @@ impl App {
                     // Andled by EntityDb::add
                 }
 
-                LogMsg::ActivateStore(store_id) => match store_id.kind {
+                LogMsg::BlueprintReady(store_id, ready_opts) => match store_id.kind {
                     StoreKind::Recording => {
-                        re_log::debug!("Opening a new recording: {store_id}");
-                        store_hub.set_active_recording_id(store_id.clone());
+                        re_log::debug!("Unexpected `BlueprintReady` message for {store_id}");
                     }
                     StoreKind::Blueprint => {
                         if let Some(info) = entity_db.store_info() {
@@ -978,7 +977,16 @@ impl App {
                                 "Activating blueprint that was loaded from {channel_source}"
                             );
                             let app_id = info.application_id.clone();
-                            store_hub.set_default_blueprint_for_app_id(store_id, &app_id);
+                            if ready_opts.make_default {
+                                store_hub.set_default_blueprint_for_app_id(store_id, &app_id);
+                            }
+                            if ready_opts.make_active {
+                                store_hub
+                                    .make_blueprint_active_for_app_id(store_id, &app_id)
+                                    .unwrap_or_else(|err| {
+                                        re_log::warn!("Failed to make blueprint active: {err}");
+                                    });
+                            }
                         } else {
                             re_log::warn!(
                                 "Got ActivateStore message without first receiving a SetStoreInfo"

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -296,6 +296,13 @@ impl StoreHub {
         }
     }
 
+    /// Clear the current default blueprint
+    pub fn clear_default_blueprint(&mut self) {
+        if let Some(app_id) = &self.active_application_id {
+            self.default_blueprint_by_app_id.remove(app_id);
+        }
+    }
+
     /// Forgets all blueprints
     pub fn clear_all_blueprints(&mut self) {
         for (_app_id, blueprint_id) in self

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -242,7 +242,7 @@ impl StoreHub {
     ///
     /// We never activate a blueprint directly. Instead, we clone it and activate the clone.
     //TODO(jleibs): In the future this can probably be handled with snapshots instead.
-    fn make_blueprint_active_for_app_id(
+    pub fn make_blueprint_active_for_app_id(
         &mut self,
         blueprint_id: &StoreId,
         app_id: &ApplicationId,

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -253,24 +253,13 @@ impl StoreHub {
             "Cloning {blueprint_id} as {new_id} the active blueprint for {app_id} to {blueprint_id}"
         );
 
-        // Create the cloned blueprint
         let blueprint = self
             .store_bundle
             .get(blueprint_id)
             .context("missing blueprint")?;
-        let info = blueprint.store_info().context("missing info")?;
 
-        let mut new_info = info.clone();
-        new_info.store_id = new_id.clone();
+        let new_blueprint = blueprint.clone_with_new_id(new_id.clone())?;
 
-        blueprint.store().sort_indices_if_needed();
-
-        let mut new_blueprint =
-            EntityDb::from_info_and_rows(new_info, blueprint.store().to_rows()?)?;
-        // Also copy the data source
-        new_blueprint.data_source = blueprint.data_source.clone();
-
-        // Insert it into the store bundle and save it as active
         self.store_bundle.insert(new_blueprint);
 
         self.active_blueprint_by_app_id

--- a/crates/re_viewer/src/ui/blueprint_panel.rs
+++ b/crates/re_viewer/src/ui/blueprint_panel.rs
@@ -25,10 +25,16 @@ pub fn blueprint_panel_ui(
 }
 
 fn reset_blueprint_button_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
+    let hover_text = if ctx.store_context.default_blueprint.is_some() {
+        "Reset to the default Blueprint for this app"
+    } else {
+        "Re-populate Viewport with automatically chosen Space Views"
+    };
+
     if ctx
         .re_ui
         .small_icon_button(ui, &re_ui::icons::RESET)
-        .on_hover_text("Re-populate Viewport with automatically chosen Space Views")
+        .on_hover_text(hover_text)
         .clicked()
     {
         ctx.command_sender

--- a/crates/re_viewer/src/ui/blueprint_panel.rs
+++ b/crates/re_viewer/src/ui/blueprint_panel.rs
@@ -26,9 +26,9 @@ pub fn blueprint_panel_ui(
 
 fn reset_blueprint_button_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
     let hover_text = if ctx.store_context.default_blueprint.is_some() {
-        "Reset to the default Blueprint for this app"
+        "Reset to the default blueprint for this app"
     } else {
-        "Re-populate Viewport with automatically chosen Space Views"
+        "Re-populate viewport with automatically chosen space views"
     };
 
     if ctx

--- a/crates/re_viewer_context/src/command_sender.rs
+++ b/crates/re_viewer_context/src/command_sender.rs
@@ -20,6 +20,9 @@ pub enum SystemCommand {
     /// Reset the `Blueprint` to the default state
     ResetBlueprint,
 
+    /// Clear the blueprint and generate a new one
+    ClearAndGenerateBlueprint,
+
     /// If this is a recording, switch to it.
     ActivateRecording(StoreId),
 

--- a/crates/re_viewer_context/src/command_sender.rs
+++ b/crates/re_viewer_context/src/command_sender.rs
@@ -21,9 +21,7 @@ pub enum SystemCommand {
     ResetBlueprint,
 
     /// If this is a recording, switch to it.
-    /// If this is a blueprint, switch to the `AppId` of the blueprint,
-    /// and make this blueprint the active blueprint for that `AppId`.
-    ActivateStore(StoreId),
+    ActivateRecording(StoreId),
 
     /// Close a recording or blueprint (free its memory).
     CloseStore(StoreId),

--- a/crates/re_viewer_context/src/store_context.rs
+++ b/crates/re_viewer_context/src/store_context.rs
@@ -16,10 +16,17 @@ pub struct StoreContext<'a> {
 
     /// All the loaded recordings and blueprints.
     pub bundle: &'a StoreBundle,
+
+    /// The current default blueprint
+    pub default_blueprint: Option<&'a StoreId>,
 }
 
 impl StoreContext<'_> {
     pub fn is_active(&self, store_id: &StoreId) -> bool {
         self.recording.store_id() == store_id || self.blueprint.store_id() == store_id
+    }
+
+    pub fn is_default_blueprint(&self, store_id: &StoreId) -> bool {
+        self.default_blueprint == Some(store_id)
     }
 }

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -559,8 +559,12 @@ impl PrintCommand {
                     }
                 }
 
-                LogMsg::BlueprintReady(store_id, ready_opts) => {
-                    println!("BlueprintReady({store_id}, {ready_opts})");
+                LogMsg::BlueprintActivationCommand(re_log_types::BlueprintActivationCommand {
+                    blueprint_id,
+                    make_active,
+                    make_default,
+                }) => {
+                    println!("BlueprintActivationCommand({blueprint_id}, make_active: {make_active}, make_default: {make_default})");
                 }
             }
         }

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -559,8 +559,8 @@ impl PrintCommand {
                     }
                 }
 
-                LogMsg::ActivateStore(store_id) => {
-                    println!("ActivateStore({store_id})");
+                LogMsg::BlueprintReady(store_id, ready_opts) => {
+                    println!("BlueprintReady({store_id}, {ready_opts})");
                 }
             }
         }

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -408,7 +408,7 @@ fn rr_recording_stream_connect_impl(
     } else {
         None
     };
-    stream.connect_opts(tcp_addr, flush_timeout, None);
+    stream.connect_opts(tcp_addr, flush_timeout);
 
     Ok(())
 }

--- a/examples/python/arkit_scenes/main.py
+++ b/examples/python/arkit_scenes/main.py
@@ -353,7 +353,7 @@ def main() -> None:
         ),
     )
 
-    rr.script_setup(args, "rerun_example_arkit_scenes", blueprint=blueprint)
+    rr.script_setup(args, "rerun_example_arkit_scenes", default_blueprint=blueprint)
     recording_path = ensure_recording_available(args.video_id, args.include_highres)
     log_arkit(recording_path, args.include_highres)
 

--- a/examples/python/blueprint/main.py
+++ b/examples/python/blueprint/main.py
@@ -36,7 +36,7 @@ def main() -> None:
             auto_space_views=args.auto_space_views,
         )
 
-    rr.init("rerun_example_blueprint", spawn=True, blueprint=blueprint)
+    rr.init("rerun_example_blueprint", spawn=True, default_blueprint=blueprint)
 
     img = np.zeros([128, 128, 3], dtype="uint8")
     for i in range(8):

--- a/examples/python/blueprint_stocks/main.py
+++ b/examples/python/blueprint_stocks/main.py
@@ -166,7 +166,8 @@ def main() -> None:
         else:
             blueprint = viewport
 
-    rr.init("rerun_example_blueprint_stocks", spawn=True, blueprint=blueprint)
+    rr.init("rerun_example_blueprint_stocks", spawn=True)
+    rr.send_blueprint(blueprint, make_active=True)
 
     # In a future blueprint release, this can move into the blueprint as well
     for symbol in symbols:

--- a/examples/python/blueprint_stocks/main.py
+++ b/examples/python/blueprint_stocks/main.py
@@ -167,7 +167,7 @@ def main() -> None:
             blueprint = viewport
 
     rr.script_setup(args, "rerun_example_blueprint_stocks")
-    rr.send_blueprint(blueprint, make_active=True)
+    rr.send_blueprint(blueprint)
 
     # In a future blueprint release, this can move into the blueprint as well
     for symbol in symbols:

--- a/examples/python/controlnet/main.py
+++ b/examples/python/controlnet/main.py
@@ -135,7 +135,7 @@ def main() -> None:
     rr.script_setup(
         args,
         "rerun_example_controlnet",
-        blueprint=rrb.Horizontal(
+        default_blueprint=rrb.Horizontal(
             rrb.Grid(
                 rrb.Spatial2DView(origin="input/raw"),
                 rrb.Spatial2DView(origin="input/canny"),

--- a/examples/python/depth_guided_stable_diffusion/main.py
+++ b/examples/python/depth_guided_stable_diffusion/main.py
@@ -122,7 +122,7 @@ expense of slower inference. This parameter will be modulated by `strength`.
         # * inputs
         # * depth & initializations
         # * diffusion outputs
-        blueprint=rrb.Blueprint(
+        default_blueprint=rrb.Blueprint(
             rrb.Horizontal(
                 rrb.Vertical(
                     rrb.Tabs(

--- a/examples/python/face_tracking/main.py
+++ b/examples/python/face_tracking/main.py
@@ -435,7 +435,7 @@ def main() -> None:
     rr.script_setup(
         args,
         "rerun_example_mp_face_detection",
-        blueprint=rrb.Horizontal(
+        default_blueprint=rrb.Horizontal(
             rrb.Spatial3DView(origin="reconstruction"),
             rrb.Vertical(
                 rrb.Spatial2DView(origin="video"),

--- a/examples/python/gesture_detection/main.py
+++ b/examples/python/gesture_detection/main.py
@@ -299,7 +299,7 @@ def main() -> None:
     rr.script_setup(
         args,
         "rerun_example_mp_gesture_recognition",
-        blueprint=rrb.Horizontal(
+        default_blueprint=rrb.Horizontal(
             rrb.Spatial2DView(name="Input & Hand", contents=["media/**", "hand2d/**"]),
             rrb.Vertical(
                 rrb.Tabs(

--- a/examples/python/human_pose_tracking/main.py
+++ b/examples/python/human_pose_tracking/main.py
@@ -217,7 +217,7 @@ def main() -> None:
     rr.script_setup(
         args,
         "rerun_example_human_pose_tracking",
-        blueprint=rrb.Horizontal(
+        default_blueprint=rrb.Horizontal(
             rrb.Vertical(
                 rrb.Spatial2DView(origin="video", name="Result"),
                 rrb.Spatial3DView(origin="person", name="3D pose"),

--- a/examples/python/live_camera_edge_detection/main.py
+++ b/examples/python/live_camera_edge_detection/main.py
@@ -66,7 +66,7 @@ def main() -> None:
     rr.script_setup(
         args,
         "rerun_example_live_camera_edge_detection",
-        blueprint=rrb.Vertical(
+        default_blueprint=rrb.Vertical(
             rrb.Horizontal(
                 rrb.Spatial2DView(origin="/image/rgb", name="Video"),
                 rrb.Spatial2DView(origin="/image/gray", name="Video (Grayscale)"),

--- a/examples/python/llm_embedding_ner/main.py
+++ b/examples/python/llm_embedding_ner/main.py
@@ -169,7 +169,7 @@ def main() -> None:
     rr.script_setup(
         args,
         "rerun_example_llm_embedding_ner",
-        blueprint=rrb.Horizontal(
+        default_blueprint=rrb.Horizontal(
             rrb.Vertical(
                 rrb.TextDocumentView(origin="/text", name="Original Text"),
                 rrb.TextDocumentView(origin="/tokenized_text", name="Tokenized Text"),

--- a/examples/python/nuscenes/main.py
+++ b/examples/python/nuscenes/main.py
@@ -269,7 +269,7 @@ def main() -> None:
         row_shares=[3, 2],
     )
 
-    rr.script_setup(args, "rerun_example_nuscenes", blueprint=blueprint)
+    rr.script_setup(args, "rerun_example_nuscenes", default_blueprint=blueprint)
 
     log_nuscenes(nusc, args.scene_name, max_time_sec=args.seconds)
 

--- a/examples/python/objectron/main.py
+++ b/examples/python/objectron/main.py
@@ -218,7 +218,7 @@ def main() -> None:
     rr.script_setup(
         args,
         "rerun_example_objectron",
-        blueprint=rrb.Horizontal(
+        default_blueprint=rrb.Horizontal(
             rrb.Spatial3DView(origin="/world", name="World"),
             rrb.Spatial2DView(origin="/world/camera", name="Camera", contents=["+ $origin/**", "+ /world/**"]),
         ),

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -142,7 +142,7 @@ def main() -> None:
         rrb.TimePanel(expanded=False),
     )
 
-    rr.script_setup(args, "rerun_example_plot", blueprint=blueprint)
+    rr.script_setup(args, "rerun_example_plot", default_blueprint=blueprint)
 
     rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
     log_bar_chart()

--- a/examples/python/rgbd/main.py
+++ b/examples/python/rgbd/main.py
@@ -164,7 +164,7 @@ def main() -> None:
     rr.script_setup(
         args,
         "rerun_example_rgbd",
-        blueprint=rrb.Horizontal(
+        default_blueprint=rrb.Horizontal(
             rrb.Spatial3DView(name="3D", origin="world"),
             rrb.Vertical(
                 # Put the origin for both 2D spaces where the pinhole is logged. Doing so allows them to understand how they're connected to the 3D space.

--- a/examples/python/signed_distance_fields/main.py
+++ b/examples/python/signed_distance_fields/main.py
@@ -198,7 +198,7 @@ def main() -> None:
     rr.script_setup(
         args,
         "rerun_example_signed_distance_fields",
-        blueprint=rrb.Horizontal(
+        default_blueprint=rrb.Horizontal(
             rrb.Vertical(
                 rrb.Horizontal(
                     rrb.Spatial3DView(name="Input Mesh", origin="/world/mesh"),

--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -232,7 +232,7 @@ def main() -> None:
         row_shares=[3, 2],
     )
 
-    rr.script_setup(args, "rerun_example_structure_from_motion", blueprint=blueprint)
+    rr.script_setup(args, "rerun_example_structure_from_motion", default_blueprint=blueprint)
     dataset_path = get_downloaded_dataset_path(args.dataset)
     read_and_log_sparse_reconstruction(dataset_path, filter_output=not args.unfiltered, resize=args.resize)
     rr.script_teardown(args)

--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -86,6 +86,7 @@ SECTION_TABLE: Final[list[Section]] = [
             "connect",
             "disconnect",
             "save",
+            "send_blueprint",
             "serve",
             "spawn",
             "memory_recording",

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -318,8 +318,8 @@ def init(
         If `False`, errors are logged as warnings instead.
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
-        already has an active blueprint, this blueprint won't become active until the user
-        clicks the "reset blueprint" button. If you want to replace the active blueprint
+        already has an active blueprint, the new blueprint won't become active until the user
+        clicks the "reset blueprint" button. If you want to activate the new blueprint
         immediately, instead use the [`rerun.send_blueprint`][] API.
 
     """

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -319,7 +319,7 @@ def init(
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
         already has an active blueprint, this blueprint won't become active until the user
-        clicks the "reset blueprint" button.  If you want to replace the active blueprint
+        clicks the "reset blueprint" button. If you want to replace the active blueprint
         immediately, instead use the [`rerun.send_blueprint`][] API.
 
     """

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -248,7 +248,7 @@ def init(
     init_logging: bool = True,
     default_enabled: bool = True,
     strict: bool = False,
-    blueprint: BlueprintLike | None = None,
+    default_blueprint: BlueprintLike | None = None,
 ) -> None:
     """
     Initialize the Rerun SDK with a user-chosen application id (name).
@@ -316,8 +316,11 @@ def init(
     strict
         If `True`, an exceptions is raised on use error (wrong parameter types, etc.).
         If `False`, errors are logged as warnings instead.
-    blueprint
-        A blueprint to use for this application. If not provided, a new one will be created.
+    default_blueprint
+        Optionally set a default blueprint to use for this application. If the application
+        already has an active blueprint, this blueprint won't become active until the user
+        clicks the "reset blueprint" button.  If you want to replace the active blueprint
+        immediately, instead use the [`rerun.send_blueprint`][] API.
 
     """
 
@@ -348,7 +351,7 @@ def init(
     if spawn:
         from rerun.sinks import spawn as _spawn
 
-        _spawn(blueprint=blueprint)
+        _spawn(default_blueprint=default_blueprint)
 
 
 # TODO(#3793): defaulting recording_id to authkey should be opt-in

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -93,6 +93,7 @@ __all__ = [
     "set_time_nanos",
     "set_time_seconds",
     "set_time_sequence",
+    "send_blueprint",
     "spawn",
 ]
 
@@ -174,7 +175,7 @@ from .recording_stream import (
     set_thread_local_data_recording,
 )
 from .script_helpers import script_add_args, script_setup, script_teardown
-from .sinks import connect, disconnect, memory_recording, save, serve, spawn, stdout
+from .sinks import connect, disconnect, memory_recording, save, send_blueprint, serve, spawn, stdout
 from .time import (
     disable_timeline,
     reset_time,
@@ -222,7 +223,7 @@ def _init_recording_stream() -> None:
     from rerun.recording_stream import _patch as recording_stream_patch
 
     recording_stream_patch(
-        [connect, save, stdout, disconnect, memory_recording, serve, spawn]
+        [connect, save, stdout, disconnect, memory_recording, serve, spawn, send_blueprint]
         + [
             set_time_sequence,
             set_time_seconds,

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -90,7 +90,7 @@ def script_setup(
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
         already has an active blueprint, this blueprint won't become active until the user
-        clicks the "reset blueprint" button.  If you want to replace the active blueprint
+        clicks the "reset blueprint" button. If you want to replace the active blueprint
         immediately, instead use the [`rerun.send_blueprint`][] API.
 
     """

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -65,7 +65,7 @@ def script_setup(
     args: Namespace,
     application_id: str,
     recording_id: str | UUID | None = None,
-    blueprint: rr.blueprint.BlueprintLike | None = None,
+    default_blueprint: rr.blueprint.BlueprintLike | None = None,
 ) -> RecordingStream:
     """
     Run common Rerun script setup actions. Connect to the viewer if necessary.
@@ -87,8 +87,11 @@ def script_setup(
         processes to log to the same Rerun instance (and be part of the same recording),
         you will need to manually assign them all the same recording_id.
         Any random UUIDv4 will work, or copy the recording id for the parent process.
-    blueprint : Optional[rr.blueprint.BlueprintLike]
-        An optional blueprint to use for the viewer.
+    default_blueprint
+        Optionally set a default blueprint to use for this application. If the application
+        already has an active blueprint, this blueprint won't become active until the user
+        clicks the "reset blueprint" button.  If you want to replace the active blueprint
+        immediately, instead use the [`rerun.send_blueprint`][] API.
 
     """
     rr.init(
@@ -102,18 +105,18 @@ def script_setup(
 
     # NOTE: mypy thinks these methods don't exist because they're monkey-patched.
     if args.stdout:
-        rec.stdout(blueprint=blueprint)  # type: ignore[attr-defined]
+        rec.stdout(default_blueprint=default_blueprint)  # type: ignore[attr-defined]
     elif args.serve:
-        rec.serve(blueprint=blueprint)  # type: ignore[attr-defined]
+        rec.serve(default_blueprint=default_blueprint)  # type: ignore[attr-defined]
     elif args.connect:
         # Send logging data to separate `rerun` process.
         # You can omit the argument to connect to the default address,
         # which is `127.0.0.1:9876`.
-        rec.connect(args.addr, blueprint=blueprint)  # type: ignore[attr-defined]
+        rec.connect(args.addr, default_blueprint=default_blueprint)  # type: ignore[attr-defined]
     elif args.save is not None:
-        rec.save(args.save, blueprint=blueprint)  # type: ignore[attr-defined]
+        rec.save(args.save, default_blueprint=default_blueprint)  # type: ignore[attr-defined]
     elif not args.headless:
-        rec.spawn(blueprint=blueprint)  # type: ignore[attr-defined]
+        rec.spawn(default_blueprint=default_blueprint)  # type: ignore[attr-defined]
 
     return rec
 

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -89,8 +89,8 @@ def script_setup(
         Any random UUIDv4 will work, or copy the recording id for the parent process.
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
-        already has an active blueprint, this blueprint won't become active until the user
-        clicks the "reset blueprint" button. If you want to replace the active blueprint
+        already has an active blueprint, the new blueprint won't become active until the user
+        clicks the "reset blueprint" button. If you want to activate the new blueprint
         immediately, instead use the [`rerun.send_blueprint`][] API.
 
     """

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -262,6 +262,40 @@ def serve(
     )
 
 
+def send_blueprint(
+    blueprint: BlueprintLike,
+    *,
+    make_active: bool = False,
+    make_default: bool = True,
+    recording: RecordingStream | None = None,
+) -> None:
+    """
+    Create a blueprint from a `BlueprintLike` and send it to the `RecordingStream`.
+
+    Parameters
+    ----------
+    blueprint:
+        A blueprint object to send to the viewer.
+    make_active:
+        Make this blueprint the active blueprint for the application.
+    make_default:
+        Make this blueprint the default blueprint for the application.
+    recording:
+        Specifies the [`rerun.RecordingStream`][] to use.
+        If left unspecified, defaults to the current active data recording, if there is one.
+        See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
+
+    """
+    recording = RecordingStream.to_native(recording)
+
+    application_id = get_application_id(recording=recording)
+    if application_id is None:
+        raise ValueError("No application id found. You must call rerun.init before sending a blueprint.")
+    blueprint_storage = create_in_memory_blueprint(application_id=application_id, blueprint=blueprint).storage
+
+    bindings.send_blueprint(blueprint_storage, make_active, make_default, recording=recording)
+
+
 # TODO(#4019): application-level handshake
 def _check_for_existing_viewer(port: int) -> bool:
     try:

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -37,8 +37,8 @@ def connect(
         and can cause a call to `flush` to block indefinitely.
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
-        already has an active blueprint, this blueprint won't become active until the user
-        clicks the "reset blueprint" button. If you want to replace the active blueprint
+        already has an active blueprint, the new blueprint won't become active until the user
+        clicks the "reset blueprint" button. If you want to activate the new blueprint
         immediately, instead use the [`rerun.send_blueprint`][] API.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
@@ -88,8 +88,8 @@ def save(
         The path to save the data to.
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
-        already has an active blueprint, this blueprint won't become active until the user
-        clicks the "reset blueprint" button. If you want to replace the active blueprint
+        already has an active blueprint, the new blueprint won't become active until the user
+        clicks the "reset blueprint" button. If you want to activate the new blueprint
         immediately, instead use the [`rerun.send_blueprint`][] API.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
@@ -135,8 +135,8 @@ def stdout(default_blueprint: BlueprintLike | None = None, recording: RecordingS
     ----------
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
-        already has an active blueprint, this blueprint won't become active until the user
-        clicks the "reset blueprint" button. If you want to replace the active blueprint
+        already has an active blueprint, the new blueprint won't become active until the user
+        clicks the "reset blueprint" button. If you want to activate the new blueprint
         immediately, instead use the [`rerun.send_blueprint`][] API.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
@@ -242,8 +242,8 @@ def serve(
         The port to serve the WebSocket server on (defaults to 9877)
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
-        already has an active blueprint, this blueprint won't become active until the user
-        clicks the "reset blueprint" button. If you want to replace the active blueprint
+        already has an active blueprint, the new blueprint won't become active until the user
+        clicks the "reset blueprint" button. If you want to activate the new blueprint
         immediately, instead use the [`rerun.send_blueprint`][] API.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
@@ -298,20 +298,28 @@ def send_blueprint(
     blueprint:
         A blueprint object to send to the viewer.
     make_active:
-        Make this blueprint the active blueprint for the application.
+        Immediately make this the active blueprint for the associated `app_id`.
+        Note that setting this to `false` does not mean the blueprint may not still end
+        up becoming active. In particular, if `make_default` is true and there is no other
+        currently active blueprint.
     make_default:
-        Make this blueprint the default blueprint for the application.
+        Make this the default blueprint for the `app_id`.
+        The default blueprint will be used as the template when the user resets the
+        blueprint for the app. It will also become the active blueprint if no other
+        blueprint is currently active.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
         If left unspecified, defaults to the current active data recording, if there is one.
         See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
 
     """
-    recording = RecordingStream.to_native(recording)
-
     application_id = get_application_id(recording=recording)
+
     if application_id is None:
         raise ValueError("No application id found. You must call rerun.init before sending a blueprint.")
+
+    recording = RecordingStream.to_native(recording)
+
     blueprint_storage = create_in_memory_blueprint(application_id=application_id, blueprint=blueprint).storage
 
     bindings.send_blueprint(blueprint_storage, make_active, make_default, recording=recording)
@@ -365,8 +373,8 @@ def spawn(
         See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
-        already has an active blueprint, this blueprint won't become active until the user
-        clicks the "reset blueprint" button. If you want to replace the active blueprint
+        already has an active blueprint, the new blueprint won't become active until the user
+        clicks the "reset blueprint" button. If you want to activate the new blueprint
         immediately, instead use the [`rerun.send_blueprint`][] API.
 
     """

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -286,7 +286,7 @@ def serve(
 def send_blueprint(
     blueprint: BlueprintLike,
     *,
-    make_active: bool = False,
+    make_active: bool = True,
     make_default: bool = True,
     recording: RecordingStream | None = None,
 ) -> None:

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -17,7 +17,7 @@ def connect(
     addr: str | None = None,
     *,
     flush_timeout_sec: float | None = 2.0,
-    blueprint: BlueprintLike | None = None,
+    default_blueprint: BlueprintLike | None = None,
     recording: RecordingStream | None = None,
 ) -> None:
     """
@@ -35,8 +35,11 @@ def connect(
         The minimum time the SDK will wait during a flush before potentially
         dropping data if progress is not being made. Passing `None` indicates no timeout,
         and can cause a call to `flush` to block indefinitely.
-    blueprint:
-        An optional blueprint to configure the UI.
+    default_blueprint
+        Optionally set a default blueprint to use for this application. If the application
+        already has an active blueprint, this blueprint won't become active until the user
+        clicks the "reset blueprint" button.  If you want to replace the active blueprint
+        immediately, instead use the [`rerun.send_blueprint`][] API.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
         If left unspecified, defaults to the current active data recording, if there is one.
@@ -56,19 +59,23 @@ def connect(
 
     # If a blueprint is provided, we need to create a blueprint storage object
     blueprint_storage = None
-    if blueprint is not None:
-        blueprint_storage = create_in_memory_blueprint(application_id=application_id, blueprint=blueprint).storage
+    if default_blueprint is not None:
+        blueprint_storage = create_in_memory_blueprint(
+            application_id=application_id, blueprint=default_blueprint
+        ).storage
 
     recording = RecordingStream.to_native(recording)
 
-    bindings.connect(addr=addr, flush_timeout_sec=flush_timeout_sec, blueprint=blueprint_storage, recording=recording)
+    bindings.connect(
+        addr=addr, flush_timeout_sec=flush_timeout_sec, default_blueprint=blueprint_storage, recording=recording
+    )
 
 
 _connect = connect  # we need this because Python scoping is horrible
 
 
 def save(
-    path: str | pathlib.Path, blueprint: BlueprintLike | None = None, recording: RecordingStream | None = None
+    path: str | pathlib.Path, default_blueprint: BlueprintLike | None = None, recording: RecordingStream | None = None
 ) -> None:
     """
     Stream all log-data to a file.
@@ -79,9 +86,11 @@ def save(
     ----------
     path:
         The path to save the data to.
-    blueprint:
-        An optional blueprint to configure the UI.
-        This will be written first to the .rrd file, before appending the recording data.
+    default_blueprint
+        Optionally set a default blueprint to use for this application. If the application
+        already has an active blueprint, this blueprint won't become active until the user
+        clicks the "reset blueprint" button.  If you want to replace the active blueprint
+        immediately, instead use the [`rerun.send_blueprint`][] API.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
         If left unspecified, defaults to the current active data recording, if there is one.
@@ -101,15 +110,17 @@ def save(
 
     # If a blueprint is provided, we need to create a blueprint storage object
     blueprint_storage = None
-    if blueprint is not None:
-        blueprint_storage = create_in_memory_blueprint(application_id=application_id, blueprint=blueprint).storage
+    if default_blueprint is not None:
+        blueprint_storage = create_in_memory_blueprint(
+            application_id=application_id, blueprint=default_blueprint
+        ).storage
 
     recording = RecordingStream.to_native(recording)
 
-    bindings.save(path=str(path), blueprint=blueprint_storage, recording=recording)
+    bindings.save(path=str(path), default_blueprint=blueprint_storage, recording=recording)
 
 
-def stdout(blueprint: BlueprintLike | None = None, recording: RecordingStream | None = None) -> None:
+def stdout(default_blueprint: BlueprintLike | None = None, recording: RecordingStream | None = None) -> None:
     """
     Stream all log-data to stdout.
 
@@ -122,8 +133,11 @@ def stdout(blueprint: BlueprintLike | None = None, recording: RecordingStream | 
 
     Parameters
     ----------
-    blueprint:
-        An optional blueprint to configure the UI.
+    default_blueprint
+        Optionally set a default blueprint to use for this application. If the application
+        already has an active blueprint, this blueprint won't become active until the user
+        clicks the "reset blueprint" button.  If you want to replace the active blueprint
+        immediately, instead use the [`rerun.send_blueprint`][] API.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
         If left unspecified, defaults to the current active data recording, if there is one.
@@ -143,11 +157,13 @@ def stdout(blueprint: BlueprintLike | None = None, recording: RecordingStream | 
 
     # If a blueprint is provided, we need to create a blueprint storage object
     blueprint_storage = None
-    if blueprint is not None:
-        blueprint_storage = create_in_memory_blueprint(application_id=application_id, blueprint=blueprint).storage
+    if default_blueprint is not None:
+        blueprint_storage = create_in_memory_blueprint(
+            application_id=application_id, blueprint=default_blueprint
+        ).storage
 
     recording = RecordingStream.to_native(recording)
-    bindings.stdout(blueprint=blueprint_storage, recording=recording)
+    bindings.stdout(default_blueprint=blueprint_storage, recording=recording)
 
 
 def disconnect(recording: RecordingStream | None = None) -> None:
@@ -200,7 +216,7 @@ def serve(
     open_browser: bool = True,
     web_port: int | None = None,
     ws_port: int | None = None,
-    blueprint: BlueprintLike | None = None,
+    default_blueprint: BlueprintLike | None = None,
     recording: RecordingStream | None = None,
     server_memory_limit: str = "25%",
 ) -> None:
@@ -224,8 +240,11 @@ def serve(
         The port to serve the web viewer on (defaults to 9090).
     ws_port:
         The port to serve the WebSocket server on (defaults to 9877)
-    blueprint:
-        An optional blueprint to configure the UI.
+    default_blueprint
+        Optionally set a default blueprint to use for this application. If the application
+        already has an active blueprint, this blueprint won't become active until the user
+        clicks the "reset blueprint" button.  If you want to replace the active blueprint
+        immediately, instead use the [`rerun.send_blueprint`][] API.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
         If left unspecified, defaults to the current active data recording, if there is one.
@@ -248,8 +267,10 @@ def serve(
 
     # If a blueprint is provided, we need to create a blueprint storage object
     blueprint_storage = None
-    if blueprint is not None:
-        blueprint_storage = create_in_memory_blueprint(application_id=application_id, blueprint=blueprint).storage
+    if default_blueprint is not None:
+        blueprint_storage = create_in_memory_blueprint(
+            application_id=application_id, blueprint=default_blueprint
+        ).storage
 
     recording = RecordingStream.to_native(recording)
     bindings.serve(
@@ -257,7 +278,7 @@ def serve(
         web_port,
         ws_port,
         server_memory_limit=server_memory_limit,
-        blueprint=blueprint_storage,
+        default_blueprint=blueprint_storage,
         recording=recording,
     )
 
@@ -317,7 +338,7 @@ def spawn(
     port: int = 9876,
     connect: bool = True,
     memory_limit: str = "75%",
-    blueprint: BlueprintLike | None = None,
+    default_blueprint: BlueprintLike | None = None,
     recording: RecordingStream | None = None,
 ) -> None:
     """
@@ -342,8 +363,11 @@ def spawn(
         Specifies the [`rerun.RecordingStream`][] to use if `connect = True`.
         If left unspecified, defaults to the current active data recording, if there is one.
         See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
-    blueprint:
-        An optional blueprint to configure the UI.
+    default_blueprint
+        Optionally set a default blueprint to use for this application. If the application
+        already has an active blueprint, this blueprint won't become active until the user
+        clicks the "reset blueprint" button.  If you want to replace the active blueprint
+        immediately, instead use the [`rerun.send_blueprint`][] API.
 
     """
 
@@ -402,4 +426,4 @@ def spawn(
             sleep(0.1)
 
     if connect:
-        _connect(f"127.0.0.1:{port}", recording=recording, blueprint=blueprint)
+        _connect(f"127.0.0.1:{port}", recording=recording, default_blueprint=default_blueprint)

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -38,7 +38,7 @@ def connect(
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
         already has an active blueprint, this blueprint won't become active until the user
-        clicks the "reset blueprint" button.  If you want to replace the active blueprint
+        clicks the "reset blueprint" button. If you want to replace the active blueprint
         immediately, instead use the [`rerun.send_blueprint`][] API.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
@@ -89,7 +89,7 @@ def save(
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
         already has an active blueprint, this blueprint won't become active until the user
-        clicks the "reset blueprint" button.  If you want to replace the active blueprint
+        clicks the "reset blueprint" button. If you want to replace the active blueprint
         immediately, instead use the [`rerun.send_blueprint`][] API.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
@@ -136,7 +136,7 @@ def stdout(default_blueprint: BlueprintLike | None = None, recording: RecordingS
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
         already has an active blueprint, this blueprint won't become active until the user
-        clicks the "reset blueprint" button.  If you want to replace the active blueprint
+        clicks the "reset blueprint" button. If you want to replace the active blueprint
         immediately, instead use the [`rerun.send_blueprint`][] API.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
@@ -243,7 +243,7 @@ def serve(
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
         already has an active blueprint, this blueprint won't become active until the user
-        clicks the "reset blueprint" button.  If you want to replace the active blueprint
+        clicks the "reset blueprint" button. If you want to replace the active blueprint
         immediately, instead use the [`rerun.send_blueprint`][] API.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use.
@@ -366,7 +366,7 @@ def spawn(
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
         already has an active blueprint, this blueprint won't become active until the user
-        clicks the "reset blueprint" button.  If you want to replace the active blueprint
+        clicks the "reset blueprint" button. If you want to replace the active blueprint
         immediately, instead use the [`rerun.send_blueprint`][] API.
 
     """

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -555,6 +555,11 @@ fn connect(
         return Ok(());
     };
 
+    if rerun::forced_sink_path().is_some() {
+        re_log::debug!("Ignored call to `connect()` since _RERUN_TEST_FORCE_SAVE is set");
+        return Ok(());
+    }
+
     let addr = if let Some(addr) = addr {
         addr.parse()?
     } else {
@@ -594,6 +599,11 @@ fn save(
         return Ok(());
     };
 
+    if rerun::forced_sink_path().is_some() {
+        re_log::debug!("Ignored call to `save()` since _RERUN_TEST_FORCE_SAVE is set");
+        return Ok(());
+    }
+
     // The call to save may internally flush.
     // Release the GIL in case any flushing behavior needs to cleanup a python object.
     py.allow_threads(|| {
@@ -624,6 +634,11 @@ fn stdout(
     let Some(recording) = get_data_recording(recording) else {
         return Ok(());
     };
+
+    if rerun::forced_sink_path().is_some() {
+        re_log::debug!("Ignored call to `stdout()` since _RERUN_TEST_FORCE_SAVE is set");
+        return Ok(());
+    }
 
     // The call to stdout may internally flush.
     // Release the GIL in case any flushing behavior needs to cleanup a python object.
@@ -742,6 +757,11 @@ fn serve(
         let Some(recording) = get_data_recording(recording) else {
             return Ok(());
         };
+
+        if rerun::forced_sink_path().is_some() {
+            re_log::debug!("Ignored call to `serve()` since _RERUN_TEST_FORCE_SAVE is set");
+            return Ok(());
+        }
 
         let server_memory_limit = re_memory::MemoryLimit::parse(&server_memory_limit)
             .map_err(|err| PyRuntimeError::new_err(format!("Bad server_memory_limit: {err}:")))?;

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -747,7 +747,7 @@ fn serve(
 
     #[cfg(not(feature = "web_viewer"))]
     {
-        _ = blueprint;
+        _ = default_blueprint;
         _ = recording;
         _ = web_port;
         _ = ws_port;

--- a/tests/python/blueprint/main.py
+++ b/tests/python/blueprint/main.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     rr.init(
         "rerun_example_blueprint_test",
         spawn=True,
-        blueprint=blueprint,
+        default_blueprint=blueprint,
     )
 
     rng = default_rng(12345)

--- a/tests/python/release_checklist/check_context_menu_add_entity_to_new_space_view.py
+++ b/tests/python/release_checklist/check_context_menu_add_entity_to_new_space_view.py
@@ -58,7 +58,7 @@ def log_some_space_views() -> None:
 
 
 def run(args: Namespace) -> None:
-    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), blueprint=blueprint())
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), default_blueprint=blueprint())
 
     log_readme()
     log_some_space_views()

--- a/tests/python/release_checklist/check_context_menu_collapse_expand_all.py
+++ b/tests/python/release_checklist/check_context_menu_collapse_expand_all.py
@@ -51,7 +51,7 @@ def log_some_space_views() -> None:
 
 
 def run(args: Namespace) -> None:
-    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), blueprint=blueprint())
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), default_blueprint=blueprint())
 
     log_readme()
     log_some_space_views()

--- a/tests/python/release_checklist/check_context_menu_invalid_sub_container.py
+++ b/tests/python/release_checklist/check_context_menu_invalid_sub_container.py
@@ -46,7 +46,7 @@ def log_some_space_views() -> None:
 
 
 def run(args: Namespace) -> None:
-    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), blueprint=blueprint())
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), default_blueprint=blueprint())
 
     log_readme()
     log_some_space_views()

--- a/tests/python/release_checklist/check_context_menu_multi_selection.py
+++ b/tests/python/release_checklist/check_context_menu_multi_selection.py
@@ -83,7 +83,7 @@ def log_some_space_views() -> None:
 
 
 def run(args: Namespace) -> None:
-    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), blueprint=blueprint())
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), default_blueprint=blueprint())
 
     log_readme()
     log_some_space_views()

--- a/tests/python/release_checklist/check_context_menu_single_selection.py
+++ b/tests/python/release_checklist/check_context_menu_single_selection.py
@@ -103,7 +103,7 @@ def log_some_space_views() -> None:
 
 
 def run(args: Namespace) -> None:
-    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), blueprint=blueprint())
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), default_blueprint=blueprint())
 
     log_readme()
     log_some_space_views()

--- a/tests/python/release_checklist/check_context_menu_single_selection_blueprint_tree.py
+++ b/tests/python/release_checklist/check_context_menu_single_selection_blueprint_tree.py
@@ -82,7 +82,7 @@ def log_some_space_views() -> None:
 
 
 def run(args: Namespace) -> None:
-    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), blueprint=blueprint())
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), default_blueprint=blueprint())
 
     log_readme()
     log_some_space_views()

--- a/tests/python/release_checklist/check_context_menu_suggested_origin.py
+++ b/tests/python/release_checklist/check_context_menu_suggested_origin.py
@@ -78,7 +78,7 @@ def log_some_space_views() -> None:
 
 
 def run(args: Namespace) -> None:
-    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), blueprint=blueprint())
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), default_blueprint=blueprint())
 
     log_readme()
     log_some_space_views()

--- a/tests/python/release_checklist/check_focus.py
+++ b/tests/python/release_checklist/check_focus.py
@@ -42,7 +42,7 @@ def log_some_space_views() -> None:
 
 
 def run(args: Namespace) -> None:
-    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), blueprint=blueprint())
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), default_blueprint=blueprint())
 
     log_readme()
     log_some_space_views()


### PR DESCRIPTION
### What
 - Partial implementation of:
   - https://github.com/rerun-io/rerun/issues/5583
   - https://github.com/rerun-io/rerun/issues/5298
 - This does not yet fully track a blueprint-per-recording-id, but playing with this I think doing so might still be worth exploring.
 - Introduces a new "default blueprint" per app-id in the store-hub.
 - Changes the ActivateStore -> BlueprintReady with a mechanism to specify `make_default` and `make_active`
 - Introduces new python API: `send_blueprint`

Important aspect of implementation:
 - When you click the reset button we now clone the default blueprint into a new blueprint. This way we don't modify the blueprint that is the target for the reset.

Future work we need to build on top of this (Feel free to push these improvements here, or we can push to a future PR).
 - [x] Biggest issue. This currently breaks File->Open / Drag-and-drop since those now **just** set the default.
   - Proposal: we should go ahead add the "force activate" bool into the `ActivateStore` message.  We should set this bool in the message when we inject it into "File->Save" pathway.  That way if you manually save a blueprint, it will always load when you open it. But if you are opening an RRD file that happens to have a blueprint it will still just use the "default" behavior.
 - [x] Should introduce SystemCommand & UI  to clear the default blueprint so resetting goes back to heuristics.

Future work:
 - Should introduce SystemCommand & UI to set a different blueprint as the default.
   - https://github.com/rerun-io/rerun/issues/5691
 - Notification to user when default blueprint changes.  Probably better as follow-on PR
   - https://github.com/rerun-io/rerun/issues/5692
 - **Make state observable** by supporting a selection of the AppId. Probably better as follow-on PR:
   - https://github.com/rerun-io/rerun/issues/5672

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5678/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5678/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5678/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5678)
- [Docs preview](https://rerun.io/preview/78935399ef8b4289c5ba6535f01e988e0cb26e70/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/78935399ef8b4289c5ba6535f01e988e0cb26e70/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)