### PR TITLE
Fix cell size test now that the overhead has shrunk

### DIFF
--- a/crates/re_log_types/src/data_cell.rs
+++ b/crates/re_log_types/src/data_cell.rs
@@ -689,8 +689,8 @@ fn data_cell_sizes() {
             DataCell::from_arrow(InstanceKey::name(), UInt64Array::from_vec(vec![]).boxed());
         cell.compute_size_bytes();
 
-        assert_eq!(184, cell.heap_size_bytes());
-        assert_eq!(184, cell.heap_size_bytes());
+        assert_eq!(168, cell.heap_size_bytes());
+        assert_eq!(168, cell.heap_size_bytes());
     }
 
     // anything else
@@ -702,7 +702,7 @@ fn data_cell_sizes() {
         cell.compute_size_bytes();
 
         // zero-sized + 3x u64s
-        assert_eq!(208, cell.heap_size_bytes());
-        assert_eq!(208, cell.heap_size_bytes());
+        assert_eq!(192, cell.heap_size_bytes());
+        assert_eq!(192, cell.heap_size_bytes());
     }
 }


### PR DESCRIPTION
Updated Rust and/or deps have reduced the overhead of `DataCell` (probably better alignment/packing order, I haven't checked in detail).

- Fixes https://github.com/rerun-io/rerun/issues/5732

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [rerun.io/viewer](https://rerun.io/viewer/pr/5917)
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5917?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5917?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5917)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)