### PR TITLE
Use consistent `PascalCase` for space view class identifiers

### DIFF
--- a/crates/re_space_view_bar_chart/src/space_view_class.rs
+++ b/crates/re_space_view_bar_chart/src/space_view_class.rs
@@ -15,7 +15,7 @@ pub struct BarChartSpaceView;
 
 impl SpaceViewClass for BarChartSpaceView {
     fn identifier() -> SpaceViewClassIdentifier {
-        "Bar Chart".into()
+        "BarChart".into()
     }
 
     fn display_name(&self) -> &'static str {

--- a/crates/re_space_view_text_document/src/space_view_class.rs
+++ b/crates/re_space_view_text_document/src/space_view_class.rs
@@ -48,7 +48,7 @@ pub struct TextDocumentSpaceView;
 
 impl SpaceViewClass for TextDocumentSpaceView {
     fn identifier() -> SpaceViewClassIdentifier {
-        "Text Document".into()
+        "TextDocument".into()
     }
 
     fn display_name(&self) -> &'static str {

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -76,7 +76,7 @@ const DEFAULT_LEGEND_CORNER: egui_plot::Corner = egui_plot::Corner::RightBottom;
 
 impl SpaceViewClass for TimeSeriesSpaceView {
     fn identifier() -> SpaceViewClassIdentifier {
-        "Time Series".into()
+        "TimeSeries".into()
     }
 
     fn display_name(&self) -> &'static str {

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -59,8 +59,7 @@ impl VisualizableFilterContext for () {
 pub trait SpaceViewClass: Send + Sync {
     /// Identifier string of this space view class.
     ///
-    /// This is similar to [`Self::identifier`] but it can be used without an actual instance of the
-    /// class.
+    /// By convention we use `PascalCase`.
     fn identifier() -> SpaceViewClassIdentifier
     where
         Self: Sized;

--- a/crates/re_viewer_context/src/space_view/space_view_class_placeholder.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class_placeholder.rs
@@ -11,7 +11,7 @@ pub struct SpaceViewClassPlaceholder;
 
 impl SpaceViewClass for SpaceViewClassPlaceholder {
     fn identifier() -> SpaceViewClassIdentifier {
-        "Unknown space view class".into()
+        "UnknownSpaceViewClass".into()
     }
 
     fn display_name(&self) -> &'static str {

--- a/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
@@ -69,7 +69,7 @@ impl SpaceViewClass for ColorCoordinatesSpaceView {
     // State type as described above.
 
     fn identifier() -> SpaceViewClassIdentifier {
-        "Color Coordinates".into()
+        "ColorCoordinates".into()
     }
 
     fn display_name(&self) -> &'static str {

--- a/rerun_py/rerun_sdk/rerun/blueprint/space_views.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/space_views.py
@@ -29,7 +29,7 @@ class BarChartView(SpaceView):
             The name of the view.
 
         """
-        super().__init__(class_identifier="Bar Chart", origin=origin, contents=contents, name=name)
+        super().__init__(class_identifier="BarChart", origin=origin, contents=contents, name=name)
 
 
 class Spatial2DView(SpaceView):
@@ -141,7 +141,7 @@ class TextDocumentView(SpaceView):
             The name of the view.
 
         """
-        super().__init__(class_identifier="Text Document", origin=origin, contents=contents, name=name)
+        super().__init__(class_identifier="TextDocument", origin=origin, contents=contents, name=name)
 
 
 class TextLogView(SpaceView):
@@ -197,4 +197,4 @@ class TimeSeriesView(SpaceView):
             The name of the view.
 
         """
-        super().__init__(class_identifier="Time Series", origin=origin, contents=contents, name=name)
+        super().__init__(class_identifier="TimeSeries", origin=origin, contents=contents, name=name)


### PR DESCRIPTION
We used to mix different casing. Using `PascalCase` makes it clear it is an identifier (NOT a name)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}})
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
