### PR TITLE
Always create a tree with a container even if we have no space-views

### DIFF
--- a/crates/re_viewport/src/auto_layout.rs
+++ b/crates/re_viewport/src/auto_layout.rs
@@ -23,10 +23,6 @@ pub(crate) fn tree_from_space_views(
 ) -> egui_tiles::Tree<SpaceViewId> {
     re_log::trace!("Auto-layout of {} space views", space_views.len());
 
-    if space_views.is_empty() {
-        return egui_tiles::Tree::empty("viewport_tree");
-    }
-
     let space_make_infos = space_views
         .iter()
         // Sort for determinism:

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -191,7 +191,7 @@ impl<'a, 'b> Viewport<'a, 'b> {
         let mut edited = false;
 
         // If the blueprint tree is empty/missing we need to auto-layout.
-        let tree = if blueprint.tree.is_empty() && !blueprint.space_views.is_empty() {
+        let tree = if blueprint.tree.is_empty() {
             edited = true;
             super::auto_layout::tree_from_space_views(
                 space_view_class_registry,


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/5852

The UI doesn't work properly if we have an empty tree view. Normally things cause us to get out of this state, but if auto_space_views is off this never happens. Instead we don't special-case empty space views and always create the default tree with the grid container.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5871)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5871?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5871?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5871)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)