### PR TITLE
If multiple ContainerLikes are passed to blueprint, wrap them in Tabs

### DIFF
--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -419,7 +419,7 @@ class Blueprint:
         self.auto_layout = auto_layout
 
         if len(contents) == 0:
-            # If there's no content, switch `auto_layout`` and `auto_space_views`` defaults to `True`.
+            # If there's no content, switch `auto_layout` and `auto_space_views` defaults to `True`.
             if self.auto_space_views is None:
                 self.auto_space_views = True
             if self.auto_layout is None:

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -77,9 +77,9 @@ class SpaceView:
 
     def to_container(self) -> Container:
         """Convert this space view to a container."""
-        from .containers import Grid
+        from .containers import Tabs
 
-        return Grid(self)
+        return Tabs(self)
 
     def to_blueprint(self) -> Blueprint:
         """Convert this space view to a full blueprint."""
@@ -367,10 +367,11 @@ class Blueprint:
         - [SelectionPanel][rerun.blueprint.SelectionPanel]
         - [TimePanel][rerun.blueprint.TimePanel]
 
-        It is an error to provide more than one of any type of part.
+        It is an error to provide more than one of instance of any of the panel types.
 
-        Blueprints only have a single top-level "root" container that defines the viewport. Any
-        other content should be nested under this container (or a nested sub-container).
+        Blueprints only have a single top-level "root" container that defines the viewport.
+        If you provide multiple `ContainerLike` instances, they will be combined under a single
+        root `Tab` container.
 
         Parameters
         ----------
@@ -390,16 +391,15 @@ class Blueprint:
             Whether to collapse the panels in the viewer. Defaults to `False`.
 
         """
+        from .containers import Tabs
 
         self.collapse_panels = collapse_panels
 
+        contents: list[ContainerLike] = []
+
         for part in parts:
             if isinstance(part, (Container, SpaceView)):
-                if hasattr(self, "root_container"):
-                    raise ValueError(
-                        "Only one ContainerLike can be provided to serve as the root container for the viewport"
-                    )
-                self.root_container = part.to_container()
+                contents.append(part)
             elif isinstance(part, BlueprintPanel):
                 if hasattr(self, "blueprint_panel"):
                     raise ValueError("Only one blueprint panel can be provided")
@@ -418,12 +418,16 @@ class Blueprint:
         self.auto_space_views = auto_space_views
         self.auto_layout = auto_layout
 
-        # If there's no `root_container`, switch `auto_layout`` and `auto_space_views`` defaults to `True`.
-        if not hasattr(self, "root_container"):
+        if len(contents) == 0:
+            # If there's no content, switch `auto_layout`` and `auto_space_views`` defaults to `True`.
             if self.auto_space_views is None:
                 self.auto_space_views = True
             if self.auto_layout is None:
                 self.auto_layout = True
+        elif len(contents) == 1:
+            self.root_container = contents[0].to_container()
+        else:
+            self.root_container = Tabs(contents=contents)
 
     def to_blueprint(self) -> Blueprint:
         """Conform with the `BlueprintLike` interface."""


### PR DESCRIPTION
### What
Previously it wass an error to do something like:
```
rrb.Blueprint(
  rrb.Spatial2DView(...),
  rrb.Spatial2DView(...),
)
```

The changes the behavior so if pass multiple ContainerLike's to the Blueprint, they get aggregated as a Tab container.
The above would be equivalent to:
```
rrb.Blueprint(
  rrb.Tabs(
    rrb.Spatial2DView(...),
    rrb.Spatial2DView(...),
  )
)
```

This seems less surprising than raising a value-error. Choice of `Tabs` over `Grid` is somewhat arbitrary, but Tabs feels more close to the "spirit" of multiple top-level contents, since each one still behaves essentially as fully-screen when selected.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5722/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5722/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5722/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5722)
- [Docs preview](https://rerun.io/preview/4bcf0832a2d2898329259f74038bfa0bc6d8cabf/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4bcf0832a2d2898329259f74038bfa0bc6d8cabf/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)