### PR TITLE
Fix argparse deprecation warning in `scripts/ci/crates.py`

### DIFF
--- a/scripts/ci/crates.py
+++ b/scripts/ci/crates.py
@@ -46,7 +46,6 @@ CARGO_PATH = shutil.which("cargo") or "cargo"
 DEFAULT_PRE_ID = "alpha"
 MAX_PUBLISH_WORKERS = 3
 
-
 R = Fore.RED
 G = Fore.GREEN
 B = Fore.BLUE
@@ -569,8 +568,7 @@ def main() -> None:
     cmds_parser = parser.add_subparsers(title="cmds", dest="cmd")
 
     version_parser = cmds_parser.add_parser("version", help="Bump the crate versions")
-    target_version_parser = version_parser.add_mutually_exclusive_group()
-    target_version_update_group = target_version_parser.add_mutually_exclusive_group()
+    target_version_update_group = version_parser.add_mutually_exclusive_group()
     target_version_update_group.add_argument(
         "--bump", type=Bump, choices=list(Bump), help="Bump version according to semver"
     )


### PR DESCRIPTION
### What

`crates.py` would emit a deprecation warning under python >= 3.11 because of some nested `add_mutually_exclusive_group`. Turns out this nesting wasn't really necessary.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}})
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
