### PR TITLE
Use new blueprint id on each sent blueprint

### DIFF
--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -508,6 +508,8 @@ def create_in_memory_blueprint(*, application_id: str, blueprint: BlueprintLike)
     blueprint_stream = RecordingStream(
         bindings.new_blueprint(
             application_id=application_id,
+            # Generate a new id every time so we don't append to overwrite previous blueprints.
+            blueprint_id=str(uuid.uuid4()),
             make_default=False,
             make_thread_default=False,
             default_enabled=True,


### PR DESCRIPTION
### What

Previously, successive `send_blueprint` calls would append new blueprints to the existing ones. This fixes this by creating a new blueprint (uu)id every time.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5760)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5760?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5760?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5760)
- [Docs preview](https://rerun.io/preview/e8fc79c543c213f190273121d860f75b39d97925/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e8fc79c543c213f190273121d860f75b39d97925/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)