### PR TITLE
Apply shadows under menus

### DIFF
--- a/crates/re_ui/src/design_tokens.rs
+++ b/crates/re_ui/src/design_tokens.rs
@@ -155,8 +155,15 @@ fn apply_design_tokens(ctx: &egui::Context) -> DesignTokens {
     egui_style.visuals.widgets.inactive.fg_stroke.color = default; // button text
     egui_style.visuals.widgets.active.fg_stroke.color = strong; // strong text and active button text
 
-    egui_style.visuals.popup_shadow = egui::epaint::Shadow::NONE;
-    egui_style.visuals.window_shadow = egui::epaint::Shadow::NONE;
+    // From figma
+    let shadow = egui::epaint::Shadow {
+        offset: egui::vec2(0.0, 15.0),
+        blur: 50.0,
+        spread: 0.0,
+        color: egui::Color32::from_black_alpha(128),
+    };
+    egui_style.visuals.popup_shadow = shadow;
+    egui_style.visuals.window_shadow = shadow;
 
     egui_style.visuals.window_fill = floating_color; // tooltips and menus
     egui_style.visuals.window_stroke = egui::Stroke::NONE;


### PR DESCRIPTION
### What
It's a bit ugly that the shadow of one menu appears on top of the other imho, but that's not easily fixed in egui (and Mårten is okay with it). The alternative is a smaller blur radius.

## Using the shadows from Figma
<img width="618" alt="Screenshot 2024-03-26 at 12 01 56" src="https://github.com/rerun-io/rerun/assets/1148717/faaa2068-681e-4fdc-b1a1-5de8d6a52b13">

<img width="421" alt="Screenshot 2024-03-26 at 12 02 54" src="https://github.com/rerun-io/rerun/assets/1148717/373f56a3-eeae-4ff6-a0aa-da480de87b69">

## Alternative
Here are the default shadows in egui:

<img width="393" alt="Screenshot 2024-03-26 at 12 05 10" src="https://github.com/rerun-io/rerun/assets/1148717/44fc95f9-4a5d-449f-aad6-0e0b62c87e80">

<img width="616" alt="Screenshot 2024-03-26 at 12 06 01" src="https://github.com/rerun-io/rerun/assets/1148717/473ad508-e7fa-441a-bbf3-aedc29060292">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
