### PR TITLE
Wider side bars by default for blueprint & selection panel

### DIFF
--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -336,7 +336,9 @@ impl AppState {
                         ..Default::default()
                     })
                     .min_width(120.0)
-                    .default_width((0.35 * ui.ctx().screen_rect().width()).min(200.0).round());
+                    .default_width(default_blueprint_panel_width(
+                        ui.ctx().screen_rect().width(),
+                    ));
 
                 let show_welcome =
                     store_context.blueprint.app_id() == Some(&StoreHub::welcome_screen_app_id());
@@ -528,4 +530,12 @@ fn check_for_clicked_hyperlinks(
             }
         }
     }
+}
+
+pub fn default_blueprint_panel_width(screen_width: f32) -> f32 {
+    (0.35 * screen_width).min(280.0).round()
+}
+
+pub fn default_selection_panel_width(screen_width: f32) -> f32 {
+    (0.45 * screen_width).min(300.0).round()
 }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -26,8 +26,8 @@ use re_viewport::{
     SelectionUpdateBehavior, Viewport, ViewportBlueprint,
 };
 
-use crate::ui::override_ui::override_ui;
 use crate::ui::override_ui::override_visualizer_ui;
+use crate::{app_state::default_selection_panel_width, ui::override_ui::override_ui};
 
 use super::{selection_history_ui::SelectionHistoryUi, visible_history::visual_time_range_ui};
 
@@ -52,7 +52,7 @@ impl SelectionPanel {
 
         let panel = egui::SidePanel::right("selection_view")
             .min_width(120.0)
-            .default_width((0.45 * screen_width).min(250.0).round())
+            .default_width(default_selection_panel_width(screen_width))
             .max_width((0.65 * screen_width).round())
             .resizable(true)
             .frame(egui::Frame {


### PR DESCRIPTION
### What

We _still_ have to be disciplined about how much space we allow things to take up, but this helps a bit:

Before:
<img width="289" alt="Screenshot 2024-04-04 at 12 21 01" src="https://github.com/rerun-io/rerun/assets/1220815/14efda8e-a20a-4adc-b453-0319279940a7">
After:
<img width="340" alt="Screenshot 2024-04-04 at 12 27 01" src="https://github.com/rerun-io/rerun/assets/1220815/7018ee4c-b9d2-437b-b252-6486b3cd5fd3">

Before:
<img width="248" alt="Screenshot 2024-04-04 at 12 20 53" src="https://github.com/rerun-io/rerun/assets/1220815/8c9463c6-8fef-4fd8-adc0-86663cf3c512">
After:
<img width="314" alt="Screenshot 2024-04-04 at 12 27 52" src="https://github.com/rerun-io/rerun/assets/1220815/8b2bb9b9-e344-42d5-8d96-aebc74c0ffbe">

Before:
<img width="270" alt="Screenshot 2024-04-04 at 12 20 46" src="https://github.com/rerun-io/rerun/assets/1220815/451e05a6-1165-47c4-963a-0d2dece92224">
After:
<img width="333" alt="Screenshot 2024-04-04 at 12 27 15" src="https://github.com/rerun-io/rerun/assets/1220815/d042b9f9-5609-40de-b8fd-e97117ba3247">


### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}})
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
