### PR TITLE
Publish docs after publishing web

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,20 +210,6 @@ jobs:
             --fill \
             --body-file pr-body.txt
 
-  update-docs:
-    name: "Update Docs"
-    needs: [version]
-    uses: ./.github/workflows/reusable_deploy_docs.yml
-    with:
-      CONCURRENCY: ${{ github.ref_name }}
-      PY_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && needs.version.outputs.final || 'dev' }}
-      CPP_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && 'stable' || 'dev' }}
-      RS_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && 'stable' || 'dev' }}
-      RELEASE_COMMIT: ${{ needs.version.outputs.release-commit }}
-      RELEASE_VERSION: ${{ needs.version.outputs.final }}
-      UPDATE_LATEST: ${{ inputs.release-type == 'final' }}
-    secrets: inherit
-
   publish-crates:
     name: "Publish Crates"
     needs: [version]
@@ -282,6 +268,21 @@ jobs:
     with:
       release-commit: ${{ needs.version.outputs.release-commit }}
       concurrency: ${{ github.ref_name }}
+    secrets: inherit
+
+  update-docs:
+    name: "Update Docs"
+    # rerun.io deployment depends on all of web viewer, examples, snippets being built
+    needs: [version, publish-web]
+    uses: ./.github/workflows/reusable_deploy_docs.yml
+    with:
+      CONCURRENCY: ${{ github.ref_name }}
+      PY_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && needs.version.outputs.final || 'dev' }}
+      CPP_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && 'stable' || 'dev' }}
+      RS_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && 'stable' || 'dev' }}
+      RELEASE_COMMIT: ${{ needs.version.outputs.release-commit }}
+      RELEASE_VERSION: ${{ needs.version.outputs.final }}
+      UPDATE_LATEST: ${{ inputs.release-type == 'final' }}
     secrets: inherit
 
   update-latest-branch:


### PR DESCRIPTION
### What

Fixes the race we encountered in the `0.15` release:
- web viewer/examples are built in parallel with `rerun.io`
- `rerun.io` has an implicit dependency on the web viewer/examples/snippets
- `rerun.io` builds first, so the build subtly fails

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
