### PR TITLE
Don't build examples on each PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,6 @@ To get an auto-generated PR description you can put "copilot:summary" or "copilo
 * [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
 * [ ] I've included a screenshot or gif (if applicable)
 * [ ] I have tested the web demo (if applicable):
-  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}})
   * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
   * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
 * [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -185,17 +185,6 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets: inherit
 
-  track-sizes:
-    name: "Track Sizes"
-    if: github.event.pull_request.head.repo.owner.login == 'rerun-io'
-    needs: [build-web]
-    uses: ./.github/workflows/reusable_track_size.yml
-    with:
-      CONCURRENCY: push-${{ github.ref_name }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      WITH_EXAMPLES: false # We don't build examples on each PR (too slow)
-    secrets: inherit
-
   save-pr-summary:
     name: "Save PR Summary"
     if: github.event.pull_request.head.repo.owner.login == 'rerun-io'

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -193,6 +193,7 @@ jobs:
     with:
       CONCURRENCY: push-${{ github.ref_name }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
+      WITH_EXAMPLES: false # We don't build examples on each PR (too slow)
     secrets: inherit
 
   save-pr-summary:

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -185,34 +185,13 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets: inherit
 
-  build-examples:
-    name: "Build Examples"
-    if: github.event.pull_request.head.repo.owner.login == 'rerun-io'
-    needs: [min-wheel-build]
-    uses: ./.github/workflows/reusable_build_examples.yml
-    with:
-      CONCURRENCY: pr-${{ github.event.pull_request.number }}
-      CHANNEL: main
-      WHEEL_ARTIFACT_NAME: linux-x64-wheel-fast
-    secrets: inherit
-
   track-sizes:
     name: "Track Sizes"
     if: github.event.pull_request.head.repo.owner.login == 'rerun-io'
-    needs: [build-web, build-examples]
+    needs: [build-web]
     uses: ./.github/workflows/reusable_track_size.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-    secrets: inherit
-
-  upload-examples:
-    name: "Upload Examples"
-    if: github.event.pull_request.head.repo.owner.login == 'rerun-io'
-    needs: [build-examples]
-    uses: ./.github/workflows/reusable_upload_examples.yml
-    with:
-      CONCURRENCY: pr-${{ github.event.pull_request.number }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets: inherit
 

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -109,6 +109,7 @@ jobs:
     uses: ./.github/workflows/reusable_track_size.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}
+      WITH_EXAMPLES: true
     secrets: inherit
 
   upload-examples:

--- a/.github/workflows/reusable_checks_cpp.yml
+++ b/.github/workflows/reusable_checks_cpp.yml
@@ -92,13 +92,21 @@ jobs:
         # using leading to random crashes: https://reviews.llvm.org/D148280
         run: sudo sysctl vm.mmap_rnd_bits=28
 
-      - name: Build and run C++ tests
+      - name: pixi run cpp-clean
         shell: bash
-        run: |
-          pixi run cpp-clean
-          ${{ matrix.extra_env_vars }} RERUN_WERROR=ON pixi run cpp-build-all
-          ${{ matrix.extra_env_vars }} RERUN_WERROR=ON pixi run cpp-test
-          ${{ matrix.additional_commands }}
+        run: pixi run cpp-clean
+
+      - name: pixi run cpp-build-all
+        shell: bash
+        run: ${{ matrix.extra_env_vars }} RERUN_WERROR=ON pixi run cpp-build-all
+
+      - name: pixi run cpp-test
+        shell: bash
+        run: ${{ matrix.extra_env_vars }} RERUN_WERROR=ON pixi run cpp-test
+
+      - name: additional_commands
+        shell: bash
+        run: ${{ matrix.additional_commands }}
 
   cpp-formatting:
     name: C++ formatting check

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -9,6 +9,9 @@ on:
       PR_NUMBER:
         required: false
         type: number
+      WITH_EXAMPLES:
+        required: true
+        type: boolean
 
 permissions:
   contents: write
@@ -50,6 +53,7 @@ jobs:
           path: web_viewer
 
       - name: Download examples
+        if: ${{ inputs.WITH_EXAMPLES }}
         uses: actions/download-artifact@v4
         with:
           name: example_data
@@ -92,10 +96,12 @@ jobs:
           entries+=("Wasm:web_viewer/re_viewer_bg.wasm:MiB")
           entries+=("JS:web_viewer/re_viewer.js:kiB")
 
-          for file in example_data/*.rrd; do
-            name=$(basename "$file")
-            entries+=("$name:$file:MiB")
-          done
+          if [ -n ${{ inputs.PR_NUMBER }} ]; then
+            for file in example_data/*.rrd; do
+              name=$(basename "$file")
+              entries+=("$name:$file:MiB")
+            done
+          fi
 
           python3 scripts/ci/count_bytes.py "${entries[@]}"  > /tmp/sizes.json
 

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -96,7 +96,7 @@ jobs:
           entries+=("Wasm:web_viewer/re_viewer_bg.wasm:MiB")
           entries+=("JS:web_viewer/re_viewer.js:kiB")
 
-          if [ -n ${{ inputs.PR_NUMBER }} ]; then
+          if [ -n ${{ inputs.WITH_EXAMPLES }} = "true" ]; then
             for file in example_data/*.rrd; do
               name=$(basename "$file")
               entries+=("$name:$file:MiB")

--- a/crates/re_viewer/src/ui/welcome_screen/example_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/example_section.rs
@@ -173,7 +173,6 @@ fn default_manifest_url() -> String {
     }
 
     let build_info = re_build_info::build_info!();
-    let short_sha = build_info.short_git_hash();
 
     if build_info.version.is_rc() || build_info.version.is_release() {
         // If this is versioned as a release or rc, always point to the versioned
@@ -182,19 +181,9 @@ fn default_manifest_url() -> String {
             "https://app.rerun.io/version/{version}/examples_manifest.json",
             version = build_info.version,
         )
-    } else if build_info.is_in_rerun_workspace {
-        // Otherwise, always point to `version/nightly` for rerun devs,
-        // because the current commit's manifest is unlikely to be uploaded to GCS.
-        // We could point to the main branch, but it's not always finished building, and so doesn't always work.
-        "https://app.rerun.io/version/nightly/examples_manifest.json".into()
-    } else if !short_sha.is_empty() {
-        // If we have a sha, try to point at it.
-        format!("https://app.rerun.io/commit/{short_sha}/examples_manifest.json")
     } else {
-        // If all else fails, point to the nightly branch
+        // We don't build examples on each PR, so we don't have much to point to except for the nightly examples
         // We could point to the main branch, but it's not always finished building, and so doesn't always work.
-        // TODO(#4729): this is better than nothing but still likely to have version
-        // compatibility issues.
         "https://app.rerun.io/version/nightly/examples_manifest.json".into()
     }
 }


### PR DESCRIPTION
* Part of https://github.com/rerun-io/rerun/issues/3033

### What
It takes almost 3 minutes per PR.

Pro:
* I don't remember it ever catching a bug
* I usually test the latest examples from `main` or `nightly` anyway

Con:
* No example size diff comparisons per PR
* This breaks the <https://www.rerun.io/viewer/pr/5910> url, unless I also update the default manifest 🤔 

Total duration: 12m -> 8m
Billable time: 51m -> 43m

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using default manifest (nightly): [rerun.io/viewer](https://rerun.io/viewer/pr/5910)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5910?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5910?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5910)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)