### PR TITLE
Improve formatting of numbers on plot Y axis

### DIFF
--- a/crates/re_log_types/src/time_point/mod.rs
+++ b/crates/re_log_types/src/time_point/mod.rs
@@ -139,7 +139,7 @@ impl TimeType {
         } else {
             match self {
                 Self::Time => Time::from(time_int).format(time_zone_for_timestamps),
-                Self::Sequence => format!("#{}", time_int.0),
+                Self::Sequence => format!("#{}", re_format::format_i64(time_int.0)),
             }
         }
     }

--- a/crates/re_time_panel/src/paint_ticks.rs
+++ b/crates/re_time_panel/src/paint_ticks.rs
@@ -79,6 +79,7 @@ fn paint_time_range_ticks(
                 |ns| Time::from_ns_since_epoch(ns).format_time_compact(time_zone_for_timestamps),
             )
         }
+
         TimeType::Sequence => {
             fn next_power_of_10(i: i64) -> i64 {
                 i * 10
@@ -91,7 +92,7 @@ fn paint_time_range_ticks(
                 &ui.clip_rect(),
                 time_range,
                 next_power_of_10,
-                |seq| format!("#{seq}"),
+                |seq| format!("#{}", re_format::format_i64(seq)),
             )
         }
     }


### PR DESCRIPTION
### What
The formatting up numbers on the plot Y axis was really bad before, showing very few digits of precision, and switching to scientific mode really early.

Now it use up to 15 digits of precision and uses thousands separators for clairy.

Sequence timelines (frames, log_tick, etc) are now also formatted with thousands separators to make them easier to read when large.

#### Before
<img width="517" alt="Screenshot 2024-04-03 at 05 30 03" src="https://github.com/rerun-io/rerun/assets/1148717/271a7f58-6d0a-4251-8d9b-4766b66404c9">

#### After
<img width="498" alt="Screenshot 2024-04-03 at 05 30 43" src="https://github.com/rerun-io/rerun/assets/1148717/f82904dc-9441-4227-a194-94db67dd0cda">

<img width="71" alt="Screenshot 2024-04-03 at 05 31 28" src="https://github.com/rerun-io/rerun/assets/1148717/4dd2b91f-4b0c-49e4-b8f6-1a7a00ed064f">

<img width="784" alt="Screenshot 2024-04-03 at 05 31 11" src="https://github.com/rerun-io/rerun/assets/1148717/8ad3cf8f-ba3b-4948-ae28-d50f665bc459">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5753)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5753?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5753?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5753)
- [Docs preview](https://rerun.io/preview/5b0f69e4f74dfb9cc855ba62d4f1241e8a103c57/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5b0f69e4f74dfb9cc855ba62d4f1241e8a103c57/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)