### PR TITLE
Pin `mediapipe` to 0.10.9 to fix Human Pose Tracking example

### DIFF
--- a/examples/python/face_tracking/requirements.txt
+++ b/examples/python/face_tracking/requirements.txt
@@ -1,4 +1,7 @@
-mediapipe>=0.10.1 ; python_version <= '3.11' # no 3.12 version yet (https://pypi.org/project/mediapipe/)
+# no 3.12 version yet (https://pypi.org/project/mediapipe/)
+# 0.10.10 no longer supports the legacy Pose model: https://github.com/rerun-io/rerun/issues/5859
+mediapipe==0.10.9 ; python_version <= '3.11'
+
 numpy
 opencv-python>4.6 # Avoid opencv-4.6 since it rotates images incorrectly (https://github.com/opencv/opencv/issues/22088)
 requests

--- a/examples/python/gesture_detection/requirements.txt
+++ b/examples/python/gesture_detection/requirements.txt
@@ -1,4 +1,7 @@
-mediapipe==0.10.9 ; python_version <= '3.11' # no 3.12 version yet (https://pypi.org/project/mediapipe/) # For mac also you may need to run this: export SYSTEM_VERSION_COMPAT=0
+# no 3.12 version yet (https://pypi.org/project/mediapipe/)
+# 0.10.10 no longer supports the legacy Pose model: https://github.com/rerun-io/rerun/issues/5859
+mediapipe==0.10.9 ; python_version <= '3.11'
+
 numpy
 opencv-python>4.9
 requests>=2.31,<3

--- a/examples/python/human_pose_tracking/requirements.txt
+++ b/examples/python/human_pose_tracking/requirements.txt
@@ -1,4 +1,7 @@
-mediapipe>=0.10.9 ; python_version <= '3.11' # no 3.12 version yet (https://pypi.org/project/mediapipe/)
+# no 3.12 version yet (https://pypi.org/project/mediapipe/)
+# 0.10.10 no longer supports the legacy Pose model: https://github.com/rerun-io/rerun/issues/5859
+mediapipe==0.10.9 ; python_version <= '3.11'
+
 numpy
 opencv-python>4.6 # Avoid opencv-4.6 since it rotates images incorrectly (https://github.com/opencv/opencv/issues/22088)
 requests>=2.31,<3


### PR DESCRIPTION
### What

Pin `mediapipe==0.10.9` becasue we're using a legacy model in Human Pos Tracking. We should migrate to the newer model:
- https://github.com/rerun-io/rerun/issues/5859

I pinned the version in all 3 media pipe examples and tested them to work:
- human pose tracking
- face detection
- gesture recognition

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}})
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
