### PR TITLE
Fix python lints, make python lint ci conditional

### DIFF
--- a/.github/workflows/auto_release_crates.yml
+++ b/.github/workflows/auto_release_crates.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -100,7 +100,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Codegen check
         shell: bash
@@ -211,7 +211,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -291,7 +291,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       # TODO(emilk): make this work somehow. Right now this just results in
       # > Compiler: GNU 12.3.0 (/__w/rerun/rerun/.pixi/env/bin/x86_64-conda-linux-gnu-c++)

--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       # These should already be in the docker container, but run for good measure. A no-op install
       # should be fast, and this way things don't break if we add new packages without rebuilding

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,6 +31,13 @@ jobs:
       ALL_CHECKS: true
     secrets: inherit
 
+  checks-python:
+    name: Checks
+    uses: ./.github/workflows/reusable_checks_python.yml
+    with:
+      CONCURRENCY: nightly
+    secrets: inherit
+
   build-web:
     name: "Build Web"
     uses: ./.github/workflows/reusable_build_web.yml

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -69,6 +69,8 @@ jobs:
           filters: |
             python_changes:
               - '**/*.py'
+              - '**/requirements.txt'
+              - '**/pyproject.toml'
 
   docs-paths-filter:
     runs-on: ubuntu-latest

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -55,6 +55,21 @@ jobs:
               - '**/CMakeLists.txt'
               - '**/*cmake'
 
+  python-paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      python_changes: ${{ steps.filter.outputs.python_changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            python_changes:
+              - '**/*.py'
+
   docs-paths-filter:
     runs-on: ubuntu-latest
     outputs:
@@ -78,6 +93,16 @@ jobs:
     # Wait for the rust-paths-filter to be completed before starting.
     needs: rust-paths-filter
     uses: ./.github/workflows/reusable_checks_rust.yml
+    with:
+      CONCURRENCY: pr-${{ github.event.pull_request.number }}
+    secrets: inherit
+
+  python-checks:
+    name: "Python Checks"
+    if: github.event.pull_request.head.repo.owner.login == 'rerun-io' && needs.python-paths-filter.outputs.python_changes == 'true'
+    # Wait for the python-paths-filter to be completed before starting.
+    needs: python-paths-filter
+    uses: ./.github/workflows/reusable_checks_python.yml
     with:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}
     secrets: inherit

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -28,6 +28,13 @@ jobs:
       CONCURRENCY: push-${{ github.ref_name }}
     secrets: inherit
 
+  python_checks:
+    name: Checks
+    uses: ./.github/workflows/reusable_checks_python.yml
+    with:
+      CONCURRENCY: push-${{ github.ref_name }}
+    secrets: inherit
+
   # Check that a CLEAN container with just `cargo` on it can build rerun:
   clean-build:
     name: cargo build on clean container

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Update crate versions
         id: versioning
@@ -392,7 +392,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -152,7 +152,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Build web-viewer (release)
         shell: bash

--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -179,7 +179,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/reusable_build_examples.yml
+++ b/.github/workflows/reusable_build_examples.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Download Wheel
         uses: actions/download-artifact@v3

--- a/.github/workflows/reusable_build_js.yml
+++ b/.github/workflows/reusable_build_js.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.3.0
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Build web-viewer (release)
         shell: bash

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -43,28 +43,11 @@ jobs:
         with:
           pixi-version: v0.16.1
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-          cache: "pip"
-          cache-dependency-path: "rerun_py/requirements-lint.txt"
-
-      - name: Install Python dependencies
-        shell: bash
-        run: |
-          pip install --upgrade pip
-          pip install -r rerun_py/requirements-lint.txt
-
       - name: Python format check
-        shell: bash
-        run: |
-          pixi run py-fmt-check
+        run: pixi run py-fmt-check
 
       - name: Lint Python
-        shell: bash
-        run: |
-          pixi run py-lint
+        run: pixi run py-lint
 
   # ---------------------------------------------------------------------------
 

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Python format check
         run: pixi run py-fmt-check
@@ -108,7 +108,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Codegen check
         shell: bash
@@ -127,7 +127,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -194,7 +194,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: prettier --check
         run: pixi run misc-fmt-check

--- a/.github/workflows/reusable_checks_cpp.yml
+++ b/.github/workflows/reusable_checks_cpp.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/reusable_checks_python.yml
+++ b/.github/workflows/reusable_checks_python.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ inputs.CONCURRENCY }}-checks
+  group: ${{ inputs.CONCURRENCY }}-checks_python
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/reusable_checks_python.yml
+++ b/.github/workflows/reusable_checks_python.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Python format check
         run: pixi run py-fmt-check

--- a/.github/workflows/reusable_checks_python.yml
+++ b/.github/workflows/reusable_checks_python.yml
@@ -1,0 +1,68 @@
+name: "Python Checks: Lints & Docs"
+
+on:
+  workflow_call:
+    inputs:
+      CONCURRENCY:
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ inputs.CONCURRENCY }}-checks
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.8"
+
+permissions:
+  contents: "read"
+  id-token: "write"
+
+jobs:
+  # ---------------------------------------------------------------------------
+
+  py-lints:
+    name: Python lints (ruff, mypy, …)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+
+      - uses: prefix-dev/setup-pixi@v0.4.1
+        with:
+          pixi-version: v0.16.1
+
+      - name: Python format check
+        run: pixi run py-fmt-check
+
+      - name: Lint Python
+        run: pixi run py-lint
+
+  # ---------------------------------------------------------------------------
+
+  py-test-docs:
+    name: Test Python Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+          cache: "pip"
+          cache-dependency-path: "rerun_py/requirements-doc.txt"
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          pip install --upgrade pip
+          pip install -r rerun_py/requirements-doc.txt
+
+      - name: Build via mkdocs
+        shell: bash
+        run: |
+          mkdocs build --strict -f rerun_py/mkdocs.yml

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       # We need to build the web viewer for `rust_checks.py` to succeed.
       # We build in release so that we can reuse the results for actual publishing, if necessary
@@ -108,7 +108,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       # We build in release so that we can reuse the results for actual publishing, if necessary
       - name: Build web-viewer (release)

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -1,4 +1,4 @@
-name: "Rust & toml Checks: Lints, Tests, Docs"
+name: "Rust Checks: Lints, Tests, Docs"
 
 on:
   workflow_call:

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -206,7 +206,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Doxygen C++ docs
         shell: bash

--- a/.github/workflows/reusable_publish_js.yml
+++ b/.github/workflows/reusable_publish_js.yml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.3.0
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Publish packages
         env:

--- a/.github/workflows/reusable_publish_web.yml
+++ b/.github/workflows/reusable_publish_web.yml
@@ -74,7 +74,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       # built by `reusable_build_and_publish_wheels`
       - name: Download Wheel

--- a/.github/workflows/reusable_release_crates.yml
+++ b/.github/workflows/reusable_release_crates.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       - name: Build web-viewer (release)
         shell: bash

--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -133,7 +133,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: v0.16.1
+          pixi-version: v0.18.0
 
       # The pip-cache setup logic doesn't work in the ubuntu docker container
       # That's probably fine since we bake these deps into the container already

--- a/examples/python/controlnet/main.py
+++ b/examples/python/controlnet/main.py
@@ -39,8 +39,8 @@ def controlnet_callback(
     rr.set_time_seconds("timestep", timestep)
     latents = callback_kwargs["latents"]
 
-    image = pipe.vae.decode(latents / pipe.vae.config.scaling_factor, return_dict=False)[0]
-    image = pipe.image_processor.postprocess(image, output_type="np").squeeze()
+    image = pipe.vae.decode(latents / pipe.vae.config.scaling_factor, return_dict=False)[0]  # type: ignore[attr-defined]
+    image = pipe.image_processor.postprocess(image, output_type="np").squeeze()  # type: ignore[attr-defined]
     rr.log("output", rr.Image(image))
     rr.log("latent", rr.Tensor(latents.squeeze(), dim_names=["channel", "height", "width"]))
 

--- a/examples/python/controlnet/requirements.txt
+++ b/examples/python/controlnet/requirements.txt
@@ -1,7 +1,7 @@
 accelerate
 opencv-python
 pillow
-diffusers
+diffusers==0.27.2
 numpy
 #TODO(#4704): clean that up when pytorch is available for 3.12
 torch ; python_version < "3.12"

--- a/examples/python/face_tracking/main.py
+++ b/examples/python/face_tracking/main.py
@@ -9,7 +9,7 @@ import logging
 import math
 import os
 from pathlib import Path
-from typing import Final, Iterable
+from typing import Any, Final, Iterable, cast
 
 import cv2
 import mediapipe as mp
@@ -302,7 +302,7 @@ def download_file(url: str, path: Path) -> None:
             f.write(chunk)
 
 
-def resize_image(image: npt.NDArray[np.uint8], max_dim: int | None) -> npt.NDArray[np.uint8]:
+def resize_image(image: npt.NDArray[Any], max_dim: int | None) -> npt.NDArray[Any]:
     """Resize an image if it is larger than max_dim."""
     if max_dim is None:
         return image

--- a/examples/python/face_tracking/main.py
+++ b/examples/python/face_tracking/main.py
@@ -9,7 +9,7 @@ import logging
 import math
 import os
 from pathlib import Path
-from typing import Any, Final, Iterable, cast
+from typing import Final, Iterable
 
 import cv2
 import mediapipe as mp
@@ -302,7 +302,7 @@ def download_file(url: str, path: Path) -> None:
             f.write(chunk)
 
 
-def resize_image(image: npt.NDArray[Any], max_dim: int | None) -> npt.NDArray[Any]:
+def resize_image(image: cv2.typing.MatLike, max_dim: int | None) -> cv2.typing.MatLike:
     """Resize an image if it is larger than max_dim."""
     if max_dim is None:
         return image

--- a/examples/python/gesture_detection/main.py
+++ b/examples/python/gesture_detection/main.py
@@ -178,7 +178,7 @@ def download_file(url: str, path: Path) -> None:
             f.write(chunk)
 
 
-def resize_image(image: npt.NDArray[np.uint8], max_dim: int | None) -> npt.NDArray[np.uint8]:
+def resize_image(image: cv2.typing.MatLike, max_dim: int | None) -> cv2.typing.MatLike:
     """Resize an image if it is larger than max_dim."""
     if max_dim is None:
         return image

--- a/examples/python/human_pose_tracking/main.py
+++ b/examples/python/human_pose_tracking/main.py
@@ -117,7 +117,7 @@ def read_landmark_positions_3d(
 
 @dataclass
 class VideoFrame:
-    data: npt.NDArray[np.uint8]
+    data: cv2.typing.MatLike
     time: float
     idx: int
 

--- a/examples/python/nv12/main.py
+++ b/examples/python/nv12/main.py
@@ -16,12 +16,11 @@ import time
 
 import cv2
 import numpy as np
-import numpy.typing as npt
 import rerun as rr  # pip install rerun-sdk
 
 
-def bgr2nv12(bgr: npt.NDArray[np.uint8]) -> npt.NDArray[np.uint8]:
-    yuv: npt.NDArray[np.uint8] = cv2.cvtColor(bgr, cv2.COLOR_BGR2YUV_I420)
+def bgr2nv12(bgr: cv2.typing.MatLike) -> cv2.typing.MatLike:
+    yuv = cv2.cvtColor(bgr, cv2.COLOR_BGR2YUV_I420)
     uv_row_cnt = yuv.shape[0] // 3
     uv_plane = np.transpose(yuv[uv_row_cnt * 2 :].reshape(2, -1), [1, 0])
     yuv[uv_row_cnt * 2 :] = uv_plane.reshape(uv_row_cnt, -1)


### PR DESCRIPTION
### What

* related to #3033

--

* Turned out most of the python lints issues I had locally (and did not see on ci) are about opencv-python missmatches. The way I fixed it should work fine with either though now!
* Various python lints on ci now use pixi and run only when py files change.
* update pixi version used on ci

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5897)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5897?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5897?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5897)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)