### PR TITLE
Remove item spacing in sibling recordings/blueprints list

### DIFF
--- a/crates/re_data_ui/src/data_source.rs
+++ b/crates/re_data_ui/src/data_source.rs
@@ -40,20 +40,22 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
             }
         }
 
-        {
+        if !recordings.is_empty() {
             ui.add_space(8.0);
             ui.strong("Recordings in this data source");
             ui.indent("recordings", |ui| {
+                ui.spacing_mut().item_spacing.y = 0.0;
                 for entity_db in recordings {
                     entity_db_button_ui(ctx, ui, entity_db, true);
                 }
             });
         }
 
-        {
+        if !blueprints.is_empty() {
             ui.add_space(8.0);
             ui.strong("Blueprints in this data source");
             ui.indent("blueprints", |ui| {
+                ui.spacing_mut().item_spacing.y = 0.0;
                 for entity_db in blueprints {
                     entity_db_button_ui(ctx, ui, entity_db, true);
                 }

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -133,6 +133,7 @@ fn sibling_stores_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui, entity_db: &Ent
             ui.strong("Recordings in this data source");
         }
         ui.indent("recordings", |ui| {
+            ui.spacing_mut().item_spacing.y = 0.0;
             for entity_db in other_recordings {
                 entity_db_button_ui(ctx, ui, entity_db, true);
             }
@@ -147,6 +148,7 @@ fn sibling_stores_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui, entity_db: &Ent
         }
         ui.indent("blueprints", |ui| {
             for entity_db in other_blueprints {
+                ui.spacing_mut().item_spacing.y = 0.0;
                 entity_db_button_ui(ctx, ui, entity_db, true);
             }
         });

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -147,8 +147,8 @@ fn sibling_stores_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui, entity_db: &Ent
             ui.strong("Blueprints in this data source");
         }
         ui.indent("blueprints", |ui| {
+            ui.spacing_mut().item_spacing.y = 0.0;
             for entity_db in other_blueprints {
-                ui.spacing_mut().item_spacing.y = 0.0;
                 entity_db_button_ui(ctx, ui, entity_db, true);
             }
         });


### PR DESCRIPTION
### What

As the title say ☝🏻
PSA: always set `spacing.item_spacing.y` to 0 when using `ListItem`.

Before: unsightly 😄 
After:

<img width="361" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/1934b736-ee72-49db-87cc-981c26e468dd">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5710/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5710/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5710/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5710)
- [Docs preview](https://rerun.io/preview/27968b00d8395aa7be2bcd8b076962533afd4bde/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/27968b00d8395aa7be2bcd8b076962533afd4bde/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)