### PR TITLE
Add support for directly copying the HTML tag created by `upload_image.py`

### DIFF
--- a/scripts/upload_image.py
+++ b/scripts/upload_image.py
@@ -137,12 +137,13 @@ class Uploader:
                 f"Aspect ratio is {aspect_ratio:.2f} but should be between {ASPECT_RATIO_RANGE[0]} and "
                 f"{ASPECT_RATIO_RANGE[1]}."
             )
-            if (
-                input(
-                    "The image aspect ratio is outside the range recommended for example screenshots. Continue? [y/N] "
-                ).lower()
-                != "y"
-            ):
+            # do not pass prompt to input as this goes to stdout
+            print(
+                "The image aspect ratio is outside the range recommended for example screenshots. Continue? [y/N] ",
+                end="",
+                file=sys.stderr,
+            )
+            if input().lower() != "y":
                 sys.exit(1)
 
     def upload_file(self, path: Path) -> str:

--- a/scripts/upload_image.py
+++ b/scripts/upload_image.py
@@ -32,6 +32,12 @@ Use the script:
 or the just command:
 
     just upload --help
+
+All info/debug output occurs on stderr. If stdout is not a tty (e.g. piping to `pbcopy`), the resulting HTML tag is also
+printed to stdout. For example, this upload the image from the clipboard and copies the resulting HTML tag back to the
+clipboard:
+
+    just upload --name some_name | pbcopy
 """
 
 from __future__ import annotations
@@ -288,7 +294,7 @@ class Uploader:
             else:
                 html_str += f'  <img src="https://static.rerun.io/{object_name}" alt="">\n'
 
-            logging.info(f"uploaded width={width or 'full'} ({index+1}/{len(image_stack)})")
+            logging.info(f"uploaded width={width or 'full'} ({index + 1}/{len(image_stack)})")
 
         html_str += "</picture>"
         return html_str
@@ -355,7 +361,7 @@ def run(args: argparse.Namespace) -> None:
                 raise RuntimeError("Path is required when uploading a single image")
 
             object_name = uploader.upload_file(args.path)
-            print(f"\nhttps://static.rerun.io/{object_name}")
+            html_str = f"https://static.rerun.io/{object_name}"
         else:
             if args.path is None:
                 if args.name is None:
@@ -364,9 +370,16 @@ def run(args: argparse.Namespace) -> None:
                     html_str = uploader.upload_stack_from_clipboard(args.name)
             else:
                 html_str = uploader.upload_stack_from_file(args.path, args.name)
-            print("\n" + html_str)
+
     except RuntimeError as e:
         print(f"Error: {e.args[0]}", file=sys.stderr)
+        return
+
+    print(f"\n{html_str}", file=sys.stderr)
+
+    if not sys.stdout.isatty():
+        # we might be piping to pbcopy or similar, so we print string again to stdout
+        print(html_str)
 
 
 DESCRIPTION = """Upload an image to static.rerun.io.


### PR DESCRIPTION
### What

Currently, `upload_image.py` (aka `just upload`) print debug output and the resulting HTML tag to stderr. Now it will _also_ print the HTML tag to stdout if stdout is not a tty. This enable piping to `pbcopy` or whatever is the equivalent on Linux/Window:

So, either:

```
# copy some image to the clipboard
just upload --name my_name | pbcopy
# paste tag to wherever
```

or:

```
just upload some_file.png | pbcopy
# paste tag to wherever
```


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5763)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5763?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5763?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5763)
- [Docs preview](https://rerun.io/preview/4459ca2d3a08d4b68147aec77828ad4b887d6588/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4459ca2d3a08d4b68147aec77828ad4b887d6588/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)