### PR TITLE
Improve documentation previews

### DIFF
--- a/.github/actions/deploy-vercel/action.yml
+++ b/.github/actions/deploy-vercel/action.yml
@@ -1,6 +1,10 @@
-# This action handles updating the target commit env variable (`RELEASE_COMMIT`)
-# which is used as the pointer for `rerun.io/docs` and `rerun.io/examples`
-# and triggering a redeploy of `rerun.io`.
+# If `target` is set to `production`, this action handles updating the
+# target commit env variable (`RELEASE_COMMIT`) which is used as the
+# pointer for `rerun.io/docs` and `rerun.io/examples` and triggering
+# a redeploy of `rerun.io`.
+
+# If `target` is set to `preview`, then this instead deploys a fresh preview
+# with an override for `release_commit`, and sets the `vercel_preview_url` output.
 
 name: "Deploy rerun.io"
 
@@ -24,6 +28,10 @@ inputs:
     required: true
   release_version:
     description: "Which release version to update the deployment to"
+    type: string
+    required: false
+  target:
+    description: "Which Vercel environment to deploy to"
     type: string
     required: true
 

--- a/.github/actions/deploy-vercel/index.mjs
+++ b/.github/actions/deploy-vercel/index.mjs
@@ -1,63 +1,32 @@
 // @ts-check
 
 import { Client } from "./vercel.mjs";
-import { assert, getRequiredInput, info } from "./util.mjs";
+import { assert, getInput, getRequiredInput } from "./util.mjs";
+import { deployToProduction } from "./production.mjs";
+import { deployToPreview } from "./preview.mjs";
 
 // These inputs are defined in `action.yml`, and should be kept in sync
 const token = getRequiredInput("vercel_token");
-const teamName = getRequiredInput("vercel_team_name");
-const projectName = getRequiredInput("vercel_project_name");
-const releaseCommit = getRequiredInput("release_commit");
-const releaseVersion = getRequiredInput("release_version");
+const team = getRequiredInput("vercel_team_name");
+const project = getRequiredInput("vercel_project_name");
+const commit = getRequiredInput("release_commit");
+const target = getRequiredInput("target");
 
 const client = new Client(token);
 
-info`Fetching team "${teamName}"`;
-const availableTeams = await client.teams();
-assert(availableTeams, `failed to get team "${teamName}"`);
-const team = availableTeams.find((team) => team.name === teamName);
-assert(team, `failed to get team "${teamName}"`);
+switch (target) {
+  case "production": {
+    const version = getRequiredInput("release_version");
+    await deployToProduction(client, { team, project, commit, version });
+    break;
+  }
 
-info`Fetching project "${projectName}"`;
-const projectsInTeam = await client.projects(team.id);
-const project = projectsInTeam.find((project) => project.name === projectName);
-assert(project, `failed to get project "${projectName}"`);
+  case "preview": {
+    await deployToPreview(client, { team, project, commit });
+    break;
+  }
 
-info`Fetching latest production deployment`;
-const productionDeployments = await client.deployments(team.id, project.id);
-const latestProductionDeployment = productionDeployments[0];
-assert(
-  latestProductionDeployment,
-  `failed to get latest production deployment`,
-);
-
-const environment = await client.envs(team.id, project.id);
-const RELEASE_COMMIT_KEY = "RELEASE_COMMIT";
-const RELEASE_VERSION_KEY = "RELEASE_VERSION";
-
-info`Fetching "${RELEASE_COMMIT_KEY}" env var`;
-const releaseCommitEnv = environment.find(
-  (env) => env.key === RELEASE_COMMIT_KEY,
-);
-assert(releaseCommitEnv, `failed to get "${RELEASE_COMMIT_KEY}" env var`);
-
-info`Fetching "${RELEASE_VERSION_KEY}" env var`;
-const releaseVersionEnv = environment.find(
-  (env) => env.key === RELEASE_VERSION_KEY,
-);
-assert(releaseVersionEnv, `failed to get "${RELEASE_VERSION_KEY}" env var`);
-
-info`Setting "${RELEASE_COMMIT_KEY}" env to "${releaseCommit}"`;
-await client.setEnv(team.id, project.id, releaseCommitEnv.id, {
-  key: RELEASE_COMMIT_KEY,
-  value: releaseCommit,
-});
-
-info`Setting "${RELEASE_VERSION_KEY}" env to "${releaseVersion}"`;
-await client.setEnv(team.id, project.id, releaseVersionEnv.id, {
-  key: RELEASE_VERSION_KEY,
-  value: releaseVersion,
-});
-
-info`Triggering redeploy`;
-await client.redeploy(team.id, latestProductionDeployment.uid, "landing");
+  default: {
+    throw new Error(`"target" must be one of: production, preview`);
+  }
+}

--- a/.github/actions/deploy-vercel/preview.mjs
+++ b/.github/actions/deploy-vercel/preview.mjs
@@ -1,0 +1,49 @@
+// @ts-check
+
+import { assert, info, setOutput } from "./util.mjs";
+import { Client } from "./vercel.mjs";
+
+/**
+ *
+ * @param {Client} client
+ * @param {{
+ *   team: string;
+ *   project: string;
+ *   commit: string;
+ * }} options
+ */
+export async function deployToPreview(client, options) {
+  info`Fetching team "${options.team}"`;
+  const availableTeams = await client.teams();
+  assert(availableTeams, `failed to get team "${options.team}"`);
+  const team = availableTeams.find((team) => team.name === options.team);
+  assert(team, `failed to get team "${options.team}"`);
+
+  info`Fetching project "${options.project}"`;
+  const projectsInTeam = await client.projects(team.id);
+  const project = projectsInTeam.find(
+    (project) => project.name === options.project,
+  );
+  assert(project, `failed to get project "${options.project}"`);
+
+  info`Fetching latest production deployment`;
+  const productionDeployments = await client.deployments(team.id, project.id);
+  const latestProductionDeployment = productionDeployments[0];
+  assert(
+    latestProductionDeployment,
+    `failed to get latest production deployment`,
+  );
+
+  info`Deploying preview with RELEASE_COMMIT=${options.commit}`;
+  const { url } = await client.deployPreviewFrom(
+    team.id,
+    latestProductionDeployment.uid,
+    "landing-preview",
+    {
+      RELEASE_COMMIT: options.commit,
+      IS_PR_PREVIEW: "true",
+    },
+  );
+
+  setOutput("vercel_preview_url", url);
+}

--- a/.github/actions/deploy-vercel/production.mjs
+++ b/.github/actions/deploy-vercel/production.mjs
@@ -1,0 +1,68 @@
+// @ts-check
+
+import { assert, info } from "./util.mjs";
+import { Client } from "./vercel.mjs";
+
+/**
+ *
+ * @param {Client} client
+ * @param {{
+ *   team: string;
+ *   project: string;
+ *   commit: string;
+ *   version: string;
+ * }} options
+ */
+export async function deployToProduction(client, options) {
+  info`Fetching team "${options.team}"`;
+  const availableTeams = await client.teams();
+  assert(availableTeams, `failed to get team "${options.team}"`);
+  const team = availableTeams.find((team) => team.name === options.team);
+  assert(team, `failed to get team "${options.team}"`);
+
+  info`Fetching project "${options.project}"`;
+  const projectsInTeam = await client.projects(team.id);
+  const project = projectsInTeam.find(
+    (project) => project.name === options.project,
+  );
+  assert(project, `failed to get project "${options.project}"`);
+
+  info`Fetching latest production deployment`;
+  const productionDeployments = await client.deployments(team.id, project.id);
+  const latestProductionDeployment = productionDeployments[0];
+  assert(
+    latestProductionDeployment,
+    `failed to get latest production deployment`,
+  );
+
+  const environment = await client.envs(team.id, project.id);
+  const RELEASE_COMMIT_KEY = "RELEASE_COMMIT";
+  const RELEASE_VERSION_KEY = "RELEASE_VERSION";
+
+  info`Fetching "${RELEASE_COMMIT_KEY}" env var`;
+  const releaseCommitEnv = environment.find(
+    (env) => env.key === RELEASE_COMMIT_KEY,
+  );
+  assert(releaseCommitEnv, `failed to get "${RELEASE_COMMIT_KEY}" env var`);
+
+  info`Fetching "${RELEASE_VERSION_KEY}" env var`;
+  const releaseVersionEnv = environment.find(
+    (env) => env.key === RELEASE_VERSION_KEY,
+  );
+  assert(releaseVersionEnv, `failed to get "${RELEASE_VERSION_KEY}" env var`);
+
+  info`Setting "${RELEASE_COMMIT_KEY}" env to "${options.commit}"`;
+  await client.setEnv(team.id, project.id, releaseCommitEnv.id, {
+    key: RELEASE_COMMIT_KEY,
+    value: options.commit,
+  });
+
+  info`Setting "${RELEASE_VERSION_KEY}" env to "${options.version}"`;
+  await client.setEnv(team.id, project.id, releaseVersionEnv.id, {
+    key: RELEASE_VERSION_KEY,
+    value: options.version,
+  });
+
+  info`Triggering redeploy`;
+  await client.redeploy(team.id, latestProductionDeployment.uid, "landing");
+}

--- a/.github/actions/deploy-vercel/test.mjs
+++ b/.github/actions/deploy-vercel/test.mjs
@@ -1,0 +1,38 @@
+// @ts-check
+
+import { Client } from "./vercel.mjs";
+import { assert, info } from "./util.mjs";
+
+const client = new Client("NzuZ9WBTnfUGiwHrhd7mit2E");
+
+const teamName = "rerun";
+const projectName = "landing";
+
+info`Fetching team "${teamName}"`;
+const availableTeams = await client.teams();
+assert(availableTeams, `failed to get team "${teamName}"`);
+const team = availableTeams.find((team) => team.name === teamName);
+assert(team, `failed to get team "${teamName}"`);
+
+info`Fetching project "${projectName}"`;
+const projectsInTeam = await client.projects(team.id);
+const project = projectsInTeam.find((project) => project.name === projectName);
+assert(project, `failed to get project "${projectName}"`);
+
+info`Fetching latest production deployment`;
+const productionDeployments = await client.deployments(team.id, project.id);
+const latestProductionDeployment = productionDeployments[0];
+assert(
+  latestProductionDeployment,
+  `failed to get latest production deployment`,
+);
+
+const response = await client.deployPreviewFrom(
+  team.id,
+  latestProductionDeployment.uid,
+  "rerun-custom-preview-test",
+  {
+    RELEASE_COMMIT: "main",
+  },
+);
+console.log(response);

--- a/.github/actions/deploy-vercel/util.mjs
+++ b/.github/actions/deploy-vercel/util.mjs
@@ -1,5 +1,8 @@
 // @ts-check
 
+import { appendFileSync } from "fs";
+import os from "os";
+
 /**
  * Log a message with level `INFO`
  *
@@ -42,6 +45,16 @@ export function getRequiredInput(name) {
 }
 
 /**
+ * Set a GitHub Actions output for other workflows steps to read.
+ * @param {string} key
+ * @param {string} value
+ */
+export function setOutput(key, value) {
+  const outputFile = /** @type {string} */ (process.env["GITHUB_OUTPUT"]);
+  appendFileSync(outputFile, `${key}=${value}${os.EOL}`);
+}
+
+/**
  * Assert that `value` is truthy, throwing an error if it is not.
  *
  * @param {any} value
@@ -61,4 +74,3 @@ export function assert(value, message) {
     throw new Error(error);
   }
 }
-

--- a/.github/actions/deploy-vercel/vercel.mjs
+++ b/.github/actions/deploy-vercel/vercel.mjs
@@ -106,7 +106,10 @@ export class Client {
    */
   async teams() {
     const response = await this.get("v2/teams");
-    assert("teams" in response, () => `failed to get teams: ${JSON.stringify(response)}`);
+    assert(
+      "teams" in response,
+      () => `failed to get teams: ${JSON.stringify(response)}`,
+    );
     return response.teams;
   }
 
@@ -119,7 +122,10 @@ export class Client {
    */
   async projects(teamId) {
     const response = await this.get("v9/projects", { teamId });
-    assert("projects" in response, () => `failed to get projects: ${JSON.stringify(response)}`);
+    assert(
+      "projects" in response,
+      () => `failed to get projects: ${JSON.stringify(response)}`,
+    );
     return response.projects;
   }
 
@@ -146,7 +152,7 @@ export class Client {
     });
     assert(
       "deployments" in response,
-      () => `failed to get deployments: ${JSON.stringify(response)}`
+      () => `failed to get deployments: ${JSON.stringify(response)}`,
     );
     return response.deployments;
   }
@@ -162,7 +168,7 @@ export class Client {
     const response = await this.get(`v9/projects/${projectId}/env`, { teamId });
     assert(
       "envs" in response,
-      () => `failed to get environment variables: ${JSON.stringify(response)}`
+      () => `failed to get environment variables: ${JSON.stringify(response)}`,
     );
     return response.envs;
   }
@@ -177,7 +183,10 @@ export class Client {
    * @returns {Promise<Env>}
    */
   async getEnvDecrypted(teamId, projectId, envId) {
-    return await this.get(`v9/projects/${projectId}/env/${envId}`, { teamId, decrypt: "true" });
+    return await this.get(`v9/projects/${projectId}/env/${envId}`, {
+      teamId,
+      decrypt: "true",
+    });
   }
 
   /**
@@ -194,12 +203,17 @@ export class Client {
     teamId,
     projectId,
     envId,
-    { key, target = ["production", "preview", "development"], type = "encrypted", value }
+    {
+      key,
+      target = ["production", "preview", "development"],
+      type = "encrypted",
+      value,
+    },
   ) {
     return await this.patch(
       `v9/projects/${projectId}/env/${envId}`,
       { gitBranch: null, key, target, type, value },
-      { teamId }
+      { teamId },
     );
   }
 
@@ -217,9 +231,36 @@ export class Client {
   async redeploy(teamId, deploymentId, name) {
     return await this.post(
       `v13/deployments`,
-      { deploymentId, meta: { action: "redeploy" }, name, target: "production" },
-      { teamId, forceNew: "1" }
+      {
+        deploymentId,
+        meta: { action: "redeploy" },
+        name,
+        target: "production",
+      },
+      { teamId, forceNew: "1" },
     );
   }
-}
 
+  /**
+   * Trigger a preview deploy using the files of an existing deployment (`deploymentId`).
+   *
+   * @param {string} teamId
+   * @param {string} deploymentId
+   * @param {string} name
+   * @param {Record<string, string>} [env]
+   * @returns {Promise<any>}
+   */
+  async deployPreviewFrom(teamId, deploymentId, name, env) {
+    // `target` not being set means "preview"
+    const body = {
+      deploymentId,
+      meta: { action: "redeploy" },
+      name,
+    };
+    if (env) {
+      body.env = env;
+      body.build = { env };
+    }
+    return await this.post(`v13/deployments`, body, { teamId, forceNew: "1" });
+  }
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,5 @@ To get an auto-generated PR description you can put "copilot:summary" or "copilo
 * [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
 
 - [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
-- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->
-- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->
 - [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
 - [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -210,4 +210,5 @@ jobs:
     uses: ./.github/workflows/reusable_deploy_landing_preview.yml
     with:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets: inherit

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -206,7 +206,7 @@ jobs:
 
   deploy-landing-preview:
     name: "Deploy Landing Preview"
-    # if: needs.docs-paths-filter.outputs.docs_changes == 'true'
+    if: needs.docs-paths-filter.outputs.docs_changes == 'true'
     uses: ./.github/workflows/reusable_deploy_landing_preview.yml
     with:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -55,6 +55,23 @@ jobs:
               - '**/CMakeLists.txt'
               - '**/*cmake'
 
+  docs-paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_changes: ${{ steps.filter.outputs.docs_changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            docs_changes:
+              - 'docs/content/**/*.md'
+              - 'examples/**/*.md'
+              - 'examples/manifest.toml'
+
   rust-checks:
     name: "Rust Checks"
     if: github.event.pull_request.head.repo.owner.login == 'rerun-io' && needs.rust-paths-filter.outputs.rust_changes == 'true'
@@ -185,4 +202,12 @@ jobs:
     with:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
+    secrets: inherit
+
+  deploy-landing-preview:
+    name: "Deploy Landing Preview"
+    if: needs.docs-paths-filter.outputs.docs_changes == 'true'
+    uses: ./.github/workflows/reusable_deploy_landing_preview.yml
+    with:
+      CONCURRENCY: pr-${{ github.event.pull_request.number }}
     secrets: inherit

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -206,7 +206,7 @@ jobs:
 
   deploy-landing-preview:
     name: "Deploy Landing Preview"
-    if: needs.docs-paths-filter.outputs.docs_changes == 'true'
+    # if: needs.docs-paths-filter.outputs.docs_changes == 'true'
     uses: ./.github/workflows/reusable_deploy_landing_preview.yml
     with:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -262,3 +262,4 @@ jobs:
           vercel_project_name: ${{ vars.VERCEL_PROJECT_NAME }}
           release_commit: ${{ inputs.RELEASE_COMMIT }}
           release_version: ${{ inputs.RELEASE_VERSION }}
+          target: "production"

--- a/.github/workflows/reusable_deploy_landing_preview.yml
+++ b/.github/workflows/reusable_deploy_landing_preview.yml
@@ -6,6 +6,9 @@ on:
       CONCURRENCY:
         required: true
         type: string
+      PR_NUMBER:
+        required: true
+        type: string
 
 concurrency:
   group: ${{ inputs.CONCURRENCY }}-deploy-landing-preview
@@ -33,6 +36,7 @@ jobs:
           echo "sha=$full_commit" >> "$GITHUB_OUTPUT"
 
       - name: Re-deploy rerun.io
+        id: deploy-vercel
         uses: ./.github/actions/deploy-vercel
         with:
           vercel_token: ${{ secrets.VERCEL_TOKEN }}
@@ -40,3 +44,15 @@ jobs:
           vercel_project_name: ${{ vars.VERCEL_PROJECT_NAME }}
           release_commit: ${{ steps.get-sha.outputs.sha }}
           target: "preview"
+
+      - name: Create PR comment
+        # https://github.com/mshick/add-pr-comment
+        uses: mshick/add-pr-comment@v2.8.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          message: |
+            ## Deployed docs
+
+            | Commit  | Link  |
+            | ------- | ----- |
+            | ${{ steps.get-sha.outputs.sha }} | ${{ steps.deploy-vercel.outputs.vercel_preview_url }} |

--- a/.github/workflows/reusable_deploy_landing_preview.yml
+++ b/.github/workflows/reusable_deploy_landing_preview.yml
@@ -14,12 +14,14 @@ concurrency:
   group: ${{ inputs.CONCURRENCY }}-deploy-landing-preview
   cancel-in-progress: true
 
+permissions:
+  contents: "write"
+  id-token: "write"
+  pull-requests: "write"
+
 jobs:
   deploy:
     name: Deploy
-    permissions:
-      contents: "read"
-      id-token: "write"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/reusable_deploy_landing_preview.yml
+++ b/.github/workflows/reusable_deploy_landing_preview.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         run: |
           full_commit="${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}"
-          echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"
+          echo "sha=$full_commit" >> "$GITHUB_OUTPUT"
 
       - name: Re-deploy rerun.io
         uses: ./.github/actions/deploy-vercel

--- a/.github/workflows/reusable_deploy_landing_preview.yml
+++ b/.github/workflows/reusable_deploy_landing_preview.yml
@@ -1,0 +1,42 @@
+name: Reusable Deploy Landing Preview
+
+on:
+  workflow_call:
+    inputs:
+      CONCURRENCY:
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ inputs.CONCURRENCY }}-deploy-landing-preview
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    runs-on: ubuntu-latest-16-cores
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.ref) || '' }}
+
+      - name: Get sha
+        id: get-sha
+        shell: bash
+        run: |
+          full_commit="${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}"
+          echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: Re-deploy rerun.io
+        uses: ./.github/actions/deploy-vercel
+        with:
+          vercel_token: ${{ secrets.VERCEL_TOKEN }}
+          vercel_team_name: ${{ vars.VERCEL_TEAM_NAME }}
+          vercel_project_name: ${{ vars.VERCEL_PROJECT_NAME }}
+          release_commit: ${{ steps.get-sha.outputs.sha }}
+          target: "preview"

--- a/.github/workflows/reusable_deploy_landing_preview.yml
+++ b/.github/workflows/reusable_deploy_landing_preview.yml
@@ -57,4 +57,4 @@ jobs:
 
             | Commit  | Link  |
             | ------- | ----- |
-            | ${{ steps.get-sha.outputs.sha }} | ${{ steps.deploy-vercel.outputs.vercel_preview_url }} |
+            | ${{ steps.get-sha.outputs.sha }} | https://${{ steps.deploy-vercel.outputs.vercel_preview_url }} |

--- a/.github/workflows/reusable_deploy_landing_preview.yml
+++ b/.github/workflows/reusable_deploy_landing_preview.yml
@@ -21,7 +21,7 @@ jobs:
       contents: "read"
       id-token: "write"
 
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable_deploy_landing_preview.yml
+++ b/.github/workflows/reusable_deploy_landing_preview.yml
@@ -57,4 +57,4 @@ jobs:
 
             | Commit  | Link  |
             | ------- | ----- |
-            | ${{ steps.get-sha.outputs.sha }} | https://${{ steps.deploy-vercel.outputs.vercel_preview_url }} |
+            | ${{ steps.get-sha.outputs.sha }} | https://${{ steps.deploy-vercel.outputs.vercel_preview_url }}/docs |

--- a/scripts/ci/update_pr_body.py
+++ b/scripts/ci/update_pr_body.py
@@ -18,13 +18,6 @@ from github import Github
 from jinja2 import DebugUndefined, select_autoescape
 from jinja2.sandbox import SandboxedEnvironment
 
-DOCS_PREVIEW_MARKER = "<!--DOCS-PREVIEW-->"
-DOCS_PREVIEW_BARE_LINK = "- [Docs preview](https://rerun.io/preview/{{ pr.commit }}/docs) <!--DOCS-PREVIEW-->"
-EXAMPLES_PREVIEW_MARKER = "<!--EXAMPLES-PREVIEW-->"
-EXAMPLES_PREVIEW_BARE_LINK = (
-    "- [Examples preview](https://rerun.io/preview/{{ pr.commit }}/examples) <!--EXAMPLES-PREVIEW-->"
-)
-
 # Need to protect code-blocks in the PR template.
 # See https://github.com/rerun-io/rerun/issues/3972
 #
@@ -118,20 +111,6 @@ def main() -> None:
     env.filters["encode_uri_component"] = encode_uri_component
 
     new_body = pr.body
-
-    docs_preview_link_end = new_body.find(DOCS_PREVIEW_MARKER)
-    if docs_preview_link_end != -1:
-        docs_preview_link_end += len(DOCS_PREVIEW_MARKER)
-        docs_preview_link_start = new_body.rfind("\n", 0, docs_preview_link_end) + 1
-        new_body = new_body[:docs_preview_link_start] + DOCS_PREVIEW_BARE_LINK + new_body[docs_preview_link_end:]
-
-    examples_preview_link_end = new_body.find(EXAMPLES_PREVIEW_MARKER)
-    if examples_preview_link_end != -1:
-        examples_preview_link_end += len(EXAMPLES_PREVIEW_MARKER)
-        examples_preview_link_start = new_body.rfind("\n", 0, examples_preview_link_end) + 1
-        new_body = (
-            new_body[:examples_preview_link_start] + EXAMPLES_PREVIEW_BARE_LINK + new_body[examples_preview_link_end:]
-        )
 
     lines = new_body.splitlines()
     codeblocks = extract_code_blocks(lines)


### PR DESCRIPTION
### What

Documentation previews are now built from the latest production deployment on every PR that includes changes to markdown files in `docs` or `examples`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5805)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5805?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5805?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5805)
- [Docs preview](https://rerun.io/preview/35c5f659949fd08ce283f077ea6de6217b38d432/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/35c5f659949fd08ce283f077ea6de6217b38d432/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)