### PR TITLE
New data APIs 7: `RangeZip` iterator machinery

### DIFF
--- a/crates/re_query2/Cargo.toml
+++ b/crates/re_query2/Cargo.toml
@@ -73,6 +73,11 @@ name = "clamped_zip"
 required-features = ["codegen"]
 
 
+[[bin]]
+name = "range_zip"
+required-features = ["codegen"]
+
+
 [[bench]]
 name = "latest_at"
 harness = false

--- a/crates/re_query2/src/bin/range_zip.rs
+++ b/crates/re_query2/src/bin/range_zip.rs
@@ -1,0 +1,503 @@
+//! CLI tool to generate `RangeZip` implementations of different arities.
+
+#![allow(clippy::tuple_array_conversions)] // false positive
+
+use itertools::{izip, Itertools};
+
+struct Params {
+    num_required: usize,
+    num_optional: usize,
+}
+
+impl Params {
+    fn to_num_required(&self) -> String {
+        self.num_required.to_string()
+    }
+
+    fn to_num_optional(&self) -> String {
+        self.num_optional.to_string()
+    }
+
+    /// `1x3`, `2x2`…
+    fn to_suffix(&self) -> String {
+        format!("{}x{}", self.to_num_required(), self.to_num_optional())
+    }
+
+    /// `r0, r1, r2…`.
+    fn to_required_names(&self) -> Vec<String> {
+        (0..self.num_required)
+            .map(|n| format!("r{n}"))
+            .collect_vec()
+    }
+
+    /// `R0, R1, R2…`.
+    fn to_required_types(&self) -> Vec<String> {
+        self.to_required_names()
+            .into_iter()
+            .map(|s| s.to_uppercase())
+            .collect()
+    }
+
+    /// `r0: IR0, r1: IR1, r2: IR2…`.
+    fn to_required_params(&self) -> Vec<String> {
+        izip!(self.to_required_names(), self.to_required_types())
+            .map(|(n, t)| format!("{n}: I{t}"))
+            .collect()
+    }
+
+    /// `IR0: (Into)Iterator<Item = (Idx, R0)>, IR1: (Into)Iterator<Item = (Idx, R1)>…`
+    fn to_required_clauses(&self, into: bool) -> Vec<String> {
+        let trait_name = if into { "IntoIterator" } else { "Iterator" };
+        self.to_required_types()
+            .into_iter()
+            .map(|t| format!("I{t}: {trait_name}<Item = (Idx, {t})>"))
+            .collect()
+    }
+
+    /// `o0, o1, o2…`.
+    fn to_optional_names(&self) -> Vec<String> {
+        (0..self.num_optional)
+            .map(|n| format!("o{n}"))
+            .collect_vec()
+    }
+
+    /// `O0, O1, O2…`.
+    fn to_optional_types(&self) -> Vec<String> {
+        self.to_optional_names()
+            .into_iter()
+            .map(|s| s.to_uppercase())
+            .collect()
+    }
+
+    /// `o0: IO0, o1: IO1, o2: IO2…`.
+    fn to_optional_params(&self) -> Vec<String> {
+        izip!(self.to_optional_names(), self.to_optional_types())
+            .map(|(n, t)| format!("{n}: I{t}"))
+            .collect()
+    }
+
+    /// `o0: Peekable<IO0>, o1: Peekable<IO1>, o2: Peekable<IO2>…`.
+    fn to_optional_peekable_params(&self) -> Vec<String> {
+        izip!(self.to_optional_names(), self.to_optional_types())
+            .map(|(n, t)| format!("{n}: Peekable<I{t}>"))
+            .collect()
+    }
+
+    /// `IO0: (Into)Iterator<Item = (Idx, O0)>, IO1: (Into)Iterator<Item = (Idx, O1)>…`
+    fn to_optional_clauses(&self, into: bool) -> Vec<String> {
+        let trait_name = if into { "IntoIterator" } else { "Iterator" };
+        self.to_optional_types()
+            .into_iter()
+            .map(|t| format!("I{t}: {trait_name}<Item = (Idx, {t})>"))
+            .collect()
+    }
+}
+
+fn backticked(strs: impl IntoIterator<Item = String>) -> Vec<String> {
+    strs.into_iter().map(|s| format!("`{s}`")).collect()
+}
+
+/// Output:
+/// ```ignore
+/// pub fn range_zip_2x2<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1>(
+///     r0: IR0,
+///     r1: IR1,
+///     o0: IO0,
+///     o1: IO1,
+/// ) -> RangeZip2x2<Idx, IR0::IntoIter, R0, IR1::IntoIter, R1, IO0::IntoIter, O0, IO1::IntoIter, O1>
+/// where
+///     Idx: std::cmp::Ord,
+///     IR0: IntoIterator<Item = (Idx, R0)>,
+///     IR1: IntoIterator<Item = (Idx, R1)>,
+///     IO0: IntoIterator<Item = (Idx, O0)>,
+///     IO1: IntoIterator<Item = (Idx, O1)>,
+/// {
+///     RangeZip2x2 {
+///         r0: r0.into_iter(),
+///         r1: r1.into_iter(),
+///         o0: o0.into_iter().peekable(),
+///         o1: o1.into_iter().peekable(),
+///
+///         o0_data_latest: None,
+///         o1_data_latest: None,
+///     }
+/// }
+/// ```
+fn generate_helper_func(params: &Params) -> String {
+    let suffix = params.to_suffix();
+    let required_names = backticked(params.to_required_names()).join(", ");
+    let required_types = izip!(
+        params
+            .to_required_types()
+            .into_iter()
+            .map(|t| format!("I{t}")),
+        params.to_required_types()
+    )
+    .flat_map(|(tr, r)| [tr, r])
+    .collect_vec()
+    .join(", ");
+    let optional_types = izip!(
+        params
+            .to_optional_types()
+            .into_iter()
+            .map(|t| format!("I{t}")),
+        params.to_optional_types()
+    )
+    .flat_map(|(tr, r)| [tr, r])
+    .collect_vec()
+    .join(", ");
+    let required_clauses = params.to_required_clauses(true /* into */).join(", ");
+    let optional_clauses = params.to_optional_clauses(true /* into */).join(", ");
+    let required_params = params.to_required_params().join(", ");
+    let optional_params = params.to_optional_params().join(", ");
+
+    let ret_clause = params
+        .to_required_types()
+        .into_iter()
+        .map(|r| format!("I{r}::IntoIter, {r}"))
+        .chain(
+            params
+                .to_optional_types()
+                .into_iter()
+                .map(|o| format!("I{o}::IntoIter, {o}")),
+        )
+        .collect_vec()
+        .join(", ");
+
+    let ret = params
+        .to_required_names()
+        .into_iter()
+        .map(|r| format!("{r}: {r}.into_iter()"))
+        .chain(
+            params
+                .to_optional_names()
+                .into_iter()
+                .map(|o| format!("{o}: {o}.into_iter().peekable()")),
+        )
+        .collect_vec()
+        .join(",\n");
+
+    let latest = params
+        .to_optional_names()
+        .into_iter()
+        .map(|o| format!("{o}_data_latest: None"))
+        .collect_vec()
+        .join(",\n");
+
+    format!(
+        r#"
+        /// Returns a new [`RangeZip{suffix}`] iterator.
+        ///
+        /// The number of elements in a range zip iterator corresponds to the number of elements in the
+        /// shortest of its required iterators ({required_names}).
+        ///
+        /// Each call to `next` is guaranteed to yield the next value for each required iterator,
+        /// as well as the most recent index amongst all of them.
+        ///
+        /// Optional iterators accumulate their state and yield their most recent value (if any),
+        /// each time the required iterators fire.
+        pub fn range_zip_{suffix}<Idx, {required_types}, {optional_types}>(
+            {required_params},
+            {optional_params},
+        ) -> RangeZip{suffix}<Idx, {ret_clause}>
+        where
+            Idx: std::cmp::Ord,
+            {required_clauses},
+            {optional_clauses},
+        {{
+            RangeZip{suffix} {{
+                {ret},
+
+                {latest},
+            }}
+        }}
+    "#
+    )
+}
+
+/// Output:
+/// ```ignore
+/// pub struct RangeZip2x2<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1>
+/// where
+///     Idx: std::cmp::Ord,
+///     IR0: Iterator<Item = (Idx, R0)>,
+///     IR1: Iterator<Item = (Idx, R1)>,
+///     IO0: Iterator<Item = (Idx, O0)>,
+///     IO1: Iterator<Item = (Idx, O1)>,
+/// {
+///     r0: IR0,
+///     r1: IR1,
+///     o0: Peekable<IO0>,
+///     o1: Peekable<IO1>,
+///
+///     o0_data_latest: Option<O0>,
+///     o1_data_latest: Option<O1>,
+/// }
+/// ```
+fn generate_struct(params: &Params) -> String {
+    let suffix = params.to_suffix();
+    let required_types = izip!(
+        params
+            .to_required_types()
+            .into_iter()
+            .map(|t| format!("I{t}")),
+        params.to_required_types()
+    )
+    .flat_map(|(tr, r)| [tr, r])
+    .collect_vec()
+    .join(", ");
+    let optional_types = izip!(
+        params
+            .to_optional_types()
+            .into_iter()
+            .map(|t| format!("I{t}")),
+        params.to_optional_types()
+    )
+    .flat_map(|(tr, r)| [tr, r])
+    .collect_vec()
+    .join(", ");
+    let required_clauses = params.to_required_clauses(false /* into */).join(", ");
+    let optional_clauses = params.to_optional_clauses(false /* into */).join(", ");
+    let required_params = params.to_required_params().join(", ");
+    let optional_params = params.to_optional_peekable_params().join(", ");
+    let optional_latest_params = izip!(params.to_optional_names(), params.to_optional_types())
+        .map(|(n, t)| format!("{n}_data_latest: Option<{t}>"))
+        .join(", ");
+
+    format!(
+        r#"
+        /// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+        /// iterators.
+        ///
+        /// See [`range_zip_{suffix}`] for more information.
+        pub struct RangeZip{suffix}<Idx, {required_types}, {optional_types}>
+        where
+            Idx: std::cmp::Ord,
+            {required_clauses},
+            {optional_clauses},
+        {{
+            {required_params},
+            {optional_params},
+
+            {optional_latest_params},
+        }}
+    "#
+    )
+}
+
+/// Output:
+/// ```ignore
+/// impl<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1> Iterator
+///     for RangeZip2x2<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1>
+/// where
+///     Idx: std::cmp::Ord,
+///     IR0: Iterator<Item = (Idx, R0)>,
+///     IR1: Iterator<Item = (Idx, R1)>,
+///     IO0: Iterator<Item = (Idx, O0)>,
+///     IO1: Iterator<Item = (Idx, O1)>,
+///     O0: Clone,
+///     O1: Clone,
+/// {
+///     type Item = (Idx, R0, R1, Option<O0>, Option<O1>);
+///
+///     #[inline]
+///     fn next(&mut self) -> Option<Self::Item> {
+///         let Self {
+///             r0,
+///             r1,
+///             o0,
+///             o1,
+///             o0_data_latest,
+///             o1_data_latest,
+///         } = self;
+///
+///         let Some((r0_index, r0_data)) = r0.next() else {
+///             return None;
+///         };
+///         let Some((r1_index, r1_data)) = r1.next() else {
+///             return None;
+///         };
+///
+///         let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+///
+///         let mut o0_data = None;
+///         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+///             o0_data = Some(data);
+///         }
+///         let o0_data = o0_data.or(o0_data_latest.take());
+///         *o0_data_latest = o0_data.clone();
+///
+///         let mut o1_data = None;
+///         while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+///             o1_data = Some(data);
+///         }
+///         let o1_data = o1_data.or(o1_data_latest.take());
+///         *o1_data_latest = o1_data.clone();
+///
+///         Some((max_index, r0_data, r1_data, o0_data, o1_data))
+///     }
+/// }
+/// ```
+fn generate_impl(params: &Params) -> String {
+    let suffix = params.to_suffix();
+    let required_types = izip!(
+        params
+            .to_required_types()
+            .into_iter()
+            .map(|t| format!("I{t}")),
+        params.to_required_types()
+    )
+    .flat_map(|(tr, r)| [tr, r])
+    .collect_vec()
+    .join(", ");
+    let optional_types = izip!(
+        params
+            .to_optional_types()
+            .into_iter()
+            .map(|t| format!("I{t}")),
+        params.to_optional_types()
+    )
+    .flat_map(|(tr, r)| [tr, r])
+    .collect_vec()
+    .join(", ");
+    let required_names = params.to_required_names().join(", ");
+    let optional_names = params.to_optional_names().join(", ");
+    let optional_latest_names = params
+        .to_optional_names()
+        .into_iter()
+        .map(|n| format!("{n}_data_latest"))
+        .join(", ");
+    let required_indices = params
+        .to_required_names()
+        .into_iter()
+        .map(|n| format!("{n}_index"))
+        .collect_vec()
+        .join(", ");
+    let required_data = params
+        .to_required_names()
+        .into_iter()
+        .map(|n| format!("{n}_data"))
+        .collect_vec()
+        .join(", ");
+    let optional_data = params
+        .to_optional_names()
+        .into_iter()
+        .map(|n| format!("{n}_data"))
+        .collect_vec()
+        .join(", ");
+    let required_clauses = params.to_required_clauses(false /* into */).join(", ");
+    let optional_clauses = params.to_optional_clauses(false /* into */).join(", ");
+    let optional_clone_clauses = params
+        .to_optional_types()
+        .into_iter()
+        .map(|o| format!("{o}: Clone"))
+        .collect_vec()
+        .join(", ");
+
+    let items = params
+        .to_required_types()
+        .into_iter()
+        .chain(
+            params
+                .to_optional_types()
+                .into_iter()
+                .map(|o| format!("Option<{o}>")),
+        )
+        .collect_vec()
+        .join(", ");
+
+    let next_required = params
+        .to_required_names()
+        .into_iter()
+        .map(|r| format!("let Some(({r}_index, {r}_data)) = {r}.next() else {{ return None; }};"))
+        .collect_vec()
+        .join("\n");
+
+    let next_optional = params
+        .to_optional_names()
+        .into_iter()
+        .map(|o| {
+            format!(
+                "
+                let mut {o}_data = None;
+                while let Some((_, data)) = {o}.next_if(|(index, _)| index <= &max_index) {{
+                    {o}_data = Some(data);
+                }}
+                let {o}_data = {o}_data.or({o}_data_latest.take());
+                *{o}_data_latest = {o}_data.clone();
+                "
+            )
+        })
+        .collect_vec()
+        .join("\n");
+
+    format!(
+        r#"
+        impl<Idx, {required_types}, {optional_types}> Iterator for RangeZip{suffix}<Idx, {required_types}, {optional_types}>
+        where
+            Idx: std::cmp::Ord,
+            {required_clauses},
+            {optional_clauses},
+            {optional_clone_clauses},
+        {{
+            type Item = (Idx, {items});
+
+            #[inline]
+            fn next(&mut self) -> Option<Self::Item> {{
+                let Self {{ {required_names}, {optional_names}, {optional_latest_names} }} = self;
+
+                {next_required}
+
+                let max_index = [{required_indices}].into_iter().max().unwrap();
+
+                {next_optional}
+
+                Some((max_index, {required_data}, {optional_data}))
+            }}
+        }}
+    "#
+    )
+}
+
+fn main() {
+    let num_required = 1..3;
+    let num_optional = 1..10;
+
+    let output = num_required
+        .flat_map(|num_required| {
+            num_optional
+                .clone()
+                .map(move |num_optional| (num_required, num_optional))
+        })
+        .flat_map(|(num_required, num_optional)| {
+            let params = Params {
+                num_required,
+                num_optional,
+            };
+
+            [
+                generate_helper_func(&params),
+                generate_struct(&params),
+                generate_impl(&params),
+            ]
+        })
+        .collect_vec()
+        .join("\n");
+
+    println!(
+        "
+        // This file was generated using `cargo r -p re_query2 --all-features --bin range_zip`.
+        // DO NOT EDIT.
+
+        // ---
+
+        #![allow(clippy::iter_on_single_items)]
+        #![allow(clippy::too_many_arguments)]
+        #![allow(clippy::type_complexity)]
+
+        use std::iter::Peekable;
+
+        {output}
+        "
+    );
+}

--- a/crates/re_query2/src/lib.rs
+++ b/crates/re_query2/src/lib.rs
@@ -1,9 +1,11 @@
 //! Provide query-centric access to the [`re_data_store`].
 
-pub mod clamped_zip;
 mod latest_at;
 mod promise;
 mod visible_history;
+
+pub mod clamped_zip;
+pub mod range_zip;
 
 pub use self::clamped_zip::*;
 pub use self::latest_at::{latest_at, LatestAtComponentResults, LatestAtResults};

--- a/crates/re_query2/src/range_zip/.gitattributes
+++ b/crates/re_query2/src/range_zip/.gitattributes
@@ -1,0 +1,1 @@
+generated.rs linguist-generated=true

--- a/crates/re_query2/src/range_zip/generated.rs
+++ b/crates/re_query2/src/range_zip/generated.rs
@@ -1,0 +1,3544 @@
+// This file was generated using `cargo r -p re_query2 --all-features --bin range_zip`.
+// DO NOT EDIT.
+
+// ---
+
+#![allow(clippy::iter_on_single_items)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::type_complexity)]
+
+use std::iter::Peekable;
+
+/// Returns a new [`RangeZip1x1`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_1x1<Idx, IR0, R0, IO0, O0>(
+    r0: IR0,
+    o0: IO0,
+) -> RangeZip1x1<Idx, IR0::IntoIter, R0, IO0::IntoIter, O0>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+{
+    RangeZip1x1 {
+        r0: r0.into_iter(),
+        o0: o0.into_iter().peekable(),
+
+        o0_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_1x1`] for more information.
+pub struct RangeZip1x1<Idx, IR0, R0, IO0, O0>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+{
+    r0: IR0,
+    o0: Peekable<IO0>,
+
+    o0_data_latest: Option<O0>,
+}
+
+impl<Idx, IR0, R0, IO0, O0> Iterator for RangeZip1x1<Idx, IR0, R0, IO0, O0>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    O0: Clone,
+{
+    type Item = (Idx, R0, Option<O0>);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            o0,
+            o0_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        Some((max_index, r0_data, o0_data))
+    }
+}
+
+/// Returns a new [`RangeZip1x2`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_1x2<Idx, IR0, R0, IO0, O0, IO1, O1>(
+    r0: IR0,
+    o0: IO0,
+    o1: IO1,
+) -> RangeZip1x2<Idx, IR0::IntoIter, R0, IO0::IntoIter, O0, IO1::IntoIter, O1>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+{
+    RangeZip1x2 {
+        r0: r0.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_1x2`] for more information.
+pub struct RangeZip1x2<Idx, IR0, R0, IO0, O0, IO1, O1>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+{
+    r0: IR0,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+}
+
+impl<Idx, IR0, R0, IO0, O0, IO1, O1> Iterator for RangeZip1x2<Idx, IR0, R0, IO0, O0, IO1, O1>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    O0: Clone,
+    O1: Clone,
+{
+    type Item = (Idx, R0, Option<O0>, Option<O1>);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            o0,
+            o1,
+            o0_data_latest,
+            o1_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        Some((max_index, r0_data, o0_data, o1_data))
+    }
+}
+
+/// Returns a new [`RangeZip1x3`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_1x3<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2>(
+    r0: IR0,
+    o0: IO0,
+    o1: IO1,
+    o2: IO2,
+) -> RangeZip1x3<Idx, IR0::IntoIter, R0, IO0::IntoIter, O0, IO1::IntoIter, O1, IO2::IntoIter, O2>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+    IO2: IntoIterator<Item = (Idx, O2)>,
+{
+    RangeZip1x3 {
+        r0: r0.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+        o2: o2.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+        o2_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_1x3`] for more information.
+pub struct RangeZip1x3<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+{
+    r0: IR0,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+    o2: Peekable<IO2>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+    o2_data_latest: Option<O2>,
+}
+
+impl<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2> Iterator
+    for RangeZip1x3<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    O0: Clone,
+    O1: Clone,
+    O2: Clone,
+{
+    type Item = (Idx, R0, Option<O0>, Option<O1>, Option<O2>);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            o0,
+            o1,
+            o2,
+            o0_data_latest,
+            o1_data_latest,
+            o2_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        let mut o2_data = None;
+        while let Some((_, data)) = o2.next_if(|(index, _)| index <= &max_index) {
+            o2_data = Some(data);
+        }
+        let o2_data = o2_data.or(o2_data_latest.take());
+        *o2_data_latest = o2_data.clone();
+
+        Some((max_index, r0_data, o0_data, o1_data, o2_data))
+    }
+}
+
+/// Returns a new [`RangeZip1x4`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_1x4<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3>(
+    r0: IR0,
+    o0: IO0,
+    o1: IO1,
+    o2: IO2,
+    o3: IO3,
+) -> RangeZip1x4<
+    Idx,
+    IR0::IntoIter,
+    R0,
+    IO0::IntoIter,
+    O0,
+    IO1::IntoIter,
+    O1,
+    IO2::IntoIter,
+    O2,
+    IO3::IntoIter,
+    O3,
+>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+    IO2: IntoIterator<Item = (Idx, O2)>,
+    IO3: IntoIterator<Item = (Idx, O3)>,
+{
+    RangeZip1x4 {
+        r0: r0.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+        o2: o2.into_iter().peekable(),
+        o3: o3.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+        o2_data_latest: None,
+        o3_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_1x4`] for more information.
+pub struct RangeZip1x4<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+{
+    r0: IR0,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+    o2: Peekable<IO2>,
+    o3: Peekable<IO3>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+    o2_data_latest: Option<O2>,
+    o3_data_latest: Option<O3>,
+}
+
+impl<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3> Iterator
+    for RangeZip1x4<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    O0: Clone,
+    O1: Clone,
+    O2: Clone,
+    O3: Clone,
+{
+    type Item = (Idx, R0, Option<O0>, Option<O1>, Option<O2>, Option<O3>);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            o0,
+            o1,
+            o2,
+            o3,
+            o0_data_latest,
+            o1_data_latest,
+            o2_data_latest,
+            o3_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        let mut o2_data = None;
+        while let Some((_, data)) = o2.next_if(|(index, _)| index <= &max_index) {
+            o2_data = Some(data);
+        }
+        let o2_data = o2_data.or(o2_data_latest.take());
+        *o2_data_latest = o2_data.clone();
+
+        let mut o3_data = None;
+        while let Some((_, data)) = o3.next_if(|(index, _)| index <= &max_index) {
+            o3_data = Some(data);
+        }
+        let o3_data = o3_data.or(o3_data_latest.take());
+        *o3_data_latest = o3_data.clone();
+
+        Some((max_index, r0_data, o0_data, o1_data, o2_data, o3_data))
+    }
+}
+
+/// Returns a new [`RangeZip1x5`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_1x5<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4>(
+    r0: IR0,
+    o0: IO0,
+    o1: IO1,
+    o2: IO2,
+    o3: IO3,
+    o4: IO4,
+) -> RangeZip1x5<
+    Idx,
+    IR0::IntoIter,
+    R0,
+    IO0::IntoIter,
+    O0,
+    IO1::IntoIter,
+    O1,
+    IO2::IntoIter,
+    O2,
+    IO3::IntoIter,
+    O3,
+    IO4::IntoIter,
+    O4,
+>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+    IO2: IntoIterator<Item = (Idx, O2)>,
+    IO3: IntoIterator<Item = (Idx, O3)>,
+    IO4: IntoIterator<Item = (Idx, O4)>,
+{
+    RangeZip1x5 {
+        r0: r0.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+        o2: o2.into_iter().peekable(),
+        o3: o3.into_iter().peekable(),
+        o4: o4.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+        o2_data_latest: None,
+        o3_data_latest: None,
+        o4_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_1x5`] for more information.
+pub struct RangeZip1x5<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+{
+    r0: IR0,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+    o2: Peekable<IO2>,
+    o3: Peekable<IO3>,
+    o4: Peekable<IO4>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+    o2_data_latest: Option<O2>,
+    o3_data_latest: Option<O3>,
+    o4_data_latest: Option<O4>,
+}
+
+impl<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4> Iterator
+    for RangeZip1x5<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    O0: Clone,
+    O1: Clone,
+    O2: Clone,
+    O3: Clone,
+    O4: Clone,
+{
+    type Item = (
+        Idx,
+        R0,
+        Option<O0>,
+        Option<O1>,
+        Option<O2>,
+        Option<O3>,
+        Option<O4>,
+    );
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            o0,
+            o1,
+            o2,
+            o3,
+            o4,
+            o0_data_latest,
+            o1_data_latest,
+            o2_data_latest,
+            o3_data_latest,
+            o4_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        let mut o2_data = None;
+        while let Some((_, data)) = o2.next_if(|(index, _)| index <= &max_index) {
+            o2_data = Some(data);
+        }
+        let o2_data = o2_data.or(o2_data_latest.take());
+        *o2_data_latest = o2_data.clone();
+
+        let mut o3_data = None;
+        while let Some((_, data)) = o3.next_if(|(index, _)| index <= &max_index) {
+            o3_data = Some(data);
+        }
+        let o3_data = o3_data.or(o3_data_latest.take());
+        *o3_data_latest = o3_data.clone();
+
+        let mut o4_data = None;
+        while let Some((_, data)) = o4.next_if(|(index, _)| index <= &max_index) {
+            o4_data = Some(data);
+        }
+        let o4_data = o4_data.or(o4_data_latest.take());
+        *o4_data_latest = o4_data.clone();
+
+        Some((
+            max_index, r0_data, o0_data, o1_data, o2_data, o3_data, o4_data,
+        ))
+    }
+}
+
+/// Returns a new [`RangeZip1x6`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_1x6<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4, IO5, O5>(
+    r0: IR0,
+    o0: IO0,
+    o1: IO1,
+    o2: IO2,
+    o3: IO3,
+    o4: IO4,
+    o5: IO5,
+) -> RangeZip1x6<
+    Idx,
+    IR0::IntoIter,
+    R0,
+    IO0::IntoIter,
+    O0,
+    IO1::IntoIter,
+    O1,
+    IO2::IntoIter,
+    O2,
+    IO3::IntoIter,
+    O3,
+    IO4::IntoIter,
+    O4,
+    IO5::IntoIter,
+    O5,
+>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+    IO2: IntoIterator<Item = (Idx, O2)>,
+    IO3: IntoIterator<Item = (Idx, O3)>,
+    IO4: IntoIterator<Item = (Idx, O4)>,
+    IO5: IntoIterator<Item = (Idx, O5)>,
+{
+    RangeZip1x6 {
+        r0: r0.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+        o2: o2.into_iter().peekable(),
+        o3: o3.into_iter().peekable(),
+        o4: o4.into_iter().peekable(),
+        o5: o5.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+        o2_data_latest: None,
+        o3_data_latest: None,
+        o4_data_latest: None,
+        o5_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_1x6`] for more information.
+pub struct RangeZip1x6<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4, IO5, O5>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+{
+    r0: IR0,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+    o2: Peekable<IO2>,
+    o3: Peekable<IO3>,
+    o4: Peekable<IO4>,
+    o5: Peekable<IO5>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+    o2_data_latest: Option<O2>,
+    o3_data_latest: Option<O3>,
+    o4_data_latest: Option<O4>,
+    o5_data_latest: Option<O5>,
+}
+
+impl<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4, IO5, O5> Iterator
+    for RangeZip1x6<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4, IO5, O5>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+    O0: Clone,
+    O1: Clone,
+    O2: Clone,
+    O3: Clone,
+    O4: Clone,
+    O5: Clone,
+{
+    type Item = (
+        Idx,
+        R0,
+        Option<O0>,
+        Option<O1>,
+        Option<O2>,
+        Option<O3>,
+        Option<O4>,
+        Option<O5>,
+    );
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            o0,
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o0_data_latest,
+            o1_data_latest,
+            o2_data_latest,
+            o3_data_latest,
+            o4_data_latest,
+            o5_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        let mut o2_data = None;
+        while let Some((_, data)) = o2.next_if(|(index, _)| index <= &max_index) {
+            o2_data = Some(data);
+        }
+        let o2_data = o2_data.or(o2_data_latest.take());
+        *o2_data_latest = o2_data.clone();
+
+        let mut o3_data = None;
+        while let Some((_, data)) = o3.next_if(|(index, _)| index <= &max_index) {
+            o3_data = Some(data);
+        }
+        let o3_data = o3_data.or(o3_data_latest.take());
+        *o3_data_latest = o3_data.clone();
+
+        let mut o4_data = None;
+        while let Some((_, data)) = o4.next_if(|(index, _)| index <= &max_index) {
+            o4_data = Some(data);
+        }
+        let o4_data = o4_data.or(o4_data_latest.take());
+        *o4_data_latest = o4_data.clone();
+
+        let mut o5_data = None;
+        while let Some((_, data)) = o5.next_if(|(index, _)| index <= &max_index) {
+            o5_data = Some(data);
+        }
+        let o5_data = o5_data.or(o5_data_latest.take());
+        *o5_data_latest = o5_data.clone();
+
+        Some((
+            max_index, r0_data, o0_data, o1_data, o2_data, o3_data, o4_data, o5_data,
+        ))
+    }
+}
+
+/// Returns a new [`RangeZip1x7`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_1x7<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4, IO5, O5, IO6, O6>(
+    r0: IR0,
+    o0: IO0,
+    o1: IO1,
+    o2: IO2,
+    o3: IO3,
+    o4: IO4,
+    o5: IO5,
+    o6: IO6,
+) -> RangeZip1x7<
+    Idx,
+    IR0::IntoIter,
+    R0,
+    IO0::IntoIter,
+    O0,
+    IO1::IntoIter,
+    O1,
+    IO2::IntoIter,
+    O2,
+    IO3::IntoIter,
+    O3,
+    IO4::IntoIter,
+    O4,
+    IO5::IntoIter,
+    O5,
+    IO6::IntoIter,
+    O6,
+>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+    IO2: IntoIterator<Item = (Idx, O2)>,
+    IO3: IntoIterator<Item = (Idx, O3)>,
+    IO4: IntoIterator<Item = (Idx, O4)>,
+    IO5: IntoIterator<Item = (Idx, O5)>,
+    IO6: IntoIterator<Item = (Idx, O6)>,
+{
+    RangeZip1x7 {
+        r0: r0.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+        o2: o2.into_iter().peekable(),
+        o3: o3.into_iter().peekable(),
+        o4: o4.into_iter().peekable(),
+        o5: o5.into_iter().peekable(),
+        o6: o6.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+        o2_data_latest: None,
+        o3_data_latest: None,
+        o4_data_latest: None,
+        o5_data_latest: None,
+        o6_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_1x7`] for more information.
+pub struct RangeZip1x7<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4, IO5, O5, IO6, O6>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+    IO6: Iterator<Item = (Idx, O6)>,
+{
+    r0: IR0,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+    o2: Peekable<IO2>,
+    o3: Peekable<IO3>,
+    o4: Peekable<IO4>,
+    o5: Peekable<IO5>,
+    o6: Peekable<IO6>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+    o2_data_latest: Option<O2>,
+    o3_data_latest: Option<O3>,
+    o4_data_latest: Option<O4>,
+    o5_data_latest: Option<O5>,
+    o6_data_latest: Option<O6>,
+}
+
+impl<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4, IO5, O5, IO6, O6> Iterator
+    for RangeZip1x7<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4, IO5, O5, IO6, O6>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+    IO6: Iterator<Item = (Idx, O6)>,
+    O0: Clone,
+    O1: Clone,
+    O2: Clone,
+    O3: Clone,
+    O4: Clone,
+    O5: Clone,
+    O6: Clone,
+{
+    type Item = (
+        Idx,
+        R0,
+        Option<O0>,
+        Option<O1>,
+        Option<O2>,
+        Option<O3>,
+        Option<O4>,
+        Option<O5>,
+        Option<O6>,
+    );
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            o0,
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o0_data_latest,
+            o1_data_latest,
+            o2_data_latest,
+            o3_data_latest,
+            o4_data_latest,
+            o5_data_latest,
+            o6_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        let mut o2_data = None;
+        while let Some((_, data)) = o2.next_if(|(index, _)| index <= &max_index) {
+            o2_data = Some(data);
+        }
+        let o2_data = o2_data.or(o2_data_latest.take());
+        *o2_data_latest = o2_data.clone();
+
+        let mut o3_data = None;
+        while let Some((_, data)) = o3.next_if(|(index, _)| index <= &max_index) {
+            o3_data = Some(data);
+        }
+        let o3_data = o3_data.or(o3_data_latest.take());
+        *o3_data_latest = o3_data.clone();
+
+        let mut o4_data = None;
+        while let Some((_, data)) = o4.next_if(|(index, _)| index <= &max_index) {
+            o4_data = Some(data);
+        }
+        let o4_data = o4_data.or(o4_data_latest.take());
+        *o4_data_latest = o4_data.clone();
+
+        let mut o5_data = None;
+        while let Some((_, data)) = o5.next_if(|(index, _)| index <= &max_index) {
+            o5_data = Some(data);
+        }
+        let o5_data = o5_data.or(o5_data_latest.take());
+        *o5_data_latest = o5_data.clone();
+
+        let mut o6_data = None;
+        while let Some((_, data)) = o6.next_if(|(index, _)| index <= &max_index) {
+            o6_data = Some(data);
+        }
+        let o6_data = o6_data.or(o6_data_latest.take());
+        *o6_data_latest = o6_data.clone();
+
+        Some((
+            max_index, r0_data, o0_data, o1_data, o2_data, o3_data, o4_data, o5_data, o6_data,
+        ))
+    }
+}
+
+/// Returns a new [`RangeZip1x8`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_1x8<
+    Idx,
+    IR0,
+    R0,
+    IO0,
+    O0,
+    IO1,
+    O1,
+    IO2,
+    O2,
+    IO3,
+    O3,
+    IO4,
+    O4,
+    IO5,
+    O5,
+    IO6,
+    O6,
+    IO7,
+    O7,
+>(
+    r0: IR0,
+    o0: IO0,
+    o1: IO1,
+    o2: IO2,
+    o3: IO3,
+    o4: IO4,
+    o5: IO5,
+    o6: IO6,
+    o7: IO7,
+) -> RangeZip1x8<
+    Idx,
+    IR0::IntoIter,
+    R0,
+    IO0::IntoIter,
+    O0,
+    IO1::IntoIter,
+    O1,
+    IO2::IntoIter,
+    O2,
+    IO3::IntoIter,
+    O3,
+    IO4::IntoIter,
+    O4,
+    IO5::IntoIter,
+    O5,
+    IO6::IntoIter,
+    O6,
+    IO7::IntoIter,
+    O7,
+>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+    IO2: IntoIterator<Item = (Idx, O2)>,
+    IO3: IntoIterator<Item = (Idx, O3)>,
+    IO4: IntoIterator<Item = (Idx, O4)>,
+    IO5: IntoIterator<Item = (Idx, O5)>,
+    IO6: IntoIterator<Item = (Idx, O6)>,
+    IO7: IntoIterator<Item = (Idx, O7)>,
+{
+    RangeZip1x8 {
+        r0: r0.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+        o2: o2.into_iter().peekable(),
+        o3: o3.into_iter().peekable(),
+        o4: o4.into_iter().peekable(),
+        o5: o5.into_iter().peekable(),
+        o6: o6.into_iter().peekable(),
+        o7: o7.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+        o2_data_latest: None,
+        o3_data_latest: None,
+        o4_data_latest: None,
+        o5_data_latest: None,
+        o6_data_latest: None,
+        o7_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_1x8`] for more information.
+pub struct RangeZip1x8<
+    Idx,
+    IR0,
+    R0,
+    IO0,
+    O0,
+    IO1,
+    O1,
+    IO2,
+    O2,
+    IO3,
+    O3,
+    IO4,
+    O4,
+    IO5,
+    O5,
+    IO6,
+    O6,
+    IO7,
+    O7,
+> where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+    IO6: Iterator<Item = (Idx, O6)>,
+    IO7: Iterator<Item = (Idx, O7)>,
+{
+    r0: IR0,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+    o2: Peekable<IO2>,
+    o3: Peekable<IO3>,
+    o4: Peekable<IO4>,
+    o5: Peekable<IO5>,
+    o6: Peekable<IO6>,
+    o7: Peekable<IO7>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+    o2_data_latest: Option<O2>,
+    o3_data_latest: Option<O3>,
+    o4_data_latest: Option<O4>,
+    o5_data_latest: Option<O5>,
+    o6_data_latest: Option<O6>,
+    o7_data_latest: Option<O7>,
+}
+
+impl<Idx, IR0, R0, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4, IO5, O5, IO6, O6, IO7, O7> Iterator
+    for RangeZip1x8<
+        Idx,
+        IR0,
+        R0,
+        IO0,
+        O0,
+        IO1,
+        O1,
+        IO2,
+        O2,
+        IO3,
+        O3,
+        IO4,
+        O4,
+        IO5,
+        O5,
+        IO6,
+        O6,
+        IO7,
+        O7,
+    >
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+    IO6: Iterator<Item = (Idx, O6)>,
+    IO7: Iterator<Item = (Idx, O7)>,
+    O0: Clone,
+    O1: Clone,
+    O2: Clone,
+    O3: Clone,
+    O4: Clone,
+    O5: Clone,
+    O6: Clone,
+    O7: Clone,
+{
+    type Item = (
+        Idx,
+        R0,
+        Option<O0>,
+        Option<O1>,
+        Option<O2>,
+        Option<O3>,
+        Option<O4>,
+        Option<O5>,
+        Option<O6>,
+        Option<O7>,
+    );
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            o0,
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            o0_data_latest,
+            o1_data_latest,
+            o2_data_latest,
+            o3_data_latest,
+            o4_data_latest,
+            o5_data_latest,
+            o6_data_latest,
+            o7_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        let mut o2_data = None;
+        while let Some((_, data)) = o2.next_if(|(index, _)| index <= &max_index) {
+            o2_data = Some(data);
+        }
+        let o2_data = o2_data.or(o2_data_latest.take());
+        *o2_data_latest = o2_data.clone();
+
+        let mut o3_data = None;
+        while let Some((_, data)) = o3.next_if(|(index, _)| index <= &max_index) {
+            o3_data = Some(data);
+        }
+        let o3_data = o3_data.or(o3_data_latest.take());
+        *o3_data_latest = o3_data.clone();
+
+        let mut o4_data = None;
+        while let Some((_, data)) = o4.next_if(|(index, _)| index <= &max_index) {
+            o4_data = Some(data);
+        }
+        let o4_data = o4_data.or(o4_data_latest.take());
+        *o4_data_latest = o4_data.clone();
+
+        let mut o5_data = None;
+        while let Some((_, data)) = o5.next_if(|(index, _)| index <= &max_index) {
+            o5_data = Some(data);
+        }
+        let o5_data = o5_data.or(o5_data_latest.take());
+        *o5_data_latest = o5_data.clone();
+
+        let mut o6_data = None;
+        while let Some((_, data)) = o6.next_if(|(index, _)| index <= &max_index) {
+            o6_data = Some(data);
+        }
+        let o6_data = o6_data.or(o6_data_latest.take());
+        *o6_data_latest = o6_data.clone();
+
+        let mut o7_data = None;
+        while let Some((_, data)) = o7.next_if(|(index, _)| index <= &max_index) {
+            o7_data = Some(data);
+        }
+        let o7_data = o7_data.or(o7_data_latest.take());
+        *o7_data_latest = o7_data.clone();
+
+        Some((
+            max_index, r0_data, o0_data, o1_data, o2_data, o3_data, o4_data, o5_data, o6_data,
+            o7_data,
+        ))
+    }
+}
+
+/// Returns a new [`RangeZip1x9`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_1x9<
+    Idx,
+    IR0,
+    R0,
+    IO0,
+    O0,
+    IO1,
+    O1,
+    IO2,
+    O2,
+    IO3,
+    O3,
+    IO4,
+    O4,
+    IO5,
+    O5,
+    IO6,
+    O6,
+    IO7,
+    O7,
+    IO8,
+    O8,
+>(
+    r0: IR0,
+    o0: IO0,
+    o1: IO1,
+    o2: IO2,
+    o3: IO3,
+    o4: IO4,
+    o5: IO5,
+    o6: IO6,
+    o7: IO7,
+    o8: IO8,
+) -> RangeZip1x9<
+    Idx,
+    IR0::IntoIter,
+    R0,
+    IO0::IntoIter,
+    O0,
+    IO1::IntoIter,
+    O1,
+    IO2::IntoIter,
+    O2,
+    IO3::IntoIter,
+    O3,
+    IO4::IntoIter,
+    O4,
+    IO5::IntoIter,
+    O5,
+    IO6::IntoIter,
+    O6,
+    IO7::IntoIter,
+    O7,
+    IO8::IntoIter,
+    O8,
+>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+    IO2: IntoIterator<Item = (Idx, O2)>,
+    IO3: IntoIterator<Item = (Idx, O3)>,
+    IO4: IntoIterator<Item = (Idx, O4)>,
+    IO5: IntoIterator<Item = (Idx, O5)>,
+    IO6: IntoIterator<Item = (Idx, O6)>,
+    IO7: IntoIterator<Item = (Idx, O7)>,
+    IO8: IntoIterator<Item = (Idx, O8)>,
+{
+    RangeZip1x9 {
+        r0: r0.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+        o2: o2.into_iter().peekable(),
+        o3: o3.into_iter().peekable(),
+        o4: o4.into_iter().peekable(),
+        o5: o5.into_iter().peekable(),
+        o6: o6.into_iter().peekable(),
+        o7: o7.into_iter().peekable(),
+        o8: o8.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+        o2_data_latest: None,
+        o3_data_latest: None,
+        o4_data_latest: None,
+        o5_data_latest: None,
+        o6_data_latest: None,
+        o7_data_latest: None,
+        o8_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_1x9`] for more information.
+pub struct RangeZip1x9<
+    Idx,
+    IR0,
+    R0,
+    IO0,
+    O0,
+    IO1,
+    O1,
+    IO2,
+    O2,
+    IO3,
+    O3,
+    IO4,
+    O4,
+    IO5,
+    O5,
+    IO6,
+    O6,
+    IO7,
+    O7,
+    IO8,
+    O8,
+> where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+    IO6: Iterator<Item = (Idx, O6)>,
+    IO7: Iterator<Item = (Idx, O7)>,
+    IO8: Iterator<Item = (Idx, O8)>,
+{
+    r0: IR0,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+    o2: Peekable<IO2>,
+    o3: Peekable<IO3>,
+    o4: Peekable<IO4>,
+    o5: Peekable<IO5>,
+    o6: Peekable<IO6>,
+    o7: Peekable<IO7>,
+    o8: Peekable<IO8>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+    o2_data_latest: Option<O2>,
+    o3_data_latest: Option<O3>,
+    o4_data_latest: Option<O4>,
+    o5_data_latest: Option<O5>,
+    o6_data_latest: Option<O6>,
+    o7_data_latest: Option<O7>,
+    o8_data_latest: Option<O8>,
+}
+
+impl<
+        Idx,
+        IR0,
+        R0,
+        IO0,
+        O0,
+        IO1,
+        O1,
+        IO2,
+        O2,
+        IO3,
+        O3,
+        IO4,
+        O4,
+        IO5,
+        O5,
+        IO6,
+        O6,
+        IO7,
+        O7,
+        IO8,
+        O8,
+    > Iterator
+    for RangeZip1x9<
+        Idx,
+        IR0,
+        R0,
+        IO0,
+        O0,
+        IO1,
+        O1,
+        IO2,
+        O2,
+        IO3,
+        O3,
+        IO4,
+        O4,
+        IO5,
+        O5,
+        IO6,
+        O6,
+        IO7,
+        O7,
+        IO8,
+        O8,
+    >
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+    IO6: Iterator<Item = (Idx, O6)>,
+    IO7: Iterator<Item = (Idx, O7)>,
+    IO8: Iterator<Item = (Idx, O8)>,
+    O0: Clone,
+    O1: Clone,
+    O2: Clone,
+    O3: Clone,
+    O4: Clone,
+    O5: Clone,
+    O6: Clone,
+    O7: Clone,
+    O8: Clone,
+{
+    type Item = (
+        Idx,
+        R0,
+        Option<O0>,
+        Option<O1>,
+        Option<O2>,
+        Option<O3>,
+        Option<O4>,
+        Option<O5>,
+        Option<O6>,
+        Option<O7>,
+        Option<O8>,
+    );
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            o0,
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            o8,
+            o0_data_latest,
+            o1_data_latest,
+            o2_data_latest,
+            o3_data_latest,
+            o4_data_latest,
+            o5_data_latest,
+            o6_data_latest,
+            o7_data_latest,
+            o8_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        let mut o2_data = None;
+        while let Some((_, data)) = o2.next_if(|(index, _)| index <= &max_index) {
+            o2_data = Some(data);
+        }
+        let o2_data = o2_data.or(o2_data_latest.take());
+        *o2_data_latest = o2_data.clone();
+
+        let mut o3_data = None;
+        while let Some((_, data)) = o3.next_if(|(index, _)| index <= &max_index) {
+            o3_data = Some(data);
+        }
+        let o3_data = o3_data.or(o3_data_latest.take());
+        *o3_data_latest = o3_data.clone();
+
+        let mut o4_data = None;
+        while let Some((_, data)) = o4.next_if(|(index, _)| index <= &max_index) {
+            o4_data = Some(data);
+        }
+        let o4_data = o4_data.or(o4_data_latest.take());
+        *o4_data_latest = o4_data.clone();
+
+        let mut o5_data = None;
+        while let Some((_, data)) = o5.next_if(|(index, _)| index <= &max_index) {
+            o5_data = Some(data);
+        }
+        let o5_data = o5_data.or(o5_data_latest.take());
+        *o5_data_latest = o5_data.clone();
+
+        let mut o6_data = None;
+        while let Some((_, data)) = o6.next_if(|(index, _)| index <= &max_index) {
+            o6_data = Some(data);
+        }
+        let o6_data = o6_data.or(o6_data_latest.take());
+        *o6_data_latest = o6_data.clone();
+
+        let mut o7_data = None;
+        while let Some((_, data)) = o7.next_if(|(index, _)| index <= &max_index) {
+            o7_data = Some(data);
+        }
+        let o7_data = o7_data.or(o7_data_latest.take());
+        *o7_data_latest = o7_data.clone();
+
+        let mut o8_data = None;
+        while let Some((_, data)) = o8.next_if(|(index, _)| index <= &max_index) {
+            o8_data = Some(data);
+        }
+        let o8_data = o8_data.or(o8_data_latest.take());
+        *o8_data_latest = o8_data.clone();
+
+        Some((
+            max_index, r0_data, o0_data, o1_data, o2_data, o3_data, o4_data, o5_data, o6_data,
+            o7_data, o8_data,
+        ))
+    }
+}
+
+/// Returns a new [`RangeZip2x1`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`, `r1`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_2x1<Idx, IR0, R0, IR1, R1, IO0, O0>(
+    r0: IR0,
+    r1: IR1,
+    o0: IO0,
+) -> RangeZip2x1<Idx, IR0::IntoIter, R0, IR1::IntoIter, R1, IO0::IntoIter, O0>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IR1: IntoIterator<Item = (Idx, R1)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+{
+    RangeZip2x1 {
+        r0: r0.into_iter(),
+        r1: r1.into_iter(),
+        o0: o0.into_iter().peekable(),
+
+        o0_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_2x1`] for more information.
+pub struct RangeZip2x1<Idx, IR0, R0, IR1, R1, IO0, O0>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+{
+    r0: IR0,
+    r1: IR1,
+    o0: Peekable<IO0>,
+
+    o0_data_latest: Option<O0>,
+}
+
+impl<Idx, IR0, R0, IR1, R1, IO0, O0> Iterator for RangeZip2x1<Idx, IR0, R0, IR1, R1, IO0, O0>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    O0: Clone,
+{
+    type Item = (Idx, R0, R1, Option<O0>);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            r1,
+            o0,
+            o0_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+        let Some((r1_index, r1_data)) = r1.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        Some((max_index, r0_data, r1_data, o0_data))
+    }
+}
+
+/// Returns a new [`RangeZip2x2`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`, `r1`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_2x2<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1>(
+    r0: IR0,
+    r1: IR1,
+    o0: IO0,
+    o1: IO1,
+) -> RangeZip2x2<Idx, IR0::IntoIter, R0, IR1::IntoIter, R1, IO0::IntoIter, O0, IO1::IntoIter, O1>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IR1: IntoIterator<Item = (Idx, R1)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+{
+    RangeZip2x2 {
+        r0: r0.into_iter(),
+        r1: r1.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_2x2`] for more information.
+pub struct RangeZip2x2<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+{
+    r0: IR0,
+    r1: IR1,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+}
+
+impl<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1> Iterator
+    for RangeZip2x2<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    O0: Clone,
+    O1: Clone,
+{
+    type Item = (Idx, R0, R1, Option<O0>, Option<O1>);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            r1,
+            o0,
+            o1,
+            o0_data_latest,
+            o1_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+        let Some((r1_index, r1_data)) = r1.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        Some((max_index, r0_data, r1_data, o0_data, o1_data))
+    }
+}
+
+/// Returns a new [`RangeZip2x3`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`, `r1`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_2x3<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2>(
+    r0: IR0,
+    r1: IR1,
+    o0: IO0,
+    o1: IO1,
+    o2: IO2,
+) -> RangeZip2x3<
+    Idx,
+    IR0::IntoIter,
+    R0,
+    IR1::IntoIter,
+    R1,
+    IO0::IntoIter,
+    O0,
+    IO1::IntoIter,
+    O1,
+    IO2::IntoIter,
+    O2,
+>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IR1: IntoIterator<Item = (Idx, R1)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+    IO2: IntoIterator<Item = (Idx, O2)>,
+{
+    RangeZip2x3 {
+        r0: r0.into_iter(),
+        r1: r1.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+        o2: o2.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+        o2_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_2x3`] for more information.
+pub struct RangeZip2x3<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+{
+    r0: IR0,
+    r1: IR1,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+    o2: Peekable<IO2>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+    o2_data_latest: Option<O2>,
+}
+
+impl<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2> Iterator
+    for RangeZip2x3<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    O0: Clone,
+    O1: Clone,
+    O2: Clone,
+{
+    type Item = (Idx, R0, R1, Option<O0>, Option<O1>, Option<O2>);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            r1,
+            o0,
+            o1,
+            o2,
+            o0_data_latest,
+            o1_data_latest,
+            o2_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+        let Some((r1_index, r1_data)) = r1.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        let mut o2_data = None;
+        while let Some((_, data)) = o2.next_if(|(index, _)| index <= &max_index) {
+            o2_data = Some(data);
+        }
+        let o2_data = o2_data.or(o2_data_latest.take());
+        *o2_data_latest = o2_data.clone();
+
+        Some((max_index, r0_data, r1_data, o0_data, o1_data, o2_data))
+    }
+}
+
+/// Returns a new [`RangeZip2x4`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`, `r1`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_2x4<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2, IO3, O3>(
+    r0: IR0,
+    r1: IR1,
+    o0: IO0,
+    o1: IO1,
+    o2: IO2,
+    o3: IO3,
+) -> RangeZip2x4<
+    Idx,
+    IR0::IntoIter,
+    R0,
+    IR1::IntoIter,
+    R1,
+    IO0::IntoIter,
+    O0,
+    IO1::IntoIter,
+    O1,
+    IO2::IntoIter,
+    O2,
+    IO3::IntoIter,
+    O3,
+>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IR1: IntoIterator<Item = (Idx, R1)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+    IO2: IntoIterator<Item = (Idx, O2)>,
+    IO3: IntoIterator<Item = (Idx, O3)>,
+{
+    RangeZip2x4 {
+        r0: r0.into_iter(),
+        r1: r1.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+        o2: o2.into_iter().peekable(),
+        o3: o3.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+        o2_data_latest: None,
+        o3_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_2x4`] for more information.
+pub struct RangeZip2x4<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2, IO3, O3>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+{
+    r0: IR0,
+    r1: IR1,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+    o2: Peekable<IO2>,
+    o3: Peekable<IO3>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+    o2_data_latest: Option<O2>,
+    o3_data_latest: Option<O3>,
+}
+
+impl<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2, IO3, O3> Iterator
+    for RangeZip2x4<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2, IO3, O3>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    O0: Clone,
+    O1: Clone,
+    O2: Clone,
+    O3: Clone,
+{
+    type Item = (Idx, R0, R1, Option<O0>, Option<O1>, Option<O2>, Option<O3>);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            r1,
+            o0,
+            o1,
+            o2,
+            o3,
+            o0_data_latest,
+            o1_data_latest,
+            o2_data_latest,
+            o3_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+        let Some((r1_index, r1_data)) = r1.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        let mut o2_data = None;
+        while let Some((_, data)) = o2.next_if(|(index, _)| index <= &max_index) {
+            o2_data = Some(data);
+        }
+        let o2_data = o2_data.or(o2_data_latest.take());
+        *o2_data_latest = o2_data.clone();
+
+        let mut o3_data = None;
+        while let Some((_, data)) = o3.next_if(|(index, _)| index <= &max_index) {
+            o3_data = Some(data);
+        }
+        let o3_data = o3_data.or(o3_data_latest.take());
+        *o3_data_latest = o3_data.clone();
+
+        Some((
+            max_index, r0_data, r1_data, o0_data, o1_data, o2_data, o3_data,
+        ))
+    }
+}
+
+/// Returns a new [`RangeZip2x5`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`, `r1`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_2x5<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4>(
+    r0: IR0,
+    r1: IR1,
+    o0: IO0,
+    o1: IO1,
+    o2: IO2,
+    o3: IO3,
+    o4: IO4,
+) -> RangeZip2x5<
+    Idx,
+    IR0::IntoIter,
+    R0,
+    IR1::IntoIter,
+    R1,
+    IO0::IntoIter,
+    O0,
+    IO1::IntoIter,
+    O1,
+    IO2::IntoIter,
+    O2,
+    IO3::IntoIter,
+    O3,
+    IO4::IntoIter,
+    O4,
+>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IR1: IntoIterator<Item = (Idx, R1)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+    IO2: IntoIterator<Item = (Idx, O2)>,
+    IO3: IntoIterator<Item = (Idx, O3)>,
+    IO4: IntoIterator<Item = (Idx, O4)>,
+{
+    RangeZip2x5 {
+        r0: r0.into_iter(),
+        r1: r1.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+        o2: o2.into_iter().peekable(),
+        o3: o3.into_iter().peekable(),
+        o4: o4.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+        o2_data_latest: None,
+        o3_data_latest: None,
+        o4_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_2x5`] for more information.
+pub struct RangeZip2x5<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+{
+    r0: IR0,
+    r1: IR1,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+    o2: Peekable<IO2>,
+    o3: Peekable<IO3>,
+    o4: Peekable<IO4>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+    o2_data_latest: Option<O2>,
+    o3_data_latest: Option<O3>,
+    o4_data_latest: Option<O4>,
+}
+
+impl<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4> Iterator
+    for RangeZip2x5<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    O0: Clone,
+    O1: Clone,
+    O2: Clone,
+    O3: Clone,
+    O4: Clone,
+{
+    type Item = (
+        Idx,
+        R0,
+        R1,
+        Option<O0>,
+        Option<O1>,
+        Option<O2>,
+        Option<O3>,
+        Option<O4>,
+    );
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            r1,
+            o0,
+            o1,
+            o2,
+            o3,
+            o4,
+            o0_data_latest,
+            o1_data_latest,
+            o2_data_latest,
+            o3_data_latest,
+            o4_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+        let Some((r1_index, r1_data)) = r1.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        let mut o2_data = None;
+        while let Some((_, data)) = o2.next_if(|(index, _)| index <= &max_index) {
+            o2_data = Some(data);
+        }
+        let o2_data = o2_data.or(o2_data_latest.take());
+        *o2_data_latest = o2_data.clone();
+
+        let mut o3_data = None;
+        while let Some((_, data)) = o3.next_if(|(index, _)| index <= &max_index) {
+            o3_data = Some(data);
+        }
+        let o3_data = o3_data.or(o3_data_latest.take());
+        *o3_data_latest = o3_data.clone();
+
+        let mut o4_data = None;
+        while let Some((_, data)) = o4.next_if(|(index, _)| index <= &max_index) {
+            o4_data = Some(data);
+        }
+        let o4_data = o4_data.or(o4_data_latest.take());
+        *o4_data_latest = o4_data.clone();
+
+        Some((
+            max_index, r0_data, r1_data, o0_data, o1_data, o2_data, o3_data, o4_data,
+        ))
+    }
+}
+
+/// Returns a new [`RangeZip2x6`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`, `r1`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_2x6<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4, IO5, O5>(
+    r0: IR0,
+    r1: IR1,
+    o0: IO0,
+    o1: IO1,
+    o2: IO2,
+    o3: IO3,
+    o4: IO4,
+    o5: IO5,
+) -> RangeZip2x6<
+    Idx,
+    IR0::IntoIter,
+    R0,
+    IR1::IntoIter,
+    R1,
+    IO0::IntoIter,
+    O0,
+    IO1::IntoIter,
+    O1,
+    IO2::IntoIter,
+    O2,
+    IO3::IntoIter,
+    O3,
+    IO4::IntoIter,
+    O4,
+    IO5::IntoIter,
+    O5,
+>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IR1: IntoIterator<Item = (Idx, R1)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+    IO2: IntoIterator<Item = (Idx, O2)>,
+    IO3: IntoIterator<Item = (Idx, O3)>,
+    IO4: IntoIterator<Item = (Idx, O4)>,
+    IO5: IntoIterator<Item = (Idx, O5)>,
+{
+    RangeZip2x6 {
+        r0: r0.into_iter(),
+        r1: r1.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+        o2: o2.into_iter().peekable(),
+        o3: o3.into_iter().peekable(),
+        o4: o4.into_iter().peekable(),
+        o5: o5.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+        o2_data_latest: None,
+        o3_data_latest: None,
+        o4_data_latest: None,
+        o5_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_2x6`] for more information.
+pub struct RangeZip2x6<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4, IO5, O5>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+{
+    r0: IR0,
+    r1: IR1,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+    o2: Peekable<IO2>,
+    o3: Peekable<IO3>,
+    o4: Peekable<IO4>,
+    o5: Peekable<IO5>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+    o2_data_latest: Option<O2>,
+    o3_data_latest: Option<O3>,
+    o4_data_latest: Option<O4>,
+    o5_data_latest: Option<O5>,
+}
+
+impl<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4, IO5, O5> Iterator
+    for RangeZip2x6<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4, IO5, O5>
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+    O0: Clone,
+    O1: Clone,
+    O2: Clone,
+    O3: Clone,
+    O4: Clone,
+    O5: Clone,
+{
+    type Item = (
+        Idx,
+        R0,
+        R1,
+        Option<O0>,
+        Option<O1>,
+        Option<O2>,
+        Option<O3>,
+        Option<O4>,
+        Option<O5>,
+    );
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            r1,
+            o0,
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o0_data_latest,
+            o1_data_latest,
+            o2_data_latest,
+            o3_data_latest,
+            o4_data_latest,
+            o5_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+        let Some((r1_index, r1_data)) = r1.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        let mut o2_data = None;
+        while let Some((_, data)) = o2.next_if(|(index, _)| index <= &max_index) {
+            o2_data = Some(data);
+        }
+        let o2_data = o2_data.or(o2_data_latest.take());
+        *o2_data_latest = o2_data.clone();
+
+        let mut o3_data = None;
+        while let Some((_, data)) = o3.next_if(|(index, _)| index <= &max_index) {
+            o3_data = Some(data);
+        }
+        let o3_data = o3_data.or(o3_data_latest.take());
+        *o3_data_latest = o3_data.clone();
+
+        let mut o4_data = None;
+        while let Some((_, data)) = o4.next_if(|(index, _)| index <= &max_index) {
+            o4_data = Some(data);
+        }
+        let o4_data = o4_data.or(o4_data_latest.take());
+        *o4_data_latest = o4_data.clone();
+
+        let mut o5_data = None;
+        while let Some((_, data)) = o5.next_if(|(index, _)| index <= &max_index) {
+            o5_data = Some(data);
+        }
+        let o5_data = o5_data.or(o5_data_latest.take());
+        *o5_data_latest = o5_data.clone();
+
+        Some((
+            max_index, r0_data, r1_data, o0_data, o1_data, o2_data, o3_data, o4_data, o5_data,
+        ))
+    }
+}
+
+/// Returns a new [`RangeZip2x7`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`, `r1`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_2x7<
+    Idx,
+    IR0,
+    R0,
+    IR1,
+    R1,
+    IO0,
+    O0,
+    IO1,
+    O1,
+    IO2,
+    O2,
+    IO3,
+    O3,
+    IO4,
+    O4,
+    IO5,
+    O5,
+    IO6,
+    O6,
+>(
+    r0: IR0,
+    r1: IR1,
+    o0: IO0,
+    o1: IO1,
+    o2: IO2,
+    o3: IO3,
+    o4: IO4,
+    o5: IO5,
+    o6: IO6,
+) -> RangeZip2x7<
+    Idx,
+    IR0::IntoIter,
+    R0,
+    IR1::IntoIter,
+    R1,
+    IO0::IntoIter,
+    O0,
+    IO1::IntoIter,
+    O1,
+    IO2::IntoIter,
+    O2,
+    IO3::IntoIter,
+    O3,
+    IO4::IntoIter,
+    O4,
+    IO5::IntoIter,
+    O5,
+    IO6::IntoIter,
+    O6,
+>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IR1: IntoIterator<Item = (Idx, R1)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+    IO2: IntoIterator<Item = (Idx, O2)>,
+    IO3: IntoIterator<Item = (Idx, O3)>,
+    IO4: IntoIterator<Item = (Idx, O4)>,
+    IO5: IntoIterator<Item = (Idx, O5)>,
+    IO6: IntoIterator<Item = (Idx, O6)>,
+{
+    RangeZip2x7 {
+        r0: r0.into_iter(),
+        r1: r1.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+        o2: o2.into_iter().peekable(),
+        o3: o3.into_iter().peekable(),
+        o4: o4.into_iter().peekable(),
+        o5: o5.into_iter().peekable(),
+        o6: o6.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+        o2_data_latest: None,
+        o3_data_latest: None,
+        o4_data_latest: None,
+        o5_data_latest: None,
+        o6_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_2x7`] for more information.
+pub struct RangeZip2x7<
+    Idx,
+    IR0,
+    R0,
+    IR1,
+    R1,
+    IO0,
+    O0,
+    IO1,
+    O1,
+    IO2,
+    O2,
+    IO3,
+    O3,
+    IO4,
+    O4,
+    IO5,
+    O5,
+    IO6,
+    O6,
+> where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+    IO6: Iterator<Item = (Idx, O6)>,
+{
+    r0: IR0,
+    r1: IR1,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+    o2: Peekable<IO2>,
+    o3: Peekable<IO3>,
+    o4: Peekable<IO4>,
+    o5: Peekable<IO5>,
+    o6: Peekable<IO6>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+    o2_data_latest: Option<O2>,
+    o3_data_latest: Option<O3>,
+    o4_data_latest: Option<O4>,
+    o5_data_latest: Option<O5>,
+    o6_data_latest: Option<O6>,
+}
+
+impl<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1, IO2, O2, IO3, O3, IO4, O4, IO5, O5, IO6, O6> Iterator
+    for RangeZip2x7<
+        Idx,
+        IR0,
+        R0,
+        IR1,
+        R1,
+        IO0,
+        O0,
+        IO1,
+        O1,
+        IO2,
+        O2,
+        IO3,
+        O3,
+        IO4,
+        O4,
+        IO5,
+        O5,
+        IO6,
+        O6,
+    >
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+    IO6: Iterator<Item = (Idx, O6)>,
+    O0: Clone,
+    O1: Clone,
+    O2: Clone,
+    O3: Clone,
+    O4: Clone,
+    O5: Clone,
+    O6: Clone,
+{
+    type Item = (
+        Idx,
+        R0,
+        R1,
+        Option<O0>,
+        Option<O1>,
+        Option<O2>,
+        Option<O3>,
+        Option<O4>,
+        Option<O5>,
+        Option<O6>,
+    );
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            r1,
+            o0,
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o0_data_latest,
+            o1_data_latest,
+            o2_data_latest,
+            o3_data_latest,
+            o4_data_latest,
+            o5_data_latest,
+            o6_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+        let Some((r1_index, r1_data)) = r1.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        let mut o2_data = None;
+        while let Some((_, data)) = o2.next_if(|(index, _)| index <= &max_index) {
+            o2_data = Some(data);
+        }
+        let o2_data = o2_data.or(o2_data_latest.take());
+        *o2_data_latest = o2_data.clone();
+
+        let mut o3_data = None;
+        while let Some((_, data)) = o3.next_if(|(index, _)| index <= &max_index) {
+            o3_data = Some(data);
+        }
+        let o3_data = o3_data.or(o3_data_latest.take());
+        *o3_data_latest = o3_data.clone();
+
+        let mut o4_data = None;
+        while let Some((_, data)) = o4.next_if(|(index, _)| index <= &max_index) {
+            o4_data = Some(data);
+        }
+        let o4_data = o4_data.or(o4_data_latest.take());
+        *o4_data_latest = o4_data.clone();
+
+        let mut o5_data = None;
+        while let Some((_, data)) = o5.next_if(|(index, _)| index <= &max_index) {
+            o5_data = Some(data);
+        }
+        let o5_data = o5_data.or(o5_data_latest.take());
+        *o5_data_latest = o5_data.clone();
+
+        let mut o6_data = None;
+        while let Some((_, data)) = o6.next_if(|(index, _)| index <= &max_index) {
+            o6_data = Some(data);
+        }
+        let o6_data = o6_data.or(o6_data_latest.take());
+        *o6_data_latest = o6_data.clone();
+
+        Some((
+            max_index, r0_data, r1_data, o0_data, o1_data, o2_data, o3_data, o4_data, o5_data,
+            o6_data,
+        ))
+    }
+}
+
+/// Returns a new [`RangeZip2x8`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`, `r1`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_2x8<
+    Idx,
+    IR0,
+    R0,
+    IR1,
+    R1,
+    IO0,
+    O0,
+    IO1,
+    O1,
+    IO2,
+    O2,
+    IO3,
+    O3,
+    IO4,
+    O4,
+    IO5,
+    O5,
+    IO6,
+    O6,
+    IO7,
+    O7,
+>(
+    r0: IR0,
+    r1: IR1,
+    o0: IO0,
+    o1: IO1,
+    o2: IO2,
+    o3: IO3,
+    o4: IO4,
+    o5: IO5,
+    o6: IO6,
+    o7: IO7,
+) -> RangeZip2x8<
+    Idx,
+    IR0::IntoIter,
+    R0,
+    IR1::IntoIter,
+    R1,
+    IO0::IntoIter,
+    O0,
+    IO1::IntoIter,
+    O1,
+    IO2::IntoIter,
+    O2,
+    IO3::IntoIter,
+    O3,
+    IO4::IntoIter,
+    O4,
+    IO5::IntoIter,
+    O5,
+    IO6::IntoIter,
+    O6,
+    IO7::IntoIter,
+    O7,
+>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IR1: IntoIterator<Item = (Idx, R1)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+    IO2: IntoIterator<Item = (Idx, O2)>,
+    IO3: IntoIterator<Item = (Idx, O3)>,
+    IO4: IntoIterator<Item = (Idx, O4)>,
+    IO5: IntoIterator<Item = (Idx, O5)>,
+    IO6: IntoIterator<Item = (Idx, O6)>,
+    IO7: IntoIterator<Item = (Idx, O7)>,
+{
+    RangeZip2x8 {
+        r0: r0.into_iter(),
+        r1: r1.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+        o2: o2.into_iter().peekable(),
+        o3: o3.into_iter().peekable(),
+        o4: o4.into_iter().peekable(),
+        o5: o5.into_iter().peekable(),
+        o6: o6.into_iter().peekable(),
+        o7: o7.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+        o2_data_latest: None,
+        o3_data_latest: None,
+        o4_data_latest: None,
+        o5_data_latest: None,
+        o6_data_latest: None,
+        o7_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_2x8`] for more information.
+pub struct RangeZip2x8<
+    Idx,
+    IR0,
+    R0,
+    IR1,
+    R1,
+    IO0,
+    O0,
+    IO1,
+    O1,
+    IO2,
+    O2,
+    IO3,
+    O3,
+    IO4,
+    O4,
+    IO5,
+    O5,
+    IO6,
+    O6,
+    IO7,
+    O7,
+> where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+    IO6: Iterator<Item = (Idx, O6)>,
+    IO7: Iterator<Item = (Idx, O7)>,
+{
+    r0: IR0,
+    r1: IR1,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+    o2: Peekable<IO2>,
+    o3: Peekable<IO3>,
+    o4: Peekable<IO4>,
+    o5: Peekable<IO5>,
+    o6: Peekable<IO6>,
+    o7: Peekable<IO7>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+    o2_data_latest: Option<O2>,
+    o3_data_latest: Option<O3>,
+    o4_data_latest: Option<O4>,
+    o5_data_latest: Option<O5>,
+    o6_data_latest: Option<O6>,
+    o7_data_latest: Option<O7>,
+}
+
+impl<
+        Idx,
+        IR0,
+        R0,
+        IR1,
+        R1,
+        IO0,
+        O0,
+        IO1,
+        O1,
+        IO2,
+        O2,
+        IO3,
+        O3,
+        IO4,
+        O4,
+        IO5,
+        O5,
+        IO6,
+        O6,
+        IO7,
+        O7,
+    > Iterator
+    for RangeZip2x8<
+        Idx,
+        IR0,
+        R0,
+        IR1,
+        R1,
+        IO0,
+        O0,
+        IO1,
+        O1,
+        IO2,
+        O2,
+        IO3,
+        O3,
+        IO4,
+        O4,
+        IO5,
+        O5,
+        IO6,
+        O6,
+        IO7,
+        O7,
+    >
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+    IO6: Iterator<Item = (Idx, O6)>,
+    IO7: Iterator<Item = (Idx, O7)>,
+    O0: Clone,
+    O1: Clone,
+    O2: Clone,
+    O3: Clone,
+    O4: Clone,
+    O5: Clone,
+    O6: Clone,
+    O7: Clone,
+{
+    type Item = (
+        Idx,
+        R0,
+        R1,
+        Option<O0>,
+        Option<O1>,
+        Option<O2>,
+        Option<O3>,
+        Option<O4>,
+        Option<O5>,
+        Option<O6>,
+        Option<O7>,
+    );
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            r1,
+            o0,
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            o0_data_latest,
+            o1_data_latest,
+            o2_data_latest,
+            o3_data_latest,
+            o4_data_latest,
+            o5_data_latest,
+            o6_data_latest,
+            o7_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+        let Some((r1_index, r1_data)) = r1.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        let mut o2_data = None;
+        while let Some((_, data)) = o2.next_if(|(index, _)| index <= &max_index) {
+            o2_data = Some(data);
+        }
+        let o2_data = o2_data.or(o2_data_latest.take());
+        *o2_data_latest = o2_data.clone();
+
+        let mut o3_data = None;
+        while let Some((_, data)) = o3.next_if(|(index, _)| index <= &max_index) {
+            o3_data = Some(data);
+        }
+        let o3_data = o3_data.or(o3_data_latest.take());
+        *o3_data_latest = o3_data.clone();
+
+        let mut o4_data = None;
+        while let Some((_, data)) = o4.next_if(|(index, _)| index <= &max_index) {
+            o4_data = Some(data);
+        }
+        let o4_data = o4_data.or(o4_data_latest.take());
+        *o4_data_latest = o4_data.clone();
+
+        let mut o5_data = None;
+        while let Some((_, data)) = o5.next_if(|(index, _)| index <= &max_index) {
+            o5_data = Some(data);
+        }
+        let o5_data = o5_data.or(o5_data_latest.take());
+        *o5_data_latest = o5_data.clone();
+
+        let mut o6_data = None;
+        while let Some((_, data)) = o6.next_if(|(index, _)| index <= &max_index) {
+            o6_data = Some(data);
+        }
+        let o6_data = o6_data.or(o6_data_latest.take());
+        *o6_data_latest = o6_data.clone();
+
+        let mut o7_data = None;
+        while let Some((_, data)) = o7.next_if(|(index, _)| index <= &max_index) {
+            o7_data = Some(data);
+        }
+        let o7_data = o7_data.or(o7_data_latest.take());
+        *o7_data_latest = o7_data.clone();
+
+        Some((
+            max_index, r0_data, r1_data, o0_data, o1_data, o2_data, o3_data, o4_data, o5_data,
+            o6_data, o7_data,
+        ))
+    }
+}
+
+/// Returns a new [`RangeZip2x9`] iterator.
+///
+/// The number of elements in a range zip iterator corresponds to the number of elements in the
+/// shortest of its required iterators (`r0`, `r1`).
+///
+/// Each call to `next` is guaranteed to yield the next value for each required iterator,
+/// as well as the most recent index amongst all of them.
+///
+/// Optional iterators accumulate their state and yield their most recent value (if any),
+/// each time the required iterators fire.
+pub fn range_zip_2x9<
+    Idx,
+    IR0,
+    R0,
+    IR1,
+    R1,
+    IO0,
+    O0,
+    IO1,
+    O1,
+    IO2,
+    O2,
+    IO3,
+    O3,
+    IO4,
+    O4,
+    IO5,
+    O5,
+    IO6,
+    O6,
+    IO7,
+    O7,
+    IO8,
+    O8,
+>(
+    r0: IR0,
+    r1: IR1,
+    o0: IO0,
+    o1: IO1,
+    o2: IO2,
+    o3: IO3,
+    o4: IO4,
+    o5: IO5,
+    o6: IO6,
+    o7: IO7,
+    o8: IO8,
+) -> RangeZip2x9<
+    Idx,
+    IR0::IntoIter,
+    R0,
+    IR1::IntoIter,
+    R1,
+    IO0::IntoIter,
+    O0,
+    IO1::IntoIter,
+    O1,
+    IO2::IntoIter,
+    O2,
+    IO3::IntoIter,
+    O3,
+    IO4::IntoIter,
+    O4,
+    IO5::IntoIter,
+    O5,
+    IO6::IntoIter,
+    O6,
+    IO7::IntoIter,
+    O7,
+    IO8::IntoIter,
+    O8,
+>
+where
+    Idx: std::cmp::Ord,
+    IR0: IntoIterator<Item = (Idx, R0)>,
+    IR1: IntoIterator<Item = (Idx, R1)>,
+    IO0: IntoIterator<Item = (Idx, O0)>,
+    IO1: IntoIterator<Item = (Idx, O1)>,
+    IO2: IntoIterator<Item = (Idx, O2)>,
+    IO3: IntoIterator<Item = (Idx, O3)>,
+    IO4: IntoIterator<Item = (Idx, O4)>,
+    IO5: IntoIterator<Item = (Idx, O5)>,
+    IO6: IntoIterator<Item = (Idx, O6)>,
+    IO7: IntoIterator<Item = (Idx, O7)>,
+    IO8: IntoIterator<Item = (Idx, O8)>,
+{
+    RangeZip2x9 {
+        r0: r0.into_iter(),
+        r1: r1.into_iter(),
+        o0: o0.into_iter().peekable(),
+        o1: o1.into_iter().peekable(),
+        o2: o2.into_iter().peekable(),
+        o3: o3.into_iter().peekable(),
+        o4: o4.into_iter().peekable(),
+        o5: o5.into_iter().peekable(),
+        o6: o6.into_iter().peekable(),
+        o7: o7.into_iter().peekable(),
+        o8: o8.into_iter().peekable(),
+
+        o0_data_latest: None,
+        o1_data_latest: None,
+        o2_data_latest: None,
+        o3_data_latest: None,
+        o4_data_latest: None,
+        o5_data_latest: None,
+        o6_data_latest: None,
+        o7_data_latest: None,
+        o8_data_latest: None,
+    }
+}
+
+/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
+/// iterators.
+///
+/// See [`range_zip_2x9`] for more information.
+pub struct RangeZip2x9<
+    Idx,
+    IR0,
+    R0,
+    IR1,
+    R1,
+    IO0,
+    O0,
+    IO1,
+    O1,
+    IO2,
+    O2,
+    IO3,
+    O3,
+    IO4,
+    O4,
+    IO5,
+    O5,
+    IO6,
+    O6,
+    IO7,
+    O7,
+    IO8,
+    O8,
+> where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+    IO6: Iterator<Item = (Idx, O6)>,
+    IO7: Iterator<Item = (Idx, O7)>,
+    IO8: Iterator<Item = (Idx, O8)>,
+{
+    r0: IR0,
+    r1: IR1,
+    o0: Peekable<IO0>,
+    o1: Peekable<IO1>,
+    o2: Peekable<IO2>,
+    o3: Peekable<IO3>,
+    o4: Peekable<IO4>,
+    o5: Peekable<IO5>,
+    o6: Peekable<IO6>,
+    o7: Peekable<IO7>,
+    o8: Peekable<IO8>,
+
+    o0_data_latest: Option<O0>,
+    o1_data_latest: Option<O1>,
+    o2_data_latest: Option<O2>,
+    o3_data_latest: Option<O3>,
+    o4_data_latest: Option<O4>,
+    o5_data_latest: Option<O5>,
+    o6_data_latest: Option<O6>,
+    o7_data_latest: Option<O7>,
+    o8_data_latest: Option<O8>,
+}
+
+impl<
+        Idx,
+        IR0,
+        R0,
+        IR1,
+        R1,
+        IO0,
+        O0,
+        IO1,
+        O1,
+        IO2,
+        O2,
+        IO3,
+        O3,
+        IO4,
+        O4,
+        IO5,
+        O5,
+        IO6,
+        O6,
+        IO7,
+        O7,
+        IO8,
+        O8,
+    > Iterator
+    for RangeZip2x9<
+        Idx,
+        IR0,
+        R0,
+        IR1,
+        R1,
+        IO0,
+        O0,
+        IO1,
+        O1,
+        IO2,
+        O2,
+        IO3,
+        O3,
+        IO4,
+        O4,
+        IO5,
+        O5,
+        IO6,
+        O6,
+        IO7,
+        O7,
+        IO8,
+        O8,
+    >
+where
+    Idx: std::cmp::Ord,
+    IR0: Iterator<Item = (Idx, R0)>,
+    IR1: Iterator<Item = (Idx, R1)>,
+    IO0: Iterator<Item = (Idx, O0)>,
+    IO1: Iterator<Item = (Idx, O1)>,
+    IO2: Iterator<Item = (Idx, O2)>,
+    IO3: Iterator<Item = (Idx, O3)>,
+    IO4: Iterator<Item = (Idx, O4)>,
+    IO5: Iterator<Item = (Idx, O5)>,
+    IO6: Iterator<Item = (Idx, O6)>,
+    IO7: Iterator<Item = (Idx, O7)>,
+    IO8: Iterator<Item = (Idx, O8)>,
+    O0: Clone,
+    O1: Clone,
+    O2: Clone,
+    O3: Clone,
+    O4: Clone,
+    O5: Clone,
+    O6: Clone,
+    O7: Clone,
+    O8: Clone,
+{
+    type Item = (
+        Idx,
+        R0,
+        R1,
+        Option<O0>,
+        Option<O1>,
+        Option<O2>,
+        Option<O3>,
+        Option<O4>,
+        Option<O5>,
+        Option<O6>,
+        Option<O7>,
+        Option<O8>,
+    );
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            r0,
+            r1,
+            o0,
+            o1,
+            o2,
+            o3,
+            o4,
+            o5,
+            o6,
+            o7,
+            o8,
+            o0_data_latest,
+            o1_data_latest,
+            o2_data_latest,
+            o3_data_latest,
+            o4_data_latest,
+            o5_data_latest,
+            o6_data_latest,
+            o7_data_latest,
+            o8_data_latest,
+        } = self;
+
+        let Some((r0_index, r0_data)) = r0.next() else {
+            return None;
+        };
+        let Some((r1_index, r1_data)) = r1.next() else {
+            return None;
+        };
+
+        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+
+        let mut o0_data = None;
+        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
+            o0_data = Some(data);
+        }
+        let o0_data = o0_data.or(o0_data_latest.take());
+        *o0_data_latest = o0_data.clone();
+
+        let mut o1_data = None;
+        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
+            o1_data = Some(data);
+        }
+        let o1_data = o1_data.or(o1_data_latest.take());
+        *o1_data_latest = o1_data.clone();
+
+        let mut o2_data = None;
+        while let Some((_, data)) = o2.next_if(|(index, _)| index <= &max_index) {
+            o2_data = Some(data);
+        }
+        let o2_data = o2_data.or(o2_data_latest.take());
+        *o2_data_latest = o2_data.clone();
+
+        let mut o3_data = None;
+        while let Some((_, data)) = o3.next_if(|(index, _)| index <= &max_index) {
+            o3_data = Some(data);
+        }
+        let o3_data = o3_data.or(o3_data_latest.take());
+        *o3_data_latest = o3_data.clone();
+
+        let mut o4_data = None;
+        while let Some((_, data)) = o4.next_if(|(index, _)| index <= &max_index) {
+            o4_data = Some(data);
+        }
+        let o4_data = o4_data.or(o4_data_latest.take());
+        *o4_data_latest = o4_data.clone();
+
+        let mut o5_data = None;
+        while let Some((_, data)) = o5.next_if(|(index, _)| index <= &max_index) {
+            o5_data = Some(data);
+        }
+        let o5_data = o5_data.or(o5_data_latest.take());
+        *o5_data_latest = o5_data.clone();
+
+        let mut o6_data = None;
+        while let Some((_, data)) = o6.next_if(|(index, _)| index <= &max_index) {
+            o6_data = Some(data);
+        }
+        let o6_data = o6_data.or(o6_data_latest.take());
+        *o6_data_latest = o6_data.clone();
+
+        let mut o7_data = None;
+        while let Some((_, data)) = o7.next_if(|(index, _)| index <= &max_index) {
+            o7_data = Some(data);
+        }
+        let o7_data = o7_data.or(o7_data_latest.take());
+        *o7_data_latest = o7_data.clone();
+
+        let mut o8_data = None;
+        while let Some((_, data)) = o8.next_if(|(index, _)| index <= &max_index) {
+            o8_data = Some(data);
+        }
+        let o8_data = o8_data.or(o8_data_latest.take());
+        *o8_data_latest = o8_data.clone();
+
+        Some((
+            max_index, r0_data, r1_data, o0_data, o1_data, o2_data, o3_data, o4_data, o5_data,
+            o6_data, o7_data, o8_data,
+        ))
+    }
+}

--- a/crates/re_query2/src/range_zip/mod.rs
+++ b/crates/re_query2/src/range_zip/mod.rs
@@ -1,0 +1,69 @@
+mod generated;
+pub use self::generated::*;
+
+#[cfg(test)]
+mod tests {
+    use itertools::Itertools as _;
+
+    use re_log_types::{RowId, TimeInt};
+
+    use super::*;
+
+    #[test]
+    fn overview_1x1() {
+        let t9 = TimeInt::new_temporal(9);
+        let t10 = TimeInt::new_temporal(10);
+        let t11 = TimeInt::new_temporal(11);
+        let t12 = TimeInt::new_temporal(12);
+        let t13 = TimeInt::new_temporal(13);
+        let t14 = TimeInt::new_temporal(14);
+
+        let p0: Vec<((TimeInt, RowId), u32)> = vec![
+            ((t9, RowId::ZERO), 90), //
+            //
+            ((t10, RowId::ZERO), 100), //
+            //
+            ((t13, RowId::ZERO.incremented_by(0)), 130), //
+            ((t13, RowId::ZERO.incremented_by(0)), 130), //
+            ((t13, RowId::ZERO.incremented_by(0)), 130), //
+            ((t13, RowId::ZERO.incremented_by(1)), 131), //
+            ((t13, RowId::ZERO.incremented_by(2)), 132), //
+            ((t13, RowId::ZERO.incremented_by(5)), 135), //
+            //
+            ((t14, RowId::ZERO), 140), //
+        ];
+
+        let c0: Vec<((TimeInt, RowId), &'static str)> = vec![
+            ((t10, RowId::ZERO.incremented_by(1)), "101"), //
+            ((t10, RowId::ZERO.incremented_by(2)), "102"), //
+            ((t10, RowId::ZERO.incremented_by(3)), "103"), //
+            //
+            ((t11, RowId::ZERO), "110"), //
+            //
+            ((t12, RowId::ZERO), "120"), //
+            //
+            ((t13, RowId::ZERO.incremented_by(1)), "131"), //
+            ((t13, RowId::ZERO.incremented_by(2)), "132"), //
+            ((t13, RowId::ZERO.incremented_by(4)), "134"), //
+            ((t13, RowId::ZERO.incremented_by(6)), "136"), //
+        ];
+
+        let expected: Vec<((TimeInt, RowId), u32, Option<&'static str>)> = vec![
+            ((t9, RowId::ZERO), 90, None), //
+            //
+            ((t10, RowId::ZERO), 100, None), //
+            //
+            ((t13, RowId::ZERO.incremented_by(0)), 130, Some("120")), //
+            ((t13, RowId::ZERO.incremented_by(0)), 130, Some("120")), //
+            ((t13, RowId::ZERO.incremented_by(0)), 130, Some("120")), //
+            ((t13, RowId::ZERO.incremented_by(1)), 131, Some("131")), //
+            ((t13, RowId::ZERO.incremented_by(2)), 132, Some("132")), //
+            ((t13, RowId::ZERO.incremented_by(5)), 135, Some("134")), //
+            //
+            ((t14, RowId::ZERO), 140, Some("136")), //
+        ];
+        let got = range_zip_1x1(p0, c0).collect_vec();
+
+        similar_asserts::assert_eq!(expected, got);
+    }
+}


### PR DESCRIPTION
Code generator, and code generated, for the new `RangeZip` machinery.

Similar to #5573, the code generation is implemented as a very low-tech binary in the crate itself (`src/bin/range_zip.rs`), that just spews the generated code on stdout.
That seems like the right complexity-to-maintenance tradeoff, considering that iterator combinators don't really ever change.

Here's an example of one of these combinators:
```rust
/// Returns a new [`RangeZip2x2`] iterator.
///
/// The number of elements in a range zip iterator corresponds to the number of elements in the
/// shortest of its required iterators (`r0`, `r1`).
///
/// Each call to `next` is guaranteed to yield the next value for each required iterator,
/// as well as the most recent index amongst all of them.
///
/// Optional iterators accumulate their state and yield their most recent value (if any),
/// each time the required iterators fire.
pub fn range_zip_2x2<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1>(
    r0: IR0,
    r1: IR1,
    o0: IO0,
    o1: IO1,
) -> RangeZip2x2<Idx, IR0::IntoIter, R0, IR1::IntoIter, R1, IO0::IntoIter, O0, IO1::IntoIter, O1>
where
    Idx: std::cmp::Ord,
    IR0: IntoIterator<Item = (Idx, R0)>,
    IR1: IntoIterator<Item = (Idx, R1)>,
    IO0: IntoIterator<Item = (Idx, O0)>,
    IO1: IntoIterator<Item = (Idx, O1)>,
{
    RangeZip2x2 {
        r0: r0.into_iter(),
        r1: r1.into_iter(),
        o0: o0.into_iter().peekable(),
        o1: o1.into_iter().peekable(),

        o0_data_latest: None,
        o1_data_latest: None,
    }
}

/// Implements a range zip iterator combinator with 2 required iterators and 2 optional
/// iterators.
///
/// See [`range_zip_2x2`] for more information.
pub struct RangeZip2x2<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1>
where
    Idx: std::cmp::Ord,
    IR0: Iterator<Item = (Idx, R0)>,
    IR1: Iterator<Item = (Idx, R1)>,
    IO0: Iterator<Item = (Idx, O0)>,
    IO1: Iterator<Item = (Idx, O1)>,
{
    r0: IR0,
    r1: IR1,
    o0: Peekable<IO0>,
    o1: Peekable<IO1>,

    o0_data_latest: Option<O0>,
    o1_data_latest: Option<O1>,
}

impl<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1> Iterator
    for RangeZip2x2<Idx, IR0, R0, IR1, R1, IO0, O0, IO1, O1>
where
    Idx: std::cmp::Ord,
    IR0: Iterator<Item = (Idx, R0)>,
    IR1: Iterator<Item = (Idx, R1)>,
    IO0: Iterator<Item = (Idx, O0)>,
    IO1: Iterator<Item = (Idx, O1)>,
    O0: Clone,
    O1: Clone,
{
    type Item = (Idx, R0, R1, Option<O0>, Option<O1>);

    #[inline]
    fn next(&mut self) -> Option<Self::Item> {
        let Self {
            r0,
            r1,
            o0,
            o1,
            o0_data_latest,
            o1_data_latest,
        } = self;

        let Some((r0_index, r0_data)) = r0.next() else {
            return None;
        };
        let Some((r1_index, r1_data)) = r1.next() else {
            return None;
        };

        let max_index = [r0_index, r1_index].into_iter().max().unwrap();

        let mut o0_data = None;
        while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
            o0_data = Some(data);
        }
        let o0_data = o0_data.or(o0_data_latest.take());
        *o0_data_latest = o0_data.clone();

        let mut o1_data = None;
        while let Some((_, data)) = o1.next_if(|(index, _)| index <= &max_index) {
            o1_data = Some(data);
        }
        let o1_data = o1_data.or(o1_data_latest.take());
        *o1_data_latest = o1_data.clone();

        Some((max_index, r0_data, r1_data, o0_data, o1_data))
    }
}
```

---

Part of a PR series to completely revamp the data APIs in preparation for the removal of instance keys and the introduction of promises:
- #5573
- #5574
- #5581
- #5605
- #5606
- #5633
- #5673
- #5679
- #5687
- #5755
- TODO
- TODO

Builds on top of the static data PR series:
- #5534

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5573/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5573/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5573/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5573)
- [Docs preview](https://rerun.io/preview/324701dbff7c03d7c13e2c7947a2e2a06a935a9d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/324701dbff7c03d7c13e2c7947a2e2a06a935a9d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)