### PR TITLE
Fix appearance of `ListItem` in a tooltip

### DIFF
--- a/crates/re_data_ui/src/data_source.rs
+++ b/crates/re_data_ui/src/data_source.rs
@@ -49,7 +49,9 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
         if !recordings.is_empty() {
             ui.add_space(8.0);
             ui.strong("Recordings from this data source");
+            let max_rect = ui.max_rect();
             ui.indent("recordings", |ui| {
+                ui.set_clip_rect(max_rect); // TODO(#5740): Hack required because `entity_db_button_ui` uses `ListItem`, which fills the full width until the clip rect.
                 ui.spacing_mut().item_spacing.y = 0.0;
                 for entity_db in recordings {
                     entity_db_button_ui(ctx, ui, entity_db, true);
@@ -60,7 +62,9 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
         if !blueprints.is_empty() {
             ui.add_space(8.0);
             ui.strong("Blueprints from this data source");
+            let max_rect = ui.max_rect();
             ui.indent("blueprints", |ui| {
+                ui.set_clip_rect(max_rect); // TODO(#5740): Hack required because `entity_db_button_ui` uses `ListItem`, which fills the full width until the clip rect.
                 ui.spacing_mut().item_spacing.y = 0.0;
                 for entity_db in blueprints {
                     entity_db_button_ui(ctx, ui, entity_db, true);


### PR DESCRIPTION
Requires a hack for the clip_rect. I opened an issue to track this:
* https://github.com/rerun-io/rerun/issues/5740

Before:
![screenshot_2024-04-02_at_11 34 18](https://github.com/rerun-io/rerun/assets/1148717/8e4e55a2-4c97-4e4c-b504-061b56d7c624)

After:
<img width="847" alt="Screenshot 2024-04-02 at 11 59 16" src="https://github.com/rerun-io/rerun/assets/1148717/e567f574-ed9c-469a-8d0c-34e344b8e7bb">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5741/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5741/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5741/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5741)
- [Docs preview](https://rerun.io/preview/04ae476663633878b1b60b6101d82e653454c0d2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/04ae476663633878b1b60b6101d82e653454c0d2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)