### PR TITLE
Build release `.wasm` with debug symbols

### DIFF
--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -202,7 +202,7 @@ jobs:
         with:
           command: run
           # We build in release so that we can reuse the results for actual publishing, if necessary
-          args: --locked -p re_build_web_viewer -- --release
+          args: --locked -p re_build_web_viewer -- --release -g
 
   toml-lints:
     name: Lint TOML files

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Build web-viewer (release)
         shell: bash
         run: |
-          pixi run cargo run --locked -p re_build_web_viewer -- --release
+          pixi run cargo run --locked -p re_build_web_viewer -- --release -g
 
       # This does not run in the pixi environment, doing so
       # causes it to select the wrong compiler on macos-arm64

--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -63,7 +63,7 @@ jobs:
           if [ ${{ inputs.CHANNEL }} = "nightly" ]; then
             export DEFAULT_EXAMPLES_MANIFEST_URL="https://app.rerun.io/version/nightly/examples_manifest.json"
           fi
-          pixi run cargo run --locked -p re_build_web_viewer -- --release
+          pixi run cargo run --locked -p re_build_web_viewer -- --release -g
 
       # We build a single manifest pointing to the `commit`
       # All the `pr`, `main`, release tag, etc. variants will always just point to the resolved commit

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Build web-viewer (release)
         shell: bash
         run: |
-          pixi run cargo run --locked -p re_build_web_viewer -- --release
+          pixi run cargo run --locked -p re_build_web_viewer -- --release -g
 
       - name: Rust checks & tests
         if: ${{ !inputs.ALL_CHECKS }}
@@ -114,7 +114,7 @@ jobs:
       - name: Build web-viewer (release)
         shell: bash
         run: |
-          pixi run cargo run --locked -p re_build_web_viewer -- --release
+          pixi run cargo run --locked -p re_build_web_viewer -- --release -g
 
   # ---------------------------------------------------------------------------
 

--- a/.github/workflows/reusable_publish_web.yml
+++ b/.github/workflows/reusable_publish_web.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Build web-viewer (release)
         shell: bash
         run: |
-          pixi run cargo run --locked -p re_build_web_viewer -- --release
+          pixi run cargo run --locked -p re_build_web_viewer -- --release -g
 
       - name: Build examples
         shell: bash

--- a/.github/workflows/reusable_release_crates.yml
+++ b/.github/workflows/reusable_release_crates.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build web-viewer (release)
         shell: bash
         run: |
-          pixi run cargo run --locked -p re_build_web_viewer -- --release
+          pixi run cargo run --locked -p re_build_web_viewer -- --release -g
 
       - name: Publish
         shell: bash

--- a/crates/re_build_web_viewer/README.md
+++ b/crates/re_build_web_viewer/README.md
@@ -6,8 +6,8 @@ This is also called by the `build.rs` of `re_web_viewer_server`.
 
 ```
 cargo r -p re_build_web_viewer -- --debug
-````
+```
 
 ```
-cargo r -p re_build_web_viewer -- --release
-````
+cargo r -p re_build_web_viewer -- --release -g
+```

--- a/pixi.toml
+++ b/pixi.toml
@@ -66,11 +66,11 @@ rerun-web-release = { cmd = "cargo run --package rerun-cli --no-default-features
   "rerun-build-web-release",
 ] }
 
-# Compile the web-viewer wasm in release mode, doe not include the cli.
+# Compile the web-viewer wasm in release mode.
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run -p re_build_web_viewer -- --release"
+rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run -p re_build_web_viewer -- --release -g"
 
 
 build-examples = "cargo run -q --locked -p re_build_examples --"

--- a/rerun_js/web-viewer/package.json
+++ b/rerun_js/web-viewer/package.json
@@ -11,7 +11,7 @@
     }
   ],
   "scripts": {
-    "build:wasm": "cargo run -p re_build_web_viewer -- --release --module -o rerun_js/web-viewer",
+    "build:wasm": "cargo run -p re_build_web_viewer -- --release -g --module -o rerun_js/web-viewer",
     "build:wasm:debug": "cargo run -p re_build_web_viewer -- --debug --module -o rerun_js/web-viewer",
     "build:types": "tsc --noEmit && dts-buddy",
     "build": "npm run build:wasm && npm run build:types"

--- a/scripts/ci/build_and_upload_wheels.py
+++ b/scripts/ci/build_and_upload_wheels.py
@@ -72,7 +72,7 @@ def build_and_upload(bucket: Bucket, mode: BuildMode, gcs_dir: str, target: str,
 
     if mode is BuildMode.PYPI:
         # Only build web viewer when publishing to pypi
-        run("pixi run cargo run --locked -p re_build_web_viewer -- --release")
+        run("pixi run cargo run --locked -p re_build_web_viewer -- --release -g")
         maturin_feature_flags = "--no-default-features --features pypi"
     elif mode is BuildMode.PR:
         maturin_feature_flags = "--no-default-features --features extension-module"

--- a/web_viewer/README.md
+++ b/web_viewer/README.md
@@ -2,4 +2,4 @@ This folder contains the files required for the web viewer app.
 
 You can build the web viewer with:
 
-`cargo r -p re_build_web_viewer -- --release`
+`cargo r -p re_build_web_viewer -- --release -g`


### PR DESCRIPTION
### What
This makes the compressed .wasm around 300kB bigger (+5%). In return we get:
* Good callstacks on panics
* In-browser profiling using the normal browser profiling tools

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5708/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5708/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5708/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5708)
- [Docs preview](https://rerun.io/preview/cc960afe63cccaddb8371596b8388033cba547bb/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/cc960afe63cccaddb8371596b8388033cba547bb/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)