### PR TITLE
Always generate a random blueprint id to avoid updating an existing blueprint

### DIFF
--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -572,8 +572,6 @@ def create_in_memory_blueprint(*, application_id: str, blueprint: BlueprintLike)
     blueprint_stream = RecordingStream(
         bindings.new_blueprint(
             application_id=application_id,
-            # Generate a new id every time so we don't append to overwrite previous blueprints.
-            blueprint_id=str(uuid.uuid4()),
             make_default=False,
             make_thread_default=False,
             default_enabled=True,

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -275,7 +275,6 @@ fn new_recording(
 #[pyfunction]
 #[pyo3(signature = (
     application_id,
-    blueprint_id=None,
     make_default=true,
     make_thread_default=true,
     default_enabled=true,
@@ -283,16 +282,13 @@ fn new_recording(
 fn new_blueprint(
     py: Python<'_>,
     application_id: String,
-    blueprint_id: Option<String>,
     make_default: bool,
     make_thread_default: bool,
     default_enabled: bool,
 ) -> PyResult<PyRecordingStream> {
-    let blueprint_id = if let Some(blueprint_id) = blueprint_id {
-        StoreId::from_string(StoreKind::Blueprint, blueprint_id)
-    } else {
-        default_store_id(py, StoreKind::Blueprint, &application_id)
-    };
+    // We don't currently support additive blueprints, so we should always be generating a new, unique
+    // blueprint id to avoid collisions.
+    let blueprint_id = StoreId::random(StoreKind::Blueprint);
 
     let mut batcher_config = re_log_types::DataTableBatcherConfig::from_env().unwrap_or_default();
     let on_release = |chunk| {


### PR DESCRIPTION
### What
- Fixes issues identified during testing

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5872)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5872?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5872?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5872)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)