### PR TITLE
Update to egui 0.27.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,9 +1554,9 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "ecolor"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb152797942f72b84496eb2ebeff0060240e0bf55096c4525ffa22dd54722d86"
+checksum = "20930a432bbd57a6d55e07976089708d4893f3d556cf42a0d79e9e321fa73b10"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1564,9 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcc8e06df6f0a6cf09a3247ff7e85fdfffc28dda4fe5561e05314bf7618a918"
+checksum = "020e2ccef6bbcec71dbc542f7eed64a5846fc3076727f5746da8fd307c91bab2"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1b8cc14b0b260aa6bd124ef12c8a94f57ffe8e40aa970f3db710c21bb945f3"
+checksum = "584c5d1bf9a67b25778a3323af222dbe1a1feb532190e103901187f92c7fe29a"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1617,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ee072f7cbd9e03ae4028db1c4a8677fbb4efc4b62feee6563763a6f041c88d"
+checksum = "469ff65843f88a702b731a1532b7d03b0e8e96d283e70f3a22b0e06c46cb9b37"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1636,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3733435d6788c760bb98ce4cb1b8b7a2d953a3a7b421656ba8b3e014019be3d0"
+checksum = "2e3da0cbe020f341450c599b35b92de4af7b00abde85624fd16f09c885573609"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1666,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70edf79855c42e55c357f7f97cd3be9be59cee2585cc39045ce8ff187aa8d4b0"
+checksum = "1b78779f35ded1a853786c9ce0b43fe1053e10a21ea3b23ebea411805ce41593"
 dependencies = [
  "egui",
  "ehttp",
@@ -1682,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f933e9e64c4d074c78ce71785a5778f648453c2b2a3efd28eea189dac3f19c28"
+checksum = "e0e5d975f3c86edc3d35b1db88bb27c15dde7c55d3b5af164968ab5ede3f44ca"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1700,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "egui_plot"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6989f08973c1142953796068f559c40e62204c90b9da07841dd5c991a4a451d8"
+checksum = "a7854b86dc1c2d352c5270db3d600011daa913d6b554141a03939761323288a1"
 dependencies = [
  "egui",
 ]
@@ -1744,9 +1744,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "emath"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555a7cbfcc52c81eb5f8f898190c840fa1c435f67f30b7ef77ce7cf6b7dcd987"
+checksum = "e4c3a552cfca14630702449d35f41c84a0d15963273771c6059175a803620f3f"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1846,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd63c37156e949bda80f7e39cc11508bc34840aecf52180567e67cdb2bf1a5fe"
+checksum = "b381f8b149657a4acf837095351839f32cd5c4aec1817fc4df84e18d76334176"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,15 +75,15 @@ re_ws_comms = { path = "crates/re_ws_comms", version = "=0.15.0-alpha.5", defaul
 rerun = { path = "crates/rerun", version = "=0.15.0-alpha.5", default-features = false }
 
 # egui-crates:
-ecolor = "0.27.1"
-eframe = { version = "0.27.1", default-features = false, features = [
+ecolor = "0.27.2"
+eframe = { version = "0.27.2", default-features = false, features = [
   "accesskit",
   "default_fonts",
   "puffin",
   "wayland",
   "x11",
 ] }
-egui = { version = "0.27.1", features = [
+egui = { version = "0.27.2", features = [
   "callstack",
   "extra_debug_asserts",
   "log",
@@ -91,11 +91,11 @@ egui = { version = "0.27.1", features = [
   "rayon",
 ] }
 egui_commonmark = { version = "0.14", default-features = false }
-egui_extras = { version = "0.27.1", features = ["http", "image", "puffin"] }
-egui_plot = "0.27.1"
+egui_extras = { version = "0.27.2", features = ["http", "image", "puffin"] }
+egui_plot = "0.27.2"
 egui_tiles = "0.8.0"
-egui-wgpu = "0.27.1"
-emath = "0.27.1"
+egui-wgpu = "0.27.2"
+emath = "0.27.2"
 
 # All of our direct external dependencies should be found here:
 ahash = "0.8"


### PR DESCRIPTION
### What
See what's new in: https://github.com/emilk/egui/releases/tag/0.27.2

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5748)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5748?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5748?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5748)
- [Docs preview](https://rerun.io/preview/4b3d1158959b50c3edb1448af5964408236219fd/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4b3d1158959b50c3edb1448af5964408236219fd/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)