### PR TITLE
Entity path query now shows simple statistics and warns if nothing is displayed

### DIFF
--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -1101,11 +1101,11 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
     // Show some statistics about the query, print a warning text if something seems off.
     let query = ctx.lookup_query_result(space_view_id);
     if query.num_matching_entities == 0 {
-        ui.label(ctx.re_ui.warning_text("Does not match any entity!"));
+        ui.label(ctx.re_ui.warning_text("Does not match any entity"));
     } else if query.num_matching_entities == 1 {
-        ui.label("Matches 1 entity.");
+        ui.label("Matches 1 entity");
     } else {
-        ui.label(format!("Matches {} entities.", query.num_matching_entities));
+        ui.label(format!("Matches {} entities", query.num_matching_entities));
     }
     if query.num_matching_entities != 0 && query.num_visualized_entities == 0 {
         // TODO(andreas): Talk about this root bit only if it's a spatial view.

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -1110,7 +1110,7 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
     if query.num_matching_entities != 0 && query.num_visualized_entities == 0 {
         // TODO(andreas): Talk about this root bit only if it's a spatial view.
         ui.label(ctx.re_ui.warning_text(
-            format!("This space view is not able to visualize any of the matched entities using the current root \"{origin}\"."),
+            format!("This space view is not able to visualize any of the matched entities using the current root \"{origin:?}\"."),
         ));
     }
 

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -1099,23 +1099,15 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
     }
 
     // Show some statistics about the query, print a warning text if something seems off.
-    let mut num_visualizable = 0;
-    let mut num_nodes = 0;
-    ctx.lookup_query_result(space_view_id)
-        .tree
-        .visit(&mut |node| {
-            num_nodes += !node.data_result.tree_prefix_only as usize;
-            num_visualizable += !node.data_result.visualizers.is_empty() as usize;
-            true
-        });
-    if num_nodes == 0 {
+    let query = ctx.lookup_query_result(space_view_id);
+    if query.num_matching_entities == 0 {
         ui.label(ctx.re_ui.warning_text("Does not match any entity!"));
-    } else if num_nodes == 1 {
+    } else if query.num_matching_entities == 1 {
         ui.label("Matches 1 entity.");
     } else {
-        ui.label(format!("Matches {num_nodes} entities."));
+        ui.label(format!("Matches {} entities.", query.num_matching_entities));
     }
-    if num_nodes != 0 && num_visualizable == 0 {
+    if query.num_matching_entities != 0 && query.num_visualized_entities == 0 {
         // TODO(andreas): Talk about this root bit only if it's a spatial view.
         ui.label(ctx.re_ui.warning_text(
             format!("This space view is not able to visualize any of the matched entities using the current root \"{origin:?}\"."),

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -1110,7 +1110,7 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
     if query.num_matching_entities != 0 && query.num_visualized_entities == 0 {
         // TODO(andreas): Talk about this root bit only if it's a spatial view.
         ui.label(ctx.re_ui.warning_text(
-            format!("This space view is not able to visualize any of the matched entities using the current root \"{origin:?}\"."),
+            format!("This space view is not able to visualize any of the matched entities using the current root \"{origin}\"."),
         ));
     }
 

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -819,11 +819,11 @@ fn blueprint_ui(
 ) {
     match item {
         Item::SpaceView(space_view_id) => {
-            blueprint_ui_for_space_view(ui, ctx, viewport, space_view_id);
+            blueprint_ui_for_space_view(ui, ctx, viewport, *space_view_id);
         }
 
         Item::DataResult(space_view_id, instance_path) => {
-            blueprint_ui_for_data_result(ui, ctx, viewport, space_view_id, instance_path);
+            blueprint_ui_for_data_result(ui, ctx, viewport, *space_view_id, instance_path);
         }
 
         Item::DataSource(_)
@@ -838,14 +838,16 @@ fn blueprint_ui_for_space_view(
     ui: &mut Ui,
     ctx: &ViewerContext<'_>,
     viewport: &mut Viewport<'_, '_>,
-    space_view_id: &SpaceViewId,
+    space_view_id: SpaceViewId,
 ) {
-    if let Some(space_view) = viewport.blueprint.space_view(space_view_id) {
+    if let Some(space_view) = viewport.blueprint.space_view(&space_view_id) {
         if let Some(new_entity_path_filter) = entity_path_filter_ui(
             ui,
+            ctx,
             viewport,
             space_view_id,
             &space_view.contents.entity_path_filter,
+            &space_view.space_origin,
         ) {
             space_view
                 .contents
@@ -862,7 +864,8 @@ fn blueprint_ui_for_space_view(
         )
         .clicked()
     {
-        if let Some(new_space_view_id) = viewport.blueprint.duplicate_space_view(space_view_id, ctx)
+        if let Some(new_space_view_id) =
+            viewport.blueprint.duplicate_space_view(&space_view_id, ctx)
         {
             ctx.selection_state()
                 .set_selection(Item::SpaceView(new_space_view_id));
@@ -874,7 +877,7 @@ fn blueprint_ui_for_space_view(
     ReUi::full_span_separator(ui);
     ui.add_space(ui.spacing().item_spacing.y / 2.0);
 
-    if let Some(space_view) = viewport.blueprint.space_view(space_view_id) {
+    if let Some(space_view) = viewport.blueprint.space_view(&space_view_id) {
         let class_identifier = *space_view.class_identifier();
 
         let space_view_state = viewport.state.space_view_state_mut(
@@ -925,10 +928,10 @@ fn blueprint_ui_for_data_result(
     ui: &mut Ui,
     ctx: &ViewerContext<'_>,
     viewport: &Viewport<'_, '_>,
-    space_view_id: &SpaceViewId,
+    space_view_id: SpaceViewId,
     instance_path: &InstancePath,
 ) {
-    if let Some(space_view) = viewport.blueprint.space_view(space_view_id) {
+    if let Some(space_view) = viewport.blueprint.space_view(&space_view_id) {
         if instance_path.instance_key.is_splat() {
             // splat - the whole entity
             let space_view_class = *space_view.class_identifier();
@@ -948,7 +951,7 @@ fn blueprint_ui_for_data_result(
                 entity_props_ui(
                     ctx,
                     ui,
-                    ctx.lookup_query_result(*space_view_id),
+                    ctx.lookup_query_result(space_view_id),
                     &space_view_class,
                     entity_path,
                     &mut props,
@@ -962,9 +965,11 @@ fn blueprint_ui_for_data_result(
 /// Returns a new filter when the editing is done, and there has been a change.
 fn entity_path_filter_ui(
     ui: &mut egui::Ui,
+    ctx: &ViewerContext<'_>,
     viewport: &mut Viewport<'_, '_>,
-    space_view_id: &SpaceViewId,
+    space_view_id: SpaceViewId,
     filter: &EntityPathFilter,
+    origin: &EntityPath,
 ) -> Option<EntityPathFilter> {
     fn entity_path_filter_help_ui(ui: &mut egui::Ui) {
         let markdown = r#"
@@ -1077,7 +1082,7 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
                     .on_hover_text("Modify the entity query using the editor")
                     .clicked()
                 {
-                    viewport.show_add_remove_entities_modal(*space_view_id);
+                    viewport.show_add_remove_entities_modal(space_view_id);
                 }
             },
         );
@@ -1091,6 +1096,30 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
     } else {
         // Reconstruct it from the filter next frame
         ui.data_mut(|data| data.remove::<String>(filter_text_id));
+    }
+
+    // Show some statistics about the query, print a warning text if something seems off.
+    let mut num_visualizable = 0;
+    let mut num_nodes = 0;
+    ctx.lookup_query_result(space_view_id)
+        .tree
+        .visit(&mut |node| {
+            num_nodes += !node.data_result.tree_prefix_only as usize;
+            num_visualizable += !node.data_result.visualizers.is_empty() as usize;
+            true
+        });
+    if num_nodes == 0 {
+        ui.label(ctx.re_ui.warning_text("Does not match any entity!"));
+    } else if num_nodes == 1 {
+        ui.label("Matches 1 entity.");
+    } else {
+        ui.label(format!("Matches {num_nodes} entities."));
+    }
+    if num_nodes != 0 && num_visualizable == 0 {
+        // TODO(andreas): Talk about this root bit only if it's a spatial view.
+        ui.label(ctx.re_ui.warning_text(
+            format!("This space view is not able to visualize any of the matched entities using the current root \"{origin:?}\"."),
+        ));
     }
 
     // Apply the edit.

--- a/crates/re_viewer_context/src/query_context.rs
+++ b/crates/re_viewer_context/src/query_context.rs
@@ -17,6 +17,15 @@ slotmap::new_key_type! {
 pub struct DataQueryResult {
     /// The [`DataResultTree`] for the query
     pub tree: DataResultTree,
+
+    /// The number of entities that matched the query, including those that are not visualizable.
+    pub num_matching_entities: usize,
+
+    /// Of the matched queries, the number of entities that are visualizable by any given visualizer.
+    ///
+    /// This does *not* take into account the actual selection of visualizers
+    /// which may be an explicit none for any given entity.
+    pub num_visualized_entities: usize,
 }
 
 impl DataQueryResult {
@@ -38,6 +47,8 @@ impl Clone for DataQueryResult {
         re_tracing::profile_function!();
         Self {
             tree: self.tree.clone(),
+            num_matching_entities: self.num_matching_entities,
+            num_visualized_entities: self.num_visualized_entities,
         }
     }
 }


### PR DESCRIPTION
### What

* Fixes  #5669

https://github.com/rerun-io/rerun/assets/1220815/91c63fbb-4b6e-4eb9-a5b5-3d14ea41d412

a small step towards making it easy to debug why no data might be shown


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5693/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5693/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5693/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5693)
- [Docs preview](https://rerun.io/preview/b9425379e1b41bf8f1891ffada4e6e0d15edc3cc/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/b9425379e1b41bf8f1891ffada4e6e0d15edc3cc/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)