### PR TITLE
Remove need for tokio runtime for supporting `serve`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4686,7 +4686,6 @@ dependencies = [
  "re_log_types",
  "re_smart_channel",
  "thiserror",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,7 +1420,6 @@ dependencies = [
  "re_crash_handler",
  "re_sdk_comms",
  "re_viewer",
- "tokio",
 ]
 
 [[package]]
@@ -1973,7 +1972,6 @@ dependencies = [
  "re_crash_handler",
  "re_sdk_comms",
  "re_viewer",
- "tokio",
 ]
 
 [[package]]
@@ -3096,7 +3094,6 @@ name = "minimal_serve"
 version = "0.16.0-alpha.1+dev"
 dependencies = [
  "rerun",
- "tokio",
 ]
 
 [[package]]
@@ -5317,7 +5314,6 @@ dependencies = [
  "re_viewer",
  "re_web_viewer_server",
  "re_ws_comms",
- "tokio",
 ]
 
 [[package]]
@@ -5332,7 +5328,6 @@ dependencies = [
  "re_log",
  "re_memory",
  "rerun",
- "tokio",
 ]
 
 [[package]]
@@ -5379,7 +5374,6 @@ dependencies = [
  "re_sdk",
  "re_web_viewer_server",
  "re_ws_comms",
- "tokio",
  "uuid",
 ]
 
@@ -6385,35 +6379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b450e3ba06251ec4fc76917dafeaf55805ffb26dbf7d5500bfb9511ce63a0d1f"
 dependencies = [
  "ahash",
-]
-
-[[package]]
-name = "tokio"
-version = "1.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
-dependencies = [
- "autocfg",
- "bytes",
- "libc",
- "mio",
- "num_cpus",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,6 @@ tiny_http = { version = "0.12", default-features = false }
 tinystl = { version = "0.0.3", default-features = false }
 tinyvec = { version = "1.6", features = ["alloc", "rustc_1_55"] }
 tobj = "4.0"
-tokio = { version = "1.24", default-features = false }
 toml = { version = "0.8.10", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tungstenite = { version = "0.20", default-features = false }

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -461,9 +461,6 @@ impl RecordingStreamBuilder {
     /// Creates a new [`RecordingStream`] that is pre-configured to stream the data through to a
     /// web-based Rerun viewer via WebSockets.
     ///
-    /// This method needs to be called in a context where a Tokio runtime is already running (see
-    /// example below).
-    ///
     /// If the `open_browser` argument is `true`, your default browser will be opened with a
     /// connected web-viewer.
     ///
@@ -481,16 +478,6 @@ impl RecordingStreamBuilder {
     /// ## Example
     ///
     /// ```ignore
-    /// // Ensure we have a running tokio runtime.
-    /// let mut tokio_runtime = None;
-    /// let tokio_runtime_handle = if let Ok(handle) = tokio::runtime::Handle::try_current() {
-    ///     handle
-    /// } else {
-    ///     let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
-    ///     tokio_runtime.get_or_insert(rt).handle().clone()
-    /// };
-    /// let _tokio_runtime_guard = tokio_runtime_handle.enter();
-    ///
     /// let rec = re_sdk::RecordingStreamBuilder::new("rerun_example_app")
     ///     .serve("0.0.0.0",
     ///            Default::default(),

--- a/crates/re_sdk/src/web_viewer.rs
+++ b/crates/re_sdk/src/web_viewer.rs
@@ -122,8 +122,6 @@ impl crate::sink::LogSink for WebViewerSink {
 /// NOTE: you can not connect one `Session` to another.
 ///
 /// This function returns immediately.
-///
-/// The caller needs to ensure that there is a `tokio` runtime running.
 #[must_use = "the sink must be kept around to keep the servers running"]
 pub fn new_sink(
     open_browser: bool,

--- a/crates/re_sdk_comms/Cargo.toml
+++ b/crates/re_sdk_comms/Cargo.toml
@@ -24,7 +24,7 @@ all-features = true
 client = ["re_log_encoding/encoder"]
 
 ## Enable the server.
-server = ["rand", "tokio", "re_log_encoding/decoder"]
+server = ["rand", "re_log_encoding/decoder"]
 
 
 [dependencies]
@@ -45,10 +45,4 @@ rand = { workspace = true, optional = true, features = [
   "std",
   "std_rng",
   "small_rng",
-] }
-
-tokio = { workspace = true, optional = true, features = [
-  "io-util",
-  "net",
-  "rt",
 ] }

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -1,7 +1,10 @@
-use std::{io::ErrorKind, time::Instant};
+use std::{
+    io::{ErrorKind, Read as _},
+    net::{TcpListener, TcpStream},
+    time::Instant,
+};
 
 use rand::{Rng as _, SeedableRng};
-use tokio::net::{TcpListener, TcpStream};
 
 use re_log_types::{LogMsg, TimePoint, TimeType, TimelineName};
 use re_smart_channel::{Receiver, Sender};
@@ -13,6 +16,9 @@ pub enum ServerError {
         bind_addr: String,
         err: std::io::Error,
     },
+
+    #[error(transparent)]
+    FailedToSpawnThread(#[from] std::io::Error),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -68,12 +74,15 @@ impl Default for ServerOptions {
 ///
 /// ``` no_run
 /// # use re_sdk_comms::{serve, ServerOptions};
-/// #[tokio::main]
-/// async fn main() {
-///     let log_msg_rx = serve("0.0.0.0", re_sdk_comms::DEFAULT_SERVER_PORT, ServerOptions::default()).await.unwrap();
+/// fn main() {
+///     let log_msg_rx = serve("0.0.0.0", re_sdk_comms::DEFAULT_SERVER_PORT, ServerOptions::default()).unwrap();
 /// }
 /// ```
-pub async fn serve(
+///
+/// Internally spawns a thread that listens for incoming TCP connections on the given `bind_ip` and `port`
+/// and one thread per connected client.
+// TODO(andreas): Reconsider if we should use `smol` tasks instead of threads both here and in re_ws_comms.
+pub fn serve(
     bind_ip: &str,
     port: u16,
     options: ServerOptions,
@@ -85,13 +94,16 @@ pub async fn serve(
     );
 
     let bind_addr = format!("{bind_ip}:{port}");
-    let listener =
-        TcpListener::bind(&bind_addr)
-            .await
-            .map_err(|err| ServerError::TcpBindError {
-                bind_addr: bind_addr.clone(),
-                err,
-            })?;
+    let listener = TcpListener::bind(&bind_addr).map_err(|err| ServerError::TcpBindError {
+        bind_addr: bind_addr.clone(),
+        err,
+    })?;
+
+    std::thread::Builder::new()
+        .name("rerun_sdk_comms: listener".to_owned())
+        .spawn(move || {
+            listen_for_new_clients(&listener, options, &tx);
+        })?;
 
     if options.quiet {
         re_log::debug!(
@@ -103,19 +115,24 @@ pub async fn serve(
         );
     }
 
-    tokio::spawn(listen_for_new_clients(listener, options, tx));
-
     Ok(rx)
 }
 
-async fn listen_for_new_clients(listener: TcpListener, options: ServerOptions, tx: Sender<LogMsg>) {
-    #[allow(clippy::infinite_loop)] // TODO(emilk): some way of aborting this loop
+fn listen_for_new_clients(listener: &TcpListener, options: ServerOptions, tx: &Sender<LogMsg>) {
+    // TODO(emilk): some way of aborting this loop
+    #[allow(clippy::infinite_loop)]
     loop {
-        match listener.accept().await {
+        match listener.accept() {
             Ok((stream, _)) => {
                 let addr = stream.peer_addr().ok();
                 let tx = tx.clone_as(re_smart_channel::SmartMessageSource::TcpClient { addr });
-                spawn_client(stream, tx, options, addr);
+
+                std::thread::Builder::new()
+                    .name("rerun_sdk_comms: client".to_owned())
+                    .spawn(move || {
+                        spawn_client(stream, &tx, options, addr);
+                    })
+                    .ok();
             }
             Err(err) => {
                 re_log::warn!("Failed to accept incoming SDK client: {err}");
@@ -126,46 +143,41 @@ async fn listen_for_new_clients(listener: TcpListener, options: ServerOptions, t
 
 fn spawn_client(
     stream: TcpStream,
-    tx: Sender<LogMsg>,
+    tx: &Sender<LogMsg>,
     options: ServerOptions,
     peer_addr: Option<std::net::SocketAddr>,
 ) {
-    tokio::spawn(async move {
-        let addr_string =
-            peer_addr.map_or_else(|| "(unknown ip)".to_owned(), |addr| addr.to_string());
+    let addr_string = peer_addr.map_or_else(|| "(unknown ip)".to_owned(), |addr| addr.to_string());
 
-        if options.quiet {
-            re_log::debug!("New SDK client connected: {addr_string}");
-        } else {
-            re_log::info!("New SDK client connected: {addr_string}");
-        }
+    if options.quiet {
+        re_log::debug!("New SDK client connected: {addr_string}");
+    } else {
+        re_log::info!("New SDK client connected: {addr_string}");
+    }
 
-        if let Err(err) = run_client(stream, &tx, options).await {
-            if let ConnectionError::SendError(err) = &err {
-                if err.kind() == ErrorKind::UnexpectedEof {
-                    // Client gracefully severed the connection.
-                    tx.quit(None).ok(); // best-effort at this point
-                    return;
-                }
+    if let Err(err) = run_client(stream, tx, options) {
+        if let ConnectionError::SendError(err) = &err {
+            if err.kind() == ErrorKind::UnexpectedEof {
+                // Client gracefully severed the connection.
+                tx.quit(None).ok(); // best-effort at this point
+                return;
             }
-            re_log::warn_once!("Closing connection to client at {addr_string}: {err}");
-            let err: Box<dyn std::error::Error + Send + Sync + 'static> = err.to_string().into();
-            tx.quit(Some(err)).ok(); // best-effort at this point
         }
-    });
+        re_log::warn_once!("Closing connection to client at {addr_string}: {err}");
+        let err: Box<dyn std::error::Error + Send + Sync + 'static> = err.to_string().into();
+        tx.quit(Some(err)).ok(); // best-effort at this point
+    }
 }
 
-async fn run_client(
+fn run_client(
     mut stream: TcpStream,
     tx: &Sender<LogMsg>,
     options: ServerOptions,
 ) -> Result<(), ConnectionError> {
     #![allow(clippy::read_zero_byte_vec)] // false positive: https://github.com/rust-lang/rust-clippy/issues/9274
 
-    use tokio::io::AsyncReadExt as _;
-
     let mut client_version = [0_u8; 2];
-    stream.read_exact(&mut client_version).await?;
+    stream.read_exact(&mut client_version)?;
     let client_version = u16::from_le_bytes(client_version);
 
     match client_version.cmp(&crate::PROTOCOL_VERSION) {
@@ -190,11 +202,11 @@ async fn run_client(
 
     loop {
         let mut packet_size = [0_u8; 4];
-        stream.read_exact(&mut packet_size).await?;
+        stream.read_exact(&mut packet_size)?;
         let packet_size = u32::from_le_bytes(packet_size);
 
         packet.resize(packet_size as usize, 0_u8);
-        stream.read_exact(&mut packet).await?;
+        stream.read_exact(&mut packet)?;
 
         re_log::trace!("Received packet of size {packet_size}.");
 

--- a/crates/re_web_viewer_server/src/lib.rs
+++ b/crates/re_web_viewer_server/src/lib.rs
@@ -37,10 +37,6 @@ pub enum WebViewerServerError {
 
     #[error("Failed to create server at address {0}: {1}")]
     CreateServerFailed(String, Box<dyn std::error::Error + Send + Sync + 'static>),
-
-    #[cfg(feature = "sync")]
-    #[error("Failed to spawn web viewer thread: {0}")]
-    ThreadSpawnFailed(#[from] std::io::Error),
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/rerun-cli/Cargo.toml
+++ b/crates/rerun-cli/Cargo.toml
@@ -67,7 +67,6 @@ rerun = { workspace = true, features = [
 
 document-features.workspace = true
 mimalloc.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 
 [build-dependencies]

--- a/crates/rerun-cli/src/bin/rerun.rs
+++ b/crates/rerun-cli/src/bin/rerun.rs
@@ -16,13 +16,12 @@ use re_memory::AccountingAllocator;
 static GLOBAL: AccountingAllocator<mimalloc::MiMalloc> =
     AccountingAllocator::new(mimalloc::MiMalloc);
 
-#[tokio::main]
-async fn main() -> std::process::ExitCode {
+fn main() -> std::process::ExitCode {
     re_log::setup_logging();
 
     let build_info = re_build_info::build_info!();
 
-    let result = rerun::run(build_info, rerun::CallSource::Cli, std::env::args()).await;
+    let result = rerun::run(build_info, rerun::CallSource::Cli, std::env::args());
 
     match result {
         Ok(exit_code) => std::process::ExitCode::from(exit_code),

--- a/crates/rerun/Cargo.toml
+++ b/crates/rerun/Cargo.toml
@@ -43,7 +43,7 @@ analytics = [
 ]
 
 ## Integration with `clap`.
-clap = ["dep:clap", "dep:tokio"]
+clap = ["dep:clap"]
 
 ## Support for using Rerun's data-loaders directly from the SDK.
 ##
@@ -84,7 +84,6 @@ run = [
   "dep:re_log_encoding",
   "dep:re_sdk_comms",
   "dep:re_ws_comms",
-  "dep:tokio",
 ]
 
 ## Support for running a TCP server that listens to incoming log messages from a Rerun SDK.
@@ -143,12 +142,6 @@ rayon.workspace = true
 
 # Native, optional:
 clap = { workspace = true, optional = true, features = ["derive"] }
-tokio = { workspace = true, optional = true, features = [
-  "macros",
-  "rt-multi-thread",
-  "time",
-] }
-
 
 [build-dependencies]
 re_build_tools.workspace = true

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -85,18 +85,24 @@ pub struct RerunArgs {
 /// were passed in.
 /// This object makes sure they live long enough and get polled as needed.
 #[doc(hidden)]
-#[derive(Default)]
 pub struct ServeGuard {
-    tokio_rt: Option<tokio::runtime::Runtime>,
+    block_on_drop: bool,
+}
+
+// TODO:
+impl Default for ServeGuard {
+    fn default() -> Self {
+        Self {
+            block_on_drop: false,
+        }
+    }
 }
 
 impl Drop for ServeGuard {
     fn drop(&mut self) {
-        if let Some(tokio_rt) = self.tokio_rt.take() {
+        if self.block_on_drop {
             eprintln!("Sleeping indefinitely while serving web viewer... Press ^C when done.");
-            tokio_rt.block_on(async {
-                tokio::time::sleep(std::time::Duration::from_secs(u64::MAX)).await;
-            });
+            std::thread::sleep(std::time::Duration::from_secs(u64::MAX));
         }
     }
 }
@@ -129,26 +135,8 @@ impl RerunArgs {
 
             #[cfg(feature = "web_viewer")]
             RerunBehavior::Serve => {
-                let mut tokio_rt = None;
-
-                // Get the Tokio runtime for the current thread, or create one if there isn't any.
-                // If we do create one, we'll have to make sure it both outlives and gets
-                // polled to completion as we return from this method!
-                let tokio_rt_handle = if let Ok(handle) = tokio::runtime::Handle::try_current() {
-                    handle
-                } else {
-                    tokio_rt
-                        .get_or_insert(tokio::runtime::Runtime::new()?)
-                        .handle()
-                        .clone()
-                };
-
                 let server_memory_limit = re_memory::MemoryLimit::parse(&self.server_memory_limit)
                     .map_err(|err| anyhow::format_err!("Bad --server-memory-limit: {err}"))?;
-
-                // Creating the actual web sink and associated servers will require the current
-                // thread to be in a Tokio context.
-                let _tokio_rt_guard = tokio_rt_handle.enter();
 
                 let open_browser = true;
                 let rec = RecordingStreamBuilder::new(application_id).serve(
@@ -159,9 +147,10 @@ impl RerunArgs {
                     open_browser,
                 )?;
 
-                // If we had to create a Tokio runtime from scratch, make sure it outlives this
-                // method and gets polled to completion.
-                let sleep_guard = ServeGuard { tokio_rt };
+                // Ensure the server stays alive until the end of the program.
+                let sleep_guard = ServeGuard {
+                    block_on_drop: true,
+                };
 
                 Ok((rec, sleep_guard))
             }

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -85,23 +85,16 @@ pub struct RerunArgs {
 /// were passed in.
 /// This object makes sure they live long enough and get polled as needed.
 #[doc(hidden)]
+#[derive(Default)]
 pub struct ServeGuard {
     block_on_drop: bool,
-}
-
-// TODO:
-impl Default for ServeGuard {
-    fn default() -> Self {
-        Self {
-            block_on_drop: false,
-        }
-    }
 }
 
 impl Drop for ServeGuard {
     fn drop(&mut self) {
         if self.block_on_drop {
             eprintln!("Sleeping indefinitely while serving web viewer... Press ^C when done.");
+            // TODO(andreas): It would be a lot better if we had a handle to the web server and could call `block_until_shutdown` on it.
             std::thread::sleep(std::time::Duration::from_secs(u64::MAX));
         }
     }

--- a/crates/rerun/src/lib.rs
+++ b/crates/rerun/src/lib.rs
@@ -166,10 +166,6 @@ pub mod external {
     #[cfg(not(target_arch = "wasm32"))]
     pub use clap;
 
-    #[cfg(feature = "run")]
-    #[cfg(not(target_arch = "wasm32"))]
-    pub use tokio;
-
     #[cfg(feature = "native_viewer")]
     pub use re_viewer;
 

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -331,7 +331,7 @@ impl CallSource {
 //
 // It would be nice to use [`std::process::ExitCode`] here but
 // then there's no good way to get back at the exit code from python
-pub async fn run<I, T>(
+pub fn run<I, T>(
     build_info: re_build_info::BuildInfo,
     call_source: CallSource,
     args: I,
@@ -382,7 +382,7 @@ where
             Command::Reset => re_viewer::reset_viewer_persistence(),
         }
     } else {
-        run_impl(build_info, call_source, args).await
+        run_impl(build_info, call_source, args)
     };
 
     match res {
@@ -594,7 +594,7 @@ fn profiler(args: &Args) -> re_tracing::Profiler {
     profiler
 }
 
-async fn run_impl(
+fn run_impl(
     _build_info: re_build_info::BuildInfo,
     call_source: CallSource,
     args: Args,
@@ -720,7 +720,6 @@ async fn run_impl(
                 args.ws_server_port,
                 server_memory_limit,
             )?;
-            let _ws_server_url = ws_server.server_url();
 
             #[cfg(feature = "web_viewer")]
             {
@@ -735,7 +734,7 @@ async fn run_impl(
                     args.web_viewer_port,
                     args.renderer,
                     open_browser,
-                    &_ws_server_url,
+                    &ws_server.server_url(),
                 )?
                 .block(); // dropping should stop the server
             }

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -636,7 +636,7 @@ async fn run_impl(
                 max_latency_sec: parse_max_latency(args.drop_at_latency.as_ref()),
                 quiet: false,
             };
-            let rx = re_sdk_comms::serve(&args.bind, args.port, server_options).await?;
+            let rx = re_sdk_comms::serve(&args.bind, args.port, server_options)?;
             vec![rx]
         }
 

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -714,7 +714,7 @@ fn run_impl(
                 .map_err(|err| anyhow::format_err!("Bad --server-memory-limit: {err}"))?;
 
             // This is the server which the web viewer will talk to:
-            let ws_server = re_ws_comms::RerunServer::new(
+            let _ws_server = re_ws_comms::RerunServer::new(
                 ReceiveSet::new(rx),
                 &args.bind,
                 args.ws_server_port,
@@ -734,7 +734,7 @@ fn run_impl(
                     args.web_viewer_port,
                     args.renderer,
                     open_browser,
-                    &ws_server.server_url(),
+                    &_ws_server.server_url(),
                 )?
                 .block(); // dropping should stop the server
             }

--- a/examples/rust/custom_data_loader/src/main.rs
+++ b/examples/rust/custom_data_loader/src/main.rs
@@ -7,20 +7,18 @@
 //! ```
 
 use rerun::{
-    external::{anyhow, re_build_info, re_data_source, re_log, tokio},
+    external::{anyhow, re_build_info, re_data_source, re_log},
     log::{DataRow, RowId},
     EntityPath, TimePoint,
 };
 
-#[tokio::main]
-async fn main() -> anyhow::Result<std::process::ExitCode> {
+fn main() -> anyhow::Result<std::process::ExitCode> {
     re_log::setup_logging();
 
     re_data_source::register_custom_data_loader(HashLoader);
 
     let build_info = re_build_info::build_info!();
     rerun::run(build_info, rerun::CallSource::Cli, std::env::args())
-        .await
         .map(std::process::ExitCode::from)
 }
 

--- a/examples/rust/custom_space_view/Cargo.toml
+++ b/examples/rust/custom_space_view/Cargo.toml
@@ -21,6 +21,3 @@ re_sdk_comms = { path = "../../../crates/re_sdk_comms", features = ["server"] }
 
 # mimalloc is a much faster allocator:
 mimalloc = "0.1"
-
-# We need tokio for re_sdk_comms:
-tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }

--- a/examples/rust/custom_space_view/src/main.rs
+++ b/examples/rust/custom_space_view/src/main.rs
@@ -27,8 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "0.0.0.0",
         re_sdk_comms::DEFAULT_SERVER_PORT,
         Default::default(),
-    )
-    .await?;
+    )?;
 
     let startup_options = re_viewer::StartupOptions::default();
 

--- a/examples/rust/custom_space_view/src/main.rs
+++ b/examples/rust/custom_space_view/src/main.rs
@@ -12,8 +12,7 @@ mod color_coordinates_visualizer_system;
 static GLOBAL: re_memory::AccountingAllocator<mimalloc::MiMalloc> =
     re_memory::AccountingAllocator::new(mimalloc::MiMalloc);
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Direct calls using the `log` crate to stderr. Control with `RUST_LOG=debug` etc.
     re_log::setup_logging();
 

--- a/examples/rust/custom_store_subscriber/src/main.rs
+++ b/examples/rust/custom_store_subscriber/src/main.rs
@@ -13,13 +13,12 @@
 use std::collections::BTreeMap;
 
 use rerun::{
-    external::{anyhow, re_build_info, re_data_store, re_log, re_log_types::TimeRange, tokio},
+    external::{anyhow, re_build_info, re_data_store, re_log, re_log_types::TimeRange},
     time::TimeInt,
     ComponentName, EntityPath, StoreEvent, StoreId, StoreSubscriber, Timeline,
 };
 
-#[tokio::main]
-async fn main() -> anyhow::Result<std::process::ExitCode> {
+fn main() -> anyhow::Result<std::process::ExitCode> {
     re_log::setup_logging();
 
     let _handle = re_data_store::DataStore::register_subscriber(Box::<Orchestrator>::default());
@@ -27,7 +26,6 @@ async fn main() -> anyhow::Result<std::process::ExitCode> {
 
     let build_info = re_build_info::build_info!();
     rerun::run(build_info, rerun::CallSource::Cli, std::env::args())
-        .await
         .map(std::process::ExitCode::from)
 }
 

--- a/examples/rust/extend_viewer_ui/Cargo.toml
+++ b/examples/rust/extend_viewer_ui/Cargo.toml
@@ -21,6 +21,3 @@ re_sdk_comms = { path = "../../../crates/re_sdk_comms", features = ["server"] }
 
 # mimalloc is a much faster allocator:
 mimalloc = "0.1"
-
-# We need tokio for re_sdk_comms:
-tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -26,8 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "0.0.0.0",
         re_sdk_comms::DEFAULT_SERVER_PORT,
         Default::default(),
-    )
-    .await?;
+    )?;
 
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default().with_app_id("rerun_extend_viewer_ui_example"),

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -11,8 +11,7 @@ use re_viewer::external::{
 static GLOBAL: re_memory::AccountingAllocator<mimalloc::MiMalloc> =
     re_memory::AccountingAllocator::new(mimalloc::MiMalloc);
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Direct calls using the `log` crate to stderr. Control with `RUST_LOG=debug` etc.
     re_log::setup_logging();
 

--- a/examples/rust/minimal_serve/Cargo.toml
+++ b/examples/rust/minimal_serve/Cargo.toml
@@ -8,4 +8,3 @@ publish = false
 
 [dependencies]
 rerun = { path = "../../../crates/rerun", features = ["web_viewer"] }
-tokio = { version = "1.24", features = ["rt-multi-thread"] }

--- a/examples/rust/minimal_serve/src/main.rs
+++ b/examples/rust/minimal_serve/src/main.rs
@@ -3,10 +3,6 @@
 use rerun::{demo_util::grid, external::glam};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // `serve()` requires to have a running Tokio runtime in the current context.
-    let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
-    let _guard = rt.enter();
-
     let open_browser = true;
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal_serve").serve(
         "0.0.0.0",

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -58,7 +58,6 @@ once_cell.workspace = true
 parking_lot.workspace = true
 pyo3 = { workspace = true, features = ["abi3-py38"] }
 rand = { workspace = true, features = ["std_rng"] }
-tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
 uuid.workspace = true
 
 


### PR DESCRIPTION
### What

Rust users now no longer need to ensure to have tokio runtime set up when using `serve`.

* Fixes #5907
* Direct follow-up / merges into #6042

Last PR in a series of PRs for removal of the tokio runtime:
* removes need for tokio in re_sdk_comms
   *similar to the refactor in re_ws_comms only in spirit - a lot simpler: no fancy broadcast, no other libraries involved. Just a bunch of threads hammering on blocking sockets).
* remove remaining usages of async in this context
* removes tokio need from all documentation

-----

Dependency count `0.15.1` -> last friday `d90ed2f7e`-> `this pr`

* `cargo build -p rerun --no-default-features` 225 -> 274 -> 275 dependencies
* `cargo build -p rerun -F default` 361 -> 364 -> 364 dependencies
* `cargo build -p rerun -F web_viewer` 409 -> 412 -> 374 dependencies

Notes:
* 0.15.1 already regressed quite a bit compared back to January: https://github.com/rerun-io/rerun/pull/4824
* we currently have a few temporary crates while migrating to re_query2 which weren't present in 0.15

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6043?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6043?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6043)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.