### PR TITLE
Make Welcome screen work without internet too

### DIFF
--- a/crates/re_viewer/src/ui/welcome_screen/example_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/example_section.rs
@@ -268,7 +268,7 @@ impl ExampleSection {
     pub(super) fn ui(
         &mut self,
         ui: &mut egui::Ui,
-        re_ui: &re_ui::ReUi,
+        _re_ui: &re_ui::ReUi,
         command_sender: &CommandSender,
         header_ui: &impl Fn(&mut Ui),
     ) {
@@ -277,14 +277,25 @@ impl ExampleSection {
             .get_or_insert_with(|| load_manifest(ui.ctx(), self.manifest_url.clone()));
 
         let Some(examples) = examples.ready_mut() else {
-            ui.spinner();
+            // Still waiting for example to load
+
+            header_ui(ui); // Always show the header
+
+            ui.separator();
+
+            ui.spinner(); // Placeholder for the examples
             return;
         };
 
         let examples = match examples {
             Ok(examples) => examples,
             Err(err) => {
-                ui.label(re_ui.error_text(format!("Failed to load examples: {err}")));
+                // Examples failed to load.
+
+                header_ui(ui); // Always show the header
+
+                re_log::warn_once!("Failed to load examples: {err}");
+
                 return;
             }
         };

--- a/crates/re_viewer/src/ui/welcome_screen/example_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/example_section.rs
@@ -550,6 +550,7 @@ fn example_source(ui: &mut Ui, example: &ExampleDesc) {
                 source_url.is_some(),
                 egui::Button::image_and_text(re_ui::icons::GITHUB.as_image(), "Source code"),
             )
+            .on_hover_cursor(egui::CursorIcon::PointingHand)
             .on_disabled_hover_text("Source code is not available for this example")
             .clicked()
         {

--- a/crates/re_viewer/src/ui/welcome_screen/mod.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/mod.rs
@@ -41,8 +41,6 @@ impl WelcomeScreen {
                     ..Default::default()
                 }
                 .show(ui, |ui| {
-                    //welcome_section_ui(ui);
-
                     self.example_page
                         .ui(ui, re_ui, command_sender, &welcome_section_ui);
                 });

--- a/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
@@ -51,6 +51,7 @@ pub(super) fn welcome_section_ui(ui: &mut egui::Ui) {
                     .color(egui::Color32::from_hex("#60A0FF").expect("this color is valid"))
                     .text_style(re_ui::ReUi::welcome_screen_body()),
             )
+            .on_hover_cursor(egui::CursorIcon::PointingHand)
             .clicked()
         {
             ui.ctx().open_url(egui::output::OpenUrl {

--- a/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
@@ -42,7 +42,7 @@ pub(super) fn welcome_section_ui(ui: &mut egui::Ui) {
 
         bullet_text(ui, "Log with the Rerun SDK in C++, Python, or Rust");
         bullet_text(ui, "Visualize and explore live or recorded data");
-        bullet_text(ui, "Customize in the UI or through code");
+        bullet_text(ui, "Customize using the UI or through code");
 
         ui.add_space(9.0);
         if ui

--- a/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
@@ -40,7 +40,7 @@ pub(super) fn welcome_section_ui(ui: &mut egui::Ui) {
             ui.add_space(4.0);
         };
 
-        bullet_text(ui, "Log with the Rerun SDK in Python, C++, or Rust");
+        bullet_text(ui, "Log with the Rerun SDK in C++, Python, or Rust");
         bullet_text(ui, "Visualize and explore live or recorded data");
         bullet_text(ui, "Customize in the UI or through code");
 

--- a/docs/content/getting-started/what-is-rerun.md
+++ b/docs/content/getting-started/what-is-rerun.md
@@ -13,7 +13,7 @@ Rerun is an SDK and engine for visualizing and interacting with multimodal data 
 Rerun is
 - Free to use
 - Simple to integrate and get started with
-- Usable from Python, Rust, and C++
+- Usable from C++, Python, and Rust
 - Powerful, flexible, and extensible
 - Built in Rust to be cross platform and fast
 - Open source, dual licensed under MIT and Apache 2


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5752

Make sure to show the welcome screen header even while downloading the manifest (slow internet) or failing to do so (no internet).

See commit messages for details.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5756)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5756?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5756?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5756)
- [Docs preview](https://rerun.io/preview/d22c288d25984b18cd438ccbbd7af1b2e6b80e91/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d22c288d25984b18cd438ccbbd7af1b2e6b80e91/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)