### PR TITLE
Fix rust wasm check not using clippy_wasm/clippy.toml

### DIFF
--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -19,7 +19,7 @@ class Timing:
         self.duration = duration
 
 
-def run_cargo(cargo_cmd, cargo_args: str) -> Timing:
+def run_cargo(cargo_cmd, cargo_args: str, clippy_conf: str | None = None) -> Timing:
     args = ["cargo", cargo_cmd]
     if cargo_cmd != "deny":
         args.append("--quiet")
@@ -32,6 +32,8 @@ def run_cargo(cargo_cmd, cargo_args: str) -> Timing:
     env = os.environ.copy()
     env["RUSTFLAGS"] = "--deny warnings"
     env["RUSTDOCFLAGS"] = "--deny warnings --deny rustdoc::missing_crate_level_docs"
+    if clippy_conf is not None:
+        env["CLIPPY_CONF_DIR"] = clippy_conf
 
     result = subprocess.run(args, env=env, check=False, capture_output=True, text=True)
     if result.returncode != 0:
@@ -110,6 +112,7 @@ def main() -> None:
             run_cargo(
                 "cranky",
                 "--all-features --target wasm32-unknown-unknown --target-dir target_wasm -p re_viewer -- --deny warnings",
+                clippy_conf="scripts/clippy_wasm",
             )
         )
         # Check re_renderer examples for wasm32.

--- a/scripts/clippy_wasm/clippy.toml
+++ b/scripts/clippy_wasm/clippy.toml
@@ -1,4 +1,4 @@
-# This is used by `scripts/clippy_wasm.sh` so we can forbid some methods that are not available in wasm.
+# This is used by `scripts/rust_checks.py` wasm checks so we can forbid some methods that are not available in wasm.
 #
 # We cannot forbid all these methods in the main `clippy.toml` because of
 # https://github.com/rust-lang/rust-clippy/issues/10406


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

https://github.com/rerun-io/rerun/pull/5922 broke wasm check by not specifying the purpose made clippy.toml for wasm.


Tested by putting in
```rs
        std::thread::spawn(move || {
            std::thread::sleep(std::time::Duration::from_secs(1));
        });
```
and then running `pixi run rs-check` (with a bunch of checks commented out inside the rust check script) to verify that we get the desired error.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
