### PR TITLE
Removed unreleased/speculative-links for 0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,15 +46,15 @@ Blueprints are currently only supported in the Python API, with C++ and Rust sup
 
 
 ### ✨ Overview & highlights
-- 🟦 Configure the layout and content of space views from Python [(docs)](https://www.rerun.io/docs/howto/configure-viewer-through-code?speculative-link)
-- 🖧 More powerful and flexible data loaders [(docs)](https://www.rerun.io/docs/reference/dataloaders?speculative-link)
+- 🟦 Configure the layout and content of space views from Python [(docs)](https://www.rerun.io/docs/howto/configure-viewer-through-code)
+- 🖧 More powerful and flexible data loaders [(docs)](https://www.rerun.io/docs/reference/data-loaders)
 - 🖵 Improved UI for managing recordings and applications
 - 💾 Save and load blueprint files in the viewer
 - 🎨 Configurable background color for 3D Space Views [#5443](https://github.com/rerun-io/rerun/pull/5443)
 - 💪 Linux ARM64 support [#5489](https://github.com/rerun-io/rerun/pull/5489) [#5503](https://github.com/rerun-io/rerun/pull/5503) [#5511](https://github.com/rerun-io/rerun/pull/5511)
 - 🖼️ Show examples in the welcome page
 - 🖱️ Improve context-menu when right-clicking items in the blueprint panel and streams tree
-- ❌ Remove `InstanceKey` from our logging APIs [#5395](https://github.com/rerun-io/rerun/pull/5395) ([migration guide](https://www.rerun.io/docs/reference/migration/migration-0-15?speculative-link))
+- ❌ Remove `InstanceKey` from our logging APIs [#5395](https://github.com/rerun-io/rerun/pull/5395) ([migration guide](https://www.rerun.io/docs/reference/migration/migration-0-15))
 - ❌ Remove groups from blueprints panel [#5326](https://github.com/rerun-io/rerun/pull/5326)
 
 ### 🔎 Details

--- a/crates/re_types/definitions/rerun/blueprint/archetypes/background_3d.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/archetypes/background_3d.fbs
@@ -12,8 +12,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Configuration for the background of the 3D space view.
 table Background3D (
-    "attr.rerun.scope": "blueprint",
-    "attr.docs.unreleased"
+    "attr.rerun.scope": "blueprint"
 ) {
     // --- Required ---
 

--- a/crates/re_types/definitions/rerun/blueprint/components/background_3d_kind.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/background_3d_kind.fbs
@@ -10,8 +10,7 @@ namespace rerun.blueprint.components;
 
 /// The type of the background in 3D space views.
 enum Background3DKind: byte (
-    "attr.rerun.scope": "blueprint",
-    "attr.docs.unreleased"
+    "attr.rerun.scope": "blueprint"
 ) {
     /// Gradient depending on the direction of the view, dark theme.
     GradientDark (default),

--- a/crates/re_types/definitions/rerun/blueprint/components/container_kind.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/components/container_kind.fbs
@@ -11,8 +11,7 @@ namespace rerun.blueprint.components;
 /// The kind of a blueprint container (tabs, grid, …).
 enum ContainerKind: byte (
     "attr.rerun.scope": "blueprint",
-    "attr.rust.override_crate": "re_viewport",
-    "attr.docs.unreleased"
+    "attr.rust.override_crate": "re_viewport"
 ) {
     Tabs,
     Horizontal,

--- a/crates/re_types/definitions/rerun/blueprint/datatypes/visible_time_range.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/datatypes/visible_time_range.fbs
@@ -11,8 +11,7 @@ namespace rerun.blueprint.datatypes;
 
 /// Kind of boundary for visible history, see `VisibleTimeRangeBoundary`.
 enum VisibleTimeRangeBoundaryKind: byte (
-  "attr.rerun.scope": "blueprint",
-  "attr.docs.unreleased"
+  "attr.rerun.scope": "blueprint"
 ) {
   /// Boundary is a value relative to the time cursor.
   RelativeToTimeCursor,
@@ -26,8 +25,7 @@ enum VisibleTimeRangeBoundaryKind: byte (
 
 /// Type of boundary for visible history.
 struct VisibleTimeRangeBoundary (
-  "attr.rerun.scope": "blueprint",
-  "attr.docs.unreleased"
+  "attr.rerun.scope": "blueprint"
 ) {
   /// Type of the boundary.
   kind: rerun.blueprint.datatypes.VisibleTimeRangeBoundaryKind (order: 100);
@@ -39,8 +37,7 @@ struct VisibleTimeRangeBoundary (
 /// Visible time range bounds.
 struct VisibleTimeRange (
   "attr.rerun.scope": "blueprint",
-  "attr.rust.derive": "PartialEq, Eq",
-  "attr.docs.unreleased"
+  "attr.rust.derive": "PartialEq, Eq"
 ) {
   // TODO(andreas): Split this up into two separate components.
 

--- a/crates/re_types/definitions/rerun/components/marker_shape.fbs
+++ b/crates/re_types/definitions/rerun/components/marker_shape.fbs
@@ -8,9 +8,8 @@ include "rerun/attributes.fbs";
 namespace rerun.components;
 
 /// Shape of a marker.
-enum MarkerShape: byte (
-    "attr.docs.unreleased"
-) {
+enum MarkerShape: byte
+ {
     Circle (default),
     Diamond,
     Square,

--- a/crates/re_types/definitions/rerun/datatypes/bool.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/bool.fbs
@@ -16,8 +16,7 @@ struct Bool (
     "attr.python.aliases": "bool",
     "attr.rust.derive": "Copy, Default, PartialEq, Eq, PartialOrd, Ord",
     "attr.rust.repr": "transparent",
-    "attr.rust.tuple_struct",
-    "attr.docs.unreleased"
+    "attr.rust.tuple_struct"
 ) {
     value: bool (order: 100);
 }

--- a/crates/re_types/definitions/rerun/datatypes/time_int.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/time_int.fbs
@@ -9,7 +9,6 @@ namespace rerun.datatypes;
 
 /// A 64-bit number describing either nanoseconds OR sequence numbers.
 struct TimeInt (
-  "attr.docs.unreleased",
   "attr.arrow.transparent",
   "attr.rust.derive": "Copy, PartialEq, Eq, PartialOrd, Ord",
   "attr.rust.tuple_struct",

--- a/crates/re_types/definitions/rerun/datatypes/uint64.fbs
+++ b/crates/re_types/definitions/rerun/datatypes/uint64.fbs
@@ -13,8 +13,7 @@ struct UInt64 (
   "attr.python.array_aliases": "int, npt.NDArray[np.uint64]",
   "attr.rust.derive": "Copy, PartialEq, Eq, PartialOrd, Ord",
   "attr.rust.override_crate": "re_types_core",
-  "attr.rust.tuple_struct",
-  "attr.docs.unreleased"
+  "attr.rust.tuple_struct"
 ) {
   value: uint64 (order: 100);
 }

--- a/docs/content/getting-started/configure-the-viewer/through-code-tutorial.md
+++ b/docs/content/getting-started/configure-the-viewer/through-code-tutorial.md
@@ -7,7 +7,7 @@ This tutorial will walk you through using the
 [Blueprint APIs](../../howto/configure-viewer-through-code.md) to better control
 the layout and appearance of your data in the Rerun Viewer in Python.
 
-This walkthrough is based on the [stock charts](https://github.com/rerun-io/rerun/tree/main/examples/python/blueprint_stocks?speculative-link) example.
+This walkthrough is based on the [stock charts](https://github.com/rerun-io/rerun/tree/main/examples/python/blueprint_stocks) example.
 The main differences between this tutorial and the linked example are related to additional processing of
 command-line flags, which are omitted here for simplicity.
 

--- a/docs/content/getting-started/data-in/open-any-file.md
+++ b/docs/content/getting-started/data-in/open-any-file.md
@@ -27,7 +27,7 @@ With the exception of `rrd` files that can be streamed from an HTTP URL (e.g. `r
 
 ## Logging file contents from the SDK
 
-To log the contents of a file from the SDK you can use the `log_file_from_path` and `log_file_from_contents` methods ([C++](https://ref.rerun.io/docs/cpp/stable/classrerun_1_1RecordingStream.html#SOME_HASH_TBD?speculative-link), [Python](https://ref.rerun.io/docs/python/stable/common/other_classes_and_functions/#rerun.log_file_from_path?speculative-link), [Rust](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.log_file_from_path)) and the associated examples ([C++](https://github.com/rerun-io/rerun/blob/main/examples/cpp/log_file/main.cpp), [Python](https://github.com/rerun-io/rerun/blob/main/examples/python/log_file/main.py), [Rust](https://github.com/rerun-io/rerun/blob/main/examples/rust/log_file/src/main.rs)).
+To log the contents of a file from the SDK you can use the `log_file_from_path` and `log_file_from_contents` methods ([C++](https://ref.rerun.io/docs/cpp/stable/classrerun_1_1RecordingStream.html#a8f253422a7adc2a19b89d1538c05bcac), [Python](https://ref.rerun.io/docs/python/stable/common/other_classes_and_functions/#rerun.log_file_from_path), [Rust](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.log_file_from_path)) and the associated examples ([C++](https://github.com/rerun-io/rerun/blob/main/examples/cpp/log_file/main.cpp), [Python](https://github.com/rerun-io/rerun/blob/main/examples/python/log_file/main.py), [Rust](https://github.com/rerun-io/rerun/blob/main/examples/rust/log_file/src/main.rs)).
 
 Note: when calling these APIs from the SDK, the data will be loaded by the process running the SDK, not the Viewer!
 

--- a/docs/content/howto/configure-viewer-through-code.md
+++ b/docs/content/howto/configure-viewer-through-code.md
@@ -11,7 +11,7 @@ Future releases will add support for the full scope of blueprint. See issues: [#
 
 ## Blueprint API overview
 
-All blueprint APIs are in the [`rerun.blueprint`](https://ref.rerun.io/docs/python/stable/common/blueprint_apis/?speculative-link) namespace. In our python examples, we typically import this using the `rrb` alias:
+All blueprint APIs are in the [`rerun.blueprint`](https://ref.rerun.io/docs/python/stable/common/blueprint_apis/) namespace. In our python examples, we typically import this using the `rrb` alias:
 
 ```python
 import rerun.blueprint as rrb

--- a/docs/content/reference/types/components/marker_shape.md
+++ b/docs/content/reference/types/components/marker_shape.md
@@ -18,9 +18,9 @@ Shape of a marker.
 * Asterisk
 
 ## Links
- * 🌊 [C++ API docs for `MarkerShape`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1MarkerShape.html?speculative-link)
- * 🐍 [Python API docs for `MarkerShape`](https://ref.rerun.io/docs/python/stable/common/components?speculative-link#rerun.components.MarkerShape)
- * 🦀 [Rust API docs for `MarkerShape`](https://docs.rs/rerun/latest/rerun/components/enum.MarkerShape.html?speculative-link)
+ * 🌊 [C++ API docs for `MarkerShape`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1MarkerShape.html)
+ * 🐍 [Python API docs for `MarkerShape`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MarkerShape)
+ * 🦀 [Rust API docs for `MarkerShape`](https://docs.rs/rerun/latest/rerun/components/enum.MarkerShape.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/bool.md
+++ b/docs/content/reference/types/datatypes/bool.md
@@ -9,8 +9,8 @@ A single boolean.
 * value: `bool`
 
 ## Links
- * 🌊 [C++ API docs for `Bool`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Bool.html?speculative-link)
- * 🐍 [Python API docs for `Bool`](https://ref.rerun.io/docs/python/stable/common/datatypes?speculative-link#rerun.datatypes.Bool)
- * 🦀 [Rust API docs for `Bool`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Bool.html?speculative-link)
+ * 🌊 [C++ API docs for `Bool`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Bool.html)
+ * 🐍 [Python API docs for `Bool`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Bool)
+ * 🦀 [Rust API docs for `Bool`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Bool.html)
 
 

--- a/docs/content/reference/types/datatypes/time_int.md
+++ b/docs/content/reference/types/datatypes/time_int.md
@@ -9,8 +9,8 @@ A 64-bit number describing either nanoseconds OR sequence numbers.
 * value: `i64`
 
 ## Links
- * 🌊 [C++ API docs for `TimeInt`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TimeInt.html?speculative-link)
- * 🐍 [Python API docs for `TimeInt`](https://ref.rerun.io/docs/python/stable/common/datatypes?speculative-link#rerun.datatypes.TimeInt)
- * 🦀 [Rust API docs for `TimeInt`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TimeInt.html?speculative-link)
+ * 🌊 [C++ API docs for `TimeInt`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TimeInt.html)
+ * 🐍 [Python API docs for `TimeInt`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TimeInt)
+ * 🦀 [Rust API docs for `TimeInt`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TimeInt.html)
 
 

--- a/docs/content/reference/types/datatypes/uint64.md
+++ b/docs/content/reference/types/datatypes/uint64.md
@@ -9,8 +9,8 @@ A 64bit unsigned integer.
 * value: `u64`
 
 ## Links
- * 🌊 [C++ API docs for `UInt64`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UInt64.html?speculative-link)
- * 🐍 [Python API docs for `UInt64`](https://ref.rerun.io/docs/python/stable/common/datatypes?speculative-link#rerun.datatypes.UInt64)
- * 🦀 [Rust API docs for `UInt64`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt64.html?speculative-link)
+ * 🌊 [C++ API docs for `UInt64`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UInt64.html)
+ * 🐍 [Python API docs for `UInt64`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UInt64)
+ * 🦀 [Rust API docs for `UInt64`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt64.html)
 
 


### PR DESCRIPTION
### What
Remove the speculative-link markers.

This should be the last thing we merge since PR jobs will fail link tests after this until the release.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5876)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5876?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5876?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5876)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)