### PR TITLE
Fix CI build of rerun_c on Linux ARM

### DIFF
--- a/crates/rerun_c/src/error.rs
+++ b/crates/rerun_c/src/error.rs
@@ -29,6 +29,9 @@ impl CError {
             c.encode_utf8(&mut bytes);
 
             for byte in &bytes[..c.len_utf8()] {
+                // `c_char` is something different depending on platforms, and this is needed for
+                // when it's the same as `u8`.
+                #[allow(trivial_numeric_casts)]
                 message_c[bytes_next] = *byte as _;
                 bytes_next += 1;
             }

--- a/crates/rerun_c/src/error.rs
+++ b/crates/rerun_c/src/error.rs
@@ -32,7 +32,9 @@ impl CError {
                 // `c_char` is something different depending on platforms, and this is needed for
                 // when it's the same as `u8`.
                 #[allow(trivial_numeric_casts)]
-                message_c[bytes_next] = *byte as _;
+                {
+                    message_c[bytes_next] = *byte as _;
+                }
                 bytes_next += 1;
             }
         }


### PR DESCRIPTION
### What

Silence a lint that would trigger only on linux arm because apparently `c_char` is something else there than elsewhere.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6086?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6086?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6086)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.