### PR TITLE
Add buttons to reset the blueprint in the app selection panel

### DIFF
--- a/crates/re_data_ui/src/app_id.rs
+++ b/crates/re_data_ui/src/app_id.rs
@@ -2,7 +2,7 @@ use itertools::Itertools as _;
 
 use re_entity_db::EntityDb;
 use re_log_types::ApplicationId;
-use re_viewer_context::{UiVerbosity, ViewerContext};
+use re_viewer_context::{SystemCommandSender as _, UiVerbosity, ViewerContext};
 
 use crate::item_ui::entity_db_button_ui;
 
@@ -30,6 +30,8 @@ impl crate::DataUi for ApplicationId {
             return;
         }
 
+        // ---------------------------------------------------------------------
+
         // Find all recordings with this app id
         let recordings: Vec<&EntityDb> = ctx
             .store_context
@@ -51,5 +53,50 @@ impl crate::DataUi for ApplicationId {
                 }
             });
         }
+
+        // ---------------------------------------------------------------------
+
+        ui.add_space(8.0);
+
+        // ---------------------------------------------------------------------
+
+        // Blueprint section.
+        let active_blueprint = ctx.store_context.blueprint;
+        let default_blueprint = ctx.store_context.hub.default_blueprint_for_app(self);
+
+        let button = egui::Button::image_and_text(
+            re_ui::icons::RESET.as_image(),
+            "Reset to default blueprint",
+        );
+
+        let is_same_as_default = default_blueprint.map_or(false, |default_blueprint| {
+            default_blueprint.latest_row_id() == active_blueprint.latest_row_id()
+        });
+
+        if is_same_as_default {
+            ui.add_enabled(false, button)
+                .on_disabled_hover_text("No modifications has been made");
+        } else if default_blueprint.is_none() {
+            ui.add_enabled(false, button)
+                .on_disabled_hover_text("There's no default blueprint");
+        } else {
+            // The active blueprint is different from the default blueprint
+            if ui
+                .add(button)
+                .on_hover_text("Reset to the default blueprint for this app")
+                .clicked()
+            {
+                ctx.command_sender
+                    .send_system(re_viewer_context::SystemCommand::ClearActiveBlueprint);
+            }
+        }
+
+        if ui.add(egui::Button::image_and_text(
+                re_ui::icons::RESET.as_image(),
+                "Reset active and default blueprint",
+            )).on_hover_text("Reset both active and default blueprint, and auto-generate a new blueprint based on heuristics").clicked() {
+                ctx.command_sender
+                    .send_system(re_viewer_context::SystemCommand::ClearAndGenerateBlueprint);
+            }
     }
 }

--- a/crates/re_data_ui/src/app_id.rs
+++ b/crates/re_data_ui/src/app_id.rs
@@ -94,7 +94,7 @@ impl crate::DataUi for ApplicationId {
         if ui.add(egui::Button::image_and_text(
                 re_ui::icons::RESET.as_image(),
                 "Reset active and default blueprint",
-            )).on_hover_text("Reset both active and default blueprint, and auto-generate a new blueprint based on heuristics").clicked() {
+            )).on_hover_text("Clear both active and default blueprint, and auto-generate a new blueprint based on heuristics").clicked() {
                 ctx.command_sender
                     .send_system(re_viewer_context::SystemCommand::ClearAndGenerateBlueprint);
             }

--- a/crates/re_data_ui/src/app_id.rs
+++ b/crates/re_data_ui/src/app_id.rs
@@ -93,7 +93,7 @@ impl crate::DataUi for ApplicationId {
 
         if ui.add(egui::Button::image_and_text(
                 re_ui::icons::RESET.as_image(),
-                "Reset active and default blueprint",
+                "Reset to heuristic blueprint",
             )).on_hover_text("Clear both active and default blueprint, and auto-generate a new blueprint based on heuristics").clicked() {
                 ctx.command_sender
                     .send_system(re_viewer_context::SystemCommand::ClearAndGenerateBlueprint);

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -120,9 +120,8 @@ impl crate::DataUi for EntityDb {
                             ui.add_space(8.0);
                             ui.label("This is the default blueprint for the current application.");
 
-                            if let Some(active_blueprint) = hub
-                                .active_blueprint_id_for_app(active_app_id)
-                                .and_then(|id| hub.store_bundle().get(id))
+                            if let Some(active_blueprint) =
+                                hub.active_blueprint_for_app(active_app_id)
                             {
                                 if active_blueprint.cloned_from() == Some(self.store_id()) {
                                     // The active blueprint is a clone of the selected blueprint.

--- a/crates/re_ui/src/icons.rs
+++ b/crates/re_ui/src/icons.rs
@@ -9,10 +9,12 @@ pub struct Icon {
 }
 
 impl Icon {
+    #[inline]
     pub const fn new(id: &'static str, png_bytes: &'static [u8]) -> Self {
         Self { id, png_bytes }
     }
 
+    #[inline]
     pub fn as_image(&self) -> Image<'static> {
         Image::new(ImageSource::Bytes {
             uri: self.id.into(),
@@ -68,8 +70,8 @@ pub const CLOSE: Icon = Icon::new("close", include_bytes!("../data/icons/close.p
 
 /// Used for HTTP URLs that leads out of the app.
 ///
-/// Remember to also use `.on_hover_cursor(egui::CursorIcon::PointingHand)`
-/// and `.on_hover_text(url)`.
+/// Remember to also use `.on_hover_cursor(egui::CursorIcon::PointingHand)`,
+/// but don't add `.on_hover_text(url)`.
 pub const EXTERNAL_LINK: Icon = Icon::new(
     "external_link",
     include_bytes!("../data/icons/external_link.png"),

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -93,6 +93,11 @@ fn loading_receivers_ui(ctx: &ViewerContext<'_>, rx: &ReceiveSet<LogMsg>, ui: &m
 fn recording_list_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
     let mut entity_dbs_map: BTreeMap<ApplicationId, Vec<&EntityDb>> = BTreeMap::new();
 
+    // Always have a place for the welcome screen, even if there is no recordings or blueprints associated with it:
+    entity_dbs_map
+        .entry(StoreHub::welcome_screen_app_id())
+        .or_default();
+
     for entity_db in ctx.store_context.bundle.entity_dbs() {
         // We want to show all open applications, even if they have no recordings
         let Some(app_id) = entity_db.app_id().cloned() else {

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -289,8 +289,7 @@ fn website_link_ui(ui: &mut egui::Ui) {
     let url = "https://rerun.io/";
     let response = ui
         .add(egui::ImageButton::new(image))
-        .on_hover_cursor(egui::CursorIcon::PointingHand)
-        .on_hover_text(url);
+        .on_hover_cursor(egui::CursorIcon::PointingHand);
     if response.clicked() {
         ui.ctx().open_url(egui::output::OpenUrl {
             url: url.to_owned(),

--- a/crates/re_viewer/src/ui/welcome_screen/example_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/example_section.rs
@@ -581,9 +581,7 @@ impl ExampleDescLayout {
                 for tag in &self.desc.tags {
                     ui.add(
                         egui::Button::new(
-                            egui::RichText::new(tag)
-                                .text_style(re_ui::ReUi::welcome_screen_tag())
-                                .strong(),
+                            egui::RichText::new(tag).text_style(re_ui::ReUi::welcome_screen_tag()),
                         )
                         .sense(egui::Sense::hover())
                         .rounding(6.0)

--- a/crates/re_viewer_context/src/store_hub.rs
+++ b/crates/re_viewer_context/src/store_hub.rs
@@ -365,6 +365,11 @@ impl StoreHub {
         self.default_blueprint_by_app_id.get(app_id)
     }
 
+    pub fn default_blueprint_for_app(&self, app_id: &ApplicationId) -> Option<&EntityDb> {
+        self.default_blueprint_id_for_app(app_id)
+            .and_then(|id| self.store_bundle.get(id))
+    }
+
     /// Change which blueprint is the default for a given [`ApplicationId`]
     #[inline]
     pub fn set_default_blueprint_for_app(
@@ -395,6 +400,11 @@ impl StoreHub {
 
     pub fn active_blueprint_id_for_app(&self, app_id: &ApplicationId) -> Option<&StoreId> {
         self.active_blueprint_by_app_id.get(app_id)
+    }
+
+    pub fn active_blueprint_for_app(&self, app_id: &ApplicationId) -> Option<&EntityDb> {
+        self.active_blueprint_id_for_app(app_id)
+            .and_then(|id| self.store_bundle.get(id))
     }
 
     /// Make blueprint active for a given [`ApplicationId`]


### PR DESCRIPTION
### What
<img width="322" alt="Screenshot 2024-04-04 at 19 03 21" src="https://github.com/rerun-io/rerun/assets/1148717/344063dc-55fd-490e-b26c-2dc1c2d71206">

It's better having them than not having them.

* Closes https://github.com/rerun-io/rerun/issues/5781

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5795)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5795?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5795?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5795)
- [Docs preview](https://rerun.io/preview/4e18583a50594353b17859bd795da4b1bb3a9df2/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/4e18583a50594353b17859bd795da4b1bb3a9df2/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)