### PR TITLE
Remove old assertion in arrow bench

### DIFF
--- a/crates/re_data_store/benches/arrow2.rs
+++ b/crates/re_data_store/benches/arrow2.rs
@@ -111,16 +111,7 @@ fn erased_clone(c: &mut Criterion) {
             .iter()
             .map(|array| array.total_size_bytes())
             .sum::<u64>();
-        let expected_total_size_bytes = data.total_size_bytes();
-        // NOTE: `+ 1` because the computation is off by one bytes, which is irrelevant for the
-        // purposes of this benchmark.
-        assert!(
-            total_size_bytes + 1 >= expected_total_size_bytes,
-            "Size for {} calculated to be {} bytes, but should be at least {} bytes",
-            T::name(),
-            total_size_bytes,
-            expected_total_size_bytes,
-        );
+        assert!(total_size_bytes > 0);
 
         group.bench_function("array", |b| {
             b.iter(|| {


### PR DESCRIPTION
We're now using our own fork anyhow -- there cannot be shenanigans going on on that front without us knowing.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5975?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5975?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5975)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.