### PR TITLE
New Blueprint.save() API

### DIFF
--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -456,7 +456,7 @@ class Blueprint:
                 default_enabled=True,
             )
         )
-        blueprint_file.set_time_sequence("blueprint", 0)
+        blueprint_file.set_time_sequence("blueprint", 0)  # type: ignore[attr-defined]
         self._log_to_stream(blueprint_file)
 
         bindings.save_blueprint(path, blueprint_file.to_native())

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -431,6 +431,36 @@ class Blueprint:
         if hasattr(self, "time_panel"):
             self.time_panel._log_to_stream(stream)
 
+    def save(self, application_id: str, path: str | None = None) -> None:
+        """
+        Save this blueprint to a file. Rerun recommends the `.rbl` suffix.
+
+        Parameters
+        ----------
+        application_id:
+            The application ID to use for this blueprint. This must match the application ID used
+            when initiating rerun for any data logging you wish to associate with this blueprint.
+        path
+            The path to save the blueprint to. Defaults to `<application_id>.rbl`.
+
+        """
+
+        if path is None:
+            path = f"{application_id}.rbl"
+
+        blueprint_file = RecordingStream(
+            bindings.new_blueprint(
+                application_id=application_id,
+                make_default=False,
+                make_thread_default=False,
+                default_enabled=True,
+            )
+        )
+        blueprint_file.set_time_sequence("blueprint", 0)
+        self._log_to_stream(blueprint_file)
+
+        bindings.save_blueprint(path, blueprint_file.to_native())
+
 
 BlueprintLike = Union[Blueprint, SpaceView, Container]
 """

--- a/tests/python/blueprint/save_blueprint.py
+++ b/tests/python/blueprint/save_blueprint.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import rerun.blueprint as rrb
+
+blueprint = rrb.Blueprint(
+    rrb.Spatial3DView(origin="/test1"),
+    rrb.TimePanel(expanded=False),
+    rrb.SelectionPanel(expanded=False),
+    rrb.BlueprintPanel(expanded=False),
+)
+
+blueprint.save("rerun_example_blueprint_test")


### PR DESCRIPTION
### What
- Marked as `do-not-merge` until https://github.com/rerun-io/rerun/pull/5678 has landed

I wanted to easily create just a `.rbl` from a script. Which required jumping through a few hoops. Figured I would streamline them.

Example script to generate an `.rbl`:
```
import rerun.blueprint as rrb

blueprint = rrb.Blueprint(
    rrb.Spatial3DView(origin="/test1"),
    rrb.TimePanel(expanded=False),
    rrb.SelectionPanel(expanded=False),
    rrb.BlueprintPanel(expanded=False),
)

blueprint.save("rerun_example_blueprint_test")
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5698/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5698/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5698/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5698)
- [Docs preview](https://rerun.io/preview/a89f0190ac343fff89209ec2d4d4a8299c943229/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/a89f0190ac343fff89209ec2d4d4a8299c943229/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)