### PR TITLE
Update Python API links to getting-started and tutorial

### DIFF
--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -370,8 +370,8 @@ with mkdocs_gen_files.open(index_path, "w") as index_file:
     index_file.write(
         """
 ## Getting Started
-* [Quick start](https://www.rerun.io/docs/getting-started/python)
-* [Tutorial](https://www.rerun.io/docs/getting-started/logging-python)
+* [Quick start](https://www.rerun.io/docs/getting-started/quick-start/python)
+* [Tutorial](https://www.rerun.io/docs/getting-started/data-in/python)
 * [Examples on GitHub](https://github.com/rerun-io/rerun/tree/latest/examples/python)
 * [Troubleshooting](https://www.rerun.io/docs/getting-started/troubleshooting)
 


### PR DESCRIPTION
Links to tutorial and getting started on https://ref.rerun.io/docs/python/0.15.0/common/ are broken, I believe this should fix it.