### PR TITLE
Fix/improve UI when viewing all components of an entity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5030,6 +5030,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "re_entity_db",
+ "re_format",
  "re_log",
  "re_log_types",
  "serde",

--- a/crates/re_data_ui/src/component.rs
+++ b/crates/re_data_ui/src/component.rs
@@ -103,7 +103,7 @@ impl DataUi for EntityComponentWithInstances {
                 .header(re_ui::ReUi::table_header_height(), |mut header| {
                     re_ui::ReUi::setup_table_header(&mut header);
                     header.col(|ui| {
-                        ui.label("Instance key");
+                        ui.label("Index");
                     });
                     header.col(|ui| {
                         ui.label(self.component_name().short_name());

--- a/crates/re_data_ui/src/component.rs
+++ b/crates/re_data_ui/src/component.rs
@@ -1,7 +1,9 @@
 use egui::NumExt;
+
 use re_entity_db::{EntityPath, InstancePath};
 use re_query::ComponentWithInstances;
 use re_types::ComponentName;
+use re_ui::SyntaxHighlighting as _;
 use re_viewer_context::{UiVerbosity, ViewerContext};
 
 use super::{table_for_verbosity, DataUi};
@@ -125,7 +127,7 @@ impl DataUi for EntityComponentWithInstances {
                                     ui,
                                     None,
                                     &instance_path,
-                                    instance_key.to_string(),
+                                    instance_key.syntax_highlighted(ui.style()),
                                 );
                             });
                             row.col(|ui| {

--- a/crates/re_data_ui/src/component.rs
+++ b/crates/re_data_ui/src/component.rs
@@ -99,7 +99,8 @@ impl DataUi for EntityComponentWithInstances {
             table_for_verbosity(verbosity, ui)
                 .resizable(false)
                 .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-                .columns(egui_extras::Column::auto(), 2)
+                .column(egui_extras::Column::auto())
+                .column(egui_extras::Column::remainder())
                 .header(re_ui::ReUi::table_header_height(), |mut header| {
                     re_ui::ReUi::setup_table_header(&mut header);
                     header.col(|ui| {

--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -283,7 +283,7 @@ pub fn instance_path_parts_buttons(
         }
 
         if !instance_path.instance_key.is_splat() {
-            ui.strong("/");
+            ui.weak("[");
             instance_path_button_to_ex(
                 ctx,
                 query,
@@ -294,6 +294,7 @@ pub fn instance_path_parts_buttons(
                 instance_path.instance_key.syntax_highlighted(ui.style()),
                 with_icon,
             );
+            ui.weak("]");
         }
     })
     .response

--- a/crates/re_format/Cargo.toml
+++ b/crates/re_format/Cargo.toml
@@ -26,6 +26,7 @@ default = []
 [dependencies]
 num-traits.workspace = true
 
+# TODO(emilk): remove these high-level dependencies, or split this crate into two.
 arrow2 = { workspace = true, optional = true }
 comfy-table = { workspace = true, optional = true }
 re_tuid = { workspace = true, optional = true }

--- a/crates/re_types_core/src/components/instance_key_ext.rs
+++ b/crates/re_types_core/src/components/instance_key_ext.rs
@@ -53,6 +53,7 @@ impl std::fmt::Display for InstanceKey {
         if self.is_splat() {
             "splat".fmt(f)
         } else {
+            // TODO(emilk): re_format::uint(self.0).fmt(f) (fix cyclic dependency!)
             self.0.fmt(f)
         }
     }

--- a/crates/re_ui/Cargo.toml
+++ b/crates/re_ui/Cargo.toml
@@ -27,6 +27,7 @@ default = []
 
 [dependencies]
 re_entity_db.workspace = true # syntax-highlighting for InstancePath. TODO(emilk): move InstancePath
+re_format.workspace = true
 re_log_types.workspace = true # syntax-highlighting for EntityPath
 
 egui_commonmark = { workspace = true, features = ["pulldown_cmark"] }

--- a/crates/re_ui/src/syntax_highlighting.rs
+++ b/crates/re_ui/src/syntax_highlighting.rs
@@ -41,9 +41,11 @@ impl SyntaxHighlighting for EntityPathPart {
 
 impl SyntaxHighlighting for InstanceKey {
     fn syntax_highlight_into(&self, style: &Style, job: &mut LayoutJob) {
-        job.append("[", 0.0, faint_text_format(style));
-        job.append(&self.to_string(), 0.0, text_format(style));
-        job.append("]", 0.0, faint_text_format(style));
+        if self.is_splat() {
+            job.append("splat", 0.0, text_format(style));
+        } else {
+            job.append(&re_format::format_uint(self.0), 0.0, text_format(style));
+        }
     }
 }
 
@@ -64,7 +66,9 @@ impl SyntaxHighlighting for InstancePath {
     fn syntax_highlight_into(&self, style: &Style, job: &mut LayoutJob) {
         self.entity_path.syntax_highlight_into(style, job);
         if !self.instance_key.is_splat() {
+            job.append("[", 0.0, faint_text_format(style));
             self.instance_key.syntax_highlight_into(style, job);
+            job.append("]", 0.0, faint_text_format(style));
         }
     }
 }


### PR DESCRIPTION
### What
#### Before
<img width="310" alt="image" src="https://github.com/rerun-io/rerun/assets/1148717/d4cae3cd-171a-4eaa-967e-d35a228c87eb">

<img width="239" alt="Screenshot 2024-04-07 at 16 58 57" src="https://github.com/rerun-io/rerun/assets/1148717/228f25a6-22af-48f3-aea1-12e451e82b41">


#### After

<img width="338" alt="Screenshot 2024-04-07 at 17 01 59" src="https://github.com/rerun-io/rerun/assets/1148717/6ca042a4-3f71-4d46-8555-dd22c30d6cfb">


<img width="339" alt="Screenshot 2024-04-07 at 17 02 05" src="https://github.com/rerun-io/rerun/assets/1148717/6a6bc327-6445-4820-a180-f8860da93671">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5831)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5831?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5831?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5831)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)