### PR TITLE
Request attention when Rerun Viewer is sent new recording in background

### DIFF
--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -984,6 +984,13 @@ impl App {
                             self.command_sender.send_system(SystemCommand::SetSelection(
                                 re_viewer_context::Item::StoreId(store_id.clone()),
                             ));
+
+                            // If the viewer is in the background, tell the user that it has received something new.
+                            egui_ctx.send_viewport_cmd(
+                                egui::ViewportCommand::RequestUserAttention(
+                                    egui::UserAttentionType::Informational,
+                                ),
+                            );
                         }
                         StoreKind::Blueprint => {
                             // We wait with activating blueprints until they are fully loaded,
@@ -1021,6 +1028,13 @@ impl App {
                                         re_log::warn!("Failed to make blueprint active: {err}");
                                     });
                                 store_hub.set_active_app(app_id); // Switch to this app, e.g. on drag-and-drop of a blueprint file
+
+                                // If the viewer is in the background, tell the user that it has received something new.
+                                egui_ctx.send_viewport_cmd(
+                                    egui::ViewportCommand::RequestUserAttention(
+                                        egui::UserAttentionType::Informational,
+                                    ),
+                                );
                             }
                         } else {
                             re_log::warn!(


### PR DESCRIPTION
### What
If the Rerun Viewer does _not_ have focus and the user sends it a new recording or blueprint, the viewer will now gently request attention _once_. On macOS it looks like this (notice the Rerun icon in the bottom left):

https://github.com/rerun-io/rerun/assets/1148717/b7f8696c-c674-4db5-ad5d-08c1cc837de0

This does NOT happen if the Rerun Viewer window already has focus (is on top).

On native this uses:
* https://docs.rs/winit/latest/winit/window/enum.UserAttentionType.html

On web this does nothing.

### Testing
* [x] Linux
* [x] macOS
* [x] Windows

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5780)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5780?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5780?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5780)
- [Docs preview](https://rerun.io/preview/31cdad871a470b3dab022f8b774f91cc73745457/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/31cdad871a470b3dab022f8b774f91cc73745457/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)