### PR TITLE
Fix docs typo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ order: 6
 The available attributes are:
 | name     | type    | required | description                                   |
 | -------- | ------- | -------- | --------------------------------------------- |
-| title    | string  | yes      | title displayes in the navigation             |
+| title    | string  | yes      | navigation item title                         |
 | order    | number  | yes      | used to sort navigation items                 |
 | redirect | string  | no       | redirect to the given url                     |
 | hidden   | boolean | no       | don't show the item in navigation             |


### PR DESCRIPTION
### What

- Fix typo introduced in https://github.com/rerun-io/rerun/pull/5716

Note to self: [Should've wasted CI time on this](https://github.com/rerun-io/rerun/pull/5716#issuecomment-2024770178)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5717/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5717/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5717/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5717)
- [Docs preview](https://rerun.io/preview/5c8bad58e9c98687c13452433ba3ae457f9b56e8/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5c8bad58e9c98687c13452433ba3ae457f9b56e8/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)