### PR TITLE
Add `@rerun-bot full-check` command

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,3 +24,5 @@ To get an auto-generated PR description you can put "copilot:summary" or "copilo
 - [PR Build Summary](https://build.rerun.io/pr/{{ pr.number }})
 - [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
 - [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)
+
+To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

--- a/.github/workflows/on_pr_comment.yml
+++ b/.github/workflows/on_pr_comment.yml
@@ -1,0 +1,27 @@
+name: "PR Comment"
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  parse-command:
+    if: |
+      contains(github.event.comment.html_url, '/pull/') &&
+      contains(github.event.comment.body, '@rerun-bot')
+    runs-on: ubuntu-latest
+    outputs:
+      command: ${{ steps.parse.outputs.command }}
+    steps:
+      - name: Parse comment
+        id: parse
+        shell: bash
+        run: |
+          # Parse `@rerun-bot <command>`
+          command=$(echo "${{ github.event.comment.body }}" | sed -n 's/.*@rerun-bot[[:space:]]\+\([a-zA-Z\-]*\).*/\1/p')
+          echo "command=$command" >> "$GITHUB_OUTPUT"
+
+  trigger-main:
+    needs: [parse-command]
+    if: needs.parse-command.outputs.command == 'full-check'
+    uses: ./.github/workflows/on_push_main.yml

--- a/.github/workflows/on_pr_comment.yml
+++ b/.github/workflows/on_pr_comment.yml
@@ -24,13 +24,65 @@ jobs:
   trigger-main:
     needs: [parse-command]
     if: needs.parse-command.outputs.command == 'full-check'
-    uses: ./.github/workflows/on_push_main.yml
-
-  notify-pr:
-    needs: [parse-command]
-    if: needs.parse-command.outputs.command == 'full-check'
     runs-on: ubuntu-latest
     steps:
+      - name: Dispatch main workflow
+        id: dispatch
+        shell: bash
+        env:
+          # NOTE: This uses `RERUN_BOT_TOKEN` instead of `GITHUB_TOKEN`,
+          # otherwise the recursive workflow protection prevents us from
+          # starting the `on_push_main` run.
+          # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+          GH_TOKEN: ${{ secrets.RERUN_BOT_TOKEN }}
+        run: |
+          get_latest_workflow_run_id () {
+            local workflow_name=$1
+            local ref_name=$2
+            local created_after=$3
+            echo $(
+              # https://cli.github.com/manual/gh_run_list
+              gh run list \
+                --workflow $workflow_name \
+                --event workflow_dispatch \
+                --branch $ref_name \
+                # https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#query-for-dates
+                --created ">$created_after" \
+                --json databaseId \
+                --jq '.[0].databaseId'
+            )
+          }
+
+          dispatch_workflow () {
+            local workflow_name=$1
+            local ref_name=$2
+            # https://cli.github.com/manual/gh_workflow_run
+            gh workflow run $workflow_name --ref $ref_name
+          }
+
+          workflow_name='on_push_main.yml'
+          ref_name='${{ github.ref_name }}'
+          now=$(date --utc --iso-8601=seconds)
+
+          echo "Dispatching workflow $workflow_name on branch $ref_name"
+          dispatch_workflow $workflow_name $ref_name $input
+
+          # `gh workflow run` does NOT return the ID.
+          # In fact, it returns absolutely nothing: https://github.com/cli/cli/issues/4001
+          # Instead, we have to wait for the workflow to start, and hope that nobody has
+          # started a workflow in parallel with us on the same branch.
+
+          echo "Fetching workflow run id…"
+          run_id=$(get_latest_workflow_run_id $workflow_name $ref_name $now)
+          while [ -z $run_id ]
+          do
+            run_id=$(get_latest_workflow_run_id $workflow_name $ref_name $now)
+            sleep 1
+          done
+          echo "Workflow run: https://github.com/rerun-io/rerun/actions/runs/$run_id"
+
+          echo "workflow_run_url=https://github.com/rerun-io/rerun/actions/runs/$run_id" >> "$GITHUB_OUTPUT"
+
       - name: Create PR comment
         # https://github.com/mshick/add-pr-comment
         uses: mshick/add-pr-comment@v2.8.2
@@ -38,4 +90,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           message-id: "pr-${{ github.event.issue.number }}-${{ github.run_id }}"
           message: |
-            Started a full build: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            Started a full build: ${{ steps.dispatch.outputs.workflow_run_url }}

--- a/.github/workflows/on_pr_comment.yml
+++ b/.github/workflows/on_pr_comment.yml
@@ -1,3 +1,9 @@
+# This workflow is triggered on any PR comment, and tries to find a `@rerun-bot` mention in it.
+# If the mention is a command, such as `@rerun-bot full-check`, then it runs the command.
+#
+# Available commands:
+#   full-check    Triggers a run of `on_push_main.yml` on the PR.
+
 name: "PR Comment"
 
 on:
@@ -87,6 +93,8 @@ jobs:
         # https://github.com/mshick/add-pr-comment
         uses: mshick/add-pr-comment@v2.8.2
         with:
+          # We use `GITHUB_TOKEN` here so there is no chance that we'll trigger another run of this workflow.
+          # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           message-id: "pr-${{ github.event.issue.number }}-${{ github.run_id }}"
           message: |

--- a/.github/workflows/on_pr_comment.yml
+++ b/.github/workflows/on_pr_comment.yml
@@ -27,7 +27,7 @@ jobs:
           command=$(echo "${{ github.event.comment.body }}" | sed -n 's/.*@rerun-bot[[:space:]]\+\([a-zA-Z\-]*\).*/\1/p')
           echo "command=$command" >> "$GITHUB_OUTPUT"
 
-  trigger-main:
+  full-check:
     needs: [parse-command]
     if: needs.parse-command.outputs.command == 'full-check'
     runs-on: ubuntu-latest

--- a/.github/workflows/on_pr_comment.yml
+++ b/.github/workflows/on_pr_comment.yml
@@ -25,3 +25,17 @@ jobs:
     needs: [parse-command]
     if: needs.parse-command.outputs.command == 'full-check'
     uses: ./.github/workflows/on_push_main.yml
+
+  notify-pr:
+    needs: [parse-command]
+    if: needs.parse-command.outputs.command == 'full-check'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create PR comment
+        # https://github.com/mshick/add-pr-comment
+        uses: mshick/add-pr-comment@v2.8.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          message-id: "pr-${{ github.event.issue.number }}-${{ github.run_id }}"
+          message: |
+            Started a full build: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "main"
 
+  workflow_call:
+
 jobs:
   checks:
     name: Checks

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - "main"
 
-  workflow_call:
+  # Can be triggered manually from within the UI or using the GH CLI,
+  # e.g. `gh workflow run on_push_main.yml --ref main`
+  workflow_dispatch:
 
 jobs:
   checks:


### PR DESCRIPTION
### What

The `full-check` command triggers the full `main` workflow on the PR

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5940?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5940?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5940)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)