### PR TITLE
Update `egui_commonmark`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,9 +1655,9 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30fc4d40a8ef399a8debfbdae0462ca45912d81b9e81b24373337669e961201"
+checksum = "013480797931a2649e03069613ed35514569372d6f79df70fc3653ae18a75c6c"
 dependencies = [
  "egui",
  "egui_extras",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ egui = { version = "0.27.2", features = [
   "puffin",
   "rayon",
 ] }
-egui_commonmark = { version = "0.14", default-features = false }
+egui_commonmark = { version = "0.15", default-features = false }
 egui_extras = { version = "0.27.2", features = ["http", "image", "puffin"] }
 egui_plot = "0.27.2"
 egui_tiles = "0.8.0"


### PR DESCRIPTION
### What
Seems pretty safe - i tested a handful of examples, and all their inline markdown looks as good or better.

https://github.com/lampsitter/egui_commonmark/blob/master/CHANGELOG.md

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5864)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5864?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5864?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5864)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)