### PR TITLE
Don't crash the stock example when the market is closed

### DIFF
--- a/examples/python/blueprint_stocks/main.py
+++ b/examples/python/blueprint_stocks/main.py
@@ -201,6 +201,8 @@ def main() -> None:
             close_time = dt.datetime.combine(day, dt.time(16, 00))
 
             hist = stock.history(start=open_time, end=close_time, interval="5m")
+            if len(hist.index) == 0:
+                continue
 
             hist.index = hist.index - et_timezone.localize(open_time)
             peak = hist.High.idxmax()


### PR DESCRIPTION
### What
Market was closed good friday, leading me to uncover a bug. 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5731/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5731/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5731/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5731)
- [Docs preview](https://rerun.io/preview/41fec0ec411fb2242fe22b8bc93e794679cb634c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/41fec0ec411fb2242fe22b8bc93e794679cb634c/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)