### PR TITLE
Shorter selection ui for tensor/annotation-context/view coordinates/recording

### DIFF
--- a/crates/re_data_ui/src/annotation_context.rs
+++ b/crates/re_data_ui/src/annotation_context.rs
@@ -107,9 +107,13 @@ impl DataUi for AnnotationContext {
             UiVerbosity::Small | UiVerbosity::Reduced => {
                 if self.0.len() == 1 {
                     let descr = &self.0[0].class_description;
-                    ui.label(format!("AnnotationContext with one class containing {} keypoints and {} connections", descr.keypoint_annotations.len(), descr.keypoint_connections.len()));
+                    ui.label(format!(
+                        "One class containing {} keypoints and {} connections",
+                        descr.keypoint_annotations.len(),
+                        descr.keypoint_connections.len()
+                    ));
                 } else {
-                    ui.label(format!("AnnotationContext with {} classes", self.0.len()));
+                    ui.label(format!("{} classes", self.0.len()));
                 }
             }
             UiVerbosity::LimitHeight | UiVerbosity::Full => {

--- a/crates/re_data_ui/src/data.rs
+++ b/crates/re_data_ui/src/data.rs
@@ -62,7 +62,8 @@ impl DataUi for ViewCoordinates {
     ) {
         match verbosity {
             UiVerbosity::Small => {
-                ui.label(format!("ViewCoordinates: {}", self.describe()));
+                ui.label(self.describe_short())
+                    .on_hover_text(self.describe());
             }
             UiVerbosity::Full | UiVerbosity::LimitHeight | UiVerbosity::Reduced => {
                 ui.label(self.describe());

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -65,7 +65,7 @@ impl crate::DataUi for EntityDb {
                 ui.label(store_kind.to_string());
                 ui.end_row();
 
-                re_ui.grid_left_hand_label(ui, "Recording started");
+                re_ui.grid_left_hand_label(ui, "Created");
                 ui.label(started.format(ctx.app_options.time_zone));
                 ui.end_row();
             }
@@ -73,7 +73,7 @@ impl crate::DataUi for EntityDb {
             if let Some(latest_row_id) = self.latest_row_id() {
                 if let Ok(nanos_since_epoch) = i64::try_from(latest_row_id.nanoseconds_since_epoch()) {
                     let time = re_log_types::Time::from_ns_since_epoch(nanos_since_epoch);
-                    re_ui.grid_left_hand_label(ui, "Last modified at");
+                    re_ui.grid_left_hand_label(ui, "Modified");
                     ui.label(time.format(ctx.app_options.time_zone));
                     ui.end_row();
                 }

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -17,7 +17,13 @@ use crate::image_meaning_for_entity;
 use super::EntityDataUi;
 
 pub fn format_tensor_shape_single_line(shape: &[TensorDimension]) -> String {
-    format!("[{}]", shape.iter().join(", "))
+    const MAX_SHOWN: usize = 4; // should be enough for width/height/depth and then some!
+    let shapes = shape.iter().take(MAX_SHOWN).join(", ");
+    if shape.len() > MAX_SHOWN {
+        format!("{shapes}…")
+    } else {
+        shapes
+    }
 }
 
 impl EntityDataUi for re_types::components::TensorData {
@@ -149,16 +155,11 @@ pub fn tensor_ui(
                     ],
                     None => tensor.shape.clone(),
                 };
-                ui.label(format!(
-                    "{} x {}{}",
-                    tensor.dtype(),
-                    format_tensor_shape_single_line(shape.as_slice()),
-                    if original_tensor.buffer.is_compressed_image() {
-                        " (compressed)"
-                    } else {
-                        ""
-                    }
-                ))
+                ui.vertical(|ui| {
+                    // Put in a vertical layout to allow wrap around.
+                    ui.label(format_tensor_shape_single_line(shape.as_slice()))
+                })
+                .inner
                 .on_hover_ui(|ui| {
                     tensor_summary_ui(
                         ctx.re_ui,

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -155,22 +155,18 @@ pub fn tensor_ui(
                     ],
                     None => tensor.shape.clone(),
                 };
-                ui.vertical(|ui| {
-                    // Put in a vertical layout to allow wrap around.
-                    ui.label(format_tensor_shape_single_line(shape.as_slice()))
-                })
-                .inner
-                .on_hover_ui(|ui| {
-                    tensor_summary_ui(
-                        ctx.re_ui,
-                        ui,
-                        original_tensor,
-                        tensor,
-                        meaning,
-                        meter,
-                        &tensor_stats,
-                    );
-                });
+                ui.add(egui::Label::new(format_tensor_shape_single_line(&shape)).wrap(true))
+                    .on_hover_ui(|ui| {
+                        tensor_summary_ui(
+                            ctx.re_ui,
+                            ui,
+                            original_tensor,
+                            tensor,
+                            meaning,
+                            meter,
+                            &tensor_stats,
+                        );
+                    });
             });
         }
 


### PR DESCRIPTION
### What

A few before/after screenshots, covers most but not all changes in this pr:

Before:
<img width="330" alt="Screenshot 2024-04-04 at 14 36 31" src="https://github.com/rerun-io/rerun/assets/1220815/113b2779-4f1a-4ca4-b7b6-2dbee260b799">

After:
<img width="321" alt="Screenshot 2024-04-04 at 14 40 19" src="https://github.com/rerun-io/rerun/assets/1220815/ef0b1b23-4775-42d1-8047-0dc18c79c594">



Before:
<img width="346" alt="Screenshot 2024-04-04 at 12 37 22" src="https://github.com/rerun-io/rerun/assets/1220815/914d9e79-f069-48c3-9445-a509bac21e28">

After:
<img width="323" alt="Screenshot 2024-04-04 at 12 50 50" src="https://github.com/rerun-io/rerun/assets/1220815/c66bd8e8-6e0f-4253-abf6-aa5a69b7363c">

After:
<img width="329" alt="Screenshot 2024-04-04 at 12 37 15" src="https://github.com/rerun-io/rerun/assets/1220815/038391e8-d493-4dba-90fb-dc9b48aaff95">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5782)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5782?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5782?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5782)
- [Docs preview](https://rerun.io/preview/0b5e0c93df89317e867a5fd169d6944c944bb91d/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/0b5e0c93df89317e867a5fd169d6944c944bb91d/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)