### PR TITLE
Set default shell to bash for all ci jobs

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -5,6 +5,10 @@ on:
   issue_comment:
     types: [created, edited]
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "read"
   actions: "write"
@@ -25,13 +29,11 @@ jobs:
           pixi-version: v0.18.0
 
       - name: Wait a few seconds
-        shell: bash
         run: |
           # Give GitHub a bit of time to synchronize everything
           sleep 5s
 
       - name: Approve workflow runs
-        shell: bash
         run: |
           pixi run python scripts/ci/approve_workflow_runs.py \
             --github-token "${{ secrets.GITHUB_TOKEN }}" \

--- a/.github/workflows/auto_release_crates.yml
+++ b/.github/workflows/auto_release_crates.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [main]
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: write
   id-token: "write"
@@ -31,7 +35,6 @@ jobs:
 
       - name: Get bumped version
         id: versioning
-        shell: bash
         run: |
           crate_version=$(pixi run python scripts/ci/crates.py get-version)
           echo "crate_version=$crate_version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/checkboxes.yml
+++ b/.github/workflows/checkboxes.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ github.event.pull_request.number }}-pr-checkboxes
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "read"
   pull-requests: "write"
@@ -33,7 +37,6 @@ jobs:
           pixi-version: v0.18.0
 
       - name: Check PR checkboxes
-        shell: bash
         run: |
           pixi run ./scripts/ci/check_pr_checkboxes.py \
             --github-token ${{ secrets.GITHUB_TOKEN }} \

--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -36,6 +36,10 @@ env:
   # these incremental artifacts when running on CI.
   CARGO_INCREMENTAL: "0"
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "read"
 
@@ -84,9 +88,7 @@ jobs:
           pixi-version: v0.19.0
 
       - name: Codegen check
-        shell: bash
-        run: |
-          pixi run codegen --force --check
+        run: pixi run codegen --force --check
 
   rs-lints:
     name: Rust lints (fmt, check, cranky, tests, doc)
@@ -157,14 +159,12 @@ jobs:
       # > Compiler: GNU 12.3.0 (/__w/rerun/rerun/.pixi/env/bin/x86_64-conda-linux-gnu-c++)
       # 😭
       # - name: Build and run C++ tests with clang++
-      #   shell: bash
       #   run: |
       #     pixi run cpp-clean
       #     RERUN_WERROR=ON RERUN_USE_ASAN=ON CXX=clang++ pixi run cpp-build-all
       #     RERUN_WERROR=ON RERUN_USE_ASAN=ON CXX=clang++ pixi run cpp-test
 
       - name: Build and run C++ tests with g++
-        shell: bash
         run: |
           pixi run cpp-clean
           RERUN_WERROR=ON RERUN_USE_ASAN=ON CXX=g++ pixi run cpp-build-all

--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -40,6 +40,10 @@ env:
   # these incremental artifacts when running on CI.
   CARGO_INCREMENTAL: "0"
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "read"
 
@@ -73,7 +77,6 @@ jobs:
 
       - name: Get version
         id: get-version
-        shell: bash
         run: |
           echo "wheel_version=$(python3 scripts/ci/crates.py get-version)" >> "$GITHUB_OUTPUT"
 
@@ -81,28 +84,23 @@ jobs:
         # Now install the wheel using a specific version and --no-index to guarantee we get the version from
         # the pre-dist folder. Note we don't use --force-reinstall here because --no-index means it wouldn't
         # find the dependencies to reinstall them.
-        shell: bash
         run: |
           pixi run -e wheel-test pip uninstall rerun-sdk
           pixi run -e wheel-test pip install rerun-sdk==${{ steps.get-version.outputs.wheel_version }} --no-index --find-links dist
 
       - name: Print wheel version
-        shell: bash
         run: |
           pixi run -e wheel-test python -m rerun --version
           pixi run -e wheel-test which rerun
           pixi run -e wheel-test rerun --version
 
       - name: Run Python unit-tests
-        shell: bash
         run: pixi run -e wheel-test cd rerun_py/tests && pixi run -e wheel-test pytest -c ../pyproject.toml
 
       - name: Run e2e test
-        shell: bash
         run: pixi run -e wheel-test RUST_LOG=debug scripts/run_python_e2e_test.py --no-build # rerun-sdk is already built and installed
 
       - name: Run tests/roundtrips.py
-        shell: bash
         # --release so we can inherit from some of the artifacts that maturin has just built before
         # --target x86_64-unknown-linux-gnu because otherwise cargo loses the target cache… even though this is the target anyhow…
         # --no-py-build because rerun-sdk is already built and installed
@@ -110,7 +108,6 @@ jobs:
           pixi run -e wheel-test RUST_LOG=debug tests/roundtrips.py --release --target x86_64-unknown-linux-gnu --no-py-build
 
       - name: Run docs/snippets/compare_snippet_output.py
-        shell: bash
         # --release so we can inherit from some of the artifacts that maturin has just built before
         # --target x86_64-unknown-linux-gnu because otherwise cargo loses the target cache… even though this is the target anyhow…
         # --no-py-build because rerun-sdk is already built and installed
@@ -126,7 +123,6 @@ jobs:
           key: structure-from-motion-dataset-structure-from-motion-fiat-v1
 
       - name: Generate Embedded RRD file
-        shell: bash
         # If you change the line below you should almost definitely change the `key:` line above by giving it a new, unique name
         run: |
           mkdir rrd

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,10 @@ on:
     # 12:15 UTC, every day
     - cron: "15 12 * * *"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   checks:
     name: Checks
@@ -52,7 +56,6 @@ jobs:
           toolchain: 1.76.0
 
       - run: cargo build -p rerun
-        shell: bash
 
   build-web:
     name: "Build web viewer"
@@ -374,7 +377,6 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Add SHORT_SHA env property with commit short sha
-        shell: bash
         run: echo "SHORT_SHA=`echo ${{github.sha}} | cut -c1-7`" >> $GITHUB_ENV
 
       # First delete the old prerelease. If we don't do this, we don't get things like

--- a/.github/workflows/on_gh_release.yml
+++ b/.github/workflows/on_gh_release.yml
@@ -17,6 +17,10 @@ concurrency:
   group: "release-${{ github.event.release.tag_name }}"
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   # required for updating the release
   contents: write

--- a/.github/workflows/on_pr_comment.yml
+++ b/.github/workflows/on_pr_comment.yml
@@ -10,6 +10,10 @@ on:
   issue_comment:
     types: [created, edited]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   parse-command:
     if: |
@@ -21,7 +25,6 @@ jobs:
     steps:
       - name: Parse comment
         id: parse
-        shell: bash
         run: |
           # Parse `@rerun-bot <command>`
           command=$(echo "${{ github.event.comment.body }}" | sed -n 's/.*@rerun-bot[[:space:]]\+\([a-zA-Z\-]*\).*/\1/p')
@@ -37,7 +40,6 @@ jobs:
 
       - name: Dispatch main workflow
         id: dispatch
-        shell: bash
         env:
           # NOTE: This uses `RERUN_BOT_TOKEN` instead of `GITHUB_TOKEN`,
           # otherwise the recursive workflow protection prevents us from

--- a/.github/workflows/on_pull_request_target_contrib.yml
+++ b/.github/workflows/on_pull_request_target_contrib.yml
@@ -10,6 +10,10 @@ on:
       - opened
       - synchronize
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "read"
   pull-requests: "write" # Updates PR body
@@ -28,7 +32,6 @@ jobs:
           pixi-version: v0.19.0
 
       - name: Update PR description
-        shell: bash
         run: |
           pixi run ./scripts/ci/update_pr_body.py \
             --github-token '${{ secrets.GITHUB_TOKEN }}' \

--- a/.github/workflows/on_push_docs.yml
+++ b/.github/workflows/on_push_docs.yml
@@ -8,6 +8,10 @@ concurrency:
   group: on-push-docs
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   redeploy-rerun-io:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ concurrency:
   group: ${{ github.ref_name }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 permissions: # wants to push commits and create a PR
   contents: write
   id-token: write
@@ -84,7 +88,6 @@ jobs:
 
       - name: Update crate versions
         id: versioning
-        shell: bash
         run: |
           echo Check that the release version matches expected format…
           pixi run python scripts/ci/crates.py check-git-branch-name
@@ -128,23 +131,20 @@ jobs:
           echo "final=$final"       >> "$GITHUB_OUTPUT"
 
       - name: Update JS package versions
-        shell: bash
         run: |
           pixi run node rerun_js/scripts/version.mjs "${{ steps.versioning.outputs.current }}"
 
       - name: Update rerun_c version
-        shell: bash
+
         # Configuring CMake is enough to change the version on rerun.h!
         run: |
           cmake -B build -S .
 
       - run: pixi run toml-fmt
-        shell: bash
 
       - name: Commit new version
         id: commit
         if: steps.versioning.outputs.previous != steps.versioning.outputs.current
-        shell: bash
         run: |
           git pull
           git config --global user.name "rerun-bot"
@@ -156,7 +156,6 @@ jobs:
       - name: Create pull request
         env:
           GH_TOKEN: ${{ secrets.RERUN_BOT_TOKEN }}
-        shell: bash
         run: |
           set +e
           pr=$(gh pr view --json headRefName 2>/dev/null || echo "{}")
@@ -300,7 +299,6 @@ jobs:
           ref: ${{ needs.version.outputs.release-commit }}
 
       - name: Update latest branch
-        shell: bash
         run: |
           git fetch
           git checkout ${{ github.ref_name }}
@@ -384,7 +382,6 @@ jobs:
           pixi-version: v0.19.0
 
       - name: Commit new version
-        shell: bash
         run: |
           # checkout + pull changes
           git config --global user.name "rerun-bot"
@@ -424,7 +421,6 @@ jobs:
       - name: Create comment
         env:
           GH_TOKEN: ${{ secrets.RERUN_BOT_TOKEN }}
-        shell: bash
         run: |
           pr_number=$(gh pr view --json number | jq '.number')
           echo "pr_number: $pr_number"

--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -44,6 +44,10 @@ env:
   # these incremental artifacts when running on CI.
   CARGO_INCREMENTAL: "0"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # ---------------------------------------------------------------------------
 
@@ -75,12 +79,10 @@ jobs:
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
       - name: Add SHORT_SHA env property with commit short sha
-        shell: bash
         run: echo "SHORT_SHA=`echo ${{github.sha}} | cut -c1-7`" >> $GITHUB_ENV
 
       - name: Run benchmark
         # Use bash shell so we get pipefail behavior with tee
-        shell: bash
         run: |
           cargo bench \
             --all-features \
@@ -105,7 +107,6 @@ jobs:
 
       - name: Download comparison bench from GCS
         if: ${{ inputs.COMPARE_TO != '' }}
-        shell: bash
         run: |
           mkdir /tmp/compare/
           gsutil cp gs://rerun-builds/benches/${{inputs.COMPARE_TO}} /tmp/compare/${{ inputs.COMPARE_TO }}
@@ -115,7 +116,6 @@ jobs:
 
       - name: Compare results with benchcmp
         if: ${{ inputs.COMPARE_TO != '' }}
-        shell: bash
         run: cargo benchcmp /tmp/compare/${{ inputs.COMPARE_TO }} /tmp/${{ env.SHORT_SHA }} > /tmp/bench_results.txt
 
       - name: "Upload bench-results to GCS"
@@ -127,7 +127,6 @@ jobs:
 
       - name: "Copy bench to named file"
         if: ${{ inputs.BENCH_NAME != '' }}
-        shell: bash
         run: cp /tmp/${{ env.SHORT_SHA }} /tmp/${{ inputs.BENCH_NAME }}
 
       # Don't upload the new named bench until the end in case the names are the same
@@ -159,7 +158,6 @@ jobs:
 
       - name: Render benchmark result
         if: github.ref == 'refs/heads/main'
-        shell: bash
         run: |
           python3 -m pip install google-cloud-storage==2.9.0
           scripts/ci/render_bench.py crates \

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -65,6 +65,10 @@ env:
   # these incremental artifacts when running on CI.
   CARGO_INCREMENTAL: "0"
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "read"
   id-token: "write"
@@ -81,7 +85,6 @@ jobs:
     steps:
       - name: Set runner and target based on platform
         id: set-config
-        shell: bash
         run: |
           case "${{ inputs.PLATFORM }}" in
             linux-arm64)
@@ -135,7 +138,6 @@ jobs:
 
     steps:
       - name: Show context
-        shell: bash
         run: |
           echo "GITHUB_CONTEXT": $GITHUB_CONTEXT
           echo "JOB_CONTEXT": $JOB_CONTEXT
@@ -168,7 +170,6 @@ jobs:
 
       - name: Get sha
         id: get-sha
-        shell: bash
         run: |
           full_commit="${{ inputs.RELEASE_COMMIT || ((github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha) }}"
           echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -66,6 +66,10 @@ env:
   # these incremental artifacts when running on CI.
   CARGO_INCREMENTAL: "0"
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "read"
   id-token: "write"
@@ -82,7 +86,6 @@ jobs:
     steps:
       - name: Set runner and target based on platform
         id: set-config
-        shell: bash
         run: |
           case "${{ inputs.PLATFORM }}" in
             linux-arm64)
@@ -136,7 +139,6 @@ jobs:
 
     steps:
       - name: Show context
-        shell: bash
         run: |
           echo "GITHUB_CONTEXT": $GITHUB_CONTEXT
           echo "JOB_CONTEXT": $JOB_CONTEXT
@@ -171,7 +173,6 @@ jobs:
       # This does not run in the pixi environment, doing so
       # causes it to select the wrong compiler on macos-arm64
       - name: Build rerun-cli
-        shell: bash
         env:
           # this stops `re_web_viewer_server/build.rs` from running
           RERUN_IS_PUBLISHING: true
@@ -186,7 +187,6 @@ jobs:
 
       - name: Get sha
         id: get-sha
-        shell: bash
         run: |
           full_commit="${{ inputs.RELEASE_COMMIT || ((github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha) }}"
           echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -86,6 +86,10 @@ env:
   # these incremental artifacts when running on CI.
   CARGO_INCREMENTAL: "0"
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "read"
   id-token: "write"
@@ -104,7 +108,6 @@ jobs:
     steps:
       - name: Set runner and target based on platform
         id: set-config
-        shell: bash
         run: |
           case "${{ inputs.PLATFORM }}" in
             linux-arm64)
@@ -160,7 +163,6 @@ jobs:
 
     steps:
       - name: Show context
-        shell: bash
         run: |
           echo "GITHUB_CONTEXT": $GITHUB_CONTEXT
           echo "JOB_CONTEXT": $JOB_CONTEXT
@@ -192,13 +194,11 @@ jobs:
 
       - name: Get sha
         id: get-sha
-        shell: bash
         run: |
           full_commit="${{ inputs.RELEASE_COMMIT || ((github.event_name == 'pull_request' && github.event.pull_request.head.ref) || github.sha) }}"
           echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
       - name: Build
-        shell: bash
         run: |
           pixi run python scripts/ci/build_and_upload_wheels.py \
             --mode ${{ inputs.MODE }} \

--- a/.github/workflows/reusable_build_examples.yml
+++ b/.github/workflows/reusable_build_examples.yml
@@ -37,6 +37,10 @@ env:
   # these incremental artifacts when running on CI.
   CARGO_INCREMENTAL: "0"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   rs-build-examples:
     name: Build Examples
@@ -71,20 +75,17 @@ jobs:
           path: wheel
 
       - name: Install example dependencies
-        shell: bash
         run: |
           pixi run -e wheel-test pip install \
             -r scripts/ci/requirements-examples-${{ inputs.CHANNEL }}.txt \
             --no-input
 
       - name: Install built wheel
-        shell: bash
         run: |
           pixi run -e wheel-test pip uninstall rerun-sdk -y
           pixi run -e wheel-test pip install rerun-sdk --no-index --find-links wheel
 
       - name: Print wheel version
-        shell: bash
         run: |
           pixi run -e wheel-test python -m rerun --version
           pixi run -e wheel-test which rerun
@@ -92,20 +93,17 @@ jobs:
 
       - name: Get sha
         id: get-sha
-        shell: bash
         run: |
           full_commit="${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}"
           echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
       - name: Build examples
-        shell: bash
         run: |
           pixi run -e wheel-test build-examples rrd \
             --channel ${{ inputs.CHANNEL }} \
             example_data
 
       - name: Build snippets
-        shell: bash
         run: |
           pixi run -e wheel-test build-examples snippets \
             example_data/snippets

--- a/.github/workflows/reusable_build_js.yml
+++ b/.github/workflows/reusable_build_js.yml
@@ -31,6 +31,10 @@ env:
   # these incremental artifacts when running on CI.
   CARGO_INCREMENTAL: "0"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     name: Build rerun_js
@@ -66,9 +70,7 @@ jobs:
           pixi-version: v0.19.0
 
       - name: Install yarn dependencies
-        shell: bash
         run: pixi run yarn --cwd rerun_js install
 
       - name: Build rerun_js package
-        shell: bash
         run: pixi run yarn --cwd rerun_js workspaces run build

--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -38,6 +38,10 @@ env:
   # these incremental artifacts when running on CI.
   CARGO_INCREMENTAL: "0"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   rs-build-web-viewer:
     name: Build web viewer
@@ -66,7 +70,6 @@ jobs:
           pixi-version: v0.19.0
 
       - name: Build web-viewer (release)
-        shell: bash
         run: |
           if [ ${{ inputs.CHANNEL }} = "nightly" ]; then
             export DEFAULT_EXAMPLES_MANIFEST_URL="https://app.rerun.io/version/nightly/examples_manifest.json"
@@ -76,7 +79,6 @@ jobs:
       # We build a single manifest pointing to the `commit`
       # All the `pr`, `main`, release tag, etc. variants will always just point to the resolved commit
       - name: Build examples manifest
-        shell: bash
         run: |
           full_commit="${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}"
           sha="$(echo $full_commit | cut -c1-7)"

--- a/.github/workflows/reusable_bundle_and_upload_rerun_cpp.yml
+++ b/.github/workflows/reusable_bundle_and_upload_rerun_cpp.yml
@@ -18,6 +18,10 @@ concurrency:
   group: ${{ inputs.CONCURRENCY }}-bundle-and-upload-rerun-cpp
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   bundle-and-upload-rerun_cpp:
     name: Bundle and upload rerun_cpp_sdk.zip
@@ -49,17 +53,14 @@ jobs:
           version: ">= 363.0.0"
 
       - name: Install python gcs library
-        shell: bash
         run: |
           python3 -m pip install google-cloud-storage
 
       - name: Get sha
         id: get-sha
-        shell: bash
         run: |
           full_commit="${{ inputs.RELEASE_COMMIT || ((github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha) }}"
           echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
       - name: "Bundle and upload rerun_cpp_sdk.zip"
-        shell: bash
         run: python3 ./scripts/ci/bundle_and_upload_rerun_cpp.py --git-hash ${{ steps.get-sha.outputs.sha }} --platform-filter=${{ inputs.PLATFORM_FILTER }}

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -32,10 +32,13 @@ env:
   # these incremental artifacts when running on CI.
   CARGO_INCREMENTAL: "0"
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "read"
   id-token: "write"
-
 jobs:
   py-test-docs:
     name: Test Python Docs
@@ -77,7 +80,6 @@ jobs:
           pixi-version: v0.19.0
 
       - name: Codegen check
-        shell: bash
         run: |
           pixi run codegen --force --check
 

--- a/.github/workflows/reusable_checks_cpp.yml
+++ b/.github/workflows/reusable_checks_cpp.yml
@@ -40,6 +40,10 @@ env:
   # these incremental artifacts when running on CI.
   CARGO_INCREMENTAL: "0"
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "read"
   id-token: "write"
@@ -55,7 +59,6 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
       - name: Load C++ test matrix
         id: set-matrix
-        shell: bash
         run: |
           echo "Full matrix: ${{ inputs.FULL }}"
           if ${{ inputs.FULL }}; then
@@ -98,19 +101,15 @@ jobs:
         run: sudo sysctl vm.mmap_rnd_bits=28
 
       - name: pixi run cpp-clean
-        shell: bash
         run: pixi run cpp-clean
 
       - name: pixi run cpp-build-all
-        shell: bash
         run: ${{ matrix.extra_env_vars }} RERUN_WERROR=ON pixi run cpp-build-all
 
       - name: pixi run cpp-test
-        shell: bash
         run: ${{ matrix.extra_env_vars }} RERUN_WERROR=ON pixi run cpp-test
 
       - name: additional_commands
-        shell: bash
         run: ${{ matrix.additional_commands }}
 
   cpp-formatting:

--- a/.github/workflows/reusable_checks_python.yml
+++ b/.github/workflows/reusable_checks_python.yml
@@ -14,6 +14,10 @@ concurrency:
 env:
   PYTHON_VERSION: "3.8"
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "read"
   id-token: "write"
@@ -55,6 +59,5 @@ jobs:
           environments: py-docs
 
       - name: Build via mkdocs
-        shell: bash
         run: |
           pixi run -e py-docs mkdocs build --strict -f rerun_py/mkdocs.yml

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -35,6 +35,10 @@ env:
   # these incremental artifacts when running on CI.
   CARGO_INCREMENTAL: "0"
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "read"
   id-token: "write"

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -30,6 +30,10 @@ concurrency:
   group: ${{ inputs.CONCURRENCY }}-deploy-docs
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "write"
   id-token: "write"
@@ -74,7 +78,6 @@ jobs:
           environments: py-docs
 
       - name: Set up git author
-        shell: bash
         run: |
           remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git config --global user.name "${GITHUB_ACTOR}"
@@ -87,7 +90,6 @@ jobs:
       # to make sure we don't accumulate unnecessary history in gh-pages branch
       - name: Deploy via mike # https://github.com/jimporter/mike
         if: ${{ inputs.UPDATE_LATEST }}
-        shell: bash
         run: |
           git fetch
           pixi run -e py-docs mike deploy -F rerun_py/mkdocs.yml --rebase -b gh-pages --prefix docs/python -u ${{inputs.PY_DOCS_VERSION_NAME}} stable
@@ -101,7 +103,6 @@ jobs:
       # to make sure we don't accumulate unnecessary history in gh-pages branch
       - name: Deploy tag via mike # https://github.com/jimporter/mike
         if: ${{ ! inputs.UPDATE_LATEST }}
-        shell: bash
         run: |
           git fetch
           pixi run -e py-docs mike deploy -F rerun_py/mkdocs.yml --rebase -b gh-pages --prefix docs/python ${{inputs.PY_DOCS_VERSION_NAME}}
@@ -118,7 +119,6 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: Show context
-        shell: bash
         run: |
           echo "GITHUB_CONTEXT": $GITHUB_CONTEXT
           echo "JOB_CONTEXT": $JOB_CONTEXT
@@ -145,7 +145,6 @@ jobs:
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
       - name: Delete existing /target/doc
-        shell: bash
         run: rm -rf ./target/doc
 
       - name: cargo doc --document-private-items
@@ -155,7 +154,6 @@ jobs:
           args: --document-private-items --no-deps --all-features --workspace --exclude rerun-cli
 
       - name: Set up git author
-        shell: bash
         run: |
           remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git config --global user.name "${GITHUB_ACTOR}"
@@ -164,18 +162,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up ghp-import
-        shell: bash
         run: pip install ghp-import
 
       - name: Patch in a redirect page
-        shell: bash
         run: echo "<meta http-equiv=\"refresh\" content=\"0; url=${REDIRECT_CRATE}\">" > target/doc/index.html
         env:
           REDIRECT_CRATE: rerun
 
       # See: https://github.com/c-w/ghp-import
       - name: Deploy the docs
-        shell: bash
         run: |
           git fetch
           python3 -m ghp_import -n -p -x docs/rust/${{ inputs.RS_DOCS_VERSION_NAME }} target/doc/ -m "Update the rust docs"
@@ -186,7 +181,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Show context
-        shell: bash
         run: |
           echo "GITHUB_CONTEXT": $GITHUB_CONTEXT
           echo "JOB_CONTEXT": $JOB_CONTEXT
@@ -208,11 +202,9 @@ jobs:
           pixi-version: v0.19.0
 
       - name: Doxygen C++ docs
-        shell: bash
         run: pixi run cpp-docs
 
       - name: Set up git author
-        shell: bash
         run: |
           remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git config --global user.name "${GITHUB_ACTOR}"
@@ -221,7 +213,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up ghp-import
-        shell: bash
         run: pip install ghp-import
 
         # TODO(andreas): Do we need this?
@@ -234,13 +225,11 @@ jobs:
       # See: https://github.com/c-w/ghp-import
       - name: Deploy the docs (versioned)
         if: ${{ inputs.RELEASE_VERSION }}
-        shell: bash
         run: |
           git fetch
           python3 -m ghp_import -n -p -x docs/cpp/${{ inputs.RELEASE_VERSION }} rerun_cpp/docs/html/ -m "Update the C++ docs (versioned)"
 
       - name: Deploy the docs (named)
-        shell: bash
         run: |
           git fetch
           python3 -m ghp_import -n -p -x docs/cpp/${{ inputs.CPP_DOCS_VERSION_NAME }} rerun_cpp/docs/html/ -m "Update the C++ docs"

--- a/.github/workflows/reusable_deploy_landing_preview.yml
+++ b/.github/workflows/reusable_deploy_landing_preview.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ inputs.CONCURRENCY }}-deploy-landing-preview
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "write"
   id-token: "write"
@@ -32,7 +36,6 @@ jobs:
 
       - name: Get sha
         id: get-sha
-        shell: bash
         run: |
           full_commit="${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}"
           echo "sha=$full_commit" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable_pip_index.yml
+++ b/.github/workflows/reusable_pip_index.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ inputs.CONCURRENCY }}-pip-index
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   pr-summary:
     name: Create a Pip Index file
@@ -48,11 +52,9 @@ jobs:
           version: ">= 363.0.0"
 
       - name: Install deps
-        shell: bash
         run: pip install google-cloud-storage Jinja2
 
       - name: Render pip index and upload to gcloud
-        shell: bash
         run: |
           full_commit="${{ inputs.COMMIT || (github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha) }}"
           commit=$(echo $full_commit | cut -c1-7)

--- a/.github/workflows/reusable_pr_summary.yml
+++ b/.github/workflows/reusable_pr_summary.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ inputs.CONCURRENCY }}-pr-summary
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   pr-summary:
     name: Create HTML summary for PR
@@ -47,7 +51,6 @@ jobs:
           version: ">= 363.0.0"
 
       - name: Render HTML template
-        shell: bash
         run: |
           pixi run python scripts/ci/generate_pr_summary.py \
           --github-token ${{secrets.GITHUB_TOKEN}} \

--- a/.github/workflows/reusable_publish_js.yml
+++ b/.github/workflows/reusable_publish_js.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ inputs.concurrency }}-publish-js
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "write"
   id-token: "write"
@@ -29,12 +33,10 @@ jobs:
     steps:
       - name: "Set short-sha"
         id: get-short-sha
-        shell: bash
         run: echo "short-sha=$(echo ${{ inputs.release-commit }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: "Set full-sha"
         id: get-full-sha
-        shell: bash
         run: echo "full-sha=${{ inputs.release-commit }}" >> $GITHUB_OUTPUT
 
   build:
@@ -68,6 +70,5 @@ jobs:
       - name: Publish packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        shell: bash
         run: |
           pixi run node rerun_js/scripts/publish.mjs

--- a/.github/workflows/reusable_publish_web.yml
+++ b/.github/workflows/reusable_publish_web.yml
@@ -23,6 +23,10 @@ on:
         type: boolean
         required: true
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "write"
   id-token: "write"
@@ -37,12 +41,10 @@ jobs:
     steps:
       - name: "Set short-sha"
         id: get-short-sha
-        shell: bash
         run: echo "short-sha=$(echo ${{ inputs.release-commit }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: "Set full-sha"
         id: get-full-sha
-        shell: bash
         run: echo "full-sha=${{ inputs.release-commit }}" >> $GITHUB_OUTPUT
 
   build-web:
@@ -85,40 +87,34 @@ jobs:
           path: wheel
 
       - name: Install example dependencies
-        shell: bash
         run: |
           pixi run pip install \
             -r scripts/ci/requirements-examples-nightly.txt \
             --no-input
 
       - name: Install Python dependencies and wheel
-        shell: bash
         run: |
           pixi -e wheel-test run pip uninstall rerun-sdk -y
           pixi -e wheel-test run pip install deprecated '"numpy>=1.23,<2"' pyarrow>=14.0.2 pytest==7.1.2
           pixi -e wheel-test run pip install rerun-sdk --no-index --find-links wheel
 
       - name: Installed wheel version
-        shell: bash
         run: |
           pixi -e wheel-test run python -m rerun --version
           pixi -e wheel-test run which rerun
           pixi -e wheel-test run rerun --version
 
       - name: Build web-viewer (release)
-        shell: bash
         run: |
           pixi -e wheel-test run rerun-build-web-release
 
       - name: Build examples
-        shell: bash
         run: |
           pixi -e wheel-test run build-examples rrd \
             --channel "release" \
             web_viewer/examples
 
       - name: Build examples manifest
-        shell: bash
         run: |
           pixi -e wheel-test run build-examples manifest \
             --base-url "https://app.rerun.io/version/${{inputs.release-version}}" \
@@ -141,6 +137,5 @@ jobs:
 
       - name: Publish app.rerun.io
         if: inputs.update-latest
-        shell: bash
         run: |
           gsutil -m cp -r 'gs://rerun-web-viewer/version/${{ inputs.release-version }}/*' gs://rerun-web-viewer/version/latest

--- a/.github/workflows/reusable_publish_wheels.yml
+++ b/.github/workflows/reusable_publish_wheels.yml
@@ -20,6 +20,10 @@ on:
         type: string
         required: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   get-commit-sha:
     name: Get Commit Sha
@@ -30,12 +34,10 @@ jobs:
     steps:
       - name: "Set short-sha"
         id: get-short-sha
-        shell: bash
         run: echo "short-sha=$(echo ${{ inputs.release-commit }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: "Set full-sha"
         id: get-full-sha
-        shell: bash
         run: echo "full-sha=${{ inputs.release-commit }}" >> $GITHUB_OUTPUT
 
   ## Build
@@ -167,7 +169,6 @@ jobs:
           version: ">= 363.0.0"
 
       - name: Publish to PyPI
-        shell: bash
         run: |
           pixi run python scripts/ci/publish_wheels.py \
             --version ${{ inputs.release-version }} \

--- a/.github/workflows/reusable_release_crates.yml
+++ b/.github/workflows/reusable_release_crates.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ inputs.CONCURRENCY }}-release-crates
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   publish-crates:
     name: "Publish Crates"

--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ inputs.CONCURRENCY }}-run-notebook
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   run-notebook:
     name: Run notebook
@@ -46,7 +50,6 @@ jobs:
 
       - name: Get version
         id: get-version
-        shell: bash
         run: |
           pixi run -e wheel-test 'echo "wheel_version=$(python scripts/ci/crates.py get-version)"' >> "$GITHUB_OUTPUT"
 
@@ -54,7 +57,6 @@ jobs:
         # Now install the wheel using a specific version and --no-index to guarantee we get the version from
         # the pre-dist folder. Note we don't use --force-reinstall here because --no-index means it wouldn't
         # find the dependencies to reinstall them.
-        shell: bash
         run: |
           pixi run -e wheel-test pip uninstall rerun-sdk
           pixi run -e wheel-test pip install rerun-sdk==${{ steps.get-version.outputs.wheel_version }} --no-index --find-links wheel
@@ -73,7 +75,6 @@ jobs:
 
       - name: Get sha
         id: get-sha
-        shell: bash
         run: |
           full_commit="${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}"
           echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable_sync_release_assets.yml
+++ b/.github/workflows/reusable_sync_release_assets.yml
@@ -19,6 +19,10 @@ concurrency:
   group: ${{ inputs.CONCURRENCY }}-sync-assets
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   sync-assets:
     name: Upload assets from build.rerun.io
@@ -51,7 +55,6 @@ jobs:
           version: ">= 363.0.0"
 
       - name: Sync release assets & build.rerun.io
-        shell: bash
         run: |
           pixi run python ./scripts/ci/sync_release_assets.py \
             --github-release ${{ inputs.RELEASE_VERSION }} \

--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -50,6 +50,10 @@ env:
   # these incremental artifacts when running on CI.
   CARGO_INCREMENTAL: "0"
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: "read"
   id-token: "write"
@@ -67,7 +71,7 @@ jobs:
     steps:
       - name: Set runner and target based on platform
         id: set-config
-        shell: bash
+
         # TODO(#5525): at least this target is broken, maybe others — we currently only use linux-x64 and windows-x64
         run: |
           case "${{ inputs.PLATFORM }}" in
@@ -118,7 +122,6 @@ jobs:
 
     steps:
       - name: Show context
-        shell: bash
         run: |
           echo "GITHUB_CONTEXT": $GITHUB_CONTEXT
           echo "JOB_CONTEXT": $JOB_CONTEXT
@@ -156,28 +159,23 @@ jobs:
 
       - name: Get version
         id: get-version
-        shell: bash
-        run: |
-          pixi run -e wheel-test 'echo "wheel_version=$(python scripts/ci/crates.py get-version)"' >> "$GITHUB_OUTPUT"
+        run: pixi run -e wheel-test 'echo "wheel_version=$(python scripts/ci/crates.py get-version)"' >> "$GITHUB_OUTPUT"
 
       - name: Install built wheel
         # Now install the wheel using a specific version and --no-index to guarantee we get the version from
         # the pre-dist folder. Note we don't use --force-reinstall here because --no-index means it wouldn't
         # find the dependencies to reinstall them.
-        shell: bash
         run: |
           pixi run -e wheel-test pip uninstall rerun-sdk
           pixi run -e wheel-test pip install rerun-sdk==${{ steps.get-version.outputs.wheel_version }} --no-index --find-links wheel
 
       - name: Print wheel version
-        shell: bash
         run: |
           pixi run -e wheel-test python -m rerun --version
           pixi run -e wheel-test which rerun
           pixi run -e wheel-test rerun --version
 
       - name: Run unit tests
-        shell: bash
         run: cd rerun_py/tests && pixi run -e wheel-test pytest -c ../pyproject.toml
 
       - name: Run e2e test

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -13,6 +13,10 @@ on:
         required: true
         type: boolean
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: write
   id-token: write
@@ -31,7 +35,6 @@ jobs:
 
       - name: Get context
         id: context
-        shell: bash
         run: |
           echo "short_sha=$(echo ${{ github.sha }} | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
@@ -60,7 +63,6 @@ jobs:
           path: example_data
 
       - name: Download base results
-        shell: bash
         run: |
           # Get base commit:
           # 1. From the index file
@@ -89,7 +91,6 @@ jobs:
 
       - name: Measure sizes
         id: measure
-        shell: bash
         run: |
           entries=()
 
@@ -145,7 +146,6 @@ jobs:
 
       - name: Create index file
         if: github.ref == 'refs/heads/main'
-        shell: bash
         run: |
           echo "${{ steps.context.outputs.short_sha }}" > "/tmp/index"
 
@@ -189,7 +189,6 @@ jobs:
 
       - name: Render benchmark result
         if: github.ref == 'refs/heads/main'
-        shell: bash
         run: |
           python3 -m pip install google-cloud-storage==2.9.0
           scripts/ci/render_bench.py sizes \

--- a/.github/workflows/reusable_update_pr_body.yml
+++ b/.github/workflows/reusable_update_pr_body.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ inputs.CONCURRENCY }}-pr-update-body
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   update-pr-body:
     name: Update PR body
@@ -36,7 +40,6 @@ jobs:
           pixi-version: v0.18.0
 
       - name: Update PR description
-        shell: bash
         run: |
           pixi run ./scripts/ci/update_pr_body.py \
             --github-token '${{ secrets.GITHUB_TOKEN }}' \

--- a/.github/workflows/reusable_upload_examples.yml
+++ b/.github/workflows/reusable_upload_examples.yml
@@ -30,6 +30,10 @@ concurrency:
   group: ${{ inputs.CONCURRENCY }}-upload-examples
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   upload-web:
     name: Upload Examples to Google Cloud
@@ -59,7 +63,6 @@ jobs:
 
       - name: Get sha
         id: get-sha
-        shell: bash
         run: |
           full_commit="${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}"
           echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable_upload_web.yml
+++ b/.github/workflows/reusable_upload_web.yml
@@ -31,6 +31,10 @@ concurrency:
   group: ${{ inputs.CONCURRENCY }}-upload-web
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   upload-web:
     name: Upload web build to google cloud (wasm32 + wasm-bindgen)
@@ -60,7 +64,6 @@ jobs:
 
       - name: Get sha
         id: get-sha
-        shell: bash
         run: |
           full_commit="${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}"
           echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### What

Default shell varies per platform (windows uses powershell) which be quite confusing on what you can put in `run` and what not! This sets the default shell to bash everywhere.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
