### PR TITLE
Fix listing `tornado` dependency twice in `python/notebook/requirements.txt`

### DIFF
--- a/examples/python/notebook/requirements.txt
+++ b/examples/python/notebook/requirements.txt
@@ -1,5 +1,4 @@
 ipython<=8.12 # ipython 8.13 or greater doesn't work with python 3.8
-tornado<=6.1 # later versions don't work with recent jupyter releases…
 jupyter
 rerun-sdk
 


### PR DESCRIPTION
### What

Overlooked this on https://github.com/rerun-io/rerun/pull/5981

Tested again that notebook still works. This time on windows:
```cmd
pixi run pip install -r .\examples\python\notebook\requirements.txt
pixi run jupyter notebook .\examples\python\notebook\cube.ipynb
```

* Should fix https://github.com/rerun-io/rerun/issues/5927


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
