### PR TITLE
Update the "Configure the viewer interactively" section

### DIFF
--- a/docs/content/getting-started/configure-the-viewer/interactively.md
+++ b/docs/content/getting-started/configure-the-viewer/interactively.md
@@ -7,79 +7,152 @@ The Rerun Viewer is configurable directly through the UI itself.
 
 ## Viewer overview
 
-TODO(#5636): Screenshot of the viewer, with the blueprint and selection panels highlighted.
+<picture>
+  <img src="https://static.rerun.io/overview/158a13691fe0364ed5d4dc420f5b2c39b60705cd/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/overview/158a13691fe0364ed5d4dc420f5b2c39b60705cd/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/overview/158a13691fe0364ed5d4dc420f5b2c39b60705cd/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/overview/158a13691fe0364ed5d4dc420f5b2c39b60705cd/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/overview/158a13691fe0364ed5d4dc420f5b2c39b60705cd/1200w.png">
+</picture>
 
-The left panel of the viewer is the "Blueprint Panel" this shows a visual tree view representing
+
+The central part is known as the viewport and contains the various views displaying the data.
+
+The left panel of the viewer is the "Blueprint Panel". It shows a visual tree view representing
 the contents of the current blueprint.
 
 The right panel of the viewer is the "Selection Panel" this panel allows you to configure
 specific blueprint properties of the currently selected element.
 
+The blueprint defines the structure, the type of views, and their content in the viewport. Changing the content of the viewport is done by editing the blueprint.
+
 After editing the viewer you may want to [save or share the blueprint](./save-and-load.md).
 
-## Configuring Layout and Contents
+## Configuring the view hierarchy
+
+The viewport is made of various views, laid out hierarchically with nested containers of various kinds: vertical, horizontal, grid, and tabs. This hierarchy is represented in the blueprint panel, with the top container corresponding to the viewport. In this section, we cover the various ways this view hierarchy can be interactively created and modified.
 
 ### Show or hide parts of the blueprint
 
-Click the "eye" icon next to the container, view, or entity in the blueprint panel.
-TODO(#5636): show_hide
+Any container or view can be hidden or shown by clicking the "eye" icon.
+
+<picture>
+  <img src="https://static.rerun.io/show_hide_btn/bbca385d4898ec220bfb91c430ea52d59553913e/full.png" alt="">
+</picture>
+
 
 ### Add new Containers or Views
 
-Clicking the "+" at the top of the blueprint panel.
-TODO(#5636): add_1
+Adding a container or a view to the view port can be done by clicking the "+" at the top of the blueprint panel.
 
-Selecting a Container and clicking the "+" in the selection panel.
-TODO(#5636): add_2
+<picture>
+  <img src="https://static.rerun.io/add_view/3933d7096846594304ddec2d51dda9c434d763bf/full.png" alt="">
+</picture>
+
+
+If a container (or the viewport) is already selected, a "+" button will also be available in the selection panel.
+
+<picture>
+  <img src="https://static.rerun.io/add_view_selection_panel/e3355e61a8ec8f2e7860968f91032f7f7bf6ab6e/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/add_view_selection_panel/e3355e61a8ec8f2e7860968f91032f7f7bf6ab6e/480w.png">
+</picture>
+
 
 ### Remove a View or Container
 
-Click the "-" button next to the container or view in the blueprint panel.
-TODO(#5636): remove
+Removing a view or a container can be done by clicking the "-" button next to it:
+
+<picture>
+  <img src="https://static.rerun.io/remove/6b9d97e4297738b8aad89158e4d15420be362b4a/full.png" alt="">
+</picture>
+
 
 ### Re-arrange existing Containers or Views
 
-Drag and drop the container or view in the blueprint panel.
-TODO(#5636): drag_1
+The viewport hierarchy can be reorganised by drag-and-dropping containers or views in the blueprint panel. It ssi also possible to drag views directly in the viewport by using their title tab:
 
-Drag and drop containers or views directly in the viewport
-TODO(#5636): drag_2
+<picture>
+  <img src="https://static.rerun.io/drag_and_drop_viewport/8521fda375a2f6af15628b04ead4ba848cb8bc27/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/drag_and_drop_viewport/8521fda375a2f6af15628b04ead4ba848cb8bc27/480w.png">
+</picture>
 
-### Change the size of Containers or Views
-
-Click and drag the edge of a view or container to resize it
-TODO(#5636): resize
 
 ### Rename a View or Container
 
-Select the Container or View and enter a name at the top of the selection panel
-TODO(#5636): rename
+Both views and containers may be assigned a custom name. This can be done by selecting the view or container, and editing the name at the top of the selection panel.
 
-### Change the type of a Container
+<picture>
+  <img src="https://static.rerun.io/rename/94be9e29a0120fbab1a7c07a8952f2cba4dcea68/full.png" alt="">
+</picture>
 
-Select the Container and choose a new type from the dropdown in the selection panel
-TODO(#5636): change_type
+### Change a Container kind
 
-### Add a new Data to a View
+Containers come in four different kinds: vertical, horizontal, grid, and tabs. To change an existing container's kind, select it and change the value from the dropdown menu in the selection panel:
 
-Select the view and click "edit" to bring up the entity editor
-TODO(#5636): add_data_1
+<picture>
+  <img src="https://static.rerun.io/container_kind/44fea90f2b3e5a699549c204948f677fc95e2157/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/container_kind/44fea90f2b3e5a699549c204948f677fc95e2157/480w.png">
+</picture>
 
-Select the view and directly edit the entity query
-See [Entity Queries](../../reference/entity-queries.md) for more information on how to write queries.
 
-TODO(#5636): add_data_2
+### Using context menus
+
+The context menu is accessed by right-clicking on a container or view in the blueprint panel. Many of the previous operations are also available there:
+
+<picture>
+  <img src="https://static.rerun.io/context_menu_container/e90e4688f306187d902467b452fb7146eec1bf4b/full.png" alt="">
+</picture>
+
+
+One key advantage of using the context menu is that it enable operations on multiple items at once. For example, you may select several views (ctrl-click, or cmd-click on Mac), and remove them all in a single operation using the context menu.
+
+
+## Configuring the content of a view
+
+The content of a view is determined by its entity query, which can be manually edited in the selection panel when the view is selected (see [Entity Queries](../../reference/entity-queries.md) for more information). This section covers the interactive means of manipulating the view content (which typically operate by actually modifying the query). 
+
+
+### Show or hide view content
+
+Like containers and views, any entity in a view may be shown and hidden with the "eye" icon or the context menu.
+
+<picture>
+  <img src="https://static.rerun.io/show_hide_entity/587a5d8fd763c0bade461bc54a66a4acdd087821/full.png" alt="">
+</picture>
+
 
 ### Remove Data from a View
 
-Click the "-" next to the entity in the blueprint panel
-TODO(#5636): remove_data_1
+Likewise, entities may be removed from a view by clicking the "-" next to it:
 
-### Change the origin of a View
+<picture>
+  <img src="https://static.rerun.io/remove_entity/ec0447ca7e420bc9d19a7bf015cc39f88b42598a/full.png" alt="">
+</picture>
 
-Select the view, then click the "Space Origin" field and type or select a new origin
-TODO(#5636): change_origin
 
-## Overriding Properties
+### Using the query editor
 
-TODO(jleibs): do we include this now or wait for generalized component overrides?
+A visual query editor is available from the selection panel when a view is selected. Click the "Edit" button next to the entity query:
+
+<picture>
+<img src="https://static.rerun.io/add_remove_entity/9b7b29b3be4816d5d42e66549d899039235b10ee/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/add_remove_entity/9b7b29b3be4816d5d42e66549d899039235b10ee/480w.png">
+</picture>
+
+The query editor allows visually adding and removing entities and entity trees from the query.
+
+### Adding entities to a new view with context menu
+
+Like with viewport hierarchy, most operations on view data are available from the context menu. In particular, a new view can be created with custom content by selecting one or more entities (either in existing views in the blueprint panel, or in the time panel's streams), and clicking "Add to new space view" in the context menu:
+
+<picture>
+  <img src="https://static.rerun.io/add_to_new_view/87f2d5ffb3ef896c82f398cd3c3d1c7321d59073/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/add_to_new_view/87f2d5ffb3ef896c82f398cd3c3d1c7321d59073/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/add_to_new_view/87f2d5ffb3ef896c82f398cd3c3d1c7321d59073/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/add_to_new_view/87f2d5ffb3ef896c82f398cd3c3d1c7321d59073/1024w.png">
+</picture>
+
+When using one of the recommended views with this method, the view's origin will automatically be set to a sensible default based on the actual data.
+
+
+

--- a/docs/content/getting-started/configure-the-viewer/interactively.md
+++ b/docs/content/getting-started/configure-the-viewer/interactively.md
@@ -69,7 +69,7 @@ Removing a view or a container can be done by clicking the "-" button next to it
 
 ### Re-arrange existing Containers or Views
 
-The viewport hierarchy can be reorganised by drag-and-dropping containers or views in the blueprint panel. It ssi also possible to drag views directly in the viewport by using their title tab:
+The viewport hierarchy can be reorganized by drag-and-dropping containers or views in the blueprint panel. It ssi also possible to drag views directly in the viewport by using their title tab:
 
 <picture>
   <img src="https://static.rerun.io/drag_and_drop_viewport/8521fda375a2f6af15628b04ead4ba848cb8bc27/full.png" alt="">
@@ -109,7 +109,7 @@ One key advantage of using the context menu is that it enable operations on mult
 
 ## Configuring the content of a view
 
-The content of a view is determined by its entity query, which can be manually edited in the selection panel when the view is selected (see [Entity Queries](../../reference/entity-queries.md) for more information). This section covers the interactive means of manipulating the view content (which typically operate by actually modifying the query). 
+The content of a view is determined by its entity query, which can be manually edited in the selection panel when the view is selected (see [Entity Queries](../../reference/entity-queries.md) for more information). This section covers the interactive means of manipulating the view content (which typically operate by actually modifying the query).
 
 
 ### Show or hide view content


### PR DESCRIPTION
### What

☝🏻 

This is a rather minimalist effort, justified by the fact that most of the content is often discovered by just looking at the UI (hopefully). In particular, screenshot favour maintainability rather than aesthetics or UX, and I avoided any that have high change of rotting in the short term (the add/remove entities comes to mind).

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5768)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5768?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5768?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5768)
- [Docs preview](https://rerun.io/preview/c7ca2c8771df892eb738dd78c90f7f52deee534c/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/c7ca2c8771df892eb738dd78c90f7f52deee534c/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)