### PR TITLE
Improve browser back-button navigation

### DIFF
--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -371,6 +371,11 @@ impl App {
                 });
             }
 
+            SystemCommand::ClearSourceAndItsStores(source) => {
+                self.rx.retain(|r| r.source() != &source);
+                store_hub.retain(|db| db.data_source.as_ref() != Some(&source));
+            }
+
             SystemCommand::AddReceiver(rx) => {
                 re_log::debug!("Received AddReceiver");
                 self.add_receiver(rx);

--- a/crates/re_viewer/src/ui/welcome_screen/example_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/example_section.rs
@@ -487,10 +487,21 @@ fn open_example_url(
 
         // So we know where to return to
         let welcome_screen_app_id = re_viewer_context::StoreHub::welcome_screen_app_id();
-        web_tools::push_history(&format!(
+        let welcome_screen_url = format!(
             "?app_id={}",
             web_tools::percent_encode(&welcome_screen_app_id.to_string())
-        ));
+        );
+
+        if web_tools::current_url_suffix()
+            .unwrap_or_default()
+            .is_empty()
+        {
+            // Replace, otherwise the user would need to hit back twice to return to
+            // whatever linked them to `https://www.rerun.io/viewer` in the first place.
+            web_tools::replace_history(&welcome_screen_url);
+        } else {
+            web_tools::push_history(&welcome_screen_url);
+        }
 
         // Where we're going:
         web_tools::push_history(&format!("?url={}", web_tools::percent_encode(rrd_url)));

--- a/crates/re_viewer/src/ui/welcome_screen/example_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/example_section.rs
@@ -446,7 +446,11 @@ fn open_example_url(command_sender: &CommandSender, rrd_url: &str) {
         use crate::web_tools;
 
         // So we know where to return to
-        web_tools::push_history("?examples");
+        let welcome_screen_app_id = re_viewer_context::StoreHub::welcome_screen_app_id();
+        web_tools::push_history(&format!(
+            "?app_id={}",
+            web_tools::percent_encode(&welcome_screen_app_id.to_string())
+        ));
 
         // Where we're going:
         web_tools::push_history(&format!("?url={}", web_tools::percent_encode(rrd_url)));

--- a/crates/re_viewer/src/web_tools.rs
+++ b/crates/re_viewer/src/web_tools.rs
@@ -79,10 +79,11 @@ pub fn translate_query_into_commands(egui_ctx: &egui::Context, command_sender: &
 
     let location = eframe::web::web_location();
 
-    // NOTE: it's unclear what to do if we find bout `examples` and `url` in the query.
-
-    if location.query_map.get("examples").is_some() {
-        command_sender.send_system(SystemCommand::CloseAllRecordings);
+    if let Some(app_ids) = location.query_map.get("app_id") {
+        if let Some(app_id) = app_ids.last() {
+            let app_id = re_log_types::ApplicationId::from(app_id.as_str());
+            command_sender.send_system(SystemCommand::ActivateApp(app_id));
+        }
     }
 
     // NOTE: we support passing in multiple urls to multiple different recorording, blueprints, etc
@@ -93,9 +94,6 @@ pub fn translate_query_into_commands(egui_ctx: &egui::Context, command_sender: &
         .flatten()
         .collect();
     if !urls.is_empty() {
-        // Clear out any already open recordings to make room for the new ones.
-        command_sender.send_system(SystemCommand::CloseAllRecordings);
-
         for url in urls {
             if let Some(receiver) = url_to_receiver(egui_ctx.clone(), url).ok_or_log_error() {
                 command_sender.send_system(SystemCommand::AddReceiver(receiver));

--- a/crates/re_viewer/src/web_tools.rs
+++ b/crates/re_viewer/src/web_tools.rs
@@ -96,6 +96,12 @@ pub fn translate_query_into_commands(egui_ctx: &egui::Context, command_sender: &
     if !urls.is_empty() {
         for url in urls {
             if let Some(receiver) = url_to_receiver(egui_ctx.clone(), url).ok_or_log_error() {
+                // We may be here because the user clicked Back/Forward in the browser while trying
+                // out examples. If we re-download the same file we should clear out the old data first.
+                command_sender.send_system(SystemCommand::ClearSourceAndItsStores(
+                    receiver.source().clone(),
+                ));
+
                 command_sender.send_system(SystemCommand::AddReceiver(receiver));
             }
         }

--- a/crates/re_viewer_context/src/command_sender.rs
+++ b/crates/re_viewer_context/src/command_sender.rs
@@ -16,6 +16,9 @@ pub enum SystemCommand {
     /// Load some data.
     LoadDataSource(DataSource),
 
+    /// Clear everything that came from this source, and close the source.
+    ClearSourceAndItsStores(re_smart_channel::SmartChannelSource),
+
     AddReceiver(re_smart_channel::Receiver<re_log_types::LogMsg>),
 
     /// Reset the `Viewer` to the default state

--- a/crates/re_viewer_context/src/store_hub.rs
+++ b/crates/re_viewer_context/src/store_hub.rs
@@ -176,6 +176,10 @@ impl StoreHub {
             .as_ref()
             .and_then(|id| self.store_bundle.get(id));
 
+        if recording.is_none() {
+            self.active_rec_id = None;
+        }
+
         Some(StoreContext {
             app_id,
             blueprint,

--- a/crates/re_viewer_context/src/store_hub.rs
+++ b/crates/re_viewer_context/src/store_hub.rs
@@ -232,6 +232,10 @@ impl StoreHub {
         }
     }
 
+    pub fn retain(&mut self, f: impl FnMut(&EntityDb) -> bool) {
+        self.store_bundle.retain(f);
+    }
+
     /// Remove all open recordings and applications, and go to the welcome page.
     pub fn clear_recordings(&mut self) {
         // Keep only the welcome screen:


### PR DESCRIPTION
### What
Loading an example and pressing back will keep the example loaded, but still get you back to the welcome screen.

Loading the example again will clear the old first before continuing.

You can open examples in a background tab by holding down a modifier or middle-clicking.

And fixed small annoyance that required an extra "Back" press to get back to the original source.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5791)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5791?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5791?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5791)
- [Docs preview](https://rerun.io/preview/e00ddd687df18e3455633ae8da9e51c3db78d18f/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e00ddd687df18e3455633ae8da9e51c3db78d18f/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)