### PR TITLE
Add inline markdown example description to public examples

### DIFF
--- a/crates/re_build_examples/src/rrd.rs
+++ b/crates/re_build_examples/src/rrd.rs
@@ -27,7 +27,7 @@ impl Rrd {
         create_dir_all(&self.output_dir)?;
 
         let workspace_root = re_build_tools::cargo_metadata()?.workspace_root;
-        let examples = if self.examples.is_empty() {
+        let mut examples = if self.examples.is_empty() {
             self.channel.examples(workspace_root)?
         } else {
             Channel::Nightly
@@ -36,6 +36,8 @@ impl Rrd {
                 .filter(|example| self.examples.contains(&example.name))
                 .collect()
         };
+        examples.sort_by(|a, b| a.name.cmp(&b.name));
+
         let progress = MultiProgress::new();
         let results: Vec<anyhow::Result<PathBuf>> = examples
             .into_par_iter()

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,12 +31,17 @@ examples/
 The important part is that each example has a `README.md` file. The contents of this `README.md` is used to render the examples in [the documentation](https://rerun.io/examples).
 Check out [`examples/python/template/README.md`](python/template/README.md) to see its format.
 
-The `manifest.toml` file describes the structure of the examples contained in this repository. Only the examples which appear in the manifest are included in the [generated documentation](https://rerun.io/examples). The file contains a description of its own format.
+You are also encourage to add a _short_ `DESCRIPTION = """…"""` markdown to the top of the `main.py` and then log it with:
+```py
+rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
+```
 
 ## Adding a new example
 
 You can base your example off of `python/template` or `rust/template`.
 Once it's ready to be displayed in the docs, add it to the [manifest](./manifest.toml).
+
+The `manifest.toml` file describes the structure of the examples contained in this repository. Only the examples which appear in the manifest are included in the [generated documentation](https://rerun.io/examples). The file contains a description of its own format.
 
 If you want to run the example on CI and include it in the in-viewer example page,
 add a `channel` entry to its README frontmatter. The available channels right now are:

--- a/examples/python/arkit_scenes/main.py
+++ b/examples/python/arkit_scenes/main.py
@@ -22,7 +22,7 @@ This example visualizes the [ARKitScenes dataset](https://github.com/apple/ARKit
 contains color images, depth images, the reconstructed mesh, and labeled bounding boxes around furniture.
 
 The full source code for this example is available
-[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/arkit_scenes/main.py).
+[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/arkit_scenes).
 """.strip()
 
 Color = Tuple[float, float, float, float]

--- a/examples/python/arkit_scenes/main.py
+++ b/examples/python/arkit_scenes/main.py
@@ -16,6 +16,15 @@ from download_dataset import AVAILABLE_RECORDINGS, ensure_recording_available
 from scipy.spatial.transform import Rotation as R
 from tqdm import tqdm
 
+DESCRIPTION = """
+# ARKitScenes
+This example visualizes the [ARKitScenes dataset](https://github.com/apple/ARKitScenes/) using Rerun. The dataset
+contains color images, depth images, the reconstructed mesh, and labeled bounding boxes around furniture.
+
+The full source code for this example is available
+[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/arkit_scenes/main.py).
+""".strip()
+
 Color = Tuple[float, float, float, float]
 
 # hack for now since dataset does not provide orientation information, only known after initial visual inspection
@@ -29,58 +38,6 @@ ORIENTATION = {
 }
 assert len(ORIENTATION) == len(AVAILABLE_RECORDINGS)
 assert set(ORIENTATION.keys()) == set(AVAILABLE_RECORDINGS)
-
-DESCRIPTION = """
-# ARKit Scenes
-This example visualizes the [ARKitScenes dataset](https://github.com/apple/ARKitScenes/) using Rerun. The dataset
-contains color images, depth images, the reconstructed mesh, and labeled bounding boxes around furniture.
-
-## How it was made
-The full source code for this example is available
-[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/arkit_scenes/main.py).
-
-### Moving RGB-D camera
-To log a moving RGB-D camera we need to log four objects: the pinhole camera (intrinsics), the camera pose
-(extrinsics), the color image and the depth image.
-
-The [rr.Pinhole archetype](https://www.rerun.io/docs/reference/types/archetypes/pinhole) is logged to
-[world/camera_lowres](recording://world/camera_lowres) to define the intrinsics of the camera. This
-determines how to go from the 3D camera frame to the 2D image plane. The extrinsics are logged as an
-[rr.Transform3D archetype](https://www.rerun.io/docs/reference/types/archetypes/transform3d) to the
-[same entity world/camera_lowres](recording://world/camera_lowres). Note that we could also log the extrinsics to
-`world/camera` and the intrinsics to `world/camera/image` instead. Here, we log both on the same entity path to keep
-the paths shorter.
-
-The RGB image is logged as an
-[rr.Image archetype](https://www.rerun.io/docs/reference/types/archetypes/image) to the
-[world/camera_lowres/rgb entity](recording://world/camera_lowres/rgb) as a child of the intrinsics + extrinsics
-entity described in the previous paragraph. Similarly the depth image is logged as an
-[rr.DepthImage archetype](https://www.rerun.io/docs/reference/types/archetypes/depth_image) to
-[world/camera_lowres/depth](recording://world/camera_lowres/depth).
-
-### Ground-truth mesh
-The mesh is logged as an [rr.Mesh3D archetype](https://www.rerun.io/docs/reference/types/archetypes/mesh3d).
-In this case the mesh is composed of mesh vertices, indices (i.e., which vertices belong to the same face), and vertex
-colors. Given a `trimesh.Trimesh` the following call is used to log it to Rerun
-```python
-rr.log(
-    "world/mesh",
-    rr.Mesh3D(
-        vertex_positions=mesh.vertices,
-        vertex_colors=mesh.visual.vertex_colors,
-        indices=mesh.faces,
-    ),
-    timeless=True,
-)
-```
-Here, the mesh is logged to the [world/mesh entity](recording://world/mesh) and is marked as timeless, since it does not
-change in the context of this visualization.
-
-### 3D bounding boxes
-The bounding boxes around the furniture is visualized by logging the
-[rr.Boxes3D archetype](https://www.rerun.io/docs/reference/types/archetypes/boxes3d). In this example, each
-bounding box is logged as a separate entity to the common [world/annotations](recording://world/annotations) parent.
-""".strip()
 
 LOWRES_POSED_ENTITY_PATH = "world/camera_lowres"
 HIGHRES_ENTITY_PATH = "world/camera_highres"
@@ -349,6 +306,7 @@ def main() -> None:
                 name="2D",
             ),
             rrb.TextDocumentView(name="Readme"),
+            row_shares=[2, 1],
         ),
     )
 

--- a/examples/python/detect_and_track_objects/main.py
+++ b/examples/python/detect_and_track_objects/main.py
@@ -25,7 +25,7 @@ This is a more elaborate example applying simple object detection and segmentati
 OpenCV. The results are visualized using Rerun.
 
 The full source code for this example is available
-[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/detect_and_track_objects/main.py).
+[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/detect_and_track_objects).
 """.strip()
 
 

--- a/examples/python/detect_and_track_objects/main.py
+++ b/examples/python/detect_and_track_objects/main.py
@@ -17,6 +17,18 @@ import requests
 import rerun as rr  # pip install rerun-sdk
 from PIL import Image
 
+DESCRIPTION = """
+# Detect and track objects
+
+This is a more elaborate example applying simple object detection and segmentation on a video using the Huggingface
+`transformers` library. Tracking across frames is performed using [CSRT](https://arxiv.org/abs/1611.08461) from
+OpenCV. The results are visualized using Rerun.
+
+The full source code for this example is available
+[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/detect_and_track_objects/main.py).
+""".strip()
+
+
 EXAMPLE_DIR: Final = Path(os.path.dirname(__file__))
 DATASET_DIR: Final = EXAMPLE_DIR / "dataset" / "tracking_sequences"
 DATASET_URL_BASE: Final = "https://storage.googleapis.com/rerun-example-datasets/tracking_sequences"
@@ -35,55 +47,6 @@ from transformers import (  # noqa: E402 module level import not at top of file
     DetrFeatureExtractor,
     DetrForSegmentation,
 )
-
-DESCRIPTION = """
-# Detect and Track Objects
-
-This is a more elaborate example applying simple object detection and segmentation on a video using the Huggingface
-`transformers` library. Tracking across frames is performed using [CSRT](https://arxiv.org/abs/1611.08461) from
-OpenCV. The results are visualized using Rerun.
-
-## How it was made
-The full source code for this example is available
-[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/detect_and_track_objects/main.py).
-
-### Input Video
-The input video is logged as a sequence of
-[rr.Image objects](https://www.rerun.io/docs/reference/types/archetypes/image) to the
-[image entity](recording://image). Since the detection and segmentation model operates on smaller images the
-resized images are logged to the separate [segmentation/rgb_scaled entity](recording://segmentation/rgb_scaled). This allows us to
-subsequently visualize the segmentation mask on top of the video.
-
-### Segmentations
-The [segmentation result](recording://image_segmentation/segmentation) is logged through a combination of two archetypes.
-The segmentation image itself is logged as an
-[rr.SegmentationImage archetype](https://www.rerun.io/docs/reference/types/archetypes/segmentation_image) and
-contains the id for each pixel. It is logged to the [segmentation entity](recording://segmentation).
-
-The color and label for each class is determined by the
-[rr.AnnotationContext archetype](https://www.rerun.io/docs/reference/types/archetypes/annotation_context) which is
-logged to the root entity using `rr.log("/", …, timeless=True` as it should apply to the whole sequence and all
-entities that have a class id.
-
-### Detections
-The detections and tracked bounding boxes are visualized by logging the
-[rr.Boxes2D archetype](https://www.rerun.io/docs/reference/types/archetypes/boxes2d) to Rerun.
-
-The color and label of the bounding boxes is determined by their class id, relying on the same
-[rr.AnnotationContext archetype](https://www.rerun.io/docs/reference/types/archetypes/annotation_context) as the
-segmentation images. This ensures that a bounding box and a segmentation image with the same class id will also have the
-same color.
-
-Note that it is also possible to log multiple annotation contexts should different colors and / or labels be desired.
-The annotation context is resolved by seeking up the entity hierarchy.
-
-### Text Log
-Through the [rr.TextLog archetype] text at different importance level can be logged. Rerun integrates with the
-[Python logging module](https://docs.python.org/3/library/logging.html). After an initial setup that is described on the
-[rr.TextLog page](https://www.rerun.io/docs/reference/types/archetypes/text_log#textlogintegration), statements
-such as `logging.info("...")`, `logging.debug("...")`, etc. will show up in the Rerun viewer. In the viewer you can
-adjust the filter level and look at the messages time-synchronized with respect to other logged data.
-""".strip()
 
 
 @dataclass

--- a/examples/python/dicom_mri/main.py
+++ b/examples/python/dicom_mri/main.py
@@ -23,32 +23,21 @@ import pydicom as dicom
 import requests
 import rerun as rr  # pip install rerun-sdk
 
-DATASET_DIR: Final = Path(os.path.dirname(__file__)) / "dataset"
-DATASET_URL: Final = "https://storage.googleapis.com/rerun-example-datasets/dicom.zip"
-
 DESCRIPTION = """
 # Dicom MRI
 This example visualizes an MRI scan using Rerun.
-
-## How it was made
-The full source code for this example is available
-[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/dicom_mri/main.py).
 
 The visualization of the data consists of just the following line
 ```python
 rr.log("tensor", rr.Tensor(voxels_volume_u16, dim_names=["right", "back", "up"]))
 ```
 
-`voxels_volume_u16` is a `numpy.array` of shape `(512, 512, 512)` containing volumetric MRI intensities. We can
-visualize such information in Rerun by logging the `numpy.array` as an
-[rr.Tensor archetype](https://www.rerun.io/docs/reference/types/archetypes/tensor). Here the tensor is logged to
-the [tensor entity](recording://tensor), however any other name for the entity could have been chosen.
-
-In the Rerun viewer you can inspect the data in detail. The `dim_names` provided in the above call to `rr.log` help to
-give semantic meaning to each axis. After selecting the tensor view, you can adjust various settings in the Blueprint
-settings on the right-hand side. For example, you can adjust the color map, the brightness, which dimensions to show as
-an image and which to select from, and more.
+The full source code for this example is available
+[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/dicom_mri/main.py).
 """
+
+DATASET_DIR: Final = Path(os.path.dirname(__file__)) / "dataset"
+DATASET_URL: Final = "https://storage.googleapis.com/rerun-example-datasets/dicom.zip"
 
 
 def extract_voxel_data(

--- a/examples/python/dicom_mri/main.py
+++ b/examples/python/dicom_mri/main.py
@@ -33,7 +33,7 @@ rr.log("tensor", rr.Tensor(voxels_volume_u16, dim_names=["right", "back", "up"])
 ```
 
 The full source code for this example is available
-[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/dicom_mri/main.py).
+[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/dicom_mri).
 """
 
 DATASET_DIR: Final = Path(os.path.dirname(__file__)) / "dataset"

--- a/examples/python/dna/main.py
+++ b/examples/python/dna/main.py
@@ -18,31 +18,8 @@ DESCRIPTION = """
 This is a minimal example that logs synthetic 3D data in the shape of a double helix. The underlying data is generated
 using numpy and visualized using Rerun.
 
-## How it was made
 The full source code for this example is available
 [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/dna/main.py).
-
-### Colored 3D points
-The colored 3D points were added to the scene by logging the
-[rr.Points3D archetype](https://www.rerun.io/docs/reference/types/archetypes/points3d) to the
-[helix/structure/left](recording://helix/structure/left) and [helix/structure/right](recording://helix/structure/right)
-entities.
-
-### 3D line strips
-The 3D line strips connecting the 3D point pairs are logged as an
-[rr.LineStrips3D archetype](https://www.rerun.io/docs/reference/types/archetypes/line_strips3d) to the
-[helix/structure/scaffolding entity](recording://helix/structure/scaffolding).
-
-### Rotation
-The whole structure is rotated over time by logging a
-[rr.Transform3D archetype](https://www.rerun.io/docs/reference/types/archetypes/transform3d) to the
-[helix/structure entity](recording://helix/structure:Transform3D) that changes over time. This transform determines the rotation of
-the [structure entity](recording://helix/structure) relative to the [helix](recording://helix) entity. Since all other
-entities are children of [helix/structure](recording://helix/structure) they will also rotate based on this transform.
-
-You can visualize this rotation by selecting the two entities on the left-hand side and activating `Show transform` in
-the Blueprint settings on the right-hand side. You will see one static frame (i.e., the frame of
-[helix](recording://helix)) and the rotating frame (i.e., the frame of [structure](recording://helix/structure)).
 """.strip()
 
 

--- a/examples/python/dna/main.py
+++ b/examples/python/dna/main.py
@@ -19,7 +19,7 @@ This is a minimal example that logs synthetic 3D data in the shape of a double h
 using numpy and visualized using Rerun.
 
 The full source code for this example is available
-[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/dna/main.py).
+[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/dna).
 """.strip()
 
 

--- a/examples/python/human_pose_tracking/main.py
+++ b/examples/python/human_pose_tracking/main.py
@@ -24,7 +24,7 @@ This example uses Rerun to visualize the output of [MediaPipe](https://developer
 of a human pose in 2D and 3D.
 
 The full source code for this example is available
-[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/human_pose_tracking/main.py).
+[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/human_pose_tracking).
 """.strip()
 
 EXAMPLE_DIR: Final = Path(os.path.dirname(__file__))

--- a/examples/python/human_pose_tracking/main.py
+++ b/examples/python/human_pose_tracking/main.py
@@ -18,46 +18,18 @@ import requests
 import rerun as rr  # pip install rerun-sdk
 import rerun.blueprint as rrb
 
-EXAMPLE_DIR: Final = Path(os.path.dirname(__file__))
-DATASET_DIR: Final = EXAMPLE_DIR / "dataset" / "pose_movement"
-DATASET_URL_BASE: Final = "https://storage.googleapis.com/rerun-example-datasets/pose_movement"
-
 DESCRIPTION = """
-# Human Pose Tracking
+# Human pose tracking
 This example uses Rerun to visualize the output of [MediaPipe](https://developers.google.com/mediapipe)-based tracking
 of a human pose in 2D and 3D.
 
-## How it was made
 The full source code for this example is available
 [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/human_pose_tracking/main.py).
-
-### Input Video
-The input video is logged as a sequence of
-[rr.Image objects](https://www.rerun.io/docs/reference/types/archetypes/image) to the [video entity](recording://video).
-
-### Segmentation
-The [segmentation result](recording://video/mask) is logged through a combination of two archetypes. The segmentation
-image itself is logged as an
-[rr.SegmentationImage archetype](https://www.rerun.io/docs/reference/types/archetypes/segmentation_image) and
-contains the id for each pixel. The color is determined by the
-[rr.AnnotationContext archetype](https://www.rerun.io/docs/reference/types/archetypes/annotation_context) which is
-logged with `rr.log(…, timeless=True` as it should apply to the whole sequence.
-
-### Skeletons
-The [2D](recording://video/pose/points) and [3D skeletons](recording://person/pose/points) are also logged through a
-similar combination of two entities.
-
-First, a timeless
-[rr.ClassDescription](https://www.rerun.io/docs/reference/types/datatypes/class_description) is logged (note, that
-this is equivalent to logging an
-[rr.AnnotationContext archetype](https://www.rerun.io/docs/reference/types/archetypes/annotation_context) as in the
-segmentation case). The class description contains the information which maps keypoint ids to labels and how to connect
-the keypoints to a skeleton.
-
-Second, the actual keypoint positions are logged in 2D
-nd 3D as [rr.Points2D](https://www.rerun.io/docs/reference/types/archetypes/points2d) and
-[rr.Points3D](https://www.rerun.io/docs/reference/types/archetypes/points3d) archetypes, respectively.
 """.strip()
+
+EXAMPLE_DIR: Final = Path(os.path.dirname(__file__))
+DATASET_DIR: Final = EXAMPLE_DIR / "dataset" / "pose_movement"
+DATASET_URL_BASE: Final = "https://storage.googleapis.com/rerun-example-datasets/pose_movement"
 
 
 def track_pose(video_path: str, *, segment: bool, max_frame_count: int | None) -> None:

--- a/examples/python/nuscenes/main.py
+++ b/examples/python/nuscenes/main.py
@@ -13,6 +13,15 @@ import rerun.blueprint as rrb
 from download_dataset import MINISPLIT_SCENES, download_minisplit
 from nuscenes import nuscenes
 
+DESCRIPTION = """
+# nuScenes
+
+Visualize the [nuScenes dataset](https://www.nuscenes.org/) including lidar, radar, images, and bounding boxes data.
+
+The full source code for this example is available
+[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/nuscenes/main.py).
+"""
+
 EXAMPLE_DIR: Final = pathlib.Path(os.path.dirname(__file__))
 DATASET_DIR: Final = EXAMPLE_DIR / "dataset"
 
@@ -264,12 +273,18 @@ def main() -> None:
         for sensor_name in nuscene_sensor_names(nusc, args.scene_name)
     ]
     blueprint = rrb.Vertical(
-        rrb.Spatial3DView(name="3D", origin="world"),
+        rrb.Horizontal(
+            rrb.Spatial3DView(name="3D", origin="world"),
+            rrb.TextDocumentView(origin="description", name="Description"),
+            column_shares=[3, 1],
+        ),
         rrb.Grid(*sensor_space_views),
-        row_shares=[3, 2],
+        row_shares=[4, 2],
     )
 
     rr.script_setup(args, "rerun_example_nuscenes", default_blueprint=blueprint)
+
+    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
 
     log_nuscenes(nusc, args.scene_name, max_time_sec=args.seconds)
 

--- a/examples/python/nuscenes/main.py
+++ b/examples/python/nuscenes/main.py
@@ -19,7 +19,7 @@ DESCRIPTION = """
 Visualize the [nuScenes dataset](https://www.nuscenes.org/) including lidar, radar, images, and bounding boxes data.
 
 The full source code for this example is available
-[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/nuscenes/main.py).
+[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/nuscenes).
 """
 
 EXAMPLE_DIR: Final = pathlib.Path(os.path.dirname(__file__))

--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -2,10 +2,6 @@
 """
 Load an Open Photogrammetry Format (OPF) project and display the cameras and point cloud.
 
-OPF specification: https://pix4d.github.io/opf-spec/index.html
-Dataset source: https://support.pix4d.com/hc/en-us/articles/360000235126-Example-projects-real-photogrammetry-data#OPF1
-pyopf: https://github.com/Pix4D/pyopf
-
 Requires Python 3.10 or higher because of [pyopf](https://pypi.org/project/pyopf/).
 """
 from __future__ import annotations
@@ -24,6 +20,20 @@ import tqdm
 from PIL import Image
 from pyopf.io import load
 from pyopf.resolve import resolve
+
+DESCRIPTION = """
+# Open Photogrammetry Format
+
+Visualizes an Open Photogrammetry Format (OPF) project, displaying the cameras and point cloud.
+
+The full source code for this example is available
+[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/open_photogrammetry_format/main.py).
+
+### Links
+* [OPF specification](https://pix4d.github.io/opf-spec/index.html)
+* [Dataset source](https://support.pix4d.com/hc/en-us/articles/360000235126-Example-projects-real-photogrammetry-data#OPF1)
+* [pyopf](https://github.com/Pix4D/pyopf)
+"""
 
 
 @dataclass
@@ -227,6 +237,7 @@ def main() -> None:
 
     # display everything in Rerun
     rr.script_setup(args, "rerun_example_open_photogrammetry_format")
+    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
     rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)
     project.log_point_cloud()
     project.log_calibrated_cameras(jpeg_quality=args.jpeg_quality)

--- a/examples/python/open_photogrammetry_format/main.py
+++ b/examples/python/open_photogrammetry_format/main.py
@@ -27,7 +27,7 @@ DESCRIPTION = """
 Visualizes an Open Photogrammetry Format (OPF) project, displaying the cameras and point cloud.
 
 The full source code for this example is available
-[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/open_photogrammetry_format/main.py).
+[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/open_photogrammetry_format).
 
 ### Links
 * [OPF specification](https://pix4d.github.io/opf-spec/index.html)

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -22,7 +22,7 @@ DESCRIPTION = """
 This example shows various plot types that you can create using Rerun. Common usecases for such plots would be logging
 losses or metrics over time, histograms, or general function plots.
 
-The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/plots/main.py).
+The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/plots).
 """.strip()
 
 

--- a/examples/python/plots/main.py
+++ b/examples/python/plots/main.py
@@ -22,27 +22,7 @@ DESCRIPTION = """
 This example shows various plot types that you can create using Rerun. Common usecases for such plots would be logging
 losses or metrics over time, histograms, or general function plots.
 
-## How it was made
 The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/plots/main.py).
-
-### Bar charts
-The [bar chart](recording://bar_chart) is created by logging the [rr.BarChart archetype](https://www.rerun.io/docs/reference/types/archetypes/bar_chart).
-
-### Time series
-All other plots are created using the
-[rr.Scalar archetype](https://www.rerun.io/docs/reference/types/archetypes/scalar)
-archetype.
-Each plot is created by logging scalars at different time steps (i.e., the x-axis).
-Additionally, the plots are styled using the
-[rr.SeriesLine](https://www.rerun.io/docs/reference/types/archetypes/series_line) and
-[rr.SeriesPoint](https://www.rerun.io/docs/reference/types/archetypes/series_point)
-archetypes respectively.
-
-For the [parabola](recording://curves/parabola) the radius and color is changed over time,
-the other plots use timeless for their styling properties where possible.
-
-[sin](recording://trig/sin) and [cos](recording://trig/cos) are logged with the same parent entity (i.e.,
-`trig/{cos,sin}`) which will put them in the same view by default.
 """.strip()
 
 
@@ -136,7 +116,7 @@ def main() -> None:
                 rrb.TimeSeriesView(name="Classification", origin="/classification"),
             ),
             rrb.TextDocumentView(name="Description", origin="/description"),
-            column_shares=[2, 1],
+            column_shares=[3, 1],
         ),
         rrb.SelectionPanel(expanded=False),
         rrb.TimePanel(expanded=False),

--- a/examples/python/raw_mesh/main.py
+++ b/examples/python/raw_mesh/main.py
@@ -25,7 +25,7 @@ DESCRIPTION = """
 # Raw meshes
 This example shows how you can log a hierarchial 3D mesh, including its transform hierarchy.
 
-The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/raw_mesh/main.py).
+The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/raw_mesh).
 """
 
 

--- a/examples/python/rgbd/main.py
+++ b/examples/python/rgbd/main.py
@@ -26,7 +26,7 @@ DESCRIPTION = """
 # RGBD
 Visualizes an example recording from [the NYUD dataset](https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html) with RGB and Depth channels.
 
-The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/rgbd/main.py).
+The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/rgbd).
 """
 
 DEPTH_IMAGE_SCALING: Final = 1e4

--- a/examples/python/rgbd/main.py
+++ b/examples/python/rgbd/main.py
@@ -22,6 +22,13 @@ import rerun as rr  # pip install rerun-sdk
 import rerun.blueprint as rrb
 from tqdm import tqdm
 
+DESCRIPTION = """
+# RGBD
+Visualizes an example recording from [the NYUD dataset](https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html) with RGB and Depth channels.
+
+The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/rgbd/main.py).
+"""
+
 DEPTH_IMAGE_SCALING: Final = 1e4
 DATASET_DIR: Final = Path(os.path.dirname(__file__)) / "dataset"
 DATASET_URL_BASE: Final = "https://static.rerun.io/rgbd_dataset"
@@ -169,14 +176,21 @@ def main() -> None:
             rrb.Vertical(
                 # Put the origin for both 2D spaces where the pinhole is logged. Doing so allows them to understand how they're connected to the 3D space.
                 # This enables interactions like clicking on a point in the 3D space to show the corresponding point in the 2D spaces and vice versa.
-                rrb.Spatial2DView(name="Depth & RGB", origin="world/camera/image"),
-                rrb.Spatial2DView(name="RGB", origin="world/camera/image", contents="world/camera/image/rgb"),
+                rrb.Spatial2DView(name="RGB & Depth", origin="world/camera/image"),
+                rrb.Tabs(
+                    rrb.Spatial2DView(name="RGB", origin="world/camera/image", contents="world/camera/image/rgb"),
+                    rrb.Spatial2DView(name="Depth", origin="world/camera/image", contents="world/camera/image/depth"),
+                ),
+                rrb.TextDocumentView(name="Description", origin="/description"),
                 name="2D",
+                row_shares=[3, 3, 2],
             ),
             column_shares=[2, 1],
         ),
     )
     recording_path = ensure_recording_downloaded(args.recording)
+
+    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
 
     log_nyud_data(
         recording_path=recording_path,

--- a/examples/python/rrt-star/main.py
+++ b/examples/python/rrt-star/main.py
@@ -26,6 +26,21 @@ from typing import Annotated, Generator, Literal
 import numpy as np
 import numpy.typing as npt
 import rerun as rr
+import rerun.blueprint as rrb
+
+DESCRIPTION = """
+Visualizes the path finding algorithm RRT* in a simple environment.
+
+The algorithm finds a [path](recording://map/path) between two points by randomly expanding a [tree](recording://map/tree/edges) from the [start point](recording://map/start).
+After it has added a [random edge](recording://map/new/new_edge) to the tree it looks at [nearby nodes](recording://map/new/close_nodes) to check if it's faster to reach them through this [new edge](recording://map/new/new_edge) instead, and if so it changes the parent of these nodes.
+This ensures that the algorithm will converge to the optimal path given enough time.
+
+A more detailed explanation can be found in the original paper
+Karaman, S. Frazzoli, S. 2011. "Sampling-based algorithms for optimal motion planning".
+or in [this medium article](https://theclassytim.medium.com/robotic-path-planning-rrt-and-rrt-212319121378).
+
+The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/rrt-star/main.py).
+""".strip()
 
 Point2D = Annotated[npt.NDArray[np.float64], Literal[2]]
 
@@ -259,7 +274,13 @@ def main() -> None:
     parser.add_argument("--max-step-size", type=float, default=0.1)
     parser.add_argument("--iterations", type=int, help="How many iterations it should do")
     args = parser.parse_args()
-    rr.script_setup(args, "rerun_example_rrt_star")
+
+    blueprint = rrb.Horizontal(
+        rrb.Spatial2DView(name="Map", origin="/map"),
+        rrb.TextDocumentView(name="Description", origin="/description"),
+        column_shares=[3, 1],
+    )
+    rr.script_setup(args, "rerun_example_rrt_star", default_blueprint=blueprint)
 
     max_step_size = args.max_step_size
     neighborhood_size = max_step_size * 1.5
@@ -268,23 +289,7 @@ def main() -> None:
     end_point = np.array([1.8, 0.5])
 
     rr.set_time_sequence("step", 0)
-    rr.log(
-        "description",
-        rr.TextDocument(
-            """
-Visualizes the path finding algorithm RRT* in a simple environment.
-
-The algorithm finds a [path](recording://map/path) between two points by randomly expanding a [tree](recording://map/tree/edges) from the [start point](recording://map/start).
-After it has added a [random edge](recording://map/new/new_edge) to the tree it looks at [nearby nodes](recording://map/new/close_nodes) to check if it's faster to reach them through this [new edge](recording://map/new/new_edge) instead, and if so it changes the parent of these nodes.
-This ensures that the algorithm will converge to the optimal path given enough time.
-
-A more detailed explanation can be found in the original paper
-Karaman, S. Frazzoli, S. 2011. "Sampling-based algorithms for optimal motion planning".
-or in [this medium article](https://theclassytim.medium.com/robotic-path-planning-rrt-and-rrt-212319121378)
-            """.strip(),
-            media_type=rr.MediaType.MARKDOWN,
-        ),
-    )
+    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
     rr.log(
         "map/start",
         rr.Points2D([start_point], radii=0.02, colors=[[255, 255, 255, 255]]),

--- a/examples/python/rrt-star/main.py
+++ b/examples/python/rrt-star/main.py
@@ -39,7 +39,7 @@ A more detailed explanation can be found in the original paper
 Karaman, S. Frazzoli, S. 2011. "Sampling-based algorithms for optimal motion planning".
 or in [this medium article](https://theclassytim.medium.com/robotic-path-planning-rrt-and-rrt-212319121378).
 
-The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/rrt-star/main.py).
+The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/rrt-star).
 """.strip()
 
 Point2D = Annotated[npt.NDArray[np.float64], Literal[2]]

--- a/examples/python/segment_anything_model/main.py
+++ b/examples/python/segment_anything_model/main.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 """
-Example of using Rerun to log and visualize the output of segment-anything.
-
-See: [segment_anything](https://segment-anything.com/).
+Example of using Rerun to log and visualize the output of [Segment Anything](https://segment-anything.com/).
 
 Can be used to test mask-generation on one or more images. Images can be local file-paths
 or remote urls.
@@ -29,12 +27,19 @@ import cv2
 import numpy as np
 import requests
 import rerun as rr  # pip install rerun-sdk
+import rerun.blueprint as rrb
 import torch
 import torchvision
 from cv2 import Mat
 from segment_anything import SamAutomaticMaskGenerator, sam_model_registry
 from segment_anything.modeling import Sam
 from tqdm import tqdm
+
+DESCRIPTION = """
+Example of using Rerun to log and visualize the output of [Segment Anything](https://segment-anything.com/).
+
+The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/segment_anything_model/main.py).
+""".strip()
 
 MODEL_DIR: Final = Path(os.path.dirname(__file__)) / "model"
 MODEL_URLS: Final = {
@@ -177,9 +182,21 @@ def main() -> None:
     rr.script_add_args(parser)
     args = parser.parse_args()
 
-    rr.script_setup(args, "rerun_example_segment_anything_model")
+    blueprint = rrb.Vertical(
+        rrb.Spatial2DView(name="Image and segmentation mask", origin="/image"),
+        rrb.Horizontal(
+            rrb.TextLogView(name="Log", origin="/logs"),
+            rrb.TextDocumentView(name="Description", origin="/description"),
+            column_shares=[2, 1],
+        ),
+        row_shares=[3, 1],
+    )
+
+    rr.script_setup(args, "rerun_example_segment_anything_model", default_blueprint=blueprint)
     logging.getLogger().addHandler(rr.LoggingHandler("logs"))
     logging.getLogger().setLevel(logging.INFO)
+
+    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
 
     sam = create_sam(args.model, args.device)
 

--- a/examples/python/segment_anything_model/main.py
+++ b/examples/python/segment_anything_model/main.py
@@ -38,7 +38,7 @@ from tqdm import tqdm
 DESCRIPTION = """
 Example of using Rerun to log and visualize the output of [Segment Anything](https://segment-anything.com/).
 
-The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/segment_anything_model/main.py).
+The full source code for this example is available [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/segment_anything_model).
 """.strip()
 
 MODEL_DIR: Final = Path(os.path.dirname(__file__)) / "model"

--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -19,13 +19,8 @@ import rerun.blueprint as rrb
 from read_write_model import Camera, read_model
 from tqdm import tqdm
 
-DATASET_DIR: Final = Path(os.path.dirname(__file__)) / "dataset"
-DATASET_URL_BASE: Final = "https://storage.googleapis.com/rerun-example-datasets/colmap"
-# When dataset filtering is turned on, drop views with less than this many valid points.
-FILTER_MIN_VISIBLE: Final = 500
-
 DESCRIPTION = """
-# Sparse Reconstruction by COLMAP
+# Sparse reconstruction by COLMAP
 This example was generated from the output of a sparse reconstruction done with COLMAP.
 
 [COLMAP](https://colmap.github.io/index.html) is a general-purpose Structure-from-Motion (SfM) and Multi-View Stereo
@@ -34,46 +29,14 @@ This example was generated from the output of a sparse reconstruction done with 
 In this example a short video clip has been processed offline by the COLMAP pipeline, and we use Rerun to visualize the
 individual camera frames, estimated camera poses, and resulting point clouds over time.
 
-## How it was made
 The full source code for this example is available
 [on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/structure_from_motion/main.py).
-
-### Images
-The images are logged through the [rr.Image archetype](https://www.rerun.io/docs/reference/types/archetypes/image)
-to the [camera/image entity](recording://camera/image).
-
-### Cameras
-The images stem from pinhole cameras located in the 3D world. To visualize the images in 3D, the pinhole projection has
-to be logged and the camera pose (this is often referred to as the intrinsics and extrinsics of the camera,
-respectively).
-
-The [rr.Pinhole archetype](https://www.rerun.io/docs/reference/types/archetypes/pinhole) is logged to
-the [camera/image entity](recording://camera/image) and defines the intrinsics of the camera. This defines how to go
-from the 3D camera frame to the 2D image plane. The extrinsics are logged as an
-[rr.Transform3D archetype](https://www.rerun.io/docs/reference/types/archetypes/transform3d) to the
-[camera entity](recording://camera).
-
-### Reprojection error
-For each image a [rr.Scalar archetype](https://www.rerun.io/docs/reference/types/archetypes/scalar)
-containing the average reprojection error of the keypoints is logged to the
-[plot/avg_reproj_err entity](recording://plot/avg_reproj_err).
-
-### 2D points
-The 2D image points that are used to triangulate the 3D points are visualized by logging
-[rr.Points3D archetype](https://www.rerun.io/docs/reference/types/archetypes/points2d)
-to the [camera/image/keypoints entity](recording://camera/image/keypoints). Note that these keypoints are a child of the
-[camera/image entity](recording://camera/image), since the points should show in the image plane.
-
-### Colored 3D points
-The colored 3D points were added to the scene by logging the
-[rr.Points3D archetype](https://www.rerun.io/docs/reference/types/archetypes/points3d)
-to the [points entity](recording://points):
-```python
-rr.log("points", rr.Points3D(points, colors=point_colors), rr.AnyValues(error=point_errors))
-```
-**Note:** we added some [custom per-point errors](recording://points) that you can see when you
-hover over the points in the 3D view.
 """.strip()
+
+DATASET_DIR: Final = Path(os.path.dirname(__file__)) / "dataset"
+DATASET_URL_BASE: Final = "https://storage.googleapis.com/rerun-example-datasets/colmap"
+# When dataset filtering is turned on, drop views with less than this many valid points.
+FILTER_MIN_VISIBLE: Final = 500
 
 
 def scale_camera(camera: Camera, resize: tuple[int, int]) -> tuple[Camera, npt.NDArray[np.float_]]:

--- a/examples/python/structure_from_motion/main.py
+++ b/examples/python/structure_from_motion/main.py
@@ -30,7 +30,7 @@ In this example a short video clip has been processed offline by the COLMAP pipe
 individual camera frames, estimated camera poses, and resulting point clouds over time.
 
 The full source code for this example is available
-[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/structure_from_motion/main.py).
+[on GitHub](https://github.com/rerun-io/rerun/blob/latest/examples/python/structure_from_motion).
 """.strip()
 
 DATASET_DIR: Final = Path(os.path.dirname(__file__)) / "dataset"


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5440

All `main` and `nightly` examples now include an inline markdown description. I made sure it is not too long. I've adjusted the blueprints where suitable.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5855)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5855?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5855?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5855)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)