### PR TITLE
Switch default plot aggregator from `MinMax` to `MinMaxAverage`

### DIFF
--- a/crates/re_entity_db/src/entity_properties.rs
+++ b/crates/re_entity_db/src/entity_properties.rs
@@ -370,10 +370,10 @@ pub enum TimeSeriesAggregator {
     /// Keep both the minimum and maximum values in the range.
     ///
     /// This will yield two aggregated points instead of one, effectively creating a vertical line.
-    #[default]
     MinMax,
 
     /// Find both the minimum and maximum values in the range, then use the average of those.
+    #[default] // Fast, and looks good
     MinMaxAverage,
 }
 


### PR DESCRIPTION
This will produce a less jagged plot

Before:
<img width="160" alt="Screenshot 2024-04-23 at 10 24 39" src="https://github.com/rerun-io/rerun/assets/1148717/12c744e0-027e-486e-913f-29f0c6a45f99">

After:
<img width="134" alt="Screenshot 2024-04-23 at 10 24 52" src="https://github.com/rerun-io/rerun/assets/1148717/aa38e376-70a9-45f8-a254-baf0f0f5c192">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6079?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6079?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6079)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.