### PR TITLE
Fix update PR body workflow

### DIFF
--- a/.github/workflows/reusable_update_pr_body.yml
+++ b/.github/workflows/reusable_update_pr_body.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ inputs.CONCURRENCY }}-pr-summary
+  group: ${{ inputs.CONCURRENCY }}-pr-update-body
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/reusable_update_pr_body.yml
+++ b/.github/workflows/reusable_update_pr_body.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install deps
         shell: bash
         run: |
-          python3 -m pip install -r ./scripts/ci/requirements.txt
+          python3 -m pip install PyGithub==1.59.0 Jinja2==3.1.2
 
       - name: Update PR description
         shell: bash


### PR DESCRIPTION
### What

It shared its concurrency ID with PR summary which meant it would be cancelled if that ran first. That would only happen if the dependencies took a really long time to install, because we were installing everything in `scripts/ci/requirements.txt`, and it wasn't cached.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
