### PR TITLE
New data APIs 8: uncached range queries

### DIFF
--- a/crates/re_query2/examples/range.rs
+++ b/crates/re_query2/examples/range.rs
@@ -1,0 +1,168 @@
+use itertools::{izip, Itertools};
+use re_data_store::{DataStore, RangeQuery};
+use re_log_types::example_components::{MyColor, MyLabel, MyPoint, MyPoints};
+use re_log_types::{build_frame_nr, DataRow, RowId, TimeRange, TimeType, Timeline};
+use re_types_core::{Archetype as _, Loggable as _};
+
+use re_query2::{
+    clamped_zip_1x2, range_zip_1x2, PromiseResolver, PromiseResult, RangeComponentResults,
+    RangeResults,
+};
+
+// ---
+
+fn main() -> anyhow::Result<()> {
+    let store = store()?;
+    eprintln!("store:\n{}", store.to_data_table()?);
+
+    let resolver = PromiseResolver::default();
+
+    let entity_path = "points";
+    let timeline = Timeline::new("frame_nr", TimeType::Sequence);
+    let query = RangeQuery::new(timeline, TimeRange::EVERYTHING);
+    eprintln!("query:{query:?}");
+
+    // First, get the raw results for this query.
+    //
+    // Raw here means that these results are neither deserialized, nor resolved/converted.
+    // I.e. this corresponds to the raw `DataCell`s, straight from our datastore.
+    let results: RangeResults = re_query2::range(
+        &store,
+        &query,
+        &entity_path.into(),
+        MyPoints::all_components().iter().cloned(), // no generics!
+    );
+
+    // Then, grab the raw results for each individual components.
+    //
+    // This is still raw data, but now a choice has been made regarding the nullability of the
+    // _component batch_ itself (that says nothing about its _instances_!).
+    //
+    // * `get_required` returns an error if the component batch is missing
+    // * `get_optional` returns an empty set of results if the component if missing
+    // * `get` returns an option
+    let all_points: &RangeComponentResults = results.get_required(MyPoint::name())?;
+    let all_colors: &RangeComponentResults = results.get_optional(MyColor::name());
+    let all_labels: &RangeComponentResults = results.get_optional(MyLabel::name());
+
+    let all_indexed_points = izip!(
+        all_points.iter_indices(),
+        all_points.iter_dense::<MyPoint>(&resolver)
+    );
+    let all_indexed_colors = izip!(
+        all_colors.iter_indices(),
+        all_colors.iter_sparse::<MyColor>(&resolver)
+    );
+    let all_indexed_labels = izip!(
+        all_labels.iter_indices(),
+        all_labels.iter_sparse::<MyLabel>(&resolver)
+    );
+
+    let all_frames = range_zip_1x2(all_indexed_points, all_indexed_colors, all_indexed_labels);
+
+    // Then comes the time to resolve/convert and deserialize the data, _for each timestamp_.
+    // These steps have to be done together for efficiency reasons.
+    //
+    // Both the resolution and deserialization steps might fail, which is why this returns a `Result<Result<T>>`.
+    // Use `PromiseResult::flatten` to simplify it down to a single result.
+    //
+    // A choice now has to be made regarding the nullability of the _component batch's instances_.
+    // Our IDL doesn't support nullable instances at the moment -- so for the foreseeable future you probably
+    // shouldn't be using anything but `iter_dense`.
+    eprintln!("results:");
+    for ((data_time, row_id), points, colors, labels) in all_frames {
+        let points = match points.flatten() {
+            PromiseResult::Pending => {
+                // Handle the fact that the data isn't ready appropriately.
+                continue;
+            }
+            PromiseResult::Ready(data) => data,
+            PromiseResult::Error(err) => return Err(err.into()),
+        };
+
+        let colors = if let Some(colors) = colors {
+            match colors.flatten() {
+                PromiseResult::Pending => {
+                    // Handle the fact that the data isn't ready appropriately.
+                    continue;
+                }
+                PromiseResult::Ready(data) => data,
+                PromiseResult::Error(err) => return Err(err.into()),
+            }
+        } else {
+            vec![]
+        };
+        let color_default_fn = || Some(MyColor::from(0xFF00FFFF));
+
+        let labels = if let Some(labels) = labels {
+            match labels.flatten() {
+                PromiseResult::Pending => {
+                    // Handle the fact that the data isn't ready appropriately.
+                    continue;
+                }
+                PromiseResult::Ready(data) => data,
+                PromiseResult::Error(err) => return Err(err.into()),
+            }
+        } else {
+            vec![]
+        };
+        let label_default_fn = || None;
+
+        // With the data now fully resolved/converted and deserialized, the joining logic can be
+        // applied.
+        //
+        // In most cases this will be either a clamped zip, or no joining at all.
+
+        let results = clamped_zip_1x2(points, colors, color_default_fn, labels, label_default_fn)
+            .collect_vec();
+        eprintln!("{data_time:?} @ {row_id}:\n    {results:?}");
+    }
+
+    Ok(())
+}
+
+// ---
+
+fn store() -> anyhow::Result<DataStore> {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        re_types::components::InstanceKey::name(),
+        Default::default(),
+    );
+
+    let entity_path = "points";
+
+    {
+        let timepoint = [build_frame_nr(123)];
+
+        let points = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+        let row = DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 2, points)?;
+        store.insert_row(&row)?;
+
+        let colors = vec![MyColor::from_rgb(255, 0, 0)];
+        let row = DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 1, colors)?;
+        store.insert_row(&row)?;
+
+        let labels = vec![MyLabel("a".into()), MyLabel("b".into())];
+        let row = DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 2, labels)?;
+        store.insert_row(&row)?;
+    }
+
+    {
+        let timepoint = [build_frame_nr(456)];
+
+        let colors = vec![MyColor::from_rgb(255, 0, 0), MyColor::from_rgb(0, 0, 255)];
+        let row = DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 1, colors)?;
+        store.insert_row(&row)?;
+
+        let points = vec![
+            MyPoint::new(10.0, 20.0),
+            MyPoint::new(30.0, 40.0),
+            MyPoint::new(50.0, 60.0),
+        ];
+        let row = DataRow::from_cells1_sized(RowId::new(), entity_path, timepoint, 2, points)?;
+        store.insert_row(&row)?;
+    }
+
+    Ok(store)
+}

--- a/crates/re_query2/src/lib.rs
+++ b/crates/re_query2/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod latest_at;
 mod promise;
+mod range;
 mod visible_history;
 
 pub mod clamped_zip;
@@ -10,6 +11,8 @@ pub mod range_zip;
 pub use self::clamped_zip::*;
 pub use self::latest_at::{latest_at, LatestAtComponentResults, LatestAtResults};
 pub use self::promise::{Promise, PromiseId, PromiseResolver, PromiseResult};
+pub use self::range::{range, RangeComponentResults, RangeResults};
+pub use self::range_zip::*;
 pub use self::visible_history::{ExtraQueryHistory, VisibleHistory, VisibleHistoryBoundary};
 
 // ---

--- a/crates/re_query2/src/range/mod.rs
+++ b/crates/re_query2/src/range/mod.rs
@@ -1,0 +1,5 @@
+mod query;
+mod results;
+
+pub use self::query::range;
+pub use self::results::{RangeComponentResults, RangeResults};

--- a/crates/re_query2/src/range/query.rs
+++ b/crates/re_query2/src/range/query.rs
@@ -1,0 +1,38 @@
+use re_data_store::{DataStore, RangeQuery};
+use re_log_types::EntityPath;
+use re_types_core::ComponentName;
+
+use crate::RangeResults;
+
+// ---
+
+/// Queries for the given `component_names` using range semantics.
+///
+/// See [`RangeResults`] for more information about how to handle the results.
+pub fn range(
+    store: &DataStore,
+    query: &RangeQuery,
+    entity_path: &EntityPath,
+    component_names: impl IntoIterator<Item = ComponentName>,
+) -> RangeResults {
+    re_tracing::profile_function!(entity_path.to_string());
+
+    let mut results = RangeResults::default();
+
+    for component_name in component_names {
+        let data = store.range(query, entity_path, [component_name]).map(
+            |(data_time, row_id, mut cells)| {
+                // Unwrap:
+                // * `cells[0]` is guaranteed to exist since we passed in `&[component_name]`
+                // * `cells[0]` is guaranteed to be non-null, otherwise this whole result would be null
+                let cell = cells[0].take().unwrap();
+
+                ((data_time, row_id), cell)
+            },
+        );
+
+        results.add(component_name, data);
+    }
+
+    results
+}

--- a/crates/re_query2/src/range/results.rs
+++ b/crates/re_query2/src/range/results.rs
@@ -1,0 +1,207 @@
+use nohash_hasher::IntMap;
+use re_log_types::{DataCell, RowId, TimeInt};
+use re_types_core::ComponentName;
+use re_types_core::{Component, DeserializationError, DeserializationResult};
+
+use crate::{Promise, PromiseResolver, PromiseResult};
+
+// ---
+
+/// Raw results for a range query.
+///
+/// The data is neither deserialized, nor resolved/converted.
+/// It it the raw [`DataCell`]s, straight from our datastore.
+///
+/// Use [`RangeResults::get`], [`RangeResults::get_required`] and [`RangeResults::get_optional`]
+/// in order to access the raw results for each individual component.
+#[derive(Debug, Clone)]
+pub struct RangeResults {
+    /// Raw results for each individual component.
+    pub components: IntMap<ComponentName, RangeComponentResults>,
+}
+
+impl Default for RangeResults {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            components: Default::default(),
+        }
+    }
+}
+
+impl RangeResults {
+    #[inline]
+    pub fn contains(&self, component_name: impl Into<ComponentName>) -> bool {
+        self.components.contains_key(&component_name.into())
+    }
+
+    /// Returns the [`RangeComponentResults`] for the specified `component_name`.
+    #[inline]
+    pub fn get(&self, component_name: impl Into<ComponentName>) -> Option<&RangeComponentResults> {
+        self.components.get(&component_name.into())
+    }
+
+    /// Returns the [`RangeComponentResults`] for the specified `component_name`.
+    ///
+    /// Returns an error if the component is not present.
+    #[inline]
+    pub fn get_required(
+        &self,
+        component_name: impl Into<ComponentName>,
+    ) -> crate::Result<&RangeComponentResults> {
+        let component_name = component_name.into();
+        if let Some(component) = self.components.get(&component_name) {
+            Ok(component)
+        } else {
+            Err(DeserializationError::MissingComponent {
+                component: component_name,
+                backtrace: ::backtrace::Backtrace::new_unresolved(),
+            }
+            .into())
+        }
+    }
+
+    /// Returns the [`RangeComponentResults`] for the specified `component_name`.
+    ///
+    /// Returns empty results if the component is not present.
+    #[inline]
+    pub fn get_optional(&self, component_name: impl Into<ComponentName>) -> &RangeComponentResults {
+        let component_name = component_name.into();
+        if let Some(component) = self.components.get(&component_name) {
+            component
+        } else {
+            static DEFAULT: RangeComponentResults = RangeComponentResults::empty();
+            &DEFAULT
+        }
+    }
+}
+
+impl RangeResults {
+    #[doc(hidden)]
+    #[inline]
+    pub fn add(
+        &mut self,
+        component_name: ComponentName,
+        data: impl Iterator<Item = ((TimeInt, RowId), DataCell)>,
+    ) {
+        let (indices, cells): (Vec<_>, Vec<_>) = data
+            .map(|(index, cell)| (index, Promise::new(cell)))
+            .unzip();
+
+        let results = RangeComponentResults { indices, cells };
+        results.sanity_check();
+
+        self.components.insert(component_name, results);
+    }
+}
+
+// ---
+
+/// Uncached results for a particular component when using a range query.
+#[derive(Debug, Clone)]
+pub struct RangeComponentResults {
+    pub indices: Vec<(TimeInt, RowId)>,
+    pub cells: Vec<Promise>,
+}
+
+impl Default for RangeComponentResults {
+    #[inline]
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl RangeComponentResults {
+    #[inline]
+    pub const fn empty() -> Self {
+        Self {
+            indices: Vec::new(),
+            cells: Vec::new(),
+        }
+    }
+
+    /// No-op in release.
+    #[inline]
+    pub fn sanity_check(&self) {
+        let Self { indices, cells } = self;
+        if cfg!(debug_assertions) {
+            assert_eq!(indices.len(), cells.len());
+        }
+    }
+}
+
+impl RangeComponentResults {
+    #[inline]
+    pub fn indices(&self) -> &[(TimeInt, RowId)] {
+        &self.indices
+    }
+
+    #[inline]
+    pub fn iter_indices(&self) -> impl ExactSizeIterator<Item = (TimeInt, RowId)> + '_ {
+        self.indices.iter().copied()
+    }
+
+    /// Returns the component data as a vector of dense vectors.
+    ///
+    /// Use [`PromiseResult::flatten`] to merge the results of resolving the promise and of
+    /// deserializing the data into a single one, if you don't need the extra flexibility.
+    #[inline]
+    pub fn to_dense<C: Component>(
+        &self,
+        resolver: &PromiseResolver,
+    ) -> Vec<PromiseResult<DeserializationResult<Vec<C>>>> {
+        self.cells
+            .iter()
+            .map(|cell| {
+                resolver.resolve(cell).map(|cell| {
+                    cell.try_to_native()
+                        .map_err(|err| DeserializationError::DataCellError(err.to_string()))
+                })
+            })
+            .collect()
+    }
+
+    /// Returns the component data as an iterator of dense vectors.
+    ///
+    /// Use [`PromiseResult::flatten`] to merge the results of resolving the promise and of
+    /// deserializing the data into a single one, if you don't need the extra flexibility.
+    #[inline]
+    pub fn iter_dense<C: Component>(
+        &self,
+        resolver: &PromiseResolver,
+    ) -> impl ExactSizeIterator<Item = PromiseResult<DeserializationResult<Vec<C>>>> {
+        self.to_dense(resolver).into_iter()
+    }
+
+    /// Returns the component data as a vector of sparse vectors.
+    ///
+    /// Use [`PromiseResult::flatten`] to merge the results of resolving the promise and of
+    /// deserializing the data into a single one, if you don't need the extra flexibility.
+    #[inline]
+    pub fn to_sparse<C: Component>(
+        &self,
+        resolver: &PromiseResolver,
+    ) -> Vec<PromiseResult<DeserializationResult<Vec<Option<C>>>>> {
+        self.cells
+            .iter()
+            .map(|cell| {
+                resolver.resolve(cell).map(|cell| {
+                    cell.try_to_native_opt()
+                        .map_err(|err| DeserializationError::DataCellError(err.to_string()))
+                })
+            })
+            .collect()
+    }
+
+    /// Returns the component data as an iterator of sparse vectors.
+    ///
+    /// Use [`PromiseResult::flatten`] to merge the results of resolving the promise and of
+    /// deserializing the data into a single one, if you don't need the extra flexibility.
+    #[inline]
+    pub fn iter_sparse<C: Component>(
+        &self,
+        resolver: &PromiseResolver,
+    ) -> impl ExactSizeIterator<Item = PromiseResult<DeserializationResult<Vec<Option<C>>>>> {
+        self.to_sparse(resolver).into_iter()
+    }
+}

--- a/crates/re_query2/src/range/results.rs
+++ b/crates/re_query2/src/range/results.rs
@@ -14,19 +14,10 @@ use crate::{Promise, PromiseResolver, PromiseResult};
 ///
 /// Use [`RangeResults::get`], [`RangeResults::get_required`] and [`RangeResults::get_optional`]
 /// in order to access the raw results for each individual component.
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct RangeResults {
     /// Raw results for each individual component.
     pub components: IntMap<ComponentName, RangeComponentResults>,
-}
-
-impl Default for RangeResults {
-    #[inline]
-    fn default() -> Self {
-        Self {
-            components: Default::default(),
-        }
-    }
 }
 
 impl RangeResults {

--- a/crates/re_query2/tests/range.rs
+++ b/crates/re_query2/tests/range.rs
@@ -1,0 +1,496 @@
+use itertools::izip;
+use re_query2::PromiseResolver;
+use re_types::{components::InstanceKey, Archetype};
+
+use re_data_store::{DataStore, TimeInt, TimeRange};
+use re_log_types::{
+    build_frame_nr,
+    example_components::{MyColor, MyPoint, MyPoints},
+    DataRow, EntityPath, RowId, TimePoint,
+};
+use re_types_core::Loggable as _;
+
+// ---
+
+#[test]
+fn simple_range() -> anyhow::Result<()> {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+
+    let resolver = PromiseResolver::default();
+
+    let entity_path: EntityPath = "point".into();
+
+    let timepoint1 = [build_frame_nr(123)];
+    {
+        let points = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+        let row =
+            DataRow::from_cells1_sized(RowId::new(), entity_path.clone(), timepoint1, 2, points)?;
+        store.insert_row(&row)?;
+
+        let colors = vec![MyColor::from_rgb(255, 0, 0)];
+        let row =
+            DataRow::from_cells1_sized(RowId::new(), entity_path.clone(), timepoint1, 1, colors)?;
+        store.insert_row(&row)?;
+    }
+
+    let timepoint2 = [build_frame_nr(223)];
+    {
+        let colors = vec![MyColor::from_rgb(255, 0, 0)];
+        let row =
+            DataRow::from_cells1_sized(RowId::new(), entity_path.clone(), timepoint2, 1, colors)?;
+        store.insert_row(&row)?;
+    }
+
+    let timepoint3 = [build_frame_nr(323)];
+    {
+        let points = vec![MyPoint::new(10.0, 20.0), MyPoint::new(30.0, 40.0)];
+        let row =
+            DataRow::from_cells1_sized(RowId::new(), entity_path.clone(), timepoint3, 2, points)?;
+        store.insert_row(&row)?;
+    }
+
+    // --- First test: `(timepoint1, timepoint3]` ---
+
+    let query = re_data_store::RangeQuery::new(
+        timepoint1[0].0,
+        TimeRange::new(timepoint1[0].1.as_i64() + 1, timepoint3[0].1),
+    );
+
+    let results = re_query2::range(
+        &store,
+        &query,
+        &entity_path,
+        MyPoints::all_components().iter().copied(),
+    );
+
+    let all_points = results.get_required(MyPoint::name())?;
+    let all_colors = results.get_optional(MyColor::name());
+
+    let all_points = izip!(
+        all_points.iter_indices(),
+        all_points.iter_dense::<MyPoint>(&resolver)
+    );
+    let all_colors = izip!(
+        all_colors.iter_indices(),
+        all_colors.iter_sparse::<MyColor>(&resolver)
+    );
+
+    let mut results = re_query2::range_zip_1x1(all_points, all_colors);
+
+    // We expect this to generate the following `DataFrame`s:
+    //
+    // Frame #323:
+    // ┌──────────────┬─────────────────┐
+    // │ MyPoint      ┆ MyColor         │
+    // ╞══════════════╪═════════════════╡
+    // │ {10.0,20.0}  ┆ 4278190080      │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ {30.0,40.0}  ┆ 4278190080      │
+    // └──────────────┴─────────────────┘
+
+    {
+        // Frame #323
+
+        let ((data_time, _row_id), points, colors) = results.next().unwrap();
+        assert_eq!(TimeInt::new_temporal(323), data_time);
+
+        let expected_points = vec![MyPoint::new(10.0, 20.0), MyPoint::new(30.0, 40.0)];
+        let expected_colors = vec![
+            Some(MyColor::from_rgb(255, 0, 0)),
+            Some(MyColor::from_rgb(255, 0, 0)),
+        ];
+
+        let points = points.flatten().unwrap();
+        let colors = colors.map_or(vec![], |colors| colors.flatten().unwrap());
+
+        let (got_points, got_colors): (Vec<_>, Vec<_>) =
+            re_query2::clamped_zip_1x1(points, colors, || None).unzip();
+
+        similar_asserts::assert_eq!(expected_points, got_points);
+        similar_asserts::assert_eq!(expected_colors, got_colors);
+    }
+
+    assert!(results.next().is_none());
+
+    // --- Second test: `[timepoint1, timepoint3]` ---
+
+    let query = re_data_store::RangeQuery::new(
+        timepoint1[0].0,
+        TimeRange::new(timepoint1[0].1, timepoint3[0].1),
+    );
+
+    let results = re_query2::range(
+        &store,
+        &query,
+        &entity_path,
+        MyPoints::all_components().iter().copied(),
+    );
+
+    let all_points = results.get_required(MyPoint::name())?;
+    let all_colors = results.get_optional(MyColor::name());
+
+    let all_points = izip!(
+        all_points.iter_indices(),
+        all_points.iter_dense::<MyPoint>(&resolver)
+    );
+    let all_colors = izip!(
+        all_colors.iter_indices(),
+        all_colors.iter_sparse::<MyColor>(&resolver)
+    );
+
+    let mut results = re_query2::range_zip_1x1(all_points, all_colors);
+
+    // We expect this to generate the following `DataFrame`s:
+    //
+    // Frame #123:
+    // ┌───────────────┬─────────────────┐
+    // │ MyPoint       ┆ MyColor         │
+    // ╞═══════════════╪═════════════════╡
+    // │ {1.0,2.0}     ┆ null            │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ {3.0,4.0}     ┆ null            │
+    // └───────────────┴─────────────────┘
+    //
+    // Frame #323:
+    // ┌───────────────┬─────────────────┐
+    // │ MyPoint       ┆ MyColor         │
+    // ╞═══════════════╪═════════════════╡
+    // │ {10.0,20.0}   ┆ 4278190080      │
+    // ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ {30.0,40.0}   ┆ 4278190080      │
+    // └───────────────┴─────────────────┘
+
+    {
+        // Frame #123
+
+        let ((data_time, _row_id), points, colors) = results.next().unwrap();
+        assert_eq!(TimeInt::new_temporal(123), data_time);
+
+        let expected_points = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+        let expected_colors = vec![None, None];
+
+        let points = points.flatten().unwrap();
+        let colors = colors.map_or(vec![], |colors| colors.flatten().unwrap());
+
+        let (got_points, got_colors): (Vec<_>, Vec<_>) =
+            re_query2::clamped_zip_1x1(points, colors, || None).unzip();
+
+        similar_asserts::assert_eq!(expected_points, got_points);
+        similar_asserts::assert_eq!(expected_colors, got_colors);
+    }
+    {
+        // Frame #323
+
+        let ((data_time, _row_id), points, colors) = results.next().unwrap();
+        assert_eq!(TimeInt::new_temporal(323), data_time);
+
+        let expected_points = vec![MyPoint::new(10.0, 20.0), MyPoint::new(30.0, 40.0)];
+        let expected_colors = vec![
+            Some(MyColor::from_rgb(255, 0, 0)),
+            Some(MyColor::from_rgb(255, 0, 0)),
+        ];
+
+        let points = points.flatten().unwrap();
+        let colors = colors.map_or(vec![], |colors| colors.flatten().unwrap());
+
+        let (got_points, got_colors): (Vec<_>, Vec<_>) =
+            re_query2::clamped_zip_1x1(points, colors, || None).unzip();
+
+        similar_asserts::assert_eq!(expected_points, got_points);
+        similar_asserts::assert_eq!(expected_colors, got_colors);
+    }
+
+    assert!(results.next().is_none());
+
+    Ok(())
+}
+
+#[test]
+fn static_range() -> anyhow::Result<()> {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        InstanceKey::name(),
+        Default::default(),
+    );
+
+    let resolver = PromiseResolver::default();
+
+    let entity_path: EntityPath = "point".into();
+
+    let timepoint1 = [build_frame_nr(123)];
+    {
+        // Create some Positions with implicit instances
+        let positions = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+        let mut row =
+            DataRow::from_cells1(RowId::new(), entity_path.clone(), timepoint1, 2, positions)?;
+        row.compute_all_size_bytes();
+        store.insert_row(&row)?;
+
+        // Assign one of them a color with an explicit instance
+        let color_instances = vec![InstanceKey(1)];
+        let colors = vec![MyColor::from_rgb(255, 0, 0)];
+        let row = DataRow::from_cells2_sized(
+            RowId::new(),
+            entity_path.clone(),
+            timepoint1,
+            1,
+            (color_instances.clone(), colors.clone()),
+        )?;
+        store.insert_row(&row)?;
+    }
+
+    let timepoint2 = [build_frame_nr(223)];
+    {
+        // Assign one of them a color with an explicit instance
+        let color_instances = vec![InstanceKey(0)];
+        let colors = vec![MyColor::from_rgb(255, 0, 0)];
+        let row = DataRow::from_cells2_sized(
+            RowId::new(),
+            entity_path.clone(),
+            timepoint2,
+            1,
+            (color_instances.clone(), colors.clone()),
+        )?;
+        store.insert_row(&row)?;
+
+        // Insert statically too!
+        let row = DataRow::from_cells1_sized(
+            RowId::new(),
+            entity_path.clone(),
+            TimePoint::default(),
+            1,
+            colors,
+        )?;
+        store.insert_row(&row)?;
+    }
+
+    let timepoint3 = [build_frame_nr(323)];
+    {
+        // Create some Positions with implicit instances
+        let positions = vec![MyPoint::new(10.0, 20.0), MyPoint::new(30.0, 40.0)];
+        let row = DataRow::from_cells1_sized(
+            RowId::new(),
+            entity_path.clone(),
+            timepoint3,
+            2,
+            positions,
+        )?;
+        store.insert_row(&row)?;
+    }
+
+    // ┌──────────┬───────────────┬────────────────────────────┐
+    // │ frame_nr ┆ MyColor       ┆ MyColor                    │
+    // ╞══════════╪═══════════════╪════════════════════════════╡
+    // │ null     ┆ [4278190080]  ┆ null                       │
+    // ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 123      ┆ null          ┆ [{1.0,2.0}, {3.0,4.0}]     │
+    // ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 123      ┆ [4278190080]  ┆ null                       │
+    // ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 223      ┆ [4278190080]  ┆ null                       │
+    // ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 223      ┆ [4278190080]  ┆ null                       │
+    // ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    // │ 323      ┆ null          ┆ [{10.0,20.0}, {30.0,40.0}] │
+    // └──────────┴───────────────┴────────────────────────────┘
+
+    // --- First test: `(timepoint1, timepoint3]` ---
+
+    let query = re_data_store::RangeQuery::new(
+        timepoint1[0].0,
+        TimeRange::new(timepoint1[0].1.as_i64() + 1, timepoint3[0].1),
+    );
+
+    let results = re_query2::range(
+        &store,
+        &query,
+        &entity_path,
+        MyPoints::all_components().iter().copied(),
+    );
+
+    let all_points = results.get_required(MyPoint::name())?;
+    let all_colors = results.get_optional(MyColor::name());
+
+    let all_points = izip!(
+        all_points.iter_indices(),
+        all_points.iter_dense::<MyPoint>(&resolver)
+    );
+    let all_colors = izip!(
+        all_colors.iter_indices(),
+        all_colors.iter_sparse::<MyColor>(&resolver)
+    );
+
+    let mut results = re_query2::range_zip_1x1(all_points, all_colors);
+
+    {
+        // Frame #323
+
+        let ((data_time, _row_id), points, colors) = results.next().unwrap();
+        assert_eq!(TimeInt::new_temporal(323), data_time);
+
+        let expected_points = vec![MyPoint::new(10.0, 20.0), MyPoint::new(30.0, 40.0)];
+        let expected_colors = vec![
+            Some(MyColor::from_rgb(255, 0, 0)),
+            Some(MyColor::from_rgb(255, 0, 0)),
+        ];
+
+        let points = points.flatten().unwrap();
+        let colors = colors.map_or(vec![], |colors| colors.flatten().unwrap());
+
+        let (got_points, got_colors): (Vec<_>, Vec<_>) =
+            re_query2::clamped_zip_1x1(points, colors, || None).unzip();
+
+        similar_asserts::assert_eq!(expected_points, got_points);
+        similar_asserts::assert_eq!(expected_colors, got_colors);
+    }
+
+    // --- Second test: `[timepoint1, timepoint3]` ---
+
+    let query = re_data_store::RangeQuery::new(
+        timepoint1[0].0,
+        TimeRange::new(timepoint1[0].1, timepoint3[0].1),
+    );
+
+    let results = re_query2::range(
+        &store,
+        &query,
+        &entity_path,
+        MyPoints::all_components().iter().copied(),
+    );
+
+    let all_points = results.get_required(MyPoint::name())?;
+    let all_colors = results.get_optional(MyColor::name());
+
+    let all_points = izip!(
+        all_points.iter_indices(),
+        all_points.iter_dense::<MyPoint>(&resolver)
+    );
+    let all_colors = izip!(
+        all_colors.iter_indices(),
+        all_colors.iter_sparse::<MyColor>(&resolver)
+    );
+
+    let mut results = re_query2::range_zip_1x1(all_points, all_colors);
+
+    {
+        // Frame #123 (partially static)
+
+        let ((data_time, _row_id), points, colors) = results.next().unwrap();
+        assert_eq!(TimeInt::new_temporal(123), data_time);
+
+        let expected_points = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+        let expected_colors = vec![
+            Some(MyColor::from_rgb(255, 0, 0)),
+            Some(MyColor::from_rgb(255, 0, 0)),
+        ];
+
+        let points = points.flatten().unwrap();
+        let colors = colors.map_or(vec![], |colors| colors.flatten().unwrap());
+
+        let (got_points, got_colors): (Vec<_>, Vec<_>) =
+            re_query2::clamped_zip_1x1(points, colors, || None).unzip();
+
+        similar_asserts::assert_eq!(expected_points, got_points);
+        similar_asserts::assert_eq!(expected_colors, got_colors);
+    }
+    {
+        // Frame #323
+
+        let ((data_time, _row_id), points, colors) = results.next().unwrap();
+        assert_eq!(TimeInt::new_temporal(323), data_time);
+
+        let expected_points = vec![MyPoint::new(10.0, 20.0), MyPoint::new(30.0, 40.0)];
+        let expected_colors = vec![
+            Some(MyColor::from_rgb(255, 0, 0)),
+            Some(MyColor::from_rgb(255, 0, 0)),
+        ];
+
+        let points = points.flatten().unwrap();
+        let colors = colors.map_or(vec![], |colors| colors.flatten().unwrap());
+
+        let (got_points, got_colors): (Vec<_>, Vec<_>) =
+            re_query2::clamped_zip_1x1(points, colors, || None).unzip();
+
+        eprintln!("{}", store.to_data_table().unwrap());
+
+        similar_asserts::assert_eq!(expected_points, got_points);
+        similar_asserts::assert_eq!(expected_colors, got_colors);
+    }
+
+    // --- Third test: `[-inf, +inf]` ---
+
+    let query =
+        re_data_store::RangeQuery::new(timepoint1[0].0, TimeRange::new(TimeInt::MIN, TimeInt::MAX));
+
+    let results = re_query2::range(
+        &store,
+        &query,
+        &entity_path,
+        MyPoints::all_components().iter().copied(),
+    );
+
+    let all_points = results.get_required(MyPoint::name())?;
+    let all_colors = results.get_optional(MyColor::name());
+
+    let all_points = izip!(
+        all_points.iter_indices(),
+        all_points.iter_dense::<MyPoint>(&resolver)
+    );
+    let all_colors = izip!(
+        all_colors.iter_indices(),
+        all_colors.iter_sparse::<MyColor>(&resolver)
+    );
+
+    let mut results = re_query2::range_zip_1x1(all_points, all_colors);
+
+    {
+        // Frame #123 (partially static)
+
+        let ((data_time, _row_id), points, colors) = results.next().unwrap();
+        assert_eq!(TimeInt::new_temporal(123), data_time);
+
+        let expected_points = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+        let expected_colors = vec![
+            Some(MyColor::from_rgb(255, 0, 0)),
+            Some(MyColor::from_rgb(255, 0, 0)),
+        ];
+
+        let points = points.flatten().unwrap();
+        let colors = colors.map_or(vec![], |colors| colors.flatten().unwrap());
+
+        let (got_points, got_colors): (Vec<_>, Vec<_>) =
+            re_query2::clamped_zip_1x1(points, colors, || None).unzip();
+
+        similar_asserts::assert_eq!(expected_points, got_points);
+        similar_asserts::assert_eq!(expected_colors, got_colors);
+    }
+    {
+        // Frame #323
+
+        let ((data_time, _row_id), points, colors) = results.next().unwrap();
+        assert_eq!(TimeInt::new_temporal(323), data_time);
+
+        let expected_points = vec![MyPoint::new(10.0, 20.0), MyPoint::new(30.0, 40.0)];
+        let expected_colors = vec![
+            Some(MyColor::from_rgb(255, 0, 0)),
+            Some(MyColor::from_rgb(255, 0, 0)),
+        ];
+
+        let points = points.flatten().unwrap();
+        let colors = colors.map_or(vec![], |colors| colors.flatten().unwrap());
+
+        let (got_points, got_colors): (Vec<_>, Vec<_>) =
+            re_query2::clamped_zip_1x1(points, colors, || None).unzip();
+
+        eprintln!("{}", store.to_data_table().unwrap());
+
+        similar_asserts::assert_eq!(expected_points, got_points);
+        similar_asserts::assert_eq!(expected_colors, got_colors);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This implements the new uncached range APIs.

Latest-at & range queries are now much more similar than before and share a lot of nice traits.

Tests have been backported from `re_query`.

Here's an example/guide of using the new API:
```rust
// First, get the raw results for this query.
//
// Raw here means that these results are neither deserialized, nor resolved/converted.
// I.e. this corresponds to the raw `DataCell`s, straight from our datastore.
let results: RangeResults = re_query2::range(
    &store,
    &query,
    &entity_path.into(),
    MyPoints::all_components().iter().cloned(), // no generics!
);

// Then, grab the raw results for each individual components.
//
// This is still raw data, but now a choice has been made regarding the nullability of the
// _component batch_ itself (that says nothing about its _instances_!).
//
// * `get_required` returns an error if the component batch is missing
// * `get_optional` returns an empty set of results if the component if missing
// * `get` returns an option
let all_points: &RangeComponentResults = results.get_required(MyPoint::name())?;
let all_colors: &RangeComponentResults = results.get_optional(MyColor::name());
let all_labels: &RangeComponentResults = results.get_optional(MyLabel::name());

let all_indexed_points = izip!(
    all_points.iter_indices(),
    all_points.iter_dense::<MyPoint>(&resolver)
);
let all_indexed_colors = izip!(
    all_colors.iter_indices(),
    all_colors.iter_sparse::<MyColor>(&resolver)
);
let all_indexed_labels = izip!(
    all_labels.iter_indices(),
    all_labels.iter_sparse::<MyLabel>(&resolver)
);

let all_frames = range_zip_1x2(all_indexed_points, all_indexed_colors, all_indexed_labels);

// Then comes the time to resolve/convert and deserialize the data, _for each timestamp_.
// These steps have to be done together for efficiency reasons.
//
// Both the resolution and deserialization steps might fail, which is why this returns a `Result<Result<T>>`.
// Use `PromiseResult::flatten` to simplify it down to a single result.
//
// A choice now has to be made regarding the nullability of the _component batch's instances_.
// Our IDL doesn't support nullable instances at the moment -- so for the foreseeable future you probably
// shouldn't be using anything but `iter_dense`.
eprintln!("results:");
for ((data_time, row_id), points, colors, labels) in all_frames {
    let points = match points.flatten() {
        PromiseResult::Pending => {
            // Handle the fact that the data isn't ready appropriately.
            continue;
        }
        PromiseResult::Ready(data) => data,
        PromiseResult::Error(err) => return Err(err.into()),
    };

    let colors = if let Some(colors) = colors {
        match colors.flatten() {
            PromiseResult::Pending => {
                // Handle the fact that the data isn't ready appropriately.
                continue;
            }
            PromiseResult::Ready(data) => data,
            PromiseResult::Error(err) => return Err(err.into()),
        }
    } else {
        vec![]
    };
    let color_default_fn = || Some(MyColor::from(0xFF00FFFF));

    let labels = if let Some(labels) = labels {
        match labels.flatten() {
            PromiseResult::Pending => {
                // Handle the fact that the data isn't ready appropriately.
                continue;
            }
            PromiseResult::Ready(data) => data,
            PromiseResult::Error(err) => return Err(err.into()),
        }
    } else {
        vec![]
    };
    let label_default_fn = || None;

    // With the data now fully resolved/converted and deserialized, the joining logic can be
    // applied.
    //
    // In most cases this will be either a clamped zip, or no joining at all.

    let results = clamped_zip_1x2(points, colors, color_default_fn, labels, label_default_fn)
        .collect_vec();
    eprintln!("{data_time:?} @ {row_id}:\n    {results:?}");
}
```

- Fixes #3379
- Part of #1893  

---

Part of a PR series to completely revamp the data APIs in preparation for the removal of instance keys and the introduction of promises:
- #5573
- #5574
- #5581
- #5605
- #5606
- #5633
- #5673
- #5679
- #5687
- #5755
- TODO
- TODO

Builds on top of the static data PR series:
- #5534

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5573/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5573/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5573/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5573)
- [Docs preview](https://rerun.io/preview/04c1fa339cdbbf6f393ccc71eb3c8301c4c2ea6f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/04c1fa339cdbbf6f393ccc71eb3c8301c4c2ea6f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)