### PR TITLE
Fix `docs-latest` deploy

### DIFF
--- a/.github/actions/vercel/index.mjs
+++ b/.github/actions/vercel/index.mjs
@@ -8,11 +8,15 @@ import { updateProjectEnv } from "./commands/update-env.mjs";
 
 // All inputs retrieved via `getInput` are defined in `action.yml`, and should be kept in sync
 
-const client = new Client(getRequiredInput("vercel_token"));
-
-const command = getRequiredInput("command");
+const token = getRequiredInput("vercel_token");
 const team = getRequiredInput("vercel_team_name");
 const project = getRequiredInput("vercel_project_name");
+const command = getRequiredInput("command");
+const commit = getInput("release_commit");
+const version = getInput("release_version");
+const target = getInput("target");
+
+const client = new Client(token);
 
 switch (command) {
   case "deploy":
@@ -31,18 +35,13 @@ switch (command) {
  * @param {string} project
  */
 async function deploy(client, team, project) {
-  const target = getRequiredInput("target");
   switch (target) {
     case "production": {
-      const commit = getRequiredInput("release_commit");
-      const version = getRequiredInput("release_version");
       await deployToProduction(client, { team, project, commit, version });
       break;
     }
 
     case "preview": {
-      const commit = getRequiredInput("release_commit");
-      const version = getInput("release_version");
       await deployToPreview(client, { team, project, commit, version });
       break;
     }
@@ -59,9 +58,6 @@ async function deploy(client, team, project) {
  * @param {string} project
  */
 async function updateEnv(client, team, project) {
-  const commit = getInput("release_commit");
-  const version = getInput("release_version");
-
   if (!commit && !version) {
     throw new Error(
       `one of "release_commit", "release_version" must be specified`,


### PR DESCRIPTION
### What

The `release_version` input was supposed to be not required

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
