### PR TITLE
Enable the `derive` feature of `serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ rmp-serde = "1"
 ron = "0.8.0"
 rust-format = "0.3"
 seq-macro = "0.3"
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1", default-features = false, features = ["std"] }
 serde_test = "1"


### PR DESCRIPTION
### What
Fix the nightly build: https://github.com/rerun-io/rerun/actions/runs/8451663141/job/23150464681

Whenever we use `serde` we want the `derive` feature. However, in many places we forgot to enable it, and things work anyway _mostly_, unless you're compiling crates individually, like we do on nightly.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5706/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5706/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5706/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5706)
- [Docs preview](https://rerun.io/preview/bc9e5ad8caffbc32ba2ed1b342c92786d7a411e2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/bc9e5ad8caffbc32ba2ed1b342c92786d7a411e2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)