### PR TITLE
Update thumbnails for some in-app examples

### DIFF
--- a/examples/cpp/dna/README.md
+++ b/examples/cpp/dna/README.md
@@ -2,8 +2,8 @@
 title = "Helix"
 tags = ["3D", "api-example"]
 description = "Simple example of logging point and line primitives to draw a 3D helix."
-thumbnail = "https://static.rerun.io/helix/f4c375546fa9d24f7cd3a1a715ebf75b2978817a/480w.png"
-thumbnail_dimensions = [480, 285]
+thumbnail = "https://static.rerun.io/dna/40d9744af3f0e21d3b174054f0a935662a574ce0/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "main"
 -->
 

--- a/examples/python/dna/README.md
+++ b/examples/python/dna/README.md
@@ -2,8 +2,8 @@
 title = "Helix"
 tags = ["3D", "api-example"]
 description = "Simple example of logging point and line primitives to draw a 3D helix."
-thumbnail = "https://static.rerun.io/helix/f4c375546fa9d24f7cd3a1a715ebf75b2978817a/480w.png"
-thumbnail_dimensions = [480, 285]
+thumbnail = "https://static.rerun.io/dna/40d9744af3f0e21d3b174054f0a935662a574ce0/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "main"
 -->
 

--- a/examples/python/nuscenes/README.md
+++ b/examples/python/nuscenes/README.md
@@ -2,8 +2,8 @@
 title = "nuScenes"
 tags = ["lidar", "3D", "2D", "object-detection", "pinhole-camera"]
 description = "Visualize the nuScenes dataset including lidar, radar, images, and bounding boxes."
-thumbnail = "https://static.rerun.io/nuscenes/64a50a9d67cbb69ae872551989ee807b195f6b5d/480w.png"
-thumbnail_dimensions = [480, 282]
+thumbnail = "https://static.rerun.io/nuscenes/9c50bf5cadb879ef818ac3d35fe75696a9586cb4/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "release"
 build_args = ["--seconds=5"]
 -->

--- a/examples/python/open_photogrammetry_format/README.md
+++ b/examples/python/open_photogrammetry_format/README.md
@@ -2,8 +2,8 @@
 title = "Open Photogrammetry Format"
 tags = ["2D", "3D", "camera", "photogrammetry"]
 description = "Displays a photogrammetrically reconstructed 3D point cloud loaded from an Open Photogrammetry Format (OPF) file."
-thumbnail = "https://static.rerun.io/open_photogrammetry_format/603d5605f9670889bc8bce3365f16b831fce1eb1/480w.png"
-thumbnail_dimensions = [480, 310]
+thumbnail = "https://static.rerun.io/open-photogrammetry-format/c9bec43a3a3abd725a55ee8eb527a4c0cb01979b/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "release"
 build_args = ["--jpeg-quality=50"]
 -->

--- a/examples/python/rrt-star/README.md
+++ b/examples/python/rrt-star/README.md
@@ -2,8 +2,8 @@
 title = "RRT*"
 tags = ["2D"]
 description = "Visualization of the path finding algorithm RRT* in a simple environment."
-thumbnail= "https://static.rerun.io/rrt-star/4d4684a24eab7d5def5768b7c1685d8b1cb2c010/full.png"
-thumbnail_dimensions = [1496, 840]
+thumbnail= "https://static.rerun.io/rrt-star/fbbda33bdbbfa469ec95c905178ac3653920473a/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "main"
 -->
 

--- a/examples/rust/dna/README.md
+++ b/examples/rust/dna/README.md
@@ -2,8 +2,8 @@
 title = "Helix"
 tags = ["3D", "api-example"]
 description = "Simple example of logging point and line primitives to draw a 3D helix."
-thumbnail = "https://static.rerun.io/helix/f4c375546fa9d24f7cd3a1a715ebf75b2978817a/480w.png"
-thumbnail_dimensions = [480, 285]
+thumbnail = "https://static.rerun.io/dna/40d9744af3f0e21d3b174054f0a935662a574ce0/480w.png"
+thumbnail_dimensions = [480, 480]
 channel = "main"
 -->
 


### PR DESCRIPTION
### What

- Closes #5700 
- Follow-up to #5699 

These were missing an up-to-date thumbnail.

<img width="319" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/ef5bccf5-cb8b-4e62-b28b-5aa812c5bec1">

<img width="277" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/632f759f-cb3b-4a2a-88e6-bb587adc7cf0">



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5707/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5707/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5707/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5707)
- [Docs preview](https://rerun.io/preview/28c1ce40fe0ac71a99c40ec2a0525e3a14405478/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/28c1ce40fe0ac71a99c40ec2a0525e3a14405478/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)