### PR TITLE
Rewrite `re_ws_comms` to work without `async` & `tokio` runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5267,8 +5267,6 @@ dependencies = [
  "bincode",
  "document-features",
  "ewebsock",
- "futures-channel",
- "futures-util",
  "parking_lot",
  "re_format",
  "re_log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5277,8 +5277,6 @@ dependencies = [
  "re_smart_channel",
  "re_tracing",
  "thiserror",
- "tokio",
- "tokio-tungstenite",
  "tungstenite",
 ]
 
@@ -6466,18 +6464,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5268,6 +5268,7 @@ dependencies = [
  "document-features",
  "ewebsock",
  "parking_lot",
+ "polling 2.8.0",
  "re_format",
  "re_log",
  "re_log_types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,6 @@ tinystl = { version = "0.0.3", default-features = false }
 tinyvec = { version = "1.6", features = ["alloc", "rustc_1_55"] }
 tobj = "4.0"
 tokio = { version = "1.24", default-features = false }
-tokio-tungstenite = { version = "0.20.0", default-features = false }
 toml = { version = "0.8.10", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tungstenite = { version = "0.20", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,8 +109,8 @@ arrow2 = { package = "re_arrow2", version = "0.17" }
 async-executor = "1.0"
 backtrace = "0.3"
 bincode = "1.3"
-bitflags = { version = "2.4", features = ["bytemuck"] }
 bit-vec = "0.6"
+bitflags = { version = "2.4", features = ["bytemuck"] }
 blackbox = "0.2.0"
 bytemuck = { version = "1.11", features = ["extern_crate_alloc"] }
 camino = "1.1"
@@ -137,20 +137,19 @@ flatbuffers = "23.0"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 getrandom = "0.2"
-glam = "0.22"                                                      # glam update blocked by macaw
+glam = "0.22" # glam update blocked by macaw
 glob = "0.3"
 gltf = "1.1"
 half = "2.3.1"
 hyper = "0.14"
 image = { version = "0.24", default-features = false }
 indent = "0.1"
-indexmap = "2.1"                                                   # Version chosen to align with other dependencies
-indicatif = "0.17.7"                                               # Progress bar
-infer = "0.15"                                                     # infer MIME type by checking the magic number signaturefer MIME type by checking the magic number signature
+indexmap = "2.1" # Version chosen to align with other dependencies
+indicatif = "0.17.7" # Progress bar
+infer = "0.15" # infer MIME type by checking the magic number signaturefer MIME type by checking the magic number signature
 insta = "1.23"
-itertools = "0.12"                                                 # updating itertools is blocked on the next egui_tiles update
+itertools = "0.12" # updating itertools is blocked on the next egui_tiles update
 js-sys = "0.3"
-# No lazy_static - use `std::sync::OnceLock` or `once_cell` instead
 libc = "0.2"
 linked-hash-map = { version = "0.5", default-features = false }
 log = "0.4"
@@ -170,7 +169,7 @@ nohash-hasher = "0.2"
 notify = "6.0"
 num-derive = "0.4"
 num-traits = "0.2"
-once_cell = "1.17"
+once_cell = "1.17" # No lazy_static - use `std::sync::OnceLock` or `once_cell` instead
 ordered-float = "4.2"
 parking_lot = "0.12"
 paste = "1.0"
@@ -178,6 +177,7 @@ pathdiff = "0.2"
 pico-args = "0.5"
 ply-rs = { version = "0.1", default-features = false }
 poll-promise = "0.3"
+polling = "2.2.0"
 pollster = "0.3"
 prettyplease = "0.2"
 proc-macro2 = { version = "1.0", default-features = false }

--- a/crates/re_sdk/src/web_viewer.rs
+++ b/crates/re_sdk/src/web_viewer.rs
@@ -45,7 +45,7 @@ impl WebViewerSink {
 
         let rerun_server = RerunServerHandle::new(
             re_smart_channel::ReceiveSet::new(vec![rerun_rx]),
-            bind_ip.to_owned(),
+            bind_ip,
             ws_port,
             server_memory_limit,
         )?;

--- a/crates/re_sdk/src/web_viewer.rs
+++ b/crates/re_sdk/src/web_viewer.rs
@@ -1,6 +1,6 @@
 use re_log_types::LogMsg;
 use re_web_viewer_server::{WebViewerServerHandle, WebViewerServerPort};
-use re_ws_comms::{RerunServerHandle, RerunServerPort};
+use re_ws_comms::{RerunServer, RerunServerPort};
 
 /// Failure to host a web viewer and/or Rerun server.
 #[derive(thiserror::Error, Debug)]
@@ -21,8 +21,8 @@ struct WebViewerSink {
     /// Sender to send messages to the [`re_ws_comms::RerunServer`]
     sender: re_smart_channel::Sender<LogMsg>,
 
-    /// Handle to keep the [`re_ws_comms::RerunServer`] alive
-    _rerun_server: RerunServerHandle,
+    /// Rerun websocket server.
+    _rerun_server: RerunServer,
 
     /// Handle to keep the [`re_web_viewer_server::WebViewerServer`] alive
     _webviewer_server: WebViewerServerHandle,
@@ -43,7 +43,7 @@ impl WebViewerSink {
             re_smart_channel::SmartChannelSource::Sdk,
         );
 
-        let rerun_server = RerunServerHandle::new(
+        let rerun_server = RerunServer::new(
             re_smart_channel::ReceiveSet::new(vec![rerun_rx]),
             bind_ip,
             ws_port,

--- a/crates/re_ws_comms/Cargo.toml
+++ b/crates/re_ws_comms/Cargo.toml
@@ -47,6 +47,6 @@ ewebsock = { workspace = true, optional = true }
 
 # Server:
 parking_lot = { workspace = true, optional = true }
+polling = { workspace = true, optional = true }
 re_smart_channel = { workspace = true, optional = true }
 tungstenite = { workspace = true, optional = true, default-features = false }
-polling = { workspace = true, optional = true }

--- a/crates/re_ws_comms/Cargo.toml
+++ b/crates/re_ws_comms/Cargo.toml
@@ -50,7 +50,6 @@ thiserror.workspace = true
 ewebsock = { workspace = true, optional = true }
 
 # Server:
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 parking_lot = { workspace = true, optional = true }
 re_smart_channel = { workspace = true, optional = true }
 tungstenite = { workspace = true, optional = true, default-features = false }

--- a/crates/re_ws_comms/Cargo.toml
+++ b/crates/re_ws_comms/Cargo.toml
@@ -24,6 +24,7 @@ server = [
   "dep:parking_lot",
   "dep:re_smart_channel",
   "tungstenite",
+  "polling",
 ] ## Enable the server.
 
 ## Enable encryption using TLS support (`wss://`).
@@ -53,3 +54,4 @@ ewebsock = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 re_smart_channel = { workspace = true, optional = true }
 tungstenite = { workspace = true, optional = true, default-features = false }
+polling = { workspace = true, optional = true }

--- a/crates/re_ws_comms/Cargo.toml
+++ b/crates/re_ws_comms/Cargo.toml
@@ -20,12 +20,8 @@ all-features = true
 ## Enable the client (viewer-side).
 client = ["ewebsock"]
 
-server = [
-  "dep:parking_lot",
-  "dep:re_smart_channel",
-  "tungstenite",
-  "polling",
-] ## Enable the server.
+## Enable the server.
+server = ["dep:parking_lot", "dep:re_smart_channel", "tungstenite", "polling"]
 
 ## Enable encryption using TLS support (`wss://`).
 tls = [

--- a/crates/re_ws_comms/Cargo.toml
+++ b/crates/re_ws_comms/Cargo.toml
@@ -20,16 +20,13 @@ all-features = true
 ## Enable the client (viewer-side).
 client = ["ewebsock"]
 
-## Enable the server.
 server = [
   "dep:futures-channel",
   "dep:futures-util",
   "dep:parking_lot",
   "dep:re_smart_channel",
-  "dep:tokio-tungstenite",
-  "dep:tokio",
   "tungstenite",
-]
+] ## Enable the server.
 
 ## Enable encryption using TLS support (`wss://`).
 tls = [
@@ -63,15 +60,4 @@ futures-util = { workspace = true, optional = true, default-features = false, fe
   "std",
 ] }
 parking_lot = { workspace = true, optional = true }
-tokio-tungstenite = { workspace = true, optional = true, features = [
-  "handshake",
-] }
-tokio = { workspace = true, optional = true, features = [
-  "io-std",
-  "macros",
-  "net",
-  "rt-multi-thread",
-  "sync",
-  "time",
-] }
 tungstenite = { workspace = true, optional = true, default-features = false }

--- a/crates/re_ws_comms/Cargo.toml
+++ b/crates/re_ws_comms/Cargo.toml
@@ -21,8 +21,6 @@ all-features = true
 client = ["ewebsock"]
 
 server = [
-  "dep:futures-channel",
-  "dep:futures-util",
   "dep:parking_lot",
   "dep:re_smart_channel",
   "tungstenite",
@@ -51,13 +49,7 @@ thiserror.workspace = true
 ewebsock = { workspace = true, optional = true }
 
 # Server:
-re_smart_channel = { workspace = true, optional = true }
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-futures-channel = { workspace = true, optional = true }
-futures-util = { workspace = true, optional = true, default-features = false, features = [
-  "sink",
-  "std",
-] }
 parking_lot = { workspace = true, optional = true }
+re_smart_channel = { workspace = true, optional = true }
 tungstenite = { workspace = true, optional = true, default-features = false }

--- a/crates/re_ws_comms/src/lib.rs
+++ b/crates/re_ws_comms/src/lib.rs
@@ -14,7 +14,7 @@ pub use client::viewer_to_server;
 #[cfg(feature = "server")]
 mod server;
 #[cfg(feature = "server")]
-pub use server::{RerunServer, RerunServerHandle};
+pub use server::RerunServer;
 
 use re_log_types::LogMsg;
 

--- a/crates/re_ws_comms/src/lib.rs
+++ b/crates/re_ws_comms/src/lib.rs
@@ -41,12 +41,8 @@ pub enum RerunServerError {
     InvalidMessage(#[from] bincode::Error),
 
     #[cfg(feature = "server")]
-    #[error("Failed to join web viewer server task: {0}")]
-    JoinError(#[from] tokio::task::JoinError),
-
-    #[cfg(feature = "server")]
-    #[error("Tokio error: {0}")]
-    TokioIoError(#[from] tokio::io::Error),
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -281,7 +281,7 @@ impl ReceiveSetBroadcaster {
         let inner_cpy = inner.clone();
 
         if let Err(err) = std::thread::Builder::new()
-            .name("rerun_ws_client_broadcaster".to_owned())
+            .name("rerun_ws_server: broadcaster".to_owned())
             .spawn(move || {
                 while let Ok(msg) = log_rx.recv() {
                     match msg.payload {

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -22,7 +22,6 @@ use re_smart_channel::ReceiveSet;
 
 use crate::{server_url, RerunServerError, RerunServerPort};
 
-#[derive(Clone)]
 struct MessageQueue {
     server_memory_limit: MemoryLimit,
     messages: VecDeque<Vec<u8>>,

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -327,6 +327,9 @@ impl ReceiveSetBroadcaster {
 
     /// Adds a websocket client to the broadcaster and replies all message history so far to it.
     fn add_client(&self, mut client: WebSocket<TcpStream>) {
+        // TODO(andreas): While it's great that we don't loose any messages while adding clients,
+        // the problem with this is that now we won't be able to keep the other clients fed, until this one is done!
+        // Meaning that if a new one connects, we stall the old connections until we have sent all messages to this one.
         let mut inner = self.inner.lock();
 
         for msg in &inner.history.messages {

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -248,9 +248,7 @@ impl RerunServer {
             return;
         }
 
-        if let Err(err) = join_handle.join() {
-            re_log::warn!("Error joining listener thread: {err:?}");
-        }
+        join_handle.join().ok();
     }
 }
 

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -197,7 +197,7 @@ impl RerunServer {
                             // Keep the client simple, otherwise we need to do polling there as well.
                             tcp_stream.set_nonblocking(false).ok();
 
-                            re_log::debug!("New WebSocket connection at {:?}", address);
+                            re_log::debug!("New WebSocket connection from {address:?}");
 
                             match tungstenite::accept(tcp_stream) {
                                 Ok(ws_stream) => {
@@ -205,7 +205,6 @@ impl RerunServer {
                                 }
                                 Err(err) => {
                                     re_log::warn!("Error accepting WebSocket connection: {err}");
-                                    return;
                                 }
                             };
                         }

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -167,7 +167,11 @@ impl RerunServer {
         message_broadcaster: &Arc<ReceiveSetBroadcaster>,
         shutdown_flag: &AtomicBool,
     ) {
+        // Each socket in `poll::Poller` needs a "name".
+        // Doesn't matter much what we're using here, as long as it's not used for something else
+        // on the same poller.
         let listener_poll_key = 1;
+
         if let Err(err) = poller.add(listener_socket, Event::readable(listener_poll_key)) {
             re_log::error!("Error when polling listener socket for incoming connections: {err}");
             return;

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -724,13 +724,12 @@ async fn run_impl(
 
             // This is the server which the web viewer will talk to:
             let ws_server = re_ws_comms::RerunServer::new(
+                ReceiveSet::new(rx),
                 &args.bind,
                 args.ws_server_port,
                 server_memory_limit,
             )?;
             let _ws_server_url = ws_server.server_url();
-            let rx = ReceiveSet::new(rx);
-            ws_server.listen(rx)?;
 
             #[cfg(feature = "web_viewer")]
             {
@@ -752,8 +751,7 @@ async fn run_impl(
                 web_server_handle.await?.map_err(anyhow::Error::from)?;
             }
 
-            // TODO:
-            return Ok(()); //ws_server_handle.await?.map_err(anyhow::Error::from);
+            return Ok(());
         }
     } else {
         #[cfg(feature = "native_viewer")]

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -724,14 +724,13 @@ async fn run_impl(
 
             // This is the server which the web viewer will talk to:
             let ws_server = re_ws_comms::RerunServer::new(
-                args.bind.clone(),
+                &args.bind,
                 args.ws_server_port,
                 server_memory_limit,
-            )
-            .await?;
+            )?;
             let _ws_server_url = ws_server.server_url();
             let rx = ReceiveSet::new(rx);
-            let ws_server_handle = tokio::spawn(ws_server.listen(rx));
+            ws_server.listen(rx)?;
 
             #[cfg(feature = "web_viewer")]
             {
@@ -753,7 +752,8 @@ async fn run_impl(
                 web_server_handle.await?.map_err(anyhow::Error::from)?;
             }
 
-            return ws_server_handle.await?.map_err(anyhow::Error::from);
+            // TODO:
+            return Ok(()); //ws_server_handle.await?.map_err(anyhow::Error::from);
         }
     } else {
         #[cfg(feature = "native_viewer")]

--- a/pixi.toml
+++ b/pixi.toml
@@ -56,13 +56,13 @@ rerun-web = { cmd = "cargo run --package rerun-cli --no-default-features --featu
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --debug"
+rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer"
 
 # Compile the web-viewer wasm and the cli.
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
+rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer && cargo build --package rerun-cli --no-default-features --features web_viewer"
 
 # Compile and run the web-viewer in release mode via rerun-cli.
 #

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -973,7 +973,8 @@ def lint_example_requirements() -> int:
 
     missing = []
     for path in glob("examples/python/*/requirements.txt"):
-        line = f"-r {os.path.relpath(path, 'examples/python')}"
+        path = str(os.path.relpath(path, "examples/python")).replace("\\", "/")
+        line = f"-r {path}"
         if line not in requirements:
             missing.append(line)
 
@@ -992,7 +993,8 @@ def lint_example_requirements() -> int:
         expected = glob("examples/python/*/requirements.txt")
         expected.sort()
         for path in expected:
-            print(f"-r {os.path.relpath(path, 'examples/python')}")
+            path = str(os.path.relpath(path, "examples/python")).replace("\\", "/")
+            print(f"-r {path}")
         return 1
 
     return 0


### PR DESCRIPTION
### What

* Big chunk of #5907

Removes tokio & async code from re_ws_comms. Achieves this by spawning a thread for listening and another one for relaying messages (the later was already the case but via tokio).
Main disadvantage of this change here is that all clients now share the same thread for sending whereas before this was handled by the tokio pool. In theory we have less latency though since before we had to go from the broadcast thread to the client worker threads in a separate step.

Ended up depending on the [`polling`](https://docs.rs/polling/latest/polling/index.html) crate because otherwise shutting down a tcplistener with vanilla std rust is close to impossible. The version I picked is such that Cargo.lock doesn't have (yet) another instance of this crate.

This change fixes a bug in the process where we'd not send all so far received messages to new clients.

⚠️ Rerun serve still needs a tokio runtime with this change ⚠️: To fix this we need to remove it also for the web server which should be quite a bit easier 🤞 

Testing done:
* [x] `pixi run rerun-web <some rrd>` to serve several local browsers
* [x] `pixi run python .\examples\python\face_tracking\main.py --serve` to serve several local browsers and checking that they catch up on old data
   * [x] keeping an eye on debug output ensuring that shutdown is graceful 
* [x] Test the same on Mac (did only windows so far)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6005?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6005?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6005
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.