### PR TITLE
Authenticate to docker hub in CI

### DIFF
--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -76,13 +76,13 @@ jobs:
             linux-arm64)
               runner="buildjet-8vcpu-ubuntu-2204-arm"
               target="aarch64-unknown-linux-gnu"
-              container="{'image': 'rerunio/ci_docker:0.12.0'}"
+              container="'rerunio/ci_docker:0.12.0'"
               lib_name="librerun_c.a"
               ;;
             linux-x64)
               runner="ubuntu-latest-16-cores"
               target="x86_64-unknown-linux-gnu"
-              container="{'image': 'rerunio/ci_docker:0.12.0'}"
+              container="'rerunio/ci_docker:0.12.0'"
               lib_name="librerun_c.a"
               ;;
             windows-x64)
@@ -116,7 +116,11 @@ jobs:
     needs: [set-config]
 
     runs-on: ${{ needs.set-config.outputs.RUNNER }}
-    container: ${{ fromJson(needs.set-config.outputs.CONTAINER) }}
+    container:
+      image: ${{ fromJson(needs.set-config.outputs.CONTAINER) }}
+      credentials:
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
     steps:
       - name: Show context

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -77,13 +77,13 @@ jobs:
             linux-arm64)
               runner="buildjet-8vcpu-ubuntu-2204-arm"
               target="aarch64-unknown-linux-gnu"
-              container="{'image': 'rerunio/ci_docker:0.12.0'}"
+              container="'rerunio/ci_docker:0.12.0'"
               bin_name="rerun"
               ;;
             linux-x64)
               runner="ubuntu-latest-16-cores"
               target="x86_64-unknown-linux-gnu"
-              container="{'image': 'rerunio/ci_docker:0.12.0'}"
+              container="'rerunio/ci_docker:0.12.0'"
               bin_name="rerun"
               ;;
             windows-x64)
@@ -117,7 +117,11 @@ jobs:
     needs: [set-config]
 
     runs-on: ${{ needs.set-config.outputs.RUNNER }}
-    container: ${{ fromJson(needs.set-config.outputs.CONTAINER) }}
+    container:
+      image: ${{ fromJson(needs.set-config.outputs.CONTAINER) }}
+      credentials:
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
     steps:
       - name: Show context

--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -101,14 +101,14 @@ jobs:
             linux-arm64)
                 runner="buildjet-8vcpu-ubuntu-2204-arm"
                 target="aarch64-unknown-linux-gnu"
-                container="{'image': 'rerunio/ci_docker:0.12.0'}"
+                container="'rerunio/ci_docker:0.12.0'"
                 compat="manylinux_2_31"
                 ;;
             linux-x64)
               runner="ubuntu-latest-16-cores"
               target="x86_64-unknown-linux-gnu"
               compat="manylinux_2_31"
-              container="{'image': 'rerunio/ci_docker:0.12.0'}"
+              container="'rerunio/ci_docker:0.12.0'"
               ;;
             windows-x64)
               runner="windows-latest-8-cores"
@@ -143,7 +143,11 @@ jobs:
     needs: [set-config]
 
     runs-on: ${{ needs.set-config.outputs.RUNNER }}
-    container: ${{ fromJson(needs.set-config.outputs.CONTAINER) }}
+    container:
+      image: ${{ fromJson(needs.set-config.outputs.CONTAINER) }}
+      credentials:
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
     steps:
       - name: Show context

--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -62,12 +62,12 @@ jobs:
             linux-arm64)
               runner="buildjet-8vcpu-ubuntu-2204-arm"
               target="aarch64-unknown-linux-gnu"
-              container="{'image': 'rerunio/ci_docker:0.12.0'}"
+              container="'rerunio/ci_docker:0.12.0'"
               ;;
             linux-x64)
               runner="ubuntu-latest-16-cores"
               target="x86_64-unknown-linux-gnu"
-              container="{'image': 'rerunio/ci_docker:0.12.0'}"
+              container="'rerunio/ci_docker:0.12.0'"
               ;;
             windows-x64)
               runner="windows-latest-8-cores"
@@ -98,7 +98,11 @@ jobs:
     needs: [set-config]
 
     runs-on: ${{ needs.set-config.outputs.RUNNER }}
-    container: ${{ fromJson(needs.set-config.outputs.CONTAINER) }}
+    container:
+      image: ${{ fromJson(needs.set-config.outputs.CONTAINER) }}
+      credentials:
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
     steps:
       - name: Show context


### PR DESCRIPTION
### What

We are getting rate-limited on our BuildJet runner:

![image](https://github.com/rerun-io/rerun/assets/49431240/221d69af-72cd-49e4-a7d2-bc753c6c0f1a)

The [documented workaround](https://buildjet.com/for-github-actions/docs/getting-started/troubleshooting#docker-rate-limiting-and-authentication) is to authenticate to docker hub. This PR does that using newly generate secrets.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5714/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5714/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5714/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5714)
- [Docs preview](https://rerun.io/preview/2849c9a78b1520a6cd316573f56bc2a96167fb70/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/2849c9a78b1520a6cd316573f56bc2a96167fb70/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)