### PR TITLE
Fix visible range not working

### DIFF
--- a/crates/re_viewer_context/src/space_view/view_query.rs
+++ b/crates/re_viewer_context/src/space_view/view_query.rs
@@ -322,7 +322,8 @@ impl DataResult {
             .and_then(|OverridePath { store_kind, path }| match store_kind {
                 // TODO(#5607): what should happen if the promise is still pending?
                 StoreKind::Blueprint => ctx
-                    .recording()
+                    .store_context
+                    .blueprint
                     .latest_at_component::<C>(path, ctx.blueprint_query),
                 StoreKind::Recording => ctx
                     .recording()


### PR DESCRIPTION
Typo during the great rebase that resulted in a massive never-ending conflict with the store hub changes :sob: 

I might do a follow-up to try and protect against it somehow -- whether at compile time or run time.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5891)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5891?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5891?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5891)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)