### PR TITLE
Fix main ci - cranky didn't understand config path env var

### DIFF
--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -33,7 +33,9 @@ def run_cargo(cargo_cmd, cargo_args: str, clippy_conf: str | None = None) -> Tim
     env["RUSTFLAGS"] = "--deny warnings"
     env["RUSTDOCFLAGS"] = "--deny warnings --deny rustdoc::missing_crate_level_docs"
     if clippy_conf is not None:
-        env["CLIPPY_CONF_DIR"] = f"{os.getcwd()}/{clippy_conf}"
+        env["CLIPPY_CONF_DIR"] = (
+            f"{os.getcwd()}/{clippy_conf}"  # Clippy has issues finding this directory on CI when we're not using an absolute path here.
+        )
 
     result = subprocess.run(args, env=env, check=False, capture_output=True, text=True)
     if result.returncode != 0:

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -33,7 +33,7 @@ def run_cargo(cargo_cmd, cargo_args: str, clippy_conf: str | None = None) -> Tim
     env["RUSTFLAGS"] = "--deny warnings"
     env["RUSTDOCFLAGS"] = "--deny warnings --deny rustdoc::missing_crate_level_docs"
     if clippy_conf is not None:
-        env["CLIPPY_CONF_DIR"] = clippy_conf
+        env["CLIPPY_CONF_DIR"] = f"{os.getcwd()}/{clippy_conf}"
 
     result = subprocess.run(args, env=env, check=False, capture_output=True, text=True)
     if result.returncode != 0:
@@ -112,7 +112,7 @@ def main() -> None:
             run_cargo(
                 "cranky",
                 "--all-features --target wasm32-unknown-unknown --target-dir target_wasm -p re_viewer -- --deny warnings",
-                clippy_conf="./scripts/clippy_wasm/clippy.toml",
+                clippy_conf="scripts/clippy_wasm",  # Use ./scripts/clippy_wasm/clippy.toml
             )
         )
         # Check re_renderer examples for wasm32.

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -112,7 +112,7 @@ def main() -> None:
             run_cargo(
                 "cranky",
                 "--all-features --target wasm32-unknown-unknown --target-dir target_wasm -p re_viewer -- --deny warnings",
-                clippy_conf="scripts/clippy_wasm",  # Use scripts/clippy_wasm/clippy.toml
+                clippy_conf="./scripts/clippy_wasm/clippy.toml",
             )
         )
         # Check re_renderer examples for wasm32.

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -112,7 +112,7 @@ def main() -> None:
             run_cargo(
                 "cranky",
                 "--all-features --target wasm32-unknown-unknown --target-dir target_wasm -p re_viewer -- --deny warnings",
-                clippy_conf="scripts/clippy_wasm", # Use scripts/clippy_wasm/clippy.toml
+                clippy_conf="scripts/clippy_wasm",  # Use scripts/clippy_wasm/clippy.toml
             )
         )
         # Check re_renderer examples for wasm32.

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -9,10 +9,10 @@ Adding "NOLINT" to any line makes the linter ignore that line.
 from __future__ import annotations
 
 import argparse
-from glob import glob
 import os
 import re
 import sys
+from glob import glob
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator
 


### PR DESCRIPTION
### What

Worked locally already, but ci didn't find the clippy config file so far, trying to address that here.
Tested that config is still picked up by putting `let _ = std::time::SystemTime::now();` into space_view.rs

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5989?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/5989?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5989)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.