### PR TITLE
0.15 migration guide for removed instance keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Blueprints are currently only supported in the Python API, with C++ and Rust sup
 - 💪 Linux ARM64 support [#5489](https://github.com/rerun-io/rerun/pull/5489) [#5503](https://github.com/rerun-io/rerun/pull/5503) [#5511](https://github.com/rerun-io/rerun/pull/5511)
 - 🖼️ Show examples in the welcome page
 - 🖱️ Improve context-menu when right-clicking items in the blueprint panel and streams tree
-- ❌ Remove `InstanceKey` from our logging APIs [#5395](https://github.com/rerun-io/rerun/pull/5395) ([migration guide](https://www.rerun.io/docs/reference/migration/migration-0-15))
+- ❌ Remove `InstanceKey` from our logging APIs [#5395](https://github.com/rerun-io/rerun/pull/5395) ([migration guide](https://www.rerun.io/docs/reference/migration/migration-0-15?speculative-link))
 - ❌ Remove groups from blueprints panel [#5326](https://github.com/rerun-io/rerun/pull/5326)
 
 ### 🔎 Details

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Blueprints are currently only supported in the Python API, with C++ and Rust sup
 - 💪 Linux ARM64 support [#5489](https://github.com/rerun-io/rerun/pull/5489) [#5503](https://github.com/rerun-io/rerun/pull/5503) [#5511](https://github.com/rerun-io/rerun/pull/5511)
 - 🖼️ Show examples in the welcome page
 - 🖱️ Improve context-menu when right-clicking items in the blueprint panel and streams tree
-- ❌ Remove `InstanceKey` from our logging APIs [#5395](https://github.com/rerun-io/rerun/pull/5395)
+- ❌ Remove `InstanceKey` from our logging APIs [#5395](https://github.com/rerun-io/rerun/pull/5395) ([migration guide](https://www.rerun.io/docs/reference/migration/migration-0-15))
 - ❌ Remove groups from blueprints panel [#5326](https://github.com/rerun-io/rerun/pull/5326)
 
 ### 🔎 Details

--- a/crates/re_types/definitions/rerun/components/instance_key.fbs
+++ b/crates/re_types/definitions/rerun/components/instance_key.fbs
@@ -10,6 +10,13 @@ namespace rerun.components;
 // ---
 
 /// A unique numeric identifier for each individual instance within a batch.
+///
+/// Instance keys are automatically assigned by the `rerun` library and should not be set manually.
+///
+/// The instance key is just the index of the instance within the batch,
+/// i.e. the first point in a point cloud has `InstanceKey = 0`, the second `InstanceKey = 1`, and so on.
+///
+/// We plan to remove the `InstanceKey` component in the near future.
 struct InstanceKey (
   "attr.python.aliases": "int",
   "attr.python.array_aliases": "int, npt.NDArray[np.uint64]",

--- a/crates/re_types_core/src/components/instance_key.rs
+++ b/crates/re_types_core/src/components/instance_key.rs
@@ -22,6 +22,13 @@ use crate::{ComponentBatch, MaybeOwnedComponentBatch};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Component**: A unique numeric identifier for each individual instance within a batch.
+///
+/// Instance keys are automatically assigned by the `rerun` library and should not be set manually.
+///
+/// The instance key is just the index of the instance within the batch,
+/// i.e. the first point in a point cloud has `InstanceKey = 0`, the second `InstanceKey = 1`, and so on.
+///
+/// We plan to remove the `InstanceKey` component in the near future.
 #[derive(
     Clone, Debug, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, ::bytemuck::Pod, ::bytemuck::Zeroable,
 )]

--- a/docs/content/concepts/batches.md
+++ b/docs/content/concepts/batches.md
@@ -16,7 +16,6 @@ In the Python APIs, the majority of archetypes are named with the plural form, f
 
 - An *entity* is a collection of *components* (see [Entities and Components](entity-component.md)).
 - When an entity is batched, it's components individual elements are called *instances*.
-- Each instance is identified within the entity by its *instance key*.
 - When every instance within an entity has the same value for a component, that component is called a *splat*. This
   is a common pattern and has dedicated support for it (see the [Splats](#splats) section below).
   For instance, you can set all the colors of a point cloud to the same color by passing a single color value to the
@@ -45,13 +44,12 @@ This can be quite convenient since updating different components at different ti
 organization of your code. It even means if a component on an entity is static, you only need to log it once.
 
 However, if both a batch of colors and a batch of positions have been logged at two different points in time, we need a way
-to know which point receives which color. This is what Rerun uses the instance keys for. When a component batch is
-logged it is always assigned a set of instance keys. By default, this key is based on the sequential index within the
-logged array. When querying a batched component, the component-values are joined together based on these keys.
+to know which point receives which color.
+For that, Rerun uses the index of the instance.
+When querying a batched component, the component-values are joined together based on this index.
 Logically, this happens as a *left-join* using the primary component for the entity. For example, if you log 3
 points and then later log 5 colors, you will still only see 3 points in the viewer.
 
-In the future you will be able to specify the instance keys manually while logging ([#1309](https://github.com/rerun-io/rerun/issues/1309)).
 
 ## Splats
 

--- a/docs/content/howto/extend/custom-data.md
+++ b/docs/content/howto/extend/custom-data.md
@@ -5,7 +5,18 @@ description: How to use Rerun with custom data
 ---
 Rerun comes with many pre-built [Types](../../reference/types.md) that you can use out of the box. As long as your own data can be decomposed into Rerun [components](../../reference/types/components.md) or can be serialized with [Apache Arrow](https://arrow.apache.org/), you can log it directly without needing to recompile Rerun.
 
-All you need to do is implement the `AsComponents` [Python protocol](https://ref.rerun.io/docs/python/0.9.0/common/interfaces/#rerun.AsComponents) or [Rust trait](https://docs.rs/rerun/latest/rerun/trait.AsComponents.html), which means implementing the function, `as_component_batches()`.
+For Python we have a helper for this, called [`AnyValues`](https://ref.rerun.io/docs/python/main/common/custom_data/), allowing you to easily attach custom values to any entity instance:
+
+```
+rr.log(
+    "my_entity", rr.AnyValues(
+        confidence=[1.2, 3.4, 5.6],
+        description="Bla bla bla…",
+    ),
+)
+```
+
+You can also create your own component by implementing the `AsComponents` [Python protocol](https://ref.rerun.io/docs/python/0.9.0/common/interfaces/#rerun.AsComponents) or [Rust trait](https://docs.rs/rerun/latest/rerun/trait.AsComponents.html), which means implementing the function, `as_component_batches()`.
 
 ## Remapping to a Rerun archetype
 Let's start with a simple example where you have your own point cloud class that is perfectly representable as a Rerun archetype.

--- a/docs/content/reference/migration.md
+++ b/docs/content/reference/migration.md
@@ -1,5 +1,5 @@
 ---
 title: Migration Guides
 order: 900
-redirect: reference/migration/migration-0-13
+redirect: reference/migration/migration-0-15
 ---

--- a/docs/content/reference/migration/migration-0-13.md
+++ b/docs/content/reference/migration/migration-0-13.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating from 0.12 to 0.13
-order: 11
+order: 130
 ---
 
 ## `TimeSeriesScalar` deprecated in favor of [Scalar](../types/archetypes/scalar.md) & [SeriesLine](../types/archetypes/series_line.md)/[SeriesPoint](../types/archetypes/series_point.md)

--- a/docs/content/reference/migration/migration-0-15.md
+++ b/docs/content/reference/migration/migration-0-15.md
@@ -20,7 +20,7 @@ For now the `InstanceKey` component as such still remains, but is always assigne
 This means that if you first log the positions `A, B, C` and then later log the colors `red, green, blue` to the same entity, they will always be matched as `(A, red), (B, green), (C, blue)`.
 We still support _splatting_, where you log one single color for the whole point cloud.
 
-If you were relying on `InstanceKey` solely to identify your instances when inspecting them in the viewer, then you can replace it with a custom value using [custom data](../../howto/extend/custom-data):
+If you were relying on `InstanceKey` solely to identify your instances when inspecting them in the viewer, then you can replace it with a custom value using [custom data](../../howto/extend/custom-data.md):
 
 ```py
 rr.log(

--- a/docs/content/reference/migration/migration-0-15.md
+++ b/docs/content/reference/migration/migration-0-15.md
@@ -10,7 +10,7 @@ What were instance keys?
 
 In Rerun, each entity can be a batch of _instances_. For instance, a point cloud can be one entity, and each point is an instance of that entity.
 An entity is made up of several components (e.g. position, color, …), and you may log these different components separately.
-For instance, this lets you update only the colors of a point cloud, keeping the same positions.
+For example, this lets you update only the colors of a point cloud, keeping the same positions.
 
 Instance keys were a way to assign identities to these instances so that you could update the components of a specific set of instances.
 This was a complicated and little used feature, that caused far more complexity in our code than it was worth.

--- a/docs/content/reference/migration/migration-0-15.md
+++ b/docs/content/reference/migration/migration-0-15.md
@@ -19,4 +19,13 @@ For now the `InstanceKey` component as such still remains, but is always assigne
 This means that if you first log the positions `A, B, C` and then later log the colors `red, green, blue` to the same entity, they will always be matched as `(A, red), (B, green), (C, blue)`.
 We still support _splatting_, where you log one single color for the whole point cloud.
 
-In the future we plan on introducing a new way to identify instances over time.
+If you were relying on `InstanceKey` solely to identify your instances when inspecting them in the viewer, then you can replace it with a custom value using [custom data](../../howto/extend/custom-data):
+
+```py
+rr.log(
+    "my/points",
+    rr.AnyValues(point_id=[17, 42, 103]),
+)
+```
+
+In the future we plan on introducing a better way to identify and track instances over time.

--- a/docs/content/reference/migration/migration-0-15.md
+++ b/docs/content/reference/migration/migration-0-15.md
@@ -1,0 +1,22 @@
+---
+title: Migrating from 0.14 to 0.15
+order: 150
+---
+
+## `InstanceKey` removed from our logging APIs
+In PR [#5395](https://github.com/rerun-io/rerun/pull/5395) we removed the `InstanceKey` component from all our archetypes.
+
+What were instance keys?
+
+In Rerun, each entity can be a batch of _instances_. For instance, a point cloud can be one entity, and each point is an instance of that entity.
+An entity is made up of several components (e.g. position, color, …), and you may log these different components separately.
+For instance, this lets you update only the colors of a point cloud, keeping the same positions.
+
+Instance keys were a way to assign identities to these instances so that you could update the components of a specific set of instances.
+This was a complicated and little used feature, that caused far more complexity in our code than it was worth.
+
+For now the `InstanceKey` component as such still remains, but is always assigned the integer index at log time (i.e. `0, 1, 2, 3, …`).
+This means that if you first log the positions `A, B, C` and then later log the colors `red, green, blue` to the same entity, they will always be matched as `(A, red), (B, green), (C, blue)`.
+We still support _splatting_, where you log one single color for the whole point cloud.
+
+In the future we plan on introducing a new way to identify instances over time.

--- a/docs/content/reference/migration/migration-0-15.md
+++ b/docs/content/reference/migration/migration-0-15.md
@@ -8,7 +8,8 @@ In PR [#5395](https://github.com/rerun-io/rerun/pull/5395) we removed the `Insta
 
 What were instance keys?
 
-In Rerun, each entity can be a batch of _instances_. For instance, a point cloud can be one entity, and each point is an instance of that entity.
+In Rerun, each entity can be a batch of _instances_.
+For instance, a point cloud is usually logged as one entity where each point is an instance of that entity.
 An entity is made up of several components (e.g. position, color, …), and you may log these different components separately.
 For example, this lets you update only the colors of a point cloud, keeping the same positions.
 

--- a/docs/content/reference/migration/migration-0-9.md
+++ b/docs/content/reference/migration/migration-0-9.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating from 0.8 to 0.9
-order: 12
+order: 90
 ---
 
 Rerun-0.9 introduces a new set of type-oriented logging APIs built on top of an updated, more concrete,

--- a/docs/content/reference/types/components/instance_key.md
+++ b/docs/content/reference/types/components/instance_key.md
@@ -4,6 +4,13 @@ title: "InstanceKey"
 
 A unique numeric identifier for each individual instance within a batch.
 
+Instance keys are automatically assigned by the `rerun` library and should not be set manually.
+
+The instance key is just the index of the instance within the batch,
+i.e. the first point in a point cloud has `InstanceKey = 0`, the second `InstanceKey = 1`, and so on.
+
+We plan to remove the `InstanceKey` component in the near future.
+
 ## Fields
 
 * value: `u64`

--- a/docs/snippets/all/any_values.py
+++ b/docs/snippets/all/any_values.py
@@ -6,7 +6,7 @@ rr.init("rerun_example_any_values", spawn=True)
 rr.log(
     "any_values",
     rr.AnyValues(
-        foo=[1.2, 3.4, 5.6],
-        bar="hello world",
+        confidence=[1.2, 3.4, 5.6],
+        description="Bla bla bla…",
     ),
 )

--- a/rerun_cpp/src/rerun/components/instance_key.hpp
+++ b/rerun_cpp/src/rerun/components/instance_key.hpp
@@ -21,6 +21,13 @@ namespace arrow {
 
 namespace rerun::components {
     /// **Component**: A unique numeric identifier for each individual instance within a batch.
+    ///
+    /// Instance keys are automatically assigned by the `rerun` library and should not be set manually.
+    ///
+    /// The instance key is just the index of the instance within the batch,
+    /// i.e. the first point in a point cloud has `InstanceKey = 0`, the second `InstanceKey = 1`, and so on.
+    ///
+    /// We plan to remove the `InstanceKey` component in the near future.
     struct InstanceKey {
         uint64_t value;
 

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -102,7 +102,8 @@ class AnyValues(AsComponents):
     ```python
     rr.log(
         "any_values", rr.AnyValues(
-            foo=[1.2, 3.4, 5.6], bar="hello world",
+            confidence=[1.2, 3.4, 5.6],
+            description="Bla bla bla…",
         ),
     )
     ```

--- a/rerun_py/rerun_sdk/rerun/components/instance_key.py
+++ b/rerun_py/rerun_sdk/rerun/components/instance_key.py
@@ -20,7 +20,16 @@ __all__ = ["InstanceKey", "InstanceKeyArrayLike", "InstanceKeyBatch", "InstanceK
 
 @define(init=False)
 class InstanceKey(InstanceKeyExt):
-    """**Component**: A unique numeric identifier for each individual instance within a batch."""
+    """
+    **Component**: A unique numeric identifier for each individual instance within a batch.
+
+    Instance keys are automatically assigned by the `rerun` library and should not be set manually.
+
+    The instance key is just the index of the instance within the batch,
+    i.e. the first point in a point cloud has `InstanceKey = 0`, the second `InstanceKey = 1`, and so on.
+
+    We plan to remove the `InstanceKey` component in the near future.
+    """
 
     def __init__(self: Any, value: InstanceKeyLike):
         """Create a new instance of the InstanceKey component."""


### PR DESCRIPTION
### What
Write a migration guide for 0.15 covering the removal of instance keys from our archetypes.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5830)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5830?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5830?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5830)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)