### PR TITLE
Fix orphaned space views by constructing from tree rather than redundant component

### DIFF
--- a/crates/re_types/definitions/rerun/blueprint/archetypes/viewport_blueprint.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/archetypes/viewport_blueprint.fbs
@@ -16,9 +16,6 @@ table ViewportBlueprint (
     // --- Required ---
 
     // --- Optional ---
-    /// All of the space-views that belong to the viewport.
-    space_views: [rerun.blueprint.components.IncludedSpaceView] ("attr.rerun.component_optional", nullable, order: 1000);
-
     /// The layout of the space-views
     root_container: rerun.blueprint.components.RootContainer ("attr.rerun.component_optional", nullable, order: 2500);
 

--- a/crates/re_viewport/src/blueprint/archetypes/viewport_blueprint.rs
+++ b/crates/re_viewport/src/blueprint/archetypes/viewport_blueprint.rs
@@ -24,9 +24,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// **Archetype**: The top-level description of the Viewport.
 #[derive(Clone, Debug, Default)]
 pub struct ViewportBlueprint {
-    /// All of the space-views that belong to the viewport.
-    pub space_views: Option<Vec<crate::blueprint::components::IncludedSpaceView>>,
-
     /// The layout of the space-views
     pub root_container: Option<crate::blueprint::components::RootContainer>,
 
@@ -59,8 +56,7 @@ pub struct ViewportBlueprint {
 impl ::re_types_core::SizeBytes for ViewportBlueprint {
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
-        self.space_views.heap_size_bytes()
-            + self.root_container.heap_size_bytes()
+        self.root_container.heap_size_bytes()
             + self.maximized.heap_size_bytes()
             + self.auto_layout.heap_size_bytes()
             + self.auto_space_views.heap_size_bytes()
@@ -69,8 +65,7 @@ impl ::re_types_core::SizeBytes for ViewportBlueprint {
 
     #[inline]
     fn is_pod() -> bool {
-        <Option<Vec<crate::blueprint::components::IncludedSpaceView>>>::is_pod()
-            && <Option<crate::blueprint::components::RootContainer>>::is_pod()
+        <Option<crate::blueprint::components::RootContainer>>::is_pod()
             && <Option<crate::blueprint::components::SpaceViewMaximized>>::is_pod()
             && <Option<crate::blueprint::components::AutoLayout>>::is_pod()
             && <Option<crate::blueprint::components::AutoSpaceViews>>::is_pod()
@@ -84,12 +79,11 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
     once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.ViewportBlueprintIndicator".into()]);
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 7usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.blueprint.components.AutoLayout".into(),
             "rerun.blueprint.components.AutoSpaceViews".into(),
-            "rerun.blueprint.components.IncludedSpaceView".into(),
             "rerun.blueprint.components.RootContainer".into(),
             "rerun.blueprint.components.SpaceViewMaximized".into(),
             "rerun.blueprint.components.ViewerRecommendationHash".into(),
@@ -97,13 +91,12 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 7usize]> =
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 8usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.blueprint.components.ViewportBlueprintIndicator".into(),
             "rerun.blueprint.components.AutoLayout".into(),
             "rerun.blueprint.components.AutoSpaceViews".into(),
-            "rerun.blueprint.components.IncludedSpaceView".into(),
             "rerun.blueprint.components.RootContainer".into(),
             "rerun.blueprint.components.SpaceViewMaximized".into(),
             "rerun.blueprint.components.ViewerRecommendationHash".into(),
@@ -112,7 +105,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 8usize]> =
     });
 
 impl ViewportBlueprint {
-    pub const NUM_COMPONENTS: usize = 8usize;
+    pub const NUM_COMPONENTS: usize = 7usize;
 }
 
 /// Indicator component for the [`ViewportBlueprint`] [`::re_types_core::Archetype`]
@@ -162,20 +155,6 @@ impl ::re_types_core::Archetype for ViewportBlueprint {
             .into_iter()
             .map(|(name, array)| (name.full_name(), array))
             .collect();
-        let space_views = if let Some(array) =
-            arrays_by_name.get("rerun.blueprint.components.IncludedSpaceView")
-        {
-            Some({
-                <crate::blueprint::components::IncludedSpaceView>::from_arrow_opt(&**array)
-                    .with_context("rerun.blueprint.archetypes.ViewportBlueprint#space_views")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.blueprint.archetypes.ViewportBlueprint#space_views")?
-            })
-        } else {
-            None
-        };
         let root_container =
             if let Some(array) = arrays_by_name.get("rerun.blueprint.components.RootContainer") {
                 <crate::blueprint::components::RootContainer>::from_arrow_opt(&**array)
@@ -236,7 +215,6 @@ impl ::re_types_core::Archetype for ViewportBlueprint {
             None
         };
         Ok(Self {
-            space_views,
             root_container,
             maximized,
             auto_layout,
@@ -252,9 +230,6 @@ impl ::re_types_core::AsComponents for ViewportBlueprint {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.space_views
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
             self.root_container
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch).into()),
@@ -285,24 +260,12 @@ impl ::re_types_core::AsComponents for ViewportBlueprint {
 impl ViewportBlueprint {
     pub fn new() -> Self {
         Self {
-            space_views: None,
             root_container: None,
             maximized: None,
             auto_layout: None,
             auto_space_views: None,
             past_viewer_recommendations: None,
         }
-    }
-
-    #[inline]
-    pub fn with_space_views(
-        mut self,
-        space_views: impl IntoIterator<
-            Item = impl Into<crate::blueprint::components::IncludedSpaceView>,
-        >,
-    ) -> Self {
-        self.space_views = Some(space_views.into_iter().map(Into::into).collect());
-        self
     }
 
     #[inline]

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -74,7 +74,6 @@ impl ViewportBlueprint {
         re_tracing::profile_function!();
 
         let crate::blueprint::archetypes::ViewportBlueprint {
-            space_views: _,
             root_container,
             maximized,
             auto_layout,
@@ -426,14 +425,6 @@ impl ViewportBlueprint {
                     position_in_parent,
                 ));
             }
-
-            let components = self
-                .space_views
-                .keys()
-                .chain(new_ids.iter())
-                .map(|id| IncludedSpaceView((*id).into()))
-                .collect::<Vec<_>>();
-            ctx.save_blueprint_component(&VIEWPORT_PATH.into(), &components);
         }
 
         new_ids

--- a/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.cpp
@@ -14,13 +14,8 @@ namespace rerun {
     ) {
         using namespace blueprint::archetypes;
         std::vector<DataCell> cells;
-        cells.reserve(7);
+        cells.reserve(6);
 
-        if (archetype.space_views.has_value()) {
-            auto result = DataCell::from_loggable(archetype.space_views.value());
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
-        }
         if (archetype.root_container.has_value()) {
             auto result = DataCell::from_loggable(archetype.root_container.value());
             RR_RETURN_NOT_OK(result.error);

--- a/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.hpp
@@ -5,7 +5,6 @@
 
 #include "../../blueprint/components/auto_layout.hpp"
 #include "../../blueprint/components/auto_space_views.hpp"
-#include "../../blueprint/components/included_space_view.hpp"
 #include "../../blueprint/components/root_container.hpp"
 #include "../../blueprint/components/space_view_maximized.hpp"
 #include "../../blueprint/components/viewer_recommendation_hash.hpp"
@@ -23,9 +22,6 @@
 namespace rerun::blueprint::archetypes {
     /// **Archetype**: The top-level description of the Viewport.
     struct ViewportBlueprint {
-        /// All of the space-views that belong to the viewport.
-        std::optional<Collection<rerun::blueprint::components::IncludedSpaceView>> space_views;
-
         /// The layout of the space-views
         std::optional<rerun::blueprint::components::RootContainer> root_container;
 
@@ -64,15 +60,6 @@ namespace rerun::blueprint::archetypes {
       public:
         ViewportBlueprint() = default;
         ViewportBlueprint(ViewportBlueprint&& other) = default;
-
-        /// All of the space-views that belong to the viewport.
-        ViewportBlueprint with_space_views(
-            Collection<rerun::blueprint::components::IncludedSpaceView> _space_views
-        ) && {
-            space_views = std::move(_space_views);
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
-        }
 
         /// The layout of the space-views
         ViewportBlueprint with_root_container(

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import itertools
 import uuid
 from typing import Any, Iterable, Optional, Union
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -104,12 +104,6 @@ class SpaceView:
 
         stream.log(self.blueprint_path(), arch, recording=stream)  # type: ignore[attr-defined]
 
-    def _iter_space_views(self) -> Iterable[bytes]:
-        """Internal method to iterate over all of the space views in the blueprint."""
-        # TODO(jleibs): This goes away when we get rid of `space_views` from the viewport and just use
-        # the entity-path lookup instead.
-        return [self.id.bytes]
-
     def _repr_html_(self) -> Any:
         """IPython interface to conversion to html."""
         return as_html(blueprint=self)
@@ -227,12 +221,6 @@ class Container:
         )
 
         stream.log(self.blueprint_path(), arch)  # type: ignore[attr-defined]
-
-    def _iter_space_views(self) -> Iterable[bytes]:
-        """Internal method to iterate over all of the space views in the blueprint."""
-        # TODO(jleibs): This goes away when we get rid of `space_views` from the viewport and just use
-        # the entity-path lookup instead.
-        return itertools.chain.from_iterable(sub._iter_space_views() for sub in self.contents)
 
     def _repr_html_(self) -> Any:
         """IPython interface to conversion to html."""
@@ -439,13 +427,10 @@ class Blueprint:
             self.root_container._log_to_stream(stream)
 
             root_container_id = self.root_container.id.bytes
-            space_views = list(self.root_container._iter_space_views())
         else:
             root_container_id = None
-            space_views = []
 
         viewport_arch = ViewportBlueprint(
-            space_views=space_views,
             root_container=root_container_id,
             auto_layout=self.auto_layout,
             auto_space_views=self.auto_space_views,

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/viewport_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/viewport_blueprint.py
@@ -24,7 +24,6 @@ class ViewportBlueprint(Archetype):
     def __init__(
         self: Any,
         *,
-        space_views: datatypes.UuidArrayLike | None = None,
         root_container: datatypes.UuidLike | None = None,
         maximized: datatypes.UuidLike | None = None,
         auto_layout: blueprint_components.AutoLayoutLike | None = None,
@@ -36,8 +35,6 @@ class ViewportBlueprint(Archetype):
 
         Parameters
         ----------
-        space_views:
-            All of the space-views that belong to the viewport.
         root_container:
             The layout of the space-views
         maximized:
@@ -66,7 +63,6 @@ class ViewportBlueprint(Archetype):
         # You can define your own __init__ function as a member of ViewportBlueprintExt in viewport_blueprint_ext.py
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(
-                space_views=space_views,
                 root_container=root_container,
                 maximized=maximized,
                 auto_layout=auto_layout,
@@ -79,7 +75,6 @@ class ViewportBlueprint(Archetype):
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""
         self.__attrs_init__(
-            space_views=None,  # type: ignore[arg-type]
             root_container=None,  # type: ignore[arg-type]
             maximized=None,  # type: ignore[arg-type]
             auto_layout=None,  # type: ignore[arg-type]
@@ -93,15 +88,6 @@ class ViewportBlueprint(Archetype):
         inst = cls.__new__(cls)
         inst.__attrs_clear__()
         return inst
-
-    space_views: blueprint_components.IncludedSpaceViewBatch | None = field(
-        metadata={"component": "optional"},
-        default=None,
-        converter=blueprint_components.IncludedSpaceViewBatch._optional,  # type: ignore[misc]
-    )
-    # All of the space-views that belong to the viewport.
-    #
-    # (Docstring intentionally commented out to hide this field from the docs)
 
     root_container: blueprint_components.RootContainerBatch | None = field(
         metadata={"component": "optional"},

--- a/rerun_py/tests/unit/test_viewport_blueprint.py
+++ b/rerun_py/tests/unit/test_viewport_blueprint.py
@@ -6,7 +6,6 @@ from typing import Optional, cast
 from rerun.blueprint.archetypes.viewport_blueprint import ViewportBlueprint
 from rerun.blueprint.components.auto_layout import AutoLayoutBatch, AutoLayoutLike
 from rerun.blueprint.components.auto_space_views import AutoSpaceViewsBatch, AutoSpaceViewsLike
-from rerun.blueprint.components.included_space_view import IncludedSpaceViewBatch
 from rerun.blueprint.components.root_container import RootContainerBatch
 from rerun.blueprint.components.space_view_maximized import SpaceViewMaximizedBatch
 from rerun.blueprint.components.viewer_recommendation_hash import (
@@ -14,13 +13,12 @@ from rerun.blueprint.components.viewer_recommendation_hash import (
     ViewerRecommendationHashBatch,
 )
 from rerun.datatypes.uint64 import UInt64ArrayLike
-from rerun.datatypes.uuid import UuidArrayLike, UuidLike
+from rerun.datatypes.uuid import UuidLike
 
-from .common_arrays import none_empty_or_value, uuid_bytes0, uuid_bytes1, uuids_arrays
+from .common_arrays import none_empty_or_value, uuid_bytes0, uuid_bytes1
 
 
 def test_viewport_blueprint() -> None:
-    space_views_arrays = uuids_arrays
     root_container_arrays = [
         None,
         uuid_bytes0,
@@ -38,7 +36,6 @@ def test_viewport_blueprint() -> None:
     ]
 
     all_arrays = itertools.zip_longest(
-        space_views_arrays,
         root_container_arrays,
         maximized_arrays,
         auto_layout_arrays,
@@ -47,17 +44,13 @@ def test_viewport_blueprint() -> None:
     )
 
     for (
-        space_views,
         root_container,
         maximized,
         auto_layout,
         auto_space_views,
         past_viewer_recommendations,
     ) in all_arrays:
-        space_views = space_views if space_views is not None else space_views_arrays[-1]
-
         # mypy can't track types properly through itertools zip so re-cast
-        space_views = cast(UuidArrayLike, space_views)
         root_container = cast(Optional[UuidLike], root_container)
         maximized = cast(Optional[UuidLike], maximized)
         auto_layout = cast(Optional[AutoLayoutLike], auto_layout)
@@ -66,7 +59,6 @@ def test_viewport_blueprint() -> None:
 
         print(
             "rr.ViewportBlueprint(\n",
-            f"    space_views={space_views!r}\n",
             f"    root_container={root_container!r}\n",
             f"    maximized={maximized!r}\n",
             f"    auto_layout={auto_layout!r}\n",
@@ -75,7 +67,6 @@ def test_viewport_blueprint() -> None:
             ")",
         )
         arch = ViewportBlueprint(
-            space_views=space_views,
             root_container=root_container,
             maximized=maximized,
             auto_layout=auto_layout,
@@ -84,7 +75,6 @@ def test_viewport_blueprint() -> None:
         )
         print(f"{arch}\n")
 
-        assert arch.space_views == IncludedSpaceViewBatch._optional(none_empty_or_value(space_views, uuids_arrays[-1]))
         assert arch.root_container == RootContainerBatch._optional(none_empty_or_value(root_container, uuid_bytes0))
         assert arch.maximized == SpaceViewMaximizedBatch._optional(none_empty_or_value(maximized, uuid_bytes1))
         assert arch.auto_layout == AutoLayoutBatch._optional(none_empty_or_value(auto_layout, True))


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/5570

This was mostly just doing a code-cleanup I'd been meaning to do to avoid a foot-gun that was documented and ignored.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5744)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5744?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5744?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5744)
- [Docs preview](https://rerun.io/preview/560dab5eeedc7953b2fe092d0a024652d72fd053/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/560dab5eeedc7953b2fe092d0a024652d72fd053/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)