### PR TITLE
Spring cleaning of `How to` section of docs

### DIFF
--- a/docs/content/howto.md
+++ b/docs/content/howto.md
@@ -1,12 +1,16 @@
 ---
-title: How-To Guides
+title: How-to
 order: 1
 ---
 
 Guides for using Rerun in more advanced ways.
- - [Limit RAM use](howto/limit-ram.md)
- - [Using Rerun with ROS2](howto/ros2-nav-turtlebot.md)
- - [Embedding Rerun within a Notebook](howto/notebook.md)
- - [Extending Rerun](howto/extend)
-    - [By using custom data](howto/extend/custom-data.md)
-    - [By extending the Viewer in Rust](howto/extend/extend-ui.md)
+ - [Configure the viewer through code](howto/configure-viewer-through-code.md)
+ - [Limit memory usage](howto/limit-ram.md)
+ - [Share recordings across multiple processes](howto/shared-recordings.md)
+ - [Clear out already logged data](howto/short-lived-entities.md)
+ - [Use Rerun with ROS2](howto/ros2-nav-turtlebot.md)
+ - [Embed Rerun in notebooks](howto/notebook.md)
+ - [Integrate Rerun with native loggers](howto/using-native-loggers.md)
+ - [Extend Rerun](howto/extend)
+    - [By logging custom data](howto/extend/custom-data.md)
+    - [By implementing custom visualizations (Rust only)](howto/extend/extend-ui.md)

--- a/docs/content/howto/configure-viewer-through-code.md
+++ b/docs/content/howto/configure-viewer-through-code.md
@@ -1,6 +1,6 @@
 ---
 title: Configure the viewer through code
-order: 0
+order: 100
 ---
 
 As of Rerun 0.15, the state of the [blueprint](../reference/viewer/blueprint.md) can be directly manipulated using the

--- a/docs/content/howto/extend.md
+++ b/docs/content/howto/extend.md
@@ -1,6 +1,6 @@
 ---
 title: Extend Rerun
-order: 8
+order: 1000
 ---
 
 There are currently two major ways of extending Rerun. You can use Rerun with [your own custom data](extend/custom-data.md), or [extend the Rerun Viewer](extend/extend-ui.md) (currently Rust only).

--- a/docs/content/howto/extend/custom-data.md
+++ b/docs/content/howto/extend/custom-data.md
@@ -1,6 +1,6 @@
 ---
-title: Use custom data
-order: 2
+title: By logging custom data
+order: 100
 description: How to use Rerun with custom data
 ---
 Rerun comes with many pre-built [Types](../../reference/types.md) that you can use out of the box. As long as your own data can be decomposed into Rerun [components](../../reference/types/components.md) or can be serialized with [Apache Arrow](https://arrow.apache.org/), you can log it directly without needing to recompile Rerun.

--- a/docs/content/howto/extend/extend-ui.md
+++ b/docs/content/howto/extend/extend-ui.md
@@ -1,5 +1,5 @@
 ---
-title: Extend the Viewer in Rust
+title: By implementing custom visualizations (Rust only)
 order: 2
 description: How to extend the Rerun Viewer UI using Rust and egui
 ---

--- a/docs/content/howto/limit-ram.md
+++ b/docs/content/howto/limit-ram.md
@@ -1,7 +1,7 @@
 ---
-title: How To Limit Memory Use
-order: 1
-description: How to limit the memory of Rerun so that it doesn't run out of RAM.
+title: Limit memory usage
+order: 200
+description: How to limit the memory used by the Rerun viewer so that it doesn't run out of RAM.
 ---
 
 ### --memory-limit

--- a/docs/content/howto/notebook.md
+++ b/docs/content/howto/notebook.md
@@ -1,6 +1,6 @@
 ---
-title: Using Rerun with Notebooks
-order: 3
+title: Embed Rerun in notebooks
+order: 600
 description: How to embed Rerun in notebooks like Jupyter or Colab
 ---
 

--- a/docs/content/howto/ros2-nav-turtlebot.md
+++ b/docs/content/howto/ros2-nav-turtlebot.md
@@ -1,6 +1,6 @@
 ---
-title: Using Rerun with ROS 2
-order: 4
+title: Use Rerun with ROS 2
+order: 500
 ogImageUrl: /docs-media/og-howto-ros.jpg
 description: Rerun does not yet have native ROS support, but many of the concepts in ROS and Rerun line up fairly well. In this guide, you will learn how to write a simple ROS 2 python node that subscribes to some common ROS topics and logs them to Rerun.
 ---

--- a/docs/content/howto/shared-recordings.md
+++ b/docs/content/howto/shared-recordings.md
@@ -1,6 +1,6 @@
 ---
-title: Share a recording across multiple processes
-order: 2
+title: Share recordings across multiple processes
+order: 300
 ---
 
 A common need is to log data from multiple processes and then visualize all of that data as part of a single shared recording.

--- a/docs/content/howto/short-lived-entities.md
+++ b/docs/content/howto/short-lived-entities.md
@@ -1,6 +1,6 @@
 ---
-title: Log short lived data
-order: 5
+title: Clear out already logged data
+order: 400
 description: How to log data that isn't valid for the whole recording
 ---
 In order to create coherent views of streaming data, the Rerun Viewer shows the latest values for each visible entity at the current timepoint. But some data may not be valid for the entire recording even if there are no updated values. How do you tell Rerun that something you've logged should no longer be shown?

--- a/docs/content/howto/using-native-loggers.md
+++ b/docs/content/howto/using-native-loggers.md
@@ -1,6 +1,6 @@
 ---
-title: Using native loggers
-order: 5
+title: Integrate Rerun with native loggers
+order: 700
 description: How to use the Rerun SDK as a native logger for the host language
 ---
 

--- a/docs/content/reference/data-loaders/overview.md
+++ b/docs/content/reference/data-loaders/overview.md
@@ -66,13 +66,13 @@ When the viewer and/or SDK executes an external loader, it will pass to it a set
 
     The data is expected to be logged timelessly.
 
-* `--time <timeline1>=<time1> <timeline2>=<time2> ...` (optional)
+* `--time <timeline1>=<time1> <timeline2>=<time2> …` (optional)
 
     The data is expected to be logged at these specific temporal timestamps.
 
     The timestamps are expected to be in nanoseconds: use `rr.set_time_nanos` (Python) / `RecordingStream::set_time_nanos` (C++, Rust) appropriately.
 
-* `--sequence <timeline1>=<seq1> <timeline2>=<seq2> ...` (optional)
+* `--sequence <timeline1>=<seq1> <timeline2>=<seq2> …` (optional)
 
     The data is expected to be logged at these specific sequence timestamps.
 


### PR DESCRIPTION
- Update index page
- Order guides by decreasing order of importance as much as possible
- Rename everything so that it always reads as "How to... do X"
- Give space for future ordering changes

Note: I haven't touch the dataloader how-to because it's going to move to Reference in an upcoming PR.

![image](https://github.com/rerun-io/rerun/assets/2910679/3b0bc8b4-0662-42ae-8fe3-7fb9fe85c091)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5803)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5803?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5803?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5803)
- [Docs preview](https://rerun.io/preview/ca4e6aced81f04420a08dab2a67cef6bb9d9fac4/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/ca4e6aced81f04420a08dab2a67cef6bb9d9fac4/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)