### PR TITLE
Fix syntax highlight in entity-queries.md

### DIFF
--- a/docs/content/reference/entity-queries.md
+++ b/docs/content/reference/entity-queries.md
@@ -74,7 +74,7 @@ rrb.Spatial3DView(
 ),
 ```
 
-## 'origin` substitution
+## `origin` substitution
 
 Query expressions also allow you to use the variable `$origin` to refer to the
 origin of the space-view that the query belongs to.


### PR DESCRIPTION
Annoying typo breaks rendering.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5801)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5801?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5801?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5801)
- [Docs preview](https://rerun.io/preview/e0fb2953291bded90f9aa294b92fdd0ad60986f5/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/e0fb2953291bded90f9aa294b92fdd0ad60986f5/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)