### PR TITLE
Fix issue where "placeholder" `DataResults` couldn't be selected

### DIFF
--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -254,6 +254,9 @@ impl ViewportBlueprint {
     }
 
     /// If `false`, the item is referring to data that is not present in this blueprint.
+    ///
+    /// TODO(#5742): note that `Item::DataResult` with entity path set to the space origin or some
+    /// of its descendent are always considered valid.
     pub fn is_item_valid(&self, item: &Item) -> bool {
         match item {
             Item::DataSource(_)
@@ -265,10 +268,16 @@ impl ViewportBlueprint {
 
             Item::DataResult(space_view_id, instance_path) => {
                 self.space_view(space_view_id).map_or(false, |space_view| {
-                    space_view
-                        .contents
-                        .entity_path_filter
-                        .is_included(&instance_path.entity_path)
+                    let entity_path = &instance_path.entity_path;
+
+                    // TODO(#5742): including any path that is—or descend from—the space origin is
+                    // necessary because such items may actually be displayed in the blueprint tree.
+                    entity_path == &space_view.space_origin
+                        || entity_path.is_descendant_of(&space_view.space_origin)
+                        || space_view
+                            .contents
+                            .entity_path_filter
+                            .is_included(&instance_path.entity_path)
                 })
             }
 


### PR DESCRIPTION
### What

- Fixes #5683

This PR fixes an issue where "placeholder" `DataResult` (as per `DataResultNodeOrPath`) could not be selected because they would be rejected as invalid by `ViewportBlueprint::is_item_valid()`.

This fix is quite hacky and should be improved:
- https://github.com/rerun-io/rerun/issues/5742

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}/index.html)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
