### PR TITLE
Update h2 to 0.3.26 to address RUSTSEC-2024-0332

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,9 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
### What

addresses

```
    = ID: RUSTSEC-2024-0332
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0332
    = An attacker can send a flood of CONTINUATION frames, causing `h2` to process them indefinitely.
      This results in an increase in CPU usage.

      Tokio task budget helps prevent this from a complete denial-of-service, as the server can still
      respond to legitimate requests, albeit with increased latency.

      More details at "https://seanmonstar.com/blog/hyper-http2-continuation-flood/.
```

as flagged by cargo deny

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5775)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5775?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5775?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5775)
- [Docs preview](https://rerun.io/preview/d0991aacd4ca9b0e4459d677f90aea68ca39fa33/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/d0991aacd4ca9b0e4459d677f90aea68ca39fa33/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)