### PR TITLE
Fix timeout in notebooks by making the app_url correctly point to app.rerun.io

### DIFF
--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -1107,6 +1107,10 @@ fn get_app_url() -> String {
 
     let build_info = re_build_info::build_info!();
 
+    // Note that it is important to us `app.rerun.io` directly here. The version hosted
+    // at `rerun.io/viewer` is not designed to be embedded in a notebook and interferes
+    // with the startup sequencing. Do not switch to `rerun.io/viewer` without considering
+    // the implications.
     if build_info.is_final() {
         format!("https://app.rerun.io/version/{}", build_info.version)
     } else if let Some(short_git_hash) = build_info.git_hash.get(..7) {

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -1096,7 +1096,7 @@ fn version() -> String {
 
 /// Get a url to an instance of the web-viewer
 ///
-/// This may point to rerun.io/viewer or localhost depending on
+/// This may point to app.rerun.io or localhost depending on
 /// whether [`start_web_viewer_server()`] was called.
 #[pyfunction]
 fn get_app_url() -> String {
@@ -1106,13 +1106,16 @@ fn get_app_url() -> String {
     }
 
     let build_info = re_build_info::build_info!();
-    if let Some(short_git_hash) = build_info.git_hash.get(..7) {
-        format!("https://rerun.io/viewer/commit/{short_git_hash}")
+
+    if build_info.is_final() {
+        format!("https://app.rerun.io/version/{}", build_info.version)
+    } else if let Some(short_git_hash) = build_info.git_hash.get(..7) {
+        format!("https://app.rerun.io/commit/{short_git_hash}")
     } else {
         re_log::warn_once!(
-            "No valid git hash found in build info. Defaulting to rerun.io/viewer for app url."
+            "No valid git hash found in build info. Defaulting to app.rerun.io for app url."
         );
-        "https://rerun.io/viewer".to_owned()
+        "https://app.rerun.io".to_owned()
     }
 }
 


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/5878

Notebooks need to go to `app.rerun.io`, not `rerun.io/viewer`.

Also go to versioned releases if the app is versioned instead of always using the sha.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5877)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5877?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5877?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5877)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)