### PR TITLE
Update concept section

### DIFF
--- a/docs/content/concepts/annotation-context.md
+++ b/docs/content/concepts/annotation-context.md
@@ -1,6 +1,6 @@
 ---
 title: Annotation Context
-order: 4
+order: 800
 ---
 
 ## Overview

--- a/docs/content/concepts/apps-and-recordings.md
+++ b/docs/content/concepts/apps-and-recordings.md
@@ -1,6 +1,6 @@
 ---
 title: Application IDs and Recording IDs
-order: 8
+order: 500
 ---
 
 ## Application ID

--- a/docs/content/concepts/batches.md
+++ b/docs/content/concepts/batches.md
@@ -1,6 +1,6 @@
 ---
 title: Batch Data
-order: 5
+order: 700
 ---
 
 Rerun has built-in support for batch data. Whenever you have a collection of things that all have the same type, rather

--- a/docs/content/concepts/blueprint.md
+++ b/docs/content/concepts/blueprint.md
@@ -44,7 +44,7 @@ all state to the blueprint.)
 
 ## Current, default, and heuristics blueprints
 
-Blueprints may originate from multiple source.
+Blueprints may originate from multiple sources.
 
 - The "current blueprint" for a given application ID is the one that is used by the viewer to display data at any given time. It is updated for each change made to the visualization within the viewer, and may be saved to a blueprint file at any time.
 - The "default blueprint" is a snapshot that is set or updated when a blueprint is received from code or loaded from a file. The current blueprint may be reset to default blueprint at any time by using the "reset" button in the blueprint panel's header.

--- a/docs/content/concepts/blueprint.md
+++ b/docs/content/concepts/blueprint.md
@@ -1,6 +1,6 @@
 ---
 title: Blueprint
-order: 9
+order: 600
 ---
 
 ## Blueprints and recordings
@@ -21,8 +21,8 @@ for the viewer to display.
 ## Loose coupling
 
 The blueprint and the recording are only loosely coupled. Rerun uses the
-"application ID" to determine whether a blueprint and a recording should be used
-together, but they are not directly linked beyond that.
+[application ID](apps-and-recordings.md) to determine whether a blueprint and a
+recording should be used together, but they are not directly linked beyond that.
 
 This means that either can be changed independently of the other. Keeping the
 blueprint constant while changing the recording will allow you to compare
@@ -41,6 +41,14 @@ In general, if you can modify an aspect of how something looks through the
 viewer, you are actually modifying the blueprint. (Note that while there may be
 some exceptions to this rule at the moment, the intent is to eventually migrate
 all state to the blueprint.)
+
+## Current, default, and heuristics blueprints
+
+Blueprints may originate from multiple source.
+
+- The "current blueprint" for a given application ID is the one that is used by the viewer to display data at any given time. It is updated for each change made to the visualization within the viewer, and may be saved to a blueprint file at any time.
+- The "default blueprint" is a snapshot that is set or updated when a blueprint is received from code or loaded from a file. The current blueprint may be reset to default blueprint at any time by using the "reset" button in the blueprint panel's header.
+- The "heuristic blueprint" is an automatically-produced blueprint based on the recording data. When no default blueprint is available, the heuristic blueprint is used when resetting the current blueprint. It is also possible to reset to the heuristic blueprint from the selection panel when an application ID is selected.
 
 ## What is a blueprint
 

--- a/docs/content/concepts/blueprint.md
+++ b/docs/content/concepts/blueprint.md
@@ -48,7 +48,7 @@ Blueprints may originate from multiple sources.
 
 - The "current blueprint" for a given application ID is the one that is used by the viewer to display data at any given time. It is updated for each change made to the visualization within the viewer, and may be saved to a blueprint file at any time.
 - The "default blueprint" is a snapshot that is set or updated when a blueprint is received from code or loaded from a file. The current blueprint may be reset to default blueprint at any time by using the "reset" button in the blueprint panel's header.
-- The "heuristic blueprint" is an automatically-produced blueprint based on the recording data. When no default blueprint is available, the heuristic blueprint is used when resetting the current blueprint. It is also possible to reset to the heuristic blueprint from the selection panel when an application ID is selected.
+- The "heuristic blueprint" is an automatically-produced blueprint based on the recording data. When no default blueprint is available, the heuristic blueprint is used when resetting the current blueprint. It is also possible to reset to the heuristic blueprint in the selection panel after selecting an application.
 
 ## What is a blueprint
 

--- a/docs/content/concepts/entity-component.md
+++ b/docs/content/concepts/entity-component.md
@@ -1,6 +1,6 @@
 ---
 title: Entities and Components
-order: 1
+order: 100
 ---
 
 ## Data model

--- a/docs/content/concepts/entity-path.md
+++ b/docs/content/concepts/entity-path.md
@@ -1,6 +1,6 @@
 ---
 title: The Entity Path Hierarchy
-order: 1
+order: 200
 ---
 
 ## Entity paths

--- a/docs/content/concepts/spaces-and-transforms.md
+++ b/docs/content/concepts/spaces-and-transforms.md
@@ -1,6 +1,6 @@
 ---
 title: Spaces and Transforms
-order: 2
+order: 300
 ---
 
 ## The definition of a space

--- a/docs/content/concepts/timelines.md
+++ b/docs/content/concepts/timelines.md
@@ -1,6 +1,6 @@
 ---
 title: Events and Timelines
-order: 3
+order: 400
 ---
 
 ## Timelines


### PR DESCRIPTION
### What

- add a current/default/heuristic bp section
- move blueprint section higher up
- fix order param

New order:
<img width="185" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/01a85c87-63be-4127-9e2d-b123f483f61c">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5834)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5834?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5834?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5834)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)