### PR TITLE
Add tooltip to timeline selector

### DIFF
--- a/crates/re_time_panel/src/time_control_ui.rs
+++ b/crates/re_time_panel/src/time_control_ui.rs
@@ -2,7 +2,7 @@ use egui::NumExt as _;
 
 use re_entity_db::TimesPerTimeline;
 use re_log_types::TimeType;
-use re_ui::UiExt as _;
+use re_ui::{list_item, UiExt as _};
 
 use re_viewer_context::{Looping, PlayState, TimeControl};
 
@@ -42,9 +42,10 @@ impl TimeControlUi {
                 })
                 .response
                 .on_hover_ui(|ui| {
-                    ui.markdown_ui(
-                        egui::Id::new("timeline_selector_tooltip"),
-                        r"
+                    list_item::list_item_scope(ui, "tooltip", |ui| {
+                        ui.markdown_ui(
+                            egui::Id::new("timeline_selector_tooltip"),
+                            r"
 Select timeline.
 
 Each piece of logged data is associated with one or more timelines.
@@ -55,13 +56,14 @@ The logging SDK always creates two timelines for you:
 
 You can also define your own timelines, e.g. for sensor time or camera frame number.
 "
-                        .trim(),
-                    );
+                            .trim(),
+                        );
 
-                    ui.re_hyperlink(
-                        "Full documentation",
-                        "https://rerun.io/docs/concepts/timelines",
-                    );
+                        ui.re_hyperlink(
+                            "Full documentation",
+                            "https://rerun.io/docs/concepts/timelines",
+                        );
+                    });
                 })
         });
     }

--- a/crates/re_time_panel/src/time_control_ui.rs
+++ b/crates/re_time_panel/src/time_control_ui.rs
@@ -39,7 +39,25 @@ impl TimeControlUi {
                             time_control.set_timeline(*timeline);
                         }
                     }
-                });
+                })
+                .response
+                .on_hover_ui(|ui| {
+                    ui.markdown_ui(
+                        egui::Id::new("timeline_selector_tooltip"),
+                        r"
+Select timeline.
+
+Each piece of logged data is associated with one or more timelines.
+
+The logging SDK always creates two timelines for you:
+* `log_tick` - a sequence timeline with the sequence number of the log call
+* `log_time` - a temporal timeline with the time of the log call
+
+You can also define your own timelines, e.g. for sensor time or camera frame number.
+"
+                        .trim(),
+                    );
+                })
         });
     }
 

--- a/crates/re_time_panel/src/time_control_ui.rs
+++ b/crates/re_time_panel/src/time_control_ui.rs
@@ -57,6 +57,11 @@ You can also define your own timelines, e.g. for sensor time or camera frame num
 "
                         .trim(),
                     );
+
+                    ui.re_hyperlink(
+                        "Full documentation",
+                        "https://rerun.io/docs/concepts/timelines",
+                    );
                 })
         });
     }


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5836
* Blocked by https://github.com/emilk/egui/issues/4338

![image](https://github.com/rerun-io/rerun/assets/1148717/0e53005a-7f75-4239-b20e-1cbddb57451a)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5842)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5842?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5842?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5842)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)