### PR TITLE
Add schematics to the blueprint section

### DIFF
--- a/docs/content/concepts/blueprint.md
+++ b/docs/content/concepts/blueprint.md
@@ -5,6 +5,9 @@ order: 600
 
 ## Blueprints and recordings
 
+<!-- source: Rerun Design System/Documentation schematics -->
+<img src="https://static.rerun.io/6e2095a0ffa4f093deb59848b7c294581ded4678_blueprints_and_recordings.png" width="550px">
+
 When you are working with the Rerun viewer, there are two separate pieces that
 combine to produce what you see: the "recording" and the "blueprint."
 
@@ -43,6 +46,9 @@ some exceptions to this rule at the moment, the intent is to eventually migrate
 all state to the blueprint.)
 
 ## Current, default, and heuristics blueprints
+
+<!-- source: Rerun Design System/Documentation schematics -->
+<img src="https://static.rerun.io/fe1fcf086752f5d7cdd64b195fb3a6cb99c50737_current_default_heuristic.png" width="550px">
 
 Blueprints may originate from multiple sources.
 


### PR DESCRIPTION
### What

Re-opening from https://github.com/rerun-io/rerun/pull/5838, which was closed due to `release-0.15` deletion.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5851)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5851?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5851?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5851)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)