### PR TITLE
New data APIs 16 (final?!): introduce non-cacheable components

### DIFF
--- a/crates/re_query/src/latest_at/query.rs
+++ b/crates/re_query/src/latest_at/query.rs
@@ -33,12 +33,19 @@ impl Caches {
 
         for component_name in component_names {
             let key = CacheKey::new(entity_path.clone(), query.timeline(), component_name);
-            let cache = Arc::clone(
-                self.latest_at_per_cache_key
-                    .write()
-                    .entry(key.clone())
-                    .or_insert_with(|| Arc::new(RwLock::new(LatestAtCache::new(key.clone())))),
-            );
+
+            let cache = if crate::cacheable(component_name) {
+                Arc::clone(
+                    self.latest_at_per_cache_key
+                        .write()
+                        .entry(key.clone())
+                        .or_insert_with(|| Arc::new(RwLock::new(LatestAtCache::new(key.clone())))),
+                )
+            } else {
+                // If the component shouldn't be cached, simply instantiate a new cache for it.
+                // It will be dropped when the user is done with it.
+                Arc::new(RwLock::new(LatestAtCache::new(key.clone())))
+            };
 
             let mut cache = cache.write();
             cache.handle_pending_invalidation();

--- a/crates/re_query/src/lib.rs
+++ b/crates/re_query/src/lib.rs
@@ -146,5 +146,5 @@ pub fn cacheable(component_name: re_types::ComponentName) -> bool {
         .into()
     });
 
-    !not_cacheable.contains(&component_name)
+    !component_name.is_indicator_component() && !not_cacheable.contains(&component_name)
 }

--- a/crates/re_query/src/range/query.rs
+++ b/crates/re_query/src/range/query.rs
@@ -33,12 +33,18 @@ impl Caches {
         for component_name in component_names {
             let key = CacheKey::new(entity_path.clone(), query.timeline(), component_name);
 
-            let cache = Arc::clone(
-                self.range_per_cache_key
-                    .write()
-                    .entry(key.clone())
-                    .or_insert_with(|| Arc::new(RwLock::new(RangeCache::new(key.clone())))),
-            );
+            let cache = if crate::cacheable(component_name) {
+                Arc::clone(
+                    self.range_per_cache_key
+                        .write()
+                        .entry(key.clone())
+                        .or_insert_with(|| Arc::new(RwLock::new(RangeCache::new(key.clone())))),
+                )
+            } else {
+                // If the component shouldn't be cached, simply instantiate a new cache for it.
+                // It will be dropped when the user is done with it.
+                Arc::new(RwLock::new(RangeCache::new(key.clone())))
+            };
 
             let mut cache = cache.write();
             cache.handle_pending_invalidation();


### PR DESCRIPTION
Make it possible to not cache some components, all while pretending really hard that they've been cached.

- Related: #5974 

---

Part of a PR series to completely revamp the data APIs in preparation for the removal of instance keys and the introduction of promises:
- #5573
- #5574
- #5581
- #5605
- #5606
- #5633
- #5673
- #5679
- #5687
- #5755
- #5990
- #5992
- #5993 
- #5994
- #6035
- #6036
- #6037

Builds on top of the static data PR series:
- #5534

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using newly built examples: [app.rerun.io](https://app.rerun.io/pr/5573/index.html)
  * Using examples from latest `main` build: [app.rerun.io](https://app.rerun.io/pr/5573/index.html?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [app.rerun.io](https://app.rerun.io/pr/5573/index.html?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/5573)
- [Docs preview](https://rerun.io/preview/5d9b00bd42db54f6e0e705a83ccb17f05cc65d62/docs) <!--DOCS-PREVIEW-->
- [Examples preview](https://rerun.io/preview/5d9b00bd42db54f6e0e705a83ccb17f05cc65d62/examples) <!--EXAMPLES-PREVIEW-->
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)