### PR TITLE
Improve the selection panel for stores and data sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5127,6 +5127,7 @@ dependencies = [
  "re_log",
  "re_log_types",
  "re_query",
+ "re_query_cache",
  "re_renderer",
  "re_smart_channel",
  "re_string_interner",

--- a/crates/re_data_source/src/load_file.rs
+++ b/crates/re_data_source/src/load_file.rs
@@ -119,6 +119,7 @@ pub(crate) fn prepare_store_info(
             info: re_log_types::StoreInfo {
                 application_id: app_id.clone(),
                 store_id: store_id.clone(),
+                cloned_from: None,
                 is_official_example: false,
                 started: re_log_types::Time::now(),
                 store_source,

--- a/crates/re_data_ui/src/data_source.rs
+++ b/crates/re_data_ui/src/data_source.rs
@@ -18,7 +18,7 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
             return;
         }
 
-        // TODO(emilk): show if we're still connected to this data source
+        // TODO(emilk): show whether we're still connected to this data source
 
         // Find all stores from this data source
         // (e.g. find the recordings and blueprint in this .rrd file).

--- a/crates/re_data_ui/src/data_source.rs
+++ b/crates/re_data_ui/src/data_source.rs
@@ -30,6 +30,12 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
             .bundle
             .entity_dbs_from_channel_source(self)
         {
+            let is_clone = other.cloned_from().is_some();
+            if is_clone {
+                // Clones are not really from this data source (e.g. a cloned blueprint
+                continue;
+            }
+
             match other.store_kind() {
                 StoreKind::Recording => {
                     recordings.push(other);
@@ -42,7 +48,7 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
 
         if !recordings.is_empty() {
             ui.add_space(8.0);
-            ui.strong("Recordings in this data source");
+            ui.strong("Recordings from this data source");
             ui.indent("recordings", |ui| {
                 ui.spacing_mut().item_spacing.y = 0.0;
                 for entity_db in recordings {
@@ -53,7 +59,7 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
 
         if !blueprints.is_empty() {
             ui.add_space(8.0);
-            ui.strong("Blueprints in this data source");
+            ui.strong("Blueprints from this data source");
             ui.indent("blueprints", |ui| {
                 ui.spacing_mut().item_spacing.y = 0.0;
                 for entity_db in blueprints {

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -111,7 +111,23 @@ impl crate::DataUi for EntityDb {
                         (false, false) => {}
                         (true, false) => {
                             ui.add_space(8.0);
-                            ui.label("This is the default blueprint for the current application, but the active one is different.");
+                            ui.label("This is the default blueprint for the current application.");
+
+                            if let Some(active_blueprint) = hub
+                                .active_blueprint_for_app(active_app_id)
+                                .and_then(|id| hub.store_bundle().get(id))
+                            {
+                                if active_blueprint.cloned_from() == Some(self.store_id()) {
+                                    // The active blueprint is a clone of the selected blueprint.
+                                    if self.latest_row_id() == active_blueprint.latest_row_id() {
+                                        ui.label(
+                                            "The active blueprint is a clone of this blueprint.",
+                                        );
+                                    } else {
+                                        ui.label("The active blueprint is a modified clone of this blueprint.");
+                                    }
+                                }
+                            }
                         }
                         (false, true) => {
                             ui.add_space(8.0);

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -99,7 +99,12 @@ impl crate::DataUi for EntityDb {
             }
         }
 
-        if ctx.store_context.is_default_blueprint(self.store_id()) {
+        let is_default_blueprint = ctx
+            .store_context
+            .hub
+            .default_blueprint_for_app(&ctx.store_context.app_id)
+            == Some(self.store_id());
+        if is_default_blueprint {
             ui.add_space(8.0);
             ui.label("This is the default blueprint")
                .on_hover_text("When you reset the blueprint for the app, this blueprint will be used as the template.");

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -103,9 +103,9 @@ impl crate::DataUi for EntityDb {
 
                 if is_active_app_id {
                     let is_default =
-                        hub.default_blueprint_for_app(active_app_id) == Some(self.store_id());
+                        hub.default_blueprint_id_for_app(active_app_id) == Some(self.store_id());
                     let is_active =
-                        hub.active_blueprint_for_app(active_app_id) == Some(self.store_id());
+                        hub.active_blueprint_id_for_app(active_app_id) == Some(self.store_id());
 
                     match (is_default, is_active) {
                         (false, false) => {}
@@ -114,7 +114,7 @@ impl crate::DataUi for EntityDb {
                             ui.label("This is the default blueprint for the current application.");
 
                             if let Some(active_blueprint) = hub
-                                .active_blueprint_for_app(active_app_id)
+                                .active_blueprint_id_for_app(active_app_id)
                                 .and_then(|id| hub.store_bundle().get(id))
                             {
                                 if active_blueprint.cloned_from() == Some(self.store_id()) {

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -40,11 +40,18 @@ impl crate::DataUi for EntityDb {
                 let re_log_types::StoreInfo {
                     application_id,
                     store_id: _,
+                    cloned_from,
                     is_official_example: _,
                     started,
                     store_source,
                     store_kind,
                 } = store_info;
+
+                if let Some(cloned_from) =  cloned_from {
+                    re_ui.grid_left_hand_label(ui, "Clone of");
+                    crate::item_ui::store_id_button_ui(ctx, ui, cloned_from);
+                    ui.end_row();
+                }
 
                 re_ui.grid_left_hand_label(ui, "Application ID");
                 ui.label(application_id.to_string());

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -3,7 +3,7 @@ use re_log_types::StoreKind;
 use re_types::SizeBytes;
 use re_viewer_context::{UiVerbosity, ViewerContext};
 
-use crate::item_ui::{data_source_button_ui, entity_db_button_ui};
+use crate::item_ui::data_source_button_ui;
 
 impl crate::DataUi for EntityDb {
     fn data_ui(
@@ -17,6 +17,7 @@ impl crate::DataUi for EntityDb {
         let re_ui = &ctx.re_ui;
 
         if verbosity == UiVerbosity::Small {
+            // TODO(emilk): standardize this formatting with that in `entity_db_button_ui`
             let mut string = self.store_id().to_string();
             if let Some(data_source) = &self.data_source {
                 string += &format!(", {data_source}");
@@ -127,68 +128,5 @@ impl crate::DataUi for EntityDb {
                 }
             }
         }
-
-        if verbosity == UiVerbosity::Full {
-            sibling_stores_ui(ctx, ui, self);
-        }
-    }
-}
-
-/// Show the other stores in the same data source.
-fn sibling_stores_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui, entity_db: &EntityDb) {
-    let Some(data_source) = &entity_db.data_source else {
-        return;
-    };
-
-    // Find other stores from the same data source
-    // (e.g. find the blueprint in this .rrd file, if any).
-    let mut other_recordings = vec![];
-    let mut other_blueprints = vec![];
-
-    for other in ctx
-        .store_context
-        .bundle
-        .entity_dbs_from_channel_source(data_source)
-    {
-        if other.store_id() == entity_db.store_id() {
-            continue;
-        }
-        match other.store_kind() {
-            StoreKind::Recording => {
-                other_recordings.push(other);
-            }
-            StoreKind::Blueprint => {
-                other_blueprints.push(other);
-            }
-        }
-    }
-
-    if !other_recordings.is_empty() {
-        ui.add_space(8.0);
-        if entity_db.store_kind() == StoreKind::Recording {
-            ui.strong("Other recordings in this data source");
-        } else {
-            ui.strong("Recordings in this data source");
-        }
-        ui.indent("recordings", |ui| {
-            ui.spacing_mut().item_spacing.y = 0.0;
-            for entity_db in other_recordings {
-                entity_db_button_ui(ctx, ui, entity_db, true);
-            }
-        });
-    }
-    if !other_blueprints.is_empty() {
-        ui.add_space(8.0);
-        if entity_db.store_kind() == StoreKind::Blueprint {
-            ui.strong("Other blueprints in this data source");
-        } else {
-            ui.strong("Blueprints in this data source");
-        }
-        ui.indent("blueprints", |ui| {
-            ui.spacing_mut().item_spacing.y = 0.0;
-            for entity_db in other_blueprints {
-                entity_db_button_ui(ctx, ui, entity_db, true);
-            }
-        });
     }
 }

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -49,10 +49,6 @@ impl crate::DataUi for EntityDb {
                 ui.label(application_id.to_string());
                 ui.end_row();
 
-                re_ui.grid_left_hand_label(ui, "Recording started");
-                ui.label(started.format(ctx.app_options.time_zone));
-                ui.end_row();
-
                 re_ui.grid_left_hand_label(ui, "Source");
                 ui.label(store_source.to_string());
                 ui.end_row();
@@ -60,6 +56,19 @@ impl crate::DataUi for EntityDb {
                 re_ui.grid_left_hand_label(ui, "Kind");
                 ui.label(store_kind.to_string());
                 ui.end_row();
+
+                re_ui.grid_left_hand_label(ui, "Recording started");
+                ui.label(started.format(ctx.app_options.time_zone));
+                ui.end_row();
+            }
+
+            if let Some(latest_row_id) = self.latest_row_id() {
+                if let Ok(nanos_since_epoch) = i64::try_from(latest_row_id.nanoseconds_since_epoch()) {
+                    let time = re_log_types::Time::from_ns_since_epoch(nanos_since_epoch);
+                    re_ui.grid_left_hand_label(ui, "Last modified at");
+                    ui.label(time.format(ctx.app_options.time_zone));
+                    ui.end_row();
+                }
             }
 
             {

--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -599,7 +599,7 @@ pub fn entity_db_button_ui(
         String::default()
     };
 
-    let time = entity_db
+    let creation_time = entity_db
         .store_info()
         .and_then(|info| {
             info.started
@@ -608,7 +608,7 @@ pub fn entity_db_button_ui(
         .unwrap_or("<unknown time>".to_owned());
 
     let size = re_format::format_bytes(entity_db.total_size_bytes() as _);
-    let title = format!("{app_id_prefix}{time} - {size}");
+    let title = format!("{app_id_prefix}{creation_time} - {size}");
 
     let store_id = entity_db.store_id().clone();
     let item = re_viewer_context::Item::StoreId(store_id.clone());

--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -579,6 +579,18 @@ pub fn data_source_button_ui(
     cursor_interact_with_selectable(ctx, response, item)
 }
 
+pub fn store_id_button_ui(
+    ctx: &ViewerContext<'_>,
+    ui: &mut egui::Ui,
+    store_id: &re_log_types::StoreId,
+) {
+    if let Some(entity_db) = ctx.store_context.bundle.get(store_id) {
+        entity_db_button_ui(ctx, ui, entity_db, true);
+    } else {
+        ui.label(store_id.to_string());
+    }
+}
+
 /// Show button for a store (recording or blueprint).
 ///
 /// You can set `include_app_id` to hide the App Id, but usually you want to show it.

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -34,45 +34,55 @@ impl DataUi for LogMsg {
 impl DataUi for SetStoreInfo {
     fn data_ui(
         &self,
-        _ctx: &ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         _verbosity: UiVerbosity,
         _query: &re_data_store::LatestAtQuery,
         _store: &re_data_store::DataStore,
     ) {
-        ui.code("SetStoreInfo");
         let SetStoreInfo { row_id: _, info } = self;
         let StoreInfo {
             application_id,
             store_id,
+            cloned_from,
             started,
             store_source,
             is_official_example,
             store_kind,
         } = info;
 
+        let re_ui = &ctx.re_ui;
+
+        ui.code("SetStoreInfo");
+
         egui::Grid::new("fields").num_columns(2).show(ui, |ui| {
-            ui.monospace("application_id:");
+            re_ui.grid_left_hand_label(ui, "application_id:");
             ui.label(application_id.to_string());
             ui.end_row();
 
-            ui.monospace("store_id:");
+            re_ui.grid_left_hand_label(ui, "store_id:");
             ui.label(format!("{store_id:?}"));
             ui.end_row();
 
-            ui.monospace("started:");
-            ui.label(started.format(_ctx.app_options.time_zone));
+            re_ui.grid_left_hand_label(ui, "cloned_from");
+            if let Some(cloned_from) = cloned_from {
+                crate::item_ui::store_id_button_ui(ctx, ui, cloned_from);
+            }
             ui.end_row();
 
-            ui.monospace("store_source:");
+            re_ui.grid_left_hand_label(ui, "started:");
+            ui.label(started.format(ctx.app_options.time_zone));
+            ui.end_row();
+
+            re_ui.grid_left_hand_label(ui, "store_source:");
             ui.label(format!("{store_source}"));
             ui.end_row();
 
-            ui.monospace("is_official_example:");
+            re_ui.grid_left_hand_label(ui, "is_official_example:");
             ui.label(format!("{is_official_example}"));
             ui.end_row();
 
-            ui.monospace("store_kind:");
+            re_ui.grid_left_hand_label(ui, "store_kind:");
             ui.label(format!("{store_kind}"));
             ui.end_row();
         });

--- a/crates/re_entity_db/src/entity_db.rs
+++ b/crates/re_entity_db/src/entity_db.rs
@@ -222,7 +222,7 @@ impl EntityDb {
     /// A cloned store always gets a new unique ID.
     ///
     /// We currently only use entity db cloning for blueprints:
-    /// when we receive a _default_ blueprints on the wire (e.g. from a recording),
+    /// when we activate a _default_ blueprint that was received on the wire (e.g. from a recording),
     /// we clone it and make the clone the _active_ blueprint.
     /// This means all active blueprints are clones.
     #[inline]

--- a/crates/re_entity_db/src/entity_db.rs
+++ b/crates/re_entity_db/src/entity_db.rs
@@ -83,6 +83,8 @@ fn insert_row_with_retries(
 /// NOTE: all mutation is to be done via public functions!
 pub struct EntityDb {
     /// Set by whomever created this [`EntityDb`].
+    ///
+    /// Clones keep the sama data source, but can be distinguished with [`Self::cloned_from()`].
     pub data_source: Option<re_smart_channel::SmartChannelSource>,
 
     /// Comes in a special message, [`LogMsg::SetStoreInfo`].

--- a/crates/re_entity_db/src/entity_db.rs
+++ b/crates/re_entity_db/src/entity_db.rs
@@ -84,7 +84,7 @@ fn insert_row_with_retries(
 pub struct EntityDb {
     /// Set by whomever created this [`EntityDb`].
     ///
-    /// Clones keep the sama data source, but can be distinguished with [`Self::cloned_from()`].
+    /// Clones of an [`EntityDb`] gets a `None` source.
     pub data_source: Option<re_smart_channel::SmartChannelSource>,
 
     /// Comes in a special message, [`LogMsg::SetStoreInfo`].
@@ -627,9 +627,13 @@ impl EntityDb {
         let mut new_db = EntityDb::new(new_id.clone());
 
         new_db.cloned_from = Some(self.store_id().clone());
-        new_db.data_source = self.data_source.clone();
         new_db.last_modified_at = self.last_modified_at;
         new_db.latest_row_id = self.latest_row_id;
+        // We do NOT clone the `data_source`, because the reason we clone an entity db
+        // is so that we can modify it, and then it would be wrong to say its from the same source.
+        // Specifically: if we load a blueprint from an `.rdd`, then modify it heavily and save it,
+        // it would be wrong to claim that this was the blueprint from that `.rrd`,
+        // and it would confuse the user.
 
         if let Some(store_info) = self.store_info() {
             let mut new_info = store_info.clone();

--- a/crates/re_entity_db/src/entity_db.rs
+++ b/crates/re_entity_db/src/entity_db.rs
@@ -616,11 +616,14 @@ impl EntityDb {
 
         new_db.last_modified_at = self.last_modified_at;
         new_db.latest_row_id = self.latest_row_id;
+
         // We do NOT clone the `data_source`, because the reason we clone an entity db
         // is so that we can modify it, and then it would be wrong to say its from the same source.
         // Specifically: if we load a blueprint from an `.rdd`, then modify it heavily and save it,
         // it would be wrong to claim that this was the blueprint from that `.rrd`,
         // and it would confuse the user.
+        // TODO(emilk): maybe we should use a special `Cloned` data source,
+        // wrapping either the original source, the original StoreId, or both.
 
         if let Some(store_info) = self.store_info() {
             let mut new_info = store_info.clone();

--- a/crates/re_entity_db/src/store_bundle.rs
+++ b/crates/re_entity_db/src/store_bundle.rs
@@ -103,6 +103,7 @@ impl StoreBundle {
                 info: re_log_types::StoreInfo {
                     application_id: id.as_str().into(),
                     store_id: id.clone(),
+                    cloned_from: None,
                     is_official_example: false,
                     started: re_log_types::Time::now(),
                     store_source: re_log_types::StoreSource::Other("viewer".to_owned()),

--- a/crates/re_log_encoding/src/decoder/mod.rs
+++ b/crates/re_log_encoding/src/decoder/mod.rs
@@ -232,6 +232,7 @@ fn test_encode_decode() {
         info: StoreInfo {
             application_id: ApplicationId("test".to_owned()),
             store_id: StoreId::random(StoreKind::Recording),
+            cloned_from: None,
             is_official_example: true,
             started: Time::now(),
             store_source: StoreSource::RustSdk {

--- a/crates/re_log_encoding/src/decoder/stream.rs
+++ b/crates/re_log_encoding/src/decoder/stream.rs
@@ -235,6 +235,7 @@ mod tests {
             info: StoreInfo {
                 application_id: ApplicationId::unknown(),
                 store_id: StoreId::from_string(StoreKind::Recording, "test".into()),
+                cloned_from: None,
                 is_official_example: false,
                 started: Time::from_ns_since_epoch(0),
                 store_source: StoreSource::Unknown,

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -330,6 +330,16 @@ pub struct StoreInfo {
     /// Should be unique for each recording.
     pub store_id: StoreId,
 
+    /// If this store is the result of a clone, which store was it cloned from?
+    ///
+    /// A cloned store always gets a new unique ID.
+    ///
+    /// We currently only clone stores for blueprints:
+    /// when we receive a _default_ blueprints on the wire (e.g. from a recording),
+    /// we clone it and make the clone the _active_ blueprint.
+    /// This means all active blueprints are clones.
+    pub cloned_from: Option<StoreId>,
+
     /// True if the recording is one of the official Rerun examples.
     pub is_official_example: bool,
 

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -175,6 +175,7 @@ pub fn new_store_info(
     re_log_types::StoreInfo {
         application_id: application_id.into(),
         store_id: StoreId::random(StoreKind::Recording),
+        cloned_from: None,
         is_official_example: called_from_official_rust_example(),
         started: re_log_types::Time::now(),
         store_source: re_log_types::StoreSource::RustSdk {

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -552,6 +552,7 @@ impl RecordingStreamBuilder {
         let store_info = StoreInfo {
             application_id,
             store_id,
+            cloned_from: None,
             is_official_example,
             started: Time::now(),
             store_source,

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -555,7 +555,6 @@ mod tests {
                 recording: &recording,
                 bundle: &Default::default(),
                 hub: &re_viewer_context::StoreHub::test_hub(),
-                default_blueprint: None,
             };
 
             let mut query_result = contents.execute_query(&ctx, &visualizable_entities);
@@ -600,7 +599,6 @@ mod tests {
                 recording: &recording,
                 bundle: &Default::default(),
                 hub: &re_viewer_context::StoreHub::test_hub(),
-                default_blueprint: None,
             };
 
             let mut query_result = contents.execute_query(&ctx, &visualizable_entities);
@@ -651,7 +649,6 @@ mod tests {
                 recording: &recording,
                 bundle: &Default::default(),
                 hub: &re_viewer_context::StoreHub::test_hub(),
-                default_blueprint: None,
             };
 
             let mut query_result = contents.execute_query(&ctx, &visualizable_entities);
@@ -925,7 +922,6 @@ mod tests {
                 recording: &recording,
                 bundle: &Default::default(),
                 hub: &re_viewer_context::StoreHub::test_hub(),
-                default_blueprint: None,
             };
             let mut query_result = space_view
                 .contents

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -554,6 +554,7 @@ mod tests {
                 blueprint: &blueprint,
                 recording: &recording,
                 bundle: &Default::default(),
+                hub: &re_viewer_context::StoreHub::test_hub(),
                 default_blueprint: None,
             };
 
@@ -598,6 +599,7 @@ mod tests {
                 blueprint: &blueprint,
                 recording: &recording,
                 bundle: &Default::default(),
+                hub: &re_viewer_context::StoreHub::test_hub(),
                 default_blueprint: None,
             };
 
@@ -648,6 +650,7 @@ mod tests {
                 blueprint: &blueprint,
                 recording: &recording,
                 bundle: &Default::default(),
+                hub: &re_viewer_context::StoreHub::test_hub(),
                 default_blueprint: None,
             };
 
@@ -921,6 +924,7 @@ mod tests {
                 blueprint: &blueprint,
                 recording: &recording,
                 bundle: &Default::default(),
+                hub: &re_viewer_context::StoreHub::test_hub(),
                 default_blueprint: None,
             };
             let mut query_result = space_view

--- a/crates/re_space_view/src/space_view_contents.rs
+++ b/crates/re_space_view/src/space_view_contents.rs
@@ -611,7 +611,7 @@ impl<'a> PropertyResolver for DataQueryPropertyResolver<'a> {
 mod tests {
     use re_entity_db::EntityDb;
     use re_log_types::{example_components::MyPoint, DataRow, RowId, StoreId, TimePoint, Timeline};
-    use re_viewer_context::{StoreContext, VisualizableEntities};
+    use re_viewer_context::{StoreContext, StoreHub, VisualizableEntities};
 
     use super::*;
 
@@ -662,6 +662,7 @@ mod tests {
             blueprint: &blueprint,
             recording: &recording,
             bundle: &Default::default(),
+            hub: &StoreHub::test_hub(),
             default_blueprint: None,
         };
 

--- a/crates/re_space_view/src/space_view_contents.rs
+++ b/crates/re_space_view/src/space_view_contents.rs
@@ -663,7 +663,6 @@ mod tests {
             recording: &recording,
             bundle: &Default::default(),
             hub: &StoreHub::test_hub(),
-            default_blueprint: None,
         };
 
         struct Scenario {

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -349,11 +349,14 @@ impl ReUi {
 
     #[allow(clippy::unused_self)]
     pub fn small_icon_button(&self, ui: &mut egui::Ui, icon: &Icon) -> egui::Response {
+        ui.add(self.small_icon_button_widget(ui, icon))
+    }
+
+    #[allow(clippy::unused_self)]
+    pub fn small_icon_button_widget(&self, ui: &egui::Ui, icon: &Icon) -> egui::ImageButton<'_> {
         // TODO(emilk): change color and size on hover
-        ui.add(
-            egui::ImageButton::new(icon.as_image().fit_to_exact_size(Self::small_icon_size()))
-                .tint(ui.visuals().widgets.inactive.fg_stroke.color),
-        )
+        egui::ImageButton::new(icon.as_image().fit_to_exact_size(Self::small_icon_size()))
+            .tint(ui.visuals().widgets.inactive.fg_stroke.color)
     }
 
     #[allow(clippy::unused_self)]

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -234,7 +234,10 @@ impl App {
             open_files_promise: Default::default(),
             state,
             background_tasks: Default::default(),
-            store_hub: Some(StoreHub::new(blueprint_loader())),
+            store_hub: Some(StoreHub::new(
+                blueprint_loader(),
+                &crate::app_blueprint::setup_welcome_screen_blueprint,
+            )),
             toasts: toasts::Toasts::new(),
             memory_panel: Default::default(),
             memory_panel_open: false,

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -365,12 +365,6 @@ impl App {
                 }
             }
 
-            SystemCommand::LoadStoreDb(entity_db) => {
-                let store_id = entity_db.store_id().clone();
-                store_hub.insert_entity_db(entity_db);
-                store_hub.set_active_recording_id(store_id);
-            }
-
             SystemCommand::ResetViewer => self.reset(store_hub, egui_ctx),
             SystemCommand::ClearAndGenerateBlueprint => {
                 re_log::debug!("Clear and generate new blueprint");

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -373,7 +373,7 @@ impl App {
                 store_hub.clear_default_blueprint();
                 store_hub.clear_active_blueprint();
             }
-            SystemCommand::ResetBlueprint => {
+            SystemCommand::ClearActiveBlueprint => {
                 // By clearing the blueprint the default blueprint will be restored
                 // at the beginning of the next frame.
                 re_log::debug!("Reset blueprint to default");

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -337,7 +337,7 @@ impl App {
     ) {
         match cmd {
             SystemCommand::ActivateRecording(store_id) => {
-                store_hub.activate_recording(store_id);
+                store_hub.set_activate_recording(store_id);
             }
             SystemCommand::CloseStore(store_id) => {
                 store_hub.remove(&store_id);
@@ -985,11 +985,11 @@ impl App {
                             );
                             let app_id = info.application_id.clone();
                             if cmd.make_default {
-                                store_hub.set_default_blueprint_for_app_id(store_id, &app_id);
+                                store_hub.set_default_blueprint_for_app(&app_id, store_id);
                             }
                             if cmd.make_active {
                                 store_hub
-                                    .make_blueprint_active_for_app_id(store_id, &app_id)
+                                    .set_cloned_blueprint_active_for_app(&app_id, store_id)
                                     .unwrap_or_else(|err| {
                                         re_log::warn!("Failed to make blueprint active: {err}");
                                     });
@@ -1142,7 +1142,7 @@ impl App {
     /// in the users face.
     fn should_show_welcome_screen(&mut self, store_hub: &StoreHub) -> bool {
         // Don't show the welcome screen if we have actual data to display.
-        if store_hub.active_recording().is_some() || store_hub.active_application_id().is_some() {
+        if store_hub.active_recording().is_some() || store_hub.active_app().is_some() {
             return false;
         }
 
@@ -1369,7 +1369,7 @@ impl eframe::App for App {
         // Heuristic to set the app_id to the welcome screen blueprint.
         // Must be called before `read_context` below.
         if self.should_show_welcome_screen(&store_hub) {
-            store_hub.set_active_app_id(StoreHub::welcome_screen_app_id());
+            store_hub.set_active_app(StoreHub::welcome_screen_app_id());
         }
 
         let store_context = store_hub.read_context();

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -149,7 +149,7 @@ impl AppState {
         // If the blueprint is invalid, reset it.
         if viewport.blueprint.is_invalid() {
             re_log::warn!("Incompatible blueprint detected. Resetting to default.");
-            command_sender.send_system(re_viewer_context::SystemCommand::ResetBlueprint);
+            command_sender.send_system(re_viewer_context::SystemCommand::ClearActiveBlueprint);
 
             // The blueprint isn't valid so nothing past this is going to work properly.
             // we might as well return and it will get fixed on the next frame.

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -8,12 +8,12 @@ use re_space_view::{determine_visualizable_entities, DataQuery as _, PropertyRes
 use re_viewer_context::{
     blueprint_timeline, AppOptions, ApplicationSelectionState, Caches, CommandSender,
     ComponentUiRegistry, PlayState, RecordingConfig, SpaceViewClassRegistry, StoreContext,
-    SystemCommandSender as _, ViewerContext,
+    StoreHub, SystemCommandSender as _, ViewerContext,
 };
 use re_viewport::{Viewport, ViewportBlueprint, ViewportState};
 
 use crate::ui::recordings_panel_ui;
-use crate::{app_blueprint::AppBlueprint, store_hub::StoreHub, ui::blueprint_panel_ui};
+use crate::{app_blueprint::AppBlueprint, ui::blueprint_panel_ui};
 
 const WATERMARK: bool = false; // Nice for recording media material
 

--- a/crates/re_viewer/src/blueprint/mod.rs
+++ b/crates/re_viewer/src/blueprint/mod.rs
@@ -1,7 +1,5 @@
-#[cfg(not(target_arch = "wasm32"))]
 pub mod validation;
-#[cfg(not(target_arch = "wasm32"))]
+
 mod validation_gen;
 
-#[cfg(not(target_arch = "wasm32"))]
 pub use validation_gen::is_valid_blueprint;

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -12,7 +12,6 @@ pub mod env_vars;
 mod loading;
 mod saving;
 mod screenshotter;
-mod store_hub;
 mod ui;
 mod viewer_analytics;
 

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -1,15 +1,13 @@
 use ahash::{HashMap, HashMapExt};
 
 use anyhow::Context as _;
+
 use re_data_store::StoreGeneration;
 use re_data_store::{DataStoreConfig, DataStoreStats};
 use re_entity_db::{EntityDb, StoreBundle};
 use re_log_types::{ApplicationId, StoreId, StoreKind};
 use re_query_cache::CachesStats;
 use re_viewer_context::{AppOptions, StoreContext};
-
-#[cfg(not(target_arch = "wasm32"))]
-use crate::{loading::load_blueprint_file, saving::default_blueprint_path};
 
 /// Interface for accessing all blueprints and recordings
 ///
@@ -422,6 +420,7 @@ impl StoreHub {
         app_options: &AppOptions,
     ) -> anyhow::Result<()> {
         re_tracing::profile_function!();
+
         // Because we save blueprints based on their `ApplicationId`, we only
         // save the blueprints referenced by `blueprint_by_app_id`, even though
         // there may be other Blueprints in the Hub.
@@ -441,7 +440,7 @@ impl StoreHub {
 
             #[cfg(not(target_arch = "wasm32"))]
             {
-                let blueprint_path = default_blueprint_path(app_id)?;
+                let blueprint_path = crate::saving::default_blueprint_path(app_id)?;
 
                 let messages = blueprint.to_messages(None)?;
 
@@ -473,9 +472,10 @@ impl StoreHub {
         &mut self,
         app_id: &ApplicationId,
     ) -> anyhow::Result<()> {
-        use crate::blueprint::is_valid_blueprint;
-
         re_tracing::profile_function!();
+        use crate::blueprint::is_valid_blueprint;
+        use crate::{loading::load_blueprint_file, saving::default_blueprint_path};
+
         let blueprint_path = default_blueprint_path(app_id)?;
         if blueprint_path.exists() {
             re_log::debug!("Trying to load blueprint for {app_id} from {blueprint_path:?}",);

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -69,7 +69,10 @@ impl StoreHub {
     /// The [`StoreHub`] will contain a single empty blueprint associated with the app ID returned
     /// by `[StoreHub::welcome_screen_app_id]`. It should be used as a marker to display the welcome
     /// screen.
-    pub fn new(persistence: BlueprintPersistence) -> Self {
+    pub fn new(
+        persistence: BlueprintPersistence,
+        setup_welcome_screen_blueprint: &dyn Fn(&mut EntityDb),
+    ) -> Self {
         re_tracing::profile_function!();
         let mut blueprint_by_app_id = HashMap::new();
         let mut store_bundle = StoreBundle::default();
@@ -84,7 +87,7 @@ impl StoreHub {
         );
 
         let welcome_screen_blueprint = store_bundle.blueprint_entry(&welcome_screen_store_id);
-        crate::app_blueprint::setup_welcome_screen_blueprint(welcome_screen_blueprint);
+        (setup_welcome_screen_blueprint)(welcome_screen_blueprint);
 
         Self {
             persistence,

--- a/crates/re_viewer/src/ui/blueprint_panel.rs
+++ b/crates/re_viewer/src/ui/blueprint_panel.rs
@@ -25,23 +25,43 @@ pub fn blueprint_panel_ui(
 }
 
 fn reset_blueprint_button_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
-    let hover_text = if ctx
+    let default_blueprint_id = ctx
         .store_context
         .hub
-        .default_blueprint_for_app(&ctx.store_context.app_id)
-        .is_some()
-    {
-        "Reset to the default blueprint for this app"
+        .default_blueprint_id_for_app(&ctx.store_context.app_id);
+
+    let default_blueprint = default_blueprint_id.and_then(|id| ctx.store_context.bundle.get(id));
+
+    let mut disabled_reason = None;
+
+    if let Some(default_blueprint) = default_blueprint {
+        let active_is_clone_of_default =
+            Some(default_blueprint.store_id()) == ctx.store_context.blueprint.cloned_from();
+        let last_modified_at_the_same_time =
+            default_blueprint.latest_row_id() == ctx.store_context.blueprint.latest_row_id();
+        if active_is_clone_of_default && last_modified_at_the_same_time {
+            disabled_reason = Some("No modifications has been made");
+        }
+    }
+
+    let enabled = disabled_reason.is_none();
+    let response = ui.add_enabled(
+        enabled,
+        ctx.re_ui.small_icon_button_widget(ui, &re_ui::icons::RESET),
+    );
+
+    let response = if let Some(disabled_reason) = disabled_reason {
+        response.on_disabled_hover_text(disabled_reason)
     } else {
-        "Re-populate viewport with automatically chosen space views"
+        let hover_text = if default_blueprint_id.is_some() {
+            "Reset to the default blueprint for this app"
+        } else {
+            "Re-populate viewport with automatically chosen space views"
+        };
+        response.on_hover_text(hover_text)
     };
 
-    if ctx
-        .re_ui
-        .small_icon_button(ui, &re_ui::icons::RESET)
-        .on_hover_text(hover_text)
-        .clicked()
-    {
+    if response.clicked() {
         ctx.command_sender
             .send_system(re_viewer_context::SystemCommand::ClearActiveBlueprint);
     }

--- a/crates/re_viewer/src/ui/blueprint_panel.rs
+++ b/crates/re_viewer/src/ui/blueprint_panel.rs
@@ -43,6 +43,6 @@ fn reset_blueprint_button_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
         .clicked()
     {
         ctx.command_sender
-            .send_system(re_viewer_context::SystemCommand::ResetBlueprint);
+            .send_system(re_viewer_context::SystemCommand::ClearActiveBlueprint);
     }
 }

--- a/crates/re_viewer/src/ui/blueprint_panel.rs
+++ b/crates/re_viewer/src/ui/blueprint_panel.rs
@@ -25,7 +25,12 @@ pub fn blueprint_panel_ui(
 }
 
 fn reset_blueprint_button_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
-    let hover_text = if ctx.store_context.default_blueprint.is_some() {
+    let hover_text = if ctx
+        .store_context
+        .hub
+        .default_blueprint_for_app(&ctx.store_context.app_id)
+        .is_some()
+    {
         "Reset to the default blueprint for this app"
     } else {
         "Re-populate viewport with automatically chosen space views"

--- a/crates/re_viewer/src/ui/memory_panel.rs
+++ b/crates/re_viewer/src/ui/memory_panel.rs
@@ -5,8 +5,9 @@ use re_format::{format_bytes, format_number};
 use re_memory::{util::sec_since_start, MemoryHistory, MemoryLimit, MemoryUse};
 use re_query_cache::{CachedComponentStats, CachedEntityStats, CachesStats};
 use re_renderer::WgpuResourcePoolStatistics;
+use re_viewer_context::store_hub::StoreHubStats;
 
-use crate::{env_vars::RERUN_TRACK_ALLOCATIONS, store_hub::StoreHubStats};
+use crate::env_vars::RERUN_TRACK_ALLOCATIONS;
 
 // ----------------------------------------------------------------------------
 

--- a/crates/re_viewer_context/Cargo.toml
+++ b/crates/re_viewer_context/Cargo.toml
@@ -21,6 +21,7 @@ re_data_store.workspace = true
 re_entity_db = { workspace = true, features = ["serde"] }
 re_log_types.workspace = true
 re_log.workspace = true
+re_query_cache.workspace = true
 re_query.workspace = true
 re_renderer.workspace = true
 re_smart_channel.workspace = true

--- a/crates/re_viewer_context/src/command_sender.rs
+++ b/crates/re_viewer_context/src/command_sender.rs
@@ -14,7 +14,7 @@ pub enum SystemCommand {
     ResetViewer,
 
     /// Reset the `Blueprint` to the default state
-    ResetBlueprint,
+    ClearActiveBlueprint,
 
     /// Clear the blueprint and generate a new one
     ClearAndGenerateBlueprint,

--- a/crates/re_viewer_context/src/command_sender.rs
+++ b/crates/re_viewer_context/src/command_sender.rs
@@ -1,5 +1,4 @@
 use re_data_source::DataSource;
-use re_entity_db::EntityDb;
 use re_log_types::{DataRow, StoreId};
 use re_ui::{UICommand, UICommandSender};
 
@@ -10,9 +9,6 @@ use re_ui::{UICommand, UICommandSender};
 pub enum SystemCommand {
     /// Load some data.
     LoadDataSource(DataSource),
-
-    /// Load some log messages.
-    LoadStoreDb(EntityDb),
 
     /// Reset the `Viewer` to the default state
     ResetViewer,

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -17,6 +17,7 @@ mod selection_history;
 mod selection_state;
 mod space_view;
 mod store_context;
+pub mod store_hub;
 mod tensor;
 mod time_control;
 mod typed_entity_collections;
@@ -58,6 +59,7 @@ pub use space_view::{
     VisualizerQueryInfo, VisualizerSystem,
 };
 pub use store_context::StoreContext;
+pub use store_hub::StoreHub;
 pub use tensor::{TensorDecodeCache, TensorStats, TensorStatsCache};
 pub use time_control::{Looping, PlayState, TimeControl, TimeView};
 pub use typed_entity_collections::{

--- a/crates/re_viewer_context/src/store_context.rs
+++ b/crates/re_viewer_context/src/store_context.rs
@@ -1,6 +1,8 @@
 use re_entity_db::{EntityDb, StoreBundle};
 use re_log_types::{ApplicationId, StoreId};
 
+use crate::StoreHub;
+
 /// The current Blueprint and Recording being displayed by the viewer
 pub struct StoreContext<'a> {
     /// The `app_id` of the current recording
@@ -15,7 +17,12 @@ pub struct StoreContext<'a> {
     pub recording: &'a EntityDb,
 
     /// All the loaded recordings and blueprints.
+    ///
+    /// This is the same bundle as is in [`Self::hub`], but extracted for ease-of-access.
     pub bundle: &'a StoreBundle,
+
+    /// The store hub, which keeps track of all the default and active blueprints, among other things.
+    pub hub: &'a StoreHub,
 
     /// The current default blueprint
     pub default_blueprint: Option<&'a StoreId>,

--- a/crates/re_viewer_context/src/store_context.rs
+++ b/crates/re_viewer_context/src/store_context.rs
@@ -5,15 +5,15 @@ use crate::StoreHub;
 
 /// The current Blueprint and Recording being displayed by the viewer
 pub struct StoreContext<'a> {
-    /// The `app_id` of the current recording
+    /// The `app_id` of the current recording.
     pub app_id: ApplicationId,
 
-    /// The current active recording.
+    /// The current active blueprint.
     pub blueprint: &'a EntityDb,
 
-    /// The current open recording.
+    /// The current active recording.
     ///
-    /// If none is open, this will point to a dummy empty recording.
+    /// If none is active, this will point to a dummy empty recording.
     pub recording: &'a EntityDb,
 
     /// All the loaded recordings and blueprints.
@@ -23,17 +23,10 @@ pub struct StoreContext<'a> {
 
     /// The store hub, which keeps track of all the default and active blueprints, among other things.
     pub hub: &'a StoreHub,
-
-    /// The current default blueprint
-    pub default_blueprint: Option<&'a StoreId>,
 }
 
 impl StoreContext<'_> {
     pub fn is_active(&self, store_id: &StoreId) -> bool {
         self.recording.store_id() == store_id || self.blueprint.store_id() == store_id
-    }
-
-    pub fn is_default_blueprint(&self, store_id: &StoreId) -> bool {
-        self.default_blueprint == Some(store_id)
     }
 }

--- a/crates/re_viewer_context/src/store_hub.rs
+++ b/crates/re_viewer_context/src/store_hub.rs
@@ -323,6 +323,12 @@ impl StoreHub {
     // ---------------------
     // Active blueprint
 
+    /// What is the active blueprint for the active application?
+    pub fn active_blueprint(&self) -> Option<&StoreId> {
+        self.active_app()
+            .and_then(|app_id| self.active_blueprint_for_app(app_id))
+    }
+
     pub fn active_blueprint_for_app(&self, app_id: &ApplicationId) -> Option<&StoreId> {
         self.active_blueprint_by_app_id.get(app_id)
     }

--- a/crates/re_viewer_context/src/store_hub.rs
+++ b/crates/re_viewer_context/src/store_hub.rs
@@ -18,6 +18,19 @@ use crate::{AppOptions, StoreContext};
 /// Internally, the [`StoreHub`] tracks which [`ApplicationId`] and `recording
 /// id` ([`StoreId`]) are currently active in the viewer. These can be configured
 /// using [`StoreHub::set_active_recording_id`] and [`StoreHub::set_active_app_id`] respectively.
+///
+/// ## Blueprints
+/// For each [`ApplicationId`], the [`StoreHub`] also keeps track of two blueprints:
+/// * The active blueprint
+/// * The default blueprint
+///
+/// Either on of these can be `None`.
+///
+/// The active blueprint is what the user would se and edit, if they were to select that app id.
+/// If there is no active blueprint, the default will be cloned and made active.
+///
+/// The default blueprint is usually the blueprint set by the SDK.
+/// This lets users reset the active blueprint to the one sent by the SDK.
 pub struct StoreHub {
     /// How we load and save blueprints.
     persistence: BlueprintPersistence,

--- a/crates/re_viewer_context/src/store_hub.rs
+++ b/crates/re_viewer_context/src/store_hub.rs
@@ -26,7 +26,7 @@ use crate::{AppOptions, StoreContext};
 ///
 /// Either on of these can be `None`.
 ///
-/// The active blueprint is what the user would se and edit, if they were to select that app id.
+/// The active blueprint is what the user would see and edit, if they were to select that app id.
 /// If there is no active blueprint, the default will be cloned and made active.
 ///
 /// The default blueprint is usually the blueprint set by the SDK.

--- a/crates/re_viewer_context/src/store_hub.rs
+++ b/crates/re_viewer_context/src/store_hub.rs
@@ -454,7 +454,6 @@ impl StoreHub {
     }
 
     /// Remove any recordings with a network source pointing at this `uri`.
-    #[cfg(target_arch = "wasm32")]
     pub fn remove_recording_by_uri(&mut self, uri: &str) {
         self.store_bundle.retain(|db| {
             let Some(data_source) = &db.data_source else {
@@ -522,11 +521,6 @@ impl StoreHub {
                 (saver)(app_id, blueprint)?;
                 self.blueprint_last_save
                     .insert(blueprint_id.clone(), blueprint.generation());
-            }
-
-            #[cfg(target_arch = "wasm32")]
-            {
-                _ = app_id;
             }
         }
 

--- a/crates/re_viewer_context/src/store_hub.rs
+++ b/crates/re_viewer_context/src/store_hub.rs
@@ -7,7 +7,8 @@ use re_data_store::{DataStoreConfig, DataStoreStats};
 use re_entity_db::{EntityDb, StoreBundle};
 use re_log_types::{ApplicationId, StoreId, StoreKind};
 use re_query_cache::CachesStats;
-use re_viewer_context::{AppOptions, StoreContext};
+
+use crate::{AppOptions, StoreContext};
 
 /// Interface for accessing all blueprints and recordings
 ///
@@ -485,10 +486,6 @@ impl StoreHub {
         if let Some(mut bundle) = (loader)(app_id)? {
             for store in bundle.drain_entity_dbs() {
                 if store.store_kind() == StoreKind::Blueprint && store.app_id() == Some(app_id) {
-                    if !crate::blueprint::is_valid_blueprint(&store) {
-                        re_log::warn_once!("Blueprint for {app_id} appears invalid - restoring to default. This is expected if you have just upgraded Rerun versions.");
-                        continue;
-                    }
                     // We found the blueprint we were looking for; make it active.
                     // borrow-checker won't let us just call `self.set_blueprint_for_app_id`
                     re_log::debug!(

--- a/crates/re_viewer_context/src/store_hub.rs
+++ b/crates/re_viewer_context/src/store_hub.rs
@@ -297,7 +297,7 @@ impl StoreHub {
     // ---------------------
     // Default blueprint
 
-    pub fn default_blueprint_for_app(&self, app_id: &ApplicationId) -> Option<&StoreId> {
+    pub fn default_blueprint_id_for_app(&self, app_id: &ApplicationId) -> Option<&StoreId> {
         self.default_blueprint_by_app_id.get(app_id)
     }
 
@@ -324,12 +324,12 @@ impl StoreHub {
     // Active blueprint
 
     /// What is the active blueprint for the active application?
-    pub fn active_blueprint(&self) -> Option<&StoreId> {
+    pub fn active_blueprint_id(&self) -> Option<&StoreId> {
         self.active_app()
-            .and_then(|app_id| self.active_blueprint_for_app(app_id))
+            .and_then(|app_id| self.active_blueprint_id_for_app(app_id))
     }
 
-    pub fn active_blueprint_for_app(&self, app_id: &ApplicationId) -> Option<&StoreId> {
+    pub fn active_blueprint_id_for_app(&self, app_id: &ApplicationId) -> Option<&StoreId> {
         self.active_blueprint_by_app_id.get(app_id)
     }
 

--- a/crates/re_viewer_context/src/store_hub.rs
+++ b/crates/re_viewer_context/src/store_hub.rs
@@ -168,7 +168,6 @@ impl StoreHub {
             .and_then(|id| self.store_bundle.get(id));
 
         Some(StoreContext {
-            default_blueprint: self.default_blueprint_by_app_id.get(&app_id),
             app_id,
             blueprint,
             recording: recording.unwrap_or(&EMPTY_ENTITY_DB),

--- a/crates/re_viewer_context/src/store_hub.rs
+++ b/crates/re_viewer_context/src/store_hub.rs
@@ -17,7 +17,7 @@ use crate::{AppOptions, StoreContext};
 ///
 /// Internally, the [`StoreHub`] tracks which [`ApplicationId`] and `recording
 /// id` ([`StoreId`]) are currently active in the viewer. These can be configured
-/// using [`StoreHub::set_active_recording_id`] and [`StoreHub::set_active_app_id`] respectively.
+/// using [`StoreHub::set_active_recording_id`] and [`StoreHub::set_active_app`] respectively.
 ///
 /// ## Blueprints
 /// For each [`ApplicationId`], the [`StoreHub`] also keeps track of two blueprints:

--- a/docs/content/getting-started/what-is-rerun.md
+++ b/docs/content/getting-started/what-is-rerun.md
@@ -11,6 +11,7 @@ To get a feeling of what you can do with Rerun
 Rerun is an SDK and engine for visualizing and interacting with multimodal data streams.
 
 Rerun is
+- Free to use
 - Simple to integrate and get started with
 - Usable from Python, Rust, and C++
 - Powerful, flexible, and extensible


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5712

A large part of this PR is just moving the `StoreHub` from `re_viewer` to `re_viewer_context` so I could put it in the store hub. Then I cleaned up the interface of `StoreHub` a bit.

The UI changes are:
* Show last modified time of recording
* Don't show cloned blueprints (the active one) as being from some data source
* Don't show sibling stores when a store is selected
* Show if a blueprint is active and/or default for the current app
* If a blueprint is cloned and modified, don't claim it came from the same source

There are more improvements we can do now that we have access to the `StoreHub`, but this PR at least removes most of the confusion.

`EntityDb` now stores the last `RowId` it knows of, which means we can use it to check if an active blueprint has been modified from the default blueprint. This is used to disable the "Reset blueprint" button in these cases.


https://github.com/rerun-io/rerun/assets/1148717/a19b59bc-1b30-44e3-ba6e-98bfa6510558



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5719/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5719/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5719/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5719)
- [Docs preview](https://rerun.io/preview/280e6b78650e4a5fbc7105853058b4aa696c78db/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/280e6b78650e4a5fbc7105853058b4aa696c78db/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)