### PR TITLE
Don't override rerun task in wheel-test environment

### DIFF
--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -172,7 +172,7 @@ jobs:
         run: |
           pixi run -e wheel-test python -m rerun --version
           pixi run -e wheel-test which rerun
-          pixi run -e wheel-test rerun --version
+          pixi run -e wheel-test rerun-from-path  --version
 
       - name: Run unit tests
         run: cd rerun_py/tests && pixi run -e wheel-test pytest -c ../pyproject.toml

--- a/pixi.toml
+++ b/pixi.toml
@@ -245,7 +245,7 @@ pip = ">=23"
 [feature.wheel-test.tasks]
 # In the wheel-test environment we want to use the wheel-installed `rerun` binary on the path.
 # This overrides the `rerun` task from the default env which otherwise executes via cargo.
-rerun = "rerun"
+rerun-from-path = "rerun"
 
 # Run the Python tests.
 # Don't call this on CI - use `nox` to run tests on all supported Python versions instead.


### PR DESCRIPTION
### What
Having the task defined in two environments creates the annoying behavior of:
```
$ pixi run rerun
? The task 'rerun' can be run in multiple environments.

Please select an environment to run the task in: ›
❯ default
  cpp
  py-docs
  wheel-test
```

We only used that task in one place in the wheel tests, so rename it to be clear.

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
