### PR TITLE
Make rerun execution script handle .exe suffix correctly and cleanup scripts

### DIFF
--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -204,7 +204,7 @@ jobs:
           --commit-sha ${{ steps.get-sha.outputs.sha }} \
           --artifact rerun-cli \
           --platform ${{ inputs.PLATFORM }} \
-          --dest rerun_py/rerun_sdk/bin
+          --dest rerun_py/rerun_sdk/rerun_cli
 
       - name: Build
         run: |

--- a/rerun_py/.gitignore
+++ b/rerun_py/.gitignore
@@ -1,6 +1,7 @@
 !Cargo.lock
 .DS_Store
-rerun_sdk/bin/**
+rerun_sdk/rerun_cli/rerun
+rerun_sdk/rerun_cli/rerun.exe
 site/
 target/
 venv/

--- a/rerun_py/build.rs
+++ b/rerun_py/build.rs
@@ -11,10 +11,12 @@ fn main() {
         #[cfg(target_os = "windows")]
         let rerun_bin = std::env::current_dir()
             .unwrap()
-            .join("rerun_sdk/bin/rerun.exe");
+            .join("rerun_sdk/rerun_cli/rerun.exe");
 
         #[cfg(not(target_os = "windows"))]
-        let rerun_bin = std::env::current_dir().unwrap().join("rerun_sdk/bin/rerun");
+        let rerun_bin = std::env::current_dir()
+            .unwrap()
+            .join("rerun_sdk/rerun_cli/rerun");
 
         if !rerun_bin.exists() {
             eprintln!("ERROR: Expected to find `rerun` at `{rerun_bin:?}`.");

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -142,7 +142,11 @@ required-imports = ["from __future__ import annotations"]
 # Even though both `rerun` and `rerun.exe` are here, only one will be included since
 # they both should not be fetched in CI when running the build.
 # Files missing from this list is not a packaging failure.
-include = ["rerun_sdk.pth", "rerun_sdk/bin/rerun", "rerun_sdk/bin/rerun.exe"]
+include = [
+  "rerun_sdk.pth",
+  "rerun_sdk/rerun_cli/rerun",
+  "rerun_sdk/rerun_cli/rerun.exe",
+]
 locked = true
 name = "rerun_bindings"
 python-packages = ["rerun_sdk/rerun", "rerun_sdk/rerun_cli"]

--- a/rerun_py/rerun_sdk/rerun/__main__.py
+++ b/rerun_py/rerun_sdk/rerun/__main__.py
@@ -15,6 +15,18 @@ import sys
 from rerun import unregister_shutdown
 
 
+def exe_suffix() -> str:
+    if sys.platform.startswith("win"):
+        return ".exe"
+    return ""
+
+
+def add_exe_suffix(path: str) -> str:
+    if not path.endswith(exe_suffix()):
+        return path + exe_suffix()
+    return path
+
+
 def main() -> int:
     # Importing of the rerun module registers a shutdown hook that we know we don't
     # need when running the CLI directly. We can safely unregister it.
@@ -24,6 +36,8 @@ def main() -> int:
         target_path = os.environ["RERUN_CLI_PATH"]
     else:
         target_path = os.path.join(os.path.dirname(__file__), "..", "bin", "rerun")
+
+    target_path = add_exe_suffix(target_path)
 
     if not os.path.exists(target_path):
         print(f"Error: Could not find rerun binary at {target_path}", file=sys.stderr)

--- a/rerun_py/rerun_sdk/rerun/__main__.py
+++ b/rerun_py/rerun_sdk/rerun/__main__.py
@@ -35,7 +35,7 @@ def main() -> int:
         print(f"Using overridden RERUN_CLI_PATH={os.environ['RERUN_CLI_PATH']}", file=sys.stderr)
         target_path = os.environ["RERUN_CLI_PATH"]
     else:
-        target_path = os.path.join(os.path.dirname(__file__), "..", "bin", "rerun")
+        target_path = os.path.join(os.path.dirname(__file__), "..", "rerun_cli", "rerun")
 
     target_path = add_exe_suffix(target_path)
 

--- a/rerun_py/rerun_sdk/rerun/__main__.py
+++ b/rerun_py/rerun_sdk/rerun/__main__.py
@@ -8,42 +8,17 @@ importing the module.
 
 from __future__ import annotations
 
-import os
-import subprocess
-import sys
+from rerun_cli.__main__ import main as cli_main
 
 from rerun import unregister_shutdown
-
-
-def exe_suffix() -> str:
-    if sys.platform.startswith("win"):
-        return ".exe"
-    return ""
-
-
-def add_exe_suffix(path: str) -> str:
-    if not path.endswith(exe_suffix()):
-        return path + exe_suffix()
-    return path
 
 
 def main() -> int:
     # Importing of the rerun module registers a shutdown hook that we know we don't
     # need when running the CLI directly. We can safely unregister it.
     unregister_shutdown()
-    if "RERUN_CLI_PATH" in os.environ:
-        print(f"Using overridden RERUN_CLI_PATH={os.environ['RERUN_CLI_PATH']}", file=sys.stderr)
-        target_path = os.environ["RERUN_CLI_PATH"]
-    else:
-        target_path = os.path.join(os.path.dirname(__file__), "..", "rerun_cli", "rerun")
 
-    target_path = add_exe_suffix(target_path)
-
-    if not os.path.exists(target_path):
-        print(f"Error: Could not find rerun binary at {target_path}", file=sys.stderr)
-        return 1
-
-    return subprocess.call([target_path, *sys.argv[1:]])
+    return cli_main()
 
 
 if __name__ == "__main__":

--- a/rerun_py/rerun_sdk/rerun_cli/__main__.py
+++ b/rerun_py/rerun_sdk/rerun_cli/__main__.py
@@ -24,7 +24,7 @@ def main() -> int:
         print(f"Using overridden RERUN_CLI_PATH={os.environ['RERUN_CLI_PATH']}", file=sys.stderr)
         target_path = os.environ["RERUN_CLI_PATH"]
     else:
-        target_path = os.path.join(os.path.dirname(__file__), "..", "bin", "rerun")
+        target_path = os.path.join(os.path.dirname(__file__), "rerun")
 
     target_path = add_exe_suffix(target_path)
 

--- a/rerun_py/rerun_sdk/rerun_cli/__main__.py
+++ b/rerun_py/rerun_sdk/rerun_cli/__main__.py
@@ -7,12 +7,26 @@ import subprocess
 import sys
 
 
+def exe_suffix() -> str:
+    if sys.platform.startswith("win"):
+        return ".exe"
+    return ""
+
+
+def add_exe_suffix(path: str) -> str:
+    if not path.endswith(exe_suffix()):
+        return path + exe_suffix()
+    return path
+
+
 def main() -> int:
     if "RERUN_CLI_PATH" in os.environ:
         print(f"Using overridden RERUN_CLI_PATH={os.environ['RERUN_CLI_PATH']}", file=sys.stderr)
         target_path = os.environ["RERUN_CLI_PATH"]
     else:
         target_path = os.path.join(os.path.dirname(__file__), "..", "bin", "rerun")
+
+    target_path = add_exe_suffix(target_path)
 
     if not os.path.exists(target_path):
         print(f"Error: Could not find rerun binary at {target_path}", file=sys.stderr)


### PR DESCRIPTION
### What
I broke the windows wheel when adding a check for the existence of the file.
Also move the rerun binary into the rerun_cli folder since this is seems more aligned
with the intent of the newly introduced package.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6046?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6046?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6046)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.