### PR TITLE
Fix weekly alpha crate release

### DIFF
--- a/.github/workflows/auto_release_crates.yml
+++ b/.github/workflows/auto_release_crates.yml
@@ -33,7 +33,7 @@ jobs:
         id: versioning
         shell: bash
         run: |
-          crate_version=$(python3 scripts/ci/crates.py get-version)
+          crate_version=$(pixi run python scripts/ci/crates.py get-version)
           echo "crate_version=$crate_version" >> "$GITHUB_OUTPUT"
 
       - name: Create pull request


### PR DESCRIPTION
### What

Fix for https://github.com/rerun-io/rerun/actions/runs/8690522249/job/23830652154

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
