### PR TITLE
Fix video elements in docs

### DIFF
--- a/docs/content/getting-started/data-in/cpp.md
+++ b/docs/content/getting-started/data-in/cpp.md
@@ -7,8 +7,7 @@ In this section we'll log and visualize our first non-trivial dataset, putting m
 
 In a few lines of code, we'll go from a blank sheet to something you don't see every day: an animated, interactive, DNA-shaped abacus:
 <video width="100%" autoplay loop muted controls>
-
-<source src="https://static.rerun.io/c4c4ef1e4a1b25002da7c44d4316b0e07ae8d6ed_logging_data1_result.webm" type="video/webm" />
+    <source src="https://static.rerun.io/c4c4ef1e4a1b25002da7c44d4316b0e07ae8d6ed_logging_data1_result.webm" type="video/webm" />
 </video>
 
 This guide aims to go wide instead of deep.

--- a/docs/content/getting-started/data-in/python.md
+++ b/docs/content/getting-started/data-in/python.md
@@ -7,8 +7,7 @@ In this section we'll log and visualize our first non-trivial dataset, putting m
 
 In a few lines of code, we'll go from a blank sheet to something you don't see every day: an animated, interactive, DNA-shaped abacus:
 <video width="100%" autoplay loop muted controls>
-
-<source src="https://static.rerun.io/c4c4ef1e4a1b25002da7c44d4316b0e07ae8d6ed_logging_data1_result.webm" type="video/webm" />
+    <source src="https://static.rerun.io/c4c4ef1e4a1b25002da7c44d4316b0e07ae8d6ed_logging_data1_result.webm" type="video/webm" />
 </video>
 
 This guide aims to go wide instead of deep.

--- a/docs/content/getting-started/data-in/rust.md
+++ b/docs/content/getting-started/data-in/rust.md
@@ -7,8 +7,7 @@ In this section we'll log and visualize our first non-trivial dataset, putting m
 
 In a few lines of code, we'll go from a blank sheet to something you don't see every day: an animated, interactive, DNA-shaped abacus:
 <video width="100%" autoplay loop muted controls>
-
-<source src="https://static.rerun.io/c4c4ef1e4a1b25002da7c44d4316b0e07ae8d6ed_logging_data1_result.webm" type="video/webm" />
+    <source src="https://static.rerun.io/c4c4ef1e4a1b25002da7c44d4316b0e07ae8d6ed_logging_data1_result.webm" type="video/webm" />
 </video>
 
 This guide aims to go wide instead of deep.


### PR DESCRIPTION
### What

- Closes https://github.com/rerun-io/rerun/issues/5822

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5826)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5826?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5826?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5826)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)