### PR TITLE
Add feedback when no match exist under space origin

### DIFF
--- a/crates/re_viewport/src/viewport_blueprint_ui.rs
+++ b/crates/re_viewport/src/viewport_blueprint_ui.rs
@@ -463,7 +463,10 @@ impl Viewport<'_, '_> {
                         }
                     });
                     if !projections.is_empty() {
-                        ui.label(egui::RichText::new("Projections:").italics());
+                        ListItem::new(ctx.re_ui, "Projections:")
+                            .interactive(false)
+                            .italics(true)
+                            .show_flat(ui);
 
                         for projection in projections {
                             self.space_view_entity_hierarchy_ui(
@@ -552,6 +555,7 @@ impl Viewport<'_, '_> {
             ctx.selection_state().highlight_for_ui_element(&item) == HoverHighlight::Hovered;
 
         let visible = data_result_node.map_or(false, |n| n.data_result.is_visible(ctx));
+        let empty_origin = entity_path == &space_view.space_origin && data_result_node.is_none();
 
         let item_label = if entity_path.is_root() {
             "/ (root)".to_owned()
@@ -578,22 +582,28 @@ impl Viewport<'_, '_> {
             .subdued(subdued)
             .force_hovered(is_item_hovered)
             .with_buttons(|re_ui: &_, ui: &mut egui::Ui| {
-                let mut visible_after = visible;
-                let vis_response =
-                    visibility_button_ui(re_ui, ui, space_view_visible, &mut visible_after);
-                if visible_after != visible {
-                    if let Some(data_result_node) = data_result_node {
-                        data_result_node
-                            .data_result
-                            .save_recursive_override_or_clear_if_redundant(
-                                ctx,
-                                &query_result.tree,
-                                &Visible(visible_after),
-                            );
+                let vis_response = if !empty_origin {
+                    let mut visible_after = visible;
+                    let vis_response =
+                        visibility_button_ui(re_ui, ui, space_view_visible, &mut visible_after);
+                    if visible_after != visible {
+                        if let Some(data_result_node) = data_result_node {
+                            data_result_node
+                                .data_result
+                                .save_recursive_override_or_clear_if_redundant(
+                                    ctx,
+                                    &query_result.tree,
+                                    &Visible(visible_after),
+                                );
+                        }
                     }
-                }
 
-                let response = remove_button_ui(
+                    Some(vis_response)
+                } else {
+                    None
+                };
+
+                let mut response = remove_button_ui(
                     re_ui,
                     ui,
                     "Remove group and all its children from the space view",
@@ -604,7 +614,11 @@ impl Viewport<'_, '_> {
                         .remove_subtree_and_matching_rules(ctx, entity_path.clone());
                 }
 
-                response | vis_response
+                if let Some(vis_response) = vis_response {
+                    response |= vis_response;
+                }
+
+                response
             });
 
         // If there's any children on the data result nodes, show them, otherwise we're good with this list item as is.
@@ -654,6 +668,12 @@ impl Viewport<'_, '_> {
         let response = response.on_hover_ui(|ui| {
             let query = ctx.current_query();
             re_data_ui::item_ui::entity_hover_card_ui(ui, ctx, &query, store, entity_path);
+
+            if empty_origin {
+                ui.label(ctx.re_ui.warning_text(
+                    "This space view's query did not match any data under the space origin",
+                ));
+            }
         });
 
         context_menu_ui_for_item(


### PR DESCRIPTION
### What

Add some feedback when the query returns no match under the space origin:
- the "eye" button is not displayed (visibility cannot be set on such entity)
- a note is added to the hover tooltip

This PR also sneakily changes the "Projections:" label for a `ListItem` for more consistent spacing.

<img width="437" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/c550cc79-7468-40e9-ae34-1286ada3d81f">

- Fixes #5410

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}})
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
