### PR TITLE
Remove the deprecated `writing_rules.md`

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,7 +3,7 @@ Guidelines for UI design, covering GUI, CLI, documentation, log messages, etc
 
 ## Text
 #### Sentences
-Short, single-sentence text do NOT end in a period.
+Short, single-sentence text do NOT end in a period in the UI.
 
 Multi-sentence text ALWAYS ends in a period.
 

--- a/design/writing_rules.md
+++ b/design/writing_rules.md
@@ -1,9 +1,0 @@
-# Writing rules
-
-This document summaries the writing rules regarding the visible text in the UI.
-
-1. If the text string references a coding convention, use the casing that respects the coding convention. E.g. `COLMAP`,  `translate3d` or `InstanceMethod`.
-2. Default to `Sentence case like this` for most elements in the UI.
-3. Rerun concepts are Title Cased: `Space View`, `Selection View`, `Command Palette`,  `Memory Panel`, `Entity`, etc.
-4. Only end sentences with a period when there are multiple sentences in the current context. For instance, if a tooltip contains two sentences, both should end with a period.
-5. Never use colons `:` when labeling a UI field.


### PR DESCRIPTION
I didn't find this when writing DESIGN.md
### Checklist
* [x] I made at least one tickmark