### PR TITLE
Fix default time range for time series space view

### DIFF
--- a/crates/re_space_view/src/lib.rs
+++ b/crates/re_space_view/src/lib.rs
@@ -22,7 +22,7 @@ pub use sub_archetypes::{
     query_space_view_sub_archetype_or_default,
 };
 pub use visual_time_range::{
-    default_time_range, query_visual_history, time_range_boundary_to_visible_history_boundary,
+    query_visual_history, time_range_boundary_to_visible_history_boundary,
     visible_history_boundary_to_time_range_boundary, visible_time_range_to_time_range,
 };
 pub use visualizable::determine_visualizable_entities;

--- a/crates/re_space_view/src/visual_time_range.rs
+++ b/crates/re_space_view/src/visual_time_range.rs
@@ -13,7 +13,7 @@ use re_types::blueprint::{
     components::VisibleTimeRange,
     datatypes::{VisibleTimeRangeBoundary, VisibleTimeRangeBoundaryKind},
 };
-use re_viewer_context::{SpaceViewClassIdentifier, ViewerContext};
+use re_viewer_context::ViewerContext;
 
 pub fn time_range_boundary_to_visible_history_boundary(
     boundary: &VisibleTimeRangeBoundary,
@@ -101,14 +101,5 @@ pub fn query_visual_history(
             nanos: VisibleHistory::default(),
             sequences: VisibleHistory::default(),
         }
-    }
-}
-
-// TODO(#4194): this should come from delegation to the space-view-class
-pub fn default_time_range(class_identifier: SpaceViewClassIdentifier) -> VisibleTimeRange {
-    if class_identifier == "Time Series" {
-        VisibleTimeRange::EVERYTHING.clone()
-    } else {
-        VisibleTimeRange::EMPTY.clone()
     }
 }

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -6,8 +6,10 @@ use re_data_store::TimeType;
 use re_format::next_grid_tick_magnitude_ns;
 use re_log_types::{EntityPath, TimeZone};
 use re_space_view::{controls, query_space_view_sub_archetype_or_default};
-use re_types::blueprint::components::Corner2D;
-use re_types::components::Range1D;
+use re_types::{
+    blueprint::components::{Corner2D, VisibleTimeRange},
+    components::Range1D,
+};
 use re_viewer_context::external::re_entity_db::{
     EditableAutoValue, EntityProperties, TimeSeriesAggregator,
 };
@@ -74,6 +76,10 @@ pub struct TimeSeriesSpaceView;
 
 const DEFAULT_LEGEND_CORNER: egui_plot::Corner = egui_plot::Corner::RightBottom;
 
+impl TimeSeriesSpaceView {
+    pub const DEFAULT_TIME_RANGE: VisibleTimeRange = VisibleTimeRange::EVERYTHING;
+}
+
 impl SpaceViewClass for TimeSeriesSpaceView {
     fn identifier() -> SpaceViewClassIdentifier {
         "TimeSeries".into()
@@ -135,6 +141,10 @@ impl SpaceViewClass for TimeSeriesSpaceView {
 
     fn layout_priority(&self) -> re_viewer_context::SpaceViewClassLayoutPriority {
         re_viewer_context::SpaceViewClassLayoutPriority::Low
+    }
+
+    fn default_visible_time_range(&self) -> VisibleTimeRange {
+        Self::DEFAULT_TIME_RANGE.clone()
     }
 
     fn selection_ui(

--- a/crates/re_space_view_time_series/src/util.rs
+++ b/crates/re_space_view_time_series/src/util.rs
@@ -1,9 +1,7 @@
 use re_log_types::{EntityPath, TimeInt, TimeRange};
-use re_space_view::{default_time_range, visible_time_range_to_time_range};
+use re_space_view::visible_time_range_to_time_range;
 use re_types::datatypes::Utf8;
-use re_viewer_context::{
-    external::re_entity_db::TimeSeriesAggregator, SpaceViewClass, ViewQuery, ViewerContext,
-};
+use re_viewer_context::{external::re_entity_db::TimeSeriesAggregator, ViewQuery, ViewerContext};
 
 use crate::{
     aggregation::{AverageAggregator, MinMaxAggregator},
@@ -39,7 +37,7 @@ pub fn determine_time_range(
 ) -> TimeRange {
     let visible_time_range_override = data_result
         .lookup_override::<re_types::blueprint::components::VisibleTimeRange>(ctx)
-        .unwrap_or(default_time_range(TimeSeriesSpaceView::identifier()));
+        .unwrap_or(TimeSeriesSpaceView::DEFAULT_TIME_RANGE);
 
     let mut time_range = visible_time_range_to_time_range(
         &visible_time_range_override,

--- a/crates/re_viewer/src/ui/visible_history.rs
+++ b/crates/re_viewer/src/ui/visible_history.rs
@@ -6,7 +6,7 @@ use egui::{NumExt as _, Response, Ui};
 use re_entity_db::{TimeHistogram, VisibleHistory, VisibleHistoryBoundary};
 use re_log_types::{TimeType, TimeZone};
 use re_space_view::{
-    default_time_range, time_range_boundary_to_visible_history_boundary,
+    time_range_boundary_to_visible_history_boundary,
     visible_history_boundary_to_time_range_boundary, visible_time_range_to_time_range,
 };
 use re_space_view_spatial::{SpatialSpaceView2D, SpatialSpaceView3D};
@@ -55,9 +55,13 @@ pub fn visual_time_range_ui(
 
     let mut interacting_with_controls = false;
 
+    let space_view_class = ctx
+        .space_view_class_registry
+        .get_class_or_log_error(&space_view_class);
+
     let mut resolved_range = data_result
         .lookup_override::<VisibleTimeRange>(ctx)
-        .unwrap_or(default_time_range(space_view_class));
+        .unwrap_or(space_view_class.default_visible_time_range());
     let mut has_individual_range = if let Some(data_result_tree) = data_result_tree {
         // If there is a data-tree, we know we have individual settings if we are our own source.
         data_result

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -1,7 +1,7 @@
 use nohash_hasher::IntSet;
 use re_entity_db::{EntityProperties, EntityPropertyMap};
 use re_log_types::EntityPath;
-use re_types::ComponentName;
+use re_types::{blueprint::components::VisibleTimeRange, ComponentName};
 
 use crate::{
     IndicatedEntities, PerSystemEntities, PerVisualizer, SmallVisualizerSet,
@@ -104,6 +104,12 @@ pub trait SpaceViewClass: Send + Sync {
 
     /// Controls how likely this space view will get a large tile in the ui.
     fn layout_priority(&self) -> SpaceViewClassLayoutPriority;
+
+    /// Determines the default time range for this space view class.
+    // TODO(#4194): This should be generalized to allow arbitrary property defaults.
+    fn default_visible_time_range(&self) -> VisibleTimeRange {
+        VisibleTimeRange::EMPTY.clone()
+    }
 
     /// Determines a suitable origin given the provided set of entities.
     ///


### PR DESCRIPTION
### What

Recent innocuous changes of space view identifiers caused an old hack to trip up. Removed the hack!

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5786)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5786?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5786?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5786)
- [Docs preview](https://rerun.io/preview/f25335cff69d5b42299c061601da1b86e8e642b0/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/f25335cff69d5b42299c061601da1b86e8e642b0/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)