### PR TITLE
Clarify tensor dimension order in image docstring

### DIFF
--- a/crates/re_types/definitions/rerun/archetypes/image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/image.fbs
@@ -8,13 +8,17 @@ namespace rerun.archetypes;
 
 /// A monochrome or color image.
 ///
-/// The shape of the `TensorData` must be mappable to:
+/// The order of dimensions in the underlying `TensorData` follows the typical
+/// row-major, interleaved-pixel image format. Additionally, Rerun orders the
+/// `TensorDimension`s within the shape description from outer-most to inner-most.
+///
+/// As such, the shape of the `TensorData` must be mappable to:
 /// - A `HxW` tensor, treated as a grayscale image.
 /// - A `HxWx3` tensor, treated as an RGB image.
 /// - A `HxWx4` tensor, treated as an RGBA image.
 ///
 /// Leading and trailing unit-dimensions are ignored, so that
-/// `1x640x480x3x1` is treated as a `640x480x3` RGB image.
+/// `1x480x640x3x1` is treated as a `480x640x3` RGB image.
 ///
 /// Rerun also supports compressed image encoded as JPEG, N12, and YUY2.
 /// Using these formats can save a lot of bandwidth and memory.

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -23,13 +23,17 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: A monochrome or color image.
 ///
-/// The shape of the `TensorData` must be mappable to:
+/// The order of dimensions in the underlying `TensorData` follows the typical
+/// row-major, interleaved-pixel image format. Additionally, Rerun orders the
+/// `TensorDimension`s within the shape description from outer-most to inner-most.
+///
+/// As such, the shape of the `TensorData` must be mappable to:
 /// - A `HxW` tensor, treated as a grayscale image.
 /// - A `HxWx3` tensor, treated as an RGB image.
 /// - A `HxWx4` tensor, treated as an RGBA image.
 ///
 /// Leading and trailing unit-dimensions are ignored, so that
-/// `1x640x480x3x1` is treated as a `640x480x3` RGB image.
+/// `1x480x640x3x1` is treated as a `480x640x3` RGB image.
 ///
 /// Rerun also supports compressed image encoded as JPEG, N12, and YUY2.
 /// Using these formats can save a lot of bandwidth and memory.

--- a/docs/content/reference/types/archetypes/image.md
+++ b/docs/content/reference/types/archetypes/image.md
@@ -4,13 +4,17 @@ title: "Image"
 
 A monochrome or color image.
 
-The shape of the `TensorData` must be mappable to:
+The order of dimensions in the underlying `TensorData` follows the typical
+row-major, interleaved-pixel image format. Additionally, Rerun orders the
+`TensorDimension`s within the shape description from outer-most to inner-most.
+
+As such, the shape of the `TensorData` must be mappable to:
 - A `HxW` tensor, treated as a grayscale image.
 - A `HxWx3` tensor, treated as an RGB image.
 - A `HxWx4` tensor, treated as an RGBA image.
 
 Leading and trailing unit-dimensions are ignored, so that
-`1x640x480x3x1` is treated as a `640x480x3` RGB image.
+`1x480x640x3x1` is treated as a `480x640x3` RGB image.
 
 Rerun also supports compressed image encoded as JPEG, N12, and YUY2.
 Using these formats can save a lot of bandwidth and memory.

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -19,13 +19,17 @@
 namespace rerun::archetypes {
     /// **Archetype**: A monochrome or color image.
     ///
-    /// The shape of the `TensorData` must be mappable to:
+    /// The order of dimensions in the underlying `TensorData` follows the typical
+    /// row-major, interleaved-pixel image format. Additionally, Rerun orders the
+    /// `TensorDimension`s within the shape description from outer-most to inner-most.
+    ///
+    /// As such, the shape of the `TensorData` must be mappable to:
     /// - A `HxW` tensor, treated as a grayscale image.
     /// - A `HxWx3` tensor, treated as an RGB image.
     /// - A `HxWx4` tensor, treated as an RGBA image.
     ///
     /// Leading and trailing unit-dimensions are ignored, so that
-    /// `1x640x480x3x1` is treated as a `640x480x3` RGB image.
+    /// `1x480x640x3x1` is treated as a `480x640x3` RGB image.
     ///
     /// Rerun also supports compressed image encoded as JPEG, N12, and YUY2.
     /// Using these formats can save a lot of bandwidth and memory.

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -22,13 +22,17 @@ class Image(ImageExt, Archetype):
     """
     **Archetype**: A monochrome or color image.
 
-    The shape of the `TensorData` must be mappable to:
+    The order of dimensions in the underlying `TensorData` follows the typical
+    row-major, interleaved-pixel image format. Additionally, Rerun orders the
+    `TensorDimension`s within the shape description from outer-most to inner-most.
+
+    As such, the shape of the `TensorData` must be mappable to:
     - A `HxW` tensor, treated as a grayscale image.
     - A `HxWx3` tensor, treated as an RGB image.
     - A `HxWx4` tensor, treated as an RGBA image.
 
     Leading and trailing unit-dimensions are ignored, so that
-    `1x640x480x3x1` is treated as a `640x480x3` RGB image.
+    `1x480x640x3x1` is treated as a `480x640x3` RGB image.
 
     Rerun also supports compressed image encoded as JPEG, N12, and YUY2.
     Using these formats can save a lot of bandwidth and memory.


### PR DESCRIPTION
### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6047?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6047?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6047)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.