### PR TITLE
Remove a bunch of title casing, and add simple lint against it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,9 +208,9 @@ Check out our [migration guide](https://www.rerun.io/docs/reference/migration/mi
   - Only show the LegacyVisualizer if a user logs with TimeSeriesScalar archetype [#5023](https://github.com/rerun-io/rerun/pull/5023)
   - Fix lagging time cursor when panning a time series plot [#4972](https://github.com/rerun-io/rerun/pull/4972)
 - New Space View and Container creation workflow:
-  - Use the "Add Space View/Container" modal for the `+` button of the blueprint tree [#5012](https://github.com/rerun-io/rerun/pull/5012)
+  - Use the "Add space view/container" modal for the `+` button of the blueprint tree [#5012](https://github.com/rerun-io/rerun/pull/5012)
   - Add support for removing container children from the selection panel [#4930](https://github.com/rerun-io/rerun/pull/4930)
-  - Add support for full span highlighting to modal and use it in the "Add Space View or Container" modal [#4822](https://github.com/rerun-io/rerun/pull/4822)
+  - Add support for full span highlighting to modal and use it in the "Add space view or container" modal [#4822](https://github.com/rerun-io/rerun/pull/4822)
   - Remove the "+" icon from the "Add SV/Container" modal and close on click [#4927](https://github.com/rerun-io/rerun/pull/4927)
   - New empty space view defaults to uncollapsed in blueprint tree [#4982](https://github.com/rerun-io/rerun/pull/4982)
   - Do not allow adding Horizontal/Vertical containers inside of containers with the same type [#5091](https://github.com/rerun-io/rerun/pull/5091)

--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -520,7 +520,7 @@ pub fn instance_hover_card_ui(
     let subtype_string = if instance_path.instance_key.is_splat() {
         "Entity"
     } else {
-        "Entity Instance"
+        "Entity instance"
     };
     ui.strong(subtype_string);
     ui.label(instance_path.syntax_highlighted(ui.style()));

--- a/crates/re_entity_db/examples/memory_usage.rs
+++ b/crates/re_entity_db/examples/memory_usage.rs
@@ -101,7 +101,7 @@ fn log_messages() {
         let used_bytes_start = live_bytes();
         let entity_path = entity_path!("points");
         let used_bytes = live_bytes() - used_bytes_start;
-        println!("Short EntityPath uses {used_bytes} bytes in RAM");
+        println!("Short entity path uses {used_bytes} bytes in RAM");
         drop(entity_path);
     }
 

--- a/crates/re_sdk/src/global.rs
+++ b/crates/re_sdk/src/global.rs
@@ -81,7 +81,7 @@ thread_local! {
 pub fn cleanup_if_forked_child() {
     if let Some(global_recording) = RecordingStream::global(StoreKind::Recording) {
         if global_recording.is_forked_child() {
-            re_log::debug!("Fork detected. Forgetting global Recording");
+            re_log::debug!("Fork detected. Forgetting global recording");
             RecordingStream::forget_global(StoreKind::Recording);
         }
     }

--- a/crates/re_sdk/src/global.rs
+++ b/crates/re_sdk/src/global.rs
@@ -88,21 +88,21 @@ pub fn cleanup_if_forked_child() {
 
     if let Some(global_blueprint) = RecordingStream::global(StoreKind::Blueprint) {
         if global_blueprint.is_forked_child() {
-            re_log::debug!("Fork detected. Forgetting global Blueprint");
+            re_log::debug!("Fork detected. Forgetting global blueprint");
             RecordingStream::forget_global(StoreKind::Recording);
         }
     }
 
     if let Some(thread_recording) = RecordingStream::thread_local(StoreKind::Recording) {
         if thread_recording.is_forked_child() {
-            re_log::debug!("Fork detected. Forgetting thread-local Recording");
+            re_log::debug!("Fork detected. Forgetting thread-local recording");
             RecordingStream::forget_thread_local(StoreKind::Recording);
         }
     }
 
     if let Some(thread_blueprint) = RecordingStream::thread_local(StoreKind::Blueprint) {
         if thread_blueprint.is_forked_child() {
-            re_log::debug!("Fork detected. Forgetting thread-local Blueprint");
+            re_log::debug!("Fork detected. Forgetting thread-local blueprint");
             RecordingStream::forget_thread_local(StoreKind::Blueprint);
         }
     }

--- a/crates/re_smart_channel/src/lib.rs
+++ b/crates/re_smart_channel/src/lib.rs
@@ -60,11 +60,11 @@ impl std::fmt::Display for SmartChannelSource {
         match self {
             Self::File(path) => path.display().fmt(f),
             Self::RrdHttpStream { url } => url.fmt(f),
-            Self::RrdWebEventListener => "Web Event Listener".fmt(f),
+            Self::RrdWebEventListener => "Web event listener".fmt(f),
             Self::Sdk => "SDK".fmt(f),
             Self::WsClient { ws_server_url } => ws_server_url.fmt(f),
-            Self::TcpServer { port } => write!(f, "TCP Server, port {port}"),
-            Self::Stdin => "Standard Input".fmt(f),
+            Self::TcpServer { port } => write!(f, "TCP server, port {port}"),
+            Self::Stdin => "Standard input".fmt(f),
         }
     }
 }

--- a/crates/re_space_view/Cargo.toml
+++ b/crates/re_space_view/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors.workspace = true
-description = "Types & utilities for defining Space View classes and communicating with the Viewport."
+description = "Types & utilities for defining space view classes and communicating with the viewport."
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -378,7 +378,7 @@ impl SpaceViewBlueprint {
                 .ui(ctx, ui, view_state, &props, query, system_output)
                 .unwrap_or_else(|err| {
                     re_log::error!(
-                        "Error in Space View UI (class: {}, display name: {}): {err}",
+                        "Error in space view UI (class: {}, display name: {}): {err}",
                         self.class_identifier,
                         class.display_name(),
                     );

--- a/crates/re_space_view_bar_chart/Cargo.toml
+++ b/crates/re_space_view_bar_chart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors.workspace = true
-description = "A Space View that shows a single bar chart."
+description = "A space view that shows a single bar chart."
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/re_space_view_dataframe/Cargo.toml
+++ b/crates/re_space_view_dataframe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors.workspace = true
-description = "A Space View that shows the data contained in entities in a table."
+description = "A space view that shows the data contained in entities in a table."
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/re_space_view_spatial/src/contexts/transform_context.rs
@@ -137,7 +137,7 @@ impl ViewContextSystem for TransformContext {
             let Some(parent_tree) = entity_tree.subtree(&parent_path) else {
                 // Unlike not having the space path in the hierarchy, this should be impossible.
                 re_log::error_once!(
-                    "Path {} is not part of the global Entity tree whereas its child {} is",
+                    "Path {} is not part of the global entity tree whereas its child {} is",
                     parent_path,
                     query.space_origin
                 );

--- a/crates/re_space_view_spatial/src/space_view_3d.rs
+++ b/crates/re_space_view_spatial/src/space_view_3d.rs
@@ -457,8 +457,8 @@ fn background_ui(ctx: &ViewerContext<'_>, space_view_id: SpaceViewId, ui: &mut e
 
 fn background_color_text(kind: Background3DKind) -> &'static str {
     match kind {
-        Background3DKind::GradientDark => "Dark Gradient",
-        Background3DKind::GradientBright => "Bright Gradient",
-        Background3DKind::SolidColor => "Solid Color",
+        Background3DKind::GradientDark => "Dark gradient",
+        Background3DKind::GradientBright => "Bright gradient",
+        Background3DKind::SolidColor => "Solid color",
     }
 }

--- a/crates/re_space_view_tensor/Cargo.toml
+++ b/crates/re_space_view_tensor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors.workspace = true
-description = "A Space View dedicated to visualizing tensors with arbitrary dimensionality."
+description = "A space view dedicated to visualizing tensors with arbitrary dimensionality."
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/re_space_view_tensor/src/space_view_class.rs
@@ -150,7 +150,7 @@ impl SpaceViewClass for TensorSpaceView {
     }
 
     fn help_text(&self, _re_ui: &re_ui::ReUi) -> egui::WidgetText {
-        "Select the Space View to configure which dimensions are shown.".into()
+        "Select the space view to configure which dimensions are shown.".into()
     }
 
     fn on_register(

--- a/crates/re_space_view_text_document/Cargo.toml
+++ b/crates/re_space_view_text_document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors.workspace = true
-description = "A simple Space View that shows a single text box."
+description = "A simple space view that shows a single text box."
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/re_space_view_text_log/Cargo.toml
+++ b/crates/re_space_view_text_log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors.workspace = true
-description = "A Space View that shows text entries in a table and scrolls with the active time."
+description = "A space view that shows text entries in a table and scrolls with the active time."
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/re_space_view_time_series/Cargo.toml
+++ b/crates/re_space_view_time_series/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors.workspace = true
-description = "A Space View that shows plots over Rerun timelines."
+description = "A space view that shows plots over Rerun timelines."
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/re_types/definitions/rerun/archetypes/disconnected_space.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/disconnected_space.fbs
@@ -12,7 +12,7 @@ namespace rerun.archetypes;
 /// It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 /// This is useful for specifying that a subgraph is independent of the rest of the scene.
 ///
-/// \example disconnected_space title="Disconnected Space" image="https://static.rerun.io/disconnected_space/b8f95b0e32359de625a765247c84935146c1fba9/1200w.png"
+/// \example disconnected_space title="Disconnected space" image="https://static.rerun.io/disconnected_space/b8f95b0e32359de625a765247c84935146c1fba9/1200w.png"
 table DisconnectedSpace (
   "attr.rust.derive": "Copy, PartialEq, Eq"
 ) {

--- a/crates/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/re_types/src/archetypes/disconnected_space.rs
@@ -30,7 +30,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// ## Example
 ///
-/// ### Disconnected Space
+/// ### Disconnected space
 /// ```ignore
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_disconnected_space").spawn()?;

--- a/crates/re_ui/src/command.rs
+++ b/crates/re_ui/src/command.rs
@@ -106,8 +106,8 @@ impl UICommand {
             Self::Open => ("Open…", "Open any supported files (.rrd, images, meshes, …)"),
 
             Self::CloseCurrentRecording => (
-                "Close current Recording",
-                "Close the current Recording (unsaved data will be lost)",
+                "Close current recording",
+                "Close the current recording (unsaved data will be lost)",
             ),
 
             #[cfg(not(target_arch = "wasm32"))]

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -192,7 +192,7 @@ impl App {
             state.app_options(),
         ) {
             re_log::error!(
-                "Failed to populate Space View type registry with built-in Space Views: {}",
+                "Failed to populate space view type registry with built-in space views: {}",
                 err
             );
         }

--- a/crates/re_viewer/src/ui/blueprint_panel.rs
+++ b/crates/re_viewer/src/ui/blueprint_panel.rs
@@ -11,7 +11,7 @@ pub fn blueprint_panel_ui(
         ctx.re_ui.panel_title_bar_with_buttons(
             ui,
             "Blueprint",
-            Some("The Blueprint is where you can configure the Rerun Viewer"),
+            Some("The blueprint is where you can configure the Rerun Viewer"),
             |ui| {
                 viewport.add_new_spaceview_button_ui(ctx, ui);
                 reset_blueprint_button_ui(ctx, ui);
@@ -28,7 +28,7 @@ fn reset_blueprint_button_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
     if ctx
         .re_ui
         .small_icon_button(ui, &re_ui::icons::RESET)
-        .on_hover_text("Re-populate Viewport with automatically chosen Space Views")
+        .on_hover_text("Re-populate viewport with automatically chosen space views")
         .clicked()
     {
         ctx.command_sender

--- a/crates/re_viewer/src/ui/memory_panel.rs
+++ b/crates/re_viewer/src/ui/memory_panel.rs
@@ -578,15 +578,15 @@ impl MemoryPanel {
                 plot_ui.line(to_line(resident).name("Resident").width(1.5));
                 plot_ui.line(to_line(counted).name("Counted").width(1.5));
                 plot_ui.line(to_line(counted_gpu).name("Counted GPU").width(1.5));
-                plot_ui.line(to_line(counted_store).name("Counted Store").width(1.5));
+                plot_ui.line(to_line(counted_store).name("Counted store").width(1.5));
                 plot_ui.line(
                     to_line(counted_primary_caches)
-                        .name("Counted Primary Caches")
+                        .name("Counted primary caches")
                         .width(1.5),
                 );
                 plot_ui.line(
                     to_line(counted_blueprint)
-                        .name("Counted Blueprint")
+                        .name("Counted blueprint")
                         .width(1.5),
                 );
             });

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -367,14 +367,14 @@ fn experimental_feature_ui(
 ) {
     #[cfg(not(target_arch = "wasm32"))]
     re_ui
-        .checkbox(ui, &mut app_options.experimental_space_view_screenshots, "Space View screenshots")
+        .checkbox(ui, &mut app_options.experimental_space_view_screenshots, "Space view screenshots")
         .on_hover_text("Allow taking screenshots of 2D and 3D Space Views via their context menu. Does not contain labels.");
 
     if re_ui
         .checkbox(
             ui,
             &mut app_options.experimental_dataframe_space_view,
-            "Dataframe Space View",
+            "Dataframe space view",
         )
         .on_hover_text("Enable the experimental dataframe space view.")
         .clicked()

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -368,7 +368,7 @@ fn experimental_feature_ui(
     #[cfg(not(target_arch = "wasm32"))]
     re_ui
         .checkbox(ui, &mut app_options.experimental_space_view_screenshots, "Space view screenshots")
-        .on_hover_text("Allow taking screenshots of 2D and 3D Space Views via their context menu. Does not contain labels.");
+        .on_hover_text("Allow taking screenshots of 2D and 3D space views via their context menu. Does not contain labels.");
 
     if re_ui
         .checkbox(

--- a/crates/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/re_viewer/src/ui/rerun_menu.rs
@@ -330,7 +330,7 @@ fn options_menu_ui(
                 ui,
                 &mut app_options.time_zone,
                 TimeZone::UnixEpoch,
-                "Unix Epoch",
+                "Unix epoch",
             )
             .on_hover_text("Display timestamps in seconds since unix epoch");
     });

--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -211,7 +211,7 @@ fn item_to_string(blueprint: &ViewportBlueprint, item: &Item) -> String {
             if let Some(container) = blueprint.container(container_id) {
                 container.display_name_or_default().as_ref().to_owned()
             } else {
-                "<removed Container>".to_owned()
+                "<removed container>".to_owned()
             }
         }
     }

--- a/crates/re_viewer/src/ui/selection_history_ui.rs
+++ b/crates/re_viewer/src/ui/selection_history_ui.rs
@@ -188,7 +188,7 @@ fn item_to_string(blueprint: &ViewportBlueprint, item: &Item) -> String {
             if let Some(space_view) = blueprint.space_view(space_view_id) {
                 space_view.display_name_or_default().as_ref().to_owned()
             } else {
-                "<removed Space View>".to_owned()
+                "<removed space view>".to_owned()
             }
         }
         Item::InstancePath(instance_path) => instance_path.to_string(),
@@ -198,7 +198,7 @@ fn item_to_string(blueprint: &ViewportBlueprint, item: &Item) -> String {
                 if let Some(space_view) = blueprint.space_view(space_view_id) {
                     space_view.display_name_or_default().as_ref().to_owned()
                 } else {
-                    "<removed Space View>".to_owned()
+                    "<removed space view>".to_owned()
                 };
 
             format!("{instance_path} in {space_view_display_name}")

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -33,7 +33,7 @@ use super::{selection_history_ui::SelectionHistoryUi, visible_history::visual_ti
 
 // ---
 
-/// The "Selection View" sidebar.
+/// The "Selection view" sidebar.
 #[derive(Default, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub(crate) struct SelectionPanel {
@@ -330,11 +330,11 @@ fn what_is_selected_ui(
                 let hover_text =
                     if let Some(display_name) = container_blueprint.display_name.as_ref() {
                         format!(
-                            "{:?} Container {display_name:?}",
+                            "{:?} container {display_name:?}",
                             container_blueprint.container_kind,
                         )
                     } else {
-                        format!("Unnamed {:?} Container", container_blueprint.container_kind,)
+                        format!("Unnamed {:?} container", container_blueprint.container_kind,)
                     };
 
                 let container_name = container_blueprint.display_name_or_default();
@@ -520,7 +520,7 @@ fn list_existing_data_blueprints(
     let (query, store) = guess_query_and_store_for_selected_entity(ctx, &instance_path.entity_path);
 
     if space_views_with_path.is_empty() {
-        ui.weak("(Not shown in any Space View)");
+        ui.weak("(Not shown in any space view)");
     } else {
         for space_view_id in &space_views_with_path {
             if let Some(space_view) = blueprint.space_view(space_view_id) {
@@ -545,7 +545,7 @@ fn list_existing_data_blueprints(
 /// Display the top-level properties of a space view.
 ///
 /// This includes the name, space origin entity, and space view type. These properties are singled
-/// out as needing to be edited in most case when creating a new Space View, which is why they are
+/// out as needing to be edited in most case when creating a new space view, which is why they are
 /// shown at the very top.
 fn space_view_top_level_properties(
     ui: &mut egui::Ui,
@@ -559,7 +559,7 @@ fn space_view_top_level_properties(
             .show(ui, |ui| {
                 let mut name = space_view.display_name.clone().unwrap_or_default();
                 ui.label("Name").on_hover_text(
-                    "The name of the Space View used for display purposes. This can be any text \
+                    "The name of the space view used for display purposes. This can be any text \
                     string.",
                 );
                 ui.text_edit_singleline(&mut name);
@@ -607,7 +607,7 @@ fn container_top_level_properties(
         .show(ui, |ui| {
             let mut name = container.display_name.clone().unwrap_or_default();
             ui.label("Name").on_hover_text(
-                "The name of the Container used for display purposes. This can be any text string.",
+                "The name of the container used for display purposes. This can be any text string.",
             );
             ui.text_edit_singleline(&mut name);
             container.set_display_name(ctx, if name.is_empty() { None } else { Some(name) });
@@ -734,7 +734,7 @@ fn show_list_item_for_container_child(
                     .with_buttons(|re_ui, ui| {
                         let response = re_ui
                             .small_icon_button(ui, &re_ui::icons::REMOVE)
-                            .on_hover_text("Remove this Space View");
+                            .on_hover_text("Remove this space view");
 
                         if response.clicked() {
                             remove_contents = true;
@@ -760,7 +760,7 @@ fn show_list_item_for_container_child(
                     .with_buttons(|re_ui, ui| {
                         let response = re_ui
                             .small_icon_button(ui, &re_ui::icons::REMOVE)
-                            .on_hover_text("Remove this Container");
+                            .on_hover_text("Remove this container");
 
                         if response.clicked() {
                             remove_contents = true;
@@ -911,7 +911,7 @@ fn blueprint_ui_for_space_view(
             &mut props,
         ) {
             re_log::error!(
-                "Error in Space View selection UI (class: {}, display name: {}): {err}",
+                "Error in space view selection UI (class: {}, display name: {}): {err}",
                 space_view.class_identifier(),
                 space_view_class.display_name(),
             );

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -284,7 +284,7 @@ fn space_view_button(
             is_selected,
             contents_name_style(&space_view_name),
         )
-        .on_hover_text("Space View");
+        .on_hover_text("Space view");
     item_ui::cursor_interact_with_selectable(ctx, response, item)
 }
 
@@ -382,13 +382,13 @@ fn what_is_selected_ui(
 
                 let hover_text = if let Some(display_name) = space_view.display_name.as_ref() {
                     format!(
-                        "Space View {:?} of type {}",
+                        "Space view {:?} of type {}",
                         display_name,
                         space_view_class.display_name()
                     )
                 } else {
                     format!(
-                        "Unnamed Space View of type {}",
+                        "Unnamed space view of type {}",
                         space_view_class.display_name()
                     )
                 };
@@ -447,7 +447,7 @@ fn what_is_selected_ui(
                     name,
                     Some(guess_instance_path_icon(ctx, instance_path)),
                     &format!(
-                        "{typ} '{instance_path}' as shown in Space View {:?}",
+                        "{typ} '{instance_path}' as shown in space view {:?}",
                         space_view.display_name
                     ),
                 );
@@ -568,8 +568,8 @@ fn space_view_top_level_properties(
                 ui.end_row();
 
                 ui.label("Space origin").on_hover_text(
-                    "The origin Entity for this Space View. For spatial Space Views, the Space \
-                    View's origin is the same as this Entity's origin and all transforms are \
+                    "The origin entity for this space view. For spatial space views, the space \
+                    View's origin is the same as this entity's origin and all transforms are \
                     relative to it.",
                 );
 
@@ -580,7 +580,7 @@ fn space_view_top_level_properties(
                 ui.end_row();
 
                 ui.label("Type")
-                    .on_hover_text("The type of this Space View");
+                    .on_hover_text("The type of this space view");
                 ui.label(
                     space_view
                         .class(ctx.space_view_class_registry)
@@ -856,9 +856,9 @@ fn blueprint_ui_for_space_view(
     }
 
     if ui
-        .button("Clone Space View")
+        .button("Clone space view")
         .on_hover_text(
-            "Create an exact duplicate of this Space View including all Blueprint settings",
+            "Create an exact duplicate of this space view including all blueprint settings",
         )
         .clicked()
     {

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -268,7 +268,7 @@ fn panel_buttons_r2l(app: &App, app_blueprint: &AppBlueprint<'_>, ui: &mut egui:
             &mut blueprint_panel_expanded,
         )
         .on_hover_text(format!(
-            "Toggle Blueprint View{}",
+            "Toggle blueprint view{}",
             UICommand::ToggleBlueprintPanel.format_shortcut_tooltip_suffix(ui.ctx())
         ))
         .clicked()

--- a/crates/re_viewer/src/ui/visible_history.rs
+++ b/crates/re_viewer/src/ui/visible_history.rs
@@ -79,15 +79,15 @@ pub fn visual_time_range_ui(
             re_ui
                 .radio_value(ui, &mut has_individual_range, false, "Default")
                 .on_hover_text(if is_space_view {
-                    "Default visible time range settings for this kind of Space View"
+                    "Default visible time range settings for this kind of space view"
                 } else {
                     "Visible time range settings inherited from parent Entity or enclosing \
-                        Space View"
+                        space view"
                 });
             re_ui
                 .radio_value(ui, &mut has_individual_range, true, "Override")
                 .on_hover_text(if is_space_view {
-                    "Set visible time range settings for the contents of this Space View"
+                    "Set visible time range settings for the contents of this space view"
                 } else {
                     "Set visible time range settings for this entity"
                 });
@@ -261,9 +261,9 @@ pub fn visual_time_range_ui(
     }
 
     let markdown = format!("# Visible time range\n
-This feature controls the time range used to display data in the Space View.
+This feature controls the time range used to display data in the space view.
 
-The settings are inherited from the parent Entity or enclosing Space View if not overridden.
+The settings are inherited from the parent Entity or enclosing space view if not overridden.
 
 Visible time range properties are stored separately for each _type_ of timelines. They may differ depending on \
 whether the current timeline is temporal or a sequence. The current settings apply to all _{}_ timelines.

--- a/crates/re_viewer_context/src/item.rs
+++ b/crates/re_viewer_context/src/item.rs
@@ -123,19 +123,19 @@ impl Item {
             },
             Item::InstancePath(instance_path) => {
                 if instance_path.instance_key.is_specific() {
-                    "Entity Instance"
+                    "Entity instance"
                 } else {
                     "Entity"
                 }
             }
-            Item::ComponentPath(_) => "Entity Component",
-            Item::SpaceView(_) => "Space View",
+            Item::ComponentPath(_) => "Entity component",
+            Item::SpaceView(_) => "Space view",
             Item::Container(_) => "Container",
             Item::DataResult(_, instance_path) => {
                 if instance_path.instance_key.is_specific() {
-                    "Data Result Instance"
+                    "Data result instance"
                 } else {
-                    "Data Result Entity"
+                    "Data result entity"
                 }
             }
         }

--- a/crates/re_viewer_context/src/space_view/mod.rs
+++ b/crates/re_viewer_context/src/space_view/mod.rs
@@ -57,7 +57,7 @@ pub enum SpaceViewSystemExecutionError {
     #[error(transparent)]
     GpuTransferError(#[from] re_renderer::CpuWriteGpuReadError),
 
-    #[error("Failed to downcast Space View's to the {0}.")]
+    #[error("Failed to downcast space view's to the {0}.")]
     StateCastError(&'static str),
 }
 

--- a/crates/re_viewer_context/src/space_view/space_view_class_placeholder.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class_placeholder.rs
@@ -11,11 +11,11 @@ pub struct SpaceViewClassPlaceholder;
 
 impl SpaceViewClass for SpaceViewClassPlaceholder {
     fn identifier() -> SpaceViewClassIdentifier {
-        "Unknown Space View Class".into()
+        "Unknown space view class".into()
     }
 
     fn display_name(&self) -> &'static str {
-        "Unknown Space View Class"
+        "Unknown space view class"
     }
 
     fn icon(&self) -> &'static re_ui::Icon {
@@ -23,7 +23,7 @@ impl SpaceViewClass for SpaceViewClassPlaceholder {
     }
 
     fn help_text(&self, _re_ui: &re_ui::ReUi) -> egui::WidgetText {
-        "The Space View Class was not recognized.\nThis happens if either the Blueprint specifies an invalid Space View Class or this version of the Viewer does not know about this type.".into()
+        "The space view class was not recognized.\nThis happens if either the blueprint specifies an invalid space view class or this version of the viewer does not know about this type.".into()
     }
 
     fn on_register(

--- a/crates/re_viewer_context/src/space_view/space_view_class_registry.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class_registry.rs
@@ -15,16 +15,16 @@ use super::{
 #[derive(Debug, thiserror::Error)]
 #[allow(clippy::enum_variant_names)]
 pub enum SpaceViewClassRegistryError {
-    #[error("Space View with class identifier {0:?} was already registered.")]
+    #[error("Space view with class identifier {0:?} was already registered.")]
     DuplicateClassIdentifier(SpaceViewClassIdentifier),
 
-    #[error("A Context System with identifier {0:?} was already registered.")]
+    #[error("A context system with identifier {0:?} was already registered.")]
     IdentifierAlreadyInUseForContextSystem(&'static str),
 
-    #[error("A Visualizer System with identifier {0:?} was already registered.")]
+    #[error("A visualizer system with identifier {0:?} was already registered.")]
     IdentifierAlreadyInUseForVisualizer(&'static str),
 
-    #[error("Space View with class identifier {0:?} was not registered.")]
+    #[error("Space view with class identifier {0:?} was not registered.")]
     UnknownClassIdentifier(SpaceViewClassIdentifier),
 }
 

--- a/crates/re_viewport/src/add_space_view_or_container_modal.rs
+++ b/crates/re_viewport/src/add_space_view_or_container_modal.rs
@@ -31,7 +31,7 @@ impl AddSpaceViewOrContainerModal {
             ctx.re_ui,
             egui_ctx,
             || {
-                re_ui::modal::Modal::new("Add Space View or Container")
+                re_ui::modal::Modal::new("Add space view or container")
                     .min_width(500.0)
                     .full_span_content(true)
             },
@@ -118,7 +118,7 @@ fn modal_ui(
         let title = space_view
             .class(ctx.space_view_class_registry)
             .display_name();
-        let subtitle = format!("Create a new Space View to display {title} content.");
+        let subtitle = format!("Create a new space view to display {title} content.");
 
         if row_ui(ui, icon, title, &subtitle).clicked() {
             viewport.add_space_views(std::iter::once(space_view), ctx, target_container, None);

--- a/crates/re_viewport/src/container.rs
+++ b/crates/re_viewport/src/container.rs
@@ -60,9 +60,9 @@ impl ContainerBlueprint {
             .map_err(|err| {
                 if !matches!(err, re_query::QueryError::PrimaryNotFound(_)) {
                     if cfg!(debug_assertions) {
-                        re_log::error!("Failed to load Container blueprint: {err}.");
+                        re_log::error!("Failed to load container blueprint: {err}.");
                     } else {
-                        re_log::debug!("Failed to load Container blueprint: {err}.");
+                        re_log::debug!("Failed to load container blueprint: {err}.");
                     }
                 }
             })
@@ -165,7 +165,7 @@ impl ContainerBlueprint {
 
         if let Some(row) =
             DataRow::from_archetype(RowId::new(), timepoint.clone(), id.as_entity_path(), &arch)
-                .warn_on_err_once("Failed to create Container blueprint.")
+                .warn_on_err_once("Failed to create container blueprint.")
         {
             deltas.push(row);
 

--- a/crates/re_viewport/src/context_menu/actions/add_entities_to_new_space_view.rs
+++ b/crates/re_viewport/src/context_menu/actions/add_entities_to_new_space_view.rs
@@ -34,7 +34,7 @@ impl ContextMenuAction for AddEntitiesToNewSpaceViewAction {
             .cloned()
             .collect();
 
-        ui.menu_button("Add to new Space View", |ui| {
+        ui.menu_button("Add to new space view", |ui| {
             let buttons_for_space_view_classes =
                 |ui: &mut egui::Ui, space_view_classes: &IntSet<SpaceViewClassIdentifier>| {
                     for (identifier, display_name) in space_view_classes

--- a/crates/re_viewport/src/context_menu/mod.rs
+++ b/crates/re_viewport/src/context_menu/mod.rs
@@ -125,7 +125,7 @@ fn action_list(
                     ],
                 }),
                 Box::new(SubMenu {
-                    label: "Add Space View".to_owned(),
+                    label: "Add space view".to_owned(),
                     actions: ctx
                         .space_view_class_registry
                         .iter_registry()

--- a/crates/re_viewport/src/space_view_entity_picker.rs
+++ b/crates/re_viewport/src/space_view_entity_picker.rs
@@ -201,9 +201,9 @@ fn add_entities_line_ui(
                 }
 
                 if is_explicitly_excluded {
-                    response.on_hover_text("Stop excluding this EntityPath.");
+                    response.on_hover_text("Stop excluding this entity path.");
                 } else if is_explicitly_included {
-                    response.on_hover_text("Stop including this EntityPath.");
+                    response.on_hover_text("Stop including this entity path.");
                 }
             } else if is_included {
                 // Remove-button
@@ -218,7 +218,7 @@ fn add_entities_line_ui(
                 }
 
                 response.on_hover_text(
-                    "Exclude this Entity and all its descendants from the Space View",
+                    "Exclude this entity and all its descendants from the space view",
                 );
             } else {
                 // Add-button:
@@ -239,11 +239,11 @@ fn add_entities_line_ui(
                     if enabled {
                         if add_info.can_add.is_compatible_and_missing() {
                             response.on_hover_text(
-                                "Include this Entity and all its descendants in the Space View",
+                                "Include this entity and all its descendants in the space view",
                             );
                         } else {
                             response
-                                .on_hover_text("Add descendants of this Entity to the Space View");
+                                .on_hover_text("Add descendants of this entity to the space view");
                         }
                     } else if let CanAddToSpaceView::No { reason } = &add_info.can_add {
                         response.on_disabled_hover_text(reason);
@@ -339,7 +339,7 @@ fn create_entity_add_info(
                 // TODO(#4826): This shouldn't necessarily prevent us from adding it.
                 CanAddToSpaceView::No {
                     reason: format!(
-                        "Entity can't be displayed by any of the available visualizers in this class of Space View ({}).",
+                        "Entity can't be displayed by any of the available visualizers in this class of space view ({}).",
                         space_view.class_identifier()
                     ),
                 }

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -38,7 +38,7 @@ pub struct ViewportState {
     /// State for the "Add Entity" modal.
     space_view_entity_modal: SpaceViewEntityPicker,
 
-    /// State for the "Add Space View or Container" modal.
+    /// State for the "Add space view or container" modal.
     add_space_view_container_modal: AddSpaceViewOrContainerModal,
 
     space_view_states: HashMap<SpaceViewId, PerSpaceViewState>,
@@ -768,7 +768,7 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
                 .ctx
                 .re_ui
                 .small_icon_button(ui, &re_ui::icons::MAXIMIZE)
-                .on_hover_text("Maximize Space View")
+                .on_hover_text("Maximize space view")
                 .clicked()
             {
                 *self.maximized = Some(space_view_id);
@@ -909,10 +909,10 @@ impl TabWidget {
                         item: Some(Item::SpaceView(*space_view_id)),
                     }
                 } else {
-                    re_log::warn_once!("Space View {space_view_id} not found");
+                    re_log::warn_once!("Space view {space_view_id} not found");
 
                     TabDesc {
-                        label: tab_viewer.ctx.re_ui.error_text("Unknown Space View").into(),
+                        label: tab_viewer.ctx.re_ui.error_text("Unknown space view").into(),
                         icon: &re_ui::icons::SPACE_VIEW_GENERIC,
                         user_named: false,
                         item: None,

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -35,7 +35,7 @@ pub struct PerSpaceViewState {
 /// is not saved.
 #[derive(Default)]
 pub struct ViewportState {
-    /// State for the "Add Entity" modal.
+    /// State for the "Add entity" modal.
     space_view_entity_modal: SpaceViewEntityPicker,
 
     /// State for the "Add space view or container" modal.
@@ -865,7 +865,7 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
 /// A tab button for a tab in the viewport.
 ///
 /// The tab can contain any `egui_tiles::Tile`,
-/// which is either a Pane with a Space View, or a Container,
+/// which is either a Pane with a Space View, or a container,
 /// e.g. a grid of tiles.
 struct TabWidget {
     galley: std::sync::Arc<egui::Galley>,
@@ -960,7 +960,7 @@ impl TabWidget {
                     re_log::warn_once!("Container for tile ID {tile_id:?} not found");
 
                     TabDesc {
-                        label: tab_viewer.ctx.re_ui.error_text("Unknown Container").into(),
+                        label: tab_viewer.ctx.re_ui.error_text("Unknown container").into(),
                         icon: &re_ui::icons::SPACE_VIEW_GENERIC,
                         user_named: false,
                         item: None,

--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -383,7 +383,7 @@ impl Viewport<'_, '_> {
         container_visible: bool,
     ) {
         let Some(space_view) = self.blueprint.space_views.get(space_view_id) else {
-            re_log::warn_once!("Bug: asked to show a ui for a Space View that doesn't exist");
+            re_log::warn_once!("Bug: asked to show a ui for a space view that doesn't exist");
             return;
         };
         debug_assert_eq!(space_view.id, *space_view_id);
@@ -418,7 +418,7 @@ impl Viewport<'_, '_> {
             .with_buttons(|re_ui, ui| {
                 let vis_response = visibility_button_ui(re_ui, ui, container_visible, &mut visible);
 
-                let response = remove_button_ui(re_ui, ui, "Remove Space View from the Viewport");
+                let response = remove_button_ui(re_ui, ui, "Remove space view from the viewport");
                 if response.clicked() {
                     self.blueprint.mark_user_interaction(ctx);
                     self.blueprint
@@ -481,7 +481,7 @@ impl Viewport<'_, '_> {
                 },
             );
 
-        response = response.on_hover_text("Space View");
+        response = response.on_hover_text("Space view");
 
         if response.clicked() {
             self.blueprint.focus_tab(space_view.id);
@@ -597,7 +597,7 @@ impl Viewport<'_, '_> {
                 let response = remove_button_ui(
                     re_ui,
                     ui,
-                    "Remove Group and all its children from the Space View",
+                    "Remove group and all its children from the space view",
                 );
                 if response.clicked() {
                     space_view.contents.add_entity_exclusion(
@@ -673,7 +673,7 @@ impl Viewport<'_, '_> {
         if ctx
             .re_ui
             .small_icon_button(ui, &re_ui::icons::ADD)
-            .on_hover_text("Add a new Space View or Container")
+            .on_hover_text("Add a new space view or container")
             .clicked()
         {
             // If a single container is selected, we use it as target. Otherwise, we target the

--- a/docs/content/reference/types/archetypes/disconnected_space.md
+++ b/docs/content/reference/types/archetypes/disconnected_space.md
@@ -20,7 +20,7 @@ This is useful for specifying that a subgraph is independent of the rest of the 
 
 ## Example
 
-### Disconnected Space
+### Disconnected space
 
 snippet: disconnected_space
 

--- a/examples/cpp/shared_recording/README.md
+++ b/examples/cpp/shared_recording/README.md
@@ -1,5 +1,5 @@
 <!--[metadata]
-title = "Shared Recording"
+title = "Shared recording"
 -->
 
 

--- a/examples/python/shared_recording/README.md
+++ b/examples/python/shared_recording/README.md
@@ -1,5 +1,5 @@
 <!--[metadata]
-title = "Shared Recording"
+title = "Shared recording"
 -->
 
 

--- a/examples/rust/custom_space_view/README.md
+++ b/examples/rust/custom_space_view/README.md
@@ -1,5 +1,5 @@
 <!--[metadata]
-title = "Custom Space View UI"
+title = "Custom space view UI"
 thumbnail = "https://static.rerun.io/custom_space_view/e05a073d64003645b6af6de91b068c2f646c1b8a/480w.jpeg"
 thumbnail_dimensions = [480, 343]
 -->

--- a/examples/rust/custom_store_subscriber/README.md
+++ b/examples/rust/custom_store_subscriber/README.md
@@ -1,5 +1,5 @@
 <!--[metadata]
-title = "Custom Store Subscriber"
+title = "Custom store subscriber"
 tags = ["store-event", "store-diff", "store-subscriber"]
 -->
 

--- a/examples/rust/custom_store_subscriber/src/main.rs
+++ b/examples/rust/custom_store_subscriber/src/main.rs
@@ -127,7 +127,7 @@ impl StoreSubscriber for ComponentsPerRecording {
         println!("---------------");
 
         for (recording, per_component) in &self.counters {
-            println!("  Recording '{recording}':");
+            println!("  Recording '{recording}':"); // NOLINT
             for (component, counter) in per_component {
                 println!("    {component}: {counter} occurrences");
             }

--- a/examples/rust/shared_recording/README.md
+++ b/examples/rust/shared_recording/README.md
@@ -1,5 +1,5 @@
 <!--[metadata]
-title = "Shared Recording"
+title = "Shared recording"
 -->
 
 

--- a/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/archetypes/disconnected_space.hpp
@@ -23,7 +23,7 @@ namespace rerun::archetypes {
     ///
     /// ## Example
     ///
-    /// ### Disconnected Space
+    /// ### Disconnected space
     /// ![image](https://static.rerun.io/disconnected_space/b8f95b0e32359de625a765247c84935146c1fba9/full.png)
     ///
     /// ```cpp

--- a/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
@@ -26,7 +26,7 @@ class DisconnectedSpace(DisconnectedSpaceExt, Archetype):
 
     Example
     -------
-    ### Disconnected Space:
+    ### Disconnected space:
     ```python
     import rerun as rr
 

--- a/rerun_py/tests/unit/test_space_view_blueprint.py
+++ b/rerun_py/tests/unit/test_space_view_blueprint.py
@@ -16,7 +16,7 @@ from .common_arrays import none_empty_or_value
 
 def test_space_view_blueprint() -> None:
     class_identifier_arrays = ["3D", SpaceViewClass("3D")]
-    display_name_arrays = ["3D View", Name("3D View"), None]
+    display_name_arrays = ["3D view", Name("3D view"), None]
     space_origin_arrays = ["/robot/arm", None, SpaceViewOrigin("/robot/arm")]
     visible_arrays = [False, Visible(False), None]
 
@@ -54,6 +54,6 @@ def test_space_view_blueprint() -> None:
 
         # Equality checks on some of these are a bit silly, but at least they test out that the serialization code runs without problems.
         assert arch.class_identifier == SpaceViewClassBatch("3D")
-        assert arch.display_name == NameBatch._optional(none_empty_or_value(display_name, "3D View"))
+        assert arch.display_name == NameBatch._optional(none_empty_or_value(display_name, "3D view"))
         assert arch.space_origin == SpaceViewOriginBatch._optional(none_empty_or_value(space_origin, "/robot/arm"))
         assert arch.visible == VisibleBatch._optional(none_empty_or_value(visible, False))

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -53,6 +53,32 @@ def is_valid_todo_part(part: str) -> bool:
     return False
 
 
+def check_string(s: str) -> str | None:
+    """Check that the string has the correct casing."""
+    if len(s) == 0:
+        return None
+
+    bad_titles = [
+        "Blueprint",
+        "Class",
+        "Container",
+        "Entity",
+        "EntityPath",
+        "Instance",
+        "Path",
+        "Result",
+        "Space",
+        "View",
+        "Viewport",
+    ]
+
+    if m := re.search(r"[^.] ([A-Z]\w+)", s):
+        if m.group(1) in bad_titles:
+            return "Do not use title casing. See https://github.com/rerun-io/rerun/blob/main/DESIGN.md"
+
+    return None
+
+
 def lint_line(
     line: str, prev_line: str | None, file_extension: str = "rs", is_in_docstring: bool = False
 ) -> str | None:
@@ -151,6 +177,10 @@ def lint_line(
     if explicit_quotes.search(line):
         return "Prefer using {:?} - it will also escape newlines etc"
 
+    if m := re.search(r'"([^"]*)"', line):
+        if err := check_string(m.group(1)):
+            return err
+
     if "rec_stream" in line or "rr_stream" in line:
         return "Instantiated RecordingStreams should be named `rec`"
 
@@ -195,7 +225,7 @@ def test_lint_line() -> None:
         "hello world",
         "this is a 2D spaceview",
         "todo lowercase is fine",
-        'todo!("macro is ok with text")',
+        'todo!("Macro is ok with text")',
         "TODO_TOKEN",
         "TODO(bob):",
         "TODO(bob,alice):",
@@ -223,6 +253,7 @@ def test_lint_line() -> None:
         "instances_count",
         "let Some(foo) = bar else { return; };",
         "{foo:?}",
+        'ui.label("This is fine. Correct casing.")',
         "rec",
         "anyhow::Result<()>",
         "The theme is great",
@@ -300,6 +331,7 @@ def test_lint_line() -> None:
         r'println!("Problem: \"{}\"", string)',
         r'println!("Problem: \"{0}\"")',
         r'println!("Problem: \"{string}\"")',
+        'ui.label("This uses ugly title casing for Space View.")',
         "trailing whitespace ",
         "rr_stream",
         "rec_stream",

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -64,10 +64,13 @@ def check_string(s: str) -> str | None:
         "Container",
         "Entity",
         "EntityPath",
+        "Epoch",
         "Instance",
         "Path",
+        "Recording",
         "Result",
         "Space",
+        "Store",
         "View",
         "Viewport",
     ]

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -77,8 +77,8 @@ def check_string(s: str) -> str | None:
 
     if m := re.search(r"[^.] ([A-Z]\w+)", s):
         word = m.group(1)
-        if word in bad_titles or True:
-            return "Do not use title casing ({word}). See https://github.com/rerun-io/rerun/blob/main/DESIGN.md"
+        if word in bad_titles:
+            return f"Do not use title casing ({word}). See https://github.com/rerun-io/rerun/blob/main/DESIGN.md"
 
     return None
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -76,8 +76,9 @@ def check_string(s: str) -> str | None:
     ]
 
     if m := re.search(r"[^.] ([A-Z]\w+)", s):
-        if m.group(1) in bad_titles:
-            return "Do not use title casing. See https://github.com/rerun-io/rerun/blob/main/DESIGN.md"
+        word = m.group(1)
+        if word in bad_titles or True:
+            return "Do not use title casing ({word}). See https://github.com/rerun-io/rerun/blob/main/DESIGN.md"
 
     return None
 

--- a/tests/python/release_checklist/check_context_menu_suggested_origin.py
+++ b/tests/python/release_checklist/check_context_menu_suggested_origin.py
@@ -14,7 +14,7 @@ README = """
 
 Repeat these steps for each of the following entities and space view class:
 - right-click the entity (either in the blueprint or streams tree)
-- select "Add to new Space View" and create the space view of the listed class
+- select "Add to new space view" and create the space view of the listed class
 - check that the created space view has the expected origin
 - delete the space view
 


### PR DESCRIPTION
### What
I discovered a bunch of places with the old convention. The lint doesn't cover everything, but it is a start.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5688/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5688/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5688/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5688)
- [Docs preview](https://rerun.io/preview/d60ac20005d31901d71daeb03898897ecb391d33/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d60ac20005d31901d71daeb03898897ecb391d33/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)