### PR TITLE
Add `urdf_loader` external example

### DIFF
--- a/examples/manifest.toml
+++ b/examples/manifest.toml
@@ -35,6 +35,7 @@ examples = [
   "ros_node",
   "nuscenes",
   "kiss-icp",
+  "urdf_loader",
   "live_depth_sensor",
   "lidar",
   "rrt-star",
@@ -99,6 +100,7 @@ Integration with 3rd party tools, formats, libraries, and APIs.
 examples = [
   # display order, most interesting first
   "ros_node",
+  "urdf_loader",
   "vrs",
   "eigen_opencv",
   "dicom_mri",

--- a/examples/python/urdf_loader/README.md
+++ b/examples/python/urdf_loader/README.md
@@ -1,0 +1,46 @@
+<!--[metadata]
+title = "URDF Loader"
+source = "https://github.com/rerun-io/rerun-loader-python-example-urdf"
+tags = ["3D", "mesh", "loader"]
+thumbnail = "https://static.rerun.io/urdf_loader/9c04fbb376cd4f7498628a98593035c6da0f17fb/480w.png"
+thumbnail_dimensions = [480, 480]
+-->
+
+<picture>
+  <img src="https://static.rerun.io/urdf_loader/fe6730519ceb0f73040fce8aa7cc89e773bafe5c/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/urdf_loader/fe6730519ceb0f73040fce8aa7cc89e773bafe5c/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/urdf_loader/fe6730519ceb0f73040fce8aa7cc89e773bafe5c/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/urdf_loader/fe6730519ceb0f73040fce8aa7cc89e773bafe5c/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/urdf_loader/fe6730519ceb0f73040fce8aa7cc89e773bafe5c/1200w.png">
+</picture>
+
+
+## Overview
+
+This is an example data-loader plugin that lets you view URDF files. It uses the [external data loader mechanism](https://www.rerun.io/docs/howto/open-any-file#external-dataloaders) to add this capability to the Rerun viewer without modifying the viewer itself.
+
+This example is written in Python, and uses [urdf_parser_py](https://github.com/ros/urdf_parser_py/tree/ros2) to read the files. ROS package-relative paths support both ROS 1 and ROS 2-based resolving.
+
+## Installing the plug-in
+
+The [repository](https://github.com/rerun-io/rerun-loader-python-example-urdf) has detailed installation instruction. In a nutshell, the easiest is to use `pipx`:
+
+```
+pipx install git+https://github.com/rerun-io/rerun-loader-python-example-urdf.git
+pipx ensurepath
+```
+
+
+## Try it out
+
+To try the plug-in, first download the provided example URDF:
+
+```bash
+curl -OL https://github.com/rerun-io/rerun-loader-python-example-urdf/raw/main/example.urdf
+```
+
+Then you can open the viewer and open the file using drag-and-drop or the open dialog, or you can open it directly from the terminal:
+
+```bash
+rerun example.urdf
+```


### PR DESCRIPTION
### What

- Part of #5666

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}})
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
