### PR TITLE
Fix various links in rust, python and toml files

### DIFF
--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -176,5 +176,6 @@ jobs:
           fail: true
           lycheeVersion: "0.14.3"
           # When given a directory, lychee checks only markdown, html and text files, everything else we have to glob in manually.
+          # Pass --verbose, so that all considered links are printed, making it easier to debug.
           args: |
-            --base . --cache --max-cache-age 1d . "**/*.rs" "**/*.toml" "**/*.hpp" "**/*.cpp" "**/CMakeLists.txt" "**/*.py" "**/*.yml"
+            --verbose --base . --cache --max-cache-age 1d . "**/*.rs" "**/*.toml" "**/*.hpp" "**/*.cpp" "**/CMakeLists.txt" "**/*.py" "**/*.yml"

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -175,4 +175,6 @@ jobs:
         with:
           fail: true
           lycheeVersion: "0.14.3"
-          args: "--base . --cache --max-cache-age 1d ."
+          # When given a directory, lychee checks only markdown, html and text files, everything else we have to glob in manually.
+          args: |
+            --base . --cache --max-cache-age 1d . "**/*.rs" "**/*.toml" "**/*.hpp" "**/*.cpp" "**/*.py" "**/*.yml"

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -177,4 +177,4 @@ jobs:
           lycheeVersion: "0.14.3"
           # When given a directory, lychee checks only markdown, html and text files, everything else we have to glob in manually.
           args: |
-            --base . --cache --max-cache-age 1d . "**/*.rs" "**/*.toml" "**/*.hpp" "**/*.cpp" "**/*.py" "**/*.yml"
+            --base . --cache --max-cache-age 1d . "**/*.rs" "**/*.toml" "**/*.hpp" "**/*.cpp" "**/CMakeLists.txt" "**/*.py" "**/*.yml"

--- a/crates/re_crash_handler/src/lib.rs
+++ b/crates/re_crash_handler/src/lib.rs
@@ -59,7 +59,7 @@ fn install_panic_hook(_build_info: BuildInfo) {
 
         eprintln!(
             "\n\
-            Troubleshooting Rerun: https://www.rerun.io/docs/getting-started/troubleshooting\n\
+            Troubleshooting Rerun: https://www.rerun.io/docs/getting-started/troubleshooting \n\
             Report bugs: https://github.com/rerun-io/rerun/issues"
         );
 
@@ -129,9 +129,9 @@ fn install_signal_handler(build_info: BuildInfo) {
             write_to_stderr(signal_name);
             write_to_stderr("\n");
             write_to_stderr(
-                "Troubleshooting Rerun: https://www.rerun.io/docs/getting-started/troubleshooting\n",
+                "Troubleshooting Rerun: https://www.rerun.io/docs/getting-started/troubleshooting \n",
             );
-            write_to_stderr("Report bugs: https://github.com/rerun-io/rerun/issues\n");
+            write_to_stderr("Report bugs: https://github.com/rerun-io/rerun/issues \n");
             write_to_stderr("\n");
         }
 

--- a/crates/re_types_core/src/lib.rs
+++ b/crates/re_types_core/src/lib.rs
@@ -28,18 +28,18 @@
 /// [`AsComponents::as_component_batches`], which describes how the bundle can be interpreted
 /// as a set of [`ComponentBatch`]es: arrays of components that are ready to be serialized.
 ///
-/// Have a look at our [Custom Data] example to learn more about handwritten bundles.
+/// Have a look at our [Custom Data Loader] example to learn more about handwritten bundles.
 ///
 /// [IDL definitions]: https://github.com/rerun-io/rerun/tree/latest/crates/re_types/definitions/rerun
-/// [Custom Data]: https://github.com/rerun-io/rerun/blob/latest/examples/rust/custom_data/src/main.rs
+/// [Custom Data Loader]: https://github.com/rerun-io/rerun/blob/latest/examples/rust/custom_data_loader
 pub trait AsComponents {
     /// Exposes the object's contents as a set of [`ComponentBatch`]s.
     ///
     /// This is the main mechanism for easily extending builtin archetypes or even writing
     /// fully custom ones.
-    /// Have a look at our [Custom Data] example to learn more about extending archetypes.
+    /// Have a look at our [Custom Data Loader] example to learn more about extending archetypes.
     ///
-    /// [Custom Data]: https://github.com/rerun-io/rerun/blob/latest/examples/rust/custom_data/src/main.rs
+    /// [Custom Data Loader]: https://github.com/rerun-io/rerun/tree/latest/examples/rust/custom_data_loader
     //
     // NOTE: Don't bother returning a CoW here: we need to dynamically discard optional components
     // depending on their presence (or lack thereof) at runtime anyway.

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -545,7 +545,8 @@ impl App {
 
             UICommand::OpenWebHelp => {
                 egui_ctx.open_url(egui::output::OpenUrl {
-                    url: "https://www.rerun.io/docs/getting-started/viewer-walkthrough".to_owned(),
+                    url: "https://www.rerun.io/docs/getting-started/navigating-the-viewer"
+                        .to_owned(),
                     new_tab: true,
                 });
             }

--- a/deny.toml
+++ b/deny.toml
@@ -81,8 +81,8 @@ allow = [
   "BSD-3-Clause",                   # https://tldrlegal.com/license/bsd-3-clause-license-(revised)
   "BSL-1.0",                        # https://tldrlegal.com/license/boost-software-license-1.0-explained
   "CC0-1.0",                        # https://creativecommons.org/publicdomain/zero/1.0/
-  "ISC",                            # https://tldrlegal.com/license/-isc-license
-  "LicenseRef-UFL-1.0",             # https://tldrlegal.com/license/ubuntu-font-license,-1.0 - no official SPDX, see https://github.com/emilk/egui/issues/2321
+  "ISC",                            # https://www.tldrlegal.com/license/isc-license
+  "LicenseRef-UFL-1.0",             # See https://github.com/emilk/egui/issues/2321
   "MIT-0",                          # https://choosealicense.com/licenses/mit-0/
   "MIT",                            # https://tldrlegal.com/license/mit-license
   "MPL-2.0",                        # https://www.mozilla.org/en-US/MPL/2.0/FAQ/ - see Q11. Used by webpki-roots on Linux.

--- a/examples/rust/log_file/src/main.rs
+++ b/examples/rust/log_file/src/main.rs
@@ -1,6 +1,6 @@
 //! Demonstrates how to log any file from the SDK using the `DataLoader` machinery.
 //!
-//! See <https://www.rerun.io/docs/reference/data-loaders/overviewers/overview> for more information.
+//! See <https://www.rerun.io/docs/reference/data-loaders/overview> for more information.
 //!
 //! Usage:
 //! ```

--- a/lychee.toml
+++ b/lychee.toml
@@ -14,6 +14,8 @@
 # Workaround for "too many open files" error on MacOS, see https://github.com/lycheeverse/lychee/issues/1248
 max_concurrency = 32
 
+# Check links inside `<code>` and `<pre>` blocks as well as Markdown code blocks.
+include_verbatim = true
 
 # URLs to check (supports regex). Has preference over all excludes.
 exclude_path = [
@@ -24,13 +26,14 @@ exclude_path = [
   ".pixi",
   "build",
   "docs/python/",
+  "rerun_cpp/_deps",
   "rerun_cpp/docs/html",
   "rerun_cpp/docs/xml",
+  "rerun_cpp/tmp/",
   "rerun_py/site/",
   "target_ra",
   "target_wasm",
   "target",
-  "rerun_cpp/tmp/",
 
   # Actually ignored files beyond .gitignore
   "scripts/screenshot_compare/assets/templates/",
@@ -41,7 +44,7 @@ exclude = [
   '.*?speculative-link',                                      # Skip speculative links
   '.github/workflows/.*.yml',                                 # GitHub action workflows cause issues on CI.
   '\$relpath\^',                                              # Relative paths as used by rerun_cpp's doc header.
-  '%7B%7B.+%7D%7D',                                           # Ignore things that look like links because of `href` but are actually replacement strings. The URL escaping is for '{{.+}}' (this seems to be needed for html embedded urls since lychee assumes they use this encoding).
+  '%7B.+%7D',                                                 # Ignore strings that look like ready to use links but contain a replacement strings. The URL escaping is for '{.+}' (this seems to be needed for html embedded urls since lychee assumes they use this encoding).
   'https://crates.io/crates/.*',                              # Avoid crates.io rate-limiting
   'https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html', # Nyud links are down every now and then.
   'https://eigen.tuxfamily.org/',                             # Website down https://gitlab.com/libeigen/eigen/-/issues/2804

--- a/lychee.toml
+++ b/lychee.toml
@@ -65,9 +65,10 @@ exclude = [
   '%7B%7D',               # Ignore links with string interpolation, escaped variant.
 
   # Local links that require further setup.
-  'http://127.0.0.1:',
+  'http://127.0.0.1',
   'http://localhost',
-  'recording:/',       # rrd recording link.
+  'recording:/',      # rrd recording link.
+  'ws:/',
 
   # Api endpoints.
   'https://fonts.googleapis.com/', # Font API entrypoint, not a link.
@@ -94,6 +95,10 @@ exclude = [
   '.github/workflows/.*.yml',    # GitHub action workflows cause issues on CI.
   'https://stackoverflow.com/.', # Stackoverflow links are no longer accessible from CI.
   'https://www.tensorflow.org/', # tensorflow.org apparently blocks CI.
+
+  # Need github login.
+  'https://github.com/rerun-io/landing',
+  'https://github.com/rerun-io/documentation',
 
   # Temporarily down or not accessible.
   'https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html',       # Nyud links are down every now and then.

--- a/lychee.toml
+++ b/lychee.toml
@@ -96,9 +96,10 @@ exclude = [
   'https://storage.googleapis.com/',                           # Storage API entrypoint, not a link.
 
   # Not accessible from CI.
-  '.github/workflows/.*.yml',    # GitHub action workflows cause issues on CI.
-  'https://stackoverflow.com/.', # Stackoverflow links are no longer accessible from CI.
-  'https://www.tensorflow.org/', # tensorflow.org apparently blocks CI.
+  '.github/workflows/.*.yml',            # GitHub action workflows cause issues on CI.
+  'https://stackoverflow.com/.',         # Stackoverflow links are no longer accessible from CI.
+  'https://www.tensorflow.org/',         # tensorflow.org apparently blocks CI.
+  'https://9p.io/sys/doc/lexnames.html', # Works locally but on ci we get: `Failed: Network error: error:0A000152:SSL routines:final_renegotiate:unsafe legacy renegotiation disabled:ssl/statem/extensions.c:946:`
 
   # Need github login.
   'https://github.com/rerun-io/landing',

--- a/lychee.toml
+++ b/lychee.toml
@@ -26,6 +26,9 @@ max_concurrency = 32
 # Check links inside `<code>` and `<pre>` blocks as well as Markdown code blocks.
 include_verbatim = true
 
+# Proceed for server connections considered insecure (invalid TLS).
+insecure = true
+
 # Exclude these filesystem paths from getting checked.
 exclude_path = [
   # Unfortunately lychee doesn't yet read .gitignore https://github.com/lycheeverse/lychee/issues/1331
@@ -69,6 +72,7 @@ exclude = [
   'http://localhost',
   'recording:/',      # rrd recording link.
   'ws:/',
+  're_viewer.js',     # Build artifact that html is linking to.
 
   # Api endpoints.
   'https://fonts.googleapis.com/', # Font API entrypoint, not a link.

--- a/lychee.toml
+++ b/lychee.toml
@@ -8,6 +8,15 @@
 # https://github.com/lycheeverse/lychee/blob/master/lychee.example.toml
 #
 # Run `lychee . --dump` to list all found links that are being checked.
+#
+# Note that by default lychee will only check markdown and html files,
+# to check any other files you have to point to them explicitly, e.g.:
+# `lychee **/*.rs`
+# To make things worse, `exclude_path` is ignored for these globs,
+# so local runs with lots of gitignored files will be slow.
+# (https://github.com/lycheeverse/lychee/issues/1405)
+#
+# This unfortunately doesn't list anything for non-glob checks.
 ################################################################################
 
 # Maximum number of concurrent link checks.
@@ -17,10 +26,11 @@ max_concurrency = 32
 # Check links inside `<code>` and `<pre>` blocks as well as Markdown code blocks.
 include_verbatim = true
 
-# URLs to check (supports regex). Has preference over all excludes.
+# Exclude these filesystem paths from getting checked.
 exclude_path = [
   # Unfortunately lychee doesn't yet read .gitignore https://github.com/lycheeverse/lychee/issues/1331
   # The following entries are there because of that:
+  ".git",
   "__pycache__",
   "_deps/",
   ".pixi",
@@ -34,6 +44,7 @@ exclude_path = [
   "target_ra",
   "target_wasm",
   "target",
+  "venv",
 
   # Actually ignored files beyond .gitignore
   "scripts/screenshot_compare/assets/templates/",
@@ -41,19 +52,53 @@ exclude_path = [
 
 # Exclude URLs and mail addresses from checking (supports regex).
 exclude = [
-  '.*?speculative-link',                                      # Skip speculative links
-  '.github/workflows/.*.yml',                                 # GitHub action workflows cause issues on CI.
-  '\$relpath\^',                                              # Relative paths as used by rerun_cpp's doc header.
-  '%7B.+%7D',                                                 # Ignore strings that look like ready to use links but contain a replacement strings. The URL escaping is for '{.+}' (this seems to be needed for html embedded urls since lychee assumes they use this encoding).
-  'https://crates.io/crates/.*',                              # Avoid crates.io rate-limiting
-  'https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html', # Nyud links are down every now and then.
-  'https://eigen.tuxfamily.org/',                             # Website down https://gitlab.com/libeigen/eigen/-/issues/2804
-  'https://fonts.googleapis.com/',                            # Font API entrypoint, not a link.
-  'https://fonts.gstatic.com/',                               # Font API entrypoint, not a link.
-  'https://github.com/rerun-io/rerun/pull/\.*',               # Ignore links to our own pull requests (typically in changelog).
-  'https://github.com/rerun-io/rerun/commit/\.*',             # Ignore links to our own commits (typically in changelog).
-  'https://stackoverflow.com/.',                              # Stackoverflow links are no longer accessible from CI.
-  'https://www.tensorflow.org/',                              # tensorflow.org apparently blocks CI.
+  # Skip speculative links
+  '.*?speculative-link',
+
+  # Strings with replacements.
+  '/__VIEWER_VERSION__/', # Replacement variable __VIEWER_VERSION__.
+  '/\$',                  # Replacement variable $.
+  '/GIT_HASH/',           # Replacement variable GIT_HASH.
+  '\{\}',                 # Ignore links with string interpolation.
+  '\$relpath\^',          # Relative paths as used by rerun_cpp's doc header.
+  '%7B.+%7D',             # Ignore strings that look like ready to use links but contain a replacement strings. The URL escaping is for '{.+}' (this seems to be needed for html embedded urls since lychee assumes they use this encoding).
+  '%7B%7D',               # Ignore links with string interpolation, escaped variant.
+
+  # Local links that require further setup.
+  'http://127.0.0.1:',
+  'http://localhost',
+  'recording:/',       # rrd recording link.
+
+  # Api endpoints.
+  'https://fonts.googleapis.com/', # Font API entrypoint, not a link.
+  'https://fonts.gstatic.com/',    # Font API entrypoint, not a link.
+  'https://tel.rerun.io/',         # Analytics endpoint.
+
+  # Avoid rate limiting.
+  'https://crates.io/crates/.*',                  # Avoid crates.io rate-limiting
+  'https://github.com/rerun-io/rerun/commit/\.*', # Ignore links to our own commits (typically in changelog).
+  'https://github.com/rerun-io/rerun/pull/\.*',   # Ignore links to our own pull requests (typically in changelog).
+
+  # Intentionally faked links.
+  'file://foo',
+  'http://foo.com/',
+  'https://link.to',
+  'https://static.rerun.io/my_screenshot/',
+
+  # Link fragments and data links in examples.
+  'https://raw.githubusercontent.com/googlefonts/noto-emoji/', # URL fragment.
+  'https://static.rerun.io/rgbd_dataset',                      # Base data link for rgbd dataset.
+  'https://storage.googleapis.com/',                           # Storage API entrypoint, not a link.
+
+  # Not accessible from CI.
+  '.github/workflows/.*.yml',    # GitHub action workflows cause issues on CI.
+  'https://stackoverflow.com/.', # Stackoverflow links are no longer accessible from CI.
+  'https://www.tensorflow.org/', # tensorflow.org apparently blocks CI.
+
+  # Temporarily down or not accessible.
+  'https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html',       # Nyud links are down every now and then.
+  'https://eigen.tuxfamily.org/',                                   # Website down https://gitlab.com/libeigen/eigen/-/issues/2804
+  'https://github.com/rerun-io/rerun/releases/download/prerelease', # Pre-release downloads may go down while a pre-release updates or pre-release CI partially breaks.
 
   # Works but is really slow at times:
   'https://openaccess.thecvf.com/content/CVPR2023/html/Du_Learning_To_Render_Novel_Views_From_Wide-Baseline_Stereo_Pairs_CVPR_2023_paper.html',

--- a/lychee.toml
+++ b/lychee.toml
@@ -101,7 +101,7 @@ exclude = [
   'https://www.tensorflow.org/',         # tensorflow.org apparently blocks CI.
   'https://9p.io/sys/doc/lexnames.html', # Works locally but on ci we get: `Failed: Network error: error:0A000152:SSL routines:final_renegotiate:unsafe legacy renegotiation disabled:ssl/statem/extensions.c:946:`
 
-  # Need github login.
+  # Need GitHub login.
   'https://github.com/rerun-io/landing',
   'https://github.com/rerun-io/documentation',
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -148,7 +148,6 @@ search-index = "cargo run -q --locked -p re_dev_tools -- search-index"
 meilisearch = "meilisearch --db-path=./meilisearch/data.ms --dump-dir=./meilisearch/dumps/ --snapshot-dir=./meilisearch/snapshots/ --env=development --no-analytics --experimental-reduce-indexing-memory-usage --master-key=test"
 
 # Update the design_tokens.json used to style the GUI.
-# See https://rerun-design-guidelines.netlify.app/tokens for their meanings.
 # To update the upstream `design_tokens.json`, modify
 # https://github.com/rerun-io/documentation/blob/main/src/utils/tokens.ts and push to main.
 download-design-tokens = "curl --fail https://rerun-docs.netlify.app/api/tokens | jq > crates/re_ui/data/design_tokens.json"
@@ -173,7 +172,7 @@ mkdocs-gen-files = "==0.5.0"
 mkdocs-literate-nav = "==0.6.1"
 mkdocs-material = "==9.4.7"
 mkdocs-material-extensions = "==1.3"
-mkdocs-redirects = { git = "https://github.com/rerun-io/mkdocs-redirects.git", rev = "fb6b074554975ba7729d68d04957ce7c7dfd5003" } # forked mkdocs-redirects with https://github.com/rerun-io/mkdocs-redirects/commit/d367a0847928438b66f73508e49852be1190409bmkdocs = "==1.5.3"
+mkdocs-redirects = { git = "https://github.com/rerun-io/mkdocs-redirects.git", rev = "fb6b074554975ba7729d68d04957ce7c7dfd5003" } # forked mkdocs-redirects ==1.5.3
 mkdocstrings = "==0.23.0"
 mkdocstrings-python = "==1.7.3"
 sphobjinv = "==2.3.1"
@@ -236,7 +235,7 @@ rerun = "rerun"
 # platforms (including linux-aarch64), or added conditionally.
 #
 # Hints:
-# - To check a given package, go to https://prefix.dev/channels/conda-forge/packages/XXXX. It should support Windows,
+# - To check a given package, go to the package on https://prefix.dev/channels/conda-forge/. It should support Windows,
 #   x86_64 and aarch64 macOS architectures, and x86_64 and aarch64 Linux architectures.
 # - Some pure Python packages may wrongly be tagged as platform-specific. In this case, use `[pypi-dependencies]`
 #   instead (e.g. `nox`).

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -22,7 +22,7 @@ pypi = ["extension-module", "native_viewer", "web_viewer"]
 ## but we cannot enable it when building tests and benchmarks, so we
 ## must make it an opt-in feature.
 ## * <https://pyo3.rs/latest/faq.html#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror>
-## * <https://pyo3.rs/latest/building_and_distribution.html#building-python-extension-modules>
+## * <https://pyo3.rs/main/building-and-distribution#building-python-extension-modules>
 extension-module = ["pyo3/extension-module"]
 
 ## Support spawning a native Rerun viewer with `spawn()`.

--- a/rerun_py/build.rs
+++ b/rerun_py/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    // Required for `cargo build` to work on mac: https://pyo3.rs/v0.14.2/building_and_distribution.html#macos
+    // Required for `cargo build` to work on mac: https://pyo3.rs/main/building-and-distribution#macos
     pyo3_build_config::add_extension_module_link_args();
 
     re_build_tools::export_build_info_vars_for_crate("rerun_py");

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -412,7 +412,7 @@ def log_file_from_contents(
     This method blocks until either at least one `DataLoader` starts
     streaming data in or all of them fail.
 
-    See <https://www.rerun.io/docs/howto/open-any-file> for more information.
+    See <https://www.rerun.io/docs/getting-started/data-in/open-any-file> for more information.
 
     Parameters
     ----------

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -347,7 +347,7 @@ def log_file_from_path(
     This method blocks until either at least one `DataLoader` starts
     streaming data in or all of them fail.
 
-    See <https://www.rerun.io/docs/howto/open-any-file> for more information.
+    See <https://www.rerun.io/docs/getting-started/data-in/open-any-file> for more information.
 
     Parameters
     ----------


### PR DESCRIPTION
### What

Code files are now included in link checking.

* Fixes #5925

Some issues encountered:
* globs don't respect exclude_files which makes working with this locally harder https://github.com/lycheeverse/lychee/issues/1405
* can't specify extensions / correct files aren't picked up automatically https://github.com/lycheeverse/lychee/issues/410

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5986?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5986?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5986)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.