### PR TITLE
Use space view icons in the "Add to new space view" menu

### DIFF
--- a/crates/re_space_view_bar_chart/src/space_view_class.rs
+++ b/crates/re_space_view_bar_chart/src/space_view_class.rs
@@ -19,7 +19,7 @@ impl SpaceViewClass for BarChartSpaceView {
     }
 
     fn display_name(&self) -> &'static str {
-        "Bar Chart"
+        "Bar chart"
     }
 
     fn icon(&self) -> &'static re_ui::Icon {

--- a/crates/re_space_view_text_document/src/space_view_class.rs
+++ b/crates/re_space_view_text_document/src/space_view_class.rs
@@ -52,7 +52,7 @@ impl SpaceViewClass for TextDocumentSpaceView {
     }
 
     fn display_name(&self) -> &'static str {
-        "Text Document"
+        "Text document"
     }
 
     fn icon(&self) -> &'static re_ui::Icon {

--- a/crates/re_space_view_text_log/src/space_view_class.rs
+++ b/crates/re_space_view_text_log/src/space_view_class.rs
@@ -45,7 +45,7 @@ impl SpaceViewClass for TextSpaceView {
     }
 
     fn display_name(&self) -> &'static str {
-        "Text Log"
+        "Text log"
     }
 
     fn icon(&self) -> &'static re_ui::Icon {

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -80,7 +80,7 @@ impl SpaceViewClass for TimeSeriesSpaceView {
     }
 
     fn display_name(&self) -> &'static str {
-        "Time Series"
+        "Time series"
     }
 
     fn icon(&self) -> &'static re_ui::Icon {

--- a/crates/re_viewport/src/context_menu/actions/add_entities_to_new_space_view.rs
+++ b/crates/re_viewport/src/context_menu/actions/add_entities_to_new_space_view.rs
@@ -35,26 +35,28 @@ impl ContextMenuAction for AddEntitiesToNewSpaceViewAction {
             .collect();
 
         ui.menu_button("Add to new space view", |ui| {
-            let buttons_for_space_view_classes =
-                |ui: &mut egui::Ui, space_view_classes: &IntSet<SpaceViewClassIdentifier>| {
-                    for (identifier, display_name) in space_view_classes
-                        .iter()
-                        .map(|identifier| {
-                            (
-                                identifier,
-                                space_view_class_registry
-                                    .get_class_or_log_error(identifier)
-                                    .display_name(),
-                            )
-                        })
-                        .sorted_by_key(|(_, display_name)| display_name.to_owned())
-                    {
-                        if ui.button(display_name).clicked() {
-                            create_space_view_for_selected_entities(ctx, *identifier);
-                            ui.close_menu();
-                        }
+            let buttons_for_space_view_classes = |ui: &mut egui::Ui,
+                                                  space_view_classes: &IntSet<
+                SpaceViewClassIdentifier,
+            >| {
+                for (identifier, class) in space_view_classes
+                    .iter()
+                    .map(|identifier| {
+                        (
+                            identifier,
+                            space_view_class_registry.get_class_or_log_error(identifier),
+                        )
+                    })
+                    .sorted_by_key(|(_, class)| class.display_name().to_owned())
+                {
+                    let btn =
+                        egui::Button::image_and_text(class.icon().as_image(), class.display_name());
+                    if ui.add(btn).clicked() {
+                        create_space_view_for_selected_entities(ctx, *identifier);
+                        ui.close_menu();
                     }
-                };
+                }
+            };
 
             ui.label(egui::WidgetText::from("Recommended:").italics());
             if recommended_space_view_classes.is_empty() {

--- a/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
@@ -73,7 +73,7 @@ impl SpaceViewClass for ColorCoordinatesSpaceView {
     }
 
     fn display_name(&self) -> &'static str {
-        "Color Coordinates"
+        "Color coordinates"
     }
 
     fn icon(&self) -> &'static re_ui::Icon {


### PR DESCRIPTION
### What
This is an opportunity to teach users what those icons mean!
<img width="371" alt="image" src="https://github.com/rerun-io/rerun/assets/1148717/de86729d-c8f5-40a1-858d-4a7c8d60b8da">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5773)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5773?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5773?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5773)
- [Docs preview](https://rerun.io/preview/7f455666bb0ddc77a2350094c9835b9e092b2634/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/7f455666bb0ddc77a2350094c9835b9e092b2634/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)