### PR TITLE
Fix cargo install of CLI

### DIFF
--- a/crates/re_ws_comms/Cargo.toml
+++ b/crates/re_ws_comms/Cargo.toml
@@ -24,7 +24,13 @@ all-features = true
 client = ["ewebsock"]
 
 ## Enable the server.
-server = ["dep:parking_lot", "dep:re_smart_channel", "tungstenite", "polling"]
+server = [
+  "dep:parking_lot",
+  "dep:re_smart_channel",
+  "dep:tungstenite",
+  "dep:polling",
+  "tungstenite/handshake",
+]
 
 ## Enable encryption using TLS support (`wss://`).
 tls = [


### PR DESCRIPTION
```
cargo install --force --path crates/rerun-cli
  Installing rerun-cli v0.16.0-alpha.2 (/home/cmc/dev/rerun-io/rerun/crates/rerun-cli)

error[E0425]: cannot find function `accept` in crate `tungstenite`
   --> crates/re_ws_comms/src/server.rs:217:36
    |
217 |                 match tungstenite::accept(tcp_stream) {
    |                                    ^^^^^^ not found in `tungstenite`
    |
note: found an item that was configured out
   --> /home/cmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tungstenite-0.20.1/src/lib.rs:44:14
    |
44  |     server::{accept, accept_hdr, accept_hdr_with_config, accept_with_config},
    |              ^^^^^^
    = note: the item is gated behind the `handshake` feature

For more information about this error, try `rustc --explain E0425`.
warning: `re_ws_comms` (lib) generated 1 warning
error: could not compile `re_ws_comms` (lib) due to 1 previous error; 1 warning emitted
warning: build failed, waiting for other jobs to finish...
error: failed to compile `rerun-cli v0.16.0-alpha.2 (/home/cmc/dev/rerun-io/rerun/crates/rerun-cli)`, intermediate artifacts can be found at `/home/cmc/dev/rerun-io/rerun/target`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```

Cannot have a server without `accept`, and cannot have `accept` without `tungstenite/handshake`.

No `Cargo.lock` changes necessary because it was already accounted in there due to implicit workspace deps union on some other path.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
