### PR TITLE
Add source URL to example manifest

### DIFF
--- a/crates/re_viewer/src/ui/welcome_screen/mod.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/mod.rs
@@ -35,7 +35,7 @@ impl WelcomeScreen {
                     inner_margin: egui::Margin {
                         left: 40.0,
                         right: 40.0,
-                        top: 32.0,
+                        top: 50.0,
                         bottom: 8.0,
                     },
                     ..Default::default()

--- a/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
@@ -21,7 +21,7 @@ pub(super) fn welcome_section_ui(ui: &mut egui::Ui) {
             .wrap(true),
         );
 
-        ui.add_space(29.0);
+        ui.add_space(18.0);
 
         let bullet_text = |ui: &mut Ui, text: &str| {
             ui.horizontal(|ui| {


### PR DESCRIPTION
### What

- Fixes #5701 
- Follow-up to #5699 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5703/index.html) - **LINKS SHOULD WORK _ONLY_ HERE**
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5703/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json) 
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5703/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5703)
- [Docs preview](https://rerun.io/preview/0530608694da108802e9898c85ea22905aadb3c5/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0530608694da108802e9898c85ea22905aadb3c5/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)